### PR TITLE
feat(seats): read the real weekly quota — the old watcher had been reporting nothing for months

### DIFF
--- a/scripts/claude_seat_quota.py
+++ b/scripts/claude_seat_quota.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""claude_seat_quota.py — real weekly/session quota for every Claude seat on this machine.
+
+WHY THIS EXISTS (2026-08-23): asked "how much weekly quota is left on the 6 seats?",
+the honest answer used to be "not obtainable" — `claude` has no `usage` subcommand, and
+`~/scripts/claude-max-usage-watcher.py` (Playwright scraping of claude.ai/settings/usage)
+has been DEAD-GREEN for months: it runs hourly, exits 0, and reports SESSION_EXPIRED for
+every account because its `~/.claude/usage-watcher/profiles/` directory is empty. It also
+only ever knew 3 accounts. A watcher that cannot fail loudly is not a watcher.
+
+The real source is the endpoint the CLI itself calls: GET /api/oauth/usage on
+api.anthropic.com. Two facts make it usable, both measured, both non-obvious:
+
+  1. THE CRON TOKENS CANNOT READ IT. A long-lived `CLAUDE_CODE_OAUTH_TOKEN_*` minted by
+     `claude setup-token` gets HTTP 403 `permission_error: "OAuth token does not meet
+     scope requirement user:profile"`. Only the INTERACTIVE credential stored in the
+     macOS Keychain by `claude auth login` carries that scope. So quota is readable per
+     LOGGED-IN PROFILE, never per cron seat — a machine whose profiles are logged out can
+     hold six perfectly good tokens and still be unable to report a single percentage.
+
+  2. THE KEYCHAIN COPY GOES STALE IN AN HOUR. `accessToken` lives ~1h; the CLI refreshes
+     it lazily when it runs. Reading the Keychain cold therefore returns an expired token
+     for any profile that has been idle, and the endpoint answers "OAuth access token has
+     expired" — which looks exactly like "no data for this account". Measured on
+     sianoantonello@ 2026-08-23: cold read = silence, after one real inference call =
+     100% session / 95% weekly. So this tool WARMS each profile first (`claude auth
+     status`, and `--deep` adds a 1-token inference for profiles that are still stale)
+     and only then reads. Skipping the warm-up turns a saturated seat into a blank row.
+
+Output: a table by default, `--json` for machines. Exit codes are the alerting surface:
+  0 = every discovered profile reported a number
+  1 = at least one profile could not be read (expired/revoked/no scope) — NEVER silent
+  2 = zero profiles discovered, or the endpoint was unreachable for all of them
+      (an empty run is an infrastructure failure masquerading as calm — never exit 0)
+
+Never prints a token, an accessToken or a refreshToken, not even truncated.
+
+Usage:
+    python3 scripts/claude_seat_quota.py                 # table, warm + read
+    python3 scripts/claude_seat_quota.py --json          # machine-readable
+    python3 scripts/claude_seat_quota.py --deep          # force refresh on stale profiles
+    python3 scripts/claude_seat_quota.py --warn-at 85    # exit 1 if any weekly >= 85%
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API_BASE = "https://api.anthropic.com"
+USAGE_PATH = "/api/oauth/usage"
+PROFILE_PATH = "/api/oauth/profile"
+# The CLI identifies itself this way; the endpoint is part of its own OAuth surface.
+UA = "claude-cli (external, cli)"
+OAUTH_BETA = "oauth-2025-04-20"
+KEYCHAIN_SERVICE_PREFIX = "Claude Code-credentials"
+HTTP_TIMEOUT = 25
+
+
+def keychain_services() -> list[str]:
+    """Every 'Claude Code-credentials[-<hash>]' entry, one per logged-in profile."""
+    try:
+        out = subprocess.run(
+            ["security", "dump-keychain"],
+            capture_output=True, text=True, timeout=60,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return []
+    found = re.findall(r'"svce"<blob>="(Claude Code-credentials[^"]*)"', out)
+    return sorted(set(found))
+
+
+def access_token(service: str) -> str | None:
+    """Pull the access token out of one Keychain entry. Never returned to the caller's log."""
+    try:
+        raw = subprocess.run(
+            ["security", "find-generic-password", "-s", service, "-w"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if raw.returncode != 0 or not raw.stdout.strip():
+        return None
+    try:
+        blob = json.loads(raw.stdout)
+    except json.JSONDecodeError:
+        return None
+    oauth = blob.get("claudeAiOauth") or blob.get("oauth") or blob
+    tok = oauth.get("accessToken") or oauth.get("access_token")
+    return tok or None
+
+
+def api_get(path: str, token: str, attempts: int = 3) -> tuple[int, Any]:
+    """GET with backoff on 429.
+
+    Probing ~8 Keychain entries back-to-back trips the endpoint's rate limiter, and a
+    rate-limited answer is indistinguishable in shape from a dead credential — it would
+    report a healthy seat as unreadable and push the exit code to 1. Retry only the
+    retryable status; everything else returns on the first answer.
+    """
+    req = urllib.request.Request(
+        API_BASE + path,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "anthropic-beta": OAUTH_BETA,
+            "User-Agent": UA,
+        },
+    )
+    last: tuple[int, Any] = (0, {"error": {"message": "no attempt made"}})
+    for i in range(attempts):
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+                return resp.status, json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode(errors="replace")
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                payload = {"raw": body[:200]}
+            last = (exc.code, payload)
+            if exc.code not in (429, 500, 502, 503, 529):
+                return last
+        except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            last = (0, {"error": {"message": str(exc)[:160]}})
+        if i < attempts - 1:
+            time.sleep(2 ** i)
+    return last
+
+
+def config_dirs() -> list[Path]:
+    home = Path.home()
+    return [d for d in sorted(home.glob(".claude*")) if d.is_dir() and (d / ".claude.json").exists()]
+
+
+def warm_profiles(deep: bool) -> None:
+    """Refresh each profile's Keychain access token before reading it.
+
+    `auth status` is enough for a token that is merely near expiry; a profile idle past
+    the ~1h window needs a real call (`--deep`). Without this the endpoint answers
+    "token has expired" and a saturated seat reads as a blank row.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+    env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)  # never let a cron seat shadow the profile
+    for d in config_dirs():
+        e = dict(env, CLAUDE_CONFIG_DIR=str(d))
+        try:
+            subprocess.run(["claude", "auth", "status"], env=e, capture_output=True,
+                           timeout=60, stdin=subprocess.DEVNULL)
+            if deep:
+                subprocess.run(
+                    ["claude", "-p", "hi", "--model", "claude-haiku-4-5-20251001"],
+                    env=e, capture_output=True, timeout=120,
+                    stdin=subprocess.DEVNULL, cwd="/tmp",
+                )
+        except (OSError, subprocess.SubprocessError):
+            continue
+
+
+def pct(block: Any) -> float | None:
+    if isinstance(block, dict):
+        v = block.get("utilization")
+        if isinstance(v, (int, float)):
+            return float(v)
+    return None
+
+
+def collect(pace: float = 1.2) -> list[dict]:
+    """Read every Keychain entry, one at a time.
+
+    `pace` matters: ~9 entries x 2 calls fired back-to-back trips the endpoint's rate
+    limiter even with per-call retry, and the result reads as a dead seat. Measured
+    2026-08-23 — without pacing, 3 of 9 entries came back "Rate limited" every run.
+
+    An entry whose PROFILE call also fails to name an account is a STALE LEFTOVER (an old
+    login whose refresh token is long gone), not a seat in trouble: it is reported, but
+    marked `stale` so it never flips the exit code. Conflating the two is what would make
+    this tool cry wolf on every run until someone stopped reading it.
+    """
+    rows: list[dict] = []
+    for idx, svc in enumerate(keychain_services()):
+        if idx:
+            time.sleep(pace)
+        tok = access_token(svc)
+        if not tok:
+            rows.append({"account": None, "stale": True,
+                         "error": "no access token in keychain entry"})
+            continue
+        _, prof = api_get(PROFILE_PATH, tok)
+        email = None
+        if isinstance(prof, dict):
+            acct = prof.get("account") or {}
+            email = acct.get("email_address") or acct.get("email")
+        code, usage = api_get(USAGE_PATH, tok)
+        if code != 200 or not isinstance(usage, dict) or "five_hour" not in usage:
+            msg = "unreadable"
+            if isinstance(usage, dict):
+                msg = (usage.get("error") or {}).get("message", msg)
+            rows.append({"account": email, "error": msg[:80], "http": code,
+                         "stale": email is None})
+            continue
+        rows.append({
+            "account": email,
+            "session_pct": pct(usage.get("five_hour")),
+            "weekly_pct": pct(usage.get("seven_day")),
+            "weekly_opus_pct": pct(usage.get("seven_day_opus")),
+            "weekly_sonnet_pct": pct(usage.get("seven_day_sonnet")),
+            "session_resets_at": (usage.get("five_hour") or {}).get("resets_at"),
+            "weekly_resets_at": (usage.get("seven_day") or {}).get("resets_at"),
+        })
+    # One account can hold several Keychain entries (same seat, two config dirs).
+    # Collapse by account so the table counts SEATS, not profiles.
+    seen: dict[str, dict] = {}
+    unnamed: list[dict] = []
+    for r in rows:
+        key = r.get("account")
+        if not key:
+            unnamed.append(r)
+        elif key not in seen or seen[key].get("error"):
+            seen[key] = r
+    return sorted(seen.values(), key=lambda r: (r.get("weekly_pct") is None,
+                                                -(r.get("weekly_pct") or 0))) + unnamed
+
+
+def fmt(v: float | None) -> str:
+    return "-" if v is None else f"{v:.0f}%"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--deep", action="store_true",
+                    help="force a 1-token inference on stale profiles (slower, more complete)")
+    ap.add_argument("--warn-at", type=float, default=None, metavar="PCT",
+                    help="exit 1 if any seat's weekly utilization is >= PCT")
+    ap.add_argument("--no-warm", action="store_true",
+                    help="skip the refresh pass (faster; idle profiles will read as expired)")
+    ap.add_argument("--pace", type=float, default=1.2, metavar="SEC",
+                    help="seconds between profiles; too low trips the endpoint rate limiter")
+    args = ap.parse_args()
+
+    if sys.platform != "darwin":
+        print("claude_seat_quota: Keychain-backed, macOS only", file=sys.stderr)
+        return 2
+
+    if not args.no_warm:
+        warm_profiles(deep=args.deep)
+
+    rows = collect(pace=args.pace)
+    if not rows:
+        print("claude_seat_quota: NO profile discovered — this is a failure, not calm.\n"
+              "  Log a profile in with: CLAUDE_CONFIG_DIR=$HOME/.claude-<name> claude auth login",
+              file=sys.stderr)
+        return 2
+
+    readable = [r for r in rows if r.get("weekly_pct") is not None]
+    # A stale Keychain leftover has no account name and no live credential: it is noise
+    # from an old login, not a seat that failed. Only a NAMED account that could not be
+    # read is a real failure.
+    stale = [r for r in rows if r.get("stale")]
+    broken = [r for r in rows if r.get("error") and not r.get("stale")]
+
+    if args.json:
+        print(json.dumps(rows, indent=2))
+    else:
+        print(f"{'account':34s} | {'5h':>5} | {'weekly':>6} | weekly resets at")
+        print("-" * 34 + "-+-" + "-" * 5 + "-+-" + "-" * 6 + "-+-" + "-" * 20)
+        for r in rows:
+            if r.get("error"):
+                label = r.get("account") or "(stale keychain entry)"
+                print(f"{label:34s} | {'-':>5} | {'-':>6} | {r['error']}")
+                continue
+            reset = (r.get("weekly_resets_at") or "")[:16].replace("T", " ")
+            flag = " <<<" if (r.get("weekly_pct") or 0) >= 85 else ""
+            print(f"{r['account']:34s} | {fmt(r.get('session_pct')):>5} | "
+                  f"{fmt(r.get('weekly_pct')):>6} | {reset}{flag}")
+        if stale:
+            print(f"\n{len(stale)} stale keychain entr{'y' if len(stale) == 1 else 'ies'} "
+                  f"(old logins, no live credential) — informational, not a seat failure")
+
+    if not readable:
+        print("claude_seat_quota: every profile was unreadable — endpoint or auth failure",
+              file=sys.stderr)
+        return 2
+    if broken:
+        names = ", ".join(r.get("account") or "?" for r in broken)
+        print(f"claude_seat_quota: {len(broken)} named seat(s) unreadable ({names}) "
+              f"— re-login or run with --deep", file=sys.stderr)
+        return 1
+    if args.warn_at is not None:
+        hot = [r for r in readable if (r.get("weekly_pct") or 0) >= args.warn_at]
+        if hot:
+            print(f"claude_seat_quota: {len(hot)} seat(s) at or above {args.warn_at:.0f}% weekly",
+                  file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_claude_seat_quota.py
+++ b/scripts/tests/test_claude_seat_quota.py
@@ -1,0 +1,207 @@
+"""Guilt+innocence for claude_seat_quota.py — no Keychain, no network.
+
+The three behaviours worth defending are the ones that were measured the hard way on
+2026-08-23 (see the module docstring): a rate-limited answer must not be reported as a
+dead seat, an empty run must never exit 0, and a token must never reach stdout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import urllib.error
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "claude_seat_quota.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("claude_seat_quota", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def mod():
+    return load_module()
+
+
+USAGE_OK = {
+    "five_hour": {"utilization": 5.0, "resets_at": "2026-08-23T09:20:00+00:00"},
+    "seven_day": {"utilization": 94.0, "resets_at": "2026-08-25T00:00:00+00:00"},
+    "seven_day_opus": None,
+    "seven_day_sonnet": None,
+}
+
+
+def test_rate_limited_answer_is_retried_not_reported_as_dead(mod, monkeypatch):
+    """A 429 is transient. Reporting it as an unreadable seat would call a healthy
+    account dead and flip the exit code — the exact false alarm this guards."""
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.HTTPError(
+                req.full_url, 429, "Too Many Requests", {},
+                io.BytesIO(b'{"error":{"message":"Rate limited."}}'),
+            )
+
+        class Resp:
+            status = 200
+
+            def read(self):
+                return json.dumps(USAGE_OK).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        return Resp()
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    code, payload = mod.api_get("/api/oauth/usage", "tok")
+    assert code == 200, "a 429 must be retried, not surfaced"
+    assert payload["seven_day"]["utilization"] == 94.0
+    assert calls["n"] == 2, "expected exactly one retry after the 429"
+
+
+def test_non_retryable_status_returns_immediately(mod, monkeypatch):
+    """403-no-scope is the answer a cron token gets. It is terminal: retrying it would
+    only slow the run down and hide the real cause."""
+    calls = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        calls["n"] += 1
+        raise urllib.error.HTTPError(
+            req.full_url, 403, "Forbidden", {},
+            io.BytesIO(b'{"error":{"message":"OAuth token does not meet scope '
+                       b'requirement user:profile"}}'),
+        )
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    code, payload = mod.api_get("/api/oauth/usage", "tok")
+    assert code == 403
+    assert calls["n"] == 1, "a 403 must not be retried"
+    assert "user:profile" in payload["error"]["message"]
+
+
+def test_zero_profiles_exits_2_never_0(mod, monkeypatch):
+    """An empty run is an infrastructure failure masquerading as calm. The predecessor
+    watcher exited 0 for months while reporting nothing — that is the disease."""
+    monkeypatch.setattr(mod, "keychain_services", lambda: [])
+    monkeypatch.setattr(mod, "warm_profiles", lambda deep: None)
+    monkeypatch.setattr(sys, "argv", ["claude_seat_quota.py"])
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        rc = mod.main()
+    assert rc == 2, "no profiles discovered must never be a green run"
+
+
+def test_all_readable_exits_0_and_prints_no_token(mod, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "keychain_services", lambda: ["Claude Code-credentials"])
+    monkeypatch.setattr(mod, "access_token", lambda svc: "sk-ant-oat0-SECRET-DO-NOT-PRINT")
+    monkeypatch.setattr(mod, "warm_profiles", lambda deep: None)
+
+    def fake_api_get(path, token, attempts=3):
+        if path == mod.PROFILE_PATH:
+            return 200, {"account": {"email_address": "someone@example.com"}}
+        return 200, USAGE_OK
+
+    monkeypatch.setattr(mod, "api_get", fake_api_get)
+    monkeypatch.setattr(sys, "argv", ["claude_seat_quota.py"])
+    monkeypatch.setattr(sys, "platform", "darwin")
+    rc = mod.main()
+    out = capsys.readouterr()
+    assert rc == 0
+    assert "someone@example.com" in out.out
+    assert "94%" in out.out
+    assert "SECRET-DO-NOT-PRINT" not in out.out + out.err, "a token must never be printed"
+    assert "sk-ant-oat" not in out.out + out.err
+
+
+def test_warn_at_flags_a_saturated_seat(mod, monkeypatch):
+    monkeypatch.setattr(mod, "keychain_services", lambda: ["Claude Code-credentials"])
+    monkeypatch.setattr(mod, "access_token", lambda svc: "tok")
+    monkeypatch.setattr(mod, "warm_profiles", lambda deep: None)
+    monkeypatch.setattr(mod, "api_get", lambda path, token, attempts=3: (
+        (200, {"account": {"email_address": "hot@example.com"}})
+        if path == mod.PROFILE_PATH else (200, USAGE_OK)
+    ))
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    monkeypatch.setattr(sys, "argv", ["claude_seat_quota.py", "--warn-at", "85"])
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        assert mod.main() == 1, "94% weekly must trip a --warn-at 85 threshold"
+
+    monkeypatch.setattr(sys, "argv", ["claude_seat_quota.py", "--warn-at", "99"])
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        assert mod.main() == 0, "94% weekly must NOT trip a --warn-at 99 threshold"
+
+
+def test_same_account_on_two_profiles_counts_once(mod, monkeypatch):
+    """Two config dirs can hold the same seat (measured: .claude-acct4 and .claude-kaiser
+    were both kaiser1987@). The table must count SEATS, not Keychain entries."""
+    monkeypatch.setattr(mod, "keychain_services",
+                        lambda: ["Claude Code-credentials", "Claude Code-credentials-abc123"])
+    monkeypatch.setattr(mod, "access_token", lambda svc: "tok")
+    monkeypatch.setattr(mod, "api_get", lambda path, token, attempts=3: (
+        (200, {"account": {"email_address": "dup@example.com"}})
+        if path == mod.PROFILE_PATH else (200, USAGE_OK)
+    ))
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    rows = mod.collect(pace=0)
+    assert len(rows) == 1, f"one account across two profiles must collapse to one row: {rows}"
+    assert rows[0]["account"] == "dup@example.com"
+
+
+def test_stale_entry_does_not_flip_the_exit_code(mod, monkeypatch):
+    """An old login left in the Keychain has no account name and no live credential.
+    Counting it as a failed seat would make the tool cry wolf on every run — which is
+    how the predecessor watcher became unreadable noise."""
+    monkeypatch.setattr(mod, "keychain_services",
+                        lambda: ["Claude Code-credentials", "Claude Code-credentials-dead"])
+    monkeypatch.setattr(mod, "access_token",
+                        lambda svc: None if svc.endswith("dead") else "tok")
+    monkeypatch.setattr(mod, "warm_profiles", lambda deep: None)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(mod, "api_get", lambda path, token, attempts=3: (
+        (200, {"account": {"email_address": "live@example.com"}})
+        if path == mod.PROFILE_PATH else (200, USAGE_OK)
+    ))
+    monkeypatch.setattr(sys, "argv", ["claude_seat_quota.py"])
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        assert mod.main() == 0, "a stale leftover must not be reported as a seat failure"
+
+
+def test_named_seat_that_cannot_be_read_does_flip_the_exit_code(mod, monkeypatch):
+    """Guilt side of the pair above: a seat we CAN name but cannot read is a real
+    failure and must be loud."""
+    monkeypatch.setattr(mod, "keychain_services",
+                        lambda: ["Claude Code-credentials", "Claude Code-credentials-x"])
+    monkeypatch.setattr(mod, "access_token", lambda svc: "tok")
+    monkeypatch.setattr(mod, "warm_profiles", lambda deep: None)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+
+    def fake(path, token, attempts=3):
+        if path == mod.PROFILE_PATH:
+            return 200, {"account": {"email_address": "named@example.com"}}
+        return 401, {"error": {"message": "OAuth access token has expired."}}
+
+    monkeypatch.setattr(mod, "api_get", fake)
+    monkeypatch.setattr(sys, "argv", ["claude_seat_quota.py"])
+    monkeypatch.setattr(sys, "platform", "darwin")
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        # every row unreadable -> rc 2 (nothing at all could be read)
+        assert mod.main() == 2


### PR DESCRIPTION
## The gap

Asked "how much weekly quota is left on the 6 Claude seats?", the answer was "not obtainable".
`claude` has no `usage` subcommand, and `~/scripts/claude-max-usage-watcher.py` — the thing that was
supposed to answer this — is **dead-green**: it runs hourly, exits 0, and reports `SESSION_EXPIRED`
for every account because its `profiles/` directory is empty. It also only ever knew 3 accounts of 6.
Cicatrix family #2 in its purest form: a watcher that cannot fail loudly is not a watcher.

## What it does

Reads `GET /api/oauth/usage` on `api.anthropic.com` — the endpoint the CLI itself calls — and prints
session + weekly utilization per seat, with reset times.

```
account                            |    5h | weekly | weekly resets at
sianoantonello@gmail.com           |  100% |    95% | 2026-08-27 21:59 <<<
antozero1987@gmail.com             |    2% |    94% | 2026-08-24 23:59 <<<
zero@balizero.com                  |    0% |     6% | 2026-08-28 19:00
kaiser198719871987@gmail.com       |    0% |     3% | 2026-08-28 15:00
antonellosiano@gmail.com           |    8% |     2% | 2026-08-30 01:00
applevisionpro1987@gmail.com       |    0% |     0% | 2026-08-29 12:59
```

## Two measured facts that make it work

1. **The cron tokens cannot read it.** A long-lived `CLAUDE_CODE_OAUTH_TOKEN_*` from `setup-token`
   gets `403 — OAuth token does not meet scope requirement user:profile`. Only the interactive
   Keychain credential from `claude auth login` has that scope, so quota is readable **per logged-in
   profile**, never per cron seat.
2. **The Keychain copy goes stale in an hour** and the CLI refreshes it lazily. Read cold, the
   endpoint answers "token has expired" — shape-identical to "no data for this account". Measured on
   one seat: cold read = blank row; after one real call = 100% session / 95% weekly. The tool
   therefore warms every profile before reading (`--deep` for the stubborn ones).

## Two false-alarm classes handled on purpose

Either one would have made the output unreadable within a week — which is how the predecessor became
noise nobody checked:

- A **429 is retried** with backoff, and the run is **paced** (`--pace`). ~9 entries × 2 calls in a
  burst trips the limiter, and a rate-limited answer looks exactly like a dead credential.
- A Keychain entry that cannot even name its account is a **stale leftover** from an old login:
  reported, but never counted as a seat failure. Only a *named* seat that fails flips the exit code.

## Exit codes are the alerting surface

`0` all read · `1` a named seat unreadable, or `--warn-at` tripped · `2` zero profiles discovered
(an empty run is an infrastructure failure, never a green one).

Tokens never reach stdout — asserted in the tests, not merely intended.

## Verification

8 tests, guilt+innocence per behaviour, no Keychain and no network — all green. Run live against the
6 real seats: table above, `--warn-at 85` correctly returns 1 with two seats over the line.