### PR TITLE
fix(wr3): an unresolvable ledger path is unreachable, not absent

### DIFF
--- a/scripts/tests/test_wr3_gatekeeper_cost.py
+++ b/scripts/tests/test_wr3_gatekeeper_cost.py
@@ -416,7 +416,45 @@ def test_unreachable_ledger_is_caught_without_relying_on_permission_bits(tmp_pat
     assert res.returncode == 0, res.stderr
     cost = _verdict(ep)["checks"]["cost"]
     assert cost["passed"] is False, cost
-    assert "not readable" in " ".join(cost["reasons"]), cost["reasons"]
+    # Reported as its own cause rather than folded into "not readable": no
+    # permission bit can turn a regular file into a directory, so the cure is
+    # a different one and the message has to say so.
+    assert "is not a directory" in " ".join(cost["reasons"]), cost["reasons"]
+
+
+def test_symlink_loop_at_the_ledger_directory_fails_closed(tmp_path):
+    """The vector that got past the first version of this guard.
+
+    A self-referencing symlink where the ledger's directory should be is
+    UNREACHABLE, not absent — a real read raises `OSError` errno 62 (ELOOP).
+    But nothing in the chain reports that. Measured on 3.11 and 3.14 alike:
+    `os.access(F_OK)` answers False, `Path.exists()` answers False, and so
+    `read_integrity()`, the malformed scan and `read_records()` each conclude
+    "no ledger here". The first spelling of `_ledger_unreachable_reason` used
+    `os.access(F_OK)` for its walk, stepped straight past the loop to a
+    perfectly readable grandparent, and returned "believable absence" — so the
+    gate read 0 spent today and PASSED against a ledger it could not open.
+
+    Same silent under-count as the unreadable-directory case above, through a
+    door that case's test could not see. Found by an independent adversarial
+    review of the fix, not by the fix's own author.
+    """
+    loop = tmp_path / "loopdir"
+    loop.symlink_to(loop)  # self-referencing: any resolution attempt is ELOOP
+    ledger_path = loop / "ledger.jsonl"
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr, ceiling 190
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+
+    assert res.returncode == 0, res.stderr
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["passed"] is False, (
+        "the gate passed against a ledger it cannot open — an unresolvable "
+        "path was read as an empty one"
+    )
+    assert "unreachable" in " ".join(cost["reasons"]), cost["reasons"]
 
 
 def test_unreadable_failures_sidecar_still_produces_a_verdict(tmp_path):
@@ -494,6 +532,36 @@ def test_unreadable_ledger_file_in_a_readable_directory_fails_closed(tmp_path):
     assert cost["passed"] is False, cost
     joined = " ".join(cost["reasons"])
     assert "unreadable" in joined, cost["reasons"]
+
+
+def test_a_working_symlinked_directory_is_still_believed(tmp_path):
+    """INNOCENCE for the loop test above.
+
+    Rejecting every symlink would be the lazy version of that fix and would
+    break any legitimate setup that puts the ledger behind one. Only a symlink
+    that cannot be RESOLVED is a fault; one that lands on a real directory is
+    ordinary.
+    """
+    real = tmp_path / "real-state"
+    real.mkdir()
+    link = tmp_path / "linked"
+    link.symlink_to(real)
+    ledger_path = link / "ledger.jsonl"
+    record_spend(
+        episode_id="via-symlink", shot_index=0, credits=10, mode="real",
+        veo_job_id="wf-link", source="test-seed", clip_cost_cr=20,
+        ledger_path=ledger_path, ts=datetime.now(timezone.utc).isoformat(),
+    )
+    ep = _episode(tmp_path, n_shots=3)  # projects 60cr, ceiling 190
+    quota_path = tmp_path / "flow-quota.json"
+    _write_quota(quota_path, daily_ceiling_cr=190, balance_remaining_cr=2400)
+
+    res = _run_gate(ep, tmp_path, ledger_path=ledger_path, quota_path=quota_path)
+
+    assert res.returncode == 0, res.stderr
+    cost = _verdict(ep)["checks"]["cost"]
+    assert cost["spent_today_cr"] == 10, cost
+    assert cost["passed"] is True, cost["reasons"]
 
 
 def test_absent_ledger_is_not_mistaken_for_an_unreachable_one(tmp_path):

--- a/scripts/wr3_gatekeeper_check.py
+++ b/scripts/wr3_gatekeeper_check.py
@@ -77,15 +77,45 @@ def _ledger_unreachable_reason(ledger_path: Path) -> str | None:
     correct: if `~/.cache` is unreadable then `~/.cache/wr3` reports "does not
     exist", and a check that stopped at the immediate parent would believe it.
 
-    `os.access` is a pre-check, not the belt — it can disagree with the kernel
-    under ACLs or on a network filesystem. The OSError handlers at the call
-    sites remain the actual guarantee; this covers only what they cannot.
+    `os.access` is still a pre-check, not the belt — it can disagree with the
+    kernel under ACLs or on a network filesystem. The OSError handlers at the
+    call sites remain the actual guarantee for everything that raises; this
+    function exists for what does NOT raise anywhere in the chain.
     """
+    # `os.access(p, F_OK)` was the first spelling of this walk and it was WRONG
+    # in the one direction that matters: it answers False both for "not there"
+    # and for "there but unresolvable", collapsing the exact distinction this
+    # function exists to make. Measured with a self-referencing symlink at the
+    # ledger's directory, on 3.11 and 3.14 alike: `os.access(F_OK)` False,
+    # `Path.exists()` False, and `open()` raising OSError errno 62 (ELOOP) — so
+    # the walk stepped straight past the loop, found a perfectly readable
+    # grandparent, and reported believable absence. End to end that meant the
+    # gate read "0 spent today" and PASSED against a ledger it could not open:
+    # the same silent under-count, through a different door.
+    #
+    # `os.stat` is used instead because it does not collapse them — it raises,
+    # and the errno says which. ENOENT alone means "keep walking up, absence is
+    # real"; anything else (ELOOP, EACCES, ENOTDIR, ENAMETOOLONG, …) means the
+    # path cannot be resolved and must not be read as empty.
     probe = ledger_path.parent
-    while not os.access(probe, os.F_OK):
-        if probe.parent == probe:
-            return None
-        probe = probe.parent
+    while True:
+        try:
+            os.stat(probe)
+        except FileNotFoundError:
+            # Genuinely not there. Keep going up: the ledger simply has not
+            # been created yet, and that IS a believable zero.
+            if probe.parent == probe:
+                return None
+            probe = probe.parent
+            continue
+        except OSError as e:
+            return f"ledger path {probe} is unreachable ({e.strerror or e})"
+        break
+    if not probe.is_dir():
+        # An ancestor is a regular file. Nothing under it can ever be a ledger,
+        # and no permission bit can make it one — reported separately from a
+        # permissions fault because the cure is different.
+        return f"ledger path {probe} is not a directory"
     if not os.access(probe, os.R_OK | os.X_OK):
         return f"ledger directory {probe} is not readable (permissions?)"
     return None


### PR DESCRIPTION
Follow-up to #4639. An independent adversarial review of that diff refuted its central claim,
and it was right.

## What was wrong

`_ledger_unreachable_reason()` walked the ancestor chain with `os.access(probe, os.F_OK)`.
That call answers `False` both for "not there" and for "there but unresolvable" — it collapses
the exact distinction the function exists to make.

Measured with a self-referencing symlink where the ledger's directory should be, identically on
3.11 and 3.14:

| probe | answer |
|---|---|
| `os.access(loop, F_OK)` | `False` |
| `os.access(loop, R_OK\|X_OK)` | `False` |
| `Path(ledger).exists()` | `False` |
| `open(ledger)` | **raises `OSError` errno 62 (ELOOP)** |

So the walk stepped straight past the loop, found a perfectly readable grandparent, and
reported believable absence — while `read_integrity()`, the malformed scan and `read_records()`
each independently concluded "no ledger here" for the same reason, **none of them raising**.
End to end: the gate read `spent_today_cr: 0` and **PASSED** against a ledger it could not open.

That is the same silent under-count #4639 set out to close, through a door #4639's own tests
could not see. The unreadable-*directory* case it did test still fails closed correctly — the
mechanism worked, it just had this blind spot.

## The fix

`os.stat` instead of `os.access`, because it does not collapse the two: it raises, and the errno
says which.

- `ENOENT` alone means absence is real → keep walking up, and a ledger that was simply never
  created still reads as a believable zero.
- `ELOOP`, `EACCES`, `ENOTDIR`, `ENAMETOOLONG`, anything else → the path cannot be resolved and
  must not be read as empty.
- An ancestor that is a regular file now reports its own cause, separately from a permissions
  fault: no permission bit can turn a file into a directory, so the cure is different.

## What proves it

Mutation-checked: restoring the `os.access` walk turns **exactly one** test red — the new one
(`1 failed, 16 passed`). With the fix, 17 pass. A well-aimed fix should move exactly the test
that describes it, and no other.

Guilt and innocence both covered. `test_symlink_loop_at_the_ledger_directory_fails_closed`
proves the gate now refuses; `test_a_working_symlinked_directory_is_still_believed` proves it
does not over-correct — rejecting every symlink would be the lazy version of this fix and would
break any legitimate setup that puts the ledger behind one.

Full suite `scripts/tests/ -k wr3`: **300 passed, 1 failed** — the failure is
`test_wr3_manifest_normalize::test_against_the_actual_on_disk_manifest`, pre-existing and
unrelated (a missing on-disk episode fixture), and fails identically on `main` without this diff.

## Adversarial review

This PR exists because a reviewer refuted my work, so the honest note is about what that says
of the previous one. #4639's own test for this defect class asserted the behaviour for the
vector its author had thought of, and passing it read as "the class is closed". It was not. The
general shape: a guard written against one construction of a fault gets tested against that same
construction, and the test then certifies the author's imagination rather than the property.

Deliberately NOT fixed here, and the more serious of the two findings: **no `pull_request:`-
triggered workflow names `scripts/tests/test_wr3_gatekeeper_cost.py`**, so none of these tests
gate anything today. Verified independently — the file appears in no workflow, and
`scripts-tests-sweep.yml` states in its own header that it is report-only, `continue-on-error`,
deliberately not `pull_request:`, and that 174 of 235 files under `scripts/tests/` are named by
nothing. That means "CI is clean" on #4639 was true and did not mean what it appeared to mean.
Wiring this file into a real check touches `.github/workflows/` and belongs in its own PR.
