### PR TITLE
docs(visa-oracle): correct impossible test counts in killswitch proof

### DIFF
--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -184,11 +184,15 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   already used live for the 2026-08-08 Cameroon/Guinea Calling Visa fix above. Proved three ways,
   all today, all local, no production DB touched: (i) the existing reviewed integration suites
   re-run fresh against an ephemeral pytest-xdist-cloned throwaway Postgres database
-  (`test_activation_writer.py` 44 passed/1 skipped, `test_replace_activation_set.py` 11 passed,
-  `test_activate_pack.py` 18 passed — never the shared `nuzantara_test`/`nuzantara_dev` DB their
-  own docstrings warn against); (ii) a custom end-to-end ceremony test using REAL Ed25519-signed
-  packs over the real evaluatable TEST rule pack (not placeholder hashes — see correction note
-  above): activate real pack A seq1 → real decision via the unmocked evaluator =
+  (`test_activation_writer.py` 43 passed/1 skipped, `test_replace_activation_set.py` 10 passed,
+  `test_activate_pack.py` 17 passed — never the shared `nuzantara_test`/`nuzantara_dev` DB their
+  own docstrings warn against; corrected 2026-08-23, count fix — the original entry read
+  44/11/18, each inflated +1 by transcribing pytest's "N collected" as "N passed" without
+  subtracting the 1 skip; re-measured against merge commit `292795a26364d` with `pytest -n 1 -q`
+  on each file, zero failures, see the report's own correction note for detail); (ii) a custom
+  end-to-end ceremony test using REAL Ed25519-signed packs over the real evaluatable TEST rule
+  pack (not placeholder hashes — see correction note above): activate real pack A seq1 → real
+  decision via the unmocked evaluator =
   `SUPPORTED_CANDIDATES [C1]` → activate real "bad deploy" pack B seq2 (tightened HARD_FILTER,
   chained from A's real hash) → SAME facts now genuinely EXCLUDE C1 through the real evaluator →
   naive reactivation of A REJECTED while B is head, B verified untouched → re-sign A's exact

--- a/research/visa/2026-08-23-killswitch-rollback-proof.md
+++ b/research/visa/2026-08-23-killswitch-rollback-proof.md
@@ -315,11 +315,26 @@ PYTHONPATH=. python -m pytest backend/tests/services/visa_engine/test_activation
 PYTHONPATH=. python -m pytest backend/tests/scripts/visa_engine/test_replace_activation_set.py -n 1 -q
 PYTHONPATH=. python -m pytest backend/tests/scripts/visa_engine/test_activate_pack.py -n 1 -q
 ```
-**Results**: `test_activation_writer.py` — **44 passed, 1 skipped** (the skip is
+**Results**: `test_activation_writer.py` — **43 passed, 1 skipped** (the skip is
 `visa_activation_executor role absent — operator provisioning not yet run`, an expected/documented
 scaffold skip on a machine with no operator-provisioned executor role, not a failure of anything
-under test). `test_replace_activation_set.py` — **11 passed**. `test_activate_pack.py` — **18
-passed**. Among these, already covering guilt+innocence for BOTH kill-switch mechanisms with real
+under test). `test_replace_activation_set.py` — **10 passed**. `test_activate_pack.py` — **17
+passed**.
+
+**Correction (2026-08-23, third pass, count fix)**: the first two versions of this report stated
+these as 44/11/18 passed — each inflated by exactly +1 against `pytest --collect-only`'s own
+item counts for these files (44/10/17 total). The cause: pytest's own summary line reads "N
+collected (1 skipped)", and the collected total (N) was transcribed as the PASSED count without
+subtracting the skip — arithmetically impossible on its face (44 passed + 1 skipped cannot come
+from a 44-item file). Independently re-measured against the exact merge commit
+`292795a26364dbf47ac31e142c3ca41597537d49` with `PYTHONPATH=. python -m pytest <file> -n 1 -q`
+against a local ephemeral Postgres 17.10: 43 passed/1 skipped, 10 passed, 17 passed — zero
+failures in any of the three suites, both before and after this correction. The substantive claim
+below (guilt+innocence proven for both kill-switch mechanisms, real Postgres roles, no mocks)
+was and remains true; only the transcribed digits were wrong. Re-derive with the command above on
+that commit (or any later one where these files are unchanged) rather than trusting this number.
+
+Among these, already covering guilt+innocence for BOTH kill-switch mechanisms with real
 Postgres roles (not mocks):
 
 - `test_activate_sequence_rollback_via_function_raises` — activates pack seq 1, then seq 2, then
@@ -369,12 +384,26 @@ on identical facts — not that a ledger row landed.
 Two things are deliberately mocked, both orthogonal to pack correctness and disclosed in the
 script's own module docstring rather than silently patched: `active_retention_policy_available`
 (stubbed `True` — the real gate lives behind a Zero retention-policy record this proof's migration
-set does not provision; it decides whether to PERSIST a decision, never what the decision IS), and
-`_save_evaluate_decision` (stubbed no-op — its target table, `visa_decisions`, is created by a
-migration outside this proof's applied set 250/251/253/254/267; the function only writes an audit
-row of an already-computed decision, it never reads or influences one). Pricing-catalog acquisition
-is untouched: `run_evaluation` already catches any exception from `get_pricing_service()` and
-degrades to `UnavailablePricingCatalog()` — that real degrade path runs here, not a test double.
+set does not provision) and `_save_evaluate_decision` (stubbed no-op — its target table,
+`visa_decisions`, is created by a migration outside this proof's applied set 250/251/253/254/267;
+the function only writes an audit row of an already-computed decision, it never reads or
+influences one). Pricing-catalog acquisition is untouched: `run_evaluation` already catches any
+exception from `get_pricing_service()` and degrades to `UnavailablePricingCatalog()` — that real
+degrade path runs here, not a test double.
+
+**Correction (2026-08-23, third pass, count fix — same pass as above)**: the module docstring's
+own characterization of `active_retention_policy_available` ("it decides whether to PERSIST a
+decision, never what the decision IS") undersells what it actually gates. Read against
+`evaluate_path.py`: it is called inside `_retention_gate_allows_persistence`
+(`evaluate_path.py:270-296`), which `run_evaluation` checks at `evaluate_path.py:1466` — **before**
+`_resolve_active_pack_binding`, i.e. before any pack is even looked up. If it returns `False`, the
+whole call short-circuits to `build_temp_unavailable_body(code="RETENTION_POLICY_UNAVAILABLE")` and
+no decision is computed at all. So it is not a downstream persistence toggle; it is a pre-check
+gate on entry to the entire evaluate path. Stubbing it `True` is still legitimate and non-hollowing
+for this proof's purpose — it does not decide or influence WHAT the decision is once the real
+evaluator runs, it only decides WHETHER the real evaluator runs at all, and the proof needs it to
+run. But "decides whether to persist" is the wrong description of what it gates; "gates entry to
+`run_evaluation` before pack resolution" is the accurate one.
 
 The scenario:
 


### PR DESCRIPTION
## Summary

An independent gate review of PR #4616 (the Visa Oracle kill-switch rollback proof) mutation-tested the pack-rollback proof for real — and while re-running the three pre-existing integration suites the report cites as supporting evidence, found their stated pass counts are arithmetically impossible against the actual files.

## What was wrong

`research/visa/2026-08-23-killswitch-rollback-proof.md` §2.2 and its mirror in `.agents/skills/visaoracle/SKILL.md` LIVE STATE both stated:
- `test_activation_writer.py` — **44 passed, 1 skipped**
- `test_replace_activation_set.py` — **11 passed**
- `test_activate_pack.py` — **18 passed**

`pytest --collect-only` on these exact files (unchanged since the report was written — verified via `git log <branch-point>..<merge-commit> -- <files>`, zero commits touch them) shows only **44, 10, 17 total test items** respectively. "44 passed + 1 skipped" from a 44-item file is not a possible pytest outcome — each count was inflated by exactly +1.

## What it is now

Corrected to the actually measured counts, re-run fresh against merge commit `292795a26364dbf47ac31e142c3ca41597537d49` on local ephemeral Postgres 17.10:
- `test_activation_writer.py` — **43 passed, 1 skipped**
- `test_replace_activation_set.py` — **10 passed**
- `test_activate_pack.py` — **17 passed**

Zero failures in any suite, both before and after this fix — the underlying substantive claim (guilt+innocence proven for both kill-switch mechanisms via real Postgres roles, no mocks) was and remains true. Only the transcribed digits were wrong.

Also corrected the report's characterization of the `active_retention_policy_available` stub used in the new pack-rollback test: it is not "decides whether to persist a decision" (a downstream write-gate) — read against `evaluate_path.py:270-296` and its call site at `evaluate_path.py:1466`, it gates entry to the *entire* evaluate path *before* pack resolution. Stubbing it `True` remains legitimate and non-hollowing (it doesn't influence what the decision IS once the real evaluator runs, only whether the evaluator runs at all — necessary since this proof's DB has no provisioned retention record), but the old description of what it gates was inaccurate.

## How I measured

```
cd apps/backend-rag && source .venv/bin/activate
export TEST_DATABASE_URL="postgresql://test@localhost:5432/nuzantara_test"
PYTHONPATH=. python -m pytest backend/tests/services/visa_engine/test_activation_writer.py -n 1 -q
PYTHONPATH=. python -m pytest backend/tests/scripts/visa_engine/test_replace_activation_set.py -n 1 -q
PYTHONPATH=. python -m pytest backend/tests/scripts/visa_engine/test_activate_pack.py -n 1 -q
```
Cross-checked against `pytest --collect-only -q` on each file (deterministic, DB-independent) to confirm the total-item ceiling.

## Scope

**Documentation only.** Does not touch the proof scripts (`2026-08-23-killswitch-mode-proof.py`, `2026-08-23-killswitch-pack-rollback-proof-test.py`), the pack-rollback mechanism, or the ENFORCE-GATE `SATISFIED 2026-08-23` bullet — that bullet and the mechanism it documents were independently verified real (see Adversarial review below) and stand unchanged. Grepped the whole repo for the three wrong numbers before editing (`44 passed`, `11 passed`, `18 passed`) — confirmed exactly these two files, two occurrences, nothing missed.

## Adversarial review

I am the adversarial pass here, and this PR exists because of that pass, not despite it. As the independent gate for PR #4616, I did not just read the pack-rollback proof — I mutation-tested it twice against a real Postgres 17.10 instance:

1. **Neutered pack B's divergence from A** (left the HARD_FILTER threshold at 60 instead of tightening to 5) → the test correctly went RED at the "C1 excluded" assertion (`assert 'C1' not in [...]` → `AssertionError: assert 'C1' not in ['C1']`), proving B's divergence from A is real and load-bearing through the actual evaluator, not merely asserted.
2. **Broke pack C's restore** (re-signed B's tightened content instead of A's original content as "C") → the test correctly went RED at the decision-equality assertion (`AssertionError: assert 'NO_SUPPORTED_PATH' == 'SUPPORTED_CANDIDATES'`), proving the restore-reproduces-original claim is real, not a self-fulfilling comparison.

Both mutations produced genuine failures at the exact predicted assertion; the unmutated proof passes cleanly. This is the strongest evidence obtainable short of the original author's own run. While doing this verification I also independently re-ran the three integration suites cited as supporting evidence (§2.2) and found the count discrepancy this PR fixes — caught by re-measuring, not by re-reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)