### PR TITLE
fix(seats): the picker's slot range stopped at 5 — the Team seat was unreachable

### DIFF
--- a/FLEET_TOPOLOGY.json
+++ b/FLEET_TOPOLOGY.json
@@ -21,34 +21,47 @@
         "A1": {
           "email": "antonellosiano@gmail.com",
           "plan": "Claude Max 20x",
-          "lane": "interactive/architect daily driver"
+          "lane": "interactive/architect daily driver",
+          "oauth_token_slot": "CLAUDE_CODE_OAUTH_TOKEN_1",
+          "config_dir": "~/.claude-antonellosiano"
         },
         "A2": {
           "email": "kaiser198719871987@gmail.com",
           "plan": "Claude Max 20x",
-          "lane": "subagents/build + Cowork cloud sessions (this session observed here)"
+          "lane": "subagents/build + Cowork cloud sessions (this session observed here)",
+          "oauth_token_slot": "CLAUDE_CODE_OAUTH_TOKEN_5",
+          "config_dir": "~/.claude-kaiser"
         },
         "A3": {
           "email": "applevisionpro1987@gmail.com",
           "plan": "Claude Max 20x",
-          "lane": "cron/batch — designated DONOR: auto-pause to free its window for the gate"
+          "lane": "cron/batch — designated DONOR: auto-pause to free its window for the gate",
+          "oauth_token_slot": "CLAUDE_CODE_OAUTH_TOKEN_3",
+          "config_dir": "~/.claude-acct3"
         },
         "A4": {
-          "email": "antozero1987@… (exact address unverified — account named by Zero 2026-08-19; confirm at first CLI login)",
+          "email": "antozero1987@gmail.com",
           "plan": "Claude Max 20x",
-          "lane": "cloud routines (afternoon PR-babysit + weekly PENDING-ARMS triage) — CLI login pending (M5 spare CLAUDE_CONFIG_DIR)"
+          "lane": "cloud routines (afternoon PR-babysit + weekly PENDING-ARMS triage) — CLI login pending (M5 spare CLAUDE_CONFIG_DIR)",
+          "oauth_token_slot": "CLAUDE_CODE_OAUTH_TOKEN_4",
+          "config_dir": "~/.claude-antozero"
         },
         "A5": {
           "email": "sianoantonello@gmail.com",
           "plan": "Claude Max 20x",
-          "lane": "Mini ~/.claude machine login (verified live 2026-08-19) + cloud routines (ssot-contradiction-hunter, secret-pattern-sweep)"
+          "lane": "Mini ~/.claude machine login (verified live 2026-08-19) + cloud routines (ssot-contradiction-hunter, secret-pattern-sweep)",
+          "oauth_token_slot": "CLAUDE_CODE_OAUTH_TOKEN_2",
+          "config_dir": "~/.claude-acct2"
         },
         "AZ": {
           "email": "zero@balizero.com",
           "plan": "Claude Team seat Premium",
-          "lane": "GATE PRIMARY (dedicated allowance for the final on-disk gate lives here — Opus 5 xhigh effort, RULED 2026-08-20; was Fable's dedicated weekly allowance) + escalations"
+          "lane": "GATE PRIMARY (dedicated allowance for the final on-disk gate lives here — Opus 5 xhigh effort, RULED 2026-08-20; was Fable's dedicated weekly allowance) + escalations",
+          "oauth_token_slot": "CLAUDE_CODE_OAUTH_TOKEN_6",
+          "config_dir": "~/.claude-zero-team"
         }
-      }
+      },
+      "oauth_slot_note": "Slot->account VERIFIED 2026-08-23 via `claude auth status` per config-dir plus the setup-token transcript (each token preceded by the command that minted it). An OAuth token carries NO identity - `auth status` on one returns only authMethod:oauth_token, no email - so this mapping and the comment beside each slot in ~/.nuzantara-secrets.env are the ONLY registry; it must be written AT setup-token time, never reconstructed afterwards. Measured the same day: `claude setup-token` does NOT revoke the account's previous token, so every superseded token stays valid ~1y and is revocable only from the web console."
     },
     "openai": {
       "mechanism": "CODEX_HOME per-account dirs (~/.codex = O1, ~/.codex-o2 = O2). --profile switches models, NOT identity; only auth.json controls identity. No native auto-failover: the conductor rotates explicitly.",

--- a/scripts/lib/claude_seat.sh
+++ b/scripts/lib/claude_seat.sh
@@ -38,6 +38,15 @@
 #   EXTRACTS the live classifier rather than copying it. If the extraction
 #   fails, this file refuses to run instead of guessing.
 
+# How many CLAUDE_CODE_OAUTH_TOKEN_<n> slots to consider. It is a VARIABLE and not
+# a literal because on 2026-08-23 this range read `1 2 3 4 5` in three separate
+# places: the Team seat was armed in the secrets file as slot 6 and no cron could
+# ever select it — with only that seat alive the picker returned SUSPEND while a
+# valid seat sat in the environment. Raise this when a seat is added; the three
+# call sites and the error message follow automatically.
+: "${CLAUDE_SEAT_SLOTS:=6}"
+_claude_seat_slots() { seq 1 "${CLAUDE_SEAT_SLOTS:-6}"; }
+
 _claude_seat_wrapper_path() {
     # Where is the cron-agent wrapper whose refusal classifier we reuse?
     # This file is deployed in TWO shapes and both must work:
@@ -114,7 +123,7 @@ _claude_seat_load_secrets() {
     # Only if the caller has not already supplied a seat — never clobber an
     # environment that was set up deliberately.
     local i var
-    for i in 1 2 3 4 5; do
+    for i in $(_claude_seat_slots); do
         var="CLAUDE_CODE_OAUTH_TOKEN_${i}"
         [ -n "${!var:-}" ] && return 0
     done
@@ -145,7 +154,7 @@ claude_seat_run() {
     }
 
     local tokens=() labels=() i var tok existing is_dup
-    for i in 1 2 3 4 5; do
+    for i in $(_claude_seat_slots); do
         var="CLAUDE_CODE_OAUTH_TOKEN_${i}"
         tok="${!var:-}"
         [ -z "$tok" ] && continue
@@ -168,7 +177,7 @@ claude_seat_run() {
         # Deliberately NOT falling through to a bare invocation: that is the
         # keychain identity, proven 0-for-905 under cron. Failing loudly beats
         # a call that silently returns an auth error as if it were an answer.
-        echo "claude_seat: no OAuth seat configured (looked for CLAUDE_CODE_OAUTH_TOKEN_1..5 and the legacy var)" >&2
+        echo "claude_seat: no OAuth seat configured (looked for CLAUDE_CODE_OAUTH_TOKEN_1..${CLAUDE_SEAT_SLOTS:-6} and the legacy var)" >&2
         echo "claude_seat: the bare keychain identity is NOT used as a fallback — it cannot work in a non-GUI session" >&2
         return 2
     fi
@@ -247,7 +256,7 @@ claude_seat_pick() {
         echo "claude_seat: default seat refused — trying numbered seats" >&2
     fi
     local i var tok seen=() dup existing
-    for i in 1 2 3 4 5; do
+    for i in $(_claude_seat_slots); do
         var="CLAUDE_CODE_OAUTH_TOKEN_${i}"; tok="${!var:-}"
         [ -z "$tok" ] && continue
         dup=0

--- a/scripts/tests/test_claude_seat_pick.sh
+++ b/scripts/tests/test_claude_seat_pick.sh
@@ -73,5 +73,15 @@ R="$(run_pick "${COMMON[@]}" CLAUDE_SEAT_BIN="$BIN" \
         CLAUDE_CODE_OAUTH_TOKEN_1=same CLAUDE_CODE_OAUTH_TOKEN_2=same CLAUDE_CODE_OAUTH_TOKEN_3=LIVE3)"
 [ "$R" = "0|token_3" ] && ok "dedup dead dupes, reach live t3 → 'token_3'" || bad "dedup: got '$R' (want 0|token_3)"
 
+# ── 6. slot 6 (the Team seat) is reachable ───────────────────────────────────
+#    Regression guard for 2026-08-23: the range said `1 2 3 4 5` in three places,
+#    so slot 6 was armed in the secrets file and NEVER selected by any cron. A
+#    seat the picker cannot see is not a seat. Keep this test slot-6 specific:
+#    it is the one the hardcoded range excluded.
+BIN="$SANDBOX/claude_t6_live"; make_fake "$BIN" "LIVE6"
+R="$(run_pick "${COMMON[@]}" CLAUDE_SEAT_TRY_DEFAULT=0 CLAUDE_SEAT_BIN="$BIN" \
+        CLAUDE_CODE_OAUTH_TOKEN_1=dead1 CLAUDE_CODE_OAUTH_TOKEN_6=LIVE6)"
+[ "$R" = "0|token_6" ] && ok "slot 6 (Team seat) reachable → 'token_6'" || bad "slot 6 unreachable: got '$R' (want 0|token_6)"
+
 echo
 [ "$FAILED" -eq 0 ] && { echo "PASS — claude_seat_pick"; exit 0; } || { echo "FAIL — claude_seat_pick"; exit 1; }


### PR DESCRIPTION
## Summary
- `scripts/lib/claude_seat.sh` hardcoded `for i in 1 2 3 4 5` in three places (the OAuth secrets loader, the rotation loop, and the interactive picker). Slot 6 — carrying the Claude Team seat `zero@balizero.com` — was armed in `~/.nuzantara-secrets.env` but invisible to every one of them: with only that seat alive in the environment, `claude_seat_pick` returned SUSPEND despite a valid seat sitting in env.
- The range is now `CLAUDE_SEAT_SLOTS` (default 6), read via a new `_claude_seat_slots()` helper, so a future seat is a one-line default bump instead of a three-site patch. The error message now reports the configured ceiling instead of a stale "1..5".
- `FLEET_TOPOLOGY.json`: ties each Anthropic account slot (A1-A5, AZ) to its verified `oauth_token_slot` env var and `config_dir`, and resolves A4's email (`antozero1987@gmail.com`, previously flagged unverified). Mapping verified 2026-08-23 via `claude auth status` per config-dir plus the setup-token transcript.

## Test plan
- [x] `bash scripts/tests/test_claude_seat_pick.sh` — PASS, including a new slot-6 regression case (was red without the fix)
- [x] `bash scripts/tests/test_claude_seat_helper.sh` — PASS (all 14 guilt/innocence checks)
- [x] `python3 -c "import json;json.load(open('FLEET_TOPOLOGY.json'))"` — valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)