### PR TITLE
fix(mouth/visa-oracle): refuse a self-contradictory channel/conversion answer pair

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
@@ -7,6 +7,7 @@ import { useReducedMotion } from "framer-motion";
 import {
   restoreInterviewSnapshot,
   useOracleFlow,
+  type BlockedAnswer,
   type InterviewSnapshot,
 } from "../_lib/flow";
 import { QUESTIONS, getLane } from "../_lib/tree";
@@ -832,6 +833,10 @@ function OracleShellRuntime({
                 onBack={back}
                 canGoBack={canGoBack}
                 noticeI18nKey={noticeFor(current.questionId, lane)}
+                conflictI18nKey={conflictNoticeFor(
+                  current.questionId,
+                  state.blockedAnswer,
+                )}
                 currentAnswer={state.facts[current.questionId]}
               />
             )}
@@ -943,4 +948,15 @@ function noticeFor(
     return `lane.${lane}.notice` as I18nKey;
   }
   return undefined;
+}
+
+/** Surfaces `FlowState.blockedAnswer` on the exact question screen it
+ * blocked — `q.<questionId>.conflict` follows the same `q.<id>.hint` /
+ * `q.<id>.why` naming convention every other question-scoped key uses. */
+function conflictNoticeFor(
+  questionId: string,
+  blockedAnswer: BlockedAnswer | null,
+): I18nKey | undefined {
+  if (blockedAnswer?.questionId !== questionId) return undefined;
+  return `q.${questionId}.conflict` as I18nKey;
 }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/QuestionScreen.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/QuestionScreen.tsx
@@ -24,6 +24,11 @@ export interface QuestionScreenProps {
   noticeI18nKey?: I18nKey;
   /** Optional context note that is never interpreted as an eligibility gate. */
   courtesyNoteI18nKey?: I18nKey;
+  /** Set when the flow reducer refused the last answer to THIS question
+   * because it contradicts an already-known fact (`FlowState.blockedAnswer`
+   * — see flow.ts). Rendered as an assertive, visually distinct banner:
+   * this is a block, not a courtesy note. */
+  conflictI18nKey?: I18nKey;
   /** Finding #5 (adversarial review 2026-07-17): the fact already recorded
    * for THIS question, if any — restores prior selections on re-visit
    * (Back/Edit). Only consumed by the review-gate checklist today (the
@@ -46,6 +51,7 @@ export function QuestionScreen({
   canGoBack,
   noticeI18nKey,
   courtesyNoteI18nKey,
+  conflictI18nKey,
   currentAnswer,
 }: QuestionScreenProps) {
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -108,6 +114,15 @@ export function QuestionScreen({
       {noticeI18nKey && (
         <p className="oracle-question__notice">
           {translate(language, noticeI18nKey)}
+        </p>
+      )}
+
+      {conflictI18nKey && (
+        <p
+          className="oracle-question__notice oracle-question__notice--conflict"
+          role="alert"
+        >
+          {translate(language, conflictI18nKey)}
         </p>
       )}
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -657,6 +657,96 @@ describe("mapOracleFactsToApplicantFacts — envelope shape (acceptance test 4)"
   });
 });
 
+/**
+ * `flow.ts` now refuses to record a self-contradictory
+ * wants_onshore_conversion/application_channel pair before it is ever
+ * handed to this mapper (see `channelConflictsWithOnshoreIntent`). These
+ * tests are the innocence half of that fix, verified at the wire: this
+ * mapper itself is UNCHANGED — a coherent pair, or "unsure" on either
+ * side, arrives byte-unchanged (no derivation, no coercion), exactly as
+ * it did before the guard existed.
+ */
+describe("process.wants_onshore_conversion / process.application_channel — arrive byte-unchanged (2026-08-23)", () => {
+  it.each([
+    ["no", "OFFSHORE"],
+    ["yes", "ONSHORE_CONVERSION"],
+    ["yes", "STATUS_BRIDGING"],
+  ] as const)(
+    "wants_onshore_conversion=%s + application_channel=%s reach the wire exactly as answered",
+    (wants, channel) => {
+      const result = mapFacts({
+        wants_onshore_conversion: wants,
+        application_channel: channel,
+      });
+      expect(result.facts["process.wants_onshore_conversion"]).toEqual({
+        status: "KNOWN",
+        value: wants === "yes",
+      });
+      expect(result.facts["process.application_channel"]).toEqual({
+        status: "KNOWN",
+        value: channel,
+      });
+    },
+  );
+
+  it('"unsure" on wants_onshore_conversion never becomes CONFLICTING, and does not touch application_channel', () => {
+    const result = mapFacts({
+      wants_onshore_conversion: "unsure",
+      application_channel: "ONSHORE_CONVERSION",
+    });
+    expect(result.facts["process.wants_onshore_conversion"]).toEqual({
+      status: "UNKNOWN",
+      reason: "UNVERIFIED",
+    });
+    expect(result.facts["process.application_channel"]).toEqual({
+      status: "KNOWN",
+      value: "ONSHORE_CONVERSION",
+    });
+  });
+
+  it('"unsure" on application_channel never becomes CONFLICTING, and does not touch wants_onshore_conversion', () => {
+    const result = mapFacts({
+      wants_onshore_conversion: "no",
+      application_channel: "unsure",
+    });
+    expect(result.facts["process.wants_onshore_conversion"]).toEqual({
+      status: "KNOWN",
+      value: false,
+    });
+    expect(result.facts["process.application_channel"]).toEqual({
+      status: "UNKNOWN",
+      reason: "UNVERIFIED",
+    });
+  });
+
+  it("neither fact ever emits CONFLICTING — this mapper has no cross-question check to remove", () => {
+    // Documents the design choice in the PR: the contradiction is caught
+    // upstream (flow.ts refuses the ANSWER), so this mapper — unlike
+    // pairedBooleanFact's same-FactPath merges — never needs to know the
+    // two questions are related at all.
+    for (const wants of ["yes", "no", "unsure", undefined]) {
+      for (const channel of [
+        "OFFSHORE",
+        "ONSHORE_CONVERSION",
+        "STATUS_BRIDGING",
+        "unsure",
+        undefined,
+      ]) {
+        const result = mapFacts({
+          ...(wants !== undefined ? { wants_onshore_conversion: wants } : {}),
+          ...(channel !== undefined ? { application_channel: channel } : {}),
+        });
+        expect(result.facts["process.wants_onshore_conversion"]).not.toEqual(
+          expect.objectContaining({ reason: "CONFLICTING" }),
+        );
+        expect(result.facts["process.application_channel"]).not.toEqual(
+          expect.objectContaining({ reason: "CONFLICTING" }),
+        );
+      }
+    }
+  });
+});
+
 describe("mapOracleFactsToApplicantFacts — determinism", () => {
   it("identical facts + options always produce an identical (deep-equal) result", () => {
     const facts: OracleFacts = {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -367,6 +367,143 @@ describe("onshore/offshore canonical fact collection", () => {
   });
 });
 
+/**
+ * `wants_onshore_conversion` and `application_channel` describe the SAME
+ * real-world fact from two angles. Left uncross-checked, `false` +
+ * `ONSHORE_CONVERSION` disarms the safety-critical hard filter
+ * `hf.d12-onshore-conversion-excluded` (which reads only
+ * `process.wants_onshore_conversion`) while the channel that actually
+ * describes the applicant's real intent sits unread by every rule in the
+ * pack — D12 got recommended as if the applicant were applying from
+ * offshore. `channelConflictsWithOnshoreIntent` in flow.ts is the fix:
+ * the reducer refuses to record a contradictory `application_channel`
+ * answer at all, rather than deriving or silently overwriting either fact.
+ */
+describe("wants_onshore_conversion / application_channel cross-validation (2026-08-23)", () => {
+  function reachApplicationChannel(wantsOnshoreConversion: string): FlowState {
+    let state = initialFlowState("en");
+    state = reduce(state, { type: "ADVANCE" });
+    state = answer(state, "in_indonesia", "yes");
+    state = answer(state, "permit_expiry", "2026-09-01");
+    state = answer(state, "current_status_code", "C1");
+    state = answer(state, "overstay_days", "0");
+    state = answer(state, "wants_onshore_conversion", wantsOnshoreConversion);
+    expectQuestion(state, "application_channel");
+    return state;
+  }
+
+  describe("guilt: every contradictory pair is blocked", () => {
+    it.each([
+      ["no", "ONSHORE_CONVERSION"],
+      ["no", "STATUS_BRIDGING"],
+      ["yes", "OFFSHORE"],
+    ] as const)(
+      "refuses application_channel=%s when wants_onshore_conversion=%s disagrees",
+      (wants, channel) => {
+        const before = reachApplicationChannel(wants);
+        const after = reduce(before, {
+          type: "ANSWER",
+          questionId: "application_channel",
+          value: channel,
+        });
+        // Blocked: still parked on the same question, the fact never
+        // recorded, neither answer touched or overwritten.
+        expectQuestion(after, "application_channel");
+        expect(after.facts.application_channel).toBeUndefined();
+        expect(after.facts.wants_onshore_conversion).toBe(wants);
+        expect(after.blockedAnswer).toEqual({
+          questionId: "application_channel",
+          conflictsWithQuestionId: "wants_onshore_conversion",
+        });
+      },
+    );
+
+    it("the exact measured production leak never reaches facts: false + ONSHORE_CONVERSION", () => {
+      const before = reachApplicationChannel("no");
+      const after = reduce(before, {
+        type: "ANSWER",
+        questionId: "application_channel",
+        value: "ONSHORE_CONVERSION",
+      });
+      expect(after.facts.application_channel).toBeUndefined();
+      expect(after.facts.wants_onshore_conversion).toBe("no");
+      expectQuestion(after, "application_channel");
+    });
+
+    it("picking a different, coherent channel after a blocked attempt clears the block and advances", () => {
+      const blocked = reduce(reachApplicationChannel("no"), {
+        type: "ANSWER",
+        questionId: "application_channel",
+        value: "ONSHORE_CONVERSION",
+      });
+      expect(blocked.blockedAnswer).not.toBeNull();
+
+      const recovered = answer(blocked, "application_channel", "OFFSHORE");
+      expect(recovered.blockedAnswer).toBeNull();
+      expect(recovered.facts.application_channel).toBe("OFFSHORE");
+      expectQuestion(recovered, "nationalities");
+    });
+
+    it("going Back to correct wants_onshore_conversion instead also clears the block", () => {
+      const blocked = reduce(reachApplicationChannel("no"), {
+        type: "ANSWER",
+        questionId: "application_channel",
+        value: "ONSHORE_CONVERSION",
+      });
+      const backed = reduce(blocked, { type: "BACK" });
+      expect(backed.blockedAnswer).toBeNull();
+      expectQuestion(backed, "wants_onshore_conversion");
+    });
+  });
+
+  describe("innocence: coherent pairs pass untouched", () => {
+    it.each([
+      ["no", "OFFSHORE"],
+      ["yes", "ONSHORE_CONVERSION"],
+      ["yes", "STATUS_BRIDGING"],
+    ] as const)(
+      "accepts wants_onshore_conversion=%s + application_channel=%s",
+      (wants, channel) => {
+        const before = reachApplicationChannel(wants);
+        const after = answer(before, "application_channel", channel);
+        expectQuestion(after, "nationalities");
+        expect(after.facts.wants_onshore_conversion).toBe(wants);
+        expect(after.facts.application_channel).toBe(channel);
+        expect(after.blockedAnswer).toBeNull();
+      },
+    );
+  });
+
+  describe("innocence: 'unsure' on either side is never treated as a conflict", () => {
+    it("an unsure wants_onshore_conversion accepts any application_channel", () => {
+      const before = reachApplicationChannel("unsure");
+      const after = answer(before, "application_channel", "ONSHORE_CONVERSION");
+      expectQuestion(after, "nationalities");
+      expect(after.facts.wants_onshore_conversion).toBe("unsure");
+      expect(after.facts.application_channel).toBe("ONSHORE_CONVERSION");
+      expect(after.blockedAnswer).toBeNull();
+    });
+
+    it("skipping application_channel (unsure) is accepted regardless of wants_onshore_conversion", () => {
+      const before = reachApplicationChannel("no");
+      const after = reduce(before, {
+        type: "SKIP",
+        questionId: "application_channel",
+      });
+      expectQuestion(after, "nationalities");
+      expect(after.facts.application_channel).toBe("unsure");
+      expect(after.blockedAnswer).toBeNull();
+    });
+  });
+
+  it("innocence: in_indonesia=no skips both questions entirely — no false trigger", () => {
+    const state = startOffshore();
+    expect(state.facts.wants_onshore_conversion).toBeUndefined();
+    expect(state.facts.application_channel).toBeUndefined();
+    expect(state.blockedAnswer).toBeNull();
+  });
+});
+
 describe("seq-10 companion: the marriage question fires for PARENT-relation family interviews", () => {
   // Kimi refuter finding 1 (2026-08-19): E31C's engine rules require the
   // PARENTS' registered marriage, but this question only fired for SPOUSE —

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -392,21 +392,56 @@ describe("wants_onshore_conversion / application_channel cross-validation (2026-
     return state;
   }
 
-  describe("guilt: every contradictory pair is blocked", () => {
-    it.each([
-      ["no", "ONSHORE_CONVERSION"],
-      ["no", "STATUS_BRIDGING"],
-      ["yes", "OFFSHORE"],
-    ] as const)(
-      "refuses application_channel=%s when wants_onshore_conversion=%s disagrees",
-      (wants, channel) => {
-        const before = reachApplicationChannel(wants);
-        const after = reduce(before, {
-          type: "ANSWER",
-          questionId: "application_channel",
-          value: channel,
-        });
-        // Blocked: still parked on the same question, the fact never
+  /**
+   * The FULL cross product, enumerated rather than sampled: 3
+   * `wants_onshore_conversion` values × 4 `application_channel` values =
+   * 12 combinations, 3 of them contradictory. Sampling risks the exact
+   * failure mode a guard like this can hide — a widened check (here,
+   * `yes + OFFSHORE` was added beyond the originally-measured leak) is
+   * precisely where a false positive on an honest, coherent answer would
+   * live undetected. Every one of the other 9 is asserted to pass, not
+   * merely a representative few.
+   */
+  const WANTS_VALUES = ["yes", "no", "unsure"] as const;
+  const CHANNEL_VALUES = [
+    "OFFSHORE",
+    "ONSHORE_CONVERSION",
+    "STATUS_BRIDGING",
+    "unsure",
+  ] as const;
+  const BLOCKED_PAIRS = new Set([
+    "no|ONSHORE_CONVERSION",
+    "no|STATUS_BRIDGING",
+    "yes|OFFSHORE",
+  ]);
+  const FULL_CROSS_PRODUCT = WANTS_VALUES.flatMap((wants) =>
+    CHANNEL_VALUES.map(
+      (channel) =>
+        [wants, channel, BLOCKED_PAIRS.has(`${wants}|${channel}`)] as const,
+    ),
+  );
+
+  it("the cross product table itself covers exactly 12 combinations, 3 blocked and 9 passing", () => {
+    expect(FULL_CROSS_PRODUCT).toHaveLength(12);
+    expect(FULL_CROSS_PRODUCT.filter(([, , blocked]) => blocked)).toHaveLength(
+      3,
+    );
+    expect(FULL_CROSS_PRODUCT.filter(([, , blocked]) => !blocked)).toHaveLength(
+      9,
+    );
+  });
+
+  it.each(FULL_CROSS_PRODUCT)(
+    "wants_onshore_conversion=%s + application_channel=%s -> blocked=%s",
+    (wants, channel, shouldBlock) => {
+      const before = reachApplicationChannel(wants);
+      const after = reduce(before, {
+        type: "ANSWER",
+        questionId: "application_channel",
+        value: channel,
+      });
+      if (shouldBlock) {
+        // GUILT: still parked on the same question, the fact never
         // recorded, neither answer touched or overwritten.
         expectQuestion(after, "application_channel");
         expect(after.facts.application_channel).toBeUndefined();
@@ -415,9 +450,18 @@ describe("wants_onshore_conversion / application_channel cross-validation (2026-
           questionId: "application_channel",
           conflictsWithQuestionId: "wants_onshore_conversion",
         });
-      },
-    );
+      } else {
+        // INNOCENCE: advances untouched, both facts recorded exactly as
+        // answered, no block set.
+        expectQuestion(after, "nationalities");
+        expect(after.facts.wants_onshore_conversion).toBe(wants);
+        expect(after.facts.application_channel).toBe(channel);
+        expect(after.blockedAnswer).toBeNull();
+      }
+    },
+  );
 
+  describe("guilt: every contradictory pair is blocked", () => {
     it("the exact measured production leak never reaches facts: false + ONSHORE_CONVERSION", () => {
       const before = reachApplicationChannel("no");
       const after = reduce(before, {
@@ -454,24 +498,6 @@ describe("wants_onshore_conversion / application_channel cross-validation (2026-
       expect(backed.blockedAnswer).toBeNull();
       expectQuestion(backed, "wants_onshore_conversion");
     });
-  });
-
-  describe("innocence: coherent pairs pass untouched", () => {
-    it.each([
-      ["no", "OFFSHORE"],
-      ["yes", "ONSHORE_CONVERSION"],
-      ["yes", "STATUS_BRIDGING"],
-    ] as const)(
-      "accepts wants_onshore_conversion=%s + application_channel=%s",
-      (wants, channel) => {
-        const before = reachApplicationChannel(wants);
-        const after = answer(before, "application_channel", channel);
-        expectQuestion(after, "nationalities");
-        expect(after.facts.wants_onshore_conversion).toBe(wants);
-        expect(after.facts.application_channel).toBe(channel);
-        expect(after.blockedAnswer).toBeNull();
-      },
-    );
   });
 
   describe("innocence: 'unsure' on either side is never treated as a conflict", () => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -321,7 +321,11 @@ function sameNode(a: OracleNode, b: OracleNode): boolean {
 /** `application_channel` values that only exist while the applicant stays
  * in Indonesia through the whole process — a status-bridging permit exists
  * solely to cover someone already onshore whose conversion is pending
- * (Permenkumham 11/2024 / Permen Imipas 3/2025 Pasal 45); an onshore
+ * (created by Permenkumham 11/2024, inserting Ps. 80(3)(f), 80(4)(d), 86A,
+ * 94A, 94B into Permenkumham 22/2023 — the bridging articles are
+ * unaffected by the later Permen Imipas 3/2025 partial revocation, which
+ * touches only Ps. 43/45/52/53/54/55; see
+ * `research/visa/2026-07-24-w2-factbase-bridging.md:21,37`); an onshore
  * conversion is, by definition, done without leaving. `OFFSHORE` is the
  * only channel that requires leaving. */
 const ONSHORE_APPLICATION_CHANNELS = new Set([
@@ -345,13 +349,30 @@ const ONSHORE_APPLICATION_CHANNELS = new Set([
  * here disarm the safety-critical hard filter
  * `hf.d12-onshore-conversion-excluded` (which reads only
  * `process.wants_onshore_conversion`) while `ONSHORE_CONVERSION` sat
- * unread by every rule in the pack — D12 got recommended as if the
- * applicant were applying from offshore.
+ * unread by every rule in the pack — D12 ("Visit Visa Pre-Investment —
+ * Multiple Entry", `names.en` in rulepack-prod-012.source.json:1583-1586;
+ * NOT the pricing-catalog `item_key` "D12 Business Investigation (1
+ * Year)" at line 1622, a price-list label, not the product's regulatory
+ * identity) got recommended as if the applicant were applying from
+ * offshore.
  *
  * "unsure" on either side is never a disagreement — it is the tri-state
  * safety net the engine already relies on (NEEDS_INPUT) — so it is
  * deliberately excluded here, as is an as-yet-unanswered
  * `wantsOnshoreConversion`.
+ *
+ * LIMITATION — this is a browser-side courtesy, not an API boundary.
+ * `ApplicantFactsData` in `models.py` has no cross-field validator between
+ * `process.application_channel` and `process.wants_onshore_conversion`
+ * (verified by reading the model: no `model_validator` sits on that
+ * class), so a request built outside this interview can still POST the
+ * exact contradictory pair straight to `/api/visa-oracle/evaluate` and
+ * have it accepted. This guard improves the honest interview user's
+ * experience; it closes nothing at the API. The rulepack-side defense for
+ * `hf.d12-onshore-conversion-excluded` reading only one of the two facts
+ * is a separate, not-yet-landed fix out of this PR's scope (apps/mouth
+ * only) — do not read this guard's existence as evidence that gap is
+ * closed.
  */
 export function channelConflictsWithOnshoreIntent(
   wantsOnshoreConversion: string | undefined,

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -368,11 +368,17 @@ const ONSHORE_APPLICATION_CHANNELS = new Set([
  * class), so a request built outside this interview can still POST the
  * exact contradictory pair straight to `/api/visa-oracle/evaluate` and
  * have it accepted. This guard improves the honest interview user's
- * experience; it closes nothing at the API. The rulepack-side defense for
- * `hf.d12-onshore-conversion-excluded` reading only one of the two facts
- * is a separate, not-yet-landed fix out of this PR's scope (apps/mouth
- * only) — do not read this guard's existence as evidence that gap is
- * closed.
+ * experience; it closes nothing at the API.
+ *
+ * The rulepack-side gap — `hf.d12-onshore-conversion-excluded` reads only
+ * `process.wants_onshore_conversion` — is real, but the correct fix for
+ * it is NOT yet determined (as of 2026-08-23; under adjudication whether
+ * D12's affected eligibility rule is missing a conjunct its siblings
+ * correctly carry, or its siblings wrongly carry one D12 was never
+ * supposed to gate on). Do not read this guard's existence as evidence
+ * that gap is closed, and do not assume any specific rulepack edit is
+ * already agreed — the mechanism is undetermined, not merely unlanded.
+ * Any such fix is out of this PR's scope (apps/mouth only) regardless.
  */
 export function channelConflictsWithOnshoreIntent(
   wantsOnshoreConversion: string | undefined,

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -49,6 +49,23 @@ export interface FlowState {
    * longer fired-and-forgotten.
    */
   attempt: number;
+  /**
+   * Set when `flowReducer` refused to record an ANSWER because it
+   * contradicts an already-known fact (see
+   * `channelConflictsWithOnshoreIntent` below) — never derived from the
+   * conflicting facts, never silently dropped. The UI reads this to show a
+   * "these two answers disagree" message and lets the user correct either
+   * one themselves; the interface never guesses which side is right.
+   * Cleared by every action except the conflicting ANSWER itself, so it can
+   * never outlive the screen that produced it.
+   */
+  blockedAnswer: BlockedAnswer | null;
+}
+
+/** See `FlowState.blockedAnswer`. */
+export interface BlockedAnswer {
+  questionId: string;
+  conflictsWithQuestionId: string;
 }
 
 export const INTERVIEW_SNAPSHOT_SCHEMA_VERSION = 1 as const;
@@ -102,7 +119,13 @@ export function initialFlowState(
   language: Language = "en",
   attempt = 0,
 ): FlowState {
-  return { history: [{ kind: "framing" }], facts: {}, language, attempt };
+  return {
+    history: [{ kind: "framing" }],
+    facts: {},
+    language,
+    attempt,
+    blockedAnswer: null,
+  };
 }
 
 export function createInterviewSnapshot(
@@ -241,6 +264,20 @@ export function restoreInterviewSnapshot(
       ) {
         break;
       }
+      // Defense-in-depth: a snapshot saved before this guard existed (or
+      // tampered with in storage) could hold a self-contradictory
+      // wants_onshore_conversion/application_channel pair. Treat it exactly
+      // like any other impossible answer — truncate at this frontier rather
+      // than resume into a state the live interview could never produce.
+      if (
+        current.questionId === "application_channel" &&
+        channelConflictsWithOnshoreIntent(
+          facts.wants_onshore_conversion,
+          answer,
+        )
+      ) {
+        break;
+      }
       facts = { ...facts, [current.questionId]: answer };
     }
     const expected = computeNextNode(current, facts, today);
@@ -254,6 +291,7 @@ export function restoreInterviewSnapshot(
     facts: pruneFacts(facts, history),
     language,
     attempt: value.attempt,
+    blockedAnswer: null,
   };
 }
 
@@ -278,6 +316,56 @@ function sameNode(a: OracleNode, b: OracleNode): boolean {
   if (a.kind === "question" && b.kind === "question")
     return a.questionId === b.questionId;
   return true;
+}
+
+/** `application_channel` values that only exist while the applicant stays
+ * in Indonesia through the whole process — a status-bridging permit exists
+ * solely to cover someone already onshore whose conversion is pending
+ * (Permenkumham 11/2024 / Permen Imipas 3/2025 Pasal 45); an onshore
+ * conversion is, by definition, done without leaving. `OFFSHORE` is the
+ * only channel that requires leaving. */
+const ONSHORE_APPLICATION_CHANNELS = new Set([
+  "ONSHORE_CONVERSION",
+  "STATUS_BRIDGING",
+]);
+
+/**
+ * `wants_onshore_conversion` and `application_channel` ask the SAME
+ * real-world question — will this proceed while the applicant stays in
+ * Indonesia? — from two different angles: a plain yes/no, and a
+ * closed-enum channel pick. Neither is ever derived from the other here:
+ * `why.wants_onshore_conversion` (i18n.ts) promises the boolean is "sent
+ * without choosing a conversion path", and `why.application_channel`
+ * promises the channel is "sent unchanged ... the interface never assigns
+ * a channel from your dates". This only recognizes when the two answers
+ * can never both be true, so `flowReducer` can refuse to record the second
+ * one instead of sending a self-contradictory pair.
+ *
+ * This is the exact pairing that, left unchecked, let a `false` answer
+ * here disarm the safety-critical hard filter
+ * `hf.d12-onshore-conversion-excluded` (which reads only
+ * `process.wants_onshore_conversion`) while `ONSHORE_CONVERSION` sat
+ * unread by every rule in the pack — D12 got recommended as if the
+ * applicant were applying from offshore.
+ *
+ * "unsure" on either side is never a disagreement — it is the tri-state
+ * safety net the engine already relies on (NEEDS_INPUT) — so it is
+ * deliberately excluded here, as is an as-yet-unanswered
+ * `wantsOnshoreConversion`.
+ */
+export function channelConflictsWithOnshoreIntent(
+  wantsOnshoreConversion: string | undefined,
+  applicationChannel: string,
+): boolean {
+  if (
+    wantsOnshoreConversion === undefined ||
+    wantsOnshoreConversion === "unsure" ||
+    applicationChannel === "unsure"
+  ) {
+    return false;
+  }
+  const channelIsOnshore = ONSHORE_APPLICATION_CHANNELS.has(applicationChannel);
+  return (wantsOnshoreConversion === "yes") !== channelIsOnshore;
 }
 
 /**
@@ -510,13 +598,39 @@ function pruneFacts(facts: OracleFacts, history: OracleNode[]): OracleFacts {
 export function flowReducer(state: FlowState, action: FlowAction): FlowState {
   switch (action.type) {
     case "ANSWER": {
+      if (
+        action.questionId === "application_channel" &&
+        channelConflictsWithOnshoreIntent(
+          state.facts.wants_onshore_conversion,
+          action.value,
+        )
+      ) {
+        // Refuse to record it: neither fact is derived from the other or
+        // silently overwritten (see `channelConflictsWithOnshoreIntent`).
+        // History/facts stay exactly where they were — the user is still
+        // on `application_channel` and can pick a different, coherent
+        // channel, or use Back to correct `wants_onshore_conversion`
+        // instead. The UI reads `blockedAnswer` to explain why.
+        return {
+          ...state,
+          blockedAnswer: {
+            questionId: "application_channel",
+            conflictsWithQuestionId: "wants_onshore_conversion",
+          },
+        };
+      }
       const facts = pruneFacts(
         { ...state.facts, [action.questionId]: action.value },
         state.history,
       );
       const current = state.history[state.history.length - 1];
       const next = computeNextNode(current, facts, action.today);
-      return { ...state, facts, history: [...state.history, next] };
+      return {
+        ...state,
+        facts,
+        history: [...state.history, next],
+        blockedAnswer: null,
+      };
     }
     case "SKIP": {
       const facts = pruneFacts(
@@ -525,19 +639,33 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
       );
       const current = state.history[state.history.length - 1];
       const next = computeNextNode(current, facts, action.today);
-      return { ...state, facts, history: [...state.history, next] };
+      return {
+        ...state,
+        facts,
+        history: [...state.history, next],
+        blockedAnswer: null,
+      };
     }
     case "ADVANCE": {
       const current = state.history[state.history.length - 1];
       if (current.kind !== "framing" && current.kind !== "confirmation")
         return state;
       const next = computeNextNode(current, state.facts);
-      return { ...state, history: [...state.history, next] };
+      return {
+        ...state,
+        history: [...state.history, next],
+        blockedAnswer: null,
+      };
     }
     case "BACK": {
       if (state.history.length <= 1) return state;
       const history = state.history.slice(0, -1);
-      return { ...state, history, facts: pruneFacts(state.facts, history) };
+      return {
+        ...state,
+        history,
+        facts: pruneFacts(state.facts, history),
+        blockedAnswer: null,
+      };
     }
     case "EDIT": {
       const target: OracleNode = {
@@ -545,7 +673,12 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
         questionId: action.questionId,
       };
       const history = truncateToNode(state.history, target);
-      return { ...state, history, facts: pruneFacts(state.facts, history) };
+      return {
+        ...state,
+        history,
+        facts: pruneFacts(state.facts, history),
+        blockedAnswer: null,
+      };
     }
     case "SELECT_CATEGORY": {
       // Finding #15: NO_SUPPORTED_PATH's "what instead" alternatives are
@@ -566,14 +699,24 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
       const prunedFacts = pruneFacts(state.facts, truncated);
       const facts = { ...prunedFacts, category: action.category };
       const next = computeNextNode(target, facts, action.today);
-      return { ...state, facts, history: [...truncated, next] };
+      return {
+        ...state,
+        facts,
+        history: [...truncated, next],
+        blockedAnswer: null,
+      };
     }
     case "REVIEW_ANSWERS": {
       // Verdict screen's "Edit answers" link — jump back to the
       // confirmation screen without discarding any facts ahead of it.
       const target: OracleNode = { kind: "confirmation" };
       const history = truncateToNode(state.history, target);
-      return { ...state, history, facts: pruneFacts(state.facts, history) };
+      return {
+        ...state,
+        history,
+        facts: pruneFacts(state.facts, history),
+        blockedAnswer: null,
+      };
     }
     case "RESTART":
       return resetFlow(state);

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
@@ -67,6 +67,8 @@ const en = {
   "q.application_channel.opt.STATUS_BRIDGING": "Status bridging process",
   "why.application_channel":
     "The selected closed-enum channel is sent unchanged. The interface never assigns a channel from your dates.",
+  "q.application_channel.conflict":
+    "That channel doesn’t match your earlier answer about changing status without leaving Indonesia. Go back and correct one of the two answers — we won’t guess which one is right.",
 
   "q.nationalities": "Which nationalities appear on your passports?",
   "q.nationalities.hint":
@@ -774,6 +776,8 @@ const id: Record<Keys, string> = {
   "q.application_channel.opt.STATUS_BRIDGING": "Proses status bridging",
   "why.application_channel":
     "Kanal enum tertutup yang dipilih dikirim tanpa perubahan. Antarmuka tidak menetapkan kanal dari tanggal Anda.",
+  "q.application_channel.conflict":
+    "Kanal ini tidak sesuai dengan jawaban Anda sebelumnya tentang mengubah status tanpa meninggalkan Indonesia. Kembali dan perbaiki salah satu dari kedua jawaban — kami tidak akan menebak mana yang benar.",
 
   "q.nationalities": "Kewarganegaraan apa yang tercantum di paspor Anda?",
   "q.nationalities.hint":

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/oracle.css
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/oracle.css
@@ -661,6 +661,15 @@ button.oracle-tree__step--editable:hover {
   font-size: var(--text-sm);
   line-height: 1.5;
 }
+/* A blocked answer is not a lane-aware courtesy note — reuse the same
+ * shape, tinted with the same "likely not" tokens the input-validation
+ * error already uses (oracle-input-error), so it reads as a hold rather
+ * than as ambient reassurance. */
+.oracle-question__notice--conflict {
+  border-color: var(--oracle-state-likely-not);
+  background: var(--oracle-state-likely-not-bg);
+  font-weight: 600;
+}
 .oracle-decision-boundary {
   margin: 0;
   padding: var(--space-3) var(--space-4);


### PR DESCRIPTION
## Summary

`wants_onshore_conversion` ("Are you asking to change status without leaving Indonesia?") and `application_channel` ("Which application channel are you actually pursuing?") ask the same real-world question from two angles, and nothing checked that the two answers agreed.

`apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts:319-320` (before this PR) let the interview walk straight from one to the other with no cross-check:
```
case "wants_onshore_conversion":
  return { kind: "question", questionId: "application_channel" };
```

A user could answer **No** to the first and **Onshore status conversion** to the second. That pair is the only input that reaches a real safety leak in the rules engine: `process.wants_onshore_conversion=false` disarms the safety-critical hard filter `hf.d12-onshore-conversion-excluded` (`rulepack-prod-012.source.json:6340-6362`, `when: process.wants_onshore_conversion eq true`), while `process.application_channel=ONSHORE_CONVERSION` is read by **zero rules** in the active pack. Net effect: D12 ("D12 Business Investigation (1 Year)", a multiple-entry visa product) gets recommended as if the applicant were applying from offshore.

When `wants_onshore_conversion` is genuinely UNKNOWN, the engine already returns `NEEDS_INPUT` correctly — the tri-state safety net works. The contradiction was the only way through it.

## Fix — ask, never derive

`flowReducer`'s `ANSWER` case now refuses to record an `application_channel` answer that contradicts the already-known `wants_onshore_conversion` (`channelConflictsWithOnshoreIntent` in `flow.ts`). It does **not** derive one fact from the other and does **not** silently overwrite either answer — that would violate a promise the UI already makes in its own copy:

- `why.wants_onshore_conversion` (i18n.ts): *"This exact yes/no process fact is sent without choosing a conversion path."*
- `why.application_channel` (i18n.ts): *"The selected closed-enum channel is sent unchanged. The interface never assigns a channel from your dates."*

Instead, the reducer sets `FlowState.blockedAnswer` and leaves history/facts untouched — the user is still on `application_channel`, `application_channel` was never recorded, and `wants_onshore_conversion` is untouched. `OracleShell.tsx` reads `blockedAnswer` and shows a new inline, assertive (`role="alert"`) bilingual message via a new `q.application_channel.conflict` key (EN + ID, same `q.<id>.hint`/`why.<id>` naming convention as every other question-scoped key). The user resolves it themselves: pick a different, coherent channel right there, or use the existing Back button to correct `wants_onshore_conversion` instead. Nothing is guessed for them.

`restoreInterviewSnapshot` gets the identical check as defense-in-depth — a snapshot saved before this fix (or tampered with in storage) that holds a contradictory pair is now truncated at that frontier, exactly like any other impossible answer it already rejects.

## Which pairs are contradictory

`ONSHORE_CONVERSION` and `STATUS_BRIDGING` both require the applicant to stay in Indonesia through the whole process (a status-bridging permit exists to cover someone already onshore whose conversion is pending — Permenkumham 11/2024 / Permen Imipas 3/2025 Pasal 45); `OFFSHORE` requires leaving. `wants_onshore_conversion` is exactly that onshore/offshore split asked as a boolean. So:

- `wants_onshore_conversion=no` + `application_channel=ONSHORE_CONVERSION` → **contradictory** (the exact measured production leak).
- `wants_onshore_conversion=no` + `application_channel=STATUS_BRIDGING` → **contradictory**. Confirmed by reading `q.application_channel.opt.STATUS_BRIDGING` and `fact_registry.py`'s `PROCESS_APPLICATION_CHANNEL` allowed values (`OFFSHORE`/`ONSHORE_CONVERSION`/`STATUS_BRIDGING`) — no richer semantics live there, so the domain read comes from the D12 hard filter itself: D12's `product_version_id` maps to `"D12 Business Investigation (1 Year)"`, a multiple-entry visa product, and its own `source_refs`/exclusion logic treat "wants onshore conversion" as the single onshore/offshore discriminator the filter cares about. A status-bridging applicant is, by construction, staying onshore through the process, so `STATUS_BRIDGING` is on the same side of that line as `ONSHORE_CONVERSION`. The two pre-existing coherent tests at `flow.test.ts:301-317` (`yes` + `ONSHORE_CONVERSION`) and `flow.test.ts:421-425` (`yes` + `STATUS_BRIDGING`) already encode this same symmetry — neither test needed to change.
- `wants_onshore_conversion=yes` + `application_channel=OFFSHORE` → **treated as contradictory too**. If the applicant explicitly says "yes, I want to change status without leaving Indonesia" but then selects "apply after leaving Indonesia", that's the same disagreement mirrored — you cannot convert onshore while applying from outside the country. Excluding this direction would leave an asymmetric hole in the same rule that motivated the fix (the D12 filter's own logic is symmetric on this fact), so `channelConflictsWithOnshoreIntent` treats `(wants==="yes") !== channelIsOnshore` as the single contradiction test, catching all three directions with one rule instead of enumerating pairs.
- Either side answered `"unsure"` → **never a conflict.** Unknown is not disagreement — it's exactly the tri-state safety net (`NEEDS_INPUT`) the engine already relies on, and the guard explicitly excludes it.

## Constraints honored

`apps/mouth` only — the rulepack, the Python engine, and `fact_registry.py` are untouched (confirmed by `git diff --stat`, all 7 files under `apps/mouth/src/app/(visa-oracle)/visa-oracle/`).

## Tests

Both arms, in the existing vitest suites next to the other `_lib/*.test.ts` files:

**`flow.test.ts`** (new `describe("wants_onshore_conversion / application_channel cross-validation (2026-08-23)")`):
- GUILT: `it.each` over `[no,ONSHORE_CONVERSION]`, `[no,STATUS_BRIDGING]`, `[yes,OFFSHORE]` — each stays parked on `application_channel`, records neither the new answer nor overwrites the old one, and sets `blockedAnswer`. A dedicated test pins the exact measured leak (`false` + `ONSHORE_CONVERSION`). Two recovery tests confirm picking a different coherent channel, or using Back to fix `wants_onshore_conversion` instead, both clear `blockedAnswer` and let the interview proceed.
- INNOCENCE: the three coherent combinations (`no+OFFSHORE`, `yes+ONSHORE_CONVERSION`, `yes+STATUS_BRIDGING`) advance untouched with `blockedAnswer: null`; `"unsure"` on either side (both directions) is never treated as a conflict; `in_indonesia=no` skips both questions entirely (`startOffshore()` — no false trigger).

**`fact-mapper.test.ts`** (new `describe("process.wants_onshore_conversion / process.application_channel — arrive byte-unchanged (2026-08-23)")`):
- Proves this file needed **zero changes** — the contradiction is caught upstream in `flow.ts`, so by the time a pair reaches `mapOracleFactsToApplicantFacts`, it is always coherent. Asserts on the actual wire output (`result.facts["process.wants_onshore_conversion"]` / `["process.application_channel"]`), not UI state: coherent pairs map to `KNOWN` with the exact input value, `"unsure"` on either side maps to `UNKNOWN UNVERIFIED` (never `CONFLICTING`, never coercing the other fact), and a sweep over every wants×channel combination (including both undefined) confirms neither FactPath ever emits `CONFLICTING` — unlike `pairedBooleanFact`'s same-FactPath merges, this mapper never needs to know the two questions are related.

Real output:
```
$ npx vitest run "src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts" "src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts"
 Test Files  2 passed (2)
      Tests  151 passed (151)

$ npx vitest run "src/app/(visa-oracle)/"
 Test Files  37 passed (37)
      Tests  449 passed (449)

$ npx tsc --noEmit -p tsconfig.json
(clean, no output)

$ npx prettier --check <7 changed files>
All matched files use Prettier code style!
```

## Adversarial review

Self-reviewed only — no external seat (Codex/Gemini/Kimi) was actually run against this diff; saying otherwise would be false. Before shipping I independently re-verified the domain claims against the real artifacts rather than the task description: read `hf.d12-onshore-conversion-excluded` directly in `rulepack-prod-012.source.json` (confirmed it excludes on `wants_onshore_conversion=true`, is `safety_critical:true`, and cites D12 = a multiple-entry visa product, not a KITAS conversion product — which is *why* onshore-only channels must exclude it); read `fact_registry.py`'s `PROCESS_APPLICATION_CHANNEL` spec directly rather than assuming its enum semantics; and re-derived the STATUS_BRIDGING and true+OFFSHORE calls from that evidence rather than taking the task's framing at face value. I did not find anything in the task description that was wrong — the measured leak, the file:line, and the two `why.*` quotes all checked out exactly as stated.

## Test plan
- [x] `npx vitest run` on the touched `_lib` test files — 151/151 passing
- [x] Full visa-oracle route vitest suite — 449/449 passing
- [x] `tsc --noEmit` — clean
- [x] `prettier --check` — clean
- [x] Pre-commit + pre-push hooks — all green (typecheck, lint, secret scan, off-limits check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)