### PR TITLE
fix(portal): an invitation is a credential — stop leaking it, stop letting it reset a live account

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal_invite.py
+++ b/apps/backend-rag/backend/app/routers/portal_invite.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, EmailStr, field_validator
 from backend.app.core.config import settings
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.services.internal_email import send_internal_email
+from backend.app.utils.crm_utils import verify_client_access
 from backend.app.utils.logging_utils import get_logger
 from backend.app.utils.service_accounts import is_human_team_member
 from backend.services.portal import InviteService
@@ -159,6 +160,20 @@ async def send_portal_invite_email(
     )
 
 
+def _invitation_public_view(result: dict[str, Any]) -> dict[str, Any]:
+    """Strip the raw invite credential from a service result before it goes in a response.
+
+    `token` and any URL that embeds it (`invite_url`) are the credential that
+    completes registration and takes over — or reactivates — a client's portal
+    account (`POST /api/portal/invite/complete` is public, unauthenticated).
+    The only legitimate channel for either value is the Brevo email built by
+    `send_portal_invite_email`. This view is applied at the ROUTER boundary,
+    never inside `InviteService`, because `send_invitation` still needs the
+    raw token/URL to build that email before stripping the HTTP response.
+    """
+    return {key: value for key, value in result.items() if key not in {"token", "invite_url"}}
+
+
 # ================================================
 # TEAM-SIDE ENDPOINTS (Require team auth)
 # ================================================
@@ -182,6 +197,17 @@ async def send_invitation(
         raise HTTPException(
             status_code=403,
             detail="Clients cannot send invitations",
+        )
+
+    # Client-level access check: a human team role alone is not enough — the
+    # caller must be assigned to (or admin over) THIS client. write=True also
+    # denies machine principals by construction (a service-account email
+    # matches neither assigned_to nor created_by). Runs before the try block
+    # below so verify_client_access's HTTPException(403/404) is never
+    # swallowed by the generic `except Exception` inside it.
+    async with db_pool.acquire() as conn:
+        await verify_client_access(
+            request.client_id, current_user, conn, allow_assigned=True, write=True
         )
 
     try:
@@ -222,10 +248,10 @@ async def send_invitation(
             + (" and email sent" if email_sent else " (email not sent - check email service)"),
             "email_sent": email_sent,
             "email_error": email_error if not email_sent else None,
-            "data": {
-                **result,
-                "full_invite_url": full_invite_url,
-            },
+            # `full_invite_url` (built above, purely for the Brevo email) is
+            # deliberately NOT included here — it embeds the same raw token as
+            # `invite_url` and would defeat the point of stripping it.
+            "data": _invitation_public_view(result),
         }
 
     except ValueError as e:
@@ -243,6 +269,7 @@ async def get_client_invitations(
     client_id: int,
     current_user: dict = Depends(get_current_user),
     invite_service: InviteService = Depends(get_invite_service),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
     """
     Get all invitations for a client (team member action).
@@ -254,6 +281,11 @@ async def get_client_invitations(
             status_code=403,
             detail="Clients cannot view invitation history",
         )
+
+    # See send_invitation for the rationale — same client-level gate, run
+    # before the try block so its HTTPException is never rewritten to a 500.
+    async with db_pool.acquire() as conn:
+        await verify_client_access(client_id, current_user, conn, allow_assigned=True, write=True)
 
     try:
         invitations = await invite_service.get_client_invitations(client_id)
@@ -274,6 +306,7 @@ async def resend_invitation(
     client_id: int,
     current_user: dict = Depends(get_current_user),
     invite_service: InviteService = Depends(get_invite_service),
+    db_pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
     """
     Resend invitation to a client (creates new token).
@@ -283,6 +316,11 @@ async def resend_invitation(
             status_code=403,
             detail="Clients cannot resend invitations",
         )
+
+    # See send_invitation for the rationale — same client-level gate, run
+    # before the try block so its HTTPException is never rewritten to a 500.
+    async with db_pool.acquire() as conn:
+        await verify_client_access(client_id, current_user, conn, allow_assigned=True, write=True)
 
     try:
         result = await invite_service.resend_invitation(
@@ -295,7 +333,7 @@ async def resend_invitation(
         return {
             "success": True,
             "message": "Invitation resent successfully",
-            "data": result,
+            "data": _invitation_public_view(result),
         }
 
     except ValueError as e:

--- a/apps/backend-rag/backend/services/portal/invite_service.py
+++ b/apps/backend-rag/backend/services/portal/invite_service.py
@@ -207,7 +207,8 @@ class InviteService:
                 existing_user = await conn.fetchrow(
                     """
                     SELECT id, active, pin_hash FROM team_members
-                    WHERE linked_client_id = $1 AND role = 'client'
+                    WHERE linked_client_id = $1
+                    ORDER BY (role = 'client') DESC, created_at
                     """,
                     invitation["client_id"],
                 )

--- a/apps/backend-rag/backend/services/portal/invite_service.py
+++ b/apps/backend-rag/backend/services/portal/invite_service.py
@@ -58,9 +58,10 @@ class InviteService:
         expires_at = datetime.now(timezone.utc) + timedelta(hours=INVITE_EXPIRY_HOURS)
 
         async with self.pool.acquire() as conn:
-            # Check if client exists
+            # Check if client exists and is not archived — an archived client
+            # must never be (re-)invited into an active portal account.
             client = await conn.fetchrow(
-                "SELECT id, full_name, email FROM clients WHERE id = $1",
+                "SELECT id, full_name, email FROM clients WHERE id = $1 AND deleted_at IS NULL",
                 client_id,
             )
             if not client:
@@ -182,7 +183,7 @@ class InviteService:
                     SELECT i.id, i.client_id, i.email, i.expires_at, i.used_at,
                            c.full_name as client_name
                     FROM client_invitations i
-                    JOIN clients c ON c.id = i.client_id
+                    JOIN clients c ON c.id = i.client_id AND c.deleted_at IS NULL
                     WHERE i.token = $1
                     FOR UPDATE
                     """,
@@ -204,14 +205,22 @@ class InviteService:
                 # Check if team_member already exists for this client
                 existing_user = await conn.fetchrow(
                     """
-                    SELECT id FROM team_members
+                    SELECT id, active FROM team_members
                     WHERE linked_client_id = $1
                     """,
                     invitation["client_id"],
                 )
 
                 if existing_user:
-                    # Update existing user
+                    # Consuming an invitation is not proof the consumer controls
+                    # the client's mailbox — it must never function as a
+                    # password reset on a live account. Re-onboarding an
+                    # INACTIVE account (the legitimate re-invite flow) stays
+                    # allowed below.
+                    if existing_user["active"]:
+                        raise ValueError("This client already has an active portal account")
+
+                    # Update existing (inactive) user
                     await conn.execute(
                         """
                         UPDATE team_members
@@ -320,9 +329,10 @@ class InviteService:
     ) -> dict[str, Any]:
         """Resend invitation to a client (creates new token)."""
         async with self.pool.acquire() as conn:
-            # Get client email
+            # Get client email — archived clients are excluded so an archived
+            # client can't be re-invited via the resend path either.
             client = await conn.fetchrow(
-                "SELECT email FROM clients WHERE id = $1",
+                "SELECT email FROM clients WHERE id = $1 AND deleted_at IS NULL",
                 client_id,
             )
             if not client or not client["email"]:

--- a/apps/backend-rag/backend/services/portal/invite_service.py
+++ b/apps/backend-rag/backend/services/portal/invite_service.py
@@ -16,6 +16,7 @@ import bcrypt
 
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.cache import cache_invalidating
+from backend.services.portal.portal_profile_service import PLACEHOLDER_PIN_HASH
 
 logger = get_logger(__name__)
 
@@ -124,7 +125,7 @@ class InviteService:
                 SELECT i.id, i.client_id, i.email, i.expires_at, i.used_at,
                        c.full_name as client_name
                 FROM client_invitations i
-                JOIN clients c ON c.id = i.client_id
+                JOIN clients c ON c.id = i.client_id AND c.deleted_at IS NULL
                 WHERE i.token = $1
                 """,
                 token,
@@ -205,8 +206,8 @@ class InviteService:
                 # Check if team_member already exists for this client
                 existing_user = await conn.fetchrow(
                     """
-                    SELECT id, active FROM team_members
-                    WHERE linked_client_id = $1
+                    SELECT id, active, pin_hash FROM team_members
+                    WHERE linked_client_id = $1 AND role = 'client'
                     """,
                     invitation["client_id"],
                 )
@@ -214,13 +215,27 @@ class InviteService:
                 if existing_user:
                     # Consuming an invitation is not proof the consumer controls
                     # the client's mailbox — it must never function as a
-                    # password reset on a live account. Re-onboarding an
-                    # INACTIVE account (the legitimate re-invite flow) stays
-                    # allowed below.
-                    if existing_user["active"]:
+                    # password reset on a LIVE account.
+                    #
+                    # `active` alone cannot express "live": `create_client` calls
+                    # `ensure_portal_profile`, which provisions EVERY CRM client as
+                    # `active=true` carrying PLACEHOLDER_PIN_HASH. Gating on the
+                    # flag therefore refuses the ordinary first-time registration
+                    # — the very flow this guard exists to protect — while the
+                    # takeover it targets keeps working on any account that
+                    # happens to be inactive.
+                    #
+                    # The credential itself is the honest signal: a row still
+                    # holding the placeholder has never been registered, so
+                    # writing the first real PIN over it is onboarding, not
+                    # takeover. Both other cases stay as before — a real PIN on
+                    # an active row is refused, and a deactivated account may be
+                    # re-onboarded.
+                    already_registered = existing_user["pin_hash"] != PLACEHOLDER_PIN_HASH
+                    if already_registered and existing_user["active"]:
                         raise ValueError("This client already has an active portal account")
 
-                    # Update existing (inactive) user
+                    # Update existing (never-registered or deactivated) user
                     await conn.execute(
                         """
                         UPDATE team_members

--- a/apps/backend-rag/backend/services/portal/portal_profile_service.py
+++ b/apps/backend-rag/backend/services/portal/portal_profile_service.py
@@ -18,7 +18,14 @@ logger = get_logger(__name__)
 
 # Placeholder bcrypt hash for "$NOLOGIN$" — login attempts will never match.
 # The real pin_hash is set when the client completes registration via invite.
-_PLACEHOLDER_PIN_HASH = "$2b$12$000000000000000000000uNOLOGIN.placeholder.hash.nevermatches"
+#
+# PUBLIC ON PURPOSE: this value is a CONTRACT between the two halves of the
+# onboarding flow, not a private detail. `ensure_portal_profile` writes it with
+# `active=true`, and `InviteService.complete_registration` reads it back as the
+# ONLY reliable "this account has never been registered" signal — the `active`
+# flag cannot carry that meaning, because every CRM-created client is already
+# active from the moment the profile is provisioned.
+PLACEHOLDER_PIN_HASH = "$2b$12$000000000000000000000uNOLOGIN.placeholder.hash.nevermatches"
 
 
 class PortalProfileService:
@@ -71,7 +78,7 @@ class PortalProfileService:
                     """,
                     full_name,
                     email,
-                    _PLACEHOLDER_PIN_HASH,
+                    PLACEHOLDER_PIN_HASH,
                     client_id,
                 )
 

--- a/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
+++ b/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
@@ -4,6 +4,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from backend.services.portal.invite_service import InviteService
+from backend.services.portal.portal_profile_service import PLACEHOLDER_PIN_HASH
+
+# A pin_hash that is NOT the placeholder: a client who really completed
+# registration once. The distinction between this and PLACEHOLDER_PIN_HASH is
+# the whole point of the guard below.
+REAL_PIN_HASH = "$2b$12$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123"
 
 
 class AcquireContext:
@@ -317,7 +323,7 @@ async def test_complete_registration_rejects_active_existing_account() -> None:
                 "used_at": None,
                 "client_name": "Client Name",
             },
-            {"id": 55, "active": True},
+            {"id": 55, "active": True, "pin_hash": REAL_PIN_HASH},
         ]
     )
     service = InviteService(FakePool(conn))
@@ -346,7 +352,7 @@ async def test_complete_registration_reactivates_inactive_existing_account() -> 
                 "used_at": None,
                 "client_name": "Client Name",
             },
-            {"id": 55, "active": False},
+            {"id": 55, "active": False, "pin_hash": REAL_PIN_HASH},
         ]
     )
     service = InviteService(FakePool(conn))
@@ -370,3 +376,99 @@ async def test_complete_registration_reactivates_inactive_existing_account() -> 
     update_query, update_args = conn.execute_calls[0]
     assert "SET pin_hash = $1, active = true, portal_access = true" in update_query
     assert update_args[1] == 55
+
+
+@pytest.mark.asyncio
+async def test_complete_registration_allows_placeholder_active_account() -> None:
+    """A2 REGRESSION — the ordinary first-time registration must succeed.
+
+    `create_client` calls `ensure_portal_profile` (crm_clients.py:736), which
+    provisions EVERY CRM client into `team_members` as `active=true` carrying
+    PLACEHOLDER_PIN_HASH. An earlier revision of this guard refused on the
+    `active` flag alone, which would have rejected essentially every real
+    client's first invite completion while still letting a takeover through on
+    any inactive row — a self-DoS of the flow the guard exists to protect.
+
+    Found by an adversarial review of the patch, not by the patch's own tests:
+    the two tests above BOTH pass under the broken guard, because neither
+    fixture carried a placeholder PIN. That is the gap this test closes."""
+    now = datetime.now(timezone.utc)
+    conn = FakeConnectionWithTransaction(
+        fetchrow_results=[
+            {
+                "id": 9,
+                "client_id": 7,
+                "email": "client@example.com",
+                "expires_at": now + timedelta(hours=1),
+                "used_at": None,
+                "client_name": "Client Name",
+            },
+            # active=True AND never registered — the provisioned-but-unused row.
+            {"id": 55, "active": True, "pin_hash": PLACEHOLDER_PIN_HASH},
+        ]
+    )
+    service = InviteService(FakePool(conn))
+
+    with patch(
+        "backend.services.common.cache._invalidate_cache",
+        new=AsyncMock(return_value=1),
+    ):
+        result = await service.complete_registration(token="tok", pin="1234")
+
+    assert result["success"] is True
+    assert result["user_id"] == 55
+    # The real PIN is written over the placeholder — this IS onboarding.
+    update_query, update_args = conn.execute_calls[0]
+    assert "SET pin_hash = $1, active = true, portal_access = true" in update_query
+    assert update_args[1] == 55
+
+
+@pytest.mark.asyncio
+async def test_existing_account_lookup_is_scoped_to_the_client_role() -> None:
+    """The lookup must not gate on an arbitrary row: `team_members` mixes staff
+    and client-portal logins in one table, so without `role = 'client'` a stray
+    staff row sharing `linked_client_id` could decide whether a client may
+    register."""
+    now = datetime.now(timezone.utc)
+    conn = FakeConnectionWithTransaction(
+        fetchrow_results=[
+            {
+                "id": 9,
+                "client_id": 7,
+                "email": "client@example.com",
+                "expires_at": now + timedelta(hours=1),
+                "used_at": None,
+                "client_name": "Client Name",
+            },
+            None,
+            {"id": 77},
+        ]
+    )
+    service = InviteService(FakePool(conn))
+
+    with patch(
+        "backend.services.common.cache._invalidate_cache",
+        new=AsyncMock(return_value=1),
+    ):
+        await service.complete_registration(token="tok", pin="1234")
+
+    lookup_query = conn.fetchrow_calls[1][0]
+    assert "FROM team_members" in lookup_query
+    assert "role = 'client'" in lookup_query
+    assert "pin_hash" in lookup_query
+
+
+@pytest.mark.asyncio
+async def test_validate_token_excludes_archived_clients() -> None:
+    """A4 completeness — `validate_token` is the PUBLIC read half of the same
+    invariant the minting paths enforce. Leaving it unfiltered let an archived
+    client's outstanding token still resolve, disclosing full_name/email/
+    client_id to whoever held the link before failing confusingly at complete."""
+    conn = FakeConnection(fetchrow_results=[None])
+    service = InviteService(FakePool(conn))
+
+    assert await service.validate_token("tok-archived") is None
+
+    query, args = conn.fetchrow_calls[0]
+    assert "JOIN clients c ON c.id = i.client_id AND c.deleted_at IS NULL" in query
+    assert args == ("tok-archived",)

--- a/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
+++ b/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
@@ -424,11 +424,12 @@ async def test_complete_registration_allows_placeholder_active_account() -> None
 
 
 @pytest.mark.asyncio
-async def test_existing_account_lookup_is_scoped_to_the_client_role() -> None:
-    """The lookup must not gate on an arbitrary row: `team_members` mixes staff
-    and client-portal logins in one table, so without `role = 'client'` a stray
-    staff row sharing `linked_client_id` could decide whether a client may
-    register."""
+async def test_existing_account_lookup_is_deterministic_without_role_filter() -> None:
+    """`team_members` mixes staff and client-portal logins in one table, so a
+    stray row sharing `linked_client_id` could decide whether a client may
+    register. The fix is ORDERING, not filtering: `email` is UNIQUE NOT NULL
+    (portal_qa_schema.sql:62), so a role filter that hides the existing row
+    sends the flow into INSERT and straight into a unique violation."""
     now = datetime.now(timezone.utc)
     conn = FakeConnectionWithTransaction(
         fetchrow_results=[
@@ -454,8 +455,14 @@ async def test_existing_account_lookup_is_scoped_to_the_client_role() -> None:
 
     lookup_query = conn.fetchrow_calls[1][0]
     assert "FROM team_members" in lookup_query
-    assert "role = 'client'" in lookup_query
     assert "pin_hash" in lookup_query
+    # The lookup must NOT filter by role. `linked_client_id` is what makes a row
+    # the client's portal login; filtering on role would miss a row carrying a
+    # different one, fall through to the INSERT branch, and hit
+    # `team_members.email UNIQUE` — a 500 on a path that works today.
+    assert "role = 'client'" not in lookup_query.replace("(role = 'client') DESC", "")
+    # ...but it must be deterministic: a client row wins when several share the link.
+    assert "ORDER BY (role = 'client') DESC" in lookup_query
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
+++ b/apps/backend-rag/backend/tests/services/portal/test_invite_service.py
@@ -217,3 +217,156 @@ async def test_get_client_invitations_maps_statuses() -> None:
 
     assert [invite["status"] for invite in invitations] == ["used", "expired", "pending"]
     assert conn.fetch_calls[0][1] == (7,)
+
+
+# ---------------------------------------------------------------------------
+# P0 account-takeover fix (2026-08-23, SPEC-p0-invite.md "PR A").
+#
+# A2: complete_registration must never let an invitation function as a
+#     password reset on an ALREADY-ACTIVE portal account. Re-onboarding an
+#     INACTIVE account (the legitimate re-invite flow) stays allowed.
+# A4: an archived client (clients.deleted_at IS NOT NULL) can't be
+#     (re-)invited, and an invitation JOIN can't resolve to an archived
+#     client's row. FakeConnection doesn't enforce SQL semantics — it
+#     returns whatever is queued regardless of query text — so these tests
+#     assert on the captured query text itself; a behavioral-only test
+#     (e.g. "returns None -> raises") wouldn't discriminate the fix, since
+#     the pre-fix query also raises on a genuinely-missing client. Removing
+#     "AND deleted_at IS NULL" (or "AND c.deleted_at IS NULL" on the JOIN)
+#     makes these fail while leaving every other test in this file green.
+# ---------------------------------------------------------------------------
+
+
+class _NoopTransaction:
+    """No-op async context manager standing in for asyncpg's real transaction."""
+
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakeConnectionWithTransaction(FakeConnection):
+    """FakeConnection + a working `.transaction()` for complete_registration,
+    which runs its body inside `async with conn.transaction():`."""
+
+    def transaction(self) -> _NoopTransaction:
+        return _NoopTransaction()
+
+
+@pytest.mark.asyncio
+async def test_create_invitation_excludes_archived_clients_by_query() -> None:
+    conn = FakeConnection(fetchrow_results=[None])
+    service = InviteService(FakePool(conn))
+
+    with pytest.raises(ValueError, match="Client with ID 501 not found"):
+        await service.create_invitation(
+            client_id=501,
+            email="archived@example.com",
+            created_by="team@example.com",
+        )
+
+    query, args = conn.fetchrow_calls[0]
+    assert "deleted_at IS NULL" in query
+    assert args == (501,)
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_excludes_archived_clients_by_query() -> None:
+    conn = FakeConnection(fetchrow_results=[None])
+    service = InviteService(FakePool(conn))
+
+    with pytest.raises(ValueError, match="Client not found or has no email"):
+        await service.resend_invitation(client_id=501, created_by="team@example.com")
+
+    query, args = conn.fetchrow_calls[0]
+    assert "deleted_at IS NULL" in query
+    assert args == (501,)
+
+
+@pytest.mark.asyncio
+async def test_complete_registration_join_excludes_archived_clients_by_query() -> None:
+    """A4 — the invitation JOIN must not resolve to an archived client's row
+    (invite created before the client was archived; token still exists but
+    must no longer function)."""
+    conn = FakeConnectionWithTransaction(fetchrow_results=[None])
+    service = InviteService(FakePool(conn))
+
+    with pytest.raises(ValueError, match="Invalid invitation token"):
+        await service.complete_registration(token="tok-archived", pin="1234")
+
+    query, args = conn.fetchrow_calls[0]
+    assert "c.deleted_at IS NULL" in query
+    assert args == ("tok-archived",)
+
+
+@pytest.mark.asyncio
+async def test_complete_registration_rejects_active_existing_account() -> None:
+    """A2 GUILT — consuming an invitation must never reset the PIN of an
+    ACTIVE account. This is the exact chain step (#3 in SPEC-p0-invite.md)
+    that turned a leaked invite link into a full account takeover."""
+    now = datetime.now(timezone.utc)
+    conn = FakeConnectionWithTransaction(
+        fetchrow_results=[
+            {
+                "id": 9,
+                "client_id": 7,
+                "email": "victim@example.com",
+                "expires_at": now + timedelta(hours=1),
+                "used_at": None,
+                "client_name": "Client Name",
+            },
+            {"id": 55, "active": True},
+        ]
+    )
+    service = InviteService(FakePool(conn))
+
+    with pytest.raises(ValueError, match="already has an active portal account"):
+        await service.complete_registration(token="tok", pin="1234")
+
+    # The guard must trip BEFORE any mutation — no UPDATE/INSERT at all.
+    assert conn.execute_calls == []
+
+
+@pytest.mark.asyncio
+async def test_complete_registration_reactivates_inactive_existing_account() -> None:
+    """A2 INNOCENCE — re-onboarding an INACTIVE account (the legitimate
+    re-invite flow) must keep working. Same fixture shape as the GUILT test
+    above except `active: False` — this is what makes the guilt test a real
+    discriminator rather than "any existing_user rejects"."""
+    now = datetime.now(timezone.utc)
+    conn = FakeConnectionWithTransaction(
+        fetchrow_results=[
+            {
+                "id": 9,
+                "client_id": 7,
+                "email": "client@example.com",
+                "expires_at": now + timedelta(hours=1),
+                "used_at": None,
+                "client_name": "Client Name",
+            },
+            {"id": 55, "active": False},
+        ]
+    )
+    service = InviteService(FakePool(conn))
+
+    with patch(
+        "backend.services.common.cache._invalidate_cache",
+        new=AsyncMock(return_value=1),
+    ):
+        result = await service.complete_registration(token="tok", pin="1234")
+
+    assert result == {
+        "success": True,
+        "user_id": 55,
+        "client_id": 7,
+        "email": "client@example.com",
+        "name": "Client Name",
+    }
+    # 3 mutations: reactivate the team_member row, mark the invitation used,
+    # seed default client_preferences.
+    assert len(conn.execute_calls) == 3
+    update_query, update_args = conn.execute_calls[0]
+    assert "SET pin_hash = $1, active = true, portal_access = true" in update_query
+    assert update_args[1] == 55

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_invite.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_invite.py
@@ -36,7 +36,7 @@ class FakeInviteService:
         }
         return {
             "client_id": client_id,
-            "client_name": "Kaiser Test",
+            "client_name": "Test Client",
             "email": email,
             "invite_url": "/portal/invite?token=tok-123",
             "token": "tok-123",
@@ -52,8 +52,8 @@ async def test_send_portal_invite_email_uses_internal_brevo_adapter() -> None:
         new=AsyncMock(),
     ) as mock_sender:
         await send_portal_invite_email(
-            to="kaiser@example.com",
-            client_name='Kaiser & "Demo"',
+            to="client@example.com",
+            client_name='Test Client & "Demo"',
             invite_url="https://my.balizero.com/portal/invite?token=abc&x=1",
             db_pool=db_pool,
             client_id=11898,
@@ -61,22 +61,31 @@ async def test_send_portal_invite_email_uses_internal_brevo_adapter() -> None:
 
     assert mock_sender.await_count == 1
     kwargs = mock_sender.await_args.kwargs
-    assert kwargs["to"] == "kaiser@example.com"
+    assert kwargs["to"] == "client@example.com"
     assert kwargs["subject"] == "Welcome to Bali Zero Client Portal"
     assert kwargs["raise_on_failure"] is True
     assert kwargs["email_type"] == "welcome"
     assert kwargs["pool"] is db_pool
     assert kwargs["client_id"] == 11898
-    assert "Kaiser &amp; &quot;Demo&quot;" in kwargs["body"]
+    assert "Test Client &amp; &quot;Demo&quot;" in kwargs["body"]
     assert "token=abc&amp;x=1" in kwargs["body"]
 
 
 @pytest.mark.asyncio
 async def test_send_invitation_sends_email_through_internal_adapter(
     monkeypatch: pytest.MonkeyPatch,
+    mock_db_pool: MagicMock,
 ) -> None:
     fake_service = FakeInviteService()
-    db_pool = MagicMock()
+    db_pool = mock_db_pool
+    # role="Founder" is admin via is_crm_admin's role check, so the A3
+    # verify_client_access(write=True) gate passes regardless of assigned_to —
+    # a row must still exist or verify_client_access 404s before we get here.
+    db_pool._mock_conn.fetchrow.return_value = {
+        "id": 11898,
+        "assigned_to": None,
+        "created_by": None,
+    }
     monkeypatch.setattr(
         "backend.app.routers.portal_invite.settings.frontend_portal_url",
         "https://my.balizero.com",
@@ -89,7 +98,7 @@ async def test_send_invitation_sends_email_through_internal_adapter(
         response = await send_invitation(
             SendInviteRequest(
                 client_id=11898,
-                email="kaiser198719871987@gmail.com",
+                email="client@example.com",
             ),
             current_user={"email": "zero@balizero.com", "role": "Founder"},
             invite_service=fake_service,  # type: ignore[arg-type]
@@ -102,23 +111,33 @@ async def test_send_invitation_sends_email_through_internal_adapter(
     assert "email sent" in response["message"]
     assert fake_service.created == {
         "client_id": 11898,
-        "email": "kaiser198719871987@gmail.com",
+        "email": "client@example.com",
         "created_by": "zero@balizero.com",
     }
     mock_sender.assert_awaited_once_with(
-        to="kaiser198719871987@gmail.com",
-        client_name="Kaiser Test",
+        to="client@example.com",
+        client_name="Test Client",
         invite_url="https://my.balizero.com/portal/invite?token=tok-123",
         db_pool=db_pool,
         client_id=11898,
     )
+    # A1 regression guard: the raw credential never reaches the response body.
+    assert "token" not in response["data"]
+    assert "invite_url" not in response["data"]
+    assert "full_invite_url" not in response["data"]
 
 
 @pytest.mark.asyncio
 async def test_send_invitation_reports_email_failure(
     monkeypatch: pytest.MonkeyPatch,
+    mock_db_pool: MagicMock,
 ) -> None:
     fake_service = FakeInviteService()
+    mock_db_pool._mock_conn.fetchrow.return_value = {
+        "id": 11898,
+        "assigned_to": None,
+        "created_by": None,
+    }
     monkeypatch.setattr(
         "backend.app.routers.portal_invite.settings.frontend_portal_url",
         "https://my.balizero.com",
@@ -131,11 +150,11 @@ async def test_send_invitation_reports_email_failure(
         response = await send_invitation(
             SendInviteRequest(
                 client_id=11898,
-                email="kaiser198719871987@gmail.com",
+                email="client@example.com",
             ),
             current_user={"email": "zero@balizero.com", "role": "Founder"},
             invite_service=fake_service,  # type: ignore[arg-type]
-            db_pool=MagicMock(),
+            db_pool=mock_db_pool,
         )
 
     assert response["success"] is True
@@ -193,10 +212,22 @@ async def test_get_client_invitations_rejects_monitoring_service_account() -> No
 
 
 @pytest.mark.asyncio
-async def test_get_client_invitations_allows_a_realistic_free_text_role() -> None:
+async def test_get_client_invitations_allows_a_realistic_free_text_role(
+    mock_db_pool: MagicMock,
+) -> None:
     """Innocence: a real, free-text team-role title must still pass through
-    to the service call (this repo's roles are job titles, not an enum)."""
+    to the service call (this repo's roles are job titles, not an enum).
+
+    "Board Member" is admin via is_crm_admin's role check (crm_utils.py), so
+    the A3 verify_client_access(write=True) gate passes regardless of
+    assigned_to — a client row must still exist or it 404s.
+    """
     fake_service = FakeInviteService()
+    mock_db_pool._mock_conn.fetchrow.return_value = {
+        "id": 1,
+        "assigned_to": None,
+        "created_by": None,
+    }
 
     async def _get_client_invitations(client_id: int) -> list[dict[str, object]]:
         return [{"client_id": client_id, "status": "pending"}]
@@ -207,6 +238,7 @@ async def test_get_client_invitations_allows_a_realistic_free_text_role() -> Non
         client_id=1,
         current_user={"email": "board@balizero.com", "role": "Board Member"},
         invite_service=fake_service,  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
     )
 
     assert response["success"] is True
@@ -225,9 +257,20 @@ async def test_resend_invitation_rejects_monitoring_service_account() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resend_invitation_allows_a_realistic_free_text_role() -> None:
-    """Innocence: a real, free-text team-role title must still pass through."""
+async def test_resend_invitation_allows_a_realistic_free_text_role(
+    mock_db_pool: MagicMock,
+) -> None:
+    """Innocence: a real, free-text team-role title must still pass through
+    when the caller is assigned to (or created) the client — "Reception" is
+    not an admin role, so the A3 verify_client_access(write=True) gate needs
+    an ownership match, unlike the Board-Member case above.
+    """
     fake_service = FakeInviteService()
+    mock_db_pool._mock_conn.fetchrow.return_value = {
+        "id": 1,
+        "assigned_to": "reception@balizero.com",
+        "created_by": "reception@balizero.com",
+    }
 
     async def _resend_invitation(*, client_id: int, created_by: str) -> dict[str, object]:
         return {"client_id": client_id, "created_by": created_by}
@@ -238,6 +281,7 @@ async def test_resend_invitation_allows_a_realistic_free_text_role() -> None:
         client_id=1,
         current_user={"email": "reception@balizero.com", "role": "Reception"},
         invite_service=fake_service,  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
     )
 
     assert response["success"] is True

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_invite_p0_capability.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_invite_p0_capability.py
@@ -1,0 +1,464 @@
+"""P0 account-takeover fix — PR A (2026-08-23).
+
+Ground-verified chain this PR closes (see SPEC-p0-invite.md, section "PR A"):
+
+1. `POST /api/portal/invite/resend/{client_id}` was guarded only by
+   `is_human_team_member(current_user.get("role"))` — no client-access check,
+   arbitrary `client_id`. Same for `send_invitation` and
+   `get_client_invitations`.
+2. The HTTP response carried the RAW token and the victim's email under
+   `data`. Anyone who could reach #1 (including, before the widened-Subhi-era
+   API-key/internal-role deny-list gap, non-human machine principals) got a
+   working credential back in the response body.
+3. `POST /api/portal/invite/complete` (public, no auth — it IS registration)
+   consumes that token and overwrites `team_members.pin_hash`, reactivating
+   ANY existing account for that client — including an already-ACTIVE one.
+4. Login with the leaked email + chosen PIN → full portal session as that
+   client.
+
+This file covers A1 (no raw token/invite_url ever leaves the router) and A3
+(client-level access gating on send/resend/history) at the router layer.
+A2 (active-account guard) and A4's InviteService-level `deleted_at` filters
+live in `backend/tests/services/portal/test_invite_service.py` — that is
+where InviteService is already unit-tested with its own FakePool/FakeConnection
+harness.
+
+IMPORTANT — nothing here mocks `verify_client_access` itself (that would
+prove nothing about the fix: patching the guard away runs no guard at all).
+Every A3 test drives the REAL `verify_client_access`
+(`backend.app.utils.crm_utils`), mocking only the asyncpg connection it reads
+from — same harness as `test_crm_portal_mark_read_bola.py`
+(`mock_db_pool._mock_conn.fetchrow`, the shared fixture in `conftest.py`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from backend.app.routers.portal_invite import (
+    SendInviteRequest,
+    _invitation_public_view,
+    get_client_invitations,
+    resend_invitation,
+    send_invitation,
+)
+
+ADMIN_EMAIL = "asya@balizero.com"  # backend.app.utils.crm_utils.CRM_EXTRA_ADMIN_EMAILS
+
+RAW_TOKEN = "super-secret-raw-invite-token"
+RAW_INVITE_URL = f"/portal/register?token={RAW_TOKEN}"
+
+
+class _StubInviteService:
+    """Minimal async stand-in for InviteService — returns realistic payloads
+    (including the raw token/invite_url) so the tests can prove the ROUTER,
+    not the service, is what strips them."""
+
+    async def create_invitation(
+        self, *, client_id: int, email: str, created_by: str
+    ) -> dict[str, Any]:
+        return {
+            "invitation_id": 1,
+            "client_id": client_id,
+            "client_name": "Stub Client",
+            "email": email,
+            "token": RAW_TOKEN,
+            "expires_at": "2026-01-01T00:00:00+00:00",
+            "invite_url": RAW_INVITE_URL,
+        }
+
+    async def get_client_invitations(self, client_id: int) -> list[dict[str, Any]]:
+        return [{"id": 1, "email": "client@example.com", "status": "pending"}]
+
+    async def resend_invitation(self, *, client_id: int, created_by: str) -> dict[str, Any]:
+        return {
+            "invitation_id": 2,
+            "client_id": client_id,
+            "client_name": "Stub Client",
+            "email": "client@example.com",
+            "token": RAW_TOKEN,
+            "expires_at": "2026-01-01T00:00:00+00:00",
+            "invite_url": RAW_INVITE_URL,
+        }
+
+
+def _client_row(*, assigned_to: str | None, created_by: str | None = None) -> dict[str, object]:
+    return {
+        "id": 1,
+        "assigned_to": assigned_to,
+        "created_by": created_by if created_by is not None else assigned_to,
+    }
+
+
+# ---------------------------------------------------------------------------
+# A1 — the raw token/invite_url never leaves the process in a response body.
+# ---------------------------------------------------------------------------
+
+
+def test_invitation_public_view_strips_token_and_invite_url() -> None:
+    """Direct unit test of the helper — the smallest possible discrimination
+    surface. Mutate the helper to drop the exclusion set (or to exclude the
+    wrong keys) and this fails immediately, independent of any router wiring.
+    """
+    result = {
+        "invitation_id": 1,
+        "client_id": 7,
+        "client_name": "Kaiser Test",
+        "email": "kaiser@example.com",
+        "token": RAW_TOKEN,
+        "expires_at": "2026-01-01T00:00:00+00:00",
+        "invite_url": RAW_INVITE_URL,
+    }
+
+    view = _invitation_public_view(result)
+
+    assert "token" not in view
+    assert "invite_url" not in view
+    # Everything else must survive untouched (spec: keep invitation_id,
+    # client_id, client_name, email, expires_at).
+    assert view == {
+        "invitation_id": 1,
+        "client_id": 7,
+        "client_name": "Kaiser Test",
+        "email": "kaiser@example.com",
+        "expires_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_response_never_carries_token_or_any_link(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_db_pool: MagicMock,
+) -> None:
+    """A1, wired end-to-end through send_invitation.
+
+    Also pins the router-level deviation from the spec's literal text: the
+    spec named only `token`/`invite_url` as the keys to strip, but
+    `send_invitation` additionally computed `full_invite_url` (base_url +
+    invite_url) and put THAT in the response too — which embeds the exact
+    same raw token in a ready-to-click link. Stripping token/invite_url alone
+    would not have closed the leak for this endpoint; `full_invite_url` must
+    never be included in the response body either.
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to=ADMIN_EMAIL)
+    monkeypatch.setattr(
+        "backend.app.routers.portal_invite.settings.frontend_portal_url",
+        "https://my.balizero.com",
+    )
+
+    with patch(
+        "backend.app.routers.portal_invite.send_portal_invite_email",
+        new=AsyncMock(),
+    ):
+        response = await send_invitation(
+            SendInviteRequest(client_id=1, email="client@example.com"),
+            current_user={"email": ADMIN_EMAIL, "role": "team"},
+            invite_service=_StubInviteService(),  # type: ignore[arg-type]
+            db_pool=mock_db_pool,
+        )
+
+    assert response["success"] is True
+    data = response["data"]
+    assert "token" not in data
+    assert "invite_url" not in data
+    assert "full_invite_url" not in data
+    # Negative-content check too — RAW_TOKEN must not appear anywhere in the
+    # serialized response, not just under the keys we know about today.
+    assert RAW_TOKEN not in repr(response)
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_response_never_carries_token_or_url(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to=ADMIN_EMAIL)
+
+    response = await resend_invitation(
+        client_id=1,
+        current_user={"email": ADMIN_EMAIL, "role": "team"},
+        invite_service=_StubInviteService(),  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
+    )
+
+    assert response["success"] is True
+    data = response["data"]
+    assert "token" not in data
+    assert "invite_url" not in data
+    assert RAW_TOKEN not in repr(response)
+
+
+# ---------------------------------------------------------------------------
+# A3 — minting/reading/resending an invitation requires client access.
+# Guilt: non-assigned, non-admin human team member -> 403, never 500.
+# Innocence: assigned team member -> allowed. Admin -> allowed regardless.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_non_assigned_non_admin_denied_403_not_500(
+    mock_db_pool: MagicMock,
+) -> None:
+    """GUILT. Before A3, `is_human_team_member` was the ONLY gate — any human
+    team-role login could mint a live Brevo invite for an arbitrary
+    `client_id`. This drives the REAL `verify_client_access` write=True
+    branch; nothing here mocks the guard away.
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await send_invitation(
+            SendInviteRequest(client_id=1, email="victim@example.com"),
+            current_user={"email": "bob@balizero.com", "role": "team"},
+            invite_service=MagicMock(),  # must never be reached
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_assigned_team_member_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_db_pool: MagicMock,
+) -> None:
+    """INNOCENCE — assigned_to match."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+    monkeypatch.setattr(
+        "backend.app.routers.portal_invite.settings.frontend_portal_url",
+        "https://my.balizero.com",
+    )
+
+    with patch(
+        "backend.app.routers.portal_invite.send_portal_invite_email",
+        new=AsyncMock(),
+    ):
+        response = await send_invitation(
+            SendInviteRequest(client_id=1, email="client@example.com"),
+            current_user={"email": "alice@balizero.com", "role": "team"},
+            invite_service=_StubInviteService(),  # type: ignore[arg-type]
+            db_pool=mock_db_pool,
+        )
+
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_admin_allowed_regardless_of_assignment(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_db_pool: MagicMock,
+) -> None:
+    """INNOCENCE — admin bypasses the ownership check entirely."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+    monkeypatch.setattr(
+        "backend.app.routers.portal_invite.settings.frontend_portal_url",
+        "https://my.balizero.com",
+    )
+
+    with patch(
+        "backend.app.routers.portal_invite.send_portal_invite_email",
+        new=AsyncMock(),
+    ):
+        response = await send_invitation(
+            SendInviteRequest(client_id=1, email="client@example.com"),
+            current_user={"email": ADMIN_EMAIL, "role": "team"},
+            invite_service=_StubInviteService(),  # type: ignore[arg-type]
+            db_pool=mock_db_pool,
+        )
+
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_client_invitations_non_assigned_non_admin_denied_403_not_500(
+    mock_db_pool: MagicMock,
+) -> None:
+    """GUILT — history endpoint. Before A3 this had no `db_pool` dependency
+    at all: any human team-role login could read any client's invitation
+    history (id/email/status/expiry).
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_client_invitations(
+            client_id=1,
+            current_user={"email": "bob@balizero.com", "role": "team"},
+            invite_service=MagicMock(),  # must never be reached
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+
+
+@pytest.mark.asyncio
+async def test_get_client_invitations_assigned_team_member_allowed(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+
+    response = await get_client_invitations(
+        client_id=1,
+        current_user={"email": "alice@balizero.com", "role": "team"},
+        invite_service=_StubInviteService(),  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
+    )
+
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_client_invitations_admin_allowed_regardless_of_assignment(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+
+    response = await get_client_invitations(
+        client_id=1,
+        current_user={"email": ADMIN_EMAIL, "role": "team"},
+        invite_service=_StubInviteService(),  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
+    )
+
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_non_assigned_non_admin_denied_403_not_500(
+    mock_db_pool: MagicMock,
+) -> None:
+    """GUILT — this is the exact endpoint named in the verified chain
+    (`POST /api/portal/invite/resend/{client_id}`, portal_invite.py:271 in
+    the spec's ground-truth read).
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resend_invitation(
+            client_id=1,
+            current_user={"email": "bob@balizero.com", "role": "team"},
+            invite_service=MagicMock(),  # must never be reached
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_assigned_team_member_allowed(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+
+    response = await resend_invitation(
+        client_id=1,
+        current_user={"email": "alice@balizero.com", "role": "team"},
+        invite_service=_StubInviteService(),  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
+    )
+
+    assert response["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_admin_allowed_regardless_of_assignment(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+
+    response = await resend_invitation(
+        client_id=1,
+        current_user={"email": ADMIN_EMAIL, "role": "team"},
+        invite_service=_StubInviteService(),  # type: ignore[arg-type]
+        db_pool=mock_db_pool,
+    )
+
+    assert response["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# A3 also closes the API-key / machine-principal vector by construction:
+# write=True requires the caller's email to match assigned_to/created_by or
+# is_crm_admin, and a machine principal's email matches neither.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_api_key_principal_denied_403_not_500(
+    mock_db_pool: MagicMock,
+) -> None:
+    """GUILT — an API-key-authenticated caller (role="user", per
+    `app/services/api_key_auth.py`) passes `is_human_team_member` (it is a
+    deny-list keyed on {"client","monitoring"}) but must still be denied by
+    the write=True ownership check, since it owns/is-assigned-to nothing.
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await send_invitation(
+            SendInviteRequest(client_id=1, email="victim@example.com"),
+            current_user={"email": "api-key-principal@balizero.com", "role": "user"},
+            invite_service=MagicMock(),
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+
+
+# ---------------------------------------------------------------------------
+# A4 (router layer) — verify_client_access's own client lookup already
+# filters `deleted_at IS NULL` (crm_utils.py), so an archived client 404s
+# before send/resend ever reaches InviteService. The InviteService-level
+# `deleted_at` filters (defense-in-depth for direct/non-router callers) are
+# covered in test_invite_service.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_invitation_archived_client_denied_404_not_500(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = None  # deleted_at IS NULL excludes the row
+
+    with pytest.raises(HTTPException) as exc_info:
+        await send_invitation(
+            SendInviteRequest(client_id=999999, email="client@example.com"),
+            current_user={"email": ADMIN_EMAIL, "role": "team"},
+            invite_service=MagicMock(),
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.status_code != 500
+
+
+@pytest.mark.asyncio
+async def test_resend_invitation_archived_client_denied_404_not_500(
+    mock_db_pool: MagicMock,
+) -> None:
+    mock_db_pool._mock_conn.fetchrow.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resend_invitation(
+            client_id=999999,
+            current_user={"email": ADMIN_EMAIL, "role": "team"},
+            invite_service=MagicMock(),
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.status_code != 500


### PR DESCRIPTION
## P0 — closes a verified, live account-takeover chain on the client portal

Found while red-teaming the kita↔my audit's auth diffs (Codex GPT-5.6, read-only xhigh), then re-verified line by line on disk before acting on it. Four steps, all reachable on `main` before this change:

1. `POST /api/portal/invite/resend/{client_id}` — guarded only by `is_human_team_member(role)`. No client-access check, arbitrary `client_id`.
2. The response carried the **raw token** and the client's email. `create_invitation` returns `token` + `invite_url`; `send_invitation` additionally added `full_invite_url` — the same secret in whole-URL form.
3. `POST /api/portal/invite/complete` is **public and unauthenticated** (it is registration). Given that token and any PIN, `complete_registration` found `team_members WHERE linked_client_id = $1` and ran `SET pin_hash = $1, active = true, portal_access = true` — overwriting a live client's PIN and reactivating the account.
4. `POST /api/auth/login` with the leaked email and the chosen PIN → full portal session as that client.

**Blast radius was wider than staff.** `is_human_team_member` is a deny-list (`role not in {"client","monitoring"}`), so ordinary API keys (role `user`) and the WA internal key (role `internal`) passed every gate built on it.

## Four cuts

| cut | what it stops |
|---|---|
| **The raw token never leaves in an HTTP response** | Stripped at the ROUTER boundary via `_invitation_public_view`, never inside `InviteService` — `send_invitation` still needs the real token to build the Brevo email, the only legitimate delivery channel. Getting this backwards would break onboarding silently. |
| **An invitation may not overwrite an ACTIVE account** | Consuming a token is not proof the consumer controls the client's mailbox, so it must never function as a password reset. Re-onboarding an **inactive** account still works — that is the legitimate re-invite flow. |
| **Minting or reading an invitation requires client access** | `write=True` on send / resend / history. This also closes the API-key vector by construction: a machine principal matches neither `assigned_to` nor `created_by` nor `is_crm_admin`. Each call sits **outside** its handler's `try`, so the 403 is never rewritten to a 500 (the defect fixed in #4594). |
| **An archived client cannot be invited or reactivated** | `deleted_at IS NULL` on the create, resend and complete lookups. This is the counterpart of #4595 — without it, the invite path could simply undo an archive. |

## Deliberately NOT done

Flipping `is_human_team_member` to an allow-list. It has 9 non-test call sites across five modules and needs a real runtime role census; guessing it locks actual staff out of kita. The `write=True` gate already denies machine principals on these endpoints, so this is defence-in-depth, not the load-bearing fix. Ledgered with its arming step in #4605.

## Also in this diff: a personal email scrubbed

`test_portal_invite.py` carried a real personal Gmail address across four fixtures — **pre-existing on `main`**, in a **public** repository. Replaced with synthetic values (Law 2). Not my mistake to fix, but I was already editing the file and leaving it would have been a choice.

## Verification

**The first pass had an untested guard and I caught it by mutation, not by reading.** Deleting the active-account check broke *no* test — the single most security-critical line in the change was decoration. That gap is now closed:

| mutation | test that catches it |
|---|---|
| remove the active-account guard | `test_complete_registration_rejects_active_existing_account` → `DID NOT RAISE <class 'ValueError'>` |
| don't strip the token | `test_send_invitation_sends_email_through_internal_adapter` → `assert 'token' not in {...}` |

- 83 tests pass across the touched surfaces.
- Wide regression (`backend/tests/unit/` + `routers/` + `services/`): exit 0, zero FAILED/ERROR.
- `ruff check` clean.
- Guards are never patched out in tests — the connection is mocked so the real code runs.

Companion PR: #4608 (the same shape in `crm_portal_integration.py`). Ledger: #4605.

⚠️ **Not armed for auto-merge yet** — a second red-team pass on this exact diff is running. It will be armed once that returns.