### PR TITLE
fix(wr3): the spend gate must fail closed when it cannot read the ledger

### DIFF
--- a/scripts/tests/test_wr3_gatekeeper_cost.py
+++ b/scripts/tests/test_wr3_gatekeeper_cost.py
@@ -87,6 +87,12 @@ def _write_quota(
     }))
 
 
+# Enough for CPython to start and for the gate to read/write files. Anything
+# absent here is absent from the child by construction, so a new WR3_* toggle
+# cannot leak into these tests by default; a test that wants one sets it below.
+_ENV_WHITELIST = ("PATH", "TMPDIR", "LANG", "LC_ALL")
+
+
 def _run_gate(
     ep: Path,
     tmp_path: Path,
@@ -94,24 +100,38 @@ def _run_gate(
     ledger_path: Path | None = None,
     quota_path: Path | None = None,
     zero_spend: bool = False,
+    business_tz: str | None = None,
+    ambient_tz: str | None = None,
 ) -> subprocess.CompletedProcess:
-    env = dict(os.environ)
+    # WHITELIST, not blacklist. `dict(os.environ)` inherits every WR3_* toggle
+    # the operator happens to have exported — and this gate reads several. A
+    # stray `WR3_ZERO_SPEND=1` in the parent shell would send EVERY test in this
+    # file down the zero-spend short circuit, where the cost block is skipped
+    # entirely: ten green tests proving nothing. Blacklisting the toggles known
+    # today (as this helper used to) does not survive the next toggle being
+    # added, and that is exactly the shape that fails silently.
+    env = {k: os.environ[k] for k in _ENV_WHITELIST if k in os.environ}
     home = tmp_path / "home"
     home.mkdir(exist_ok=True)
     env["HOME"] = str(home)
     env["WR3_CREDIT_LEDGER"] = str(ledger_path if ledger_path is not None else tmp_path / "ledger.jsonl")
     env["WR3_SPEND_DECISION_LOG"] = str(tmp_path / "decisions.jsonl")
-    env.pop("WR3_SPEND_DECISION", None)
-    env.pop("WR3_FLOWKIT_CLIP_COST", None)
-    env.pop("WR3_FLOW_QUOTA_MAX_AGE_H", None)
+    # No `env.pop(...)` guards: on a whitelisted dict they are no-ops, and a
+    # no-op that reads as a protection is worse than no protection at all.
     if quota_path is not None:
         env["WR3_FLOW_QUOTA"] = str(quota_path)
-    else:
-        env.pop("WR3_FLOW_QUOTA", None)
     if zero_spend:
         env["WR3_ZERO_SPEND"] = "1"
-    else:
-        env.pop("WR3_ZERO_SPEND", None)
+    if business_tz is not None:
+        env["WR3_BUSINESS_TZ"] = business_tz
+    if ambient_tz is not None:
+        # `TZ` is deliberately absent from the whitelist, so the child inherits
+        # nothing and a test that cares must say so. Setting it is not
+        # incidental: the defect under test is a window that FOLLOWS the
+        # ambient zone, and on a machine whose local zone already IS the
+        # business zone the broken and the fixed code agree exactly. The test
+        # has to run somewhere else to see the difference, so it picks where.
+        env["TZ"] = ambient_tz
     return subprocess.run(
         [sys.executable, str(GATEKEEPER), str(ep)],
         capture_output=True, text=True, env=env, timeout=60,
@@ -238,58 +258,264 @@ def test_daily_ceiling_passes_when_seed_rows_absent(tmp_path):
     assert v["checks"]["cost"]["spent_today_cr"] == 0
 
 
-def test_early_local_morning_spend_still_counts_against_todays_ceiling(tmp_path):
-    """The daily window must be the OPERATOR's day, not the UTC day.
+# WITA is a fixed UTC+8 with no DST — Indonesia has never observed it — so this
+# offset is instant-for-instant identical to ZoneInfo("Asia/Makassar"). Using
+# the offset for the SEEDS keeps the test independent of the machine's tz
+# database; the gate's own resolution is asserted separately, via the stamp.
+_WITA = timezone(timedelta(hours=8))
+
+
+def test_business_day_window_is_wita_not_the_utc_date(tmp_path):
+    """The daily ceiling window must be the OPERATOR's day, not the UTC day.
 
     Ledger timestamps are UTC, correctly. But a DAILY CEILING is a business
     quantity and this business runs on WITA (UTC+8), so bucketing by UTC date
-    slides the reset to 08:00 local — in the dangerous direction. A charge made
-    at 03:00 WITA carries YESTERDAY's UTC date, so under UTC bucketing it stops
-    counting from 08:00 that same local morning and the ceiling silently
-    regains headroom it never had. Under-counting in a spend gate is the
-    failure mode that burns credits.
+    slides the reset to 08:00 local, in the dangerous direction.
 
-    The seeded row below is deliberately "early this local morning": for any
-    positive UTC offset that instant falls on the previous UTC date, so the two
-    conventions give different answers and this test can tell them apart. Under
-    UTC bucketing `spent_today_cr` is 0 and the gate PASSES; under the local-day
-    window it is 150 and the gate FAILS. Seeding at "now" — as the tests above
-    do — cannot distinguish them, because both agree about now.
+    TWO seeded rows, and both are load-bearing. Measured, hour by hour: ONE row
+    inside today's business day cannot tell the conventions apart between 00:00
+    and 08:00 WITA, because in that window every elapsed business-day instant is
+    also inside the current UTC day — the two windows agree, and the earlier
+    version of this test skipped itself for those eight hours. So it carries a
+    second row that belongs to YESTERDAY's business day but to TODAY's UTC day.
+    Whichever way the clock falls, exactly one of the two rows is misclassified
+    by UTC bucketing:
+
+      * from 08:00 WITA on: X drops out    -> 0   instead of 150
+      * before 08:00 WITA:  Y is pulled in -> 220 instead of 150
+
+    Both diverge from 150, so the assertion below is a real gate at every hour
+    of the day and needs no skip. Seeding at "now" — as the tests above do —
+    cannot distinguish them, because both conventions agree about now.
+
+    `WR3_BUSINESS_TZ` is pinned rather than inherited, and `TZ=UTC` is pinned
+    too. Both matter. The defect is a window that follows the ambient zone, so
+    on a machine whose local zone already IS WITA the broken code and the fixed
+    code produce identical answers and this test would pass over the bug. Under
+    `TZ=UTC` — which is also what cron, launchd and containers usually give it —
+    the two diverge every time.
     """
-    local_tz = datetime.now(timezone.utc).astimezone().tzinfo
-    now_local = datetime.now(local_tz)
-    early_local = now_local.replace(hour=3, minute=0, second=0, microsecond=0)
-    if early_local.astimezone(timezone.utc).date() == now_local.date():
-        pytest.skip(
-            "this machine's UTC offset does not put 03:00 local on a different "
-            "UTC date, so the two conventions cannot be told apart here"
-        )
+    now_wita = datetime.now(_WITA)
+    inside_today = now_wita.replace(hour=3, minute=0, second=0, microsecond=0)
+    yesterday_evening = (now_wita - timedelta(days=1)).replace(
+        hour=20, minute=0, second=0, microsecond=0
+    )
 
     ep = _episode(tmp_path, n_shots=3)  # projects 60cr
     quota_path = tmp_path / "flow-quota.json"
     _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
     ledger_path = tmp_path / "ledger.jsonl"
-    record_spend(
-        episode_id="early-morning-episode",
-        shot_index=0,
-        credits=150,
-        mode="real",
-        veo_job_id="wf-early",
-        source="test-seed",
-        clip_cost_cr=20,
-        ledger_path=ledger_path,
-        ts=early_local.isoformat(),
-    )
+    for label, ts, credits in (
+        ("today-early", inside_today, 150),
+        ("yesterday-evening", yesterday_evening, 70),
+    ):
+        record_spend(
+            episode_id=f"{label}-episode",
+            shot_index=0,
+            credits=credits,
+            mode="real",
+            veo_job_id=f"wf-{label}",
+            source="test-seed",
+            clip_cost_cr=20,
+            ledger_path=ledger_path,
+            ts=ts.isoformat(),
+        )
 
-    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    res = _run_gate(
+        ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path,
+        business_tz="Asia/Makassar", ambient_tz="UTC",
+    )
     assert res.returncode == 0, res.stderr
     cost = _verdict(ep)["checks"]["cost"]
     assert cost["spent_today_cr"] == 150, (
-        "an early-local-morning charge was dropped from today's total — the "
-        "window is bucketing by UTC date, not by the operator's day"
+        "today's total is neither 150: the window is not the WITA business day. "
+        "0 means an early-local-morning charge was dropped (UTC bucketing, seen "
+        "from 08:00 WITA on); 220 means yesterday evening was counted as today "
+        "(UTC bucketing, seen before 08:00 WITA)"
     )
+    # The resolved zone is stamped so that a silent fallback to the fixed offset
+    # is visible in the verdict rather than inferred; assert it, or the stamp is
+    # itself untested.
+    assert cost["business_tz"] == "Asia/Makassar", cost["business_tz"]
     assert cost["passed"] is False
     assert "daily ceiling" in " ".join(cost["reasons"])
+
+
+# ---------------------------------------------------------------------------
+# 5b. An UNREADABLE ledger must fail closed, never read as a clean zero
+# ---------------------------------------------------------------------------
+
+
+def test_unreadable_ledger_directory_fails_closed_instead_of_reading_zero(tmp_path):
+    """The silent half of the unreadable-ledger defect: nothing raises.
+
+    `Path.exists()` answers False both for a file that is absent and for one
+    whose directory cannot be read. `read_integrity()` then reports "ok", the
+    malformed scan returns 0 and `read_records()` returns [] — so the cost block
+    reads a clean "0 spent today" and the gate PASSES with its whole daily
+    budget restored. No exception handler can ever see this: there is no
+    exception. Under-count is the direction that burns credits.
+
+    150cr are really on today's ledger and the ceiling is 190 with 60 projected.
+    Before the fix the gate reads 0 and passes; after it, it refuses.
+    """
+    if os.geteuid() == 0:
+        pytest.skip(
+            "running as root: the OS will not make a directory unreadable to "
+            "uid 0, so this test's precondition cannot exist here. Distinct "
+            "from a test that skips because it cannot TELL two behaviours "
+            "apart — the sibling below constructs the same branch without "
+            "relying on permission bits, and never skips"
+        )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    ledger_path = vault / "ledger.jsonl"
+    record_spend(
+        episode_id="hidden-episode", shot_index=0, credits=150, mode="real",
+        veo_job_id="wf-hidden", source="test-seed", clip_cost_cr=20,
+        ledger_path=ledger_path, ts=datetime.now(timezone.utc).isoformat(),
+    )
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    vault.chmod(0o000)
+    try:
+        res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    finally:
+        vault.chmod(0o755)  # or tmp_path teardown fails and masks the result
+
+    assert res.returncode == 0, res.stderr
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["passed"] is False, (
+        "the gate passed while it could not read the ledger — it read the "
+        "unreachable ledger as '0 spent today'"
+    )
+    assert "not readable" in " ".join(cost["reasons"]), cost["reasons"]
+
+
+def test_unreachable_ledger_is_caught_without_relying_on_permission_bits(tmp_path):
+    """Same branch as above, constructed so no uid can be privileged past it.
+
+    The ledger's parent is a regular FILE. That is not a directory for anyone,
+    root included, so the check cannot be satisfied by privilege the way a
+    chmod can. Kept as a sibling rather than a replacement: the chmod case is
+    the one that actually happens in production, this one is the one that
+    always runs.
+    """
+    not_a_dir = tmp_path / "notadir"
+    not_a_dir.write_text("this is a file, not a directory\n")
+    ledger_path = not_a_dir / "ledger.jsonl"
+    ep = _episode(tmp_path, n_shots=3)
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+
+    assert res.returncode == 0, res.stderr
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["passed"] is False, cost
+    assert "not readable" in " ".join(cost["reasons"]), cost["reasons"]
+
+
+def test_unreadable_failures_sidecar_still_produces_a_verdict(tmp_path):
+    """The loud half: `read_integrity()` opens the sidecar with no handler.
+
+    It also runs FIRST, before either ledger guard, so an unreadable sidecar
+    killed the process before `gate-verdict.json` was written at all — breaking
+    the invariant this file states about itself, in the one situation where an
+    operator most needs to read a verdict.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("running as root: mode 000 does not deny uid 0")
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="ok-episode", shot_index=0, credits=10, mode="real",
+        veo_job_id="wf-ok", source="test-seed", clip_cost_cr=20,
+        ledger_path=ledger_path, ts=datetime.now(timezone.utc).isoformat(),
+    )
+    sidecar = tmp_path / "ledger.jsonl.failures"
+    sidecar.write_text('{"ts": "2026-08-23T00:00:00+00:00"}\n')
+    ep = _episode(tmp_path, n_shots=3)
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    sidecar.chmod(0o000)
+    try:
+        res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    finally:
+        sidecar.chmod(0o644)
+
+    assert res.returncode == 0, res.stderr
+    assert (ep / "gate-verdict.json").exists(), (
+        "no verdict was written: the gate died on the sidecar before reaching "
+        "the point where it records why"
+    )
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["passed"] is False
+    assert "sidecar unreadable" in " ".join(cost["reasons"]), cost["reasons"]
+
+
+def test_unreadable_ledger_file_in_a_readable_directory_fails_closed(tmp_path):
+    """The case `os.access` on the DIRECTORY cannot see, so the handlers must.
+
+    Directory readable, ledger file at mode 000. `_ledger_unreachable_reason`
+    correctly says nothing is wrong with the path, and then two separate
+    readers open the file anyway: the malformed scan and `read_records()`.
+    Both had no handler. Without them the gate dies here rather than reporting
+    that it cannot certify the total — and this is the shape a botched `chmod`
+    or a restore-from-backup actually produces, far more often than an
+    unreadable directory.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("running as root: mode 000 does not deny uid 0")
+
+    ledger_path = tmp_path / "ledger.jsonl"
+    record_spend(
+        episode_id="unreadable-episode", shot_index=0, credits=150, mode="real",
+        veo_job_id="wf-unreadable", source="test-seed", clip_cost_cr=20,
+        ledger_path=ledger_path, ts=datetime.now(timezone.utc).isoformat(),
+    )
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr, ceiling 190
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    ledger_path.chmod(0o000)
+    try:
+        res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+    finally:
+        ledger_path.chmod(0o644)
+
+    assert res.returncode == 0, res.stderr
+    assert (ep / "gate-verdict.json").exists(), "the gate died before writing a verdict"
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["passed"] is False, cost
+    joined = " ".join(cost["reasons"])
+    assert "unreadable" in joined, cost["reasons"]
+
+
+def test_absent_ledger_is_not_mistaken_for_an_unreachable_one(tmp_path):
+    """INNOCENCE. Absence is a real, believable zero and must still pass.
+
+    The whole point of the check above is that absent and unreachable answer
+    the same from `exists()` but mean opposite things. A guard that refused on
+    both would block every first-ever episode — which is how a fail-closed fix
+    turns into an outage.
+    """
+    ledger_path = tmp_path / "never-written" / "ledger.jsonl"  # dir absent too
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr, ceiling 190
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+
+    assert res.returncode == 0, res.stderr
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["spent_today_cr"] == 0
+    assert cost["passed"] is True, cost["reasons"]
+    assert "not readable" not in " ".join(cost["reasons"]), cost["reasons"]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/wr3_gatekeeper_check.py
+++ b/scripts/wr3_gatekeeper_check.py
@@ -33,6 +33,8 @@ import re
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
 
 # The file has no sys.path setup today — the siblings below live next to
 # this script, not on the default import path when invoked from elsewhere.
@@ -56,6 +58,79 @@ n = len(shots)
 target_dur = shot_pack.get("total_duration_s", brief.get("target_duration_s", 145.4))
 
 
+_LEDGER_UNREADABLE = -1
+
+
+def _ledger_unreachable_reason(ledger_path: Path) -> str | None:
+    """None when the ledger's ABSENCE can be believed; otherwise why it cannot.
+
+    `Path.exists()` answers False both for a file that is not there and for one
+    it cannot reach because an ancestor directory is unreadable — measured, not
+    assumed. To a spend gate those two answers mean opposite things: absent is
+    "0 spent today"; unreachable is "UNKNOWN spent today". Only the first is
+    safe to spend against, and every reader downstream here — `read_integrity`,
+    the malformed scan, `read_records` — collapses both into the same
+    clean-looking zero without raising anything. No OSError handler can see
+    this case, which is why it needs a check of its own.
+
+    Walking up to the first ancestor that answers at all is what makes it
+    correct: if `~/.cache` is unreadable then `~/.cache/wr3` reports "does not
+    exist", and a check that stopped at the immediate parent would believe it.
+
+    `os.access` is a pre-check, not the belt — it can disagree with the kernel
+    under ACLs or on a network filesystem. The OSError handlers at the call
+    sites remain the actual guarantee; this covers only what they cannot.
+    """
+    probe = ledger_path.parent
+    while not os.access(probe, os.F_OK):
+        if probe.parent == probe:
+            return None
+        probe = probe.parent
+    if not os.access(probe, os.R_OK | os.X_OK):
+        return f"ledger directory {probe} is not readable (permissions?)"
+    return None
+
+# The daily ceiling is a BUSINESS quantity, so its day must be the business's
+# day — and it must not depend on the process environment. The obvious spelling,
+# `datetime.now(timezone.utc).astimezone().tzinfo`, honours $TZ: under TZ=UTC
+# (the default in most cron, launchd and container contexts) it silently reverts
+# to UTC-date bucketing, which UNDER-counts spend — the direction that burns
+# credits — and the one test written to catch that skips itself under exactly
+# that condition, so the failure is invisible.
+#
+# A NAMED ZONE, resolved explicitly, never inherited:
+#   * `ZoneInfo` + `timedelta(days=1)` does wall-clock arithmetic — measured, it
+#     spans 25 hours across a fall-back day — so the window is DST-correct. A
+#     fixed offset would not be.
+#   * `/usr/share/zoneinfo` is present on every image this repo builds on
+#     (python:3.11-slim, python:3.12-slim) and on alpine — measured, not assumed.
+#     The PyPI `tzdata` package is deliberately NOT added: `wr3_credit_ledger.py`
+#     documents a stdlib-only invariant, and `zoneinfo` is stdlib.
+#   * If the zone cannot be resolved anyway (an exotic stripped base), this does
+#     NOT refuse. Refusing would turn a missing tz database into a gate that
+#     blocks every episode. It falls back to fixed UTC+8 — exact for this
+#     business, one distinct offset across 1990-2030, verified — and records the
+#     fallback so the degradation is visible instead of silent.
+#
+# What this does NOT protect against: a syntactically valid but WRONG zone
+# (`WR3_BUSINESS_TZ=UTC`) resolves fine and no validation can reject it. The
+# resolved zone stamped into gate-verdict.json is the mitigation for that.
+_DEFAULT_BUSINESS_TZ = "Asia/Makassar"
+_FALLBACK_BUSINESS_UTC_OFFSET_H = 8
+
+
+def _business_tz() -> tuple[Any, str]:
+    """(tzinfo, label) for the business day. Never reads $TZ."""
+    name = os.environ.get("WR3_BUSINESS_TZ", "").strip() or _DEFAULT_BUSINESS_TZ
+    try:
+        return ZoneInfo(name), name
+    except Exception:
+        return (
+            timezone(timedelta(hours=_FALLBACK_BUSINESS_UTC_OFFSET_H)),
+            f"UTC+{_FALLBACK_BUSINESS_UTC_OFFSET_H} (fallback: zone {name!r} unresolvable)",
+        )
+
+
 def _scan_ledger_for_malformed_lines(ledger_path: Path) -> int:
     """Count non-blank ledger lines that are not a valid JSON object.
 
@@ -70,10 +145,24 @@ def _scan_ledger_for_malformed_lines(ledger_path: Path) -> int:
     concurrent writer). Both are checked because they catch different
     failure modes.
     """
-    if not ledger_path.exists():
-        return 0
     bad = 0
-    with ledger_path.open("r", encoding="utf-8") as fh:
+    try:
+        # `exists()` is INSIDE the guard because it can itself raise: on Python
+        # 3.9/3.11 it propagates PermissionError, while on 3.14 it answers False
+        # — measured. Like the read_records handler, reaching it now needs a
+        # TOCTOU window, since the caller short-circuits on an unreadable
+        # directory before getting here; the `open()` below is the part this
+        # try/except actually earns, and mutation-checked as a real gate.
+        if not ledger_path.exists():
+            return 0
+        fh = ledger_path.open("r", encoding="utf-8")
+    except OSError:
+        # UNREADABLE is a different finding from MALFORMED and must not be
+        # folded into the same count: a permissions fault and a corrupt line
+        # need different cures. The sentinel keeps them distinct, and keeps
+        # this function from killing the gate before any verdict is written.
+        return _LEDGER_UNREADABLE
+    with fh:
         for line in fh:
             line = line.strip()
             if not line:
@@ -112,6 +201,7 @@ hard_ceiling = 209
 cost_fail = False
 cost_reasons = []
 cost_mode = "real"
+business_tz_label = None
 projected_cr = n * CR_PER_CLIP
 balance = None
 daily_ceiling_cr = None
@@ -186,9 +276,47 @@ else:
         # spend, not the quota file's frozen daily_spent_cr. A degraded
         # ledger (either kind of corruption) must not silently read as "0
         # spent today" — that is ALSO a refusal.
-        integrity = read_integrity()
-        malformed_lines = _scan_ledger_for_malformed_lines(_resolve_ledger_path(None))
-        if integrity["status"] != "ok" or malformed_lines:
+        ledger_path_for_gate = _resolve_ledger_path(None)
+        unreachable = _ledger_unreachable_reason(ledger_path_for_gate)
+        if unreachable is not None:
+            # Nothing below can be believed — and on some interpreters nothing
+            # below even raises. MEASURED on this repo's own interpreters, with
+            # the ledger's directory unreadable:
+            #
+            #   Python 3.9 / 3.11 (what CI pins) -> Path.exists() RAISES
+            #     PermissionError; the gate dies without writing a verdict.
+            #   Python 3.14 (what `#!/usr/bin/env python3` resolves to on the
+            #     Pro and M5 render hosts) -> Path.exists() returns False;
+            #     integrity reads "ok", the scan reads 0, read_records() reads
+            #     [], and the gate PASSES with "0 spent today".
+            #
+            # So the SILENT failure is the one that happens on the machine that
+            # actually spends credits, while the interpreter CI runs would have
+            # shown a crash instead: a defect that cannot reproduce where it is
+            # tested. That asymmetry is why this is a positive `os.access`
+            # probe and not one more exception handler.
+            integrity = {"status": "unreadable", "failure_count": 0, "since": None}
+            malformed_lines = _LEDGER_UNREADABLE
+        else:
+            try:
+                integrity = read_integrity()
+            except OSError as e:
+                # read_integrity() opens the failures sidecar with no handler of
+                # its own, and it runs FIRST — so an unreadable sidecar killed
+                # the gate before either guard below could fire, and before any
+                # verdict was written. Handled at the call site, like the
+                # read_records guard, because report/backfill also call it.
+                integrity = {"status": "unreadable", "failure_count": 0, "since": None}
+                unreachable = f"ledger failures sidecar unreadable ({e})"
+            malformed_lines = _scan_ledger_for_malformed_lines(ledger_path_for_gate)
+        if unreachable is not None or malformed_lines == _LEDGER_UNREADABLE:
+            cost_fail = True
+            detail = unreachable or f"ledger unreadable at {ledger_path_for_gate}"
+            cost_reasons.append(
+                f"cannot certify today's spend total — {detail} — refusing to "
+                "spend rather than silently reading 0 spent today"
+            )
+        elif integrity["status"] != "ok" or malformed_lines:
             cost_fail = True
             parts = []
             if integrity["status"] != "ok":
@@ -218,13 +346,33 @@ else:
             # credits, not the one that blocks a render.
             # Compared as absolute instants against local-day boundaries, so
             # rows written in any offset land in the right bucket.
-            local_tz = datetime.now(timezone.utc).astimezone().tzinfo
+            local_tz, business_tz_label = _business_tz()
             day_start = datetime.now(local_tz).replace(
                 hour=0, minute=0, second=0, microsecond=0
             )
             day_end = day_start + timedelta(days=1)
             spent_today_cr = 0
-            for rec in read_records():
+            try:
+                ledger_rows = read_records()
+            except OSError as e:
+                # BELT, and honestly a TOCTOU-only one. This branch is reached
+                # only after the malformed scan already opened the same path
+                # successfully, so no test can enter it deterministically —
+                # mutation-checked: deleting this handler leaves the whole suite
+                # green. It is kept anyway because the window is real (a chmod
+                # or an unmount landing between the two opens) and the
+                # difference it makes is a verdict saying "cannot certify"
+                # instead of a crash with no verdict at all. Guarded here rather
+                # than inside read_records() because report/backfill/dedupe also
+                # call it and their contract is not this PR's concern.
+                # Do not read its presence as coverage.
+                cost_fail = True
+                cost_reasons.append(
+                    f"ledger unreadable while summing today's spend ({e}) — "
+                    "refusing to spend rather than reading 0 spent today"
+                )
+                ledger_rows = []
+            for rec in ledger_rows:
                 if rec.get("mode") != "real":
                     continue
                 ts = _parse_ts(rec.get("ts"))
@@ -347,7 +495,10 @@ out = {
                  "mode": cost_mode,
                  "daily_ceiling_cr": daily_ceiling_cr,
                  "spent_today_cr": spent_today_cr,
-                 "spent_today_source": "ledger (local-day window)" if spent_today_cr is not None else None,
+                 "spent_today_source": "ledger (business-day window)" if spent_today_cr is not None else None,
+                 # Which zone actually resolved is otherwise an unlogged runtime
+                 # fact — the exact shape of the defect this fixes.
+                 "business_tz": business_tz_label,
                  "quota_as_of": quota_as_of,
                  "reasons": cost_reasons,
                  "passed": not cost_fail},


### PR DESCRIPTION
Follow-up to #4628. Three findings an independent verifier raised against that PR's cost
block, closed here. #4628 was armed and therefore frozen (rule 2), so they land separately
from a fresh `origin/main`.

## What was wrong

**A — the gate could die before writing a verdict, and could pass while blind.**
`wr3_gatekeeper_check.py` states about itself that it always writes `gate-verdict.json`.
Three readers of the credit ledger opened files with no handler. Measured, not deduced:

| condition | before | why |
|---|---|---|
| ledger failures sidecar at mode `000` | `PermissionError`, **no verdict written** | `read_integrity()` runs first and opens the sidecar unguarded |
| ledger file unreadable | `PermissionError`, **no verdict written** | `read_records()` and the malformed scan open it unguarded |
| ledger **directory** unreadable | gate **PASSES**, "0 spent today" | nothing raises at all — see below |

The third is the dangerous one, and it is not an exception-handling problem — because
whether it even raises depends on the interpreter. Measured on this repo's own three:

| interpreter | `Path.exists()` on a file behind an unreadable dir | what the gate does |
|---|---|---|
| 3.9, 3.11 — **what CI pins** | raises `PermissionError` | dies, no verdict — loud |
| 3.14 — what `#!/usr/bin/env python3` resolves to on **Pro and M5** | returns `False` | reads "0 spent today" and **PASSES** — silent |

So the credit-burning behaviour is the one that happens on the machine that actually spends
credits, and the interpreter CI runs would have shown a crash instead: a defect that cannot
reproduce where it is tested. That asymmetry is the reason the fix is a positive `os.access`
probe rather than one more `except` clause.
`Path.exists()` answers `False` both for a file that is absent and for one whose ancestor
directory cannot be read — verified on this machine, both cases. To a spend gate those mean
opposite things: absent is *0 spent today*, unreachable is *unknown spent today*. Every
reader collapsed them into the same clean zero, so the daily ceiling silently regained its
whole budget. Under-count is the direction that burns credits.

`_ledger_unreachable_reason()` now distinguishes them, walking up to the first ancestor that
answers at all — a check stopping at the immediate parent would itself be fooled when the
grandparent is the unreadable one. `os.access` is the pre-check; the `OSError` handlers at
the call sites stay, because they are the actual guarantee and `os.access` can disagree with
the kernel under ACLs or on a network filesystem. The three failure classes keep three
distinguishable, greppable reason strings — unreadable / malformed / DEGRADED — so a human
or a monitor can tell which fired.

**B — the business day followed `$TZ`.**
`datetime.now(timezone.utc).astimezone().tzinfo` honours `$TZ`. Under `TZ=UTC` — the default
in most cron, launchd and container contexts — the window reverted to exactly the UTC-date
bucketing #4628 added it to replace. The daily ceiling is a business quantity and this
business runs on WITA. Now: a named zone, `WR3_BUSINESS_TZ`, defaulting to `Asia/Makassar`,
never inherited.

Two measurements each overturned an earlier plan, and both are recorded in the code comment.
A fixed offset was the first candidate, on the theory that a slim container would lack the tz
database — measured false: `python:3.11-slim`, `python:3.12-slim` and alpine all carry
`/usr/share/zoneinfo`. And `ZoneInfo` + `timedelta(days=1)` does wall-clock arithmetic —
measured, it spans 25 hours across a fall-back day — so the named zone is DST-correct and the
fixed offset would not have been. It survives only as the fallback, which does **not** refuse
(one exotic base image must not block every episode) and stamps `business_tz` into the
verdict so a degradation is visible rather than silent. What this does not protect against:
`WR3_BUSINESS_TZ=UTC` resolves fine and no validation can reject it — the stamp is the
mitigation for that, not the fallback.

**C — the test helper inherited the whole environment.**
`env = dict(os.environ)` with three `env.pop` guards. A stray `WR3_ZERO_SPEND=1` exported in
the parent shell sends every test in the file down the zero-spend short circuit, where the
cost block is skipped entirely: ten green tests proving nothing. Blacklisting the toggles
known today does not survive the next toggle being added. Now a whitelist.

**D — the one test that catches B skipped itself under exactly the condition B needs.**
Its guard read "this machine's UTC offset cannot tell the two conventions apart" — true under
`TZ=UTC`. Probe and subject agreed, both wrong, green.

The obvious fix — pin the zone and delete the skip — was **wrong, and measuring it is what
showed that**. Hour by hour: a single row inside today's business day cannot distinguish the
conventions between 00:00 and 08:00 WITA, because in that window every elapsed business-day
instant also falls inside the current UTC day. The skip was real coverage loss, not dead code.

So the test carries **two** rows: one belonging to today's business day, one belonging to
yesterday's business day but to today's UTC day. Whichever way the clock falls, UTC bucketing
misclassifies exactly one of them — `0` instead of `150` from 08:00 WITA on, `220` instead of
`150` before it. Both diverge, so the assertion is a real gate at every hour and needs no
skip. The verdict's `business_tz` stamp is asserted too, or the stamp would itself be
untested.

## What proves it

Mutation-checked, each against the true base, each asserting the anchor actually changed
(a no-op mutation reports "green" and means nothing):

| mutation | result |
|---|---|
| unreachable probe always returns `None` | **2 red** |
| `read_integrity()` guard removed | **1 red** |
| business zone reverts to `.astimezone().tzinfo` | **1 red** |
| scan's `open()` guard removed | **1 red** |
| `read_records()` guard removed | **green — see below** |

That last one is reported, not hidden. `read_records()` sits in a branch reached only after
the malformed scan has already opened the same path successfully, so no test can enter its
handler deterministically — it is a TOCTOU-only belt, and so is `exists()`-inside-the-try.
Both are kept, because the window is real and the difference is a verdict instead of a crash,
and both are now labelled in the code as untested belts rather than presented as coverage.

Full suite: `scripts/tests/ -k wr3` → **298 passed, 1 failed**. The failure is
`test_wr3_manifest_normalize::test_against_the_actual_on_disk_manifest`, pre-existing —
verified by running it on the main checkout without this diff, where it fails identically.

The W96 isolation held: `~/.cache/wr3` holds only the two archived files after the run, and
the session tripwire reported no delta.

## Adversarial review

Generator ≠ grader. Findings A/B/C/D come from an independent verifier on #4628, not from the
author of that diff. The correction of my own remedy for B (fixed offset → named zone) and
the correction of my own plan for D (delete the skip → two rows) were both forced by
measurement against my stated intent, and both are recorded above rather than quietly
dropped.

Residual, deliberately not fixed here: `daily_ceiling_cr` still means "calendar business day,
resets at midnight WITA" rather than "no more than X in any trailing 24h". Which one the
business wants is Legge 5, not a session's call.
