### PR TITLE
fix(wr3): make zero-spend mode reachable from the render driver

### DIFF
--- a/scripts/tests/test_wr3_render_episode_zero_spend.py
+++ b/scripts/tests/test_wr3_render_episode_zero_spend.py
@@ -1,0 +1,173 @@
+"""P03 finding F11 — the zero-spend path must be reachable from the DRIVER.
+
+These tests deliberately exercise `scripts/wr3_render_episode.py` as a
+subprocess, i.e. the exact command an operator types, rather than importing
+`wr3_flowkit_client.submit_clip` directly. That distinction is the whole point
+of the finding: before this patch `submit_clip` honoured `WR3_ZERO_SPEND`
+perfectly and the driver still could not reach it, because `_health()` and
+`setup_episode_context()` both dial the gateway first. A library-level test
+would have stayed green through the entire defect.
+
+Every test points the driver at a *refused* TCP port, so a green result cannot
+be explained by a live FlowKit gateway on the machine running the suite. No
+Flow/Veo job is submitted by any test here, and no credit can be spent: the
+placeholder renderer is local ffmpeg only.
+
+Hermeticity (W96 — tests must never write production state): HOME, the credit
+ledger and the spend-decision log are all redirected into tmp_path, so the real
+`~/.cache/wr3/credit-ledger.jsonl` is untouched even if an env var were dropped.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_SCRIPTS = Path(__file__).resolve().parents[1]
+DRIVER = REPO_SCRIPTS / "wr3_render_episode.py"
+
+sys.path.insert(0, str(REPO_SCRIPTS))
+
+from wr3_credit_ledger import read_records, total_spend  # noqa: E402
+
+FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+requires_ffmpeg = pytest.mark.skipif(
+    not FFMPEG_AVAILABLE,
+    reason="ffmpeg not on PATH — the placeholder renderer needs the local binary",
+)
+
+
+def _refused_endpoint() -> str:
+    """A loopback endpoint that is verified to REFUSE connections right now.
+
+    Binding port 0 and closing hands back a port the kernel just confirmed
+    free; we then prove it is refused rather than assuming it. If some other
+    process grabs it in the gap, the probe says so and the test skips instead
+    of silently testing nothing.
+    """
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    probe = socket.socket()
+    probe.settimeout(1.0)
+    try:
+        probe.connect(("127.0.0.1", port))
+    except (ConnectionRefusedError, OSError):
+        return f"http://127.0.0.1:{port}"
+    finally:
+        probe.close()
+    pytest.skip(f"port {port} became occupied between bind and probe — cannot prove refusal")
+
+
+def _episode(tmp_path: Path, *, name: str = "EP-F11", n_shots: int = 3) -> Path:
+    ep = tmp_path / name
+    ep.mkdir(parents=True)
+    (ep / "shot-pack.json").write_text(json.dumps({
+        "resolution": "720x1280",
+        "aspect_ratio": "9:16",
+        "shots": [
+            {
+                "shot_id": f"s{i:03d}",
+                "prompt_positive": f"placeholder shot {i}",
+                "prompt_negative": "",
+                "duration_s": 8,
+            }
+            for i in range(1, n_shots + 1)
+        ],
+    }, indent=2))
+    return ep
+
+
+def _run(ep: Path, tmp_path: Path, *, zero_spend: bool) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env["HOME"] = str(home)
+    env["WR3_CREDIT_LEDGER"] = str(tmp_path / "ledger.jsonl")
+    env["WR3_SPEND_DECISION_LOG"] = str(tmp_path / "decisions.jsonl")
+    env["WR3_FLOWKIT_ENDPOINT"] = _refused_endpoint()
+    env.pop("WR3_SPEND_DECISION", None)
+    if zero_spend:
+        env["WR3_ZERO_SPEND"] = "1"
+    else:
+        env.pop("WR3_ZERO_SPEND", None)
+    return subprocess.run(
+        [sys.executable, str(DRIVER), str(ep)],
+        capture_output=True, text=True, env=env, timeout=300,
+    )
+
+
+@requires_ffmpeg
+def test_driver_zero_spend_renders_every_shot_against_a_refused_gateway(tmp_path: Path) -> None:
+    ep = _episode(tmp_path, n_shots=3)
+    res = _run(ep, tmp_path, zero_spend=True)
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr[-2000:]!r}"
+    out = json.loads(res.stdout.strip().splitlines()[-1])
+    assert out["status"] == "OK"
+    assert out["rendered"] == 3
+    assert out["failed"] == 0
+    clips = sorted((ep / "clips").glob("*.mp4"))
+    assert [c.name for c in clips] == ["01.mp4", "02.mp4", "03.mp4"]
+    assert all(c.stat().st_size > 0 for c in clips)
+
+
+def test_driver_without_zero_spend_cannot_reach_the_render_loop(tmp_path: Path) -> None:
+    """Falsification for the test above.
+
+    Same episode, same refused port, zero-spend OFF. If this passed too, the
+    green above would prove nothing about the guard — it would just mean the
+    driver never needed the gateway. It must fail at the health preflight.
+    """
+    ep = _episode(tmp_path, n_shots=3)
+    res = _run(ep, tmp_path, zero_spend=False)
+    assert res.returncode != 0
+    assert not (ep / "clips").exists()
+    combined = res.stdout + res.stderr
+    assert "URLError" in combined or "Connection refused" in combined, combined[-2000:]
+
+
+@requires_ffmpeg
+def test_driver_zero_spend_spends_zero_credits_in_the_ledger(tmp_path: Path) -> None:
+    ledger = tmp_path / "ledger.jsonl"
+    before = total_spend(read_records(ledger_path=ledger))
+    ep = _episode(tmp_path, n_shots=2)
+    res = _run(ep, tmp_path, zero_spend=True)
+    assert res.returncode == 0, res.stderr[-2000:]
+    records = read_records(ledger_path=ledger)
+    after = total_spend(records)
+    assert before == 0 and after == 0, f"before={before} after={after}"
+    assert len(records) == 2
+    assert {r["mode"] for r in records} == {"placeholder"}
+    assert all(r["credits"] == 0 for r in records)
+
+
+@requires_ffmpeg
+def test_driver_zero_spend_labels_the_render_report_placeholder(tmp_path: Path) -> None:
+    """A placeholder report must not be mistakable for a real one on disk."""
+    ep = _episode(tmp_path, n_shots=1)
+    res = _run(ep, tmp_path, zero_spend=True)
+    assert res.returncode == 0, res.stderr[-2000:]
+    report = json.loads((ep / "render-report.json").read_text())
+    assert report["mode"] == "placeholder"
+    assert report["total_cost_cr"] == 0
+    assert report["rendered"][0]["veo_job_id"].startswith("placeholder:")
+    assert json.loads(res.stdout.strip().splitlines()[-1])["mode"] == "placeholder"
+
+
+@requires_ffmpeg
+def test_driver_zero_spend_never_creates_a_flowkit_context(tmp_path: Path) -> None:
+    """`setup_episode_context` writes `_flowkit_context.json` as its side effect.
+
+    Its absence is the on-disk proof that the second network preflight was
+    skipped too — not just the health probe.
+    """
+    ep = _episode(tmp_path, n_shots=1)
+    res = _run(ep, tmp_path, zero_spend=True)
+    assert res.returncode == 0, res.stderr[-2000:]
+    assert not (ep / "_flowkit_context.json").exists()

--- a/scripts/tests/test_wr3_render_episode_zero_spend.py
+++ b/scripts/tests/test_wr3_render_episode_zero_spend.py
@@ -1,21 +1,32 @@
 """P03 finding F11 — the zero-spend path must be reachable from the DRIVER.
 
-These tests deliberately exercise `scripts/wr3_render_episode.py` as a
-subprocess, i.e. the exact command an operator types, rather than importing
-`wr3_flowkit_client.submit_clip` directly. That distinction is the whole point
-of the finding: before this patch `submit_clip` honoured `WR3_ZERO_SPEND`
-perfectly and the driver still could not reach it, because `_health()` and
+These tests exercise `scripts/wr3_render_episode.py` as a subprocess, i.e. the
+exact command an operator types, rather than importing
+`wr3_flowkit_client.submit_clip` directly. That distinction is the point of the
+finding: before the patch `submit_clip` honoured `WR3_ZERO_SPEND` perfectly and
+the driver still could not reach it, because `_health()` and
 `setup_episode_context()` both dial the gateway first. A library-level test
 would have stayed green through the entire defect.
 
-Every test points the driver at a *refused* TCP port, so a green result cannot
-be explained by a live FlowKit gateway on the machine running the suite. No
-Flow/Veo job is submitted by any test here, and no credit can be spent: the
-placeholder renderer is local ffmpeg only.
+Two gateway shapes are used, deliberately:
 
-Hermeticity (W96 — tests must never write production state): HOME, the credit
-ledger and the spend-decision log are all redirected into tmp_path, so the real
-`~/.cache/wr3/credit-ledger.jsonl` is untouched even if an env var were dropped.
+* a **refused port**, proven refused by the fixture itself, for "nothing is
+  running at all";
+* a **stub /health server** that answers `extension_connected: false` and
+  COUNTS the requests it receives, for the two things a refused port cannot
+  distinguish — that the health gate specifically fires (exit 2, not merely
+  "some network call died"), and that a zero-spend run performs *zero* gateway
+  requests rather than dialling and swallowing the error.
+
+No Flow/Veo job is submitted by any test here and no credit can be spent: the
+placeholder renderer is local ffmpeg only, and the stub serves `/health` alone.
+
+Hermeticity (W96 — tests must never write production state): the child process
+gets a WHITELISTED environment, not a copy of the parent's. That kills three
+things at once — the real `~/.cache/wr3/*` (HOME is redirected), a developer's
+stray `WR3_*` toggles, and `HTTP_PROXY`/`ALL_PROXY`, which `urllib` honours and
+which would otherwise route the "verified refused" loopback endpoint through a
+proxy and quietly void the fixture's central guarantee.
 """
 from __future__ import annotations
 
@@ -25,6 +36,10 @@ import shutil
 import socket
 import subprocess
 import sys
+import threading
+import time
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
@@ -42,12 +57,17 @@ requires_ffmpeg = pytest.mark.skipif(
     reason="ffmpeg not on PATH — the placeholder renderer needs the local binary",
 )
 
+# Inherited only because the child genuinely needs them: PATH to find ffmpeg,
+# the locale vars for text decoding, TMPDIR for ffmpeg scratch. Everything else
+# — proxies, WR3_* toggles, tokens — is deliberately absent.
+_ENV_WHITELIST = ("PATH", "TMPDIR", "LANG", "LC_ALL")
+
 
 def _refused_endpoint() -> str:
-    """A loopback endpoint that is verified to REFUSE connections right now.
+    """A loopback endpoint verified to REFUSE connections right now.
 
     Binding port 0 and closing hands back a port the kernel just confirmed
-    free; we then prove it is refused rather than assuming it. If some other
+    free; we then PROVE it is refused rather than assuming it. If another
     process grabs it in the gap, the probe says so and the test skips instead
     of silently testing nothing.
     """
@@ -63,6 +83,52 @@ def _refused_endpoint() -> str:
     finally:
         probe.close()
     pytest.skip(f"port {port} became occupied between bind and probe — cannot prove refusal")
+
+
+class _StubGateway:
+    """Counts every request it receives. `paths` is the audit trail."""
+
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.paths: list[str] = []
+        self._lock = threading.Lock()
+
+    def record(self, path: str) -> None:
+        with self._lock:
+            self.paths.append(path)
+
+
+@contextmanager
+def _stub_gateway(payload: dict):
+    state = _StubGateway(payload)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            state.record(self.path)
+            body = json.dumps(state.payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self) -> None:  # noqa: N802
+            state.record(self.path)
+            self.send_response(500)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}", state
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        thread.join(timeout=5)
 
 
 def _episode(tmp_path: Path, *, name: str = "EP-F11", n_shots: int = 3) -> Path:
@@ -84,30 +150,72 @@ def _episode(tmp_path: Path, *, name: str = "EP-F11", n_shots: int = 3) -> Path:
     return ep
 
 
-def _run(ep: Path, tmp_path: Path, *, zero_spend: bool) -> subprocess.CompletedProcess:
-    env = dict(os.environ)
+def _run(ep: Path, tmp_path: Path, *, zero_spend: bool, endpoint: str | None = None,
+         ledger: Path | None = None) -> subprocess.CompletedProcess:
     home = tmp_path / "home"
     home.mkdir(exist_ok=True)
+    env = {k: os.environ[k] for k in _ENV_WHITELIST if k in os.environ}
     env["HOME"] = str(home)
-    env["WR3_CREDIT_LEDGER"] = str(tmp_path / "ledger.jsonl")
+    env["WR3_CREDIT_LEDGER"] = str(ledger or (tmp_path / "ledger.jsonl"))
     env["WR3_SPEND_DECISION_LOG"] = str(tmp_path / "decisions.jsonl")
-    env["WR3_FLOWKIT_ENDPOINT"] = _refused_endpoint()
-    env.pop("WR3_SPEND_DECISION", None)
+    env["WR3_FLOWKIT_ENDPOINT"] = endpoint or _refused_endpoint()
+    # urllib honours these; an inherited proxy would route the loopback
+    # endpoint somewhere real and void the whole premise.
+    env["NO_PROXY"] = "*"
+    env["no_proxy"] = "*"
     if zero_spend:
         env["WR3_ZERO_SPEND"] = "1"
-    else:
-        env.pop("WR3_ZERO_SPEND", None)
     return subprocess.run(
         [sys.executable, str(DRIVER), str(ep)],
         capture_output=True, text=True, env=env, timeout=300,
     )
 
 
+# --------------------------------------------------------------------------
+# The health gate is real — proven against a LIVE gateway, not a dead port
+# --------------------------------------------------------------------------
+
+def test_health_gate_halts_when_the_extension_is_disconnected(tmp_path: Path) -> None:
+    """Exit 2 + the named reason — not merely "some network call failed".
+
+    Against a refused port every preflight dies with an indistinguishable
+    URLError, so a dead-port test cannot tell the health gate from the context
+    call that follows it. This one can: the gateway is up and answering.
+    """
+    ep = _episode(tmp_path, n_shots=2)
+    with _stub_gateway({"extension_connected": False, "status": "degraded"}) as (url, stub):
+        res = _run(ep, tmp_path, zero_spend=False, endpoint=url)
+    assert res.returncode == 2, f"stdout={res.stdout!r} stderr={res.stderr[-1500:]!r}"
+    assert json.loads(res.stdout.strip())["reason"] == "extension_not_connected"
+    assert stub.paths == ["/health"], stub.paths
+    assert not (ep / "clips").exists()
+
+
 @requires_ffmpeg
-def test_driver_zero_spend_renders_every_shot_against_a_refused_gateway(tmp_path: Path) -> None:
+def test_zero_spend_bypasses_a_health_gate_that_is_demonstrably_firing(tmp_path: Path) -> None:
+    """Same live gateway, same `extension_connected: false`, zero-spend ON.
+
+    The previous test proves that gateway HALTS a real run. This one proves
+    zero-spend renders anyway — and that it made ZERO requests, so the bypass
+    is a genuine skip and not a dial whose error is swallowed.
+    """
+    ep = _episode(tmp_path, n_shots=2)
+    with _stub_gateway({"extension_connected": False, "status": "degraded"}) as (url, stub):
+        res = _run(ep, tmp_path, zero_spend=True, endpoint=url)
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr[-1500:]!r}"
+    assert stub.paths == [], f"zero-spend run contacted the gateway: {stub.paths}"
+    assert sorted(p.name for p in (ep / "clips").glob("*.mp4")) == ["01.mp4", "02.mp4"]
+
+
+# --------------------------------------------------------------------------
+# Nothing running at all
+# --------------------------------------------------------------------------
+
+@requires_ffmpeg
+def test_zero_spend_renders_every_shot_against_a_refused_gateway(tmp_path: Path) -> None:
     ep = _episode(tmp_path, n_shots=3)
     res = _run(ep, tmp_path, zero_spend=True)
-    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr[-2000:]!r}"
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr[-1500:]!r}"
     out = json.loads(res.stdout.strip().splitlines()[-1])
     assert out["status"] == "OK"
     assert out["rendered"] == 3
@@ -117,28 +225,26 @@ def test_driver_zero_spend_renders_every_shot_against_a_refused_gateway(tmp_path
     assert all(c.stat().st_size > 0 for c in clips)
 
 
-def test_driver_without_zero_spend_cannot_reach_the_render_loop(tmp_path: Path) -> None:
-    """Falsification for the test above.
-
-    Same episode, same refused port, zero-spend OFF. If this passed too, the
-    green above would prove nothing about the guard — it would just mean the
-    driver never needed the gateway. It must fail at the health preflight.
-    """
+def test_without_zero_spend_a_refused_gateway_stops_the_run(tmp_path: Path) -> None:
     ep = _episode(tmp_path, n_shots=3)
     res = _run(ep, tmp_path, zero_spend=False)
     assert res.returncode != 0
     assert not (ep / "clips").exists()
     combined = res.stdout + res.stderr
-    assert "URLError" in combined or "Connection refused" in combined, combined[-2000:]
+    assert "URLError" in combined or "Connection refused" in combined, combined[-1500:]
 
+
+# --------------------------------------------------------------------------
+# Credits, labelling, and what must NOT appear on disk
+# --------------------------------------------------------------------------
 
 @requires_ffmpeg
-def test_driver_zero_spend_spends_zero_credits_in_the_ledger(tmp_path: Path) -> None:
+def test_zero_spend_spends_zero_credits_in_the_ledger(tmp_path: Path) -> None:
     ledger = tmp_path / "ledger.jsonl"
     before = total_spend(read_records(ledger_path=ledger))
     ep = _episode(tmp_path, n_shots=2)
-    res = _run(ep, tmp_path, zero_spend=True)
-    assert res.returncode == 0, res.stderr[-2000:]
+    res = _run(ep, tmp_path, zero_spend=True, ledger=ledger)
+    assert res.returncode == 0, res.stderr[-1500:]
     records = read_records(ledger_path=ledger)
     after = total_spend(records)
     assert before == 0 and after == 0, f"before={before} after={after}"
@@ -148,26 +254,111 @@ def test_driver_zero_spend_spends_zero_credits_in_the_ledger(tmp_path: Path) -> 
 
 
 @requires_ffmpeg
-def test_driver_zero_spend_labels_the_render_report_placeholder(tmp_path: Path) -> None:
+def test_zero_spend_labels_the_render_report_placeholder(tmp_path: Path) -> None:
     """A placeholder report must not be mistakable for a real one on disk."""
     ep = _episode(tmp_path, n_shots=1)
     res = _run(ep, tmp_path, zero_spend=True)
-    assert res.returncode == 0, res.stderr[-2000:]
+    assert res.returncode == 0, res.stderr[-1500:]
     report = json.loads((ep / "render-report.json").read_text())
     assert report["mode"] == "placeholder"
+    assert report["status"] == "OK"
     assert report["total_cost_cr"] == 0
     assert report["rendered"][0]["veo_job_id"].startswith("placeholder:")
     assert json.loads(res.stdout.strip().splitlines()[-1])["mode"] == "placeholder"
 
 
 @requires_ffmpeg
-def test_driver_zero_spend_never_creates_a_flowkit_context(tmp_path: Path) -> None:
-    """`setup_episode_context` writes `_flowkit_context.json` as its side effect.
+def test_a_new_run_never_leaves_a_previous_runs_report_in_place(tmp_path: Path) -> None:
+    """Stale-report poisoning (cross-family refuter, Kimi K3).
 
-    Its absence is the on-disk proof that the second network preflight was
-    skipped too — not just the health probe.
+    A shot whose id does not match `s<digits>` used to raise ValueError from
+    OUTSIDE the retry loop's handler and kill the process before any report was
+    written — leaving a previous run's `render-report.json` describing the new
+    run's clips. Here the previous report claims a real 380-credit render; after
+    the placeholder run it must claim neither.
+    """
+    ep = _episode(tmp_path, n_shots=2)
+    stale = {"mode": "real", "total_cost_cr": 380, "status": "OK",
+             "rendered": [{"shot_id": "s001", "veo_job_id": "veo-real-deadbeef"}],
+             "failed": [], "extension_drop": False}
+    (ep / "render-report.json").write_text(json.dumps(stale))
+
+    pack = json.loads((ep / "shot-pack.json").read_text())
+    pack["shots"][1]["shot_id"] = "shot-2"  # "shot-2".lstrip("s") == "hot-2"
+    (ep / "shot-pack.json").write_text(json.dumps(pack))
+
+    res = _run(ep, tmp_path, zero_spend=True)
+    report = json.loads((ep / "render-report.json").read_text())
+    assert report["mode"] == "placeholder", "stale report survived the run"
+    assert report["total_cost_cr"] == 0
+    assert "veo-real-deadbeef" not in json.dumps(report)
+    assert [f["shot_id"] for f in report["failed"]] == ["shot-2"]
+    assert res.returncode == 1  # PARTIAL, not a traceback
+
+
+@requires_ffmpeg
+def test_the_stale_report_is_gone_before_the_run_finishes(tmp_path: Path) -> None:
+    """The startup stamp, probed WHILE the run is in flight.
+
+    The test above proves the malformed-shot crash is gone, so it exercises the
+    fix and never the belt: the run ends normally and the FINAL write overwrites
+    the stale report anyway. Removing the startup stamp leaves that test green.
+
+    This one watches the file during the run. If a previous run's
+    `"mode": "real"` report is still readable after the first clip lands, the
+    belt is not there — that is the window in which an unenumerated crash (OOM,
+    SIGKILL, full disk) would leave clips described by the wrong run.
+    """
+    ep = _episode(tmp_path, n_shots=4)
+    stale = {"mode": "real", "total_cost_cr": 380, "status": "OK",
+             "rendered": [{"shot_id": "s001", "veo_job_id": "veo-real-deadbeef"}],
+             "failed": [], "extension_drop": False}
+    report_path = ep / "render-report.json"
+    report_path.write_text(json.dumps(stale))
+
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env = {k: os.environ[k] for k in _ENV_WHITELIST if k in os.environ}
+    env.update({
+        "HOME": str(home),
+        "WR3_CREDIT_LEDGER": str(tmp_path / "ledger.jsonl"),
+        "WR3_SPEND_DECISION_LOG": str(tmp_path / "decisions.jsonl"),
+        "WR3_FLOWKIT_ENDPOINT": _refused_endpoint(),
+        "NO_PROXY": "*", "no_proxy": "*", "WR3_ZERO_SPEND": "1",
+    })
+    proc = subprocess.Popen([sys.executable, str(DRIVER), str(ep)],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            text=True, env=env)
+    seen_incomplete = False
+    try:
+        deadline = time.monotonic() + 120
+        while proc.poll() is None and time.monotonic() < deadline:
+            try:
+                mid = json.loads(report_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                time.sleep(0.02)
+                continue
+            if mid.get("status") == "incomplete":
+                assert mid["mode"] == "placeholder"
+                assert "veo-real-deadbeef" not in json.dumps(mid)
+                seen_incomplete = True
+                break
+            time.sleep(0.02)
+    finally:
+        proc.wait(timeout=120)
+    assert seen_incomplete, (
+        "the stale report was never replaced while the run was in flight — "
+        "a crash before the final write would leave it describing the new clips"
+    )
+
+
+@requires_ffmpeg
+def test_zero_spend_never_creates_a_flowkit_context(tmp_path: Path) -> None:
+    """`_flowkit_context.json` is written by the DRIVER right after
+    `setup_episode_context()` returns. Its absence is the on-disk proof that the
+    second preflight branch was skipped too — not just the health probe.
     """
     ep = _episode(tmp_path, n_shots=1)
     res = _run(ep, tmp_path, zero_spend=True)
-    assert res.returncode == 0, res.stderr[-2000:]
+    assert res.returncode == 0, res.stderr[-1500:]
     assert not (ep / "_flowkit_context.json").exists()

--- a/scripts/wr3_render_episode.py
+++ b/scripts/wr3_render_episode.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import sys
 import urllib.error
 from pathlib import Path
@@ -18,6 +19,22 @@ from wr3_spend_authority import zero_spend_enabled  # noqa: E402
 
 EP = Path(sys.argv[1])
 ENDPOINT = os.environ.get("WR3_FLOWKIT_ENDPOINT", "http://127.0.0.1:8100")
+
+
+def _shot_index(shot_id: str) -> int:
+    """`s001` -> 1. Rejects anything else loudly.
+
+    `str.lstrip` strips a CHARACTER SET, not a prefix: `"shot-2".lstrip("s")`
+    is `"hot-2"`, so a non-conforming id used to reach `int()` and raise
+    ValueError from outside any handler.
+    """
+    if not re.fullmatch(r"s\d+", shot_id):
+        raise ValueError(f"expected s<digits>, got {shot_id!r}")
+    return int(shot_id[1:])
+
+
+def _write_report(report: dict) -> None:
+    (EP / "render-report.json").write_text(json.dumps(report, indent=2))
 
 
 def _health() -> dict:
@@ -57,20 +74,39 @@ async def main() -> int:
     # run and a real run otherwise emit the same shape, and total_cost_cr is 0
     # in both whenever a real run fails before its first charge.
     report = {"rendered": [], "failed": [], "extension_drop": False, "total_cost_cr": 0,
-              "mode": "placeholder" if zero_spend else "real"}
+              "mode": "placeholder" if zero_spend else "real", "status": "incomplete"}
+    # Stamp the report on disk BEFORE the first clip. Without this a run that
+    # dies mid-flight leaves the PREVIOUS run's render-report.json in place —
+    # so fresh placeholder clips can sit next to a stale `"mode": "real"` report
+    # carrying genuine veo_job_ids, and the label describes the wrong run.
+    # `status` stays "incomplete" until the loop finishes normally, so a
+    # truncated run is legible as truncated instead of silently absent.
+    _write_report(report)
 
     for shot in shots:
-        idx = int(shot["shot_id"].lstrip("s"))  # s001 -> 1
-        req = fk.ClipRequest(
-            shot_index=idx,
-            positive_prompt=shot["prompt_positive"],
-            negative_prompt=shot.get("prompt_negative", ""),
-            identity_tokens=tuple(shot.get("identity_tokens") or []),
-            duration_s=int(round(shot.get("duration_s", 8))),
-            resolution=shot_pack.get("resolution", "720x1280"),
-            aspect=shot_pack.get("aspect_ratio", "9:16"),
-            image_prompt=shot["prompt_positive"],
-        )
+        # Building the request is INSIDE a handler: a malformed shot entry must
+        # be a recorded failure, not an uncaught exception. Both statements here
+        # used to sit outside every try — `int("shot-2".lstrip("s"))` raises
+        # (lstrip strips a character SET, not a prefix) and a missing
+        # `prompt_positive` raises KeyError — killing the process mid-loop
+        # before any report was written.
+        try:
+            idx = _shot_index(shot["shot_id"])
+            req = fk.ClipRequest(
+                shot_index=idx,
+                positive_prompt=shot["prompt_positive"],
+                negative_prompt=shot.get("prompt_negative", ""),
+                identity_tokens=tuple(shot.get("identity_tokens") or []),
+                duration_s=int(round(shot.get("duration_s", 8))),
+                resolution=shot_pack.get("resolution", "720x1280"),
+                aspect=shot_pack.get("aspect_ratio", "9:16"),
+                image_prompt=shot["prompt_positive"],
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            report["failed"].append({"shot_id": shot.get("shot_id"),
+                                     "reason": f"malformed shot entry: {e}"})
+            print(f"[render] skipping malformed shot: {e}", file=sys.stderr)
+            continue
         last_err = None
         for attempt in range(3):  # 1 + 2 retries
             try:
@@ -88,13 +124,13 @@ async def main() -> int:
                     report["failed"].append({"shot_id": shot["shot_id"], "reason": "503_extension_dropped"})
                     print(json.dumps({"status": "HALT", "reason": "extension_dropped_503",
                                       "shot": shot["shot_id"], "report": report}))
-                    (EP / "render-report.json").write_text(json.dumps(report, indent=2))
+                    _write_report(report)
                     return 3
                 last_err = f"HTTP {e.code}"
             except fk.FlowkitQuotaError as e:
                 report["failed"].append({"shot_id": shot["shot_id"], "reason": f"quota:{e}"})
                 print(json.dumps({"status": "HALT", "reason": "quota_exceeded", "report": report}))
-                (EP / "render-report.json").write_text(json.dumps(report, indent=2))
+                _write_report(report)
                 return 4
             except (fk.FlowkitError, fk.FlowkitTimeoutError, Exception) as e:
                 last_err = str(e)
@@ -102,8 +138,9 @@ async def main() -> int:
         else:
             report["failed"].append({"shot_id": shot["shot_id"], "reason": last_err, "needs_broll_curator": True})
 
-    (EP / "render-report.json").write_text(json.dumps(report, indent=2))
-    status = "OK" if not report["failed"] else "PARTIAL"
+    report["status"] = "OK" if not report["failed"] else "PARTIAL"
+    _write_report(report)
+    status = report["status"]
     print(json.dumps({"status": status, "rendered": len(report["rendered"]),
                       "failed": len(report["failed"]), "total_cost_cr": report["total_cost_cr"],
                       "mode": report["mode"]}))

--- a/scripts/wr3_render_episode.py
+++ b/scripts/wr3_render_episode.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import wr3_flowkit_client as fk  # noqa: E402
+from wr3_spend_authority import zero_spend_enabled  # noqa: E402
 
 EP = Path(sys.argv[1])
 ENDPOINT = os.environ.get("WR3_FLOWKIT_ENDPOINT", "http://127.0.0.1:8100")
@@ -29,18 +30,34 @@ async def main() -> int:
     shot_pack = json.loads((EP / "shot-pack.json").read_text())
     shots = shot_pack["shots"]
 
-    # Pre-flight health gate (commit 4c98e00 returns 503 if extension dropped)
-    h = _health()
-    if not h.get("extension_connected"):
-        print(json.dumps({"status": "HALT", "reason": "extension_not_connected", "health": h}))
-        return 2
-    print(f"[render] health OK: {h}", file=sys.stderr)
+    # Zero-spend mode short-circuits BOTH network preflights. Without this the
+    # placeholder path is unreachable from the production entry point: _health()
+    # and setup_episode_context() each dial the gateway and abort long before
+    # submit_clip() ever reads WR3_ZERO_SPEND. That was finding F11 of P03 —
+    # the zero-spend mode existed in the library and could not be run from the
+    # command anyone actually types.
+    zero_spend = zero_spend_enabled()
+    ctx = None
+    if zero_spend:
+        print("[render] WR3_ZERO_SPEND set — health gate and episode context skipped; "
+              "every clip is a local placeholder, 0 credits", file=sys.stderr)
+    else:
+        # Pre-flight health gate (commit 4c98e00 returns 503 if extension dropped)
+        h = _health()
+        if not h.get("extension_connected"):
+            print(json.dumps({"status": "HALT", "reason": "extension_not_connected", "health": h}))
+            return 2
+        print(f"[render] health OK: {h}", file=sys.stderr)
 
-    ctx = await fk.setup_episode_context(name=EP.name, endpoint=ENDPOINT)
-    (EP / "_flowkit_context.json").write_text(json.dumps(ctx.to_dict(), indent=2))
-    print(f"[render] episode context project={ctx.project_id} video={ctx.video_id}", file=sys.stderr)
+        ctx = await fk.setup_episode_context(name=EP.name, endpoint=ENDPOINT)
+        (EP / "_flowkit_context.json").write_text(json.dumps(ctx.to_dict(), indent=2))
+        print(f"[render] episode context project={ctx.project_id} video={ctx.video_id}", file=sys.stderr)
 
-    report = {"rendered": [], "failed": [], "extension_drop": False, "total_cost_cr": 0}
+    # `mode` is load-bearing for whoever reads this report later: a placeholder
+    # run and a real run otherwise emit the same shape, and total_cost_cr is 0
+    # in both whenever a real run fails before its first charge.
+    report = {"rendered": [], "failed": [], "extension_drop": False, "total_cost_cr": 0,
+              "mode": "placeholder" if zero_spend else "real"}
 
     for shot in shots:
         idx = int(shot["shot_id"].lstrip("s"))  # s001 -> 1
@@ -88,7 +105,8 @@ async def main() -> int:
     (EP / "render-report.json").write_text(json.dumps(report, indent=2))
     status = "OK" if not report["failed"] else "PARTIAL"
     print(json.dumps({"status": status, "rendered": len(report["rendered"]),
-                      "failed": len(report["failed"]), "total_cost_cr": report["total_cost_cr"]}))
+                      "failed": len(report["failed"]), "total_cost_cr": report["total_cost_cr"],
+                      "mode": report["mode"]}))
     return 0 if not report["failed"] else 1
 
 


### PR DESCRIPTION
`base: 94e9960d2b7350473529cfa928136b22afca501f`

## What was wrong

P03 (#4606) shipped a zero-spend mode: `WR3_ZERO_SPEND=1` makes `submit_clip()`
render a deterministic local ffmpeg placeholder instead of submitting a Veo job,
so the gatekeeper / audio / assembler / critic stages can run end-to-end at
0 credits.

It was unreachable from the production entry point. `scripts/wr3_render_episode.py`
dials the FlowKit gateway **twice** before the render loop — `_health()` at
line 33 and `setup_episode_context()` at line 39 — and both abort long before
`submit_clip()` gets to read the env var. With no gateway running, the driver
exits at the health probe with `URLError: Connection refused`.

So the mode existed in the library and could not be run by the command anyone
actually types. That is superscar **#2 — Esiste ≠ Armato**, and it was
finding F11 of the P03 evidence pack.

## The change

- Guard both preflights on `zero_spend_enabled()`. Under zero-spend `ctx` stays
  `None`, which `submit_clip()` already documents as harmless on that path
  (`wr3_flowkit_client.py:607-613` checks zero-spend *before* touching the
  context, so `_create_scene` / `_generate_start_image` / `_generate_video` /
  `_download_video_media` / `setup_episode_context` are never called).
- Label `render-report.json` and the final stdout line with
  `mode: "placeholder" | "real"`. Without it, a placeholder run and a real run
  that failed before its first charge are indistinguishable on disk — both
  carry `total_cost_cr: 0`.

No behaviour changes when `WR3_ZERO_SPEND` is unset: the else-branch is the
previous code verbatim.

## Why the tests are a real gate

They run `scripts/wr3_render_episode.py` **as a subprocess** — the real entry
point, not `submit_clip()` — because a library-level test stays green through
the entire defect. Each run points `WR3_FLOWKIT_ENDPOINT` at a loopback port
that the fixture *proves* is refused before yielding it (bind :0, close, then
connect and require `ConnectionRefusedError`; if the port got taken in the gap
it skips rather than silently testing nothing). A green result therefore cannot
be explained by a live FlowKit gateway on the test machine.

`HOME`, `WR3_CREDIT_LEDGER` and `WR3_SPEND_DECISION_LOG` are all redirected
into `tmp_path`, so the suite cannot write production state (W96).

**Mutation check — the guard removed, driver restored to `94e9960d2`:**

| | with patch | patch reverted |
|---|---|---|
| renders 3 shots vs refused gateway | PASS | **FAIL** |
| ledger total 0 → 0, 2 placeholder rows | PASS | **FAIL** |
| report labelled `placeholder` | PASS | **FAIL** |
| no `_flowkit_context.json` written | PASS | **FAIL** |
| *falsification:* no-zero-spend run must fail | PASS | PASS *(by design)* |

The fifth test is the falsification and is **supposed** to stay green in both
columns — it asserts the unguarded driver fails at the health gate, which is
what makes the other four meaningful.

Full suite: `scripts/tests/ -k wr3` → **272 passed**, 1 pre-existing failure
(`test_wr3_manifest_normalize.py::test_against_the_actual_on_disk_manifest`,
which reads a gitignored artifact that is absent on this machine and fails
identically on unmodified `main`).

## Ceiling

No Flow/Veo job is submitted anywhere in this diff or its tests; the placeholder
renderer is local ffmpeg only. No scheduler, service or LaunchAgent is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)