### PR TITLE
fix(research-os): make object_hash invariant to equivalent UTC spellings

### DIFF
--- a/apps/backend-rag/backend/tests/unit/research_os/test_hashing_timestamp_parity.py
+++ b/apps/backend-rag/backend/tests/unit/research_os/test_hashing_timestamp_parity.py
@@ -1,0 +1,183 @@
+"""Regression coverage for the UTC-timestamp hash-parity defect.
+
+CONTRACTS.md sec 3's ``UtcDateTime`` accepts two wire spellings of the same
+instant (trailing ``Z`` or ``+00:00``, ``_UTC_OFFSET_PATTERN`` in
+``primitives.py``) and places no constraint on fractional-second digit count.
+``research_os.hashing.object_hash`` has two entry paths:
+
+- a ``BaseModel`` is re-rendered through ``model_dump(mode="json", ...)``,
+  which pydantic *always* normalizes to a single spelling (``Z``, fractional
+  seconds omitted when exactly zero else zero-padded to 6 digits);
+- a plain ``Mapping`` is hashed byte-for-byte as received.
+
+A wire-valid document carrying the ``+00:00`` spelling (or non-canonical
+fractional-second padding) therefore hashes differently depending on which
+path computes it -- breaking CONTRACTS.md sec 2's "the hash procedure must be
+identical in every implementation" promise. This is a hash-computation defect
+inside ``object_hash``/``canonicalize``, not a schema-acceptance question:
+both spellings remain wire-valid; they must simply hash identically.
+
+No fixture named ``fixtures/intel_event/`` exists in this package -- only the
+foundation slice's two implemented contract kinds (``object_successor_edge``,
+``revocation_receipt``) ship fixtures today -- so the reproduction below uses
+those two real, checked-in fixtures instead.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import research_os.hashing as hashing
+from pydantic import BaseModel, ValidationError
+from research_os.cli import FIXTURES_ROOT, PACKAGE_ROOT
+from research_os.models.revocation_receipt import RevocationReceipt
+from research_os.models.successor_edge import ObjectSuccessorEdge
+
+CONTRACT_MODELS: dict[str, type[BaseModel]] = {
+    "object_successor_edge": ObjectSuccessorEdge,
+    "revocation_receipt": RevocationReceipt,
+}
+UTC_FIELD_BY_CONTRACT = {
+    "object_successor_edge": "recorded_at",
+    "revocation_receipt": "issued_at",
+}
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "research_os.cli", *args],
+        check=False,
+        capture_output=True,
+        cwd=PACKAGE_ROOT,
+        text=True,
+    )
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# --- 1. object_hash() itself must be invariant to spelling -----------------
+
+
+def test_object_hash_invariant_to_utc_offset_spelling() -> None:
+    z_spelled = {"contract_version": "research-os/v1.0.0", "issued_at": "2026-02-01T00:01:00Z"}
+    offset_spelled = {
+        "contract_version": "research-os/v1.0.0",
+        "issued_at": "2026-02-01T00:01:00+00:00",
+    }
+
+    assert hashing.object_hash(z_spelled) == hashing.object_hash(offset_spelled)
+
+
+def test_object_hash_invariant_to_fractional_second_padding() -> None:
+    unpadded = {"contract_version": "research-os/v1.0.0", "issued_at": "2026-02-01T00:01:00.5Z"}
+    padded = {
+        "contract_version": "research-os/v1.0.0",
+        "issued_at": "2026-02-01T00:01:00.500000Z",
+    }
+    zero_fraction = {
+        "contract_version": "research-os/v1.0.0",
+        "issued_at": "2026-02-01T00:01:00.000000Z",
+    }
+    no_fraction = {"contract_version": "research-os/v1.0.0", "issued_at": "2026-02-01T00:01:00Z"}
+
+    assert hashing.object_hash(unpadded) == hashing.object_hash(padded)
+    assert hashing.object_hash(zero_fraction) == hashing.object_hash(no_fraction)
+    # a genuinely different instant must still hash differently -- the fix
+    # must not collapse everything that merely *contains* a timestamp.
+    assert hashing.object_hash(unpadded) != hashing.object_hash(no_fraction)
+
+
+def test_object_hash_still_distinguishes_non_timestamp_content() -> None:
+    base = {"contract_version": "research-os/v1.0.0", "issued_at": "2026-02-01T00:01:00Z"}
+    changed = {**base, "issued_at": "2026-02-01T00:01:01Z"}
+
+    assert hashing.object_hash(base) != hashing.object_hash(changed)
+
+
+# --- 2. end-to-end reproduction on the two real, implemented fixtures ------
+
+
+def test_offset_rewritten_wire_document_validates_against_both_foundation_contracts() -> None:
+    for contract_kind, model in CONTRACT_MODELS.items():
+        field = UTC_FIELD_BY_CONTRACT[contract_kind]
+        fixture_path = FIXTURES_ROOT / contract_kind / "valid_minimal.json"
+        doc = _load(fixture_path)
+        assert doc[field].endswith("Z"), f"fixture assumption violated: {doc[field]!r}"
+
+        rewritten = copy.deepcopy(doc)
+        rewritten[field] = rewritten[field][:-1] + "+00:00"
+        # A real cross-language producer would hash the wire-valid document
+        # it is about to send using the raw-dict path (it has no reason to
+        # instantiate a Python pydantic model first).
+        rewritten["object_hash"] = hashing.object_hash(rewritten)
+
+        try:
+            model.model_validate(rewritten)
+        except ValidationError as exc:  # pragma: no cover -- failure path asserted below
+            codes = {str(error["type"]) for error in exc.errors()}
+            raise AssertionError(
+                f"{contract_kind}: a +00:00-spelled, self-consistently-hashed wire "
+                f"document was rejected by model validation: {codes}"
+            ) from exc
+
+
+# --- 3. the two CLI verbs must agree ----------------------------------------
+
+
+def test_cli_hash_and_validate_agree_on_offset_rewritten_fixture(tmp_path: Path) -> None:
+    contract_kind = "revocation_receipt"
+    field = UTC_FIELD_BY_CONTRACT[contract_kind]
+    doc = _load(FIXTURES_ROOT / contract_kind / "valid_minimal.json")
+    doc[field] = doc[field][:-1] + "+00:00"
+    doc["object_hash"] = hashing.object_hash(doc)
+
+    rewritten_path = tmp_path / "offset_variant.json"
+    rewritten_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    hash_result = _run_cli("hash", "--file", str(rewritten_path))
+    validate_result = _run_cli(
+        "validate", "--contract", contract_kind, "--file", str(rewritten_path)
+    )
+
+    assert hash_result.returncode == 0, hash_result.stdout
+    assert validate_result.returncode == 0, validate_result.stdout
+    assert json.loads(hash_result.stdout)["object_hash"] == doc["object_hash"]
+    assert json.loads(validate_result.stdout)["valid"] is True
+
+
+def test_cli_hash_matches_stored_object_hash_for_every_checked_in_fixture() -> None:
+    """The user-visible symptom: `hash` and `validate` must never disagree.
+
+    For every checked-in ``valid_*.json`` fixture (already self-consistent by
+    construction), `cli hash` must reproduce the document's own stored
+    ``object_hash`` and `cli validate` must accept it. If the two verbs ever
+    computed the hash differently, at least one of these would fail for a
+    fixture that is -- by its own filename convention -- supposed to be
+    valid.
+    """
+
+    checked = 0
+    for contract_kind in CONTRACT_MODELS:
+        contract_dir = FIXTURES_ROOT / contract_kind
+        for fixture_path in sorted(contract_dir.glob("valid_*.json")):
+            checked += 1
+            doc = _load(fixture_path)
+
+            hash_result = _run_cli("hash", "--file", str(fixture_path))
+            validate_result = _run_cli(
+                "validate", "--contract", contract_kind, "--file", str(fixture_path)
+            )
+
+            assert hash_result.returncode == 0, (fixture_path, hash_result.stdout)
+            assert validate_result.returncode == 0, (fixture_path, validate_result.stdout)
+            assert json.loads(hash_result.stdout)["object_hash"] == doc["object_hash"], fixture_path
+            assert json.loads(validate_result.stdout)["valid"] is True, fixture_path
+
+    assert checked >= 2, "expected both foundation-slice contract kinds to ship a valid fixture"

--- a/packages/research-os-core/research_os/hashing.py
+++ b/packages/research-os-core/research_os/hashing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
+from datetime import datetime
 from hashlib import sha256
 from types import MappingProxyType
 from typing import Any
@@ -22,6 +23,11 @@ from research_os.version import CONTRACT_VERSION
 
 SHA256_HEX_PATTERN = r"^[0-9a-f]{64}$"
 _SHA256_HEX_RE = re.compile(SHA256_HEX_PATTERN)
+# Recognizes a UTC-instant string in either wire-valid spelling CONTRACTS.md
+# sec 3's UtcDateTime accepts (trailing "Z" or "+00:00"), with any fractional-
+# second digit count. Disjoint, non-nested quantifiers over fixed-width digit
+# classes -- linear time, no possessive/atomic constructs needed.
+_UTC_TIMESTAMP_HASH_RE = re.compile(r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d+)?(?:Z|\+00:00)$")
 TRANSPORT_METADATA_FIELDS: Mapping[str, frozenset[str]] = MappingProxyType(
     {
         # v1.0.0 marks no field as transport metadata. Adding one changes
@@ -43,11 +49,61 @@ class HashFormatError(ValueError):
     """A canonical SHA-256 value violates the lowercase unprefixed wire rule."""
 
 
+def _fold_utc_timestamp_spelling(value: Any) -> Any:
+    """Fold every wire-valid spelling of a UTC instant to one hashable form.
+
+    ``UtcDateTime`` accepts both a trailing ``Z`` and a trailing ``+00:00``
+    for the same instant, and places no constraint on fractional-second
+    digit count -- "...T00:00:00Z" and "...T00:00:00.500Z" and
+    "...T00:00:00.500000Z" are all independently wire-valid. RFC 8785 (the
+    JCS step in `canonicalize`, below) fixes JSON *structure* only; it has no
+    opinion on datetime *semantics*, so two of these spellings survive JCS as
+    different byte strings and hash differently -- breaking CONTRACTS.md
+    sec 2's "the hash procedure must be identical in every implementation"
+    promise for the single most common field type in the contract family.
+    Confirmed reproducible on both implemented foundation contracts
+    (object_successor_edge, revocation_receipt): a document rewritten from
+    ``Z`` to ``+00:00`` and re-hashed via this raw-dict path fails model
+    validation with ``object_hash_mismatch``, because the model path
+    re-renders through pydantic's ``model_dump(mode="json")``, which always
+    normalizes to ``Z`` with 0-or-6 fractional digits.
+
+    This folds every UTC-timestamp-shaped string to the exact rendering
+    Python's own ``datetime.isoformat()`` produces for a UTC value (``Z``
+    suffix; fractional seconds omitted when exactly zero, else zero-padded
+    to 6 digits) before hashing, on BOTH the model path and the raw-dict
+    path, so a document's hash depends on the instant it names, never the
+    spelling a particular producer sent. Every other-language implementation
+    computing this same `object_hash` independently (a pre-submission
+    self-check, a content-addressed store) must apply this identical rule --
+    see CONTRACTS.md sec 2 follow-up amendment tracked alongside this fix.
+
+    Deliberately narrow, not a general timezone/format normalizer: only the
+    two spellings the frozen schema itself declares equivalent are folded.
+    A non-UTC offset, or a separator pydantic's parser tolerates but RFC3339
+    does not (e.g. a space instead of "T"), does not match and is passed
+    through unchanged -- those are schema-conformance gaps for
+    `_utc_datetime`/`_UTC_OFFSET_PATTERN` to close, not a hashing concern.
+    """
+
+    if isinstance(value, str) and _UTC_TIMESTAMP_HASH_RE.match(value):
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00" if value.endswith("Z") else value)
+        microsecond = parsed.microsecond
+        base = parsed.strftime("%Y-%m-%dT%H:%M:%S")
+        return f"{base}.{microsecond:06d}Z" if microsecond else f"{base}Z"
+    if isinstance(value, Mapping):
+        return {key: _fold_utc_timestamp_spelling(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_fold_utc_timestamp_spelling(item) for item in value]
+    return value
+
+
 def canonicalize(value: Any) -> bytes:
     """Serialize a JSON-compatible value with RFC 8785 JCS semantics."""
 
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="json", exclude_unset=True)
+    value = _fold_utc_timestamp_spelling(value)
     try:
         return rfc8785.dumps(value)
     except rfc8785.CanonicalizationError as exc:


### PR DESCRIPTION
**HIGH, and already on `main`** — not introduced by any open contract PR. `hashing.py` landed in #4586 (`f6a7dfff6`), so this has been live since the P04 foundation.

base: `868b62322df0be7fddd9cf48ebdb1c01f50b7f8d`

## The defect

`CONTRACTS.md` §2 promises the hash procedure is identical in every implementation, computed over the canonical form of the validated document. It was not. The schema deliberately accepts **two spellings of the same instant**, and the hash was not invariant to which one was used:

```
primitives.py:84   _UTC_OFFSET_PATTERN = r"(?:Z|\+00:00)$"
hashing.py:66-77   model path -> model_dump(mode="json") re-renders the value
                   dict path  -> raw wire document as-is
```

Reproduced on **both** foundation kinds, rewriting one timestamp `Z` → `+00:00` and recomputing the hash over the document:

| kind | result |
|---|---|
| `revocation_receipt` | `object_hash_mismatch` |
| `object_successor_edge` | `object_hash_mismatch` |

The package's own two public verbs disagreed on the same file: `cli hash` printed a digest that `cli validate` then rejected.

**Second axis, found while reproducing:** fractional-second padding diverges identically. `model_dump` renders `microsecond=0` with no fraction and any nonzero value zero-padded to exactly 6 digits — so `…00.5Z` and `…00.500000Z`, the same instant, hashed differently.

## Why not narrow the wire format instead

The obvious-looking alternative — "make the pattern accept only `Z`" — **would not have fixed the reproduced bug at all**. `_UTC_OFFSET_PATTERN` reaches `UtcDateTime` through `WithJsonSchema` only, which is **export-only and never runs at validation time**. Editing that constant changes the exported schema and nothing else.

That route would need a new runtime check *plus* a narrowing of a frozen contract — a version question under rule 10, not a bug fix. Raised separately below rather than smuggled in here.

A related gap this surfaced, deliberately left out of scope: Python validation is **more permissive than the exported schema**. It accepts `+0000` (no colon), a space separator instead of `T`, and nanosecond precision (silently truncated). That is a `UtcDateTime` runtime-hardening bug, distinct from this one.

## Cross-language impact — measured, not assumed

| spelling | our `object_hash` | plain RFC 8785 JCS |
|---|---|---|
| `Z` | `6ee57ff0…` | `6ee57ff0…` — **identical** |
| `+00:00` | `6ee57ff0…` | `abd69241…` — which we already rejected |

So a producer emitting canonical `Z` and computing a plain JCS digest gets **exactly our digest** and needs no folding logic. The folding is only what lets the non-canonical spelling interoperate at all. **Nothing that previously validated stops validating.**

## `exclude_unset` — investigated, not a defect

Checked as a third possible divergence and it is **not reachable today**: `model_validate` marks a key set iff it was present in the input, so the dump and the raw dict agree on presence. Two existing tests already lock that in. Left untouched rather than "fixed" speculatively.

## Tests

6 new, **proven RED first** against unmodified `hashing.py` (4 failed, 2 passed), green after. They cover both axes, a negative check that genuinely different instants still hash differently (guard against over-collapse), and a sweep asserting `cli hash` reproduces the stored `object_hash` for **every** checked-in fixture — the user-visible symptom.

## Gates

**110 passed**, bytecode purged and `PYTHONDONTWRITEBYTECODE=1` (W121) · `ruff check` 0 · `ruff format --check` 0 · `mypy --strict` clean on 11 source files · Prettier clean.

Diff is 2 files: `hashing.py` (+56, pure addition) and one new test file. No schema artifacts regenerated — this cure does not touch the exported JSON Schema.

## Owed follow-ups (Conductor)

1. `CONTRACTS.md` §2 should document the folding step.
2. Whether the wire format should **also** be narrowed to a single spelling is a separate decision, with a version-bump question attached. Not a side effect of a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)