### PR TITLE
docs(visa-oracle): repoint ENFORCE-GATE runbook's DPIA citation from V1 to V2

### DIFF
--- a/docs/runbooks/visa-oracle-privacy-enforce-gate.md
+++ b/docs/runbooks/visa-oracle-privacy-enforce-gate.md
@@ -217,8 +217,17 @@ carry a future review deadline.
 
 ### 7. Complete and approve the DPIA
 
-Use `docs/audits/2026-08-06-visa-oracle-dpia-v1.md` as the evidence packet.
-It intentionally remains `DRAFT / NO-GO` while any high residual risk is open.
+Use `docs/audits/2026-08-20-visa-oracle-dpia-v2.md` as the evidence packet
+(corrected 2026-08-23: supersedes `docs/audits/2026-08-06-visa-oracle-dpia-v1.md`,
+which stays on disk as the incorporated baseline record — V2 references its
+processing description, data-flow table and rights/deletion model rather than
+restating them). Its §8 is signed: Product owner (Zero) in person, 2026-08-23;
+the Privacy/DPO and Security/Infra owner lines are recorded as adopted on Zero's
+instruction, not personally executed (§8 provenance note). Signing approved the
+assessment — it does not authorize ENFORCE. Two High residual risks stay open
+per §8/§D and keep mode in SHADOW: the analytics destination behind
+`NEXT_PUBLIC_ANALYTICS_ENDPOINT` is still unidentified, and the cross-border
+processor/subprocessor register (Annex 1) is still `OPEN`/`UNKNOWN`.
 The signed DPIA must name:
 
 - controller, processors, storage regions and cross-border safeguards;


### PR DESCRIPTION
## Summary

`docs/runbooks/visa-oracle-privacy-enforce-gate.md` step 7 ("Complete and
approve the DPIA") told an executor to use the superseded
`docs/audits/2026-08-06-visa-oracle-dpia-v1.md` as the evidence packet, and
described it as intentionally `DRAFT / NO-GO`. Both are stale: the operative
document is `docs/audits/2026-08-20-visa-oracle-dpia-v2.md`, and its §8 is
**signed** (Product owner Zero in person, 2026-08-23; Privacy/DPO and
Security/Infra owner lines recorded as adopted on Zero's instruction per
Legge 5, not personally executed).

Someone running this step today would open the wrong file and conclude the
DPIA is unsigned — misrouting the whole step, worse than a stale number
because it sends the reader to the wrong artifact entirely.

The replacement names the actual current gate correctly rather than just
swapping the filename: signing approved the privacy-impact assessment, it
does **not** authorize ENFORCE, and mode stays SHADOW because two specific
High residual risks are still open per DPIA V2 §8/§D — the analytics
destination behind `NEXT_PUBLIC_ANALYTICS_ENDPOINT` (still unidentified) and
the cross-border processor/subprocessor register (Annex 1, still
`OPEN`/`UNKNOWN`) — not "any high risk" generically.

## Confirmed correct, not touched

Per the directing agent's own verification before assigning this fix: the
header's `Authority: docs/policies/visa-oracle-privacy-policy-v1.md` line and
section 3's "Register Privacy Policy V1" heading are correct as written —
that policy has no v2.

## Swept the rest of the runbook for the same class, found nothing else to fold in

- Line 3 `Last verified: 2026-08-06` — a freshness marker about the runbook's
  own audit cadence, not a citation to a document. Different class.
- "Zero's remaining actions" item 1, "approve the completed DPIA/residual-risk
  record" — genuinely ambiguous now that Zero's own §8 signature is done but
  the DPO/Security-Infra lines are only adopted-on-instruction, not personally
  executed. Whether that satisfies "the completed record" is a judgment call
  about DPIA completeness, not a mechanical pointer fix — surfacing it rather
  than silently resolving it either way.
- "Store the signed PDF immutably... do not store it in the public source KB"
  — **resolved, no action needed.** Checked directly: `find`/`grep -rl "dpia"`
  against `apps/backend-rag/backend/kb/` (the RAG-ingested corpus, what
  CLAUDE.md calls "curated") both return zero hits. "Public source KB" means
  that ingested corpus, not `docs/`, and the constraint already holds — the
  signed DPIA V2 living in `docs/audits/` does not violate it. Nothing to fix.

Two of these three needed nothing folded in; the third is now a closed
question rather than an open one.

## Adversarial review

This is the fourth PR in a same-day chain correcting stale DPIA/TTL
references discovered while gate-reviewing #4616 (see #4651, #4655, #4657).
The directing agent independently re-checked my prior "leave alone" call on
this file and corrected it — the distinction: an audit narrates what
happened then, a runbook instructs what to do now. This PR is that
correction's second half (the DPIA pointer), scoped tight per the directing
agent's explicit narrowing (policy-v1 authority line confirmed correct,
left alone).

This branch is from fresh `origin/main` — not stacked on #4657 (also open
and armed) per the repo's "arm means freeze" rule; zero file-content overlap
between the two PRs' diffs beyond touching the same file in different
paragraphs, so ordering is safe either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
