### PR TITLE
fix(sota): promoter runs a real R1 adversarial review by construction

### DIFF
--- a/apps/backend-rag/backend/services/sota_loop/_promote.py
+++ b/apps/backend-rag/backend/services/sota_loop/_promote.py
@@ -40,12 +40,97 @@ logger = logging.getLogger("sota.m13.promote")
 _GIT_TIMEOUT = 30
 _GH_TIMEOUT = 30
 _BROKER_TIMEOUT = 60
+_ADVERSARIAL_TIMEOUT = 200
+_ADVERSARIAL_SEAT = "kimi-k3"
 
 
 def _run(cmd: list[str], *, cwd: Path, timeout: int) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout, check=False
     )
+
+
+def _run_adversarial_review(content: str, rel: str) -> str | None:
+    """Best-effort dispatch of a REAL refuter (Kimi K3 — cross-family, never
+    the author of these reports) over one promoted research/**/*.md file.
+
+    Returns the refuter's raw findings, or None if the seat could not be
+    reached/returned nothing usable within the timeout. Callers MUST treat
+    None as "no review happened" and fall back to an honest `exempt-` R1
+    marker — never fabricate a `adversarial_review: kimi-k3` claim for a
+    review that never ran (that would be exactly the generator==grader
+    failure R1 exists to catch, just laundered through a fake seat name).
+    """
+    prompt = (
+        f"Adversarial review of this auto-generated Bali Zero SOTA growth-loop "
+        f"report ({rel}). Which claims, numbers, or status labels are "
+        f"unsupported by the data shown, internally inconsistent, or "
+        f"overreach — including if the underlying data itself looks broken "
+        f"or stubbed (e.g. suspiciously flat/zero values). Say NONE if clean. "
+        f"Terse, max 5 findings.\n\n---\n{content}\n---"
+    )
+    try:
+        result = subprocess.run(
+            ["kimi", "-p", prompt, "-m", "kimi-code/k3"],
+            capture_output=True,
+            text=True,
+            timeout=_ADVERSARIAL_TIMEOUT,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.warning("promote: adversarial review dispatch failed for %s: %s", rel, exc)
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        logger.warning(
+            "promote: adversarial review unusable for %s (rc=%s, empty=%s)",
+            rel,
+            result.returncode,
+            not result.stdout.strip(),
+        )
+        return None
+    return result.stdout.strip()
+
+
+def _ensure_r1_compliance(path: Path, rel: str) -> None:
+    """Inject the R1 generator!=grader frontmatter + section (CLAUDE.md §Agent
+    PR Contract / scripts/check_adversarial_review.py) into a promoter-written
+    research/**/*.md file, so the PR this module opens is never born red on
+    the R1 gate.
+
+    Idempotent: a no-op if the file already opens with '---' frontmatter — a
+    future hand-authored report must never be silently overwritten. Runs a
+    real refuter when reachable; falls back to a truthfully-labeled
+    `exempt-refuter-unreachable` marker (never a fake seat name) when it is
+    not — see _run_adversarial_review.
+    """
+    if path.suffix != ".md" or "research" not in path.parts:
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    if text.splitlines()[:1] == ["---"]:
+        return  # already carries frontmatter — never clobber
+
+    review = _run_adversarial_review(text, rel)
+    if review is not None:
+        seat = _ADVERSARIAL_SEAT
+        section = (
+            "\n\n## Adversarial review\n\n"
+            f"Seat: `kimi -m kimi-code/k3` (automated, dispatched by "
+            f"_promote.py over {rel} at promotion time).\n\n"
+            f"{review}\n"
+        )
+    else:
+        seat = "exempt-refuter-unreachable"
+        section = ""
+        logger.warning(
+            "promote: %s promoted with exempt-refuter-unreachable — no real "
+            "adversarial review ran (kimi seat unavailable)",
+            rel,
+        )
+
+    path.write_text(f"---\nadversarial_review: {seat}\n---\n\n{text}{section}", encoding="utf-8")
 
 
 def promote_research_output(
@@ -106,6 +191,7 @@ def promote_research_output(
             dst = wt_path / rel
             dst.parent.mkdir(parents=True, exist_ok=True)
             dst.write_bytes(src.read_bytes())
+            _ensure_r1_compliance(dst, rel)
             status = _run(["git", "status", "--porcelain", "--", rel], cwd=wt_path, timeout=_GIT_TIMEOUT)
             if status.stdout.strip():
                 changed.append(rel)

--- a/apps/backend-rag/backend/tests/unit/services/sota_loop/test_promote.py
+++ b/apps/backend-rag/backend/tests/unit/services/sota_loop/test_promote.py
@@ -8,12 +8,40 @@ subprocess-mocked; no real git repo, network, or gh CLI is exercised.
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock
 
 from backend.services.sota_loop._promote import promote_research_output
 
 _REL = "research/sota-social-2026-v1/weekly_report_2026-08-08.md"
+
+
+def _find_repo_root() -> Path:
+    """Walk up from this file until scripts/check_adversarial_review.py is
+    found — mirrors scripts/tests/test_adversarial_review_gate.py's own
+    loader convention (scripts/ is a flat bag, not a package)."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "scripts" / "check_adversarial_review.py").is_file():
+            return parent
+    raise RuntimeError("could not locate repo root from test_promote.py")
+
+
+def _load_r1_gate() -> ModuleType:
+    module_path = _find_repo_root() / "scripts" / "check_adversarial_review.py"
+    spec = importlib.util.spec_from_file_location("check_adversarial_review", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+r1_gate = _load_r1_gate()
 
 
 def _cp(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -180,3 +208,121 @@ def test_gh_pr_create_failure_returns_false_but_branch_stays_pushed(tmp_path, mo
     ok = promote_research_output(tmp_path, [_REL], commit_subject="x", commit_body="y")
     assert ok is False
     assert merge_called == []
+
+
+# --------------------------------------------------------------------------- #
+# R1 generator!=grader compliance (cure-B, follow-up to PR #4581): every
+# research/**/*.md this module promotes must pass scripts/check_adversarial_
+# review.py by construction, never born red on the R1 gate.
+# --------------------------------------------------------------------------- #
+
+
+def test_promoted_md_passes_r1_gate_when_refuter_reachable(tmp_path, monkeypatch):
+    """INNOCENCE: kimi reachable and returns findings -> real seat + section,
+    and the resulting file PASSES the actual R1 gate (not a re-implementation
+    of its rule)."""
+    target = _write_target(tmp_path)
+    wt = tmp_path / ".worktrees" / "wr2-sota-weekly-5"
+    wt.mkdir(parents=True)
+
+    def fake_run(cmd, **kwargs):
+        if "--lane" in cmd:
+            return _cp(stdout=f"WORKTREE_READY {wt}\n")
+        if cmd[:1] == ["kimi"]:
+            return _cp(stdout="NONE — deltas reconcile with kpi_timeline.csv.\n")
+        if cmd[:2] == ["git", "status"]:
+            return _cp(stdout=f" M {_REL}\n")
+        if cmd[:2] == ["git", "branch"]:
+            return _cp(stdout="agent/host/wr2/sota-weekly-5\n")
+        if cmd[:2] == ["git", "push"]:
+            return _cp()
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return _cp(stdout="https://github.com/org/repo/pull/1001\n")
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return _cp()
+        return _cp()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok = promote_research_output(tmp_path, [_REL], commit_subject="x", commit_body="y")
+    assert ok is True
+
+    promoted = wt / _REL
+    verdict = r1_gate.evaluate_file(promoted)
+    assert verdict.ok is True, verdict.reason
+    assert "kimi" in promoted.read_text()
+    assert target.read_text() == "content"  # source file untouched
+
+
+def test_promoted_md_passes_r1_gate_when_refuter_unreachable(tmp_path, monkeypatch):
+    """GUILT-adjacent INNOCENCE: kimi missing/times out -> the promoter must
+    NOT fabricate a `kimi-k3` claim for a review that never ran. It falls
+    back to an honest `exempt-` marker, which the real R1 gate accepts."""
+    _write_target(tmp_path)
+    wt = tmp_path / ".worktrees" / "wr2-sota-weekly-6"
+    wt.mkdir(parents=True)
+
+    def fake_run(cmd, **kwargs):
+        if "--lane" in cmd:
+            return _cp(stdout=f"WORKTREE_READY {wt}\n")
+        if cmd[:1] == ["kimi"]:
+            raise FileNotFoundError("kimi not on PATH")
+        if cmd[:2] == ["git", "status"]:
+            return _cp(stdout=f" M {_REL}\n")
+        if cmd[:2] == ["git", "branch"]:
+            return _cp(stdout="agent/host/wr2/sota-weekly-6\n")
+        if cmd[:2] == ["git", "push"]:
+            return _cp()
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return _cp(stdout="https://github.com/org/repo/pull/1002\n")
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return _cp()
+        return _cp()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok = promote_research_output(tmp_path, [_REL], commit_subject="x", commit_body="y")
+    assert ok is True
+
+    promoted = wt / _REL
+    verdict = r1_gate.evaluate_file(promoted)
+    assert verdict.ok is True, verdict.reason
+    assert "exempt-" in promoted.read_text()
+    assert "kimi-k3" not in promoted.read_text().split("---", 2)[1]  # not in frontmatter
+
+
+def test_existing_frontmatter_is_never_clobbered(tmp_path, monkeypatch):
+    """A future hand-authored report that already opens with frontmatter
+    must pass through untouched — the promoter never overwrites a real
+    human/seat review with its own automated one."""
+    rel = "research/sota-social-2026-v1/checkpoint_day_30.md"
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    original = "---\nadversarial_review: human-zero\n---\n\n# Title\n\n### Adversarial review\n\nReviewed live.\n"
+    p.write_text(original)
+
+    wt = tmp_path / ".worktrees" / "wr2-sota-checkpoint-1"
+    wt.mkdir(parents=True)
+    kimi_called: list = []
+
+    def fake_run(cmd, **kwargs):
+        if "--lane" in cmd:
+            return _cp(stdout=f"WORKTREE_READY {wt}\n")
+        if cmd[:1] == ["kimi"]:
+            kimi_called.append(cmd)
+            return _cp(stdout="NONE\n")
+        if cmd[:2] == ["git", "status"]:
+            return _cp(stdout=f" M {rel}\n")
+        if cmd[:2] == ["git", "branch"]:
+            return _cp(stdout="agent/host/wr2/sota-checkpoint-1\n")
+        if cmd[:2] == ["git", "push"]:
+            return _cp()
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return _cp(stdout="https://github.com/org/repo/pull/1003\n")
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return _cp()
+        return _cp()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    ok = promote_research_output(tmp_path, [rel], commit_subject="x", commit_body="y")
+    assert ok is True
+    assert kimi_called == [], "must not dispatch a review over an already-reviewed file"
+    assert (wt / rel).read_text() == original


### PR DESCRIPTION
## Summary

Follow-up to PR #4581 (born red on the R1 generator!=grader gate because
the M13 weekly/checkpoint/monthly promoter never wrote an
`adversarial_review` frontmatter key or `## Adversarial review` section
into the reports it promotes). This PR fixes the structural cause in
`_promote.py` so no future run of any of the three M13 crons is born red.

- `_promote.py` now dispatches a real refuter (`kimi -m kimi-code/k3`) over
  every promoted `research/**/*.md` file before opening its PR, and writes
  the refuter's actual findings into a real `## Adversarial review` section.
- Design choice: a real review, not a blanket `exempt-`. These reports make
  real claims (per-channel/pillar deltas, breach status, retrain outcomes)
  that drive an auto-toggle of live publishers — exactly the shape R1 exists
  to gate, and exactly what it caught live on #4581 (every `[OK]` delta was
  a `compute_delta_vs_baseline` div-by-zero fallback, not a real measurement,
  because `post_metrics_history` is still empty).
- If the seat is unreachable (missing/timeout/empty output), the promoter
  falls back to an honest `exempt-refuter-unreachable` marker rather than
  fabricating a `kimi-k3` claim for a review that never ran.
- Idempotent: a file that already opens with frontmatter (e.g. a future
  hand-authored report) is never touched.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/unit/services/sota_loop/ -q` — 15/15 pass (12 pre-existing + 3 new)
- [x] `python3 scripts/check_adversarial_review.py --selftest` — 27/27 pass, unaffected
- [x] New tests load the REAL `scripts/check_adversarial_review.py` gate (importlib, mirrors `scripts/tests/test_adversarial_review_gate.py`'s convention) and assert the promoter's output passes it — for both the reachable-seat and unreachable-fallback paths — plus a guard that existing frontmatter is never clobbered.

lanes: wr2

🤖 Generated with [Claude Code](https://claude.com/claude-code)