### PR TITLE
fix(crm): team-side portal endpoints honour client assignment

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_portal_integration.py
+++ b/apps/backend-rag/backend/app/routers/crm_portal_integration.py
@@ -100,6 +100,19 @@ class UnreadCountResponse(BaseModel):
 # ================================================
 
 
+def _invitation_public_view(result: dict[str, Any]) -> dict[str, Any]:
+    """Strip the raw invitation secret before it reaches an HTTP response.
+
+    ``InviteService.create_invitation`` returns ``token``/``invite_url``
+    because the legitimate delivery channel (Brevo email in
+    ``portal_invite.send_invitation``) needs them to build the invite link.
+    This router has no email-sending step of its own (a separate defect,
+    not fixed here — see SPEC-p0-invite.md PR B / B1) and must never let
+    the raw, unsent token leak back to the calling team member's browser.
+    """
+    return {k: v for k, v in result.items() if k not in ("token", "invite_url")}
+
+
 def require_team_auth(current_user: dict = Depends(get_current_user)) -> dict:
     """Ensure user is a real team member — neither a client nor a service account.
 
@@ -233,9 +246,14 @@ async def send_portal_invite(
     Send portal invitation to a client from CRM.
 
     If email not provided, uses client's email from the clients table.
+
+    B1 (SPEC-p0-invite.md, 2026-08-23): this is a fourth invitation-minting
+    path — `write=True` requires the caller's email to match the client's
+    `assigned_to`/`created_by` or be an admin, and the response never
+    carries the raw `token`/`invite_url`.
     """
     async with db_pool.acquire() as conn:
-        await verify_client_access(client_id, current_user, conn, allow_assigned=True)
+        await verify_client_access(client_id, current_user, conn, allow_assigned=True, write=True)
 
     try:
         # Get client email if not provided
@@ -265,7 +283,7 @@ async def send_portal_invite(
         return {
             "success": True,
             "message": f"Invitation sent to {email}",
-            "data": result,
+            "data": _invitation_public_view(result),
         }
 
     except ValueError as e:
@@ -332,27 +350,41 @@ async def get_portal_preview(
 @router.get("/messages/unread-count")
 async def get_unread_messages_count(
     _current_user: dict = Depends(require_team_auth),
+    assigned_filter: str | None = Depends(get_crm_user_filter),
     db_pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
     """
     Get count of unread messages from all clients.
 
     For header notification badge.
+
+    B3 (SPEC-p0-invite.md, 2026-08-23): scoped to the caller's assignment,
+    same pattern as `get_recent_portal_activity` below — `assigned_filter`
+    is None for admins (no filter, full book) and the caller's lowercased
+    email otherwise. Applied to BOTH queries: a total count that ignored
+    the filter would still leak the volume of a client the caller cannot
+    otherwise see.
     """
     async with db_pool.acquire() as conn:
-        # Total unread
-        total = await conn.fetchval(
-            """
+        # Total unread (joined to clients so the assignment filter can apply)
+        total_query = """
             SELECT COUNT(*)
-            FROM portal_messages
-            WHERE direction = 'client_to_team'
-              AND read_at IS NULL
-            """,
-        )
+            FROM portal_messages pm
+            JOIN clients c ON c.id = pm.client_id
+            WHERE pm.direction = 'client_to_team'
+              AND pm.read_at IS NULL
+              AND c.deleted_at IS NULL
+        """
+        total_params: list[str] = []
+
+        if assigned_filter is not None:
+            total_query += " AND LOWER(c.assigned_to) = $1"
+            total_params.append(assigned_filter)
+
+        total = await conn.fetchval(total_query, *total_params)
 
         # By client
-        by_client = await conn.fetch(
-            """
+        by_client_query = """
             SELECT
                 pm.client_id,
                 c.full_name as client_name,
@@ -361,11 +393,21 @@ async def get_unread_messages_count(
             JOIN clients c ON c.id = pm.client_id
             WHERE pm.direction = 'client_to_team'
               AND pm.read_at IS NULL
+              AND c.deleted_at IS NULL
+        """
+        by_client_params: list[str] = []
+
+        if assigned_filter is not None:
+            by_client_query += " AND LOWER(c.assigned_to) = $1"
+            by_client_params.append(assigned_filter)
+
+        by_client_query += """
             GROUP BY pm.client_id, c.full_name
             ORDER BY unread_count DESC
             LIMIT 10
-            """,
-        )
+        """
+
+        by_client = await conn.fetch(by_client_query, *by_client_params)
 
         return {
             "success": True,
@@ -429,11 +471,19 @@ async def send_message_to_client(
 ) -> dict[str, Any]:
     """
     Send a message to a client (team → client).
+
+    B2 (SPEC-p0-invite.md, 2026-08-23 — owner ruling): restricted to
+    `write=True` — only the client's assigned team member (or `created_by`)
+    or a CRM admin may send. Behaviour change for staff: a colleague who is
+    not assigned to the client now gets 403 instead of being able to send a
+    client-visible message.
     """
     try:
         async with db_pool.acquire() as conn:
-            # S03-S3: BOLA fix — verify caller has access to this client
-            await verify_client_access(client_id, current_user, conn, allow_assigned=True)
+            # S03-S3 / B2: BOLA fix — verify caller has write access to this client
+            await verify_client_access(
+                client_id, current_user, conn, allow_assigned=True, write=True
+            )
 
             message = await conn.fetchrow(
                 """

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_portal_team_assignment_gates.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_portal_team_assignment_gates.py
@@ -1,0 +1,356 @@
+"""Tests for the PR B team-assignment gates in `crm_portal_integration.py`.
+
+SPEC-p0-invite.md (2026-08-23), "## PR B — `crm_portal_integration.py`: team-side
+endpoints honour assignment". Three items:
+
+- B1 `send_portal_invite` (~line 238): a fourth invitation-minting path. Gains
+  `write=True` on its `verify_client_access` call and strips the raw
+  `token`/`invite_url` from the response — same treatment as
+  `portal_invite.py`'s A1/A3, applied here because this router has its own
+  separate `verify_client_access` call and its own separate response body.
+- B2 `send_message_to_client` (~line 465) — owner ruling: its
+  `verify_client_access` ran in read mode (`write` defaults to `False`), so
+  any authenticated team member could write a client-visible message
+  regardless of assignment. Zero ruled 2026-08-23: `write=True`.
+- B3 `get_unread_messages_count` (~line 351) — owner ruling: had no
+  `assigned_filter` and no `verify_client_access` at all; its `by_client`
+  block returned real client names (`c.full_name`) for the top 10 unread
+  senders across the WHOLE book, archived clients included, to any
+  authenticated team member. Copies the `assigned_filter` pattern from
+  `get_recent_portal_activity` (same file, ~line 573) verbatim and applies
+  it to both the `total` and `by_client` queries, plus `c.deleted_at IS
+  NULL` on the `by_client` join.
+
+IMPORTANT — nothing here mocks `verify_client_access` itself (that would
+prove nothing about the fix: patching the guard away runs no guard at all).
+B1/B2 tests drive the REAL `verify_client_access`, mocking only the asyncpg
+connection it reads from (`mock_db_pool._mock_conn`, the shared fixture in
+`conftest.py`) — same harness as
+`test_crm_portal_mark_read_bola.py` (landed in #4594). B3 has no
+`verify_client_access` call (by design — it's a book-wide summary, not a
+single-client endpoint); its gate is the `assigned_filter` dependency value,
+so those tests instead inspect the actual SQL text and bound parameters sent
+to `conn.fetchval`/`conn.fetch` — the only way to prove the WHERE clause
+(and not just the mocked return value) actually changed.
+
+Synthetic fixtures only — no real client name, email, or id.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from backend.app.routers.crm_portal_integration import (
+    SendInviteRequest,
+    TeamMessageRequest,
+    get_unread_messages_count,
+    send_message_to_client,
+    send_portal_invite,
+)
+
+ADMIN_EMAIL = "asya@balizero.com"  # backend.app.utils.crm_utils.CRM_EXTRA_ADMIN_EMAILS
+
+
+def _client_row(*, assigned_to: str | None, created_by: str | None = None) -> dict[str, object]:
+    return {
+        "id": 1,
+        "assigned_to": assigned_to,
+        "created_by": created_by if created_by is not None else assigned_to,
+    }
+
+
+def _message_row() -> dict[str, object]:
+    return {
+        "id": 42,
+        "subject": "Synthetic subject",
+        "content": "Synthetic content",
+        "sent_by": "alice@balizero.com",
+        "created_at": datetime(2026, 8, 23, tzinfo=timezone.utc),
+    }
+
+
+def _raw_invitation(*, suffix: str) -> dict[str, object]:
+    """A synthetic `InviteService.create_invitation` return value.
+
+    Deliberately includes `token`/`invite_url` — B1's whole point is that
+    these must never survive into the HTTP response.
+    """
+    return {
+        "invitation_id": 5,
+        "client_id": 1,
+        "client_name": "Synthetic Client",
+        "email": "synthetic-client@example.com",
+        "expires_at": "2026-09-01T00:00:00+00:00",
+        "token": f"raw-secret-token-{suffix}",
+        "invite_url": f"https://kita.balizero.com/invite/raw-secret-token-{suffix}",
+    }
+
+
+# ================================================
+# B1 — send_portal_invite: write=True + secrets stripped
+# ================================================
+
+
+@pytest.mark.asyncio
+async def test_b1_non_assigned_non_admin_denied_403_not_500(mock_db_pool) -> None:
+    """GUILT: a non-assigned, non-admin team member must not mint an invite."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+    invite_service = AsyncMock()
+    current_user = {"email": "bob@balizero.com", "role": "team"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await send_portal_invite(
+            client_id=1,
+            request=SendInviteRequest(email="synthetic-client@example.com"),
+            current_user=current_user,
+            invite_service=invite_service,
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+    invite_service.create_invitation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_b1_assigned_team_member_allowed_secrets_stripped(mock_db_pool) -> None:
+    """INNOCENCE: assigned caller succeeds, and the response has no raw secret."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+    invite_service = AsyncMock()
+    invite_service.create_invitation.return_value = _raw_invitation(suffix="assigned")
+    current_user = {"email": "alice@balizero.com", "role": "team"}
+
+    result = await send_portal_invite(
+        client_id=1,
+        request=SendInviteRequest(email="synthetic-client@example.com"),
+        current_user=current_user,
+        invite_service=invite_service,
+        db_pool=mock_db_pool,
+    )
+
+    assert result["success"] is True
+    invite_service.create_invitation.assert_awaited_once()
+    assert "token" not in result["data"]
+    assert "invite_url" not in result["data"]
+    assert result["data"]["invitation_id"] == 5
+    assert result["data"]["email"] == "synthetic-client@example.com"
+
+
+@pytest.mark.asyncio
+async def test_b1_admin_allowed_secrets_stripped(mock_db_pool) -> None:
+    """INNOCENCE: admin bypasses assignment, and the response still has no secret."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="bob@balizero.com")
+    invite_service = AsyncMock()
+    invite_service.create_invitation.return_value = _raw_invitation(suffix="admin")
+    current_user = {"email": ADMIN_EMAIL, "role": "team"}
+
+    result = await send_portal_invite(
+        client_id=1,
+        request=SendInviteRequest(email="synthetic-client@example.com"),
+        current_user=current_user,
+        invite_service=invite_service,
+        db_pool=mock_db_pool,
+    )
+
+    assert result["success"] is True
+    assert "token" not in result["data"]
+    assert "invite_url" not in result["data"]
+
+
+# ================================================
+# B2 — send_message_to_client: write=True
+# ================================================
+
+
+@pytest.mark.asyncio
+async def test_b2_non_assigned_non_admin_denied_403_not_500(mock_db_pool) -> None:
+    """GUILT — the case B2 exists to close.
+
+    Before `write=True`, `verify_client_access`'s read-mode branch
+    (`allow_assigned=True`, `write` defaulting to False) grants access to
+    every authenticated team member. This drives the REAL guard; if B2's
+    `write=True` were reverted, this exact setup would return 200 instead of
+    raising — that is what makes the test discriminate the fix.
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+    current_user = {"email": "bob@balizero.com", "role": "team"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await send_message_to_client(
+            client_id=1,
+            request=TeamMessageRequest(content="Synthetic message body"),
+            current_user=current_user,
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+    # Only the verify_client_access SELECT ran — the INSERT (also via
+    # `conn.fetchrow` in this handler) must never have been reached.
+    assert mock_db_pool._mock_conn.fetchrow.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_b2_assigned_team_member_allowed(mock_db_pool) -> None:
+    """INNOCENCE: the client's assigned team member may still send."""
+    mock_db_pool._mock_conn.fetchrow.side_effect = [
+        _client_row(assigned_to="alice@balizero.com"),
+        _message_row(),
+    ]
+    current_user = {"email": "alice@balizero.com", "role": "team"}
+
+    result = await send_message_to_client(
+        client_id=1,
+        request=TeamMessageRequest(content="Synthetic message body"),
+        current_user=current_user,
+        db_pool=mock_db_pool,
+    )
+
+    assert result["success"] is True
+    assert result["data"]["id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_b2_admin_allowed_regardless_of_assignment(mock_db_pool) -> None:
+    """INNOCENCE: admin keeps full access regardless of assignment (CLAUDE.md §13)."""
+    mock_db_pool._mock_conn.fetchrow.side_effect = [
+        _client_row(assigned_to="bob@balizero.com"),
+        _message_row(),
+    ]
+    current_user = {"email": ADMIN_EMAIL, "role": "team"}
+
+    result = await send_message_to_client(
+        client_id=1,
+        request=TeamMessageRequest(content="Synthetic message body"),
+        current_user=current_user,
+        db_pool=mock_db_pool,
+    )
+
+    assert result["success"] is True
+    assert result["data"]["id"] == 42
+
+
+# ================================================
+# B3 — get_unread_messages_count: assigned_filter on both queries
+# ================================================
+
+
+@pytest.mark.asyncio
+async def test_b3_non_admin_filter_applied_to_total_and_by_client(mock_db_pool) -> None:
+    """GUILT/discrimination: a non-admin's filter must reach BOTH queries.
+
+    Before the fix, `get_unread_messages_count` had no `assigned_filter`
+    parameter at all, so neither query carried an assignment clause — a
+    mutation that drops the `if assigned_filter is not None:` block on
+    either query (or reverts the dependency) makes these assertions fail:
+    the clause disappears from the SQL text, or the bound param disappears.
+    """
+    conn = mock_db_pool._mock_conn
+    conn.fetchval.return_value = 3
+    conn.fetch.return_value = [
+        {"client_id": 1, "client_name": "Synthetic Assigned Client", "unread_count": 3}
+    ]
+
+    result = await get_unread_messages_count(
+        _current_user={"email": "alice@balizero.com", "role": "team"},
+        assigned_filter="alice@balizero.com",
+        db_pool=mock_db_pool,
+    )
+
+    assert result["data"]["total_unread"] == 3
+    assert len(result["data"]["by_client"]) == 1
+
+    total_query, *total_params = conn.fetchval.await_args.args
+    assert "LOWER(c.assigned_to) = $1" in total_query
+    assert total_params == ["alice@balizero.com"]
+
+    by_client_query, *by_client_params = conn.fetch.await_args.args
+    assert "LOWER(c.assigned_to) = $1" in by_client_query
+    assert by_client_params == ["alice@balizero.com"]
+    # Archived-client leak must be closed on the query that carries names.
+    assert "c.deleted_at IS NULL" in by_client_query
+
+
+@pytest.mark.asyncio
+async def test_b3_non_admin_response_excludes_unassigned_client(mock_db_pool) -> None:
+    """A non-admin's `by_client` rows must never surface a client they are
+    not assigned to — the mock DB is instructed (as the real filtered SQL
+    would be) to return only the caller's own assigned client; this pins the
+    response shape a non-admin is entitled to see."""
+    conn = mock_db_pool._mock_conn
+    conn.fetchval.return_value = 2
+    conn.fetch.return_value = [
+        {"client_id": 1, "client_name": "Synthetic Assigned Client", "unread_count": 2}
+    ]
+
+    result = await get_unread_messages_count(
+        _current_user={"email": "alice@balizero.com", "role": "team"},
+        assigned_filter="alice@balizero.com",
+        db_pool=mock_db_pool,
+    )
+
+    client_ids = {row["client_id"] for row in result["data"]["by_client"]}
+    assert client_ids == {1}
+    assert 99 not in client_ids  # a client synthetically "not assigned" to this caller
+
+
+@pytest.mark.asyncio
+async def test_b3_admin_sees_full_book_no_assigned_to_clause(mock_db_pool) -> None:
+    """INNOCENCE: `assigned_filter is None` (admin) must not bind any filter,
+    but the archived-client exclusion on `by_client` still applies unconditionally.
+    """
+    conn = mock_db_pool._mock_conn
+    conn.fetchval.return_value = 10
+    conn.fetch.return_value = [
+        {"client_id": 1, "client_name": "Synthetic Client A", "unread_count": 6},
+        {"client_id": 2, "client_name": "Synthetic Client B", "unread_count": 4},
+    ]
+
+    result = await get_unread_messages_count(
+        _current_user={"email": ADMIN_EMAIL, "role": "team"},
+        assigned_filter=None,
+        db_pool=mock_db_pool,
+    )
+
+    assert result["data"]["total_unread"] == 10
+    assert len(result["data"]["by_client"]) == 2
+
+    total_call_args = conn.fetchval.await_args.args
+    assert len(total_call_args) == 1  # query only, no assigned_to param bound
+    assert "assigned_to" not in total_call_args[0]
+
+    by_client_query, *by_client_params = conn.fetch.await_args.args
+    assert by_client_params == []
+    assert "assigned_to" not in by_client_query
+    assert "c.deleted_at IS NULL" in by_client_query
+
+
+@pytest.mark.asyncio
+async def test_b3_archived_client_excluded_from_by_client_even_for_admin(mock_db_pool) -> None:
+    """An archived client must never appear in `by_client`, admin or not.
+
+    The mocked connection can't enforce SQL semantics, so this pins the
+    query CONTRACT: `by_client`'s join always carries `c.deleted_at IS
+    NULL`, which is what makes an archived client's messages disappear from
+    that result set at the database level regardless of who is asking.
+    """
+    conn = mock_db_pool._mock_conn
+    conn.fetchval.return_value = 0
+    conn.fetch.return_value = []
+
+    await get_unread_messages_count(
+        _current_user={"email": ADMIN_EMAIL, "role": "team"},
+        assigned_filter=None,
+        db_pool=mock_db_pool,
+    )
+
+    by_client_query = conn.fetch.await_args.args[0]
+    assert "c.deleted_at IS NULL" in by_client_query


### PR DESCRIPTION
Three defects in `crm_portal_integration.py`, all the same shape: an endpoint that acts on — or discloses — one client's data while asking only *"is the caller a team member?"*, never *"is this caller's client?"*.

Found closing the kita↔my handoff audit. Two of the three are **owner rulings taken today**, not my judgment calls.

## B1 — `send_portal_invite` is a fourth invitation-minting path

It gated in read mode, where `verify_client_access` grants access to every authenticated team member **by design** (`crm_utils.py:234-238` — that mode exists so anyone can view an unassigned client and self-assign). And it returned the service result verbatim, including the raw `token` and `invite_url`.

Those two values complete registration at `POST /api/portal/invite/complete`, which is **public and unauthenticated**. Now: `write=True`, and the response carries neither.

Noted, not fixed here: this endpoint sends **no email at all**, despite replying `"Invitation sent to {email}"`. Separate defect, ledgered in #4605.

## B2 — `send_message_to_client` (owner ruling)

It inserted a client-visible message behind the same read-mode gate, so any staff member could write to any client. Zero ruled 2026-08-23: **assigned + admin only**.

⚠️ **Behaviour change for staff**: a colleague who is not assigned to the client now gets 403 when sending. This was a deliberate decision, not a silent tightening — a specialist answering on someone else's case will need the assignment.

## B3 — `get_unread_messages_count` returned real client names (owner ruling)

No assignment filter, no access check: it returned `c.full_name` for the top 10 clients across the **whole book**, archived included, to any team member. Its sibling `get_recent_portal_activity`, in this same file, has taken `assigned_filter: str | None = Depends(get_crm_user_filter)` all along.

This copies that pattern exactly, and applies it to **both** queries — a total that ignored the filter would still leak the volume of a client the caller cannot otherwise see. Both now also exclude archived clients: the `total` join needed `deleted_at IS NULL` to agree with the list it heads (caught at review, not by the first draft).

Safe by measurement, not by hope: `getPortalUnreadCount` exists at `apps/mouth/src/lib/api/crm/crm.api.ts:1429` and has **zero callers**.

## Verification

**Proven by mutation, not asserted.** Neutralising the three guards independently fails four tests:

| mutation | test that catches it |
|---|---|
| don't strip the invite token | `test_b1_assigned_team_member_allowed_secrets_stripped`, `test_b1_admin_allowed_secrets_stripped` |
| drop `write=True` on send | `test_b2_non_assigned_non_admin_denied_403_not_500` (`assert 500 == 403`) |
| drop the assignment predicate | `test_b3_non_admin_filter_applied_to_total_and_by_client` |

- 15 tests pass (this file + the `mark_client_message_read` file from #4594).
- Regression over `backend/tests/unit/routers/` + `backend/tests/routers/`: **exit 0, zero FAILED/ERROR**.
- `ruff check` clean.
- The guard is never patched out in tests — the connection is mocked so the real `verify_client_access` runs.