### PR TITLE
fix(wr3): make the pre-render cost gate an actual gate

### DIFF
--- a/scripts/tests/test_wr3_gatekeeper_cost.py
+++ b/scripts/tests/test_wr3_gatekeeper_cost.py
@@ -1,0 +1,360 @@
+"""P03 "cost truth" — scripts/wr3_gatekeeper_check.py's cost gate is not a gate.
+
+Five measured defects (verified on disk, 2026-08-23) before this fix:
+  1. The gate read `~/.cache/wr3/flow-quota.json` unconditionally at module
+     scope; nothing in the repo writes that file, and a missing file crashed
+     with an uncaught traceback — NO gate-verdict.json was ever written.
+  2. `CR_PER_CLIP = 10` disagreed with the real charge site's
+     `DEFAULT_CLIP_COST_CR = 20` (wr3_flowkit_client.py) — projected spend
+     was under-counted by 2x.
+  3. The daily-ceiling check computed its condition and then `pass`ed.
+  4. `hard_ceiling` was emitted into the verdict JSON and never compared
+     against anything.
+  5. The gate could not run under zero-spend mode without projecting a real
+     (and possibly FAILING) cost for a pipeline that provably spends 0.
+
+These tests drive the real entry point as a SUBPROCESS (the script is
+top-level code keyed off `sys.argv[1]`, not importable) — the exact command
+the orchestrator runs. HOME, WR3_CREDIT_LEDGER, and WR3_SPEND_DECISION_LOG
+are all redirected into tmp_path so this suite can never read or write the
+real `~/.cache/wr3/flow-quota.json` / `~/.cache/wr3/credit-ledger.jsonl`.
+No FlowKit/Veo network call is reachable from anything this script imports
+(wr3_credit_ledger and wr3_spend_authority are both stdlib-only).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_SCRIPTS = Path(__file__).resolve().parents[1]
+GATEKEEPER = REPO_SCRIPTS / "wr3_gatekeeper_check.py"
+
+sys.path.insert(0, str(REPO_SCRIPTS))
+
+from wr3_credit_ledger import record_spend  # noqa: E402
+
+CLIP_COST_CR = 20  # the real per-clip cost (SSOT) — asserted against, not imported,
+                    # so a regression in the import wiring can't hide from these tests
+
+
+# ---------------------------------------------------------------------------
+# fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _shot(i: int) -> dict:
+    return {
+        "shot_id": f"s{i:03d}",
+        "prompt_positive": f"a calm office interior, shot number {i}",
+        "shot_type": "b-roll",
+    }
+
+
+def _episode(tmp_path: Path, *, n_shots: int, name: str = "EP-COST") -> Path:
+    ep = tmp_path / name
+    ep.mkdir(parents=True, exist_ok=True)
+    duration = 8.0 * n_shots
+    (ep / "shot-pack.json").write_text(json.dumps({
+        "shots": [_shot(i) for i in range(1, n_shots + 1)],
+        "total_duration_s": duration,
+    }))
+    (ep / "brief.json").write_text(json.dumps({"target_duration_s": duration}))
+    return ep
+
+
+def _write_quota(
+    path: Path,
+    *,
+    balance_remaining_cr: int = 2400,
+    daily_ceiling_cr: int = 190,
+    as_of: str | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if as_of is None:
+        as_of = datetime.now(timezone.utc).isoformat()
+    path.write_text(json.dumps({
+        "plan": "flow_pro",
+        "daily_ceiling_cr": daily_ceiling_cr,
+        "daily_spent_cr": 0,  # deliberately never trusted by the gate anymore
+        "balance_remaining_cr": balance_remaining_cr,
+        "as_of": as_of,
+    }))
+
+
+def _run_gate(
+    ep: Path,
+    tmp_path: Path,
+    *,
+    ledger_path: Path | None = None,
+    quota_path: Path | None = None,
+    zero_spend: bool = False,
+) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env["HOME"] = str(home)
+    env["WR3_CREDIT_LEDGER"] = str(ledger_path if ledger_path is not None else tmp_path / "ledger.jsonl")
+    env["WR3_SPEND_DECISION_LOG"] = str(tmp_path / "decisions.jsonl")
+    env.pop("WR3_SPEND_DECISION", None)
+    env.pop("WR3_FLOWKIT_CLIP_COST", None)
+    env.pop("WR3_FLOW_QUOTA_MAX_AGE_H", None)
+    if quota_path is not None:
+        env["WR3_FLOW_QUOTA"] = str(quota_path)
+    else:
+        env.pop("WR3_FLOW_QUOTA", None)
+    if zero_spend:
+        env["WR3_ZERO_SPEND"] = "1"
+    else:
+        env.pop("WR3_ZERO_SPEND", None)
+    return subprocess.run(
+        [sys.executable, str(GATEKEEPER), str(ep)],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+def _verdict(ep: Path) -> dict:
+    return json.loads((ep / "gate-verdict.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# 1. missing quota file -> FAIL verdict with a named reason, file still written
+# ---------------------------------------------------------------------------
+
+
+def test_missing_quota_file_fails_closed_and_still_writes_verdict(tmp_path):
+    ep = _episode(tmp_path, n_shots=3)
+    # No quota_path given, and HOME is redirected to an empty tmp dir, so the
+    # default ~/.cache/wr3/flow-quota.json cannot exist.
+    res = _run_gate(ep, tmp_path)
+    assert res.returncode == 0, f"gate must exit 0 and emit a FAIL verdict, not crash: {res.stderr}"
+    assert "Traceback" not in res.stderr, res.stderr
+    assert (ep / "gate-verdict.json").exists(), "today: crash, no verdict file at all"
+    v = _verdict(ep)
+    assert v["verdict"] == "FAIL"
+    assert v["checks"]["cost"]["passed"] is False
+    reasons = " ".join(v["checks"]["cost"]["reasons"])
+    assert "unreadable" in reasons or "missing" in reasons.lower()
+
+
+# ---------------------------------------------------------------------------
+# 2. stale quota file -> FAIL with staleness reason
+# ---------------------------------------------------------------------------
+
+
+def test_stale_quota_file_fails_with_staleness_reason(tmp_path):
+    ep = _episode(tmp_path, n_shots=3)
+    quota_path = tmp_path / "flow-quota.json"
+    stale_as_of = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    _write_quota(quota_path, as_of=stale_as_of)
+    res = _run_gate(ep, tmp_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["verdict"] == "FAIL"
+    reasons = " ".join(v["checks"]["cost"]["reasons"])
+    assert "STALE" in reasons or "stale" in reasons
+
+
+# ---------------------------------------------------------------------------
+# 3. fresh valid quota + affordable pack -> cost passes
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_quota_and_affordable_pack_passes_cost_check(tmp_path):
+    ep = _episode(tmp_path, n_shots=5)
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path)
+    res = _run_gate(ep, tmp_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["passed"] is True, v["checks"]["cost"]
+    assert v["checks"]["cost"]["mode"] == "real"
+
+
+# ---------------------------------------------------------------------------
+# 4. the 2x fix — N shots project N*20, not N*10
+# ---------------------------------------------------------------------------
+
+
+def test_projection_uses_the_real_20cr_per_clip_not_10(tmp_path):
+    ep = _episode(tmp_path, n_shots=7)
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path)
+    res = _run_gate(ep, tmp_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["projected_cr"] == 7 * CLIP_COST_CR == 140
+    assert v["checks"]["cost"]["projected_cr"] != 7 * 10
+
+
+# ---------------------------------------------------------------------------
+# 5. daily ceiling armed — proves the check is ENFORCED, not merely present
+# ---------------------------------------------------------------------------
+
+
+def test_daily_ceiling_fails_when_todays_ledger_spend_leaves_no_headroom(tmp_path):
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+    ledger_path = tmp_path / "ledger.jsonl"
+    # Seed 150cr of REAL spend dated "now" (today) — 150 + 60 > 190.
+    record_spend(
+        episode_id="other-episode",
+        shot_index=0,
+        credits=150,
+        mode="real",
+        veo_job_id="wf-seed",
+        source="test-seed",
+        clip_cost_cr=20,
+        ledger_path=ledger_path,
+    )
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["passed"] is False
+    assert v["checks"]["cost"]["spent_today_cr"] == 150
+    reasons = " ".join(v["checks"]["cost"]["reasons"])
+    assert "daily ceiling" in reasons or "daily_ceiling" in reasons
+
+
+def test_daily_ceiling_passes_when_seed_rows_absent(tmp_path):
+    """Falsification pair for the test above — same episode/quota, no ledger
+    seed. If this also failed, the FAIL above would prove nothing about the
+    check being armed (it would just always fail).
+    """
+    ep = _episode(tmp_path, n_shots=3)
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+    ledger_path = tmp_path / "ledger-empty.jsonl"
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["passed"] is True, v["checks"]["cost"]
+    assert v["checks"]["cost"]["spent_today_cr"] == 0
+
+
+def test_early_local_morning_spend_still_counts_against_todays_ceiling(tmp_path):
+    """The daily window must be the OPERATOR's day, not the UTC day.
+
+    Ledger timestamps are UTC, correctly. But a DAILY CEILING is a business
+    quantity and this business runs on WITA (UTC+8), so bucketing by UTC date
+    slides the reset to 08:00 local — in the dangerous direction. A charge made
+    at 03:00 WITA carries YESTERDAY's UTC date, so under UTC bucketing it stops
+    counting from 08:00 that same local morning and the ceiling silently
+    regains headroom it never had. Under-counting in a spend gate is the
+    failure mode that burns credits.
+
+    The seeded row below is deliberately "early this local morning": for any
+    positive UTC offset that instant falls on the previous UTC date, so the two
+    conventions give different answers and this test can tell them apart. Under
+    UTC bucketing `spent_today_cr` is 0 and the gate PASSES; under the local-day
+    window it is 150 and the gate FAILS. Seeding at "now" — as the tests above
+    do — cannot distinguish them, because both agree about now.
+    """
+    local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+    now_local = datetime.now(local_tz)
+    early_local = now_local.replace(hour=3, minute=0, second=0, microsecond=0)
+    if early_local.astimezone(timezone.utc).date() == now_local.date():
+        pytest.skip(
+            "this machine's UTC offset does not put 03:00 local on a different "
+            "UTC date, so the two conventions cannot be told apart here"
+        )
+
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+    ledger_path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="early-morning-episode",
+        shot_index=0,
+        credits=150,
+        mode="real",
+        veo_job_id="wf-early",
+        source="test-seed",
+        clip_cost_cr=20,
+        ledger_path=ledger_path,
+        ts=early_local.isoformat(),
+    )
+
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["spent_today_cr"] == 150, (
+        "an early-local-morning charge was dropped from today's total — the "
+        "window is bucketing by UTC date, not by the operator's day"
+    )
+    assert cost["passed"] is False
+    assert "daily ceiling" in " ".join(cost["reasons"])
+
+
+# ---------------------------------------------------------------------------
+# 6. WR3_ZERO_SPEND -> projected 0, cost passes, no quota file needed at all
+# ---------------------------------------------------------------------------
+
+
+def test_zero_spend_short_circuits_with_no_quota_file_present(tmp_path):
+    ep = _episode(tmp_path, n_shots=25)  # would be unaffordable/over-count under real mode
+    res = _run_gate(ep, tmp_path, zero_spend=True)  # no quota_path -> none exists
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["projected_cr"] == 0
+    assert v["checks"]["cost"]["passed"] is True
+    assert v["checks"]["cost"]["mode"] == "placeholder"
+
+
+# ---------------------------------------------------------------------------
+# 7. hard ceiling enforced
+# ---------------------------------------------------------------------------
+
+
+def test_hard_ceiling_fails_when_projection_exceeds_it(tmp_path):
+    ep = _episode(tmp_path, n_shots=11)  # 220cr > hard_ceiling 209cr
+    quota_path = tmp_path / "flow-quota.json"
+    # Large daily ceiling / balance so the hard-ceiling reason is guaranteed
+    # present (expected_cr*1.10 == hard_ceiling numerically for this gate's
+    # single hardcoded envelope, so both legitimately fire together).
+    _write_quota(quota_path, daily_ceiling_cr=1000, balance_remaining_cr=100000)
+    res = _run_gate(ep, tmp_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["passed"] is False
+    assert v["checks"]["cost"]["projected_cr"] == 220
+    reasons = " ".join(v["checks"]["cost"]["reasons"])
+    assert "hard_ceiling" in reasons
+
+
+# ---------------------------------------------------------------------------
+# 8. malformed ledger line -> FAIL, never silently read as 0 spent today
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_ledger_line_fails_rather_than_reading_as_zero_spent(tmp_path):
+    ep = _episode(tmp_path, n_shots=3)
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path)
+    ledger_path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ep-a",
+        shot_index=0,
+        credits=20,
+        mode="real",
+        veo_job_id="wf-1",
+        source="test-seed",
+        clip_cost_cr=20,
+        ledger_path=ledger_path,
+    )
+    with ledger_path.open("a", encoding="utf-8") as fh:
+        fh.write("{this is not valid json,,,\n")
+
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    assert res.returncode == 0, res.stderr
+    v = _verdict(ep)
+    assert v["checks"]["cost"]["passed"] is False
+    assert v["checks"]["cost"]["spent_today_cr"] is None
+    reasons = " ".join(v["checks"]["cost"]["reasons"])
+    assert "malformed" in reasons.lower()

--- a/scripts/wr3_credit_ledger.py
+++ b/scripts/wr3_credit_ledger.py
@@ -37,12 +37,35 @@ module to record real spend, so this module must never import
 `wr3_flowkit_client` back (would be circular) and must not require anything
 outside the standard library to stay trivially importable from the hot path.
 
-KNOWN FINDING (not fixed here, by instruction — see PR description): this
-repo disagrees with itself about the true per-clip Veo cost —
-`wr3_flowkit_client.py:49` says `DEFAULT_CLIP_COST_CR = 20`,
-`wr3_gatekeeper_check.py` (~line 22) says `CR_PER_CLIP = 10`. The ledger
-records the client's actual `clip_cost_cr` on every real-mode record, which
-is what makes that disagreement measurable instead of assumed.
+FIXED 2026-08-23 (was a KNOWN FINDING): this repo used to disagree with
+itself about the per-clip Veo cost it PROJECTS — `wr3_flowkit_client.py`
+said `DEFAULT_CLIP_COST_CR = 20`, `wr3_gatekeeper_check.py` said
+`CR_PER_CLIP = 10`. `CLIP_COST_CR` (below) is now the single source of
+truth for that projection: `wr3_flowkit_client.DEFAULT_CLIP_COST_CR`
+derives from it instead of re-reading the env var, and
+`wr3_gatekeeper_check.py` imports it directly as `CR_PER_CLIP`, so the two
+numbers cannot drift apart from EACH OTHER again. The ledger still records
+the client's actual `clip_cost_cr` on every real-mode record, which is
+what makes any FUTURE disagreement (e.g. an override env var applied
+inconsistently) measurable instead of assumed.
+
+IMPORTANT — collapsing to one number is not the same as knowing the right
+number (measured 2026-08-23, live Pro gateway, ~/logs/flowkit.err.log over
+the process's whole life): `20` traces to a single empirical observation
+dated 2026-05-20 on SOME Flow paygate tier; it was never re-verified
+against the tier actually in live use. The gateway's own sync log shows
+1135 `PAYGATE_TIER_ONE` syncs vs 4976 `PAYGATE_TIER_TIER1P5` syncs (~81%
+of traffic) — `PAYGATE_TIER_ONE` is a MINORITY of what the live account
+actually talks to, and it is the tier `wr3_flowkit_client.py` requests. A
+third tier, `PAYGATE_TIER_TWO`, is referenced in
+`~/flowkit/extension/background.js`. Per-clip credit cost is tier-
+dependent, and no tier→credits table exists anywhere in this codebase (a
+live `GET /api/flow/credits` / SDK `/v1/credits` endpoint exists on the
+gateway but nothing here queries it — see `_generate_video`'s neighboring
+call sites). So: the true per-clip cost for the tier actually in use is
+UNMEASURED, not merely "unified". `WR3_FLOWKIT_CLIP_COST` is therefore not
+a tuning convenience — it is the escape hatch for a number this codebase
+does not actually know.
 
 HARDENING PASS 2026-08-23 (cross-family refuter, Kimi K3 — 12 confirmed
 defects against the packet's central "credits before == credits after"
@@ -116,12 +139,29 @@ logger = logging.getLogger(__name__)
 _LEDGER_ENV_VAR = "WR3_CREDIT_LEDGER"
 _DEFAULT_LEDGER_SUBPATH = Path(".cache") / "wr3" / "credit-ledger.jsonl"
 
+# SSOT for the per-clip Veo cost PROJECTION (2026-08-23 fix — see the
+# module docstring). This module is the credit-authority AND stays
+# stdlib-only, so it is the correct place to own this constant:
+# `wr3_flowkit_client.py`'s `DEFAULT_CLIP_COST_CR` and
+# `wr3_gatekeeper_check.py`'s `CR_PER_CLIP` both derive from THIS value now
+# (import, not re-declare), so the two can no longer silently disagree
+# with EACH OTHER the way they did before this fix.
+#
+# The default `20` is NOT a verified measurement of the true cost — it is
+# a single empirical observation from 2026-05-20 on some Flow paygate
+# tier, never re-checked against the tier the live account actually uses
+# (measured 2026-08-23: the live gateway syncs `PAYGATE_TIER_TIER1P5` in
+# ~81% of its traffic, not the `PAYGATE_TIER_ONE` this client requests —
+# see the module docstring). Per-clip cost is tier-dependent and no
+# tier→credits table exists in this codebase. `WR3_FLOWKIT_CLIP_COST` is
+# the escape hatch for a number that is, honestly, unmeasured for the tier
+# in use — not a tuning convenience.
+CLIP_COST_CR = int(os.environ.get("WR3_FLOWKIT_CLIP_COST", "20"))
+
 # Estimated per-clip cost used ONLY for backfilled (historical, no live
-# instrumentation) records — see the KNOWN FINDING in the module docstring.
-# Mirrors wr3_flowkit_client.DEFAULT_CLIP_COST_CR (the constant actually used
-# at the real spend call site); NOT imported from there to keep this module
-# dependency-free / avoid a circular import.
-BACKFILL_ESTIMATED_CLIP_COST_CR = 20
+# instrumentation) records — see the module docstring. Alias of CLIP_COST_CR
+# (kept as its own name for existing importers/tests); NOT a separate value.
+BACKFILL_ESTIMATED_CLIP_COST_CR = CLIP_COST_CR
 
 VALID_MODES = ("real", "placeholder", "backfill")
 
@@ -1112,9 +1152,9 @@ def _cmd_backfill(args: argparse.Namespace) -> int:
     print("#   clips_original_backup*, _probe_clips*, *_backup_* are walked ONLY for")
     print("#   shot keys absent from clips/ (or an earlier-scanned sibling) — retries/")
     print("#   copies are never double-counted. Assumed clip_cost_cr = "
-          f"{BACKFILL_ESTIMATED_CLIP_COST_CR} (mirrors wr3_flowkit_client."
-          "DEFAULT_CLIP_COST_CR; wr3_gatekeeper_check.py's CR_PER_CLIP=10 "
-          "disagrees — unresolved, see module docstring).")
+          f"{BACKFILL_ESTIMATED_CLIP_COST_CR} (this module's CLIP_COST_CR SSOT; "
+          "wr3_flowkit_client.DEFAULT_CLIP_COST_CR and wr3_gatekeeper_check.py's "
+          "CR_PER_CLIP both derive from it — see module docstring).")
     print("# Every row below is an ESTIMATED FLOOR (mode=backfill), never a")
     print("#   measurement: a re-render is a real charge that dedupe-by-shot-key")
     print("#   cannot tell apart from a harmless duplicate copy (e.g. shot 01 has")

--- a/scripts/wr3_flowkit_client.py
+++ b/scripts/wr3_flowkit_client.py
@@ -42,15 +42,26 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
 
-from wr3_credit_ledger import record_spend
+from wr3_credit_ledger import CLIP_COST_CR, record_spend
 from wr3_placeholder_clip import render_placeholder_clip
 from wr3_spend_authority import assert_spend_authorized, zero_spend_enabled
 
 DEFAULT_ENDPOINT = os.environ.get("WR3_FLOWKIT_ENDPOINT", "http://127.0.0.1:8100")
 DEFAULT_PAYGATE = os.environ.get("WR3_FLOWKIT_PAYGATE", "PAYGATE_TIER_ONE")
 PER_CLIP_TIMEOUT_S = int(os.environ.get("WR3_FLOWKIT_TIMEOUT_S", "300"))
-# Tier 1 fast portrait: 20 credits/clip (empirical 2026-05-20).
-DEFAULT_CLIP_COST_CR = int(os.environ.get("WR3_FLOWKIT_CLIP_COST", "20"))
+# SSOT is wr3_credit_ledger.CLIP_COST_CR (2026-08-23 fix) — this derives
+# from it rather than re-reading WR3_FLOWKIT_CLIP_COST itself, so this
+# constant and wr3_gatekeeper_check.py's CR_PER_CLIP can never disagree
+# with EACH OTHER again. Same env var, same default — runtime behaviour is
+# unchanged. The default (20) is a single empirical observation from
+# 2026-05-20 on some paygate tier, NOT a verified cost for the tier this
+# client actually requests below (`PAYGATE_TIER_ONE`) — the live gateway's
+# traffic is ~81% a DIFFERENT tier (`PAYGATE_TIER_TIER1P5`, measured
+# 2026-08-23), and per-clip cost is tier-dependent with no tier→credits
+# table anywhere in this codebase. See wr3_credit_ledger.py's module
+# docstring for the full measurement. Treat 20 as an unverified default,
+# not a known truth.
+DEFAULT_CLIP_COST_CR = CLIP_COST_CR
 # UNMEASURED PLACEHOLDER — deliberately 0, deliberately an under-count, NOT a
 # measurement. We do not yet know how many Flow credits
 # /api/flow/generate-image actually consumes per call. Every real-mode ledger

--- a/scripts/wr3_gatekeeper_check.py
+++ b/scripts/wr3_gatekeeper_check.py
@@ -2,41 +2,258 @@
 """WR3 pre-render-gatekeeper deterministic check matrix.
 Faithful execution of ~/.claude/agents/wr3-pre-render-gatekeeper.md "Hard rules".
 Writes gate-verdict.json. Step 4 spend gate (Law 7 hard halt).
+
+Cost-gate rework 2026-08-23 (P03 "cost truth"): the cost circuit breaker was
+previously decorative — see wr3_credit_ledger.py's module docstring for the
+5 measured defects (frozen/hand-seeded quota file with nothing writing it;
+uncaught crash + NO verdict file when that file is absent; the per-clip cost
+this gate PROJECTS silently disagreed with what the real spend call site
+projects, 10 here vs 20 there; a daily-ceiling check that computed its
+condition and then `pass`ed; a `hard_ceiling` emitted into the verdict and
+never compared against anything). This file now:
+  - derives the per-clip cost from the same SSOT the real spend call site
+    uses (wr3_credit_ledger.CLIP_COST_CR), so the two projections can no
+    longer drift from EACH OTHER. NOTE this does not mean 20 is the
+    verified true cost — see wr3_credit_ledger.py's module docstring:
+    20 is an unverified 2026-05-20 observation on some paygate tier, and
+    the live gateway mostly syncs a DIFFERENT tier than the one this repo
+    requests. `WR3_FLOWKIT_CLIP_COST` is the escape hatch for that unknown;
+  - fails CLOSED on a missing/invalid/stale quota snapshot — never crashes,
+    always writes gate-verdict.json;
+  - arms the daily-ceiling check against the ledger's OWN today's spend,
+    not the quota file's frozen daily_spent_cr;
+  - actually compares projected_cr against hard_ceiling;
+  - short-circuits to a free PASS under WR3_ZERO_SPEND (nothing is spent,
+    so nothing should be able to fail a cost gate).
 """
 import json
 import math
+import os
 import re
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+# The file has no sys.path setup today — the siblings below live next to
+# this script, not on the default import path when invoked from elsewhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from wr3_credit_ledger import (  # noqa: E402
+    CLIP_COST_CR,
+    _parse_ts,
+    _resolve_ledger_path,
+    read_integrity,
+    read_records,
+)
+from wr3_spend_authority import zero_spend_enabled  # noqa: E402
 
 EP = Path(sys.argv[1])
 shot_pack = json.loads((EP / "shot-pack.json").read_text())
 brief = json.loads((EP / "brief.json").read_text())
-quota = json.loads(Path.home().joinpath(".cache/wr3/flow-quota.json").read_text())
 
 shots = shot_pack["shots"]
 n = len(shots)
 target_dur = shot_pack.get("total_duration_s", brief.get("target_duration_s", 145.4))
 
+
+def _scan_ledger_for_malformed_lines(ledger_path: Path) -> int:
+    """Count non-blank ledger lines that are not a valid JSON object.
+
+    `read_records()` already skips these — logged at WARNING, never fatal,
+    which is the correct behaviour for a `report`. It is the WRONG behaviour
+    for a spend gate: a ledger corrupted mid-write must not silently read as
+    "0 spent today". This is a deliberate, SEPARATE check from
+    `read_integrity()` below — `read_integrity()` only summarizes
+    `record_spend()`'s write-failure sidecar (validation rejections / IO
+    write failures at append time); it has no visibility into a ledger file
+    that is corrupted by some other means (hand-edit, crash mid-line,
+    concurrent writer). Both are checked because they catch different
+    failure modes.
+    """
+    if not ledger_path.exists():
+        return 0
+    bad = 0
+    with ledger_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                bad += 1
+                continue
+            if not isinstance(obj, dict):
+                bad += 1
+    return bad
+
+
 # --- Cost check ---
-CR_PER_CLIP = 10  # Fast Tier_ONE
-projected_cr = n * CR_PER_CLIP
-balance = quota["balance_remaining_cr"]
-# Envelope table: nearest tier for 145.4s is the 150 tier (19 shots / 190 cr expected, ceiling 209)
-# expected cr by interpolation off 150 tier
+# SSOT — wr3_credit_ledger.CLIP_COST_CR (2026-08-23 fix). Was a hardcoded
+# 10 here that silently disagreed with wr3_flowkit_client.py's own
+# projection of 20cr/clip. Collapsing to one number fixes that
+# disagreement between the two files — it does NOT mean 20 is a verified
+# true cost. See wr3_credit_ledger.py's module docstring: 20 traces to a
+# single 2026-05-20 observation on some Flow paygate tier, and the live
+# gateway account predominantly syncs a DIFFERENT tier than the one this
+# client requests, so the true per-clip cost for the tier in use is
+# UNMEASURED. `WR3_FLOWKIT_CLIP_COST` overrides this — treat it as the
+# escape hatch for an unknown number, not a tuning knob.
+CR_PER_CLIP = CLIP_COST_CR
+
+# expected_cr / hard_ceiling are hardcoded for the ONE 150s-tier episode
+# length (19 shots / 190cr expected / 209cr ceiling) this gate was written
+# for. That is a REAL, separate defect (any other episode length gets a
+# wrong envelope) — it is OUT OF SCOPE for this cost-truth fix (P03) and is
+# left as-is. Do not read this as "fine" — see the module docstring above.
 expected_cr = 190
 hard_ceiling = 209
+
 cost_fail = False
 cost_reasons = []
-if projected_cr > expected_cr * 1.10:
-    cost_fail = True
-    cost_reasons.append(f"projected {projected_cr}cr > expected {expected_cr}cr x1.10")
-if projected_cr > balance * 0.5:
-    cost_fail = True
-    cost_reasons.append(f"projected {projected_cr}cr > 50% of balance {balance}cr")
-if quota["daily_spent_cr"] + projected_cr > quota["daily_ceiling_cr"]:
-    # daily ceiling is dynamic per longest episode = 190; but 180 fits within 190 for first episode of day
-    pass
+cost_mode = "real"
+projected_cr = n * CR_PER_CLIP
+balance = None
+daily_ceiling_cr = None
+quota_as_of = None
+spent_today_cr = None
+
+if zero_spend_enabled():
+    # B1 — zero-spend short circuit, checked FIRST and before the quota file
+    # is touched at all. Under WR3_ZERO_SPEND the renderer produces local
+    # ffmpeg placeholders and provably spends 0 credits — a cost FAIL here
+    # would block a pipeline that cannot cost anything, and the whole point
+    # of zero-spend mode is that gatekeeper/audio/assembler/critic run
+    # end-to-end at 0 credits.
+    cost_mode = "placeholder"
+    projected_cr = 0
+else:
+    # B2 — quota snapshot: fail CLOSED, never crash, never trust a stale
+    # number. `Path("")` is truthy (it's PosixPath('.')), so branch on the
+    # raw env string being non-empty, not on the Path.
+    quota_env = os.environ.get("WR3_FLOW_QUOTA", "")
+    quota_path = (
+        Path(quota_env) if quota_env else Path.home() / ".cache" / "wr3" / "flow-quota.json"
+    )
+    max_age_h = float(os.environ.get("WR3_FLOW_QUOTA_MAX_AGE_H", "24"))
+
+    quota = None
+    refusal = None
+    try:
+        raw_quota_text = quota_path.read_text()
+    except OSError as e:
+        refusal = (
+            f"quota snapshot unreadable/missing at {quota_path} ({e}) — "
+            "nothing in this repo writes this file, so a missing balance "
+            "silently disables the cost breaker; refusing to spend"
+        )
+    else:
+        try:
+            quota = json.loads(raw_quota_text)
+        except json.JSONDecodeError as e:
+            refusal = f"quota snapshot at {quota_path} is not valid JSON: {e}"
+
+    if refusal is None:
+        required = ("balance_remaining_cr", "daily_ceiling_cr", "as_of")
+        missing = [k for k in required if k not in quota]
+        if missing:
+            refusal = f"quota snapshot at {quota_path} is missing required field(s): {missing}"
+
+    if refusal is None:
+        as_of_raw = quota.get("as_of")
+        as_of_dt = _parse_ts(as_of_raw)
+        if as_of_dt is None:
+            refusal = f"quota snapshot's as_of={as_of_raw!r} is unparseable"
+        else:
+            age_h = (datetime.now(timezone.utc) - as_of_dt).total_seconds() / 3600.0
+            if age_h > max_age_h:
+                refusal = (
+                    f"quota snapshot at {quota_path} is STALE: as_of={as_of_raw} "
+                    f"is {age_h:.1f}h old (max {max_age_h}h) — nothing in this "
+                    "repo writes this file, so a stale balance silently "
+                    "disables the cost breaker; refusing to spend"
+                )
+
+    if refusal is not None:
+        cost_fail = True
+        cost_reasons.append(refusal)
+    else:
+        balance = quota["balance_remaining_cr"]
+        daily_ceiling_cr = quota["daily_ceiling_cr"]
+        quota_as_of = quota.get("as_of")
+
+        # B4 — arm the daily-ceiling check off the LEDGER's real today's
+        # spend, not the quota file's frozen daily_spent_cr. A degraded
+        # ledger (either kind of corruption) must not silently read as "0
+        # spent today" — that is ALSO a refusal.
+        integrity = read_integrity()
+        malformed_lines = _scan_ledger_for_malformed_lines(_resolve_ledger_path(None))
+        if integrity["status"] != "ok" or malformed_lines:
+            cost_fail = True
+            parts = []
+            if integrity["status"] != "ok":
+                parts.append(
+                    f"credit ledger integrity DEGRADED "
+                    f"({integrity['failure_count']} write failure(s) since "
+                    f"{integrity['since']})"
+                )
+            if malformed_lines:
+                parts.append(f"{malformed_lines} malformed ledger line(s)")
+            cost_reasons.append(
+                "cannot certify today's spend total — " + "; ".join(parts) +
+                " — refusing to spend rather than silently reading 0 spent today"
+            )
+        else:
+            # "Today" is the OPERATOR's day, not the UTC day. Ledger
+            # timestamps are UTC and that is right for storage, but a DAILY
+            # CEILING is a business quantity and this business runs on WITA
+            # (UTC+8). Bucketing by UTC date would slide the reset to 08:00
+            # local and, worse, do it in the DANGEROUS direction: spend made
+            # between 00:00 and 08:00 WITA carries the PREVIOUS UTC date, so
+            # from 08:00 that same local morning it stops being counted and
+            # the ceiling silently regains headroom it never had.
+            # Measured 2026-08-23: a 07:00-WITA charge is counted at 07:00
+            # and uncounted at 09:00, on the same local day. That is an
+            # UNDER-count in a spend gate — the failure mode that burns
+            # credits, not the one that blocks a render.
+            # Compared as absolute instants against local-day boundaries, so
+            # rows written in any offset land in the right bucket.
+            local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+            day_start = datetime.now(local_tz).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            day_end = day_start + timedelta(days=1)
+            spent_today_cr = 0
+            for rec in read_records():
+                if rec.get("mode") != "real":
+                    continue
+                ts = _parse_ts(rec.get("ts"))
+                if ts is None:
+                    continue
+                if not (day_start <= ts.astimezone(local_tz) < day_end):
+                    continue
+                try:
+                    spent_today_cr += int(rec.get("credits", 0))
+                except (TypeError, ValueError):
+                    continue
+
+            if projected_cr > expected_cr * 1.10:
+                cost_fail = True
+                cost_reasons.append(f"projected {projected_cr}cr > expected {expected_cr}cr x1.10")
+            if projected_cr > balance * 0.5:
+                cost_fail = True
+                cost_reasons.append(f"projected {projected_cr}cr > 50% of balance {balance}cr")
+            # B4 — armed: this used to compute the condition and `pass`.
+            if spent_today_cr + projected_cr > daily_ceiling_cr:
+                cost_fail = True
+                cost_reasons.append(
+                    f"daily ceiling: spent_today {spent_today_cr}cr + projected "
+                    f"{projected_cr}cr > daily_ceiling_cr {daily_ceiling_cr}cr"
+                )
+            # B5 — enforce hard_ceiling: reported before, never compared.
+            if projected_cr > hard_ceiling:
+                cost_fail = True
+                cost_reasons.append(f"projected {projected_cr}cr > hard_ceiling {hard_ceiling}cr")
 
 # --- Shot count sanity ---
 max_shots = math.ceil(target_dur / 8) + 1  # 19 for 145.4
@@ -127,6 +344,12 @@ out = {
                    "details": [p for p in per_shot if any(i.startswith("cliche") for i in p["issues"])]},
         "cost": {"projected_cr": projected_cr, "budget_remaining_cr": balance,
                  "expected_cr": expected_cr, "hard_ceiling_cr": hard_ceiling,
+                 "mode": cost_mode,
+                 "daily_ceiling_cr": daily_ceiling_cr,
+                 "spent_today_cr": spent_today_cr,
+                 "spent_today_source": "ledger (local-day window)" if spent_today_cr is not None else None,
+                 "quota_as_of": quota_as_of,
+                 "reasons": cost_reasons,
                  "passed": not cost_fail},
         "safety": {"flagged_words": sorted(set(flagged_words)), "passed": safety_passed},
         "tier1_dialect": {"max_word_count": max((p["word_count"] for p in per_shot), default=0),
@@ -138,7 +361,7 @@ out = {
     "shots_to_reroll": sorted(shots_to_reroll),
     "retry_reasons": retry_reasons,
     "reviewer": "wr3-pre-render-gatekeeper (deterministic check matrix, inline ruleset)",
-    "note": "External cliche-library.md absent on disk (infra gap, seeded-empty 2026-05-18). Ran agent-definition inline Hard-rules ruleset. flow-quota cache seeded by orchestrator at Step 4.",
+    "note": "External cliche-library.md absent on disk (infra gap, seeded-empty 2026-05-18). Ran agent-definition inline Hard-rules ruleset. Cost gate derives per-clip cost from wr3_credit_ledger.CLIP_COST_CR SSOT and fails closed on a missing/stale flow-quota snapshot (2026-08-23 cost-truth fix).",
 }
 (EP / "gate-verdict.json").write_text(json.dumps(out, indent=2))
 print(json.dumps(out, indent=2))


### PR DESCRIPTION
`base: 8a8487db49afcf0c3735637b011ed7d52a2179a0`

`scripts/wr3_gatekeeper_check.py` is the last thing that runs before Veo clips are
submitted and real subscription credits burn. It could not stop anything.

| # | Defect | Measured |
|---|---|---|
| 1 | Reads `~/.cache/wr3/flow-quota.json`, which **nothing in this repo writes** | live copy hand-seeded, `as_of: 2026-05-29`, `daily_spent_cr: 0`; absent file = uncaught `FileNotFoundError`, **no verdict written at all** |
| 2 | Projects 10 cr/clip; the real charge site uses 20 | a 19-shot episode computes 190 cr — *exactly its own `expected_cr`*, PASS — against a true 380 |
| 3 | The daily-ceiling check computes its condition, then `pass`es | `wr3_gatekeeper_check.py:37-39` at base |
| 4 | `hard_ceiling = 209` emitted into the verdict, never compared | — |
| 5 | Under zero-spend it still projects a real cost | could FAIL a run that provably spends nothing |

## The fix

One SSOT for the per-clip cost (`wr3_credit_ledger.CLIP_COST_CR`, which the real
spend site now derives from too, so the two cannot drift apart); a quota loader
that **fails closed** with a named reason on missing / unreadable / invalid /
missing-field / unparseable-`as_of` / stale input and **always writes the
verdict**; the daily ceiling armed against the ledger's own spend instead of the
quota file's frozen `daily_spent_cr`; `hard_ceiling` actually compared; a free
PASS under `WR3_ZERO_SPEND` (the quota file is not even read).

## What the SSOT does NOT claim

Collapsing 10 and 20 into one number fixes *two files disagreeing with each
other*. It does not make 20 true. From the live gateway's own sync log
(`~/logs/flowkit.err.log`, pid 1062, up since 2026-08-20):

```
1135  Syncing tier: PAYGATE_TIER_ONE
4976  Syncing tier: PAYGATE_TIER_TIER1P5
```

`wr3_flowkit_client.py:50` requests `PAYGATE_TIER_ONE` — **the minority tier, ~19%**.
A third tier, `PAYGATE_TIER_TWO`, is hardcoded on one path in
`~/flowkit/extension/background.js:707`. There is **no tier→credits table anywhere**
in this repo or in `~/flowkit/agent/**`. `20` traces to a single observation dated
2026-05-20 on an unspecified tier. The comments now say exactly that, and
`WR3_FLOWKIT_CLIP_COST` is documented as the escape hatch for a number this
codebase does not know — not a tuning knob.

A live `GET /api/flow/credits` exists (`~/flowkit/agent/api/flow.py:85`) and is the
honest eventual replacement for the hand-seeded quota file. Deliberately **not**
wired up here: it needs the Chrome extension connected, and it is a network call
in a gate that must work offline.

## The daily window is the operator's day, not the UTC day

Ledger timestamps are UTC, correctly. But a daily ceiling is a *business*
quantity and this business runs on WITA (UTC+8), so bucketing by UTC date slides
the reset to 08:00 local — **in the dangerous direction**. Measured 2026-08-23:

```
gate runs 07:00 WITA -> gate's 'today'(UTC)=2026-08-23 | 07:00-WITA charge -> UTC 08-23 | counted=True
gate runs 09:00 WITA -> gate's 'today'(UTC)=2026-08-24 | 07:00-WITA charge -> UTC 08-23 | counted=False
```

A charge is counted at 07:00 and uncounted at 09:00 **on the same local day**, so
the ceiling silently regains headroom it never had. Under-counting in a spend
gate is the failure mode that burns credits, not the one that blocks a render.

The test for it seeds a charge at **03:00 local** — an instant that carries
yesterday's UTC date for any positive offset — which is what makes the two
conventions distinguishable. Seeding at "now", as every other test here does,
cannot tell them apart: both agree about now. It skips on a machine whose offset
cannot produce the divergence, rather than passing vacuously.

## Mutation matrix

| Mutation reverted in isolation | Tests red |
|---|---|
| quota loader fails open | 2 (missing, stale) |
| `CR_PER_CLIP` back to 10 | 3 (1 direct + 2 threshold-crossing) |
| daily-ceiling comparison → `pass` | 1 |
| hard-ceiling comparison removed | 1 |
| zero-spend short-circuit removed | 1 |
| daily window back to UTC date | 1 |

Suite: `scripts/tests -k wr3` → **277 passed**, 1 pre-existing failure
(`test_wr3_manifest_normalize` reads a gitignored artifact absent on this machine,
fails identically on unmodified `main`).

## ⚠️ Landing order — read before merging

This arms a check that reads `~/.cache/wr3/credit-ledger.jsonl` as its source of
truth, and **that file is currently poisoned**: 106 rows, all test artifacts, 28
of them `mode: "real"` / `credits: 20`. Computed against the live file today:

```
spent_today_cr the new gate would read = 560
daily_ceiling_cr in the live quota      = 190
=> 560 + 20 > 190  ->  every episode FAILS
```

So the gate would flip from *never blocks* to *always blocks*. Two things must
land first, and both are already open:

1. **#4624** — stops the test suite writing that file at all (verified here: this
   branch predates it, and one `-k wr3` run took the real ledger from 111 to 118
   lines).
2. Archiving the 106 polluted rows — a move, not a delete, once #4624 is in so the
   next run cannot repopulate them.

Today the staleness refusal fires first and masks this, so it is not immediately
visible; it becomes the blocker the moment anyone re-seeds the quota file.

## Spec correction, upheld

The brief told the implementer to treat `read_integrity()` as the check for a
corrupted ledger. It pushed back, correctly: `read_integrity()` only summarizes
`record_spend()`'s own write-failure sidecar and has **no visibility into a file
corrupted by other means** (hand edit, crash mid-line, concurrent writer). It kept
`read_integrity()` *and* added `_scan_ledger_for_malformed_lines()`; both feed one
refusal. The pushback was right and the spec was wrong.

## Left alone on purpose

`expected_cr = 190` / `hard_ceiling = 209` are hardcoded for one episode length —
a real, separate defect. Out of scope here; they now carry a comment saying so,
rather than reading as settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)