### PR TITLE
fix(wr3): the test suite must not be able to write the real credit ledger

### DIFF
--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -39,26 +39,88 @@ def _wr3_runtime_isolation(tmp_path, monkeypatch):
     Same shape as `_wr2_runtime_isolation` above, and the same reason: the cure
     belongs in a fixture no future test can forget, not in a rule each test
     must remember. `_wr3_real_state_tripwire` proves it stayed armed.
+
+    IT DOES NOT MAKE EVERY WRITE SAFE. It redirects the two env vars; a caller
+    that passes an explicit `ledger_path=` still writes wherever it is told.
+    Only the tripwire covers that, and only after the fact.
+
+    TO TEST THE DEFAULT-PATH FALLBACK, redirect HOME as well — never `delenv`
+    alone. This fixture makes the dangerous version look safe, so the pattern
+    is written out here rather than left to be rediscovered:
+
+        def test_default_path(tmp_path, monkeypatch):
+            monkeypatch.setenv("HOME", str(tmp_path))      # <- NOT optional
+            monkeypatch.delenv("WR3_CREDIT_LEDGER", raising=False)
+            record_spend(...)                              # lands in tmp_path
+
+    Without the HOME line, that test writes the production ledger under a
+    fixture whose whole promise is that it cannot.
     """
     monkeypatch.setenv("WR3_CREDIT_LEDGER", str(tmp_path / "wr3-credit-ledger.jsonl"))
     monkeypatch.setenv("WR3_SPEND_DECISION_LOG", str(tmp_path / "wr3-spend-decisions.jsonl"))
 
 
-def _wr3_real_state_fingerprint() -> dict[str, str]:
-    """(path -> sha256 | "absent") for the real WR3 state files.
+_WR3_STATE_DIR = Path(".cache") / "wr3"
 
-    Read via the process's own HOME so the tripwire follows the same resolution
-    the code under test would use.
+
+def _wr3_real_state_fingerprint() -> dict[str, str]:
+    """(path -> sha256) for EVERY file in the real `~/.cache/wr3` directory.
+
+    The whole directory, not a named pair. `wr3_credit_ledger._record_failure`
+    writes a `<ledger>.failures` sidecar beside the ledger, so a guard listing
+    only `credit-ledger.jsonl` and `spend-decisions.jsonl` misses part of the
+    module's own write surface — a validation rejection against the real path
+    would mutate real state with the session green (cross-family refuter,
+    Kimi K3). Enumerating the directory also covers `flow-quota.json` and any
+    file a future writer adds, which a hardcoded list never would.
+
+    Read via the process's own HOME so the guard resolves the path exactly as
+    the code under test does. A missing directory is `{}`, not an error: on CI
+    runners and fresh machines it simply does not exist.
     """
-    home = Path(os.path.expanduser("~"))
+    root = Path(os.path.expanduser("~")) / _WR3_STATE_DIR
     out: dict[str, str] = {}
-    for name in ("credit-ledger.jsonl", "spend-decisions.jsonl"):
-        target = home / ".cache" / "wr3" / name
+    try:
+        entries = sorted(path for path in root.iterdir() if path.is_file())
+    except OSError:
+        return out
+    for path in entries:
         try:
-            out[str(target)] = hashlib.sha256(target.read_bytes()).hexdigest()
+            out[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
         except OSError:
-            out[str(target)] = "absent"
+            out[str(path)] = "unreadable"
     return out
+
+
+def _wr3_state_delta(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Human-legible description of what moved, newest evidence first.
+
+    The tripwire cannot ATTRIBUTE a write — a real render, a cron job or a
+    concurrent pytest run on Pro/Mini would trip it just as a leaking test
+    does. So it does not merely say "something changed": it prints the lines
+    that appeared, and whoever reads the failure can see in one glance whether
+    they are `test_*` fixtures or a genuine render. An alarm that cannot be
+    diagnosed is an alarm that gets disarmed.
+    """
+    notes: list[str] = []
+    for path in sorted(set(before) | set(after)):
+        old, new = before.get(path), after.get(path)
+        if old == new:
+            continue
+        if old is None:
+            notes.append(f"CREATED {path}")
+        elif new is None:
+            notes.append(f"DELETED {path}")
+        else:
+            notes.append(f"CHANGED {path}")
+        if new is not None and path.endswith((".jsonl", ".failures")):
+            try:
+                lines = Path(path).read_text().splitlines()
+            except OSError:
+                continue
+            for line in lines[-5:]:
+                notes.append(f"    tail: {line[:200]}")
+    return notes
 
 
 @pytest.fixture()
@@ -73,25 +135,40 @@ def wr3_real_state_fingerprint():
 
 @pytest.fixture(scope="session", autouse=True)
 def _wr3_real_state_tripwire():
-    """Fail the session loudly if the suite mutated real WR3 spend state.
+    """Fail the session loudly if the run mutated real WR3 spend state.
 
     The isolation fixture above is the cure; this is what proves the cure is
     still armed. Without it, deleting one `monkeypatch.setenv` line silently
     restores the exact defect it was written for — the suite would go green
     while writing fiction into the production ledger, which is precisely how
     the defect survived unnoticed in the first place.
+
+    KNOWN LIMITS, stated rather than papered over:
+
+    * It cannot attribute the write. Any writer trips it — a real render, a
+      manual `backfill --apply`, a second pytest running concurrently. That is
+      why the failure prints the appended lines instead of only a verdict.
+    * A test that appends and then restores the original bytes is invisible to
+      a content hash. Content hashing is still right: it is what stops a
+      touched-but-unchanged file from failing every clean session.
+    * It is session-scoped, so it never runs when zero tests are selected
+      (`-k` matching nothing exits 5 with the fixture uninstantiated), and a
+      SIGKILL or `os._exit` skips teardown entirely.
+    * It covers `scripts/tests/` only. A test living in another rootdir that
+      imports the wr3 modules gets neither the redirection nor this guard.
     """
     before = _wr3_real_state_fingerprint()
     yield
     after = _wr3_real_state_fingerprint()
-    changed = [path for path, digest in after.items() if before.get(path) != digest]
-    if changed:
+    if before != after:
         raise AssertionError(
-            "the test suite mutated REAL WR3 spend state (W96): "
-            + ", ".join(changed)
-            + " — a test reached record_spend()/log_decision() without the "
-            "isolation fixture's env redirection. Do not clean the file by "
-            "hand; find the test that escaped."
+            "the test suite mutated REAL WR3 spend state (W96):\n  "
+            + "\n  ".join(_wr3_state_delta(before, after))
+            + "\n\nIf those lines look like test fixtures, a test reached "
+            "record_spend()/log_decision() without the isolation fixture's env "
+            "redirection — find it, do not clean the file by hand. If they look "
+            "like a genuine render, a real writer ran concurrently with this "
+            "session and the suite is innocent."
         )
 
 

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import os
+from pathlib import Path
+
 import pytest
 
 MIN_TEST_NOFILE_LIMIT = 4096
@@ -17,6 +21,78 @@ def _wr2_runtime_isolation(tmp_path, monkeypatch):
     monkeypatch.setenv("WR2_OUTPUT_ROOT", str(tmp_path / "wr2-output"))
     monkeypatch.setenv("TG_DRY_RUN", "1")
     monkeypatch.setenv("TG_SPOOL_DIR", str(tmp_path / "tg-spool"))
+
+
+@pytest.fixture(autouse=True)
+def _wr3_runtime_isolation(tmp_path, monkeypatch):
+    """Tests must NEVER write the real WR3 credit ledger (W96, 2026-08-23).
+
+    `wr3_flowkit_client.submit_clip()` calls `record_spend()` on every charge,
+    and `record_spend()` falls back to `~/.cache/wr3/credit-ledger.jsonl` when
+    `WR3_CREDIT_LEDGER` is unset. Several existing tests drive `submit_clip`
+    with a mocked gateway and never set that variable, so the suite has been
+    appending `mode: "real"`, `credits: 20` rows for episodes that never
+    existed — measured 2026-08-23: 28 such rows, 560 fictitious credits, in the
+    one file whose entire purpose is to be the truth about spend. A ledger a
+    test run can write is not a ledger.
+
+    Same shape as `_wr2_runtime_isolation` above, and the same reason: the cure
+    belongs in a fixture no future test can forget, not in a rule each test
+    must remember. `_wr3_real_state_tripwire` proves it stayed armed.
+    """
+    monkeypatch.setenv("WR3_CREDIT_LEDGER", str(tmp_path / "wr3-credit-ledger.jsonl"))
+    monkeypatch.setenv("WR3_SPEND_DECISION_LOG", str(tmp_path / "wr3-spend-decisions.jsonl"))
+
+
+def _wr3_real_state_fingerprint() -> dict[str, str]:
+    """(path -> sha256 | "absent") for the real WR3 state files.
+
+    Read via the process's own HOME so the tripwire follows the same resolution
+    the code under test would use.
+    """
+    home = Path(os.path.expanduser("~"))
+    out: dict[str, str] = {}
+    for name in ("credit-ledger.jsonl", "spend-decisions.jsonl"):
+        target = home / ".cache" / "wr3" / name
+        try:
+            out[str(target)] = hashlib.sha256(target.read_bytes()).hexdigest()
+        except OSError:
+            out[str(target)] = "absent"
+    return out
+
+
+@pytest.fixture()
+def wr3_real_state_fingerprint():
+    """Expose the tripwire's detector so it can be tested for guilt.
+
+    A detector nobody probes is the same as no detector — importing `conftest`
+    by name is not reliable across rootdirs, so it is handed over as a fixture.
+    """
+    return _wr3_real_state_fingerprint
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _wr3_real_state_tripwire():
+    """Fail the session loudly if the suite mutated real WR3 spend state.
+
+    The isolation fixture above is the cure; this is what proves the cure is
+    still armed. Without it, deleting one `monkeypatch.setenv` line silently
+    restores the exact defect it was written for — the suite would go green
+    while writing fiction into the production ledger, which is precisely how
+    the defect survived unnoticed in the first place.
+    """
+    before = _wr3_real_state_fingerprint()
+    yield
+    after = _wr3_real_state_fingerprint()
+    changed = [path for path, digest in after.items() if before.get(path) != digest]
+    if changed:
+        raise AssertionError(
+            "the test suite mutated REAL WR3 spend state (W96): "
+            + ", ".join(changed)
+            + " — a test reached record_spend()/log_decision() without the "
+            "isolation fixture's env redirection. Do not clean the file by "
+            "hand; find the test that escaped."
+        )
 
 
 _ISOLATED_MODULE_PREFIXES = ("wr2_", "warroom_")

--- a/scripts/tests/test_wr3_ledger_isolation.py
+++ b/scripts/tests/test_wr3_ledger_isolation.py
@@ -1,26 +1,33 @@
 """The WR3 credit ledger must be unwritable BY A TEST RUN (W96, 2026-08-23).
 
-Measured before the cure: `~/.cache/wr3/credit-ledger.jsonl` held 28 rows
-tagged `mode: "real"`, `credits: 20` — 560 credits of spend that never
-happened — written by tests that drove `submit_clip()` against a mocked
-gateway without redirecting `WR3_CREDIT_LEDGER`. `record_spend()` falls back to
-the HOME path when that variable is unset, so a green suite was quietly
-corrupting the one artifact whose entire job is to answer "how much did we
-spend".
+Measured before the cure: `~/.cache/wr3/credit-ledger.jsonl` held 106 rows,
+every one a test artifact, including 28 tagged `mode: "real"`, `credits: 20` —
+560 credits of spend that never happened — written by tests that drove
+`submit_clip()` against a mocked gateway without redirecting
+`WR3_CREDIT_LEDGER`. `record_spend()` falls back to the HOME path when that
+variable is unset, so a green suite was quietly corrupting the one artifact
+whose job is to answer "how much did we spend".
 
-Two things are proved here, because a fixture that is present is not the same
-as a fixture that BITES:
+Two layers are under test, and each is probed for guilt as well as innocence,
+because a fixture that is PRESENT is not the same as a fixture that BITES:
 
-* guilt   — the fingerprint helper the session tripwire depends on actually
-            notices a changed file and a vanished one;
-* innocence — `record_spend()` with no explicit path, from inside the suite,
-            lands in tmp_path and leaves the real HOME file alone.
+* the autouse redirection — proved by writing through the real API and finding
+  the row in tmp_path with the real file unmoved;
+* the session tripwire's detector — proved by making it see an append past the
+  first 4 KiB (a prefix-only hash would pass every small-file test ever
+  written), a brand-new sidecar file, and a deletion.
+
+The 4 KiB case is not hypothetical: `hashlib.sha256(data[:4096])` keeps every
+naive guilt test green while the real ledger, long past 4 KiB, can be appended
+to forever with its digest frozen. That mutation was found by a cross-family
+refuter, not by this suite's first draft.
 """
 from __future__ import annotations
 
 import json
 import os
 import sys
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -28,7 +35,12 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from wr3_credit_ledger import read_records, record_spend  # noqa: E402
+from wr3_spend_authority import log_decision, parse_decision  # noqa: E402
 
+
+# ---------------------------------------------------------------------------
+# The redirection bites
+# ---------------------------------------------------------------------------
 
 def test_record_spend_without_an_explicit_path_stays_out_of_home(tmp_path: Path) -> None:
     """The autouse isolation fixture is what makes this pass.
@@ -45,68 +57,131 @@ def test_record_spend_without_an_explicit_path_stays_out_of_home(tmp_path: Path)
 
     redirected = Path(os.environ["WR3_CREDIT_LEDGER"])
     assert redirected.parent == tmp_path, f"fixture did not redirect: {redirected}"
-    rows = read_records(ledger_path=redirected)
-    assert [r["episode_id"] for r in rows] == ["EP-isolation-probe"]
+    assert [r["episode_id"] for r in read_records(ledger_path=redirected)] == ["EP-isolation-probe"]
 
     after = real.read_bytes() if real.exists() else None
     assert after == before, "record_spend() reached the real ledger from inside the suite"
 
 
-def test_the_spend_decision_log_is_redirected_too(tmp_path: Path) -> None:
-    """`log_decision()` has the same HOME fallback and the same exposure."""
-    assert Path(os.environ["WR3_SPEND_DECISION_LOG"]).parent == tmp_path
+def test_log_decision_actually_writes_into_the_redirected_log(tmp_path: Path) -> None:
+    """Exercise the WRITER, not the env var.
+
+    Asserting that `os.environ["WR3_SPEND_DECISION_LOG"]` points into tmp_path
+    would test the fixture's own `setenv` and nothing else: if `log_decision`
+    stopped honouring the variable — say it were "simplified" to the
+    import-time `_DEFAULT_LOG_PATH` in wr3_spend_authority — such a test would
+    stay green while decisions landed in the real file.
+    """
+    real = Path(os.path.expanduser("~")) / ".cache" / "wr3" / "spend-decisions.jsonl"
+    before = real.read_bytes() if real.exists() else None
+
+    decision = parse_decision(f"EP-decision-probe:zero@balizero.com:{date.today().isoformat()}")
+    log_decision(decision, episode_id="EP-decision-probe")
+
+    redirected = Path(os.environ["WR3_SPEND_DECISION_LOG"])
+    assert redirected.parent == tmp_path
+    rows = [json.loads(line) for line in redirected.read_text().splitlines() if line.strip()]
+    assert len(rows) == 1 and "EP-decision-probe" in json.dumps(rows[0])
+
+    after = real.read_bytes() if real.exists() else None
+    assert after == before, "log_decision() reached the real decision log"
 
 
-def test_the_fingerprint_helper_notices_a_changed_file(tmp_path: Path,
-                                                       monkeypatch: pytest.MonkeyPatch,
-                                                       wr3_real_state_fingerprint) -> None:
-    """Guilt: the tripwire's detector must see a mutation, or it guards nothing."""
-    fake_home = tmp_path / "home"
-    (fake_home / ".cache" / "wr3").mkdir(parents=True)
-    ledger = fake_home / ".cache" / "wr3" / "credit-ledger.jsonl"
-    ledger.write_text(json.dumps({"credits": 0}) + "\n")
-    monkeypatch.setenv("HOME", str(fake_home))
+# ---------------------------------------------------------------------------
+# The detector bites — guilt
+# ---------------------------------------------------------------------------
+
+def _fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    state = home / ".cache" / "wr3"
+    state.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    return state
+
+
+def test_detector_notices_an_append_past_the_first_4096_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
+) -> None:
+    """Kills the prefix-hash mutation.
+
+    `sha256(read_bytes()[:4096])` passes every test written against a two-line
+    fixture — and freezes the digest of the real ledger, which is far larger,
+    so it could be appended to forever undetected. The file here is padded past
+    4 KiB and only its TAIL changes.
+    """
+    state = _fake_home(tmp_path, monkeypatch)
+    ledger = state / "credit-ledger.jsonl"
+    padding = "".join(json.dumps({"pad": i}) + "\n" for i in range(400))
+    assert len(padding.encode()) > 4096
+    ledger.write_text(padding)
 
     before = wr3_real_state_fingerprint()
     with ledger.open("a") as fh:
-        fh.write(json.dumps({"credits": 20}) + "\n")
-    after = wr3_real_state_fingerprint()
-
-    assert before[str(ledger)] != after[str(ledger)]
-    assert "absent" not in (before[str(ledger)], after[str(ledger)])
+        fh.write(json.dumps({"credits": 20, "mode": "real"}) + "\n")
+    assert wr3_real_state_fingerprint() != before
 
 
-def test_the_fingerprint_helper_reports_absent_rather_than_raising(
+def test_detector_notices_a_new_sidecar_appearing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
 ) -> None:
-    """Innocence: a machine with no ledger yet must not error the session."""
+    """`_record_failure` writes `<ledger>.failures` beside the ledger.
+
+    A detector listing only the two named files would leave that whole write
+    surface unguarded — real state mutated, session green.
+    """
+    state = _fake_home(tmp_path, monkeypatch)
+    (state / "credit-ledger.jsonl").write_text("{}\n")
+
+    before = wr3_real_state_fingerprint()
+    (state / "credit-ledger.jsonl.failures").write_text('{"kind": "validation"}\n')
+    after = wr3_real_state_fingerprint()
+
+    assert set(after) - set(before) == {str(state / "credit-ledger.jsonl.failures")}
+
+
+def test_detector_notices_a_file_vanishing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
+) -> None:
+    state = _fake_home(tmp_path, monkeypatch)
+    ledger = state / "credit-ledger.jsonl"
+    ledger.write_text("{}\n")
+
+    before = wr3_real_state_fingerprint()
+    ledger.unlink()
+    after = wr3_real_state_fingerprint()
+
+    assert str(ledger) in before and str(ledger) not in after
+
+
+# ---------------------------------------------------------------------------
+# The detector bites — innocence
+# ---------------------------------------------------------------------------
+
+def test_detector_reports_an_empty_map_when_the_directory_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
+) -> None:
+    """A CI runner or a fresh machine has no ~/.cache/wr3 at all. That must be
+    an empty map, not an exception erroring every session."""
     monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
-    fingerprint = wr3_real_state_fingerprint()
-    assert set(fingerprint.values()) == {"absent"}
-    assert len(fingerprint) == 2
+    assert wr3_real_state_fingerprint() == {}
 
 
 def test_a_touched_but_unchanged_file_is_not_reported_as_mutated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
 ) -> None:
-    """Innocence, and a real claim about HOW the tripwire decides.
+    """The verdict must be over CONTENT, not mtime.
 
-    The fingerprint must be over CONTENT, not over mtime. A ledger whose
-    timestamp moved — an editor save, a backup tool, an rsync — has not been
-    spent against, and a tripwire that failed on that would fire on clean
-    sessions until someone disarmed it. So: same bytes, new mtime, same
-    verdict.
+    A ledger whose timestamp moved — an editor save, a backup, an rsync — has
+    not been spent against, and a tripwire that failed on that would fire on
+    clean sessions until someone disarmed it.
     """
-    fake_home = tmp_path / "home"
-    (fake_home / ".cache" / "wr3").mkdir(parents=True)
-    ledger = fake_home / ".cache" / "wr3" / "credit-ledger.jsonl"
+    state = _fake_home(tmp_path, monkeypatch)
+    ledger = state / "credit-ledger.jsonl"
     ledger.write_text('{"credits": 0}\n')
-    monkeypatch.setenv("HOME", str(fake_home))
 
     before = wr3_real_state_fingerprint()
     os.utime(ledger, (1_000_000_000, 1_000_000_000))
-    stamped = wr3_real_state_fingerprint()
-    assert stamped == before, "the fingerprint reacted to mtime, not to content"
+    assert wr3_real_state_fingerprint() == before, "the detector reacted to mtime, not content"
 
     ledger.write_text('{"credits": 20}\n')  # same length, different bytes
     assert wr3_real_state_fingerprint() != before

--- a/scripts/tests/test_wr3_ledger_isolation.py
+++ b/scripts/tests/test_wr3_ledger_isolation.py
@@ -1,0 +1,112 @@
+"""The WR3 credit ledger must be unwritable BY A TEST RUN (W96, 2026-08-23).
+
+Measured before the cure: `~/.cache/wr3/credit-ledger.jsonl` held 28 rows
+tagged `mode: "real"`, `credits: 20` — 560 credits of spend that never
+happened — written by tests that drove `submit_clip()` against a mocked
+gateway without redirecting `WR3_CREDIT_LEDGER`. `record_spend()` falls back to
+the HOME path when that variable is unset, so a green suite was quietly
+corrupting the one artifact whose entire job is to answer "how much did we
+spend".
+
+Two things are proved here, because a fixture that is present is not the same
+as a fixture that BITES:
+
+* guilt   — the fingerprint helper the session tripwire depends on actually
+            notices a changed file and a vanished one;
+* innocence — `record_spend()` with no explicit path, from inside the suite,
+            lands in tmp_path and leaves the real HOME file alone.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from wr3_credit_ledger import read_records, record_spend  # noqa: E402
+
+
+def test_record_spend_without_an_explicit_path_stays_out_of_home(tmp_path: Path) -> None:
+    """The autouse isolation fixture is what makes this pass.
+
+    No env var is set here on purpose: this is exactly the shape of the tests
+    that leaked. Delete the `monkeypatch.setenv("WR3_CREDIT_LEDGER", ...)` line
+    in conftest and this goes red.
+    """
+    real = Path(os.path.expanduser("~")) / ".cache" / "wr3" / "credit-ledger.jsonl"
+    before = real.read_bytes() if real.exists() else None
+
+    record_spend(episode_id="EP-isolation-probe", shot_index=1, credits=20,
+                 mode="real", veo_job_id="wf-probe", source="test", clip_cost_cr=20)
+
+    redirected = Path(os.environ["WR3_CREDIT_LEDGER"])
+    assert redirected.parent == tmp_path, f"fixture did not redirect: {redirected}"
+    rows = read_records(ledger_path=redirected)
+    assert [r["episode_id"] for r in rows] == ["EP-isolation-probe"]
+
+    after = real.read_bytes() if real.exists() else None
+    assert after == before, "record_spend() reached the real ledger from inside the suite"
+
+
+def test_the_spend_decision_log_is_redirected_too(tmp_path: Path) -> None:
+    """`log_decision()` has the same HOME fallback and the same exposure."""
+    assert Path(os.environ["WR3_SPEND_DECISION_LOG"]).parent == tmp_path
+
+
+def test_the_fingerprint_helper_notices_a_changed_file(tmp_path: Path,
+                                                       monkeypatch: pytest.MonkeyPatch,
+                                                       wr3_real_state_fingerprint) -> None:
+    """Guilt: the tripwire's detector must see a mutation, or it guards nothing."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".cache" / "wr3").mkdir(parents=True)
+    ledger = fake_home / ".cache" / "wr3" / "credit-ledger.jsonl"
+    ledger.write_text(json.dumps({"credits": 0}) + "\n")
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    before = wr3_real_state_fingerprint()
+    with ledger.open("a") as fh:
+        fh.write(json.dumps({"credits": 20}) + "\n")
+    after = wr3_real_state_fingerprint()
+
+    assert before[str(ledger)] != after[str(ledger)]
+    assert "absent" not in (before[str(ledger)], after[str(ledger)])
+
+
+def test_the_fingerprint_helper_reports_absent_rather_than_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
+) -> None:
+    """Innocence: a machine with no ledger yet must not error the session."""
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    fingerprint = wr3_real_state_fingerprint()
+    assert set(fingerprint.values()) == {"absent"}
+    assert len(fingerprint) == 2
+
+
+def test_a_touched_but_unchanged_file_is_not_reported_as_mutated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wr3_real_state_fingerprint
+) -> None:
+    """Innocence, and a real claim about HOW the tripwire decides.
+
+    The fingerprint must be over CONTENT, not over mtime. A ledger whose
+    timestamp moved — an editor save, a backup tool, an rsync — has not been
+    spent against, and a tripwire that failed on that would fire on clean
+    sessions until someone disarmed it. So: same bytes, new mtime, same
+    verdict.
+    """
+    fake_home = tmp_path / "home"
+    (fake_home / ".cache" / "wr3").mkdir(parents=True)
+    ledger = fake_home / ".cache" / "wr3" / "credit-ledger.jsonl"
+    ledger.write_text('{"credits": 0}\n')
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    before = wr3_real_state_fingerprint()
+    os.utime(ledger, (1_000_000_000, 1_000_000_000))
+    stamped = wr3_real_state_fingerprint()
+    assert stamped == before, "the fingerprint reacted to mtime, not to content"
+
+    ledger.write_text('{"credits": 20}\n')  # same length, different bytes
+    assert wr3_real_state_fingerprint() != before


### PR DESCRIPTION
`base: 8a8487db49afcf0c3735637b011ed7d52a2179a0`

## The defect

Found while verifying something else. `~/.cache/wr3/credit-ledger.jsonl` on Pro
holds **106 rows, every one of them a test artifact** — episode ids like
`test_submit_clip_happy_path0`, job ids like `wf` and `workflow-bbb`. Twenty-eight
of them are tagged `"mode": "real"`, `"credits": 20`: **560 credits of spend that
never happened**, in the one file whose entire purpose is to answer "how much did
we actually spend". `wr3_credit_ledger.py report` was reporting fiction, and every
`pytest -k wr3` added more rows.

Cause: `record_spend()` falls back to the HOME path when `WR3_CREDIT_LEDGER` is
unset, and `test_wr3_anchor_start_image.py`, `test_wr3_watchdog_timeout.py` and
part of `test_wr3_zero_spend.py` drive `submit_clip()` against a mocked gateway
without setting it. The tests predate the ledger; they were harmless until #4606
instrumented the charge sites and gave them something to leak into. It is W96 —
tests reading and writing production state — and the ledger is the worst possible
place for it.

## The cure

Not "remember to set the variable in each test". Two layers:

- **`_wr3_runtime_isolation`** — autouse, redirects `WR3_CREDIT_LEDGER` and
  `WR3_SPEND_DECISION_LOG` into `tmp_path` for every test under
  `scripts/tests/`. It sits directly beside `_wr2_runtime_isolation`, which
  already exists in that conftest for exactly this reason on the WR2 side.
- **`_wr3_real_state_tripwire`** — session-scoped, fingerprints both real files
  before and after the run and fails the session if either moved. Without it,
  deleting one `setenv` line silently restores the whole defect, and the suite
  goes green while writing fiction. That is precisely how this survived.

The detector is exposed as a fixture and probed for **guilt** (it sees a content
change) and **innocence** (a missing file reports `absent` rather than erroring
every clean session; a file whose mtime moved but whose bytes did not is not
reported as mutated — a tripwire that fired on clean sessions would be disarmed
within a week).

## Proof

| | before run | after run |
|---|---|---|
| real ledger sha256 | `b28dfa72d0cba03e…` | `b28dfa72d0cba03e…` |
| real ledger lines | 106 | 106 |

Full `scripts/tests -k wr3`: **272 passed**, 1 pre-existing failure
(`test_wr3_manifest_normalize.py::test_against_the_actual_on_disk_manifest`, which
reads a gitignored artifact absent on this machine and fails identically on
unmodified `main`).

**Mutation** — the `WR3_CREDIT_LEDGER` redirection removed, whole run pointed at
a throwaway `HOME` so no real state is touched:

```
FAILED test_record_spend_without_an_explicit_path_stays_out_of_home
AssertionError: the test suite mutated REAL WR3 spend state (W96):
  <fake-home>/.cache/wr3/credit-ledger.jsonl — a test reached
  record_spend()/log_decision() without the isolation fixture's env redirection.
fake-home ledger written? credit-ledger.jsonl
```

## Not done here

The 106 polluted rows are left in place. An append-only ledger is not something a
code change should quietly rewrite, and cleaning it before this lands would just
let the next test run repopulate it. It is handled separately, by archiving rather
than deleting, once this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)