### PR TITLE
docs(visa-oracle): correct stale 90-day analytics TTL in ENFORCE-GATE runbook

### DIFF
--- a/docs/runbooks/visa-oracle-privacy-enforce-gate.md
+++ b/docs/runbooks/visa-oracle-privacy-enforce-gate.md
@@ -26,18 +26,18 @@ These are latent while mode is SHADOW, but are hard ENFORCE blockers.
 
 ## Approved values
 
-| Control            | Value                                                     | Operational owner       |
-| ------------------ | --------------------------------------------------------- | ----------------------- |
-| Decision retention | 30 days from `evaluated_at`                               | Privacy owner           |
-| Idempotency        | 24 hours                                                  | Backend owner           |
-| PII-free telemetry | 90 days                                                   | Product analytics owner |
-| Retention cadence  | Every 15 minutes                                          | Infra/on-call           |
-| Purge-lag alert    | Any backlog remaining after a run, or lag over 60 minutes | Infra/on-call           |
-| DSR SLA            | 3 x 24 hours                                              | Privacy owner           |
-| Legal-hold review  | Every 30 days                                             | Legal/privacy owner     |
-| CRM / WhatsApp     | Separate explicit opt-ins                                 | Product owner           |
-| Minor              | Parent/guardian confirmation; otherwise human review      | Privacy/product owner   |
-| DPIA               | Approved before ENFORCE                                   | Zero + privacy owner    |
+| Control            | Value                                                                    | Operational owner       |
+| ------------------ | ------------------------------------------------------------------------ | ----------------------- |
+| Decision retention | 30 days from `evaluated_at`                                              | Privacy owner           |
+| Idempotency        | 24 hours                                                                 | Backend owner           |
+| PII-free telemetry | 365 days (12 months, DPIA V2 §A ruling 2026-08-20, signed §8 2026-08-23) | Product analytics owner |
+| Retention cadence  | Every 15 minutes                                                         | Infra/on-call           |
+| Purge-lag alert    | Any backlog remaining after a run, or lag over 60 minutes                | Infra/on-call           |
+| DSR SLA            | 3 x 24 hours                                                             | Privacy owner           |
+| Legal-hold review  | Every 30 days                                                            | Legal/privacy owner     |
+| CRM / WhatsApp     | Separate explicit opt-ins                                                | Product owner           |
+| Minor              | Parent/guardian confirmation; otherwise human review                     | Privacy/product owner   |
+| DPIA               | Approved before ENFORCE                                                  | Zero + privacy owner    |
 
 ## Change order
 
@@ -165,14 +165,17 @@ and uninstalled. It intentionally performs zero immediate retries: backlog or
 lag exit `2` must page rather than being retried until the evidence disappears;
 the next bounded attempt is the next 15-minute tick.
 
-### 5. Enforce the 90-day analytics deletion
+### 5. Enforce the 365-day (12-month) analytics deletion
 
 The frontend now omits generic user/session identifiers and sends only the Visa
 Oracle field allowlist. Before enabling its analytics endpoint, configure the
-destination dataset with a 90-day TTL/deletion job and prove deletion with a
-synthetic event older than 90 days. If the destination cannot enforce a
-Visa-specific TTL, keep `NEXT_PUBLIC_ANALYTICS_ENDPOINT` unset for this surface;
-no telemetry is safer than over-retention.
+destination dataset with a 365-day TTL/deletion job and prove deletion with a
+synthetic event older than 365 days (corrected 2026-08-23: supersedes the old
+90-day provisional per Zero's 2026-08-20 retention ruling, DPIA V2 §A,
+`docs/audits/2026-08-20-visa-oracle-dpia-v2.md`, signed §8 2026-08-23). If the
+destination cannot enforce a Visa-specific TTL, keep
+`NEXT_PUBLIC_ANALYTICS_ENDPOINT` unset for this surface; no telemetry is safer
+than over-retention.
 
 ### 6. Operate DSR and legal hold
 
@@ -229,7 +232,8 @@ The signed DPIA must name:
 - minors and guardian-consent path;
 - threat model for signed RulePacks, HMACs, replay, rollback, DB failure,
   unauthorized activation and DSR abuse;
-- 30-day/24-hour/90-day deletion evidence and legal-hold exceptions;
+- 30-day/24-hour/365-day deletion evidence and legal-hold exceptions (the
+  telemetry figure is 365 days, not 90 — DPIA V2 §A, signed §8 2026-08-23);
 - residual risks, owners, due dates and Zero's approval.
 
 Any open high risk keeps mode in SHADOW. Store the signed PDF immutably with


### PR DESCRIPTION
## Summary

`docs/runbooks/visa-oracle-privacy-enforce-gate.md` still instructed a 90-day
analytics-destination TTL in three live places. That figure is stale: Zero's
2026-08-20 retention ruling (DPIA V2 §A, `docs/audits/2026-08-20-visa-oracle-dpia-v2.md`)
set PII-free telemetry retention at **365 days (12 months)**, signed at §8 on
2026-08-23. PR #4593 already landed the matching code/doc amendment elsewhere
(`EXPECTED_TTL_DAYS` in `scripts/visa_oracle_analytics_retention_preflight.py`,
`docs/runbooks/visa-oracle-retention-operations.md`) — this runbook was the one
place that never got the correction.

- Approved-values table: PII-free telemetry row, 90 days → 365 days.
- Step 5 heading + body: "Enforce the 90-day analytics deletion" → 365-day,
  with a correction note citing the ruling.
- DPIA evidence-packet checklist bullet: 90-day → 365-day deletion evidence.

**Why a runbook and not left alone like other 90-day mentions in the repo:**
an audit/execution record narrates what was true on a dated snapshot — leaving
those alone is correct. A runbook is a live instrument someone opens to
configure infrastructure *now*. A stale number here is not a stale claim, it's
a wrong instruction someone would act on.

## Out of scope (flagged, not fixed)

This same file's header ("Authority: `docs/policies/visa-oracle-privacy-policy-v1.md`")
and its evidence-packet reference near the bottom ("Use
`docs/audits/2026-08-06-visa-oracle-dpia-v1.md` as the evidence packet...")
both still point at DPIA **V1**, not the now-signed/operative V2. Related
staleness, but a separate correction outside what was scoped for this fix —
noted for a follow-up.

Untouched by design: the analytics preflight script, its attestation example,
and precondition 5's open status (destination is still unidentified —
unrelated to the TTL-value correction).

## Adversarial review

Self-caught, then independently re-checked by the directing agent. During a
prior sweep (#4655) I judged three stale "90-day"/DPIA-V1 docs safe to leave
untouched, reasoning they were historical narration. The directing agent
personally re-read all three and ruled two correct to leave (a dated
execution record, and two DPIA V2 §A citation hits) but this one wrong —
the audit-vs-runbook distinction above is theirs, and it's right: I had
applied "is this frozen?" when the real question is "would someone act on
this?". This PR is that correction, scoped to exactly the four hits named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)