### PR TITLE
feat(wr3): zero-spend mode + credit ledger — no Veo charge without a logged decision

### DIFF
--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/01-findings-and-design.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/01-findings-and-design.md
@@ -1,0 +1,167 @@
+# P03 — WR3/FlowKit zero-spend — design decision
+
+**Builder:** H3 · **Gear:** 2 · **base:** `5117d9908a37cdc5f23924f6fe19cd823e2ed6c5`
+**Ceiling:** no Flow/Veo submission, no credit spend, no render/publish execution, no WR2 edits,
+no scheduler/service/LaunchAgent load-unload-install. `service_control: none`.
+
+## Ground findings (all re-verified on disk this session)
+
+| # | Finding | Evidence |
+|---|---|---|
+| F1 | **No credit ledger exists.** The cost circuit breaker reads `~/.cache/wr3/flow-quota.json`; **nothing in the repo ever writes it.** Hand-seeded `as_of: 2026-05-29`, `daily_spent_cr: 0`, `balance_remaining_cr: 2400` — while real clips were rendered (see F1b for the corrected count). | only reader: `scripts/wr3_gatekeeper_check.py:15`; zero writers (repo-wide grep) |
+| F2 | **Per-clip cost disagrees 2×.** Client charges 20 cr/clip; gate projects 10 cr/clip. A 19-shot episode: gate computes 190 cr (== its own `expected_cr`, PASSES) while reality is 380 cr. **The breaker passes an episode costing 2× its ceiling.** | `wr3_flowkit_client.py:48-49` = 20 · `wr3_gatekeeper_check.py:24` `CR_PER_CLIP = 10` · `wr3_probe_single_clip.py:4` "~10 Veo cr" |
+| F3 | **The gatekeeper is advisory, not enforcing.** `wr3_render_episode.py` — the actual render driver — never reads `gate-verdict.json` and never calls the gatekeeper. It checks `/health.extension_connected`, then goes straight to `submit_clip`. | `wr3_render_episode.py:28-70` |
+| F4 | **`wr3_probe_single_clip.py` bypasses `submit_clip` entirely**, calling `fk._generate_start_image` + `fk._generate_video` directly. A guard in `submit_clip` alone is bypassable. | `wr3_probe_single_clip.py:38-45` |
+| F5 | **Fail-open by configuration.** `flow-quota.json` is an unvalidated user-writable HOME cache; a large seeded `balance_remaining_cr` silently disables the breaker. Missing file = uncaught exception, not a named refusal. | `wr3_gatekeeper_check.py:15` (no try/except) |
+| F6 | **WR2 shares the same credit pool.** `scripts/wr2_flowkit_client.py` posts to the same gateway `/api/flow/generate-image`. Out of this packet's scope to change (ceiling), so **the ledger cannot claim to be a complete account of Flow credit consumption** — it accounts for WR3 only. Stated as a limitation, never papered over. | `wr2_flowkit_client.py:81,308` |
+| F7 | **`drawtext` is not compiled into this ffmpeg** (8.1, no libfreetype); `/tmp/ffmpeg-full/ffmpeg` referenced by the post-assembler docs does not exist. A placeholder spec naming `drawtext` would fail at runtime. PIL 12.1.1 is present — burned-in text goes through a PIL-rendered overlay PNG. | `ffmpeg -h filter=drawtext` → `Unknown filter` |
+
+## Decision
+
+**Guard at the lowest network layer, not at the caller.** Every credit-charging HTTP call in WR3
+goes through exactly two functions — `_generate_start_image` and `_generate_video`. The spend
+authorization check is installed **there**, so F4-class bypasses (and any future caller) fail
+closed by construction rather than by remembering to add a check.
+
+Three layers, defence in depth:
+
+1. **`submit_clip` zero-spend short-circuit** — when `WR3_ZERO_SPEND` is truthy, returns a
+   deterministic placeholder `ClipResult` (`cost_credits=0`) without touching the network.
+2. **Low-level fail-closed gate** — `_generate_start_image` / `_generate_video` raise
+   `SpendNotAuthorizedError` unless a well-formed `WR3_SPEND_DECISION=<episode_id>:<who>:<date>`
+   is present, matches the episode being rendered, and is dated today. Raised *before* the POST.
+3. **Ledger record at the same choke point** — every authorized spend and every placeholder is
+   appended to the JSONL ledger, so before/after is measurable rather than asserted.
+
+**Why not fix F2/F3 here:** repairing the gatekeeper's `CR_PER_CLIP` and wiring it as a blocker
+changes render-path behaviour, which the frozen "must not" bars in this dispatch. They are
+recorded as findings + PENDING-ARMS lines for the successor (P11 owns the paid pilot).
+
+## Falsifiable acceptance criteria
+
+- A1 `python3 scripts/wr3_credit_ledger.py report --days 30` prints per-episode credits from local artifacts only, exit 0, on an empty ledger too.
+- A2 With `WR3_ZERO_SPEND=1`, a full episode run produces N placeholder mp4s, 8s, 720x1280, distinguishable per shot, and **zero** network calls to :8100 (proven by a listener-absent run, not by trust).
+- A3 Without `WR3_SPEND_DECISION`, a direct call to `_generate_video` raises `SpendNotAuthorizedError` **before** any socket is opened.
+- A4 With a *mismatched* or *stale-dated* `WR3_SPEND_DECISION`, same refusal.
+- A5 Ledger total before the dry run == ledger total after the dry run.
+- A6 Codex red-team finds no path to a charge that skips the gate; Kimi K3 does not falsify the ledger arithmetic.
+
+## Live Pro-side facts (measured 2026-08-23 ~11:53 WITA, this session)
+
+- FlowKit gateway **ALIVE**: PID 1062, `/Users/nuzantara/flowkit/venv/bin/python -m agent.main`,
+  uptime **2d 17h 55m**, LISTEN on 127.0.0.1:8100 **and** :9222. Note the binary lives under
+  `$HOME/flowkit/` — HOME-executed payload, superscar #1 surface (recorded, not touched here).
+- `GET /health` → `{"status":"ok","version":"0.2.0","extension_connected":false,`
+  `"ws":{"connected":false,"connects":17,"disconnects":17,"uptime_s":null}}`
+  → **`status:"ok"` while `extension_connected:false`** — superscar #2 in the flesh: the top-level
+  field a naive monitor reads says healthy; the field that decides whether a render can succeed
+  says the browser extension is gone. 17 connects / 17 disconnects = it has flapped and is down.
+- Consequence for the dry-run proof: **the listener is present**, so "nothing was listening" is NOT
+  available as evidence of zero spend. Replaced by a falsifiable probe (below).
+
+## Falsifiable zero-spend probe (what would make it RED)
+
+Run the zero-spend path with `WR3_FLOWKIT_ENDPOINT=http://127.0.0.1:1` (a port with no listener).
+- If zero-spend genuinely never opens a socket → the run **succeeds** and the ledger records 0 cr.
+- If any code path still tries to reach the gateway → **ECONNREFUSED**, the run fails loudly.
+This is the probe's answer to "what would have made this red": a single reachable byte to the
+gateway turns it red. Absence of a listener is not being used as the proof; the *inversion* is.
+
+## Dry-run episode: synthetic fixture, and why
+
+**No episode on disk has a `shot-pack.json`** (checked all three under
+`apps/war-room/output/episode/`). Generating a real one would be *storyboard execution*, which the
+frozen "must not" bars. The dry run therefore uses a **synthetic fixture** episode
+(`simulated: true`, neutral placeholder prompt strings, no regulatory claim, no PII) — which the
+packet itself sanctions (deliverable 5 requires exactly a `simulated=true` fixture).
+Verified this session: the fixture **PASSES the real gatekeeper** — `verdict: PASS`, 3/3 shots,
+`projected_cr: 30`.
+
+That gatekeeper run also **measured F2**: it projected `30 cr` for 3 shots (3 × 10) while the
+client charges 20/clip → true cost 60 cr. The breaker under-reports by exactly 2×, on real output,
+not by argument.
+
+## F8 — THE PACKET'S BIGGEST FINDING: five doors, one credit pool, one gate
+
+The mandate scopes the guard to WR3 (`wr3-clip-renderer` / the gatekeeper). Class-audited this
+session (modus VERIFY: "a cure applied to 1-of-N paths is a time bomb"), the same charging
+endpoints `/api/flow/generate-video` and `/api/flow/generate-image` on the same gateway
+`127.0.0.1:8100` are reachable through **five** independent doors:
+
+| Door | Lines | Charging call | Live? | Covered by this packet's gate |
+|---|---|---|---|---|
+| `scripts/wr3_flowkit_client.py` (WR3) | — | both | live | **YES** |
+| `scripts/flowkit_cli.py` | 854 | `:617` image, `:382` video | **live** — a plain CLI, any terminal | no |
+| `scripts/wr2_flowkit_client.py` (WR2) | — | `:308` image | **live** — `WR2_IMAGE_BACKEND=auto` probes FlowKit first | no — ceiling forbids WR2 edits |
+| `apps/zantara-media/zantara_media/magazine/media_resolver.py` | 954 | `:671` image | **live** | no |
+| `apps/nuzantara-mcp/nuzantara_mcp/tools/flowkit.py` | 424 | `:339` image, `:395` video | **DORMANT** | no |
+
+**On the MCP door, stated precisely rather than dramatically** (verified, not assumed):
+`.mcp.json` registers only `nuzantara-knowledge` → `server_knowledge.py`, which is fail-closed by
+allowlist and registers ONLY `knowledge` + `pricing`. The flowkit tools are registered in
+`server.py:184`, and `server.py` is **not** in `.mcp.json`. So no LLM can spend Veo credits through
+MCP today. The risk is latent, not active: registering `server.py` would hand any model a
+credit-spending tool (`flowkit_generate_video`) with no decision token anywhere in its path — and
+that tool stages the CLI onto Pro over ssh, so it is remote execution as well as spend.
+
+**Consequence, said plainly:** delivered exactly as specified, this packet makes WR3 zero-spend and
+leaves four other doors to the same pool ungated. That is not a reason to widen the diff past the
+ceiling — it is a reason the successor dispatch must be scoped to the CHOKE POINT (the gateway
+itself, or a shared authority module every client imports), not to WR3. One PENDING-ARMS line per
+door, and the P11 handoff inherits the whole list.
+
+## F9 — the ledger records the charge in the wrong place (found reviewing the lane's diff)
+`record_spend` was placed after `_download_video_media` succeeds. The charge happens at
+`_generate_video`. A download failure therefore loses the record of a charge that already occurred —
+and `wr3_render_episode.py` retries a failed shot **3×**, so one shot can be charged three times and
+logged zero. Fixed during integration: record at the charge, not after the artifact arrives.
+
+
+## F1b — CORRECTION to my own count: 34 was wrong, and the right answer is a RANGE
+
+I asserted "34 real `.mp4` clips were rendered". That was a raw `find -name '*.mp4' | wc -l` over
+the whole episode tree. The implementer lane caught it; I re-verified on disk and the lane is right:
+
+- `master.mp4` (81,942,171 bytes, Jun 2) is the **assembled final episode**, not a clip charge.
+- `clips_lipsync_bak_20260602T201944/` holds the **identical 11 shot numbers** as `clips_lipsync/` — a pure backup.
+- `clips_original_backup_2026-06-01/606.mp4` duplicates `clips/606.mp4`.
+
+Distinct shot keys: `01 02 04 06 07 09 10 11 13 17 18 606` = **12**.
+
+**But 12 is a FLOOR, not a measurement, and that is the sharper point.**
+`clips_lipsync_incoming_2026-06-03/` contains **both** `01_before_0432.mp4` and
+`01_replaced_0433.mp4` — a **re-render of shot 01**. A re-render is a fresh Veo charge, and
+dedupe-by-shot-key cannot see it. So the true number of charges lies in **[12, 34]** and **nothing
+on disk can settle it**.
+
+That range IS finding F1. The artifacts cannot tell you what was spent — which is precisely why a
+ledger written at the charge site is the deliverable, and why a backfill must be reported as a lower
+bound rather than a number.
+
+## D4 proof design — REVISED after the refuter's verdict
+
+The refuter's bottom line: *"the per-record arithmetic is correct where tested, but the claim
+'before == after ⇒ no overspend' is not supported by this ledger"* — and specifically:
+**a windowed report cannot carry the proof**, because with `--days 30` any spend older than the
+window is invisible, so two windowed reports straddling an old overspend read identically.
+
+So the PROVE-LIVE pair is NOT `report --days 30` before and after. It is a **four-part tuple**,
+captured before and after, unwindowed:
+
+1. **unwindowed total credits** (no `--days`) — a windowed total can hide an old delta;
+2. **total record COUNT** — proves *no new rows appeared*, which a credit total of 0 cannot
+   (a placeholder row and a swallowed-write both read as "no change" in credits alone);
+3. **the resolved absolute ledger path** — printed by both runs, so a comparison across two
+   different files (the `WR3_CREDIT_LEDGER` divergence) is visible on its face;
+4. **the integrity line** — `OK` vs `DEGRADED — N write failure(s)`. A run whose ledger could not
+   certify completeness does not get to claim zero spend.
+
+**What would make this proof RED** (stated in advance, per the verification discipline):
+any of — total credits differ; record count differs by anything other than the expected N
+`placeholder` rows; the two runs print different ledger paths; integrity reads DEGRADED; or a
+socket to the gateway is opened at all (caught by pointing `WR3_FLOWKIT_ENDPOINT` at a dead port).
+
+**What this proof still CANNOT certify, stated plainly rather than glossed:** the ledger sees only
+spend that passes the one instrumented call site. Per F8 there are four other live doors to the same
+credit pool. So the honest claim is *"this run spent zero credits through WR3"*, never *"zero
+credits were spent"*. The packet must not be reported as more than that.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/01-findings-and-design.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/01-findings-and-design.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: kimi-k3
+---
+
 # P03 — WR3/FlowKit zero-spend — design decision
 
 **Builder:** H3 · **Gear:** 2 · **base:** `5117d9908a37cdc5f23924f6fe19cd823e2ed6c5`
@@ -104,7 +108,8 @@ MCP today. The risk is latent, not active: registering `server.py` would hand an
 credit-spending tool (`flowkit_generate_video`) with no decision token anywhere in its path — and
 that tool stages the CLI onto Pro over ssh, so it is remote execution as well as spend.
 
-**Consequence, said plainly:** delivered exactly as specified, this packet makes WR3 zero-spend and
+**Consequence, said plainly:** delivered exactly as specified, this packet makes the WR3 **library**
+zero-spend (through the CLI driver it is unreachable — see F11) and
 leaves four other doors to the same pool ungated. That is not a reason to widen the diff past the
 ceiling — it is a reason the successor dispatch must be scoped to the CHOKE POINT (the gateway
 itself, or a shared authority module every client imports), not to WR3. One PENDING-ARMS line per
@@ -165,3 +170,69 @@ socket to the gateway is opened at all (caught by pointing `WR3_FLOWKIT_ENDPOINT
 spend that passes the one instrumented call site. Per F8 there are four other live doors to the same
 credit pool. So the honest claim is *"this run spent zero credits through WR3"*, never *"zero
 credits were spent"*. The packet must not be reported as more than that.
+
+
+## F1c — the range [12, 34] was ALSO wrong, and the correct answer is "undeterminable"
+
+Byte-comparing the artifacts (this session) refutes both my `[12, 34]` and the implementer lane's
+judgement that the sibling dirs are staging copies:
+
+| Comparison | Result |
+|---|---|
+| `clips_lipsync_bak_20260602T201944` vs `clips_lipsync` | **3 identical, 8 DIFFERING** — not a pure backup |
+| `clips_original_backup_2026-06-01/606.mp4` vs `clips/606.mp4` | identical — a true backup |
+| `clips_lipsync_incoming_2026-06-03` vs `clips_lipsync` | 7 identical (staging copies), **shot 01 has two files, both differing** |
+
+Byte-distinct contents, excluding `master.mp4` and exact duplicates: **22**.
+
+**But 22 is not an upper bound on Veo charges, and this is the point.** Those directories hold
+**lipsync** output — a local post-process. Re-encoding a clip changes its bytes **without any Veo
+call**. So a byte difference does not evidence a second render, and the filesystem cannot
+distinguish "re-rendered by Veo" from "re-encoded locally".
+
+**Corrected finding:** the lower bound is 12 (distinct shot keys). There is **no derivable upper
+bound** — not 34, not 22. The artifacts cannot settle the historical spend *even in principle*,
+because the evidence a charge leaves (an API call) and the evidence a file carries (bytes) are not
+the same evidence.
+
+That is a stronger statement of F1 than the one it replaces: the ledger is not merely missing, it
+is **unreconstructible after the fact**. Only a record written at the charge site can ever answer
+this question — which is what this packet adds, and why the backfill is labelled a FLOOR with no
+ceiling claimed.
+
+
+## Adversarial review
+
+Refuted by **Kimi K3** (cross-family, fresh context) against the whole evidence package. Accepted
+findings, applied above or recorded here:
+
+1. **A SIXTH door exists and this document missed it — the Google Flow web UI.** A human opening
+   Flow in a browser and clicking generate spends the *same* credit pool and traverses none of the
+   five code doors. The repo even carries a skill (`nuzantara-flowkit-flow-generation`) describing
+   that manual path. No code gate can ever cover it. F8's table is therefore a count of *repo* doors,
+   not of ways to spend.
+2. **The MCP dormancy claim was scoped too broadly.** I proved it from ONE config file (`.mcp.json`
+   registering only `server_knowledge.py`). Other agent CLIs on this fleet (kimi, codex, agy) carry
+   their own MCP registrations, unexamined. Corrected claim: *no MCP server registered in this repo's
+   `.mcp.json` exposes the flowkit tools*; whether another client registers `server.py` is
+   **UNVERIFIED**.
+3. **F8's audit is a lower bound, not a census.** It found doors by grepping charging-endpoint
+   strings; a caller reaching the gateway via `localhost:8100`, a tailnet address, or an
+   env-configured base URL would not match. "Five doors" means "five found by this search".
+4. **The floor was challenged as 13, not 12 — and the challenge is itself refuted by F1c.** The
+   refuter argued the surviving `01_before`/`01_replaced` pair proves a second charge, so the floor
+   is 13. But F1c establishes that these directories hold **lipsync** output, and a local re-encode
+   changes bytes with no Veo call. Byte difference does not evidence a render. **The floor stays 12**,
+   and the reason it cannot be raised is the same reason it cannot be capped.
+5. **The dead-port canary covers less than implied — CONCEDED, verified.** It only redirects paths
+   that honor `WR3_FLOWKIT_ENDPOINT`. Measured: `wr3_probe_single_clip.py:17` **hardcodes**
+   `http://127.0.0.1:8100`, and `flowkit_cli.py:26` reads a *different* variable
+   (`FLOWKIT_BASE_URL`). The probe script is nonetheless safe — but by the **gate**, which raises
+   before any socket, not by the canary. Two distinct protections; conflating them overstated the
+   canary.
+6. **The most dangerous unstated assumption — ACCEPTED, and it belongs at the top of any report of
+   this packet.** *The Google account balance is never queried.* Every claim here is about the
+   instrumentation, not about credits. The honest ceiling on what this packet can ever prove is
+   **"this process spent nothing through the instrumented WR3 path"** — never "no credits were
+   spent". Concurrent spend from another door, a queued job completing later, or a human in the web
+   UI are all invisible to it by construction.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/02-tunnel-diagnosis.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/02-tunnel-diagnosis.md
@@ -1,0 +1,105 @@
+# P03 Deliverable 3 — `com.balizero.flowkit-pro-tunnel` (M5 → Pro)
+
+**Method:** read-only. No `launchctl load/unload/bootout/kickstart`, no plist edit, no write on M5
+beyond the repo probe's own heartbeat sidecar. `service_control: none` respected.
+
+## Verdict: the mandate's premise is FALSIFIED — the tunnel is ALIVE
+
+The dispatch states the tunnel "is **exit 255 / silent 43h** … currently dead". Measured this
+session, it is not dead and, on the evidence, was not dead then either.
+
+| Claim | Measurement (2026-08-23 ~11:55 WITA) |
+|---|---|
+| tunnel dead | **`curl http://127.0.0.1:8100/health` FROM M5 → HTTP 200**, returning byte-identical JSON to what Pro's gateway serves locally (`connects:17,disconnects:17`). A real HTTP reply traversed the tunnel. |
+| exit 255 | `launchctl print` returns **`state = running`, `pid = 18724`, `last exit code = 255` in the same read**. 255 belongs to a PREVIOUS instance. `ps -p 18724` → alive, ELAPSED **09:52:31**. |
+| silent 43h | `~/Library/Logs/flowkit-pro-tunnel.err` last write **Aug 23 02:02:46**, i.e. ~9h52m of silence — and this log is written **only on failure**. For this organ, **silence is the signature of health.** |
+
+**Why the false alarm is structural, not a typo.** `ssh -N -T` writes nothing to stdout and nothing
+to stderr while it works. So a healthy tunnel produces an eternally silent error log. The digest
+used *log silence* + *last exit code* as evidence of death — for an organ whose healthy output IS
+silence. The modus doctrine already names this exact failure ("a receptor whose HEALTHY output is
+silence must expose a self-probe that distinguishes healthy-silent from dead"); the digest violated
+it. Silence was read as death, and the 43h of quiet was 43h of the tunnel working.
+
+## Root cause, ATTRIBUTED (not inferred) — two organs disagree, right now
+
+Running M5's own detector read-only, live:
+
+```json
+{"label":"com.balizero.flowkit-pro-tunnel","verdict":"FAILING-HONESTLY",
+ "last_exit":255,"program":"/usr/bin/ssh","program_exists":true,
+ "log_marker":null,"stale_green":false}
+```
+— `scripts/launchd_liveness_detector.py --json`, on M5, **while the tunnel was serving HTTP 200**.
+
+Its sibling, `scripts/check_flowkit_tunnel.py` (registered in `proprioception.py:1056`, `machines:
+["m5"]`, P2), had written 1 minute earlier:
+
+```json
+{"organ":"m5.flowkit_tunnel","status":"ok","degraded":false,
+ "note":"PID 18724 alive, http://127.0.0.1:8100/ answered (HTTP 404)","ts":"2026-08-23T03:54:23Z"}
+```
+
+**Two probes, same machine, same job, opposite verdicts in the same minute — and the digest quotes
+the wrong one.** `launchd_liveness_detector.py` judges on `last_exit` and never reads `state`/`pid`,
+so it structurally cannot tell "currently running" from "dead". `check_flowkit_tunnel.py` — written
+2026-08-21, whose docstring documents this precise trap ("`launchctl list` prints the LAST exit code
+even while the job is CURRENTLY RUNNING") — gets it right and is already armed.
+
+**CORRECTION to my own first reading.** I initially inferred from the sidecar's fresh mtime that
+`check_flowkit_tunnel.py` was armed and running. That was false: the 11:54 write was **this
+dispatch's own manual invocation** — I measured a system my own agent was perturbing. Verified
+after the fact:
+
+- M5 has **no proprioception plist and no proprioception cron** — the sweep is session-triggered only.
+- M5's last sweep is `2026-08-22T01:56:41+0800` (**34h old**) and ran **1 probe out of the whole
+  registry** — `organs_heartbeat` alone. `flowkit` is **ABSENT from `last.json`**.
+
+So the probe is **registered but never armed**: `proprioception.py:1056` declares it, nothing
+schedules it, and it did not run in the last recorded sweep. Between 2026-08-22 01:56 and my manual
+run at 11:54 today, nothing on M5 ever contradicted the detector's false verdict.
+
+## The two defects compose — that is the actual disease
+
+1. `launchd_liveness_detector.py` **emits** the false signal (judges `last_exit`, never reads
+   `state`/`pid`, so it cannot distinguish running from dead).
+2. `check_flowkit_tunnel.py` — the probe written specifically to refute that signal, whose docstring
+   names the trap verbatim — is **registered and unscheduled**, so nothing periodically refutes it.
+
+Either alone is survivable. Together they produce a confident, wrong, unchallenged claim that
+outlived two days and reached a work-packet dispatch as a stated fact. Superscar #2 (Esiste ≠
+Armato) in its purest form: the cure was written on 2026-08-21, and has never run.
+
+## NAMED DECISION: **REPAIR** — of the detector, not of the tunnel
+
+- **Not RETIREMENT**: the tunnel is live, needed (M5 control → Pro render), correctly configured
+  (`KeepAlive` + `ThrottleInterval=10` is the right shape for a persistent `-N -T` forward, and it
+  self-healed twice through real Tailscale flaps).
+- **Not "write a probe"**: it exists, is armed, and is right.
+- **The repair, both halves** (fixing only one leaves the disease):
+  (a) `scripts/launchd_liveness_detector.py` must not return a failure verdict for a job whose
+      `state = running` with a live pid. `last exit code` is not a verdict for a KeepAlive
+      long-runner — it is the previous instance's epitaph. Classify on the CURRENT instance.
+  (b) **Arm `check_flowkit_tunnel.py`** — it exists, is tested, is right, and is scheduled nowhere.
+      A `StartInterval` LaunchAgent on M5 (NOT `KeepAlive` — it is one-shot, superscar #7), or a
+      Mini cron given that Pro's crontab is TCC-blocked over ssh.
+  Proof-of-armed for (b) is NOT "the plist is installed": it is the sidecar
+  `~/.organism/last_seen/m5.flowkit_tunnel.json` showing a `ts` that advances **without anyone
+  running it by hand** — the exact distinction this dispatch just got wrong once.
+
+**This is a successor dispatch, not mine.** `launchd_liveness_detector.py` is outside P03's owned
+scope (`wr3_*`, `docs/wr3/`, `evidence/p03/`). It ships as a PENDING-ARMS line, per the dispatch's
+own instruction that the ledger line — not the `launchctl` call — is this deliverable.
+
+## Ruled out, each with its evidence
+- **HOME-fork (#1)**: `ProgramArguments[0]` = `/usr/bin/ssh`, a system binary. No `~/scripts/` wrapper exists to diverge.
+- **Pro-side listener absent**: Pro PID 1062 `~/flowkit/venv/bin/python -m agent.main`, uptime 2d17h51m — never restarted across the incident window.
+- **KeepAlive-on-one-shot (#7)**: `-N -T` is a persistent forward; `KeepAlive=true` is correct here and is what performed the self-heal.
+- **TCC/keychain (#4/W84)**: `BatchMode=yes` + `IdentitiesOnly yes` + explicit `IdentityFile`; no host-key or auth failure in 844 lines of stderr.
+
+## Evidence caveat I corrected
+The lane's first end-to-end proof was `nc -z` on M5. That probe cannot be red in the right way:
+`ssh -L` binds the local port **even when the remote side is unreachable**, so `nc -z` succeeds
+against a bound-but-dead tunnel — the lane's own log excerpt (`channel 2: open failed: connect
+failed`) is that exact state. Replaced with a real HTTP request through the forward, which is the
+probe that can fail. The verdict survived the stronger probe; the evidence for it did not.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/02-tunnel-diagnosis.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/02-tunnel-diagnosis.md
@@ -1,105 +1,117 @@
+---
+adversarial_review: kimi-k3
+---
+
 # P03 Deliverable 3 — `com.balizero.flowkit-pro-tunnel` (M5 → Pro)
 
 **Method:** read-only. No `launchctl load/unload/bootout/kickstart`, no plist edit, no write on M5
 beyond the repo probe's own heartbeat sidecar. `service_control: none` respected.
 
-## Verdict: the mandate's premise is FALSIFIED — the tunnel is ALIVE
+> This document was rewritten after adversarial review. An earlier draft claimed the tunnel "was
+> not dead then either" and that "the 43h of quiet was 43h of the tunnel working". **Both were
+> wrong**, and the refuter proved it from this document's own numbers. The correction is in the
+> body, not in a footnote — an annotation underneath does not unsay an assertion above it.
 
-The dispatch states the tunnel "is **exit 255 / silent 43h** … currently dead". Measured this
-session, it is not dead and, on the evidence, was not dead then either.
+## Verdict: the tunnel is ALIVE NOW — but it has been dying and self-healing
 
-| Claim | Measurement (2026-08-23 ~11:55 WITA) |
+| Claim under test | Measurement (2026-08-23, this session) |
 |---|---|
-| tunnel dead | **`curl http://127.0.0.1:8100/health` FROM M5 → HTTP 200**, returning byte-identical JSON to what Pro's gateway serves locally (`connects:17,disconnects:17`). A real HTTP reply traversed the tunnel. |
-| exit 255 | `launchctl print` returns **`state = running`, `pid = 18724`, `last exit code = 255` in the same read**. 255 belongs to a PREVIOUS instance. `ps -p 18724` → alive, ELAPSED **09:52:31**. |
-| silent 43h | `~/Library/Logs/flowkit-pro-tunnel.err` last write **Aug 23 02:02:46**, i.e. ~9h52m of silence — and this log is written **only on failure**. For this organ, **silence is the signature of health.** |
+| tunnel currently dead | **FALSE.** `curl http://127.0.0.1:8100/health` **from M5** → HTTP 200, byte-identical JSON to what Pro's gateway serves locally (`connects:17,disconnects:17`). A real HTTP reply traversed the forward. |
+| exit 255 means dead | **Misleading.** `launchctl print` returns `state = running`, `pid = 18724`, `last exit code = 255` **in the same read**. 255 is the *previous* instance's epitaph. `ps -p 18724` → alive, ELAPSED `09:52:31`. |
+| silent 43h means dead | **The silence is real; the inference was wrong in BOTH directions — see below.** |
 
-**Why the false alarm is structural, not a typo.** `ssh -N -T` writes nothing to stdout and nothing
-to stderr while it works. So a healthy tunnel produces an eternally silent error log. The digest
-used *log silence* + *last exit code* as evidence of death — for an organ whose healthy output IS
-silence. The modus doctrine already names this exact failure ("a receptor whose HEALTHY output is
-silence must expose a self-probe that distinguishes healthy-silent from dead"); the digest violated
-it. Silence was read as death, and the 43h of quiet was 43h of the tunnel working.
+## The arithmetic that overturns the first draft
 
-## Root cause, ATTRIBUTED (not inferred) — two organs disagree, right now
+- `~/Library/Logs/flowkit-pro-tunnel.err` last write: **2026-08-23 02:02:46**.
+- `ps` ELAPSED for pid 18724 at 11:55:17: **09:52:31** → the process started at **02:02:46**.
+- `11:55:17 − 9:52:31 = 02:02:46`. **Delta zero, to the second.**
 
-Running M5's own detector read-only, live:
+The current instance was born at the exact second of the last stderr write. Since this log is
+written *only on failure*, that write is **the death of the previous instance**, and the pid's
+birth is KeepAlive restarting it. So:
+
+- The 9h52m of silence **since** 02:02:46 does indicate a healthy tunnel.
+- But the tunnel **demonstrably died and was restarted today**, and its stderr holds **844 failure
+  lines**. Deaths are happening; `KeepAlive` is hiding them by healing them.
+
+**Corrected reading of the digest.** The digest was not simply wrong. It read a *real* signal —
+this job does fail — through a *broken instrument* (last-exit-code plus log silence), and drew a
+wrong conclusion (permanently dead for 43h) from partially true evidence. That is worse than a
+plain false positive, because the underlying phenomenon is genuine and will recur.
+
+## Root cause, ATTRIBUTED — two organs disagree, right now
+
+M5's own detector, run read-only, live:
 
 ```json
 {"label":"com.balizero.flowkit-pro-tunnel","verdict":"FAILING-HONESTLY",
  "last_exit":255,"program":"/usr/bin/ssh","program_exists":true,
  "log_marker":null,"stale_green":false}
 ```
-— `scripts/launchd_liveness_detector.py --json`, on M5, **while the tunnel was serving HTTP 200**.
+— `scripts/launchd_liveness_detector.py --json`, **while the tunnel was serving HTTP 200**.
 
-Its sibling, `scripts/check_flowkit_tunnel.py` (registered in `proprioception.py:1056`, `machines:
-["m5"]`, P2), had written 1 minute earlier:
+`launchd_liveness_detector.py` judges on `last_exit` and never reads `state`/`pid`, so it
+structurally cannot tell "currently running" from "dead".
 
-```json
-{"organ":"m5.flowkit_tunnel","status":"ok","degraded":false,
- "note":"PID 18724 alive, http://127.0.0.1:8100/ answered (HTTP 404)","ts":"2026-08-23T03:54:23Z"}
-```
+Its sibling `scripts/check_flowkit_tunnel.py` — written 2026-08-21, whose docstring names this exact
+trap — gets it right. **But it is registered and NOT armed**, and the first draft of this document
+got that wrong too: I inferred "armed" from a fresh heartbeat sidecar that **this dispatch's own
+manual run had just written**. Measured properly afterwards:
 
-**Two probes, same machine, same job, opposite verdicts in the same minute — and the digest quotes
-the wrong one.** `launchd_liveness_detector.py` judges on `last_exit` and never reads `state`/`pid`,
-so it structurally cannot tell "currently running" from "dead". `check_flowkit_tunnel.py` — written
-2026-08-21, whose docstring documents this precise trap ("`launchctl list` prints the LAST exit code
-even while the job is CURRENTLY RUNNING") — gets it right and is already armed.
+- M5 has **no proprioception plist and no proprioception cron** — sweeps are session-triggered only.
+- M5's last sweep is `2026-08-22T01:56:41+0800` (**34h old**) and ran **1 probe** — `organs_heartbeat`
+  alone. `flowkit` is **ABSENT from `last.json`**.
 
-**CORRECTION to my own first reading.** I initially inferred from the sidecar's fresh mtime that
-`check_flowkit_tunnel.py` was armed and running. That was false: the 11:54 write was **this
-dispatch's own manual invocation** — I measured a system my own agent was perturbing. Verified
-after the fact:
+So between 2026-08-22 01:56 and the manual run at 11:54 today, nothing on M5 ever contradicted the
+detector's verdict.
 
-- M5 has **no proprioception plist and no proprioception cron** — the sweep is session-triggered only.
-- M5's last sweep is `2026-08-22T01:56:41+0800` (**34h old**) and ran **1 probe out of the whole
-  registry** — `organs_heartbeat` alone. `flowkit` is **ABSENT from `last.json`**.
+## NAMED DECISION: **REPAIR** — of the instrumentation, not the tunnel
 
-So the probe is **registered but never armed**: `proprioception.py:1056` declares it, nothing
-schedules it, and it did not run in the last recorded sweep. Between 2026-08-22 01:56 and my manual
-run at 11:54 today, nothing on M5 ever contradicted the detector's false verdict.
+- **Not RETIREMENT**: the tunnel is live, needed (M5 control → Pro render), and correctly shaped
+  (`KeepAlive` + `ThrottleInterval=10` is right for a persistent `-N -T` forward; it is what performed
+  the self-heal).
+- **Not "write a probe"**: the correct probe exists and is right.
+- **The repair, all three parts** — fixing one leaves the disease:
+  1. `launchd_liveness_detector.py` must not return a failure verdict for a job whose `state = running`
+     with a live pid. `last exit code` is the previous instance's epitaph, not a verdict.
+  2. **Arm `check_flowkit_tunnel.py`** — `StartInterval` LaunchAgent on M5 (**not** `KeepAlive`; it is
+     one-shot, superscar #7), or a Mini cron given Pro's crontab is TCC-blocked over ssh.
+  3. **Count the death-restart cycles.** This is the part the first draft would have missed entirely:
+     a tunnel that dies and self-heals every few hours is *not* healthy, and both a point-in-time HTTP
+     probe and an exit-code reader report it as fine. The signal is the stderr write rate and the pid's
+     age resetting — neither is watched today.
 
-## The two defects compose — that is the actual disease
+Proof-of-armed for (2) is **not** "the plist is installed": it is the sidecar
+`~/.organism/last_seen/m5.flowkit_tunnel.json` showing a `ts` that advances **with nobody running it
+by hand** — the exact distinction this dispatch got wrong once.
 
-1. `launchd_liveness_detector.py` **emits** the false signal (judges `last_exit`, never reads
-   `state`/`pid`, so it cannot distinguish running from dead).
-2. `check_flowkit_tunnel.py` — the probe written specifically to refute that signal, whose docstring
-   names the trap verbatim — is **registered and unscheduled**, so nothing periodically refutes it.
-
-Either alone is survivable. Together they produce a confident, wrong, unchallenged claim that
-outlived two days and reached a work-packet dispatch as a stated fact. Superscar #2 (Esiste ≠
-Armato) in its purest form: the cure was written on 2026-08-21, and has never run.
-
-## NAMED DECISION: **REPAIR** — of the detector, not of the tunnel
-
-- **Not RETIREMENT**: the tunnel is live, needed (M5 control → Pro render), correctly configured
-  (`KeepAlive` + `ThrottleInterval=10` is the right shape for a persistent `-N -T` forward, and it
-  self-healed twice through real Tailscale flaps).
-- **Not "write a probe"**: it exists, is armed, and is right.
-- **The repair, both halves** (fixing only one leaves the disease):
-  (a) `scripts/launchd_liveness_detector.py` must not return a failure verdict for a job whose
-      `state = running` with a live pid. `last exit code` is not a verdict for a KeepAlive
-      long-runner — it is the previous instance's epitaph. Classify on the CURRENT instance.
-  (b) **Arm `check_flowkit_tunnel.py`** — it exists, is tested, is right, and is scheduled nowhere.
-      A `StartInterval` LaunchAgent on M5 (NOT `KeepAlive` — it is one-shot, superscar #7), or a
-      Mini cron given that Pro's crontab is TCC-blocked over ssh.
-  Proof-of-armed for (b) is NOT "the plist is installed": it is the sidecar
-  `~/.organism/last_seen/m5.flowkit_tunnel.json` showing a `ts` that advances **without anyone
-  running it by hand** — the exact distinction this dispatch just got wrong once.
-
-**This is a successor dispatch, not mine.** `launchd_liveness_detector.py` is outside P03's owned
-scope (`wr3_*`, `docs/wr3/`, `evidence/p03/`). It ships as a PENDING-ARMS line, per the dispatch's
-own instruction that the ledger line — not the `launchctl` call — is this deliverable.
+**Successor dispatch, not mine.** `launchd_liveness_detector.py` is outside P03's owned scope. Ships
+as a PENDING-ARMS line, per the dispatch's instruction that the ledger line — not the `launchctl`
+call — is this deliverable.
 
 ## Ruled out, each with its evidence
-- **HOME-fork (#1)**: `ProgramArguments[0]` = `/usr/bin/ssh`, a system binary. No `~/scripts/` wrapper exists to diverge.
-- **Pro-side listener absent**: Pro PID 1062 `~/flowkit/venv/bin/python -m agent.main`, uptime 2d17h51m — never restarted across the incident window.
-- **KeepAlive-on-one-shot (#7)**: `-N -T` is a persistent forward; `KeepAlive=true` is correct here and is what performed the self-heal.
-- **TCC/keychain (#4/W84)**: `BatchMode=yes` + `IdentitiesOnly yes` + explicit `IdentityFile`; no host-key or auth failure in 844 lines of stderr.
+- **HOME-fork (#1)**: `ProgramArguments[0]` = `/usr/bin/ssh`, a system binary. No `~/scripts/` wrapper can diverge.
+- **Pro-side listener absent**: Pro PID 1062 `~/flowkit/venv/bin/python -m agent.main`, uptime 2d17h51m — never restarted across the window.
+- **KeepAlive-on-one-shot (#7)**: `-N -T` is a persistent forward; `KeepAlive=true` is correct here.
+- **TCC/keychain (#4/W84)**: `BatchMode=yes` + `IdentitiesOnly yes` + explicit `IdentityFile`; no auth or host-key failure in 844 stderr lines.
 
-## Evidence caveat I corrected
-The lane's first end-to-end proof was `nc -z` on M5. That probe cannot be red in the right way:
-`ssh -L` binds the local port **even when the remote side is unreachable**, so `nc -z` succeeds
-against a bound-but-dead tunnel — the lane's own log excerpt (`channel 2: open failed: connect
-failed`) is that exact state. Replaced with a real HTTP request through the forward, which is the
-probe that can fail. The verdict survived the stronger probe; the evidence for it did not.
+## Adversarial review
+
+Refuted by **Kimi K3** (cross-family, fresh context), which attacked this document's tunnel verdict
+directly. Findings accepted and applied:
+
+1. **"Was not dead then either" / "the 43h of quiet was 43h of the tunnel working" — REFUTED.** The
+   refuter derived from this document's own figures that the pid's birth coincides with the last
+   stderr write. I re-computed it independently: `11:55:17 − 09:52:31 = 02:02:46`, **delta zero**.
+   A log written only on failure, written at the instant the current process was born, records a
+   death. Both sentences were removed and the section above replaces them.
+2. **Self-contradiction — REFUTED.** The draft said both "is already armed" and "registered but never
+   armed". Only the second is true; the first came from a heartbeat sidecar my own manual run had
+   written moments earlier. Rewritten in place.
+3. **"HTTP 200 proves the forward carried it" — PARTIALLY CONCEDED.** The refuter notes no
+   `lsof -i :8100` on M5 was cited to bind the answering socket to pid 18724. The byte-identical
+   payload including the `connects:17/disconnects:17` counters makes the attribution strong but not
+   airtight. Recorded as a residual, not repaired — the successor's armed probe settles it.
+4. **Residual, declared:** the death-restart *rate* over the digest's 43h window remains
+   **UNVERIFIED** — 844 stderr lines are cited without a per-event breakdown. Repair part (3) exists
+   precisely because nothing measures it today.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/03-dryrun-prove-live.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/03-dryrun-prove-live.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: kimi-k3
+---
+
 # P03 Deliverable 4 — zero-spend dry run (PROVE-LIVE)
 
 **Host:** Pro · **Date:** 2026-08-23 ~12:23 WITA · **base:** `5117d9908a37cdc5f23924f6fe19cd823e2ed6c5`
@@ -39,13 +43,16 @@ _generate_video → URLError <urlopen error [Errno 61] Connection refused>
 So the port is genuinely dead **and** the charging path genuinely reaches for it. The zero-spend
 run's success is not an artifact of an unused code path.
 
-**B — the gate fires BEFORE the socket.** Same episode, no decision token:
+**B — an authorization error is raised before any connection is attempted.** Same episode, no token:
 ```
 _generate_video      → SpendNotAuthorizedError: WR3_SPEND_DECISION is unset or empty
 _generate_start_image → SpendNotAuthorizedError: WR3_SPEND_DECISION is unset or empty
 ```
 Note the discriminator: an **authorization** error, not a connection error. If the guard sat after
-the POST we would have seen `URLError` here, as in A.
+the POST we would have seen `URLError` here, as in A. **Stated precisely:** this shows the auth check
+runs and raises first; the ordering relative to the socket syscall is *inferred from the exception
+type*, not instrumented. Proving "no socket opened" outright would need a counting socket mock or
+`dtrace`. Recorded as a residual, not claimed as measured.
 
 **What would make this RED:** credits differ · row count differs by anything but the 3 placeholder
 rows · the two runs print different ledger paths · integrity reads DEGRADED · any byte reaches the
@@ -95,3 +102,25 @@ if not zero_spend_enabled():
 else:
     print("[render] WR3_ZERO_SPEND — health gate skipped, placeholder path", file=sys.stderr)
 ```
+
+
+## Adversarial review
+
+Refuted by **Kimi K3** (cross-family, fresh context). Accepted findings, applied above or recorded:
+
+1. **"The gate fires BEFORE the socket" was stronger than the evidence.** Exception-type
+   discrimination shows an auth error precedes a connection error; it does not instrument the socket.
+   Softened in place.
+2. **`BEFORE = 0` is partly tautological.** The run used a *fresh temp ledger*, so "before" was an
+   empty file by construction, not a measurement of prior state. What the pair genuinely proves is
+   the **delta**: three `placeholder` rows, **zero `real` rows**, zero credits — and `integrity: OK`,
+   so no write was silently lost. That delta is the load-bearing claim, not the absolute `0`.
+3. **The dead-port canary scopes to `WR3_FLOWKIT_ENDPOINT`-honoring paths.** Verified:
+   `wr3_probe_single_clip.py:17` hardcodes the URL, `flowkit_cli.py:26` reads `FLOWKIT_BASE_URL`.
+   Those paths are protected by the **gate**, not by this canary.
+4. **"The live production call shape" overstated it.** The run replicates the driver's
+   `shot_id → shot_index` mapping by hand at library level; **the production CLI driver itself was
+   never executed** (see F11 — it cannot enter zero-spend mode). Say "library-level call shape",
+   never "production path".
+5. **Ground truth is never consulted.** The Google account balance is not queried anywhere in this
+   packet. The provable claim is "this process spent nothing through the instrumented WR3 path".

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/03-dryrun-prove-live.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/03-dryrun-prove-live.md
@@ -1,0 +1,97 @@
+# P03 Deliverable 4 — zero-spend dry run (PROVE-LIVE)
+
+**Host:** Pro · **Date:** 2026-08-23 ~12:23 WITA · **base:** `5117d9908a37cdc5f23924f6fe19cd823e2ed6c5`
+**Episode:** synthetic fixture `simulated: true` (no real episode on disk carries a `shot-pack.json`,
+and generating one would be *storyboard execution*, barred by the frozen must-not).
+
+## The run
+
+Path exercised: `submit_clip` per shot, adapting `shot_id → shot_index` **exactly as
+`wr3_render_episode.py:46` does** (`int(shot["shot_id"].lstrip("s"))`) — i.e. the live production
+call shape, not a convenience fixture. Env: `WR3_ZERO_SPEND=1`,
+`WR3_FLOWKIT_ENDPOINT=http://127.0.0.1:1` (**dead port**), `WR3_CREDIT_LEDGER=<temp>`.
+
+```
+clips: 3
+  shot 1  cost_cr=0  job=placeholder:dryrun-episode:01  01.mp4
+  shot 2  cost_cr=0  job=placeholder:dryrun-episode:02  02.mp4
+  shot 3  cost_cr=0  job=placeholder:dryrun-episode:03  03.mp4
+SUM cost_credits = 0
+```
+
+| Property | Measured |
+|---|---|
+| clips | 3 × h264, **720×1280**, **8.000000 s**, 200 frames |
+| clips distinct | sha256 `e10b59c7…` / `8ce10087…` / `a6a4a6c2…` — all different |
+| ledger rows | 3, all `mode=placeholder`, `credits=0`, `veo_job_id=None`, `source=submit_clip:zero_spend` |
+| **credits BEFORE → AFTER** | **0 → 0** |
+| rows BEFORE → AFTER | 0 → 3 (three placeholder rows — the expected delta) |
+
+## Why this proof is not empty — the two falsification checks
+
+A green run against a dead port proves nothing on its own: the code might simply never have needed
+the network. Both halves were therefore tested.
+
+**A — the socket WOULD have opened.** Same episode, zero-spend OFF, valid decision token:
+```
+_generate_video → URLError <urlopen error [Errno 61] Connection refused>
+```
+So the port is genuinely dead **and** the charging path genuinely reaches for it. The zero-spend
+run's success is not an artifact of an unused code path.
+
+**B — the gate fires BEFORE the socket.** Same episode, no decision token:
+```
+_generate_video      → SpendNotAuthorizedError: WR3_SPEND_DECISION is unset or empty
+_generate_start_image → SpendNotAuthorizedError: WR3_SPEND_DECISION is unset or empty
+```
+Note the discriminator: an **authorization** error, not a connection error. If the guard sat after
+the POST we would have seen `URLError` here, as in A.
+
+**What would make this RED:** credits differ · row count differs by anything but the 3 placeholder
+rows · the two runs print different ledger paths · integrity reads DEGRADED · any byte reaches the
+gateway (caught by A/B above).
+
+## Gate mutation-verified (5/5 bite)
+| Mutation of `wr3_spend_authority.py` | Result |
+|---|---|
+| gate always authorizes | **12 tests red** |
+| `WR3_ZERO_SPEND` no longer wins over a token | **1 red** |
+| log-write failure swallowed (spend unlogged) | **2 red** |
+| `episode_id` match removed (token replay) | **1 red** |
+| date check removed (stale token authorizes) | **2 red** |
+
+## F10 / F11 — two gaps this run exposed, both stated rather than hidden
+
+**F10 — `render_shot_pack` cannot read a real shot-pack.** It reads `shot["index"]` /
+`positive_prompt`; the real schema is `shot_id` / `prompt_positive`. **Pre-existing** — present at
+base SHA `5117d9908:scripts/wr3_flowkit_client.py:656-657` — and **knowingly** so: the 2026-05-30
+design doc declares it out of scope verbatim ("pre-existing, the real renderer is the clip-renderer
+agent dispatcher, not this function. Not introduced or fixed here"). Consequence for this packet:
+any zero-spend test driven through `render_shot_pack` with an `{"index": …}` fixture would be
+**green on a code path production never executes**. Not fixed here (it would change behaviour on a
+real spend path, outside the mandate); the dry run above deliberately routes around it.
+
+**F11 — the production driver does not honour zero-spend.** `scripts/wr3_render_episode.py:33`
+calls `_health()` unconditionally, before any zero-spend consideration. Measured against a dead
+port it dies with `URLError [Errno 61]`. Against the **live** gateway the consequence follows from
+two independently measured facts — (i) that unconditional `_health()` call plus its
+`return 2` on `extension_connected` false, read on disk this session; (ii) the live gateway answering
+`extension_connected: false`, measured by curl this session — therefore **under zero-spend the
+production driver halts with exit 2 and renders nothing**. *(Deduced from those two measurements; I
+did not execute the driver against the live gateway — that command was declined, and I did not
+retry it.)*
+
+So zero-spend is currently reachable at the **library** level (`submit_clip`, `_generate_video`,
+`_generate_start_image`, `render_shot_pack`) but **not** through the CLI driver. `wr3_render_episode.py`
+is **outside this packet's owned file scope**, so it is NOT edited here. The exact successor patch:
+
+```python
+# scripts/wr3_render_episode.py, top of main(), before `h = _health()`
+from wr3_spend_authority import zero_spend_enabled   # noqa: E402
+if not zero_spend_enabled():
+    h = _health()
+    if not h.get("extension_connected"):
+        ...
+else:
+    print("[render] WR3_ZERO_SPEND — health gate skipped, placeholder path", file=sys.stderr)
+```

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/fixture-episode/brief.json
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/fixture-episode/brief.json
@@ -1,0 +1,11 @@
+{
+  "simulated": true,
+  "episode_id": "p03-zerospend-fixture-2026-08-23",
+  "note": "SYNTHETIC FIXTURE — no NotebookLM query produced this, it carries no regulatory claim and must never reach a client-facing surface.",
+  "target_duration_s": 24,
+  "audience_segment": "internal-test",
+  "key_facts": [],
+  "key_numbers": [],
+  "regulatory_citations": [],
+  "claim_ids": []
+}

--- a/research/operations/execution/research-os-v1.0.0/evidence/p03/fixture-episode/shot-pack.json
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p03/fixture-episode/shot-pack.json
@@ -1,0 +1,34 @@
+{
+  "simulated": true,
+  "episode_id": "p03-zerospend-fixture-2026-08-23",
+  "note": "SYNTHETIC FIXTURE for work packet P03 zero-spend dry run. Not an editorial storyboard: prompts are neutral placeholder strings written to exercise the gatekeeper check matrix, not to be rendered. No real Veo job may ever be submitted from this pack.",
+  "total_duration_s": 24,
+  "resolution": "720x1280",
+  "aspect_ratio": "9:16",
+  "shots": [
+    {
+      "shot_id": "s001",
+      "shot_type": "zantara_presenter",
+      "duration_s": 8,
+      "identity_tokens": ["A007"],
+      "prompt_positive": "A calm presenter seated at a plain desk, neutral grey backdrop, soft even light, steady frame, muted palette",
+      "prompt_negative": "text overlay, logo, watermark, distortion"
+    },
+    {
+      "shot_id": "s002",
+      "shot_type": "insert_abstract",
+      "duration_s": 8,
+      "identity_tokens": [],
+      "prompt_positive": "Slow push across an empty meeting room, chairs aligned, morning light through vertical blinds, quiet and still",
+      "prompt_negative": "people, faces, text overlay, watermark"
+    },
+    {
+      "shot_id": "s003",
+      "shot_type": "insert_abstract",
+      "duration_s": 8,
+      "identity_tokens": [],
+      "prompt_positive": "Overhead view of a bare wooden table, a closed folder and a glass of water, neutral tones, static camera",
+      "prompt_negative": "hands, faces, text overlay, watermark"
+    }
+  ]
+}

--- a/scripts/tests/test_wr3_anchor_start_image.py
+++ b/scripts/tests/test_wr3_anchor_start_image.py
@@ -60,8 +60,11 @@ async def _ok_scene(ctx, *, shot_index, positive_prompt, timeout_s=30):
     return f"scene-{shot_index}"
 
 
-async def _ok_video(ctx, *, start_image_media_id, scene_id, prompt, timeout_s=180):
+async def _ok_video(ctx, *, start_image_media_id, scene_id, prompt, timeout_s=180, **_kwargs):
     # echo the start image id back so the test can assert which id Veo received
+    # (**_kwargs swallows shot_index, added 2026-08-23 for the credit-ledger fix —
+    # these fakes replace _generate_video's real spend-recording body entirely,
+    # they don't need to assert on the value)
     return (f"wf-{start_image_media_id}", f"vmedia-{start_image_media_id}")
 
 
@@ -77,7 +80,8 @@ async def test_anchor_uploaded_and_used_as_start_image(tmp_path: Path) -> None:
     gen_img = AsyncMock(return_value="should-not-be-used")
     captured = {}
 
-    async def _capture_video(c, *, start_image_media_id, scene_id, prompt, timeout_s=180):
+    async def _capture_video(c, *, start_image_media_id, scene_id, prompt, timeout_s=180, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         captured["start"] = start_image_media_id
         return ("wf", "vmedia")
 
@@ -115,7 +119,8 @@ async def test_explicit_start_image_wins_over_anchor(tmp_path: Path) -> None:
     upload = AsyncMock(return_value="anchor-media")
     captured = {}
 
-    async def _capture_video(c, *, start_image_media_id, scene_id, prompt, timeout_s=180):
+    async def _capture_video(c, *, start_image_media_id, scene_id, prompt, timeout_s=180, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         captured["start"] = start_image_media_id
         return ("wf", "vmedia")
 
@@ -137,7 +142,8 @@ async def test_no_anchor_falls_back_to_text_prompt(tmp_path: Path) -> None:
     upload = AsyncMock(return_value="should-not-upload")
     captured = {}
 
-    async def _capture_video(c, *, start_image_media_id, scene_id, prompt, timeout_s=180):
+    async def _capture_video(c, *, start_image_media_id, scene_id, prompt, timeout_s=180, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         captured["start"] = start_image_media_id
         return ("wf", "vmedia")
 

--- a/scripts/tests/test_wr3_credit_ledger.py
+++ b/scripts/tests/test_wr3_credit_ledger.py
@@ -1,0 +1,898 @@
+"""Tests for wr3_credit_ledger — the missing spend-truth ledger (2026-08-23).
+
+Hermetic: every test uses a tmp_path-scoped ledger/episode-root. No network,
+no touching ~/.cache/wr3/, no touching apps/war-room/output/episode/.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr3_credit_ledger as ledger  # noqa: E402
+from wr3_credit_ledger import (  # noqa: E402
+    BackfillFinding,
+    dedupe_against_ledger,
+    discover_backfill_records,
+    main,
+    read_integrity,
+    read_records,
+    record_spend,
+    spend_by_episode,
+    total_spend,
+    total_spend_by_kind,
+)
+
+
+# ---------------------------------------------------------------------------
+# append + read round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_record_spend_then_read_records_round_trip(tmp_path):
+    path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ep-1",
+        shot_index=0,
+        credits=20,
+        mode="real",
+        veo_job_id="wf-1",
+        source="submit_clip",
+        clip_cost_cr=20,
+        ledger_path=path,
+    )
+    record_spend(
+        episode_id="ep-1",
+        shot_index=1,
+        credits=20,
+        mode="real",
+        veo_job_id="wf-2",
+        source="submit_clip",
+        clip_cost_cr=20,
+        ledger_path=path,
+    )
+
+    assert path.exists()
+    # mode 0600 on creation
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+    records = read_records(ledger_path=path)
+    assert len(records) == 2
+    assert {r["shot_index"] for r in records} == {0, 1}
+    for rec in records:
+        assert set(rec.keys()) == set(ledger.LEDGER_FIELDS)
+        assert rec["episode_id"] == "ep-1"
+        assert rec["mode"] == "real"
+        assert rec["clip_cost_cr"] == 20
+
+
+def test_record_spend_rejects_unknown_mode_without_writing(tmp_path, caplog):
+    path = tmp_path / "ledger.jsonl"
+    with caplog.at_level(logging.ERROR):
+        record_spend(
+            episode_id="ep-1",
+            shot_index=0,
+            credits=20,
+            mode="bogus",
+            veo_job_id=None,
+            source="test",
+            clip_cost_cr=20,
+            ledger_path=path,
+        )
+    assert not path.exists()
+    assert any("unknown mode" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# --days window filtering, including the exact boundary
+# ---------------------------------------------------------------------------
+
+
+class _FrozenDateTime(datetime):
+    """Subclass that freezes .now() so window-boundary math is deterministic."""
+
+    FIXED_NOW: datetime
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is not None:
+            return cls.FIXED_NOW.astimezone(tz)
+        return cls.FIXED_NOW
+
+
+def test_days_window_filters_older_records_and_keeps_exact_boundary(tmp_path, monkeypatch):
+    fixed_now = datetime(2026, 8, 23, 12, 0, 0, tzinfo=timezone.utc)
+    frozen = type("Frozen", (_FrozenDateTime,), {"FIXED_NOW": fixed_now})
+    monkeypatch.setattr(ledger, "datetime", frozen)
+
+    path = tmp_path / "ledger.jsonl"
+
+    def _write(ts: datetime, shot_index: int) -> None:
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "ts": ts.isoformat(),
+                        "episode_id": "ep-1",
+                        "shot_index": shot_index,
+                        "credits": 20,
+                        "mode": "real",
+                        "veo_job_id": f"wf-{shot_index}",
+                        "source": "test",
+                        "clip_cost_cr": 20,
+                    }
+                )
+                + "\n"
+            )
+
+    _write(fixed_now - timedelta(days=6), shot_index=1)  # clearly inside 7d window
+    _write(fixed_now - timedelta(days=7), shot_index=2)  # EXACT boundary -> kept
+    _write(fixed_now - timedelta(days=7, seconds=1), shot_index=3)  # just outside -> excluded
+    _write(fixed_now - timedelta(days=30), shot_index=4)  # way outside -> excluded
+
+    records = read_records(since_days=7, ledger_path=path)
+    kept = {r["shot_index"] for r in records}
+    assert kept == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# spend_by_episode arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_spend_by_episode_arithmetic_on_mixed_modes():
+    records = [
+        {"episode_id": "ep-A", "credits": 20, "mode": "real", "ts": "2026-06-01T00:00:00+00:00"},
+        {"episode_id": "ep-A", "credits": 20, "mode": "real", "ts": "2026-06-01T00:05:00+00:00"},
+        # A valid placeholder ALWAYS carries credits=0 — enforced at write time
+        # by record_spend (refuter finding #6); this fixture reflects that
+        # invariant rather than a physically-impossible "20cr placeholder".
+        {"episode_id": "ep-A", "credits": 0, "mode": "placeholder", "ts": "2026-06-01T00:10:00+00:00"},
+        {"episode_id": "ep-B", "credits": 20, "mode": "backfill", "ts": "2026-05-29T00:00:00+00:00"},
+        {"episode_id": "ep-B", "credits": 20, "mode": "backfill", "ts": "2026-05-29T00:01:00+00:00"},
+    ]
+
+    by_ep = spend_by_episode(records)
+
+    assert by_ep["ep-A"]["clips"] == 3
+    assert by_ep["ep-A"]["real_clips"] == 2
+    assert by_ep["ep-A"]["placeholder_clips"] == 1
+    assert by_ep["ep-A"]["backfill_clips"] == 0
+    assert by_ep["ep-A"]["credits"] == 40
+    assert by_ep["ep-A"]["first_ts"] == "2026-06-01T00:00:00+00:00"
+    assert by_ep["ep-A"]["last_ts"] == "2026-06-01T00:10:00+00:00"
+
+    assert by_ep["ep-B"]["clips"] == 2
+    assert by_ep["ep-B"]["backfill_clips"] == 2
+    assert by_ep["ep-B"]["real_clips"] == 0
+    assert by_ep["ep-B"]["credits"] == 40
+
+    assert total_spend(records) == 80
+
+
+def test_spend_by_episode_credits_is_floor_flag():
+    all_real = [
+        {"episode_id": "ep-A", "credits": 20, "mode": "real", "ts": "2026-06-01T00:00:00+00:00"},
+    ]
+    mixed = [
+        {"episode_id": "ep-B", "credits": 20, "mode": "real", "ts": "2026-06-01T00:00:00+00:00"},
+        {"episode_id": "ep-B", "credits": 20, "mode": "backfill", "ts": "2026-05-29T00:00:00+00:00"},
+    ]
+    assert spend_by_episode(all_real)["ep-A"]["credits_is_floor"] is False
+    assert spend_by_episode(mixed)["ep-B"]["credits_is_floor"] is True
+
+
+# ---------------------------------------------------------------------------
+# estimate_kind: derived from mode, never a caller-supplied value
+# ---------------------------------------------------------------------------
+
+
+def test_record_spend_estimate_kind_is_none_for_real_and_floor_for_backfill(tmp_path):
+    path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ep-1", shot_index=0, credits=20, mode="real",
+        veo_job_id="wf-1", source="submit_clip", clip_cost_cr=20, ledger_path=path,
+    )
+    record_spend(
+        episode_id="ep-1", shot_index=1, credits=20, mode="backfill",
+        veo_job_id=None, source="backfill:test", clip_cost_cr=20, ledger_path=path,
+    )
+    records = {r["shot_index"]: r for r in read_records(ledger_path=path)}
+    assert records[0]["estimate_kind"] is None
+    assert records[1]["estimate_kind"] == "floor"
+
+
+def test_record_spend_ts_override_is_preserved_not_overwritten_with_now(tmp_path):
+    path = tmp_path / "ledger.jsonl"
+    historical_ts = "2026-06-01T12:00:00+00:00"
+    record_spend(
+        episode_id="ep-1", shot_index=0, credits=20, mode="backfill",
+        veo_job_id=None, source="backfill:test", clip_cost_cr=20,
+        ts=historical_ts, ledger_path=path,
+    )
+    records = read_records(ledger_path=path)
+    assert records[0]["ts"] == historical_ts
+
+
+# ---------------------------------------------------------------------------
+# ledger IO failure must never raise out of record_spend
+# ---------------------------------------------------------------------------
+
+
+def test_record_spend_logs_error_and_does_not_raise_on_unwritable_path(tmp_path, caplog):
+    blocker_file = tmp_path / "blocker"
+    blocker_file.write_text("not a directory")
+    # Parent path tries to mkdir *under a file* -> guaranteed OSError subclass.
+    bad_ledger = blocker_file / "nested" / "ledger.jsonl"
+
+    with caplog.at_level(logging.ERROR):
+        record_spend(
+            episode_id="ep-1",
+            shot_index=0,
+            credits=20,
+            mode="real",
+            veo_job_id="wf-1",
+            source="submit_clip",
+            clip_cost_cr=20,
+            ledger_path=bad_ledger,
+        )  # must not raise
+
+    assert any(
+        "failed to append spend record" in r.message and r.levelno == logging.ERROR
+        for r in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# malformed / truncated JSONL line is skipped, not fatal
+# ---------------------------------------------------------------------------
+
+
+def test_read_records_skips_malformed_lines(tmp_path, caplog):
+    path = tmp_path / "ledger.jsonl"
+    good_1 = {
+        "ts": "2026-06-01T00:00:00+00:00",
+        "episode_id": "ep-1",
+        "shot_index": 0,
+        "credits": 20,
+        "mode": "real",
+        "veo_job_id": "wf-1",
+        "source": "test",
+        "clip_cost_cr": 20,
+    }
+    good_2 = {**good_1, "shot_index": 1, "veo_job_id": "wf-2"}
+    path.write_text(
+        json.dumps(good_1) + "\n"
+        + '{"episode_id": "ep-1", "shot_index": 1, "trunc' + "\n"  # truncated/malformed
+        + json.dumps(good_2) + "\n"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        records = read_records(ledger_path=path)
+
+    assert len(records) == 2
+    assert {r["shot_index"] for r in records} == {0, 1}
+    assert any("malformed JSONL line" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# backfill counting rule
+# ---------------------------------------------------------------------------
+
+
+def _touch(path: Path, content: bytes = b"fake-mp4-bytes") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def test_backfill_same_shot_key_in_canonical_and_sibling_dir_counts_once(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    _touch(ep / "clips_lipsync" / "00.mp4")  # same shot key -> must NOT double count
+
+    findings, skipped, notes = discover_backfill_records(root)
+
+    assert skipped == []
+    assert len(findings) == 1
+    assert findings[0].episode_id == "ep-fixture"
+    assert findings[0].shot_index == 0
+    assert findings[0].mode == "backfill"
+    assert "canonical-clips-dir" in findings[0].source
+
+
+def test_backfill_new_shot_key_in_sibling_dir_is_counted_bak_dir_is_not(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "606.mp4")  # canonical, odd 3-digit id
+    _touch(ep / "clips_lipsync" / "01.mp4")  # new shot key -> counted
+    _touch(ep / "clips_lipsync" / "02.mp4")  # new shot key -> counted
+    # A backup dir duplicating the SAME shot keys already seen in clips_lipsync
+    # must contribute zero additional findings.
+    _touch(ep / "clips_lipsync_bak_20260602T201944" / "01.mp4")
+    _touch(ep / "clips_lipsync_bak_20260602T201944" / "02.mp4")
+    # An unrelated directory (not on the allowlist) must never be walked, even
+    # though it holds an .mp4 file.
+    _touch(ep / "audio" / "not_a_clip.mp4")
+    # The final assembled episode video lives at episode root — never counted.
+    _touch(ep / "master.mp4")
+
+    findings, skipped, notes = discover_backfill_records(root)
+
+    assert skipped == []
+    shot_keys = sorted(f.shot_index for f in findings)
+    assert shot_keys == [1, 2, 606]
+    sources = "\n".join(f.source for f in findings)
+    assert "audio" not in sources
+    assert "master.mp4" not in sources
+    # every finding is an estimate, never presented as measured
+    assert all(f.mode == "backfill" for f in findings)
+
+
+def test_backfill_episode_with_zero_clips_is_reported_skipped(tmp_path):
+    root = tmp_path / "episode"
+    empty_ep = root / "empty-ep"
+    empty_ep.mkdir(parents=True)
+    (empty_ep / "brief.json").write_text("{}")  # non-clip artifact, irrelevant
+
+    findings, skipped, notes = discover_backfill_records(root)
+
+    assert findings == []
+    assert skipped == ["empty-ep"]
+
+
+def test_backfill_records_are_ledger_writable(tmp_path):
+    """BackfillFinding fields map cleanly onto record_spend's kwargs."""
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    findings, _, _ = discover_backfill_records(root)
+    assert len(findings) == 1
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    f: BackfillFinding = findings[0]
+    record_spend(
+        episode_id=f.episode_id,
+        shot_index=f.shot_index,
+        credits=f.credits,
+        mode=f.mode,
+        veo_job_id=f.veo_job_id,
+        source=f.source,
+        clip_cost_cr=f.clip_cost_cr,
+        ts=f.ts,
+        ledger_path=ledger_path,
+    )
+    records = read_records(ledger_path=ledger_path)
+    assert len(records) == 1
+    assert records[0]["mode"] == "backfill"
+    assert records[0]["veo_job_id"] is None
+    assert records[0]["estimate_kind"] == "floor"
+    assert records[0]["ts"] == f.ts
+
+
+# ---------------------------------------------------------------------------
+# backfill FLOOR semantics: ts dating + re-render undercounting
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_finding_ts_is_source_mtime_not_now(tmp_path):
+    import os as _os
+    import time as _time
+
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    mp4 = ep / "clips" / "00.mp4"
+    _touch(mp4)
+    historical = _time.time() - 90 * 86400  # 90 days ago
+    _os.utime(mp4, (historical, historical))
+
+    findings, _, _ = discover_backfill_records(root)
+    assert len(findings) == 1
+    finding_dt = datetime.fromisoformat(findings[0].ts)
+    now = datetime.now(timezone.utc)
+    age_days = (now - finding_dt).total_seconds() / 86400
+    assert 89 <= age_days <= 91  # dated to the mp4's mtime, not "now"
+
+
+def test_backfill_re_render_same_shot_key_in_same_dir_counts_once(tmp_path):
+    """Mirrors the real 01_before_0432.mp4 / 01_replaced_0433.mp4 case: a
+    genuine re-render (real charge) is indistinguishable, on disk, from a
+    harmless duplicate — dedupe-by-shot-key collapses both to ONE finding.
+    This IS the floor property, proven structurally, not just asserted in
+    prose.
+    """
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips_lipsync_incoming_2026-06-03" / "01_before_0432.mp4")
+    _touch(ep / "clips_lipsync_incoming_2026-06-03" / "01_replaced_0433.mp4")
+
+    findings, _, _ = discover_backfill_records(root)
+
+    assert len(findings) == 1  # NOT 2 — this is the undercount the floor covers
+    assert findings[0].shot_index == 1
+    assert findings[0].mode == "backfill"
+
+
+def test_backfill_apply_dates_records_to_artifact_mtime_drops_out_of_short_window(tmp_path):
+    """End-to-end proof of requirement (1): a June-old artifact must NOT
+    appear in `report --days 30` once backfilled, but must appear in a wide
+    window. If this test passes, the headline 30-day report cannot be
+    silently corrupted by backfilled history.
+    """
+    import os as _os
+    import time as _time
+
+    episode_root = tmp_path / "episode"
+    ep = episode_root / "old-episode"
+    mp4 = ep / "clips" / "00.mp4"
+    _touch(mp4)
+    ninety_days_ago = _time.time() - 90 * 86400
+    _os.utime(mp4, (ninety_days_ago, ninety_days_ago))
+
+    findings, _, _ = discover_backfill_records(episode_root)
+    assert len(findings) == 1
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    f = findings[0]
+    record_spend(
+        episode_id=f.episode_id, shot_index=f.shot_index, credits=f.credits,
+        mode=f.mode, veo_job_id=f.veo_job_id, source=f.source,
+        clip_cost_cr=f.clip_cost_cr, ts=f.ts, ledger_path=ledger_path,
+    )
+
+    short_window = read_records(since_days=30, ledger_path=ledger_path)
+    wide_window = read_records(since_days=9999, ledger_path=ledger_path)
+    assert short_window == []  # dropped out — dated to its real (old) mtime
+    assert len(wide_window) == 1
+
+
+# ---------------------------------------------------------------------------
+# report CLI on an empty ledger
+# ---------------------------------------------------------------------------
+
+
+def test_report_cli_exits_zero_on_empty_ledger(tmp_path, capsys):
+    empty_ledger = tmp_path / "does-not-exist.jsonl"
+    rc = main(["report", "--ledger", str(empty_ledger), "--days", "30"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "TOTAL" in out
+
+
+def test_report_cli_json_on_empty_ledger(tmp_path, capsys):
+    empty_ledger = tmp_path / "does-not-exist.jsonl"
+    rc = main(["report", "--ledger", str(empty_ledger), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["total_credits"] == 0
+    assert payload["episodes"] == {}
+
+
+def test_backfill_cli_dry_run_does_not_write_ledger(tmp_path, capsys):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    ledger_path = tmp_path / "ledger.jsonl"
+
+    rc = main(["backfill", "--episode-root", str(root), "--ledger", str(ledger_path)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "DRY RUN" in out
+    assert not ledger_path.exists()
+
+
+def test_backfill_cli_apply_writes_ledger(tmp_path, capsys):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    ledger_path = tmp_path / "ledger.jsonl"
+
+    rc = main(
+        ["backfill", "--episode-root", str(root), "--ledger", str(ledger_path), "--apply"]
+    )
+    assert rc == 0
+    assert ledger_path.exists()
+    records = read_records(ledger_path=ledger_path)
+    assert len(records) == 1
+    assert records[0]["mode"] == "backfill"
+    assert records[0]["estimate_kind"] == "floor"
+
+
+def test_report_cli_marks_backfill_episode_as_floor_with_ge_prefix(tmp_path, capsys):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    ledger_path = tmp_path / "ledger.jsonl"
+    main(["backfill", "--episode-root", str(root), "--ledger", str(ledger_path), "--apply"])
+    capsys.readouterr()  # discard backfill's own stdout
+
+    rc = main(["report", "--ledger", str(ledger_path)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "≥20" in out  # floor-marked credits, not a bare "20"
+    assert "~ep-fixture" in out
+    assert "FLOOR" in out
+    assert "cannot see" in out  # the honesty footnote, not just the marker
+
+
+# ===========================================================================
+# HARDENING PASS 2026-08-23 — refuter (Kimi K3) confirmed 12 defects.
+# One test class per finding, numbered to match the team-lead's list.
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# #1 — backfill --apply must be idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_against_ledger_filters_already_applied_findings(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    _touch(ep / "clips" / "01.mp4")
+    findings, _, _ = discover_backfill_records(root)
+    assert len(findings) == 2
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    new_findings, already_present = dedupe_against_ledger(findings, ledger_path=ledger_path)
+    assert len(new_findings) == 2
+    assert already_present == 0
+
+    for f in new_findings:
+        record_spend(
+            episode_id=f.episode_id, shot_index=f.shot_index, credits=f.credits,
+            mode=f.mode, veo_job_id=f.veo_job_id, source=f.source,
+            clip_cost_cr=f.clip_cost_cr, ts=f.ts, ledger_path=ledger_path,
+        )
+
+    # Re-discover (simulates a second `backfill --apply` run) and dedupe again.
+    findings_again, _, _ = discover_backfill_records(root)
+    new_findings_2, already_present_2 = dedupe_against_ledger(findings_again, ledger_path=ledger_path)
+    assert new_findings_2 == []
+    assert already_present_2 == 2
+    assert len(read_records(ledger_path=ledger_path)) == 2  # NOT doubled
+
+
+def test_backfill_cli_apply_twice_is_idempotent_end_to_end(tmp_path, capsys):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    _touch(ep / "clips_lipsync" / "01.mp4")
+    ledger_path = tmp_path / "ledger.jsonl"
+
+    rc1 = main(["backfill", "--episode-root", str(root), "--ledger", str(ledger_path), "--apply"])
+    out1 = capsys.readouterr().out
+    assert rc1 == 0
+    assert "Applied 2 new record(s), 0 already present" in out1
+    assert len(read_records(ledger_path=ledger_path)) == 2
+
+    rc2 = main(["backfill", "--episode-root", str(root), "--ledger", str(ledger_path), "--apply"])
+    out2 = capsys.readouterr().out
+    assert rc2 == 0
+    assert "Applied 0 new record(s), 2 already present" in out2
+    # THE central proof: re-applying must NOT double the ledger.
+    assert len(read_records(ledger_path=ledger_path)) == 2
+
+
+def test_backfill_cli_dry_run_previews_idempotency(tmp_path, capsys):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    ledger_path = tmp_path / "ledger.jsonl"
+    main(["backfill", "--episode-root", str(root), "--ledger", str(ledger_path), "--apply"])
+    capsys.readouterr()
+
+    rc = main(["backfill", "--episode-root", str(root), "--ledger", str(ledger_path)])  # no --apply
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0 new record(s) would be written, 1 already present" in out
+    assert len(read_records(ledger_path=ledger_path)) == 1  # dry run never writes
+
+
+# ---------------------------------------------------------------------------
+# #2 — report --json must split measured vs estimated-floor, never blend
+# ---------------------------------------------------------------------------
+
+
+def test_total_spend_by_kind_splits_measured_from_floor():
+    records = [
+        {"episode_id": "e", "credits": 20, "mode": "real"},
+        {"episode_id": "e", "credits": 0, "mode": "placeholder"},
+        {"episode_id": "e", "credits": 20, "mode": "backfill"},
+    ]
+    split = total_spend_by_kind(records)
+    assert split == {"measured": 20, "estimated_floor": 20, "total": 40}
+
+
+def test_report_cli_json_splits_measured_and_floor_credits(tmp_path, capsys):
+    ledger_path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ep-real", shot_index=0, credits=20, mode="real",
+        veo_job_id="wf-1", source="test", clip_cost_cr=20, ledger_path=ledger_path,
+    )
+    record_spend(
+        episode_id="ep-old", shot_index=0, credits=20, mode="backfill",
+        veo_job_id=None, source="backfill:test", clip_cost_cr=20,
+        ts="2026-05-01T00:00:00+00:00", ledger_path=ledger_path,
+    )
+
+    rc = main(["report", "--ledger", str(ledger_path), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+
+    assert payload["measured_credits"] == 20
+    assert payload["estimated_floor_credits"] == 20
+    assert payload["total_credits"] == 40  # present, but ALWAYS alongside the split
+    assert payload["episodes"]["ep-old"]["estimate_kind"] == "floor"
+    assert payload["episodes"]["ep-real"]["estimate_kind"] is None
+    assert "ledger" in payload and Path(payload["ledger"]).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# #3 / #5 — validation & write failures must be VISIBLE, never silently lost
+# ---------------------------------------------------------------------------
+
+
+def test_record_spend_does_not_raise_on_none_credits_or_shot_index(tmp_path, caplog):
+    path = tmp_path / "ledger.jsonl"
+    with caplog.at_level(logging.ERROR):
+        record_spend(  # must NOT raise TypeError (refuter finding #5)
+            episode_id="ep-1", shot_index=None, credits=None, mode="real",
+            veo_job_id="wf-1", source="test", clip_cost_cr=None, ledger_path=path,
+        )
+    assert not path.exists()  # rejected, nothing written
+    assert any("not coercible to int" in r.message for r in caplog.records)
+
+
+def test_record_spend_rejection_is_recorded_and_report_shows_degraded_integrity(tmp_path, capsys):
+    ledger_path = tmp_path / "ledger.jsonl"
+    assert read_integrity(ledger_path=ledger_path) == {
+        "status": "ok", "failure_count": 0, "since": None,
+    }
+
+    record_spend(
+        episode_id="ep-1", shot_index=0, credits="not-a-number", mode="real",
+        veo_job_id="wf-1", source="test", clip_cost_cr=20, ledger_path=ledger_path,
+    )
+
+    integrity = read_integrity(ledger_path=ledger_path)
+    assert integrity["status"] == "degraded"
+    assert integrity["failure_count"] == 1
+    assert integrity["since"] is not None
+
+    rc = main(["report", "--ledger", str(ledger_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ledger integrity: DEGRADED" in out
+    assert "CANNOT certify completeness" in out
+
+
+def test_record_spend_write_failure_is_also_recorded_as_integrity_degradation(tmp_path):
+    blocker_file = tmp_path / "blocker"
+    blocker_file.write_text("not a directory")
+    bad_ledger = blocker_file / "nested" / "ledger.jsonl"
+
+    record_spend(
+        episode_id="ep-1", shot_index=0, credits=20, mode="real",
+        veo_job_id="wf-1", source="test", clip_cost_cr=20, ledger_path=bad_ledger,
+    )  # must not raise (pre-existing contract, still true after the rewrite)
+
+    integrity = read_integrity(ledger_path=bad_ledger)
+    # Best-effort: the failures sidecar lives under the SAME broken parent, so
+    # it too fails to write (logged CRITICAL) — this asserts the write-failure
+    # path was at least ATTEMPTED, not that it always succeeds when the
+    # ledger's own directory is unwritable. When the ledger dir IS writable
+    # but e.g. permissions deny the ledger file specifically, the sidecar
+    # (different filename, same dir) succeeds — covered by the report test
+    # above via a coercion failure, which shares a writable tmp_path.
+    assert integrity["status"] in ("ok", "degraded")
+
+
+def test_report_cli_shows_ok_integrity_when_no_failures(tmp_path, capsys):
+    ledger_path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ep-1", shot_index=0, credits=20, mode="real",
+        veo_job_id="wf-1", source="test", clip_cost_cr=20, ledger_path=ledger_path,
+    )
+    rc = main(["report", "--ledger", str(ledger_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ledger integrity: OK" in out
+
+
+# ---------------------------------------------------------------------------
+# #4 — resolved absolute ledger path must be visible in the header
+# ---------------------------------------------------------------------------
+
+
+def test_report_cli_table_header_shows_resolved_absolute_ledger_path(tmp_path, capsys):
+    ledger_path = tmp_path / "sub" / "ledger.jsonl"
+    rc = main(["report", "--ledger", str(ledger_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    lines = out.splitlines()
+    assert lines[0].startswith("# ledger: ")
+    shown_path = lines[0][len("# ledger: "):]
+    assert Path(shown_path).is_absolute()
+    assert Path(shown_path) == ledger_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# #6 — mode="placeholder" MUST carry credits==0 and clip_cost_cr==0
+# ---------------------------------------------------------------------------
+
+
+def test_record_spend_rejects_placeholder_with_nonzero_credits(tmp_path, caplog):
+    path = tmp_path / "ledger.jsonl"
+    with caplog.at_level(logging.ERROR):
+        record_spend(
+            episode_id="ep-1", shot_index=0, credits=20, mode="placeholder",
+            veo_job_id=None, source="submit_clip:zero_spend", clip_cost_cr=0,
+            ledger_path=path,
+        )
+    assert not path.exists()
+    assert any("placeholder" in r.message and "nonzero" in r.message for r in caplog.records)
+
+
+def test_record_spend_accepts_the_exact_wiring_lane_placeholder_shape(tmp_path):
+    """Must not reject the shape the zero-spend wiring lane actually calls:
+    credits=0, clip_cost_cr=0, veo_job_id=None, source="submit_clip:zero_spend".
+    """
+    path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ep-1", shot_index=3, credits=0, mode="placeholder",
+        veo_job_id=None, source="submit_clip:zero_spend", clip_cost_cr=0,
+        ledger_path=path,
+    )
+    records = read_records(ledger_path=path)
+    assert len(records) == 1
+    assert records[0]["mode"] == "placeholder"
+    assert records[0]["credits"] == 0
+    assert records[0]["veo_job_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# #7 — missing/unparseable ts must warn regardless of --days
+# ---------------------------------------------------------------------------
+
+
+def _write_raw_line(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def test_bad_ts_record_warns_when_no_days_window_and_is_included(tmp_path, caplog):
+    path = tmp_path / "ledger.jsonl"
+    _write_raw_line(path, {
+        "episode_id": "ep-1", "shot_index": 0, "credits": 20, "mode": "real",
+        "veo_job_id": "wf-1", "source": "test", "clip_cost_cr": 20,
+        "ts": "not-a-timestamp",
+    })
+    with caplog.at_level(logging.WARNING):
+        records = read_records(ledger_path=path)  # no since_days
+    assert len(records) == 1  # included...
+    assert any("unparseable ts" in r.message for r in caplog.records)  # ...but WARNED
+
+
+def test_bad_ts_record_warns_and_is_excluded_when_days_window_active(tmp_path, caplog):
+    path = tmp_path / "ledger.jsonl"
+    _write_raw_line(path, {
+        "episode_id": "ep-1", "shot_index": 0, "credits": 20, "mode": "real",
+        "veo_job_id": "wf-1", "source": "test", "clip_cost_cr": 20,
+        "ts": None,
+    })
+    with caplog.at_level(logging.WARNING):
+        records = read_records(since_days=30, ledger_path=path)
+    assert records == []  # excluded — cannot verify it's within the window
+    assert any("unparseable ts" in r.message for r in caplog.records)  # but WARNED, not silent
+
+
+# ---------------------------------------------------------------------------
+# #8 — non-numeric credits must warn, not silently vanish
+# ---------------------------------------------------------------------------
+
+
+def test_non_numeric_credits_warns_in_spend_by_episode(caplog):
+    records = [{"episode_id": "ep-1", "credits": "20.5", "mode": "real", "ts": "2026-06-01T00:00:00+00:00"}]
+    with caplog.at_level(logging.WARNING):
+        by_ep = spend_by_episode(records)
+    assert by_ep["ep-1"]["credits"] == 0  # unparseable -> contributes 0...
+    assert by_ep["ep-1"]["clips"] == 1  # ...but the clip event itself still counts
+    assert any("non-numeric credits" in r.message for r in caplog.records)  # ...and it's LOUD
+
+
+def test_non_numeric_credits_warns_in_total_spend(caplog):
+    records = [{"episode_id": "ep-1", "credits": "twenty", "mode": "real"}]
+    with caplog.at_level(logging.WARNING):
+        total = total_spend(records)
+    assert total == 0
+    assert any("non-numeric credits" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# #9 — a 0-byte mp4 (failed download) must not be charged as a full clip
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_skips_zero_byte_mp4(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4", content=b"")  # 0 bytes — failed render
+    _touch(ep / "clips" / "01.mp4")  # normal
+
+    findings, _, notes = discover_backfill_records(root)
+
+    assert [f.shot_index for f in findings] == [1]
+    assert any("0-byte mp4" in n for n in notes)
+
+
+# ---------------------------------------------------------------------------
+# #10 / #11 — recursive + case-insensitive discovery; unrecognized dirs noted
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_finds_nested_mp4_under_clips_recursively(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "subdir" / "03.mp4")  # previously missed (flat glob)
+
+    findings, _, _ = discover_backfill_records(root)
+    assert [f.shot_index for f in findings] == [3]
+
+
+def test_backfill_finds_uppercase_mp4_extension(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.MP4")  # previously invisible to glob("*.mp4")
+
+    findings, _, _ = discover_backfill_records(root)
+    assert [f.shot_index for f in findings] == [0]
+
+
+def test_backfill_reports_unrecognized_directory_with_mp4_files(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "00.mp4")
+    # "clips2" matches NEITHER the canonical name NOR the sibling allowlist —
+    # a genuine second batch that would previously vanish with no trace.
+    _touch(ep / "clips2" / "05.mp4")
+
+    findings, _, notes = discover_backfill_records(root)
+
+    assert [f.shot_index for f in findings] == [0]  # clips2 NOT counted...
+    assert any("clips2" in n and "NOT counted" in n for n in notes)  # ...but NOTED
+
+
+# ---------------------------------------------------------------------------
+# #12 — differently-named files colliding on the same shot key must be noted
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_notes_shot_key_collision_between_differently_named_files(tmp_path):
+    root = tmp_path / "episode"
+    ep = root / "ep-fixture"
+    _touch(ep / "clips" / "01.mp4")
+    _touch(ep / "clips" / "1.mp4")  # same numeric key (1) as "01.mp4"
+
+    findings, _, notes = discover_backfill_records(root)
+
+    assert len(findings) == 1  # still deduped — floor semantics unchanged
+    assert any("shot key 1 seen via both" in n for n in notes)  # ...but VISIBLE
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_wr3_watchdog_timeout.py
+++ b/scripts/tests/test_wr3_watchdog_timeout.py
@@ -82,9 +82,31 @@ async def test_submit_clip_timeout_raises(tmp_path: Path, fake_request, fake_ctx
             )
 
 
+def _authorize_spend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, episode_id: str) -> None:
+    """Give the spend-authority gate a valid token for `episode_id`, dated
+    today, and route its decision log to a tmp_path file — never the real
+    ~/.cache/wr3/spend-decisions.jsonl. Added 2026-08-23: these tests exercise
+    the REAL _generate_start_image/_generate_video (only their inner HTTP call
+    is mocked), and both now call assert_spend_authorized() before doing
+    anything else — without this they raise SpendNotAuthorizedError instead
+    of the FlowkitQuotaError/FlowkitError this test is actually checking."""
+    import datetime as _dt
+
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.setenv(
+        "WR3_SPEND_DECISION",
+        f"{episode_id}:pytest:{_dt.date.today().isoformat()}",
+    )
+    monkeypatch.setenv("WR3_SPEND_DECISION_LOG", str(tmp_path / "spend-decisions.jsonl"))
+
+
 @pytest.mark.asyncio
-async def test_submit_clip_quota_error(tmp_path: Path, fake_request, fake_ctx) -> None:
+async def test_submit_clip_quota_error(
+    tmp_path: Path, fake_request, fake_ctx, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Gateway returning QUOTA_EXCEEDED → FlowkitQuotaError."""
+    _authorize_spend(monkeypatch, tmp_path, fake_ctx.project_name)
+
     async def _quota_image(*_args, **_kwargs):
         # _check_quota inside _generate_start_image fires.
         # Note: dict input — _check_quota inspects only the {"error": ...} envelope.
@@ -104,8 +126,12 @@ async def test_submit_clip_quota_error(tmp_path: Path, fake_request, fake_ctx) -
 
 
 @pytest.mark.asyncio
-async def test_submit_clip_malformed_response(tmp_path: Path, fake_request, fake_ctx) -> None:
+async def test_submit_clip_malformed_response(
+    tmp_path: Path, fake_request, fake_ctx, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """generate-image response missing media → FlowkitError."""
+    _authorize_spend(monkeypatch, tmp_path, fake_ctx.project_name)
+
     async def _ok_scene(ctx, shot_index, positive_prompt, timeout_s=30):
         ctx.scene_ids[shot_index] = "scene-id-xyz"
         return "scene-id-xyz"
@@ -129,10 +155,12 @@ async def test_submit_clip_happy_path(tmp_path: Path, fake_request, fake_ctx) ->
         ctx.scene_ids[shot_index] = "scene-id-xyz"
         return "scene-id-xyz"
 
-    async def _ok_image(ctx, prompt, timeout_s=90):
+    async def _ok_image(ctx, prompt, timeout_s=90, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         return "img-media-aaa"
 
-    async def _ok_video(ctx, start_image_media_id, scene_id, prompt, timeout_s=180):
+    async def _ok_video(ctx, start_image_media_id, scene_id, prompt, timeout_s=180, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         return ("workflow-bbb", "video-media-ccc")
 
     async def _ok_download(ctx, media_id, dest, timeout_s=120):
@@ -161,10 +189,12 @@ async def test_download_timeout_raises(tmp_path: Path, fake_request, fake_ctx) -
         ctx.scene_ids[shot_index] = "scene-id-xyz"
         return "scene-id-xyz"
 
-    async def _ok_image(ctx, prompt, timeout_s=90):
+    async def _ok_image(ctx, prompt, timeout_s=90, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         return "img-media-aaa"
 
-    async def _ok_video(ctx, start_image_media_id, scene_id, prompt, timeout_s=180):
+    async def _ok_video(ctx, start_image_media_id, scene_id, prompt, timeout_s=180, **_kwargs):
+        # **_kwargs swallows shot_index (added 2026-08-23, credit-ledger fix)
         return ("workflow-bbb", "video-media-ccc")
 
     async def _hang_download(ctx, media_id, dest, timeout_s=120):

--- a/scripts/tests/test_wr3_zero_spend.py
+++ b/scripts/tests/test_wr3_zero_spend.py
@@ -1,0 +1,673 @@
+"""Tests for the WR3 zero-spend packet: placeholder clip render + spend gate.
+
+Hermetic and offline by construction:
+  - `wr3_placeholder_clip` never opens a socket — it only shells out to a
+    local `ffmpeg` binary and renders with local PIL. No Flow/Veo job is
+    ever submitted here.
+  - `wr3_spend_authority` is stdlib-only and touches only `tmp_path`-scoped
+    files via `log_path`/`WR3_SPEND_DECISION_LOG` — never the real
+    `~/.cache/wr3/spend-decisions.jsonl` unless a test explicitly opts in.
+
+Run: `python3 -m pytest scripts/tests/test_wr3_zero_spend.py -q`
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wr3_placeholder_clip import (  # noqa: E402
+    PlaceholderRenderError,
+    render_placeholder_clip,
+)
+from wr3_spend_authority import (  # noqa: E402
+    SpendDecision,
+    SpendNotAuthorizedError,
+    assert_spend_authorized,
+    log_decision,
+    parse_decision,
+    zero_spend_enabled,
+)
+
+FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+FFPROBE_AVAILABLE = shutil.which("ffprobe") is not None
+
+requires_ffmpeg = pytest.mark.skipif(
+    not (FFMPEG_AVAILABLE and FFPROBE_AVAILABLE),
+    reason="ffmpeg/ffprobe not on PATH — placeholder-clip tests are hermetic but need the local binary",
+)
+
+
+def _ffprobe_json(path: Path) -> dict:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-print_format",
+            "json",
+            "-show_entries",
+            "stream=codec_name,width,height,duration,pix_fmt:format=duration",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Module 1: wr3_placeholder_clip
+# ---------------------------------------------------------------------------
+
+
+@requires_ffmpeg
+def test_placeholder_render_produces_real_file_with_expected_geometry(tmp_path: Path) -> None:
+    dest = tmp_path / "clip.mp4"
+    out = render_placeholder_clip(episode_id="EP01", shot_index=1, dest=dest)
+
+    assert out == dest
+    assert dest.exists()
+    assert dest.stat().st_size > 0
+
+    probe = _ffprobe_json(dest)
+    video_streams = [s for s in probe["streams"] if s.get("codec_name") is not None]
+    assert len(video_streams) == 1
+    stream = video_streams[0]
+    assert stream["codec_name"] == "h264"
+    assert stream["pix_fmt"] == "yuv420p"
+    assert stream["width"] == 720
+    assert stream["height"] == 1280
+
+    duration = float(probe["format"]["duration"])
+    assert abs(duration - 8.0) <= 0.3
+
+
+@requires_ffmpeg
+def test_placeholder_render_determinism_byte_identical(tmp_path: Path) -> None:
+    """Determinism claim ACTUALLY ACHIEVED on this machine: byte-identical
+    sha256, not merely frame-identical framemd5. Verified via
+    `-fflags +bitexact -flags:v +bitexact`, `-map_metadata -1`, a fixed
+    `-metadata:s:v:0 encoder=` tag, `-threads 1` + `sliced_threads=0`, a
+    fixed frame rate/`-fps_mode cfr`, and a timestamp-free PIL PNG overlay.
+    """
+    import hashlib
+
+    dest_a = tmp_path / "a.mp4"
+    dest_b = tmp_path / "b.mp4"
+
+    render_placeholder_clip(episode_id="EP01", shot_index=3, dest=dest_a)
+    render_placeholder_clip(episode_id="EP01", shot_index=3, dest=dest_b)
+
+    sha_a = hashlib.sha256(dest_a.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(dest_b.read_bytes()).hexdigest()
+    assert sha_a == sha_b, "identical inputs must render byte-identical output"
+
+
+@requires_ffmpeg
+def test_placeholder_render_different_shot_index_differs(tmp_path: Path) -> None:
+    """A placeholder that looked the same for every shot would let the
+    assembler silently mix shots up — the label must actually vary."""
+    import hashlib
+
+    dest_shot3 = tmp_path / "shot3.mp4"
+    dest_shot4 = tmp_path / "shot4.mp4"
+
+    render_placeholder_clip(episode_id="EP01", shot_index=3, dest=dest_shot3)
+    render_placeholder_clip(episode_id="EP01", shot_index=4, dest=dest_shot4)
+
+    sha3 = hashlib.sha256(dest_shot3.read_bytes()).hexdigest()
+    sha4 = hashlib.sha256(dest_shot4.read_bytes()).hexdigest()
+    assert sha3 != sha4
+
+
+@requires_ffmpeg
+def test_placeholder_render_different_episode_id_differs(tmp_path: Path) -> None:
+    import hashlib
+
+    dest_a = tmp_path / "epa.mp4"
+    dest_b = tmp_path / "epb.mp4"
+
+    render_placeholder_clip(episode_id="EP01", shot_index=1, dest=dest_a)
+    render_placeholder_clip(episode_id="EP02", shot_index=1, dest=dest_b)
+
+    sha_a = hashlib.sha256(dest_a.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(dest_b.read_bytes()).hexdigest()
+    assert sha_a != sha_b
+
+
+def test_placeholder_render_missing_ffmpeg_raises_named_error(tmp_path: Path) -> None:
+    dest = tmp_path / "clip.mp4"
+    with pytest.raises(PlaceholderRenderError):
+        render_placeholder_clip(
+            episode_id="EP01",
+            shot_index=1,
+            dest=dest,
+            ffmpeg_bin="/definitely/not/a/real/ffmpeg-binary",
+        )
+    # Never a silent 0-byte artifact.
+    assert not dest.exists()
+
+
+@requires_ffmpeg
+def test_placeholder_render_ffmpeg_failure_leaves_no_partial_file(tmp_path: Path) -> None:
+    dest = tmp_path / "clip.mp4"
+    with pytest.raises(PlaceholderRenderError):
+        render_placeholder_clip(episode_id="EP01", shot_index=1, dest=dest, duration_s=0)
+    assert not dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Module 2: wr3_spend_authority — zero_spend_enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("yes", True),
+        ("YES", True),
+        ("on", True),
+        ("On", True),
+        (" 1 ", True),
+        ("0", False),
+        ("false", False),
+        ("False", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        ("garbage", False),
+        ("2", False),
+    ],
+)
+def test_zero_spend_enabled_truthy_falsy_matrix(monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool) -> None:
+    monkeypatch.setenv("WR3_ZERO_SPEND", raw)
+    assert zero_spend_enabled() is expected
+
+
+def test_zero_spend_enabled_unset_is_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    assert zero_spend_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Module 2: wr3_spend_authority — parse_decision
+# ---------------------------------------------------------------------------
+
+
+def test_parse_decision_happy_path() -> None:
+    decision = parse_decision("EP01:zero@balizero.com:2026-08-23")
+    assert decision == SpendDecision(
+        episode_id="EP01",
+        who="zero@balizero.com",
+        date=date(2026, 8, 23),
+        raw="EP01:zero@balizero.com:2026-08-23",
+    )
+
+
+def test_parse_decision_strips_surrounding_whitespace() -> None:
+    decision = parse_decision("  EP01:zero:2026-08-23  ")
+    assert decision.episode_id == "EP01"
+    assert decision.who == "zero"
+    assert decision.date == date(2026, 8, 23)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "EP01:zero",  # 2 fields
+        "EP01:zero:2026-08-23:extra",  # 4 fields
+        "EP01",  # 1 field
+        "",  # empty
+        "   ",  # blank
+        "EP01:zero:2026-8-1",  # non-strict date format
+        "EP01:zero:2026/08/23",  # wrong separator in date
+        "EP01:zero:20260823",  # no dashes
+        "EP01:zero:2026-13-40",  # invalid calendar date
+        "EP 01:zero:2026-08-23",  # internal whitespace in episode_id
+        "EP01: zero:2026-08-23",  # internal whitespace padding who
+        "EP01:zero :2026-08-23",  # internal whitespace padding who
+        "EP01:ze ro:2026-08-23",  # internal whitespace inside who
+        "EP01:zero:2026- 08-23",  # internal whitespace inside date field
+        ":zero:2026-08-23",  # empty episode_id
+        "EP01::2026-08-23",  # empty who
+        "EP01:zero:",  # empty date
+        "EP#01:zero:2026-08-23",  # invalid char in episode_id
+        "EP01:zero!:2026-08-23",  # invalid char in who
+    ],
+)
+def test_parse_decision_rejects_invalid_tokens(raw: str) -> None:
+    with pytest.raises(ValueError):
+        parse_decision(raw)
+
+
+# ---------------------------------------------------------------------------
+# Module 2: wr3_spend_authority — assert_spend_authorized
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def decision_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Route the decision log to a tmp_path file for every test in this
+    section, so no test ever touches the real ~/.cache/wr3 log."""
+    log_path = tmp_path / "spend-decisions.jsonl"
+    monkeypatch.setenv("WR3_SPEND_DECISION_LOG", str(log_path))
+    return log_path
+
+
+def test_assert_spend_authorized_raises_when_env_unset(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.delenv("WR3_SPEND_DECISION", raising=False)
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+    assert not decision_log.exists()
+
+
+def test_assert_spend_authorized_raises_when_env_empty(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.setenv("WR3_SPEND_DECISION", "")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_two_fields(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.setenv("WR3_SPEND_DECISION", "EP01:zero")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_four_fields(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP01:zero:{today}:extra")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_bad_date_format(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.setenv("WR3_SPEND_DECISION", "EP01:zero:2026-8-1")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_internal_whitespace(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP 01:zero:{today}")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_wrong_episode_id(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP02:zero:{today}")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_yesterdays_date(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP01:zero:{yesterday}")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_on_tomorrows_date(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    tomorrow = (date.today() + timedelta(days=1)).isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP01:zero:{tomorrow}")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+
+
+def test_assert_spend_authorized_raises_even_with_valid_token_when_zero_spend_on(
+    monkeypatch: pytest.MonkeyPatch, decision_log: Path
+) -> None:
+    """Zero-spend always wins over a decision token — this is a required
+    safety behaviour, not an incidental ordering detail."""
+    monkeypatch.setenv("WR3_ZERO_SPEND", "1")
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP01:zero@balizero.com:{today}")
+    with pytest.raises(SpendNotAuthorizedError):
+        assert_spend_authorized(episode_id="EP01")
+    # Zero-spend refusal must not even attempt to log an "authorization"
+    # that never happened.
+    assert not decision_log.exists()
+
+
+def test_assert_spend_authorized_happy_path_returns_decision_and_logs_once(
+    monkeypatch: pytest.MonkeyPatch, decision_log: Path
+) -> None:
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP01:zero@balizero.com:{today}")
+
+    decision = assert_spend_authorized(episode_id="EP01")
+
+    assert decision.episode_id == "EP01"
+    assert decision.who == "zero@balizero.com"
+    assert decision.date == date.today()
+
+    assert decision_log.exists()
+    lines = decision_log.read_text(encoding="utf-8").strip("\n").split("\n")
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["episode_id"] == "EP01"
+    assert record["who"] == "zero@balizero.com"
+    assert record["decision_date"] == today
+    assert record["raw"] == f"EP01:zero@balizero.com:{today}"
+    assert "ts" in record
+
+
+def test_assert_spend_authorized_accepts_explicit_now_override(monkeypatch: pytest.MonkeyPatch, decision_log: Path) -> None:
+    """`now=` lets a caller pin "today" for testing without touching the
+    system clock — the decision token must match that pinned date."""
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    fixed_today = date(2030, 1, 1)
+    monkeypatch.setenv("WR3_SPEND_DECISION", "EP01:zero:2030-01-01")
+
+    decision = assert_spend_authorized(episode_id="EP01", now=fixed_today)
+    assert decision.date == fixed_today
+
+
+def test_log_path_unwritable_raises_and_does_not_return(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail-closed contract: if the decision log can't be written, the
+    call must raise SpendNotAuthorizedError — never return a decision."""
+    readonly_dir = tmp_path / "readonly"
+    readonly_dir.mkdir(mode=0o500)
+    unwritable_log = readonly_dir / "spend-decisions.jsonl"
+
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP01:zero:{today}")
+    monkeypatch.setenv("WR3_SPEND_DECISION_LOG", str(unwritable_log))
+
+    try:
+        with pytest.raises(SpendNotAuthorizedError):
+            assert_spend_authorized(episode_id="EP01")
+    finally:
+        readonly_dir.chmod(0o700)  # allow tmp_path cleanup
+
+    assert not unwritable_log.exists()
+
+
+def test_log_decision_direct_unwritable_path_raises(tmp_path: Path) -> None:
+    readonly_dir = tmp_path / "readonly2"
+    readonly_dir.mkdir(mode=0o500)
+    unwritable_log = readonly_dir / "spend-decisions.jsonl"
+    decision = SpendDecision(episode_id="EP01", who="zero", date=date.today(), raw="EP01:zero:2026-01-01")
+    try:
+        with pytest.raises(SpendNotAuthorizedError):
+            log_decision(decision, episode_id="EP01", log_path=unwritable_log)
+    finally:
+        readonly_dir.chmod(0o700)
+
+
+def test_log_decision_sets_mode_0600(tmp_path: Path) -> None:
+    log_path = tmp_path / "spend-decisions.jsonl"
+    decision = SpendDecision(episode_id="EP01", who="zero", date=date.today(), raw="EP01:zero:2026-01-01")
+    log_decision(decision, episode_id="EP01", log_path=log_path)
+    mode = log_path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Module 3: wr3_flowkit_client — zero-spend wiring (2026-08-23 P03 packet)
+#
+# The gate wiring itself: assert_spend_authorized() at the top of the two
+# functions that actually POST a charging request (_generate_start_image,
+# _generate_video); the zero-spend short-circuit in submit_clip/
+# render_shot_pack; and the fix for the defect where a real Veo charge could
+# be recorded 0x (download failed) or up to 3x (wr3_render_episode.py's
+# per-shot retry) because the ledger write used to fire only after a
+# successful download instead of at the actual charge.
+# ---------------------------------------------------------------------------
+
+
+@requires_ffmpeg
+@pytest.mark.asyncio
+async def test_submit_clip_zero_spend_renders_placeholder_and_opens_no_socket(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Under WR3_ZERO_SPEND, submit_clip must render a real placeholder mp4,
+    report cost_credits=0, and never reach any charging/network call site —
+    proven by making every one of them explode if reached."""
+    monkeypatch.setenv("WR3_ZERO_SPEND", "1")
+
+    import wr3_flowkit_client as fk
+
+    async def _boom(*_a, **_k):
+        raise AssertionError("network path reached")
+
+    with patch.object(fk, "_create_scene", new=_boom), \
+         patch.object(fk, "_generate_start_image", new=_boom), \
+         patch.object(fk, "_generate_video", new=_boom), \
+         patch.object(fk, "_download_video_media", new=_boom), \
+         patch.object(fk, "setup_episode_context", new=_boom):
+        req = fk.ClipRequest(shot_index=5, positive_prompt="a placeholder shot")
+        result = await fk.submit_clip(req, episode_dir=tmp_path)
+
+    assert result.cost_credits == 0
+    expected_path = tmp_path / "clips" / "05.mp4"
+    assert result.mp4_path == expected_path
+    assert expected_path.exists()
+    assert expected_path.stat().st_size > 0
+    assert result.veo_job_id.startswith("placeholder:")
+
+
+@requires_ffmpeg
+@pytest.mark.asyncio
+async def test_render_shot_pack_zero_spend_renders_all_placeholders_no_setup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """render_shot_pack under zero-spend on a 3-shot fixture: 3 placeholder
+    mp4s, all cost_credits==0, setup_episode_context never called (it opens
+    sockets to create the Flow project/video shell)."""
+    monkeypatch.setenv("WR3_ZERO_SPEND", "1")
+
+    import wr3_flowkit_client as fk
+
+    async def _boom(*_a, **_k):
+        raise AssertionError("network path reached")
+
+    shot_pack = {
+        "episode_id": "ep-zero-spend-pack",
+        "shots": [
+            {"index": 1, "positive_prompt": "shot one"},
+            {"index": 2, "positive_prompt": "shot two"},
+            {"index": 3, "positive_prompt": "shot three"},
+        ],
+    }
+    sp_path = tmp_path / "shot-pack.json"
+    sp_path.write_text(json.dumps(shot_pack))
+
+    with patch.object(fk, "_create_scene", new=_boom), \
+         patch.object(fk, "_generate_start_image", new=_boom), \
+         patch.object(fk, "_generate_video", new=_boom), \
+         patch.object(fk, "_download_video_media", new=_boom), \
+         patch.object(fk, "setup_episode_context", new=_boom):
+        results = await fk.render_shot_pack(sp_path, tmp_path)
+
+    assert len(results) == 3
+    for r in results:
+        assert r.cost_credits == 0
+        assert r.mp4_path.exists()
+        assert r.mp4_path.stat().st_size > 0
+    # setup_episode_context creates this on success — its absence is direct
+    # evidence the boomed fake was never actually called (had it been
+    # called, this test would already have failed on the AssertionError).
+    assert not (tmp_path / "_flowkit_context.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_failure_after_generate_video_still_records_real_spend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE regression this packet fixes. The Veo charge happens at
+    _generate_video (the POST that actually costs credits), not at
+    _download_video_media. Before the fix, record_spend lived in submit_clip
+    AFTER a successful download — so a download failure (timeout, transient
+    5xx, ...) left a real charge completely unlogged, and
+    wr3_render_episode.py's up-to-3x per-shot retry could then charge the
+    SAME shot multiple times while logging it zero times. This proves the
+    ledger records the charge exactly once, at the moment it actually
+    happens, independent of what happens to the download afterward.
+
+    This test is written to FAIL against the pre-fix code (0 ledger rows,
+    because the download exception aborts submit_clip before its old
+    post-download record_spend call) and PASS against the fix (1 row,
+    written inside _generate_video itself).
+    """
+    import wr3_flowkit_client as fk
+    from wr3_credit_ledger import read_records
+
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    today = date.today().isoformat()
+    monkeypatch.setenv("WR3_SPEND_DECISION", f"EP-regression:pytest:{today}")
+    monkeypatch.setenv("WR3_SPEND_DECISION_LOG", str(tmp_path / "spend-decisions.jsonl"))
+
+    ledger_path = tmp_path / "credit-ledger.jsonl"
+    monkeypatch.setenv("WR3_CREDIT_LEDGER", str(ledger_path))
+
+    ctx = fk.EpisodeContext(
+        project_id="p", video_id="v", project_name="EP-regression",
+        endpoint="http://127.0.0.1:8100", paygate="PAYGATE_TIER_ONE",
+    )
+    # start_image_media_id preset → _generate_start_image is never called,
+    # isolating this test to the _generate_video charge under test.
+    req = fk.ClipRequest(
+        shot_index=7, positive_prompt="regression shot",
+        start_image_media_id="preset-start-img",
+    )
+
+    async def _ok_scene(ctx, *, shot_index, positive_prompt, timeout_s=30):
+        return f"scene-{shot_index}"
+
+    async def _fake_post_json(url, payload, timeout_s):
+        # Only _generate_video's POST is reached in this test — the scene
+        # create is faked above, and the start image is preset on the
+        # request, so _generate_start_image is never invoked.
+        return {
+            "workflows": [{"name": "wf-real-charge-007"}],
+            "media": [{"name": "vmedia-abc"}],
+        }
+
+    async def _fail_download(ctx, *, media_id, dest, timeout_s=120, poll_interval_s=10):
+        raise fk.FlowkitTimeoutError("simulated download timeout AFTER the Veo charge")
+
+    with patch.object(fk, "_create_scene", new=_ok_scene), \
+         patch.object(fk, "_http_post_json", new=_fake_post_json), \
+         patch.object(fk, "_download_video_media", new=_fail_download):
+        with pytest.raises(fk.FlowkitTimeoutError):
+            await fk.submit_clip(req, episode_dir=tmp_path, episode_context=ctx)
+
+    records = read_records(ledger_path=ledger_path)
+    real_video_rows = [
+        r for r in records
+        if r["mode"] == "real"
+        and r["source"] == "_generate_video"
+        and r["episode_id"] == "EP-regression"
+        and r["shot_index"] == 7
+    ]
+    assert len(real_video_rows) == 1, (
+        f"expected exactly ONE real _generate_video ledger row for shot 7 "
+        f"despite the download failure — got {len(real_video_rows)}. "
+        f"All records: {records}"
+    )
+    assert real_video_rows[0]["veo_job_id"] == "wf-real-charge-007"
+
+
+@pytest.mark.asyncio
+async def test_generate_video_direct_call_blocked_without_decision_no_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """scripts/wr3_probe_single_clip.py calls _generate_video DIRECTLY,
+    bypassing submit_clip entirely — this proves the gate protects that path
+    for free: no valid WR3_SPEND_DECISION → SpendNotAuthorizedError, and the
+    HTTP layer is never touched (assert_spend_authorized runs before any
+    socket opens)."""
+    import wr3_flowkit_client as fk
+
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.delenv("WR3_SPEND_DECISION", raising=False)
+
+    async def _boom_http(*_a, **_k):
+        raise AssertionError("network path reached")
+
+    ctx = fk.EpisodeContext(
+        project_id="p", video_id="v", project_name="EP-direct-video",
+        endpoint="http://127.0.0.1:8100", paygate="PAYGATE_TIER_ONE",
+    )
+    with patch.object(fk, "_http_post_json", new=_boom_http):
+        with pytest.raises(SpendNotAuthorizedError):
+            await fk._generate_video(
+                ctx, start_image_media_id="img", scene_id="scene", prompt="p",
+            )
+
+
+@pytest.mark.asyncio
+async def test_generate_start_image_direct_call_blocked_without_decision_no_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract for _generate_start_image — the other direct call site
+    scripts/wr3_probe_single_clip.py exercises."""
+    import wr3_flowkit_client as fk
+
+    monkeypatch.delenv("WR3_ZERO_SPEND", raising=False)
+    monkeypatch.delenv("WR3_SPEND_DECISION", raising=False)
+
+    async def _boom_http(*_a, **_k):
+        raise AssertionError("network path reached")
+
+    ctx = fk.EpisodeContext(
+        project_id="p", video_id="v", project_name="EP-direct-image",
+        endpoint="http://127.0.0.1:8100", paygate="PAYGATE_TIER_ONE",
+    )
+    with patch.object(fk, "_http_post_json", new=_boom_http):
+        with pytest.raises(SpendNotAuthorizedError):
+            await fk._generate_start_image(ctx, prompt="p")
+
+
+@requires_ffmpeg
+@pytest.mark.asyncio
+async def test_submit_clip_zero_spend_placeholders_differ_by_shot_index(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end through submit_clip (not just render_placeholder_clip
+    directly): two shots of the same zero-spend episode must not produce
+    identical mp4s — the burned-in label must actually vary per shot, or a
+    downstream stage could silently mix shots up."""
+    import hashlib
+
+    monkeypatch.setenv("WR3_ZERO_SPEND", "1")
+
+    import wr3_flowkit_client as fk
+
+    req_a = fk.ClipRequest(shot_index=1, positive_prompt="shot one")
+    req_b = fk.ClipRequest(shot_index=2, positive_prompt="shot two")
+
+    result_a = await fk.submit_clip(req_a, episode_dir=tmp_path)
+    result_b = await fk.submit_clip(req_b, episode_dir=tmp_path)
+
+    sha_a = hashlib.sha256(result_a.mp4_path.read_bytes()).hexdigest()
+    sha_b = hashlib.sha256(result_b.mp4_path.read_bytes()).hexdigest()
+    assert sha_a != sha_b

--- a/scripts/wr3_credit_ledger.py
+++ b/scripts/wr3_credit_ledger.py
@@ -1,0 +1,1223 @@
+#!/usr/bin/env python3
+"""WR3 credit ledger — append-only spend truth for Veo/Flow clip generation.
+
+Problem this fixes (verified on disk, 2026-08-23): `wr3_gatekeeper_check.py`
+reads `~/.cache/wr3/flow-quota.json` to enforce a cost circuit breaker before
+any Veo spend, but nothing in the repo ever WRITES that file — it was
+hand-seeded once (`as_of: 2026-05-29`) and never updated, while real clips
+kept getting rendered. The budget gate was decorative: it divided against a
+static number that never decremented.
+
+This module is the missing machine-readable ledger:
+
+  - `record_spend()` is called from `wr3_flowkit_client.py`'s charging call
+    sites, appending one JSONL record per clip/image charge.
+  - `backfill` (CLI subcommand) reconstructs what it can of the PRE-ledger
+    history from local render artifacts under
+    `apps/war-room/output/episode/*/` — no cloud call, no gateway call, ever.
+    Backfilled numbers are ESTIMATES (`mode="backfill"`), never presented as
+    measurements, and — critically — they are a FLOOR, not a measurement of
+    the true spend: the dedupe-by-shot-key counting rule (see
+    discover_backfill_records docstring) conservatively collapses retries
+    and copies, but a retry/re-render is a REAL Veo charge that looks
+    identical, on disk, to a harmless duplicate copy. E.g.
+    `clips_lipsync_incoming_2026-06-03/` holds both `01_before_0432.mp4` and
+    `01_replaced_0433.mp4` for the same shot — a genuine re-render — which
+    this rule (correctly, conservatively) counts once. Nothing on disk can
+    settle whether a given duplicate shot key was a retry (extra charge) or
+    a mere copy (no extra charge), so every backfilled number is a LOWER
+    BOUND on real spend, never the true figure. `estimate_kind="floor"` is
+    stamped on every backfill-mode record for exactly this reason, and
+    `spend_by_episode()` exposes the aggregate as `credits_is_floor`.
+  - `report` (CLI subcommand) is the "one command" that answers "what did we
+    actually spend": `python3 scripts/wr3_credit_ledger.py report --days 30`.
+
+Dependency-free by design (stdlib only): `wr3_flowkit_client.py` imports this
+module to record real spend, so this module must never import
+`wr3_flowkit_client` back (would be circular) and must not require anything
+outside the standard library to stay trivially importable from the hot path.
+
+KNOWN FINDING (not fixed here, by instruction — see PR description): this
+repo disagrees with itself about the true per-clip Veo cost —
+`wr3_flowkit_client.py:49` says `DEFAULT_CLIP_COST_CR = 20`,
+`wr3_gatekeeper_check.py` (~line 22) says `CR_PER_CLIP = 10`. The ledger
+records the client's actual `clip_cost_cr` on every real-mode record, which
+is what makes that disagreement measurable instead of assumed.
+
+HARDENING PASS 2026-08-23 (cross-family refuter, Kimi K3 — 12 confirmed
+defects against the packet's central "credits before == credits after"
+claim): every fix below closes a specific way the ledger could silently
+lie. See individual functions/docstrings for detail; the summary:
+
+  1. `backfill --apply` is now idempotent — `dedupe_against_ledger()` checks
+     existing (episode_id, shot_index, source) triples before writing, so a
+     re-run reports "N already present, 0 added" instead of doubling.
+  2. `report --json` now splits `measured_credits` / `estimated_floor_credits`
+     / `total_credits`, plus per-episode `estimate_kind`, so an automated
+     before/after check can no longer compare a number that silently blends
+     measurements with estimates.
+  3+5. `record_spend()` never raises (unchanged contract) but a validation
+     rejection or an IO write failure is now recorded to a durable sidecar
+     (`<ledger>.failures`) that `report` surfaces as an INTEGRITY line — a
+     report that cannot certify completeness now says so out loud, instead
+     of a real charge silently becoming invisible.
+  4. `report` prints the RESOLVED ABSOLUTE ledger path in its header (table
+     and json), so a before/after comparison across two different files
+     (e.g. cron vs interactive shell disagreeing on $WR3_CREDIT_LEDGER) is
+     visible on its face instead of silently "passing" by comparing nothing
+     to nothing.
+  6. `mode == "placeholder"` now REQUIRES `credits == 0` and
+     `clip_cost_cr == 0` — enforced at write time, so a real charge can
+     never be laundered through the zero-spend path, and a zero-spend run
+     can never report non-zero credits.
+  7. A record with a missing/unparseable `ts` now WARNS regardless of
+     whether `--days` is given (previously silent when no window was
+     requested), even though it is still included only when there is no
+     cutoff to fail.
+  8. A non-numeric `credits` value now WARNS instead of silently
+     contributing 0 credits while still counting as a clip.
+  9. Zero-byte `.mp4` files (failed/incomplete renders) are skipped from
+     backfill counting instead of being charged as a full clip.
+  10. The canonical `clips/` dir is now walked recursively (was flat,
+      inconsistent with the sibling dirs), and any directory that matches
+      NEITHER `clips/` nor the sibling allowlist but contains `.mp4` files
+      is now reported via `notes`, not silently skipped.
+  11. mp4 discovery is case-insensitive (`.MP4` no longer invisible).
+  12. Two differently-named files colliding on the same leading-digit shot
+      key (e.g. "01.mp4" and "1.mp4") still dedupe to one finding (floor
+      semantics, unchanged) but the collision is now recorded in `notes`
+      instead of being a silent drop.
+
+NOT a defect (explicitly, per the packet owner): dedupe-by-shot-key
+undercounting genuine re-renders is BY DESIGN — that is what makes a
+backfilled number a floor rather than a guess. This pass does not try to
+distinguish "retry" from "copy"; it only makes every other silent miscount
+loud.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_LEDGER_ENV_VAR = "WR3_CREDIT_LEDGER"
+_DEFAULT_LEDGER_SUBPATH = Path(".cache") / "wr3" / "credit-ledger.jsonl"
+
+# Estimated per-clip cost used ONLY for backfilled (historical, no live
+# instrumentation) records — see the KNOWN FINDING in the module docstring.
+# Mirrors wr3_flowkit_client.DEFAULT_CLIP_COST_CR (the constant actually used
+# at the real spend call site); NOT imported from there to keep this module
+# dependency-free / avoid a circular import.
+BACKFILL_ESTIMATED_CLIP_COST_CR = 20
+
+VALID_MODES = ("real", "placeholder", "backfill")
+
+# estimate_kind is derived from mode, never caller-supplied: "floor" for
+# backfill records, None (a real measurement, not an estimate) otherwise.
+ESTIMATE_KIND_FLOOR = "floor"
+
+LEDGER_FIELDS = (
+    "ts",
+    "episode_id",
+    "shot_index",
+    "credits",
+    "mode",
+    "veo_job_id",
+    "source",
+    "clip_cost_cr",
+    "estimate_kind",
+)
+
+
+def _default_ledger_path() -> Path:
+    env = os.environ.get(_LEDGER_ENV_VAR)
+    if env:
+        return Path(env)
+    return Path.home() / _DEFAULT_LEDGER_SUBPATH
+
+
+def _resolve_ledger_path(ledger_path: Path | None) -> Path:
+    return ledger_path if ledger_path is not None else _default_ledger_path()
+
+
+def _resolved_absolute_ledger_path(ledger_path: Path | None) -> Path:
+    """The path to DISPLAY to a human/machine — always absolute, symlinks
+    resolved — so two different `$WR3_CREDIT_LEDGER`/`--ledger` values that
+    LOOK different but resolve to the same file (or vice versa) are visible
+    on their face (refuter finding #4). Internal read/write plumbing keeps
+    using `_resolve_ledger_path` unresolved; this is display-only.
+    """
+    return _resolve_ledger_path(ledger_path).resolve()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_ts(ts: Any) -> datetime | None:
+    if not isinstance(ts, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _coerce_credits(value: Any, *, context: str) -> int:
+    """Coerce a record's `credits` field to int, WARNING (never raising, never
+    silently swallowing — refuter finding #8) when it can't be. A corrupt
+    credits value contributes 0 to arithmetic, but the corruption is now
+    logged instead of disappearing.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "wr3_credit_ledger: record has non-numeric credits=%r (%s) — "
+            "contributing 0 to totals, but this record is CORRUPT, not zero-cost; "
+            "inspect the ledger",
+            value,
+            context,
+        )
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Integrity sidecar — a failed write must become visible, never invisible
+# ---------------------------------------------------------------------------
+
+
+def _failures_path(ledger_path: Path) -> Path:
+    return ledger_path.parent / f"{ledger_path.name}.failures"
+
+
+def _record_failure(*, ledger_path: Path, kind: str, detail: dict[str, Any]) -> None:
+    """Best-effort durable marker for a spend event that could NOT be
+    recorded in the main ledger (validation rejection or IO write failure).
+
+    This is what makes refuter finding #3 fixable without ever raising out
+    of record_spend(): the render still doesn't crash, but the failure is no
+    longer purely a log line — `report`'s INTEGRITY check reads this file.
+    Never raises further; if even THIS write fails, logs CRITICAL (the
+    absolute last resort) rather than propagate.
+    """
+    fail_path = _failures_path(ledger_path)
+    record = {"ts": _now_iso(), "kind": kind, **detail}
+    try:
+        fail_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, sort_keys=True) + "\n"
+        fd = os.open(str(fail_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+    except Exception:  # noqa: BLE001 — absolute last resort, must not raise
+        logger.critical(
+            "wr3_credit_ledger: COULD NOT RECORD THE FAILURE MARKER EITHER (%s) — "
+            "this failure is now invisible even to the integrity check. "
+            "Original failure: %s",
+            fail_path,
+            detail,
+            exc_info=True,
+        )
+
+
+def read_integrity(ledger_path: Path | None = None) -> dict[str, Any]:
+    """Summarize the failures sidecar for `report`'s INTEGRITY line.
+
+    Returns {"status": "ok"|"degraded", "failure_count": int, "since": str|None}.
+    "degraded" means: at least one spend event since `since` could NOT be
+    durably recorded — a report reading this MUST say it cannot certify
+    completeness, not silently present a clean-looking total.
+    """
+    path = _resolve_ledger_path(ledger_path)
+    fail_path = _failures_path(path)
+    if not fail_path.exists():
+        return {"status": "ok", "failure_count": 0, "since": None}
+
+    count = 0
+    since: str | None = None
+    with fail_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            count += 1
+            ts = rec.get("ts")
+            if isinstance(ts, str) and (since is None or ts < since):
+                since = ts
+
+    if count == 0:
+        return {"status": "ok", "failure_count": 0, "since": None}
+    return {"status": "degraded", "failure_count": count, "since": since}
+
+
+# ---------------------------------------------------------------------------
+# Core append/read API
+# ---------------------------------------------------------------------------
+
+
+def _write_line(record: dict[str, Any], ledger_path: Path) -> None:
+    """Append one JSON line to ledger_path; fsync; mode 0600 on creation.
+
+    Raises on failure — record_spend() is the layer that swallows errors so
+    a ledger problem never crashes a render; this helper stays honest.
+    """
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new = not ledger_path.exists()
+    line = json.dumps(record, sort_keys=True) + "\n"
+    fd = os.open(str(ledger_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    with os.fdopen(fd, "a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.flush()
+        os.fsync(fh.fileno())
+    if is_new:
+        try:
+            os.chmod(ledger_path, 0o600)
+        except OSError:
+            logger.warning(
+                "wr3_credit_ledger: could not chmod 0600 on new ledger %s", ledger_path
+            )
+
+
+class _ValidationError(Exception):
+    """Internal only — NEVER escapes record_spend(). Carries the reason a
+    spend event was rejected, so it can be logged and durably marked instead
+    of silently dropped or (worse) raised into a live render.
+    """
+
+
+def _validate_and_build_record(
+    *,
+    episode_id: str,
+    shot_index: Any,
+    credits: Any,
+    mode: str,
+    veo_job_id: str | None,
+    source: str,
+    clip_cost_cr: Any,
+    ts: str | None,
+) -> dict[str, Any]:
+    """All coercion/validation in ONE place, ALWAYS inside a guarded caller
+    (record_spend) — refuter finding #5: the previous version built the
+    record dict (with bare `int(...)` calls) OUTSIDE the try/except, so
+    `credits=None` raised TypeError straight into the caller, crashing a
+    live render. Every int() call now happens here, where the caller can
+    catch _ValidationError and route to the failure marker instead.
+    """
+    if mode not in VALID_MODES:
+        raise _ValidationError(f"unknown mode={mode!r} — valid modes: {VALID_MODES}")
+
+    try:
+        shot_index_i = int(shot_index)
+    except (TypeError, ValueError) as e:
+        raise _ValidationError(f"shot_index={shot_index!r} not coercible to int: {e}") from e
+    try:
+        credits_i = int(credits)
+    except (TypeError, ValueError) as e:
+        raise _ValidationError(f"credits={credits!r} not coercible to int: {e}") from e
+    try:
+        clip_cost_cr_i = int(clip_cost_cr)
+    except (TypeError, ValueError) as e:
+        raise _ValidationError(f"clip_cost_cr={clip_cost_cr!r} not coercible to int: {e}") from e
+
+    if mode == "placeholder" and (credits_i != 0 or clip_cost_cr_i != 0):
+        # Refuter finding #6: nothing previously stopped a real charge from
+        # being laundered through the zero-spend path, or a zero-spend run
+        # from reporting non-zero credits. A placeholder render MUST carry
+        # zero cost basis, full stop.
+        raise _ValidationError(
+            f"mode='placeholder' requires credits==0 and clip_cost_cr==0 "
+            f"(got credits={credits_i}, clip_cost_cr={clip_cost_cr_i}) — a "
+            f"placeholder render must never carry a nonzero charge"
+        )
+
+    return {
+        "ts": ts if ts is not None else _now_iso(),
+        "episode_id": episode_id,
+        "shot_index": shot_index_i,
+        "credits": credits_i,
+        "mode": mode,
+        "veo_job_id": veo_job_id,
+        "source": source,
+        "estimate_kind": ESTIMATE_KIND_FLOOR if mode == "backfill" else None,
+        "clip_cost_cr": clip_cost_cr_i,
+    }
+
+
+def record_spend(
+    *,
+    episode_id: str,
+    shot_index: int,
+    credits: int,
+    mode: str,
+    veo_job_id: str | None,
+    source: str,
+    clip_cost_cr: int,
+    ts: str | None = None,
+    ledger_path: Path | None = None,
+) -> None:
+    """Append one clip-submission spend record.
+
+    NEVER raises into the caller's render path — a ledger failure must not
+    crash a render. Both a validation rejection (bad mode, non-coercible
+    field, placeholder-with-nonzero-cost) and an IO write failure are caught,
+    logged at ERROR, and durably marked via `_record_failure` so `report`'s
+    INTEGRITY check can surface them — a rejected/lost record is now VISIBLE
+    downstream instead of silently vanishing (refuter findings #3, #5, #6).
+
+    `ts` defaults to now (the real, live spend path always wants "when this
+    actually happened", which IS now). Pass an explicit ISO8601 `ts` only for
+    reconstruction — the backfill CLI passes the source mp4's mtime so a
+    historical clip is dated to when it was actually rendered, not to when
+    it was backfilled.
+
+    `estimate_kind` is NOT a caller-supplied parameter — it is derived from
+    `mode` ("floor" for backfill, None otherwise) so it can never be
+    forgotten or set inconsistently at a call site.
+    """
+    path = _resolve_ledger_path(ledger_path)
+
+    try:
+        record = _validate_and_build_record(
+            episode_id=episode_id,
+            shot_index=shot_index,
+            credits=credits,
+            mode=mode,
+            veo_job_id=veo_job_id,
+            source=source,
+            clip_cost_cr=clip_cost_cr,
+            ts=ts,
+        )
+    except _ValidationError as e:
+        logger.error(
+            "wr3_credit_ledger: refusing to record spend — %s "
+            "(episode_id=%s shot_index=%r)",
+            e,
+            episode_id,
+            shot_index,
+        )
+        _record_failure(
+            ledger_path=path,
+            kind="rejected",
+            detail={
+                "episode_id": str(episode_id),
+                "shot_index_raw": repr(shot_index),
+                "mode": str(mode),
+                "reason": str(e),
+            },
+        )
+        return
+
+    try:
+        _write_line(record, path)
+    except Exception:  # noqa: BLE001 — a ledger write must never crash the render
+        logger.error(
+            "wr3_credit_ledger: failed to append spend record "
+            "episode_id=%s shot_index=%s ledger=%s",
+            episode_id,
+            shot_index,
+            path,
+            exc_info=True,
+        )
+        _record_failure(
+            ledger_path=path,
+            kind="write_failure",
+            detail={
+                "episode_id": str(episode_id),
+                "shot_index": record["shot_index"],
+                "mode": mode,
+            },
+        )
+
+
+def read_records(
+    *,
+    since_days: int | None = None,
+    ledger_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Read all well-formed records, optionally windowed to the last N days.
+
+    Malformed/truncated JSONL lines are skipped (logged at WARNING), never
+    fatal — a half-written line from a crash must not kill the report.
+
+    A record with a missing/unparseable `ts` now WARNS regardless of whether
+    a window is requested (refuter finding #7 — previously this only warned,
+    and only excluded, when `since_days` was given; with no window it was
+    silently included with zero indication anything was wrong, so the SAME
+    ledger produced two different totals depending on `--days` with no
+    signal). It is still excluded only when a cutoff is active (cannot prove
+    it's within an unknown-age window) — included, but WARNED, otherwise.
+    """
+    path = _resolve_ledger_path(ledger_path)
+    if not path.exists():
+        return []
+
+    cutoff: datetime | None = None
+    if since_days is not None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, raw_line in enumerate(fh, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "wr3_credit_ledger: skipping malformed JSONL line %d in %s",
+                    line_no,
+                    path,
+                )
+                continue
+            if not isinstance(rec, dict):
+                logger.warning(
+                    "wr3_credit_ledger: skipping non-object JSONL line %d in %s",
+                    line_no,
+                    path,
+                )
+                continue
+
+            rec_dt = _parse_ts(rec.get("ts"))
+            if rec_dt is None:
+                logger.warning(
+                    "wr3_credit_ledger: record at line %d in %s has a missing/"
+                    "unparseable ts=%r — %s",
+                    line_no,
+                    path,
+                    rec.get("ts"),
+                    "EXCLUDED (cannot verify it's within the --days window)"
+                    if cutoff is not None
+                    else "included as-is (no --days window active)",
+                )
+                if cutoff is not None:
+                    continue
+                records.append(rec)
+                continue
+
+            if cutoff is not None and rec_dt < cutoff:
+                continue
+            records.append(rec)
+    return records
+
+
+def spend_by_episode(records: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Per-episode spend rollup.
+
+    Returns {episode_id: {"credits", "clips", "real_clips",
+    "placeholder_clips", "backfill_clips", "credits_is_floor",
+    "estimate_kind", "first_ts", "last_ts"}}.
+
+    `credits_is_floor` is True whenever this episode's `credits` total
+    includes ANY backfill-mode record — i.e. the number is a LOWER BOUND on
+    real spend, not a measurement (retries/re-renders that dedupe-by-shot-key
+    cannot distinguish from harmless copies are undercounted; see module
+    docstring). `estimate_kind` mirrors the ledger record's own field
+    ("floor" or None) so a JSON consumer reading only this rollup sees the
+    same vocabulary as one reading raw records. A machine reader must not
+    treat `credits` as exact when either flag says otherwise.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        eid = str(rec.get("episode_id", "unknown"))
+        entry = out.setdefault(
+            eid,
+            {
+                "credits": 0,
+                "clips": 0,
+                "real_clips": 0,
+                "placeholder_clips": 0,
+                "backfill_clips": 0,
+                "credits_is_floor": False,
+                "first_ts": None,
+                "last_ts": None,
+            },
+        )
+        entry["credits"] += _coerce_credits(
+            rec.get("credits", 0), context=f"episode_id={eid}"
+        )
+        entry["clips"] += 1
+        mode = rec.get("mode")
+        if mode == "real":
+            entry["real_clips"] += 1
+        elif mode == "placeholder":
+            entry["placeholder_clips"] += 1
+        elif mode == "backfill":
+            entry["backfill_clips"] += 1
+            entry["credits_is_floor"] = True
+        ts = rec.get("ts")
+        if isinstance(ts, str):
+            if entry["first_ts"] is None or ts < entry["first_ts"]:
+                entry["first_ts"] = ts
+            if entry["last_ts"] is None or ts > entry["last_ts"]:
+                entry["last_ts"] = ts
+
+    for entry in out.values():
+        entry["estimate_kind"] = ESTIMATE_KIND_FLOOR if entry["credits_is_floor"] else None
+    return out
+
+
+def total_spend(records: Iterable[dict[str, Any]]) -> int:
+    total = 0
+    for rec in records:
+        total += _coerce_credits(rec.get("credits", 0), context="total_spend")
+    return total
+
+
+def total_spend_by_kind(records: Iterable[dict[str, Any]]) -> dict[str, int]:
+    """Split spend into `measured` (mode real/placeholder — an actual
+    instrumented event, even when its credits are 0) vs `estimated_floor`
+    (mode=backfill — a reconstruction, never a measurement). Refuter finding
+    #2: a bare `total_credits` blends the two with no marker, so an
+    automated before/after check cannot tell a June estimate from a today
+    measurement. Callers (report --json) must present both, not just the sum.
+    """
+    measured = 0
+    estimated_floor = 0
+    for rec in records:
+        c = _coerce_credits(rec.get("credits", 0), context="total_spend_by_kind")
+        if rec.get("mode") == "backfill":
+            estimated_floor += c
+        else:
+            measured += c
+    return {
+        "measured": measured,
+        "estimated_floor": estimated_floor,
+        "total": measured + estimated_floor,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Backfill — reconstruct historical spend from local render artifacts ONLY.
+# No cloud call, no gateway call, no network of any kind.
+# ---------------------------------------------------------------------------
+
+DEFAULT_EPISODE_ROOT = (
+    Path(__file__).resolve().parents[1] / "apps" / "war-room" / "output" / "episode"
+)
+
+_CANONICAL_CLIP_DIRNAME = "clips"
+
+# Sibling-directory allowlist (regex over the directory's basename). Anything
+# NOT matching one of these is out of scope for backfill counting — we do
+# NOT walk audio/, variants/, _rebuild_scripts/, or any unrecognized dir
+# SILENTLY: if such a directory holds .mp4 files, discover_backfill_records
+# now says so via `notes` (refuter finding #10) instead of just not walking
+# it. Allowlist, not blocklist: safer to under-count-and-report than to
+# hoover up unrelated mp4s as if they were Veo spends.
+_SIBLING_CLIP_DIR_RE = re.compile(
+    r"^("
+    r"clips_lipsync.*"  # clips_lipsync, clips_lipsync_bak_*, clips_lipsync_incoming_*
+    r"|clips_old_identity_fail.*"
+    r"|clips_original_backup.*"
+    r"|_probe_clips.*"
+    r"|.*_backup_.*"
+    r")$"
+)
+
+_LEADING_INT_RE = re.compile(r"^\d+")
+
+
+def _find_mp4_files(directory: Path, *, recursive: bool) -> list[Path]:
+    """Case-insensitive `.mp4` discovery (refuter finding #11 — a bare
+    `glob("*.mp4")` is case-SENSITIVE even on a case-insensitive filesystem,
+    because Path.glob's pattern matcher is POSIX normcase, not a filesystem
+    lookup). `recursive=True` for BOTH the canonical dir and sibling dirs
+    (refuter finding #10 — canonical was previously flat while siblings were
+    recursive, so a file under `clips/subdir/03.mp4` was silently missed).
+    """
+    it = directory.rglob("*") if recursive else directory.glob("*")
+    return sorted(p for p in it if p.is_file() and p.suffix.lower() == ".mp4")
+
+
+def _shot_key(stem: str) -> tuple[int | None, str]:
+    """Derive a dedup key from an mp4 filename stem.
+
+    Returns (numeric_key, raw_key). numeric_key is the leading run of digits
+    interpreted as int (e.g. "01_before_0432" -> 1, "606" -> 606, "00" -> 0),
+    or None if the stem does not start with a digit — those never dedup
+    against a numeric canonical entry (conservative: better to over-count an
+    oddly named file than to silently merge it into an unrelated shot).
+
+    NOTE two structurally different filenames CAN collide on this key (e.g.
+    "01.mp4" and "1.mp4" both -> 1) — refuter finding #12. This is left
+    unresolved BY DESIGN (dedupe-by-shot-key still applies, consistent with
+    floor semantics) but the caller (`_consider_mp4_for_backfill`) now
+    records the collision in `notes` instead of a silent drop.
+    """
+    m = _LEADING_INT_RE.match(stem)
+    if not m:
+        return None, stem
+    return int(m.group(0)), stem
+
+
+@dataclass(frozen=True)
+class BackfillFinding:
+    """One reconstructed historical clip.
+
+    `ts` is the source mp4's filesystem mtime (ISO8601 UTC) — the artifact's
+    actual render date, NOT the time `backfill --apply` was run. This is
+    what record_spend() writes as the ledger record's `ts` when applied, so
+    a June render stays dated to June, not to whenever it was backfilled.
+
+    `mp4_path` is informational only — it is NOT part of the ledger schema
+    and is never passed to record_spend.
+    """
+
+    episode_id: str
+    shot_index: int
+    credits: int
+    mode: str
+    veo_job_id: str | None
+    source: str
+    clip_cost_cr: int
+    ts: str
+    mp4_path: str
+
+
+def _mtime_iso(mp4: Path) -> str:
+    return datetime.fromtimestamp(mp4.stat().st_mtime, tz=timezone.utc).isoformat()
+
+
+def _make_finding(*, episode_id: str, shot_key: int | str, mp4: Path, source: str) -> BackfillFinding:
+    shot_index = shot_key if isinstance(shot_key, int) else -1
+    return BackfillFinding(
+        episode_id=episode_id,
+        shot_index=shot_index,
+        credits=BACKFILL_ESTIMATED_CLIP_COST_CR,
+        mode="backfill",
+        veo_job_id=None,
+        source=source,
+        clip_cost_cr=BACKFILL_ESTIMATED_CLIP_COST_CR,
+        ts=_mtime_iso(mp4),
+        mp4_path=str(mp4),
+    )
+
+
+def _consider_mp4_for_backfill(
+    mp4: Path,
+    *,
+    episode_id: str,
+    episode_dir: Path,
+    source_label: str,
+    seen_numeric: dict[int, Path],
+    seen_raw: set[str],
+    notes: list[str],
+) -> BackfillFinding | None:
+    """Shared per-file logic for both the canonical dir and sibling dirs.
+
+    Returns a new BackfillFinding, or None if the file was skipped — a
+    0-byte file (refuter #9) or a dedup-collision against an already-seen
+    shot key. Both kinds of skip are appended to `notes`: nothing here is a
+    SILENT drop, even when the counting decision itself (skip/dedupe) is
+    unchanged from before.
+    """
+    if mp4.stat().st_size == 0:
+        notes.append(
+            f"{episode_id}: {mp4.relative_to(episode_dir)} is a 0-byte mp4 "
+            f"(failed/incomplete render) — SKIPPED, not counted"
+        )
+        logger.warning("wr3_credit_ledger: skipping 0-byte mp4 %s", mp4)
+        return None
+
+    key, raw = _shot_key(mp4.stem)
+    if key is not None:
+        if key in seen_numeric:
+            prior = seen_numeric[key]
+            if prior.name != mp4.name:
+                notes.append(
+                    f"{episode_id}: shot key {key} seen via both "
+                    f"{prior.relative_to(episode_dir)} (counted) and "
+                    f"{mp4.relative_to(episode_dir)} (skipped as dup — same leading "
+                    f"digits, different filename) — floor semantics unchanged, but "
+                    f"verify these are really the same shot"
+                )
+            return None
+        seen_numeric[key] = mp4
+    else:
+        if raw in seen_raw:
+            return None
+        seen_raw.add(raw)
+
+    rel = mp4.relative_to(episode_dir)
+    return _make_finding(
+        episode_id=episode_id,
+        shot_key=key if key is not None else raw,
+        mp4=mp4,
+        source=f"backfill:{source_label}:{rel}",
+    )
+
+
+def discover_backfill_records(
+    episode_root: Path,
+) -> tuple[list[BackfillFinding], list[str], list[str]]:
+    """Walk episode_root/*/ and reconstruct one finding per DISTINCT real clip.
+
+    Counting rule (stated once here; every finding's `source` names it too):
+
+      1. `<episode>/clips/**/*.mp4` is the canonical output dir — every file
+         there is counted (recursively, case-insensitively — see
+         `_find_mp4_files`), keyed by its filename stem's leading digits.
+      2. Sibling directories matching `_SIBLING_CLIP_DIR_RE` (clips_lipsync*,
+         clips_old_identity_fail*, clips_original_backup*, _probe_clips*,
+         *_backup_*) are walked recursively too, in SORTED order for
+         determinism. A file there counts as a NEW clip only if its shot key
+         has not already been seen — from `clips/` or an earlier-scanned
+         sibling in this same pass. This is what stops `clips_lipsync_bak_*`
+         / `clips_lipsync_incoming_*` / `clips_original_backup_*` (retries or
+         copies, by their own naming) from being double-counted against
+         `clips_lipsync/` or `clips/`.
+      3. Any OTHER directory (`audio/`, `variants/`, `_rebuild_scripts/`,
+         ...) is never walked for counting — but if it contains `.mp4`
+         files, that is now reported in `notes`, not silently ignored.
+      4. The episode-root-level `master.mp4` (final assembly) is never
+         counted — rule 3 already excludes it, since it lives outside every
+         clips-shaped directory (and IS itself an "unrecognized" file at
+         episode-root, though `notes` only checks directories, not loose
+         root-level files, since master.mp4's nature — one file, always
+         named the same, always the final assembly — is already understood
+         and documented, unlike an unrecognized DIRECTORY of unknown origin).
+      5. A 0-byte `.mp4` (failed/incomplete render) is skipped, not counted
+         as a full charge — noted, not silently dropped.
+      6. Two differently-named files colliding on the same leading-digit
+         shot key still dedupe to one finding (floor semantics unchanged)
+         but the collision is recorded in `notes`.
+
+    Returns (findings, skipped_episode_ids, notes):
+      - `skipped_episode_ids` lists episode dirs where zero clips were
+        discoverable under this rule.
+      - `notes` collects the two previously-silent anomaly classes above
+        (unrecognized directory with mp4s; shot-key collision) so nothing
+        that affects count accuracy is invisible.
+
+    FLOOR, not a measurement: rule 2's dedupe-by-shot-key is deliberately
+    conservative, and that conservatism cuts only one way — it can only
+    UNDERcount, never overcount. A genuine re-render (a real Veo charge)
+    looks, on disk, identical to a harmless duplicate copy — e.g.
+    `clips_lipsync_incoming_2026-06-03/` holds both `01_before_0432.mp4` and
+    `01_replaced_0433.mp4`, i.e. shot 01 was re-rendered at least once, a
+    real charge this rule counts as zero additional clips. Nothing in the
+    filesystem can distinguish "re-rendered" from "copied" after the fact,
+    so every BackfillFinding is tagged mode="backfill" /
+    estimate_kind="floor" and callers must present it as a lower bound. This
+    is NOT something this hardening pass tries to fix — it is the packet's
+    intentional, load-bearing floor semantics.
+    """
+    findings: list[BackfillFinding] = []
+    skipped: list[str] = []
+    notes: list[str] = []
+
+    if not episode_root.exists():
+        logger.warning(
+            "wr3_credit_ledger: episode root does not exist: %s", episode_root
+        )
+        return findings, [f"<episode root does not exist: {episode_root}>"], notes
+
+    for episode_dir in sorted(p for p in episode_root.iterdir() if p.is_dir()):
+        episode_id = episode_dir.name
+        seen_numeric: dict[int, Path] = {}
+        seen_raw: set[str] = set()
+        episode_findings: list[BackfillFinding] = []
+
+        canonical_dir = episode_dir / _CANONICAL_CLIP_DIRNAME
+        if canonical_dir.is_dir():
+            for mp4 in _find_mp4_files(canonical_dir, recursive=True):
+                finding = _consider_mp4_for_backfill(
+                    mp4,
+                    episode_id=episode_id,
+                    episode_dir=episode_dir,
+                    source_label="canonical-clips-dir",
+                    seen_numeric=seen_numeric,
+                    seen_raw=seen_raw,
+                    notes=notes,
+                )
+                if finding is not None:
+                    episode_findings.append(finding)
+
+        sibling_dirs: list[Path] = []
+        unrecognized_dirs: list[Path] = []
+        for p in sorted(q for q in episode_dir.iterdir() if q.is_dir()):
+            if p.name == _CANONICAL_CLIP_DIRNAME:
+                continue
+            if _SIBLING_CLIP_DIR_RE.match(p.name):
+                sibling_dirs.append(p)
+            else:
+                unrecognized_dirs.append(p)
+
+        for sib in sibling_dirs:
+            for mp4 in _find_mp4_files(sib, recursive=True):
+                finding = _consider_mp4_for_backfill(
+                    mp4,
+                    episode_id=episode_id,
+                    episode_dir=episode_dir,
+                    source_label="sibling-dir-new-shot",
+                    seen_numeric=seen_numeric,
+                    seen_raw=seen_raw,
+                    notes=notes,
+                )
+                if finding is not None:
+                    episode_findings.append(finding)
+
+        for other in unrecognized_dirs:
+            mp4s = _find_mp4_files(other, recursive=True)
+            if mp4s:
+                notes.append(
+                    f"{episode_id}: {len(mp4s)} mp4 file(s) in unrecognized "
+                    f"directory {other.relative_to(episode_dir)} — NOT counted "
+                    f"(matches neither clips/ nor the sibling allowlist; add a "
+                    f"pattern or investigate)"
+                )
+
+        if not episode_findings:
+            skipped.append(episode_id)
+            continue
+        findings.extend(episode_findings)
+
+    return findings, skipped, notes
+
+
+def dedupe_against_ledger(
+    findings: list[BackfillFinding],
+    *,
+    ledger_path: Path | None = None,
+) -> tuple[list[BackfillFinding], int]:
+    """Filter out findings already present in the ledger as a mode="backfill"
+    record with the same (episode_id, shot_index, source) — refuter finding
+    #1: `backfill --apply` had no memory of what it already wrote, so a
+    second run silently doubled the historical total. A baseline that can
+    silently double is worse than no baseline.
+
+    Returns (new_findings, already_present_count). Calling `--apply` twice
+    now reports "N already present, 0 added" on the second run.
+    """
+    existing = read_records(ledger_path=ledger_path)
+    existing_keys = {
+        (rec.get("episode_id"), rec.get("shot_index"), rec.get("source"))
+        for rec in existing
+        if rec.get("mode") == "backfill"
+    }
+    new_findings: list[BackfillFinding] = []
+    already_present = 0
+    for f in findings:
+        key = (f.episode_id, f.shot_index, f.source)
+        if key in existing_keys:
+            already_present += 1
+            continue
+        new_findings.append(f)
+        existing_keys.add(key)  # guard duplicate keys within this same findings list
+    return new_findings, already_present
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wr3_credit_ledger.py",
+        description="WR3 Veo/Flow credit ledger — spend truth CLI.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common_ledger = argparse.ArgumentParser(add_help=False)
+    common_ledger.add_argument(
+        "--ledger",
+        type=str,
+        default=None,
+        help=(
+            "Path to the ledger JSONL file (default: $WR3_CREDIT_LEDGER or "
+            "~/.cache/wr3/credit-ledger.jsonl)"
+        ),
+    )
+
+    p_report = sub.add_parser(
+        "report", parents=[common_ledger], help="Print spend-by-episode table."
+    )
+    p_report.add_argument(
+        "--days", type=int, default=None, help="Only include records from the last N days."
+    )
+    p_report.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON instead of a table."
+    )
+
+    p_backfill = sub.add_parser(
+        "backfill",
+        parents=[common_ledger],
+        help="Reconstruct historical spend from local render artifacts (no network).",
+    )
+    p_backfill.add_argument(
+        "--episode-root",
+        type=str,
+        default=None,
+        help=f"Override episode root directory (default: {DEFAULT_EPISODE_ROOT})",
+    )
+    p_backfill.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the reconstructed records to the ledger. Default is dry-run (print only).",
+    )
+    p_backfill.add_argument(
+        "--json", action="store_true", help="Also emit the full findings as machine-readable JSON."
+    )
+
+    return parser
+
+
+def _fmt_row(vals: list[Any], widths: list[int]) -> str:
+    return "  ".join(str(v).ljust(w) for v, w in zip(vals, widths))
+
+
+def _integrity_line(integrity: dict[str, Any]) -> str:
+    if integrity["status"] == "ok":
+        return "ledger integrity: OK"
+    return (
+        f"ledger integrity: DEGRADED — {integrity['failure_count']} write "
+        f"failure(s) since {integrity['since']}; this report CANNOT certify "
+        f"completeness"
+    )
+
+
+def _cmd_report(args: argparse.Namespace) -> int:
+    ledger_path = Path(args.ledger) if args.ledger else None
+    records = read_records(since_days=args.days, ledger_path=ledger_path)
+    by_ep = spend_by_episode(records)
+    split = total_spend_by_kind(records)
+    integrity = read_integrity(ledger_path)
+    resolved_path = _resolved_absolute_ledger_path(ledger_path)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ledger": str(resolved_path),
+                    "days": args.days,
+                    "episodes": by_ep,
+                    "measured_credits": split["measured"],
+                    "estimated_floor_credits": split["estimated_floor"],
+                    "total_credits": split["total"],
+                    "total_clips": len(records),
+                    "integrity": integrity,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    # Header FIRST — refuter finding #4: a resolved, absolute ledger path
+    # must be visible up front, or a before/after comparison across two
+    # different files is invisible on its face.
+    print(f"# ledger: {resolved_path}")
+    print(
+        f"# window: last {args.days} day(s)"
+        if args.days is not None
+        else "# window: ALL records (no --days given)"
+    )
+    print()
+
+    cols = ["episode_id", "clips", "real", "placeholder", "backfill", "credits", "first_ts", "last_ts"]
+    widths = [40, 6, 6, 11, 8, 8, 26, 26]
+    print(_fmt_row(cols, widths))
+    print("-" * (sum(widths) + 2 * (len(widths) - 1)))
+
+    any_backfill = False
+    for eid in sorted(by_ep):
+        e = by_ep[eid]
+        is_floor = e["credits_is_floor"]
+        marker = "~" if is_floor else ""
+        if is_floor:
+            any_backfill = True
+        credits_display = f"≥{e['credits']}" if is_floor else str(e["credits"])
+        print(
+            _fmt_row(
+                [
+                    f"{marker}{eid}",
+                    e["clips"],
+                    e["real_clips"],
+                    e["placeholder_clips"],
+                    e["backfill_clips"],
+                    credits_display,
+                    e["first_ts"] or "-",
+                    e["last_ts"] or "-",
+                ],
+                widths,
+            )
+        )
+
+    print("-" * (sum(widths) + 2 * (len(widths) - 1)))
+    print(
+        _fmt_row(
+            [
+                "TOTAL",
+                len(records),
+                sum(e["real_clips"] for e in by_ep.values()),
+                sum(e["placeholder_clips"] for e in by_ep.values()),
+                sum(e["backfill_clips"] for e in by_ep.values()),
+                split["total"],
+                "",
+                "",
+            ],
+            widths,
+        )
+    )
+    print(
+        f"  measured: {split['measured']} cr  |  estimated floor: "
+        f"{split['estimated_floor']} cr"
+    )
+
+    print(f"\n{_integrity_line(integrity)}")
+    if any_backfill:
+        print(
+            "\n~ = episode's credits shown as ≥N cr (estimated FLOOR, not a "
+            "measurement): retries/re-renders are real charges that "
+            "dedupe-by-shot-key cannot see, so the artifacts on disk cannot "
+            "settle the true figure — the real spend may be higher."
+        )
+    return 0
+
+
+def _cmd_backfill(args: argparse.Namespace) -> int:
+    episode_root = Path(args.episode_root) if args.episode_root else DEFAULT_EPISODE_ROOT
+    findings, skipped, notes = discover_backfill_records(episode_root)
+    ledger_path = Path(args.ledger) if args.ledger else None
+    resolved_path = _resolved_absolute_ledger_path(ledger_path)
+
+    print(f"# wr3_credit_ledger backfill — episode_root={episode_root}")
+    print(f"# ledger: {resolved_path}")
+    print("# Counting rule: clips/**/*.mp4 is canonical (recursive, case-insensitive);")
+    print("#   sibling dirs matching clips_lipsync*, clips_old_identity_fail*,")
+    print("#   clips_original_backup*, _probe_clips*, *_backup_* are walked ONLY for")
+    print("#   shot keys absent from clips/ (or an earlier-scanned sibling) — retries/")
+    print("#   copies are never double-counted. Assumed clip_cost_cr = "
+          f"{BACKFILL_ESTIMATED_CLIP_COST_CR} (mirrors wr3_flowkit_client."
+          "DEFAULT_CLIP_COST_CR; wr3_gatekeeper_check.py's CR_PER_CLIP=10 "
+          "disagrees — unresolved, see module docstring).")
+    print("# Every row below is an ESTIMATED FLOOR (mode=backfill), never a")
+    print("#   measurement: a re-render is a real charge that dedupe-by-shot-key")
+    print("#   cannot tell apart from a harmless duplicate copy (e.g. shot 01 has")
+    print("#   BOTH 01_before_0432.mp4 and 01_replaced_0433.mp4 on disk — a real")
+    print("#   re-render, counted once here). `ts` is the source mp4's mtime (the")
+    print("#   artifact's actual render date), not the time this command was run.")
+    print("# --apply is IDEMPOTENT: a finding already present in the ledger")
+    print("#   (same episode_id/shot_index/source) is never re-written.")
+    print()
+
+    by_episode: dict[str, list[BackfillFinding]] = {}
+    for f in findings:
+        by_episode.setdefault(f.episode_id, []).append(f)
+
+    total_credits = 0
+    for eid in sorted(by_episode):
+        rows = by_episode[eid]
+        credits = sum(r.credits for r in rows)
+        total_credits += credits
+        print(f"{eid}: {len(rows)} clip(s), ≥{credits} cr (estimated FLOOR)")
+        for r in rows:
+            shot_label = r.shot_index if r.shot_index >= 0 else "n/a"
+            print(f"    shot_key={shot_label}  ts={r.ts}  {r.source}")
+
+    if skipped:
+        print()
+        print(f"No clips discoverable in: {', '.join(skipped)}")
+
+    if notes:
+        print()
+        print("NOTES (anomalies — verify these, they affect count accuracy):")
+        for n in notes:
+            print(f"  - {n}")
+
+    print()
+    print(
+        f"TOTAL: {len(findings)} clip(s) across {len(by_episode)} episode(s), "
+        f"≥{total_credits} cr (estimated FLOOR — retries/re-renders are real "
+        f"charges that dedupe by shot key cannot see; the artifacts cannot "
+        f"settle the true figure)"
+    )
+
+    if args.json:
+        print()
+        print(
+            json.dumps(
+                {
+                    "ledger": str(resolved_path),
+                    "episode_root": str(episode_root),
+                    "findings": [f.__dict__ for f in findings],
+                    "skipped_episodes_no_clips_found": skipped,
+                    "notes": notes,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+
+    # Idempotency check runs regardless of --apply, so a DRY RUN preview
+    # already tells you what --apply would actually do (refuter finding #1).
+    new_findings, already_present = dedupe_against_ledger(findings, ledger_path=ledger_path)
+
+    if not args.apply:
+        print()
+        print(
+            f"DRY RUN — {len(new_findings)} new record(s) would be written, "
+            f"{already_present} already present in the ledger (idempotent). "
+            f"Re-run with --apply to write them."
+        )
+        return 0
+
+    for f in new_findings:
+        record_spend(
+            episode_id=f.episode_id,
+            shot_index=f.shot_index,
+            credits=f.credits,
+            mode=f.mode,
+            veo_job_id=f.veo_job_id,
+            source=f.source,
+            clip_cost_cr=f.clip_cost_cr,
+            ts=f.ts,
+            ledger_path=ledger_path,
+        )
+
+    print()
+    print(
+        f"Applied {len(new_findings)} new record(s), {already_present} already "
+        f"present (skipped, idempotent) to {resolved_path}"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.command == "report":
+        return _cmd_report(args)
+    if args.command == "backfill":
+        return _cmd_backfill(args)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    sys.exit(main())

--- a/scripts/wr3_flowkit_client.py
+++ b/scripts/wr3_flowkit_client.py
@@ -42,11 +42,23 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
 
+from wr3_credit_ledger import record_spend
+from wr3_placeholder_clip import render_placeholder_clip
+from wr3_spend_authority import assert_spend_authorized, zero_spend_enabled
+
 DEFAULT_ENDPOINT = os.environ.get("WR3_FLOWKIT_ENDPOINT", "http://127.0.0.1:8100")
 DEFAULT_PAYGATE = os.environ.get("WR3_FLOWKIT_PAYGATE", "PAYGATE_TIER_ONE")
 PER_CLIP_TIMEOUT_S = int(os.environ.get("WR3_FLOWKIT_TIMEOUT_S", "300"))
 # Tier 1 fast portrait: 20 credits/clip (empirical 2026-05-20).
 DEFAULT_CLIP_COST_CR = int(os.environ.get("WR3_FLOWKIT_CLIP_COST", "20"))
+# UNMEASURED PLACEHOLDER — deliberately 0, deliberately an under-count, NOT a
+# measurement. We do not yet know how many Flow credits
+# /api/flow/generate-image actually consumes per call. Every real-mode ledger
+# row for the image charge (source="_generate_start_image") is tagged with
+# this constant so the gap stays visible in `wr3_credit_ledger.py report`
+# instead of being silently absorbed into DEFAULT_CLIP_COST_CR. Override via
+# WR3_FLOWKIT_IMAGE_COST_CR once the real per-call cost is measured.
+DEFAULT_IMAGE_COST_CR = int(os.environ.get("WR3_FLOWKIT_IMAGE_COST_CR", "0"))
 
 # Backwards-compat alias — older callers passed plan="pro".
 DEFAULT_PLAN = DEFAULT_PAYGATE
@@ -322,8 +334,24 @@ async def _generate_start_image(
     *,
     prompt: str,
     timeout_s: int = 90,
+    shot_index: int | None = None,
 ) -> str:
-    """POST /api/flow/generate-image — returns media_id (synchronous response)."""
+    """POST /api/flow/generate-image — returns media_id (synchronous response).
+
+    Charging call site (Veo credit-consuming, exact per-call cost unmeasured
+    — see DEFAULT_IMAGE_COST_CR). `assert_spend_authorized` is the FIRST
+    thing this function does — before any socket is opened — so a caller
+    that reaches this function without a valid spend decision (including
+    `scripts/wr3_probe_single_clip.py`, which calls this directly and
+    bypasses `submit_clip`) fails closed with no HTTP attempted.
+
+    `shot_index` is optional because some direct callers (the probe script)
+    don't know it; when absent the ledger row records shot_index=-1 (the
+    same "unknown shot" sentinel `wr3_credit_ledger.py`'s backfill CLI
+    uses) rather than skip logging a real charge.
+    """
+    assert_spend_authorized(episode_id=ctx.project_name)
+
     url = urljoin(ctx.endpoint + "/", "api/flow/generate-image")
     body = {
         "prompt": prompt,
@@ -344,7 +372,18 @@ async def _generate_start_image(
     media = resp.get("media") or []
     if not media or not media[0].get("name"):
         raise FlowkitError(f"generate-image returned no media: {str(resp)[:200]}")
-    return media[0]["name"]
+    media_id = media[0]["name"]
+
+    record_spend(
+        episode_id=ctx.project_name,
+        shot_index=shot_index if shot_index is not None else -1,
+        credits=DEFAULT_IMAGE_COST_CR,
+        mode="real",
+        veo_job_id=media_id,
+        source="_generate_start_image",
+        clip_cost_cr=DEFAULT_IMAGE_COST_CR,
+    )
+    return media_id
 
 
 async def _upload_image_asset(
@@ -388,12 +427,32 @@ async def _generate_video(
     scene_id: str,
     prompt: str,
     timeout_s: int = 180,
+    shot_index: int | None = None,
 ) -> tuple[str, str]:
     """POST /api/flow/generate-video — returns (workflow_id, video_media_id).
 
     Veo 3.1 Fast Tier_ONE portrait is synchronous → media is ready
     immediately upon HTTP 200. No polling required for this tier.
+
+    THE charging call site (2026-08-23 fix): the Veo credit spend happens
+    HERE, on this POST — not when the mp4 is later downloaded. The ledger
+    write below fires immediately once workflow_id/video_media_id are
+    parsed, so a subsequent `_download_video_media` failure (timeout,
+    transient 500, whatever) can never leave a real charge unlogged. Before
+    this fix `record_spend` lived in `submit_clip` AFTER the download
+    succeeded — `wr3_render_episode.py` retries a failed shot up to 3x, so
+    one shot could be charged 3x and logged 0x. `assert_spend_authorized` is
+    the FIRST thing this function does, before any socket opens, so this
+    also fails closed for `scripts/wr3_probe_single_clip.py`, which calls
+    this function directly and bypasses `submit_clip` entirely.
+
+    `shot_index` is optional (some direct callers don't know it); when
+    absent the ledger row uses shot_index=-1, the same "unknown shot"
+    sentinel `wr3_credit_ledger.py`'s backfill CLI uses, rather than skip
+    logging a real charge.
     """
+    assert_spend_authorized(episode_id=ctx.project_name)
+
     url = urljoin(ctx.endpoint + "/", "api/flow/generate-video")
     body = {
         "start_image_media_id": start_image_media_id,
@@ -421,6 +480,19 @@ async def _generate_video(
     video_media_id = media[0].get("name") or ""
     if not video_media_id:
         raise FlowkitError(f"generate-video no media_id: {str(resp)[:200]}")
+
+    # Spend-truth ledger insert — fires here, at the actual charge, not at
+    # download (see docstring). This is the one call site that actually
+    # causes a Veo video charge.
+    record_spend(
+        episode_id=ctx.project_name,
+        shot_index=shot_index if shot_index is not None else -1,
+        credits=DEFAULT_CLIP_COST_CR,
+        mode="real",
+        veo_job_id=workflow_id,
+        source="_generate_video",
+        clip_cost_cr=DEFAULT_CLIP_COST_CR,
+    )
     return workflow_id, video_media_id
 
 
@@ -532,6 +604,39 @@ async def submit_clip(
     project — but in production wr3-clip-renderer creates the context once
     upstream and threads it through.
     """
+    if zero_spend_enabled():
+        # Zero-spend short-circuit — checked FIRST, before episode_context is
+        # touched in any way, so this path NEVER calls _create_scene,
+        # _generate_start_image, _generate_video, _download_video_media, or
+        # setup_episode_context. episode_context may legitimately be None
+        # here (render_shot_pack skips creating one under zero-spend) and
+        # that must stay harmless — nothing below reads it.
+        started = asyncio.get_event_loop().time()
+        mp4_path = episode_dir / "clips" / f"{request.shot_index:02d}.mp4"
+        await asyncio.to_thread(
+            render_placeholder_clip,
+            episode_id=episode_dir.name,
+            shot_index=request.shot_index,
+            dest=mp4_path,
+        )
+        duration_ms = int((asyncio.get_event_loop().time() - started) * 1000)
+        record_spend(
+            episode_id=episode_dir.name,
+            shot_index=request.shot_index,
+            credits=0,
+            mode="placeholder",
+            veo_job_id=None,
+            source="submit_clip:zero_spend",
+            clip_cost_cr=0,
+        )
+        return ClipResult(
+            shot_index=request.shot_index,
+            mp4_path=mp4_path,
+            duration_ms=duration_ms,
+            cost_credits=0,
+            veo_job_id=f"placeholder:{episode_dir.name}:{request.shot_index:02d}",
+        )
+
     if plan is not None and paygate == DEFAULT_PAYGATE:
         # legacy plan="pro" → Tier 1
         paygate = DEFAULT_PAYGATE
@@ -576,15 +681,22 @@ async def submit_clip(
         img_prompt = request.image_prompt or request.positive_prompt
         start_image_id = await _generate_start_image(
             episode_context, prompt=img_prompt, timeout_s=90,
+            shot_index=request.shot_index,
         )
 
-    # 2c. Video generation (synchronous on portrait fast Tier 1)
+    # 2c. Video generation (synchronous on portrait fast Tier 1).
+    # The Veo charge — and its ledger record — happen INSIDE _generate_video,
+    # not here and not after the download below. See that function's
+    # docstring for why: charging on download success let a shot be billed
+    # up to 3x (wr3_render_episode.py retries) and logged 0x whenever the
+    # download step itself failed.
     workflow_id, video_media_id = await _generate_video(
         episode_context,
         start_image_media_id=start_image_id,
         scene_id=scene_id,
         prompt=request.positive_prompt,
         timeout_s=min(timeout_s - 30, 180),
+        shot_index=request.shot_index,
     )
 
     # 2d-e. Download base64 → MP4
@@ -597,6 +709,7 @@ async def submit_clip(
     )
 
     duration_ms = int((asyncio.get_event_loop().time() - started) * 1000)
+
     return ClipResult(
         shot_index=request.shot_index,
         mp4_path=mp4_path,
@@ -624,12 +737,19 @@ async def render_shot_pack(
 
     Creates a per-episode FlowKit project+video if episode_context is None
     (derives name from shot-pack JSON or path stem).
+
+    Under WR3_ZERO_SPEND, setup_episode_context is skipped entirely (it
+    opens sockets to create the Flow project/video shell) — every shot goes
+    straight through submit_clip's own zero-spend placeholder path with
+    episode_context left as whatever was passed in (typically None).
     """
     shot_pack = json.loads(shot_pack_path.read_text())
     shots = shot_pack.get("shots") or []
     results: list[ClipResult] = []
 
-    if episode_context is None:
+    zero_spend = zero_spend_enabled()
+
+    if not zero_spend and episode_context is None:
         episode_name = (
             shot_pack.get("episode_id")
             or shot_pack.get("topic", "")[:60]
@@ -645,8 +765,14 @@ async def render_shot_pack(
         ctx_path.write_text(json.dumps(episode_context.to_dict(), indent=2))
 
     # Identity anchor (root-level shot-pack field) → drives i2v start image so
-    # every shot preserves the A007 face. Only set if not already on the context.
-    if episode_context.anchor_image_path is None:
+    # every shot preserves the A007 face. Only set if not already on the
+    # context — and only when there IS a context (zero-spend never creates
+    # one and submit_clip's placeholder path never reads it).
+    if (
+        not zero_spend
+        and episode_context is not None
+        and episode_context.anchor_image_path is None
+    ):
         anchor_path = shot_pack.get("anchor_image_path")
         if anchor_path:
             episode_context.anchor_image_path = anchor_path

--- a/scripts/wr3_placeholder_clip.py
+++ b/scripts/wr3_placeholder_clip.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""WR3 zero-spend placeholder clip generator.
+
+Renders a deterministic 8s, 720x1280 (9:16 portrait) H.264/yuv420p MP4 so the
+WR3 pipeline (gatekeeper -> audio -> assembler -> critic) can run end-to-end
+with ZERO Veo/Flow credits. This module never opens a network socket and
+never talks to FlowKit — it is pure local ffmpeg + PIL rendering.
+
+Visual: ffmpeg `smptebars` colour bars as the base plate, composited with a
+PIL-rendered burned-in label (episode_id, shot_index, PLACEHOLDER, NO VEO
+SPEND) via ffmpeg's `overlay` filter. `drawtext` is deliberately NOT used —
+this ffmpeg build (8.1, Homebrew) has no libfreetype and
+`ffmpeg -h filter=drawtext` reports `Unknown filter 'drawtext'`. Do not
+reintroduce it without re-verifying the build.
+
+Determinism: rendering the same (episode_id, shot_index, duration, size)
+twice is required to produce byte-identical (or at minimum frame-identical)
+output — see `render_placeholder_clip` docstring for exactly what is
+guaranteed and how, and `scripts/tests/test_wr3_zero_spend.py` for the
+empirical proof.
+
+CLI:
+    python3 scripts/wr3_placeholder_clip.py --episode-id EP01 --shot-index 3 \
+        --dest /tmp/out.mp4
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Final
+
+from PIL import Image, ImageDraw, ImageFont
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WIDTH: Final[int] = 720
+DEFAULT_HEIGHT: Final[int] = 1280
+DEFAULT_DURATION_S: Final[int] = 8
+FRAME_RATE: Final[int] = 25
+
+# Fixed stream-metadata tag so the "encoder" tag libavformat writes into the
+# output does not vary across ffmpeg builds/versions — part of the
+# determinism contract (see module docstring).
+_ENCODER_TAG: Final[str] = "wr3-placeholder-clip"
+
+# Deterministic font search order. Tried in sequence; falls back to PIL's
+# bundled default font (scaled up) if none is found on this machine. The
+# choice matters only for legibility, not correctness — any font that
+# resolves the same way twice on the SAME machine keeps determinism.
+_FONT_CANDIDATES: Final[tuple[str, ...]] = (
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "/System/Library/Fonts/Supplemental/Arial.ttf",
+)
+
+
+class PlaceholderRenderError(RuntimeError):
+    """Raised when the placeholder clip cannot be rendered.
+
+    Never swallow this to produce a 0-byte or missing file — a downstream
+    WR3 stage (gatekeeper/audio/assembler/critic) must see a hard failure,
+    not silently proceed on a placeholder that doesn't exist.
+    """
+
+
+def _resolve_ffmpeg(ffmpeg_bin: str | None) -> str:
+    candidate = ffmpeg_bin or "ffmpeg"
+    resolved = shutil.which(candidate) if not Path(candidate).is_absolute() else (
+        candidate if Path(candidate).exists() else None
+    )
+    if resolved is None:
+        raise PlaceholderRenderError(
+            f"ffmpeg binary not found (looked for {candidate!r}) — cannot render placeholder clip"
+        )
+    return resolved
+
+
+def _load_font(size_px: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    for candidate in _FONT_CANDIDATES:
+        path = Path(candidate)
+        if path.exists():
+            try:
+                return ImageFont.truetype(str(path), size=size_px)
+            except OSError:
+                logger.warning("font candidate %s exists but failed to load, trying next", candidate)
+                continue
+    logger.warning("no system font found among %s — falling back to PIL default font", _FONT_CANDIDATES)
+    # Pillow >=10.1 supports a `size` kwarg on load_default(); it stays
+    # deterministic across runs on the same Pillow install.
+    return ImageFont.load_default(size=size_px)
+
+
+def _render_label_png(
+    *,
+    episode_id: str,
+    shot_index: int,
+    width: int,
+    height: int,
+    dest: Path,
+) -> Path:
+    """Render the burned-in label to a transparent RGBA PNG via PIL.
+
+    No `drawtext` filter is used (unavailable in this ffmpeg build — see
+    module docstring). No timestamp/metadata is embedded: Pillow's default
+    PNG writer does not add a tIME chunk unless explicitly asked, so two
+    renders of identical text/font/size produce byte-identical PNG bytes.
+    """
+    image = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+
+    title_size = max(24, width // 14)
+    body_size = max(18, width // 22)
+    title_font = _load_font(title_size)
+    body_font = _load_font(body_size)
+
+    lines = [
+        (str(episode_id), title_font),
+        (f"SHOT {shot_index:03d}", body_font),
+        ("PLACEHOLDER", body_font),
+        ("NO VEO SPEND", body_font),
+    ]
+
+    # Measure the text block to size a legibility backdrop behind it.
+    line_metrics: list[tuple[str, ImageFont.FreeTypeFont | ImageFont.ImageFont, int, int]] = []
+    max_line_w = 0
+    total_h = 0
+    line_gap = max(4, body_size // 4)
+    for text, font in lines:
+        bbox = draw.textbbox((0, 0), text, font=font)
+        line_w = bbox[2] - bbox[0]
+        line_h = bbox[3] - bbox[1]
+        line_metrics.append((text, font, line_w, line_h))
+        max_line_w = max(max_line_w, line_w)
+        total_h += line_h + line_gap
+    total_h -= line_gap
+
+    pad_x, pad_y = 28, 24
+    block_w = max_line_w + 2 * pad_x
+    block_h = total_h + 2 * pad_y
+    block_x0 = (width - block_w) // 2
+    block_y0 = (height - block_h) // 2
+    draw.rectangle(
+        [block_x0, block_y0, block_x0 + block_w, block_y0 + block_h],
+        fill=(0, 0, 0, 200),
+    )
+
+    y = block_y0 + pad_y
+    for text, font, line_w, line_h in line_metrics:
+        x = (width - line_w) // 2
+        draw.text((x, y), text, font=font, fill=(255, 221, 0, 255))
+        y += line_h + line_gap
+
+    # optimize=False, compress_level fixed: keep PNG bytes deterministic and
+    # independent of any ambient zlib tuning.
+    image.save(dest, format="PNG", optimize=False, compress_level=6)
+    return dest
+
+
+def render_placeholder_clip(
+    *,
+    episode_id: str,
+    shot_index: int,
+    dest: Path,
+    duration_s: int = DEFAULT_DURATION_S,
+    width: int = DEFAULT_WIDTH,
+    height: int = DEFAULT_HEIGHT,
+    ffmpeg_bin: str | None = None,
+) -> Path:
+    """Render a deterministic zero-spend placeholder clip.
+
+    Video: `duration_s` seconds at `width`x`height` (9:16 portrait by
+    default), H.264 (libx264) + yuv420p so every downstream ffmpeg/critic
+    step can read it. Base plate is ffmpeg `smptebars`; a PIL-rendered label
+    (episode_id, zero-padded shot_index, PLACEHOLDER, NO VEO SPEND) is
+    composited on top via ffmpeg `overlay`.
+
+    Determinism: two calls with identical (episode_id, shot_index,
+    duration_s, width, height) on the SAME ffmpeg build are made
+    byte-identical (identical sha256 of the output MP4) via:
+      - `-fflags +bitexact -flags:v +bitexact` (removes the libx264 version
+        SEI + any lavf timestamp banners from the bitstream/container —
+        this is the same incantation ffmpeg's own FATE regression suite
+        uses for reproducible encodes);
+      - `-map_metadata -1` (drop all source/container metadata) plus a
+        fixed `-metadata:s:v:0 encoder=` tag (overrides the
+        Lavc<version>/libx264<build> string lavf would otherwise stamp,
+        which would vary across ffmpeg installs though not across runs on
+        THIS one);
+      - a fixed `-r`/output frame rate and `-fps_mode cfr`;
+      - `-threads 1` + `x264-params threads=1:sliced_threads=0` and
+        `-filter_threads 1` (removes frame/slice-parallel encode ordering
+        as a theoretical nondeterminism source — smptebars + overlay have
+        no cross-frame state, but the encoder's bitstream packing can
+        depend on thread interleaving without this);
+      - a PIL-rendered label PNG that embeds no timestamp (see
+        `_render_label_png`).
+    This was verified empirically (not assumed) by rendering twice and
+    comparing `shasum -a 256` — see the test suite for the exact command
+    and the measured result, and do not trust this docstring over a fresh
+    measurement if the ffmpeg build changes.
+
+    Raises PlaceholderRenderError (never leaves a 0-byte/partial file at
+    `dest`) if ffmpeg is missing or the render fails.
+    """
+    if duration_s <= 0:
+        raise PlaceholderRenderError(f"duration_s must be positive, got {duration_s}")
+    if width <= 0 or height <= 0:
+        raise PlaceholderRenderError(f"width/height must be positive, got {width}x{height}")
+
+    ffmpeg = _resolve_ffmpeg(ffmpeg_bin)
+    dest = Path(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="wr3-placeholder-") as tmp_dir:
+        label_png = Path(tmp_dir) / "label.png"
+        try:
+            _render_label_png(
+                episode_id=episode_id,
+                shot_index=shot_index,
+                width=width,
+                height=height,
+                dest=label_png,
+            )
+        except Exception as exc:  # noqa: BLE001 — re-raise as our named error
+            raise PlaceholderRenderError(f"failed to render label overlay PNG: {exc}") from exc
+
+        tmp_dest = Path(tmp_dir) / "render.mp4"
+        cmd = [
+            ffmpeg,
+            "-y",
+            "-fflags",
+            "+bitexact",
+            "-f",
+            "lavfi",
+            "-i",
+            f"smptebars=size={width}x{height}:rate={FRAME_RATE}:duration={duration_s}",
+            "-i",
+            str(label_png),
+            "-filter_complex",
+            "[0:v][1:v]overlay=0:0:format=auto,format=yuv420p",
+            "-filter_threads",
+            "1",
+            "-map_metadata",
+            "-1",
+            "-map_chapters",
+            "-1",
+            "-metadata:s:v:0",
+            f"encoder={_ENCODER_TAG}",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "23",
+            "-threads",
+            "1",
+            "-x264-params",
+            "threads=1:sliced_threads=0",
+            "-flags:v",
+            "+bitexact",
+            "-pix_fmt",
+            "yuv420p",
+            "-r",
+            str(FRAME_RATE),
+            "-fps_mode",
+            "cfr",
+            "-t",
+            str(duration_s),
+            "-an",
+            "-movflags",
+            "+faststart",
+            str(tmp_dest),
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0 or not tmp_dest.exists() or tmp_dest.stat().st_size == 0:
+            raise PlaceholderRenderError(
+                "ffmpeg placeholder render failed "
+                f"(returncode={result.returncode}): {result.stderr[-4000:]}"
+            )
+
+        # Atomic-ish move into place so a partially-written dest is never
+        # observable by a concurrent reader (assembler/gatekeeper).
+        shutil.move(str(tmp_dest), str(dest))
+
+    if not dest.exists() or dest.stat().st_size == 0:
+        raise PlaceholderRenderError(f"placeholder render reported success but {dest} is missing/empty")
+
+    logger.info(
+        "rendered zero-spend placeholder clip: episode=%s shot=%d dest=%s (%d bytes)",
+        episode_id,
+        shot_index,
+        dest,
+        dest.stat().st_size,
+    )
+    return dest
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--episode-id", required=True, help="episode id, e.g. EP01")
+    parser.add_argument("--shot-index", required=True, type=int, help="shot index, zero-padded in the label")
+    parser.add_argument("--dest", required=True, type=Path, help="output .mp4 path")
+    parser.add_argument("--duration-s", type=int, default=DEFAULT_DURATION_S)
+    parser.add_argument("--width", type=int, default=DEFAULT_WIDTH)
+    parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
+    parser.add_argument("--ffmpeg-bin", default=None, help="override ffmpeg binary path")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        out = render_placeholder_clip(
+            episode_id=args.episode_id,
+            shot_index=args.shot_index,
+            dest=args.dest,
+            duration_s=args.duration_s,
+            width=args.width,
+            height=args.height,
+            ffmpeg_bin=args.ffmpeg_bin,
+        )
+    except PlaceholderRenderError as exc:
+        logger.error("placeholder render failed: %s", exc)
+        return 1
+    print(str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wr3_spend_authority.py
+++ b/scripts/wr3_spend_authority.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""WR3 spend authority gate — fail-closed guard in front of every Veo/Flow spend.
+
+This is the security-relevant module of the WR3 zero-spend packet: every
+call site that is about to open a socket to FlowKit/Veo (credit-consuming)
+MUST call `assert_spend_authorized(...)` first and let any
+`SpendNotAuthorizedError` propagate. There is deliberately no bypass
+argument, no "dry_run=False, force=True" escape hatch, and no default that
+authorizes silently.
+
+Threat model this module defends against:
+  - A stale/forgotten `WR3_ZERO_SPEND=1` env var lying around from a
+    previous session and someone SEPARATELY setting a spend-decision token,
+    assuming the token wins. It does not: zero-spend always wins.
+  - A decision token minted for episode A being replayed against episode B.
+  - A decision token from yesterday (or a future date) authorizing spend
+    "just this once" outside the day it was actually decided.
+  - An unlogged authorization: if the append-only decision log cannot be
+    written, the spend is refused rather than silently allowed through.
+
+Stdlib-only by design: this module must NEVER import `wr3_flowkit_client`
+(or vice versa) — that would create a circular import between the gate and
+the thing it gates.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+# <episode_id>:<who>:<YYYY-MM-DD> — every field character class deliberately
+# excludes whitespace, so internal whitespace in any field fails validation
+# by construction (see parse_decision docstring).
+_EPISODE_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_WHO_RE = re.compile(r"^[A-Za-z0-9._@-]+$")
+_DATE_SHAPE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+_DEFAULT_LOG_PATH = Path.home() / ".cache" / "wr3" / "spend-decisions.jsonl"
+
+
+class SpendNotAuthorizedError(Exception):
+    """Raised whenever a Veo/Flow spend is not authorized.
+
+    Every charging call site must let this propagate — never catch it to
+    fall back to "spend anyway".
+    """
+
+
+@dataclass(frozen=True)
+class SpendDecision:
+    """A validated, single-day, single-episode spend authorization."""
+
+    episode_id: str
+    who: str
+    date: date
+    raw: str
+
+
+def zero_spend_enabled() -> bool:
+    """True when WR3_ZERO_SPEND is set to a truthy value.
+
+    Truthy (case-insensitive, surrounding whitespace stripped): "1", "true",
+    "yes", "on". Everything else — including "0", "false", "", and unset —
+    is false.
+    """
+    raw = os.environ.get("WR3_ZERO_SPEND", "")
+    return raw.strip().lower() in _TRUTHY_VALUES
+
+
+def parse_decision(raw: str) -> SpendDecision:
+    """Parse and strictly validate a `<episode_id>:<who>:<YYYY-MM-DD>` token.
+
+    Raises ValueError (never returns a partially-valid decision) when:
+      - there are not exactly 3 colon-separated fields;
+      - episode_id is empty or contains a character outside [A-Za-z0-9._-];
+      - who is empty or contains a character outside [A-Za-z0-9._@-];
+      - the date field is not exactly YYYY-MM-DD, or is not a real calendar
+        date.
+
+    Surrounding whitespace on the whole token is stripped before
+    validation; internal whitespace (inside a field, or padding a field
+    after a colon) is rejected because none of the field character classes
+    above include whitespace.
+    """
+    if raw is None:
+        raise ValueError("decision token is None")
+
+    stripped = raw.strip()
+    if not stripped:
+        raise ValueError("decision token is empty")
+
+    parts = stripped.split(":")
+    if len(parts) != 3:
+        raise ValueError(
+            "decision token must have exactly 3 colon-separated fields "
+            f"<episode_id>:<who>:<YYYY-MM-DD>, got {len(parts)} field(s): {raw!r}"
+        )
+
+    episode_id, who, date_str = parts
+
+    if not episode_id or not _EPISODE_ID_RE.match(episode_id):
+        raise ValueError(f"invalid episode_id field {episode_id!r} (expected [A-Za-z0-9._-]+)")
+
+    if not who or not _WHO_RE.match(who):
+        raise ValueError(f"invalid who field {who!r} (expected [A-Za-z0-9._@-]+)")
+
+    if not _DATE_SHAPE_RE.match(date_str):
+        raise ValueError(f"invalid date field {date_str!r} (expected exactly YYYY-MM-DD)")
+
+    try:
+        parsed_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError(f"date field {date_str!r} is not a real calendar date") from exc
+
+    return SpendDecision(episode_id=episode_id, who=who, date=parsed_date, raw=raw)
+
+
+def log_decision(decision: SpendDecision, *, episode_id: str, log_path: Path | None = None) -> None:
+    """Append one JSONL record to the spend-decision log. Fail closed.
+
+    A failure to write MUST propagate as SpendNotAuthorizedError — an
+    unlogged spend is exactly what this packet exists to prevent, so a
+    logging failure is treated as an authorization failure, not a warning.
+    """
+    path = log_path if log_path is not None else Path(
+        os.environ.get("WR3_SPEND_DECISION_LOG", str(_DEFAULT_LOG_PATH))
+    )
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "episode_id": episode_id,
+        "who": decision.who,
+        "decision_date": decision.date.isoformat(),
+        "raw": decision.raw,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+        path.chmod(0o600)
+    except OSError as exc:
+        raise SpendNotAuthorizedError(
+            f"failed to write spend-decision log at {path}: {exc} — spend refused (fail-closed)"
+        ) from exc
+
+    logger.info(
+        "spend authorized+logged: episode=%s who=%s date=%s log=%s",
+        episode_id,
+        decision.who,
+        decision.date.isoformat(),
+        path,
+    )
+
+
+def assert_spend_authorized(*, episode_id: str, now: date | None = None) -> SpendDecision:
+    """The gate every charging call site invokes before opening a socket.
+
+    Raises SpendNotAuthorizedError when ANY of:
+      - `zero_spend_enabled()` is true (checked FIRST — zero-spend always
+        wins over a decision token, even a perfectly valid one for today);
+      - WR3_SPEND_DECISION is unset or empty;
+      - the token fails `parse_decision`;
+      - the token's episode_id does not match `episode_id`;
+      - the token's date is not exactly `now` (today by default) — neither
+        a stale token nor a future-dated one authorizes.
+
+    On success: logs the authorization via `log_decision` (itself
+    fail-closed — see its docstring) and returns the `SpendDecision`.
+    """
+    today = now if now is not None else date.today()
+
+    if zero_spend_enabled():
+        raise SpendNotAuthorizedError(
+            "WR3_ZERO_SPEND is active — spend refused unconditionally, "
+            "regardless of any WR3_SPEND_DECISION token present"
+        )
+
+    raw = os.environ.get("WR3_SPEND_DECISION", "")
+    if not raw or not raw.strip():
+        raise SpendNotAuthorizedError("WR3_SPEND_DECISION is unset or empty — spend not authorized")
+
+    try:
+        decision = parse_decision(raw)
+    except ValueError as exc:
+        raise SpendNotAuthorizedError(f"WR3_SPEND_DECISION failed validation: {exc}") from exc
+
+    if decision.episode_id != episode_id:
+        raise SpendNotAuthorizedError(
+            f"decision token was minted for episode {decision.episode_id!r}, "
+            f"not the requesting episode {episode_id!r}"
+        )
+
+    if decision.date != today:
+        raise SpendNotAuthorizedError(
+            f"decision token is dated {decision.date.isoformat()}, "
+            f"not today ({today.isoformat()}) — stale/future tokens do not authorize"
+        )
+
+    log_decision(decision, episode_id=episode_id)
+    return decision


### PR DESCRIPTION
Work packet **P03 — WR3 / FlowKit zero-spend** (Research OS v1.0.0, Wave 0, builder H3).

**base: `5117d9908a37cdc5f23924f6fe19cd823e2ed6c5`** — review every diff against THAT sha, not against a moving `origin/main` tip.

## The problem

`wr3_gatekeeper_check.py:15` enforces a cost circuit breaker by reading `~/.cache/wr3/flow-quota.json`. **Nothing in this repo has ever written that file.** It was hand-seeded on 2026-05-29 with `daily_spent_cr: 0` and has never moved, while real clips were rendered. The breaker divided against a constant.

## What lands

1. **`wr3_credit_ledger.py`** — append-only JSONL ledger written **at the charge site**, plus a report CLI reading only local artifacts. `record_spend` fires inside `_generate_video`, not after the mp4 downloads: the credit is spent on the POST, and `wr3_render_episode.py` retries a failed shot 3×, so the original placement could bill a shot three times and log it zero times. That regression is pinned by a test that fails against the old code and passes against the new.
2. **`wr3_spend_authority.py`** — fail-closed gate at the **two charging functions**, not at their caller. Deliberate: `wr3_probe_single_clip.py` calls both directly and bypasses `submit_clip`, so a guard on `submit_clip` alone would not stop it. It now fails closed with **zero edits to that file**. A spend needs `WR3_SPEND_DECISION=<episode_id>:<who>:<YYYY-MM-DD>` matching the episode, dated today, and successfully logged; an unloggable decision refuses. `WR3_ZERO_SPEND` always wins over a token.
3. **`wr3_placeholder_clip.py`** — deterministic 8s 720×1280 colour-bar clips with a burned-in shot id. `drawtext` is not compiled into this ffmpeg, so the label is composited from a PIL-rendered PNG. Byte-identical across runs on the same ffmpeg build.

## PROVE-LIVE

| | BEFORE | AFTER |
|---|---|---|
| credits (unwindowed) | 0 | **0** |
| rows | 0 | 3 — all `placeholder`, **0 `real`** |
| ledger path | printed, identical | printed, identical |
| integrity | `OK` | `OK` |

Run with `WR3_FLOWKIT_ENDPOINT` on a **dead port**. Two falsification checks make the proof non-empty: without zero-spend the same path returns `URLError [Errno 61] Connection refused` (the socket *would* have opened), and without a token both charging functions raise `SpendNotAuthorizedError` rather than a connection error.

**Gate mutation-verified, 5/5 bite** — including "zero-spend no longer wins over a token" and "log-write failure swallowed". Suite: **267 wr3 tests pass**.

## Adversarial review

A cross-family refuter (**Kimi K3**, fresh context) ran twice: once on the ledger arithmetic, once on the evidence package.

- Round 1 found **12 defects**, several fatal to the packet's own claim — non-idempotent backfill (double-apply doubled the total), `--json` blending estimates with measurements unlabelled, swallowed write failures making a real charge invisible, `record_spend(credits=None)` raising `TypeError` into a live render. All 12 fixed and independently re-measured by a separate verifier seat; idempotence measured again by the gate seat (two applies → 12 rows, not 24).
- Round 2 refuted the **evidence documents** and forced corrections in place: the tunnel diagnosis wrongly claimed "43h of quiet was 43h of the tunnel working" — the err log's last write and pid 18724's birth coincide **to the second**, so that write records a *death*, not health. A sixth spend door (the Google Flow web UI) was missed. The dead-port canary was shown to cover less than implied.

## Honest limits — please read before treating this as "WR3 is safe"

- **The decision token is UNAUTHENTICATED.** It verifies the *shape* of a decision, not that a human made one: anything able to set an env var can self-authorize. An HMAC over a secret held by a human ceremony is the real fix, out of scope here.
- **The gate is boolean, not a quota.** It authorizes per clip; it caps nothing.
- **WR3 is one of SIX doors to the same credit pool** (`flowkit_cli.py`, WR2, `zantara-media`, a dormant MCP tool, the Google Flow web UI). This gate covers one. The successor should target the **choke point**, not WR3.
- **The Google account balance is never queried.** Every claim is about the instrumentation. The ceiling on what this packet proves is *"this process spent nothing through the instrumented WR3 path"* — never *"no credits were spent"*.
- **Backfilled figures are a FLOOR with no derivable ceiling.** These are lipsync directories; a local re-encode changes bytes with no Veo call, so the artifacts cannot settle historical spend even in principle.
- **F11: the production driver `wr3_render_episode.py` does not honour zero-spend** (unconditional health gate at line 33). It is outside this packet's owned file scope, so it is not edited here; the exact patch is in the evidence.

## Pre-existing, untouched
`test_wr3_manifest_normalize.py::test_against_the_actual_on_disk_manifest` fails identically on unmodified `main` — it reads a gitignored artifact that is absent.

## Size
~3.9k lines, deliberately one PR: the ledger and the gate only make sense together (a ledger nothing writes to is the exact disease F1 describes), and the mutation tests, dry run and refuter passes all verified them as one system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
