### PR TITLE
fix(visa-engine): close E31C WNA-WNI nationality gap, remove D12's ungrounded conjunct (seq-13 rules-only)

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules.py
@@ -1,0 +1,473 @@
+"""fold_pack_seq13_rules.py — assemble RulePack seq-13's RULES-ONLY half from
+seq-12 + the inc6 cure.
+
+E5 increment 6. This fold covers ONLY the rule-graph half of seq-13 — a
+separate lane owns re-verifying the 18 portal `source_records` for freshness
+(the seq-12 pattern this repo already uses for that concern, `fold_pack_
+seq12.py`); a third step folds both halves together into the actual
+`rulepack-prod-013.source.json`. This module therefore does **not** write
+that file — it writes an intermediate `rulepack-prod-013.rules-only.json`
+carrying the full RulePackPayload shape with `source_records` and
+`sequence`/`version`/`rule_pack_id`/`previous_payload_sha256`/`created_at`/
+`created_by` left at seq-12's own values (the combining step owns identity
+and chaining; this fold's job is provably correct RULE bytes, nothing else).
+
+**A rule tightening is a DATA entry, never bespoke code.** Every fix this
+fold applies — one rule or nine — is one or more entries in `inc6-pack-edits/
+inc6-rule-manifest.json` (the claim-backed body, compiled through `compile_
+claims`) plus the matching declarative entries in `inc6-pack-edits/cure-
+seq13-rule-tightenings.json` (`rule_edits`/`insertions`, with ledger-drift
+{current_value, new_value} pairs). The set of edited/inserted rule_ids is
+**derived from the cure file at run time** (`_edited_rule_ids`/`_inserted_
+rule_ids` below) — there is no hardcoded tuple anywhere in this module to
+fall out of sync. Adding a fix means adding manifest + cure entries; it
+never means touching this file's logic. The "delta is exactly what was
+declared" sweep (`_assert_untouched`) enumerates its touched-rule set from
+that same cure data, so an accidental Nth change (one nobody added an entry
+for) fails the sweep by construction rather than silently widening the diff.
+
+Fixes carried by the current manifest/cure data, closing the gap
+`.agents/skills/visaoracle/SKILL.md`'s 2026-08-23 LIVE STATE entry names as
+"audit the class, not patch one rule" — `hit_policy.eligibility =
+COVER_ALL_DECLARED_PURPOSES` makes rule coverage OR-like, so ONE untouched
+broad SUPPORT rule silently carries a product past every tightened sibling:
+
+1. **E31C nationality leg** (Fix 1). `el.e31c-child-mixed-marriage-support`
+   is edited in place to add the `family.sponsor_nationalities intersects
+   [ID]` conjunct its sibling `el.e31c-mixed-marriage-parents` already
+   carries (seq-10) — proven live against the real evaluator to reach
+   SUPPORTED for a child of two foreign parents on its own. A paired
+   HARD_FILTER `hf.e31c-sponsor-not-indonesian` is inserted, mirroring
+   `hf.e31c-marriage-not-registered`'s exact shape (seq-10), so a FUTURE
+   untouched sibling cannot silently re-open the same gap — HARD_FILTER
+   stage runs before any SUPPORT rule is even consulted.
+2. **D12 missing sibling conjunct** (Fix 3). `el.d12-multi-entry-support` is
+   the only one of D12's 6 ELIGIBILITY rules missing `investment.
+   pt_pma_committed != true`, restructured in place into the identical
+   nested-all shape its 5 siblings already use. Mutation-proven red->green:
+   adding the conjunct makes all 7 D12 rules resolve FALSE for a
+   `pt_pma_committed=True` applicant.
+3. **Sponsor-status value check** (Fix 4). Nine rules across four products
+   (E31B/E31E/E31H/E31J) test `family.sponsor_status_code` with `op:known`
+   — presence only, never value, so any non-empty string (a visit-visa code,
+   an expired permit) passes a rule literally named `*-sponsor-itas-itap`.
+   Each of the nine is edited in place to `op:in, values:[ITAS_ACTIVE,
+   ITAP_ACTIVE, VITAS_APPROVED]` — grounded by four independently-worded
+   articles, one per product (Permenkumham 22/2023 Pasal 44(2)(b)/47(2)(c)/
+   50(2)(b), 11/2024 Pasal 50A(2)(c) for E31J), each with its own VITAS
+   fallback clause (44(3)/47(3)/50(3)/50A(3)) — see `inc6-sponsor-status-
+   claim-ledger.md`.
+
+**E31D is deliberately NOT touched by this fold.** The team-lead's mandate
+named a third fix there; `research/visa/2026-08-15-gold-family-refuter.md`
+explicitly blocks a direct pack edit for it — the fact vocabulary has no
+STEPCHILD `relation_to_sponsor` value and no dedicated WNA-WNI
+mixed-marriage-basis fact (re-verified live 2026-08-23: `RelationType` enum
+and all three `el.e31d-*` rules are byte-unchanged since that audit), and
+overloading the existing CHILD/PARENT facts with new semantics is the exact
+"legally misleading boundary" the refuter warns against. That fix needs a
+Zero/legal decision plus a fact-vocabulary extension (backend reader +
+frontend writer) — outside a RULES-ONLY fold's authority.
+
+Every input is read from disk at run time. The chain hash is read LIVE from
+`rulepack-prod-012.signed.json` and asserted against the expected anchor; the
+seq-12 source bytes are additionally re-hashed (RFC 8785 JCS) and must equal
+that same value — a source/signed mismatch aborts the fold. Every rule edit
+carries ledger-drift guards ({current_value, new_value} pairs asserted against
+the seq-12 bytes before mutating), and the compiled body from `compile_
+claims` is cross-checked byte-for-byte against the cure file's own
+declarative edit — two independent statements of the new rule body, any
+mismatch aborts. Deterministic: fixed timestamps, no `datetime.now()` —
+re-running is byte-identical.
+
+Usage::
+
+    PYTHONPATH=. python -m backend.scripts.visa_engine.fold_pack_seq13_rules
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from backend.scripts.visa_engine.compile_claims import compile_manifest, load_manifest
+from backend.services.visa_engine.bundle import canonicalize_json
+from backend.services.visa_engine.claim_ledger import ClaimLedgerError, load_claim_ledgers
+from backend.services.visa_engine.models import Rule, RulePackPayload
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_THIS_FILE = Path(__file__).resolve()
+_BACKEND_ROOT = _THIS_FILE.parents[2]  # apps/backend-rag/backend
+_REPO_ROOT = _THIS_FILE.parents[5]
+
+_PACKS_DIR = _BACKEND_ROOT / "services" / "visa_engine" / "contracts" / "packs"
+_SEQ12_SOURCE = _PACKS_DIR / "rulepack-prod-012.source.json"
+_SEQ12_SIGNED = _PACKS_DIR / "rulepack-prod-012.signed.json"
+_SEQ13_RULES_ONLY_OUT = _PACKS_DIR / "rulepack-prod-013.rules-only.json"
+
+_E5_DIR = _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "e5"
+_INC6_EDITS_DIR = _E5_DIR / "inc6-pack-edits"
+_CURE_FILE = _INC6_EDITS_DIR / "cure-seq13-rule-tightenings.json"
+_INC6_MANIFEST = _INC6_EDITS_DIR / "inc6-rule-manifest.json"
+
+_CLAIMS_DIR = _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "claims"
+_LEDGER_FILES = [
+    _CLAIMS_DIR / "e2a-claim-ledger.md",
+    _CLAIMS_DIR / "inc4-c2-e31c-claim-ledger.md",
+    _CLAIMS_DIR / "inc6-sponsor-status-claim-ledger.md",
+]
+
+_PRETTIER_BIN = _REPO_ROOT / "node_modules" / ".bin" / "prettier"
+
+# ---------------------------------------------------------------------------
+# Chain verification against the SIGNED seq-12 pack (identity itself is left
+# to the combining fold — see module docstring).
+# ---------------------------------------------------------------------------
+
+_EXPECTED_SEQ12_PAYLOAD_SHA256 = (
+    "ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d"
+)
+
+_RULE_KEY_ORDER = (
+    "rule_id",
+    "stage",
+    "scope",
+    "priority",
+    "valid_period",
+    "when",
+    "effect",
+    "on_unknown",
+    "required_facts",
+    "source_refs",
+    "explanation_key",
+    "safety_critical",
+    "product_version_ids",
+)
+
+
+class FoldPackError(RuntimeError):
+    """A fail-loud gate inside the fold tripped — never silently degrade."""
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _verify_chain(seq12_source: dict[str, Any]) -> str:
+    signed = _load_json(_SEQ12_SIGNED)
+    declared = signed.get("payload_sha256")
+    if declared != _EXPECTED_SEQ12_PAYLOAD_SHA256:
+        raise FoldPackError(
+            f"{_SEQ12_SIGNED} declares payload_sha256={declared!r}, expected "
+            f"{_EXPECTED_SEQ12_PAYLOAD_SHA256!r} — the signed seq-12 on disk is "
+            "not the one this fold was authored against"
+        )
+    recomputed = hashlib.sha256(canonicalize_json(seq12_source)).hexdigest()
+    if recomputed != declared:
+        raise FoldPackError(
+            f"seq-12 SOURCE bytes re-hash to {recomputed}, but the signed file "
+            f"declares {declared} — source/signed mismatch, refusing to chain"
+        )
+    return declared
+
+
+# ---------------------------------------------------------------------------
+# Data-driven touched-rule sets — derived from the cure file, never hardcoded.
+# Adding a fix means adding cure/manifest entries, never editing these.
+# ---------------------------------------------------------------------------
+
+
+def _edited_rule_ids(cure: dict[str, Any]) -> tuple[str, ...]:
+    """Every rule_id named by ``cure["rule_edits"]``, in first-seen order,
+    deduplicated (one rule commonly carries 2+ field edits, e.g. `when` +
+    `required_facts`)."""
+
+    seen: list[str] = []
+    for edit in cure["rule_edits"]:
+        rid = edit["rule_id"]
+        if rid not in seen:
+            seen.append(rid)
+    return tuple(seen)
+
+
+def _inserted_rule_ids(cure: dict[str, Any]) -> tuple[str, ...]:
+    return tuple(e["rule_id"] for e in cure["insertions"])
+
+
+# ---------------------------------------------------------------------------
+# Compile the inc6 manifest against the claim ledgers
+# ---------------------------------------------------------------------------
+
+
+def _compile_inc6_rules(cure: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    try:
+        ledger = load_claim_ledgers(_LEDGER_FILES)
+    except (OSError, ClaimLedgerError) as exc:
+        raise FoldPackError(f"failed to load claim ledgers: {exc}") from exc
+
+    manifest = load_manifest(_INC6_MANIFEST)
+    report = compile_manifest(manifest, ledger)
+    if not report.ok:
+        raise FoldPackError("inc6-rule-manifest.json failed to compile clean:\n" + report.render())
+
+    compiled: dict[str, dict[str, Any]] = {}
+    for entry in report.compiled:
+        rule_dict = _to_pack_rule_dict(entry.rule.model_dump(mode="json", by_alias=True))
+        compiled[rule_dict["rule_id"]] = rule_dict
+
+    # Two independent declarations of "what this fold touches" — the
+    # manifest's compiled output and the cure file's edits/insertions — must
+    # name exactly the same rule_ids, or one of the two data files drifted
+    # from the other without anyone updating its twin.
+    expected = set(_edited_rule_ids(cure)) | set(_inserted_rule_ids(cure))
+    if set(compiled) != expected:
+        raise FoldPackError(
+            f"manifest compiled {sorted(compiled)}, cure file declares "
+            f"{sorted(expected)} — manifest and cure file have drifted apart"
+        )
+    return compiled
+
+
+def _to_pack_rule_dict(rule_src: dict[str, Any]) -> dict[str, Any]:
+    clean = {k: v for k, v in rule_src.items() if not k.startswith("_")}
+    out: dict[str, Any] = {}
+    for key in _RULE_KEY_ORDER:
+        if key in clean:
+            out[key] = clean[key]
+        else:
+            raise FoldPackError(f"rule {clean.get('rule_id')!r} is missing required key {key!r}")
+    extra = set(clean) - set(_RULE_KEY_ORDER)
+    if extra:
+        raise FoldPackError(f"rule {clean.get('rule_id')!r} has unexpected key(s): {sorted(extra)}")
+    Rule.model_validate(out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Apply the two in-place edits + one insertion, all cross-checked against
+# the compiled bodies above.
+# ---------------------------------------------------------------------------
+
+
+def _rule_edits_for(cure: dict[str, Any], rule_id: str) -> list[dict[str, Any]]:
+    edits = [e for e in cure["rule_edits"] if e["rule_id"] == rule_id]
+    if not edits:
+        raise FoldPackError(f"cure file declares no rule_edits for {rule_id!r}")
+    return edits
+
+
+def _seq12_baseline_value(seq12_source: dict[str, Any], rule_id: str, key: str) -> Any:
+    """The seq-12 value for ``key`` on ``rule_id``: for a field this cure
+    edits, the correct baseline is the cure file's own declared
+    ``current_value`` (already drift-asserted against the real bytes); for
+    every other key the edit never touches it, so the post-edit value IS
+    the seq-12 value — read straight off the source pack."""
+
+    rule = next(r for r in seq12_source["rules"] if r["rule_id"] == rule_id)
+    return rule.get(key)
+
+
+def _apply_rule_edits(
+    payload: dict[str, Any], seq12_source: dict[str, Any], cure: dict[str, Any],
+    compiled: dict[str, dict[str, Any]],
+) -> None:
+    rules_by_id = {r["rule_id"]: r for r in payload["rules"]}
+
+    for rule_id in _edited_rule_ids(cure):
+        edited = rules_by_id.get(rule_id)
+        if edited is None:
+            raise FoldPackError(f"rule {rule_id!r} not found for the seq-13 edit")
+
+        touched_fields: set[str] = set()
+        for edit in _rule_edits_for(cure, rule_id):
+            field = edit["field"]
+            touched_fields.add(field)
+            if edited.get(field) != edit["current_value"]:
+                raise FoldPackError(
+                    f"rule {rule_id!r} field {field!r} does not match "
+                    "cure-seq13-rule-tightenings.json's declared current_value — "
+                    "ledger drift, not applying blind"
+                )
+            edited[field] = edit["new_value"]
+
+        compiled_edit = compiled[rule_id]
+        if _canon(edited) != _canon(compiled_edit):
+            raise FoldPackError(
+                f"the edited {rule_id!r} does not equal the manifest-compiled "
+                "body — cure file and manifest have drifted apart"
+            )
+
+        diff_keys = {
+            k
+            for k in _RULE_KEY_ORDER
+            if _canon(compiled_edit.get(k)) != _canon(_seq12_baseline_value(seq12_source, rule_id, k))
+        }
+        if diff_keys != touched_fields:
+            raise FoldPackError(
+                f"{rule_id!r} edit touched {sorted(diff_keys)}, cure file "
+                f"declares exactly {sorted(touched_fields)} — only the "
+                "declared fields may change"
+            )
+
+
+def _apply_insertions(payload: dict[str, Any], cure: dict[str, Any], compiled: dict[str, dict[str, Any]]) -> None:
+    cure_insertions = cure["insertions"]
+    declared_ids = [e["rule_id"] for e in cure_insertions]
+    if len(declared_ids) != len(set(declared_ids)):
+        raise FoldPackError(
+            f"cure-seq13-rule-tightenings.json insertions names a duplicate "
+            f"rule_id: {declared_ids!r}"
+        )
+
+    rules_by_id = {r["rule_id"]: r for r in payload["rules"]}
+    for cure_ins_raw in cure_insertions:
+        rule_id = cure_ins_raw["rule_id"]
+        inserted = copy.deepcopy(compiled[rule_id])
+        cure_ins = {k: v for k, v in cure_ins_raw.items() if not k.startswith("_")}
+        for key in _RULE_KEY_ORDER:
+            if _canon(cure_ins.get(key)) != _canon(inserted.get(key)):
+                raise FoldPackError(
+                    f"cure-seq13-rule-tightenings.json insertion field {key!r} for "
+                    f"{rule_id!r} does not match the manifest-compiled rule — cure "
+                    "file and manifest drifted apart"
+                )
+        if rule_id in rules_by_id:
+            raise FoldPackError(f"rule {rule_id!r} already exists — cannot insert")
+        payload["rules"] = [*payload["rules"], inserted]
+        rules_by_id[rule_id] = inserted
+
+
+# ---------------------------------------------------------------------------
+# Byte-invariance sweep — everything not declared touched must match seq-12
+# ---------------------------------------------------------------------------
+
+_IDENTITY_KEYS = frozenset(
+    {"sequence", "version", "rule_pack_id", "previous_payload_sha256", "created_at", "created_by"}
+)
+
+
+def _assert_untouched(payload: dict[str, Any], seq12: dict[str, Any], cure: dict[str, Any]) -> None:
+    """Enumerate the touched-rule set from the cure file's OWN data (never a
+    hardcoded tuple) — this is the guard that stops a fold from silently
+    carrying an Nth change nobody added a manifest/cure entry for: any rule
+    not named by `cure["rule_edits"]`/`cure["insertions"]` must be
+    byte-identical to seq-12, full stop."""
+
+    for key in set(seq12) | set(payload):
+        if key in _IDENTITY_KEYS or key == "rules":
+            continue
+        if _canon(payload.get(key)) != _canon(seq12.get(key)):
+            raise FoldPackError(
+                f"top-level payload key {key!r} drifted from seq-12 — this fold "
+                "declares no edit there (products/source_records are untouched: "
+                "the rules-only lane owns neither)"
+            )
+
+    seq12_rules = {r["rule_id"]: r for r in seq12["rules"]}
+    new_rules = {r["rule_id"]: r for r in payload["rules"]}
+    touched_rules = set(_edited_rule_ids(cure)) | set(_inserted_rule_ids(cure))
+
+    for rid, rule in new_rules.items():
+        if rid in touched_rules:
+            continue
+        if rid not in seq12_rules or _canon(rule) != _canon(seq12_rules[rid]):
+            raise FoldPackError(f"rule {rid!r} drifted from seq-12 outside the declared edit set")
+    missing = set(seq12_rules) - set(new_rules)
+    if missing:
+        raise FoldPackError(f"rule(s) vanished unexpectedly: {sorted(missing)}")
+
+
+# ---------------------------------------------------------------------------
+# Write (atomic + prettier — fold_pack.py's Codex-finding-7 shape)
+# ---------------------------------------------------------------------------
+
+
+def _write_pack(payload: dict[str, Any], out_path: Path) -> None:
+    if not _PRETTIER_BIN.exists():
+        raise FoldPackError(
+            f"prettier binary not found at {_PRETTIER_BIN} — run `npm install` at repo root"
+        )
+
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"{out_path.stem}.tmp.", suffix=out_path.suffix, dir=str(out_path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with open(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        result = subprocess.run(
+            [str(_PRETTIER_BIN), "--write", str(tmp_path)],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise FoldPackError(
+                f"prettier --write {tmp_path} failed (rc={result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        tmp_path.replace(out_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def assemble_payload() -> dict[str, Any]:
+    seq12_original = _load_json(_SEQ12_SOURCE)
+    _verify_chain(seq12_original)
+    payload = copy.deepcopy(seq12_original)
+
+    cure = _load_json(_CURE_FILE)
+    compiled = _compile_inc6_rules(cure)
+    _apply_rule_edits(payload, seq12_original, cure, compiled)
+    _apply_insertions(payload, cure, compiled)
+    _assert_untouched(payload, seq12_original, cure)
+
+    try:
+        RulePackPayload.model_validate(payload)
+    except Exception as exc:  # re-raised loud with context
+        raise FoldPackError(
+            f"assembled seq-13 rules-only payload failed RulePackPayload validation: {exc}"
+        ) from exc
+
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # no CLI flags — deterministic single-purpose script
+    try:
+        payload = assemble_payload()
+    except FoldPackError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    _write_pack(payload, _SEQ13_RULES_ONLY_OUT)
+    print(
+        f"wrote {_SEQ13_RULES_ONLY_OUT} — {len(payload['rules'])} rule(s), "
+        f"{len(payload['products'])} product(s), {len(payload['source_records'])} source_record(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.rules-only.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.rules-only.json
@@ -1,0 +1,9005 @@
+{
+  "created_at": "2026-08-20T07:00:00Z",
+  "created_by": "agent.air-m5.backend-rag.visa-seq12-restamp.fold-2026-08-20",
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_contract_version": "1.0.0",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "environment": "PRODUCTION",
+  "hit_policy": {
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL",
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+  },
+  "jurisdiction": "ID",
+  "previous_payload_sha256": "836acc511bcadd41c28284e7f00bd8be27c6109ebcc5536f7053c3f61eaa2865",
+  "rollback_of_payload_sha256": null,
+  "products": [
+    {
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "product_code": "E28A",
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 730,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 100,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Investor KITAS 2 Years (Offshore)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "product_code": "E28B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "product_code": "E28C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work", "corporate_establishment"],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "product_code": "E28D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "product_code": "E28F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "product_code": "E33",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33 Second Home (5 Years)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "product_code": "E33A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "product_code": "E33B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "product_code": "E33C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "product_code": "E33E",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Retirement (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "product_code": "E33F",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "product_code": "E33G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33G Remote Worker (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "product_code": "A1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "A1 Visa-Free Tourism"
+      },
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "product_code": "B1",
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa on Arrival — Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 30,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "B1 Visa on Arrival (VOA)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "product_code": "C1",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C1 Tourism"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "product_code": "C2",
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C2 Business"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "product_code": "C6",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": ["paid_employment", "business_meetings"],
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C6 Social Activity"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "product_code": "BRIDGING",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Bridging Visa — Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "category": "OTHER",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": null,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "Bridging Visa"
+      },
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "product_code": "E23",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "product_code": "E23U",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_non_diplomat_employer"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "product_code": "E23V",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_standard_corporate_employers"],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "product_code": "E31A",
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": [],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "product_code": "E31B",
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "product_code": "E31C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "product_code": "E31D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "product_code": "E31E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "product_code": "E31F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "product_code": "E31G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "product_code": "E31H",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "product_code": "E31J",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "product_code": "D1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Tourism — Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata — Beberapa Kali Perjalanan (D1)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "product_code": "D2",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Business — Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "product_code": "D12",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Pre-Investment — Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 180,
+        "maximum_days": 180
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 180,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "product_code": "E30",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "product_code": "E30A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30A Education Visa (1 Year)"
+      },
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "product_code": "E30B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 1460
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30B Higher Education (1 Year)"
+      },
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "product_code": "E30E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "product_code": "E30F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hf.citizen",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.calling-visa",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.active-overstay",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.a1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.b1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "el.c1.tourism-family",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "rule_id": "el.c2.business",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "el.c6.social",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.investment_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "el.e28a.investment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "rule_id": "el.e33.deposit-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-qualification",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.guarantee-maintenance",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "any",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33a.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "review.e33b.expertise-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "review.e33c.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "hf.e33e.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.age-55-59-disputed-band",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "between",
+                "fact": "derived.age_years",
+                "lower": 55,
+                "upper": 59
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "gte",
+                "fact": "derived.age_years",
+                "value": 55
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 50000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.passive_monthly_income_usd",
+                "value": 3000
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY", "RETIREMENT", "SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "hf.e33f.sponsor-required",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["family.sponsor_confirmed"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "el.e33f.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-employer",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.indonesia_source_compensation"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-market",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-company-ownership",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e33g.remote-work",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.bridging.offshore",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.from-visit-itk",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.to-bridging",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.t3-window-manual",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.overstay-shield-payment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.source-status-verify",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_code"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.adverse-history",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.destination-stated",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.e23-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.employer_is_indonesian_entity",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e23-operational-work-boundary",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "investment.proposed_role",
+                "op": "in",
+                "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "work.employer_is_indonesian_entity",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "work.indonesian_work_sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.proposed_role",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e31a-spouse-wni-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-funds-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_FUNDS_2000",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-spousal-work-article-61",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-spousal-work-article-61",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-kitap-prerequisites",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "process.wants_onshore_conversion",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes",
+        "process.wants_onshore_conversion"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-kitap-prerequisites",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31b-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31c-mixed-marriage-parents",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31d-stepchild-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-step-parent-relation",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_STEP_PARENT_RELATION",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-step-parent-relation",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-sponsor-mixed-marriage",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hf.e31e-adult-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "derived.age_years",
+        "op": "gte",
+        "value": 18
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hf.e31e-married-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "person.marital_status",
+        "op": "neq",
+        "value": "SINGLE"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.marital_status"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+      ],
+      "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31f-adult-age-review",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+      ],
+      "explanation_key": "explain.el.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31h-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-dependency-age",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.d1-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D1",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d2-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D2",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d12-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-funds-usd-5000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D12",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.e30-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+      ]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.e30a-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["PRIMARY", "SECONDARY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hf.e30b-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30b-izin-belajar",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.b1.not-voa-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "review.citizenship-conflict",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.minor-without-guardian",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-09T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "derived.is_minor",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.review.minor-without-guardian",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.e33f.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33f.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "review.e33g.income-evidence",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_INCOME_EVIDENCE_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.review.e33g.income-evidence",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e30e-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "values": ["EDUCATION", "INDIVIDUAL"],
+            "op": "in"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e30e-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "rule_id": "el.e30f-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "value": "EDUCATION",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30f-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "rule_id": "hf.e33a.sponsor-not-government",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "value": "GOVERNMENT",
+        "op": "neq"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33a.sponsor-not-government",
+      "safety_critical": true,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "hf.e33b.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "hf.e33c.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "review.e23u.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23U",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23u.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "review.e23v.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23V",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23v.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hf.e31c-marriage-not-registered",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["FAMILY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT",
+            "op": "eq"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "value": false,
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-marriage-not-registered",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "hf.e31c-sponsor-not-indonesian",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-23T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["FAMILY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT",
+            "op": "eq"
+          },
+          {
+            "op": "not",
+            "arg": {
+              "fact": "family.sponsor_nationalities",
+              "values": ["ID"],
+              "op": "intersects"
+            }
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    }
+  ],
+  "rule_pack_id": "dd98e153-4f89-5176-b32e-d936b7bb2351",
+  "sequence": 12,
+  "version": "2026.8.20",
+  "valid_period": {
+    "from": "2026-07-25T00:00:00Z",
+    "to": null
+  },
+  "source_records": [
+    {
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Kepmen M.IP-08.GR.01.01/2025 — Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "language": "id",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 — Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "language": "id",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 39"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 40"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 57"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 58"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 59"
+        }
+      ],
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 10/2026 — Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "language": "id",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "locators": [],
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "legal_period": {
+        "from": "2026-07-09T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian — kewarganegaraan dan ketentuan overstay",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "language": "id",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "locators": [],
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Calling Visa — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 — Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "legal_period": {
+        "from": "2024-04-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 5/2025 — Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "language": "id",
+      "document_number": "Permen Imipas 5/2025",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "legal_period": {
+        "from": "2025-02-07T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Layanan Alih Status — Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "language": "id",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "language": "id",
+      "document_number": "22/2023",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33"
+        }
+      ],
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "legal_period": {
+        "from": "2023-08-22T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "language": "id",
+      "document_number": "11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+      "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Pasal 60 ayat (2) dan Pasal 61",
+      "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+      "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 60 ayat (2)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-10T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-10T00:00:00Z",
+      "verified_at": "2026-08-10T00:00:00Z",
+      "verified_by": "agent.air-m5.visa-seq6-semantics",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Bisnis (D2) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Pra-Investasi (D12) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Tinggi (E30B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "version": 1,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-08T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    }
+  ]
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_rules_pack.HELD-fix4-tests-2026-08-23.py.txt
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_rules_pack.HELD-fix4-tests-2026-08-23.py.txt
@@ -1,0 +1,148 @@
+# HELD 2026-08-23 -- FIX 4 (sponsor-status value check) test class, removed from
+# test_seq13_rules_pack.py in step with the cure/manifest entries being pulled into
+# HELD-fix4-sponsor-status-2026-08-23.json (same directory tree, one level up in
+# doctrine-factory/e5/inc6-pack-edits/). Reason: team-lead found the FOLDED ARTIFACT
+# still contained Fix 4 despite two chat-only "holding" messages -- a hold that lives
+# only in a message is not a hold; the artifact and the test suite have to say so too.
+# This file is NOT collected by pytest (.py.txt extension, not .py) -- it is verbatim
+# preserved source, paste back into test_seq13_rules_pack.py (restoring imports/module-
+# level context already present there) once Fix 4 is re-armed. See the HELD json's own
+# _comment for the three open questions that gate re-arming.
+
+# ---------------------------------------------------------------------------
+# (f) evaluator witnesses — sponsor-status value check, 4 products (Fix 4)
+# ---------------------------------------------------------------------------
+
+#: rule_id pairs (plus E31J's advisory third rule) per product, and the base
+#: facts each product's rules need BESIDES `family.sponsor_status_code` to
+#: reach their support rules at all.
+_SPONSOR_STATUS_PRODUCTS: dict[str, dict[str, Any]] = {
+    "E31B": {
+        "base": {
+            "intent.purposes": _known(["FAMILY"]),
+            "family.relation_to_sponsor": _known("SPOUSE"),
+            "family.marriage_registered": _known(True),
+        },
+        "support_rule_ids": {"el.e31b-spouse-itas-support", "el.e31b-sponsor-itas-itap"},
+    },
+    "E31E": {
+        "base": {
+            "intent.purposes": _known(["FAMILY"]),
+            "family.relation_to_sponsor": _known("PARENT"),
+            # baseline person.birth_date is 1990-01-01 (adult) — E31E's rules
+            # require derived.age_years < 18, so a minor birth_date is a
+            # required override, not incidental. A minor applicant also
+            # trips the GLOBAL_PREPASS minor-guardian review gate unless
+            # family.sponsor_confirmed is explicitly true (house pattern,
+            # test_evaluator_gold.py persona 6) — required here too, or
+            # every E31E case resolves REVIEW/MINOR_WITHOUT_CONFIRMED_
+            # GUARDIAN before the product-level rules are even consulted.
+            "person.birth_date": _known("2015-01-01"),
+            "person.marital_status": _known("SINGLE"),
+            "family.sponsor_confirmed": _known(True),
+        },
+        "support_rule_ids": {"el.e31e-child-itas-support", "el.e31e-sponsor-itas-itap"},
+    },
+    "E31H": {
+        "base": {
+            "intent.purposes": _known(["FAMILY"]),
+            "family.relation_to_sponsor": _known("CHILD"),
+        },
+        "support_rule_ids": {"el.e31h-parent-itas-child-support", "el.e31h-sponsor-itas-itap"},
+    },
+    "E31J": {
+        "base": {
+            "intent.purposes": _known(["FAMILY"]),
+            "family.relation_to_sponsor": _known("SIBLING"),
+            # baseline person.birth_date (1990-01-01, adult) already
+            # satisfies el.e31j-dependency-age's derived.age_years >= 18
+            # leg, so that advisory rule fires alongside the other two.
+        },
+        "support_rule_ids": {
+            "el.e31j-sibling-itas-support",
+            "el.e31j-sponsor-itas-itap",
+            "el.e31j-dependency-age",
+        },
+    },
+}
+
+#: A real, in-catalog visit-visa code — exactly the "any non-empty string
+#: passes" shape team-lead named: a legitimate status code, just not one of
+#: the three that mean "sponsor holds ITAS/ITAP/approved-VITAS".
+_NON_ENUM_SPONSOR_STATUS = "C1"
+_VALID_SPONSOR_STATUSES = ("ITAS_ACTIVE", "ITAP_ACTIVE", "VITAS_APPROVED")
+
+
+class TestSponsorStatusValueCheckWitnesses:
+    """Grading standard is stricter here (team-lead, explicit): guilt per
+    product (4) AND innocence per product PER enum value (12) — a
+    tightening that also excludes a legitimate ITAS/ITAP/VITAS sponsor is a
+    worse defect than the one it cures, so every one of the three values
+    gets its own witness, never a single representative."""
+
+    @pytest.mark.parametrize("product_code", sorted(_SPONSOR_STATUS_PRODUCTS))
+    def test_guilt_non_enum_status_code_is_unsupported(
+        self, seq13: compiler.CompiledRulePack, product_code: str
+    ) -> None:
+        spec = _SPONSOR_STATUS_PRODUCTS[product_code]
+        proof = _proof(
+            seq13,
+            product_code,
+            {**spec["base"], "family.sponsor_status_code": _known(_NON_ENUM_SPONSOR_STATUS)},
+        )
+        assert proof.status is ProductProofStatus.UNSUPPORTED, product_code
+        assert proof.support_rules == (), product_code
+
+    @pytest.mark.parametrize("product_code", sorted(_SPONSOR_STATUS_PRODUCTS))
+    def test_pinned_seq12_defect_non_enum_status_code_was_supported(
+        self, seq12: compiler.CompiledRulePack, product_code: str
+    ) -> None:
+        """Pinned so the fix is measurable — if this ever starts failing,
+        seq-12's bytes changed. Reproduces team-lead's own finding: `op:
+        known` accepts ANY non-empty string, so a visit-visa code like `C1`
+        (not ITAS/ITAP/VITAS) reached SUPPORTED on seq-12."""
+        spec = _SPONSOR_STATUS_PRODUCTS[product_code]
+        proof = _proof(
+            seq12,
+            product_code,
+            {**spec["base"], "family.sponsor_status_code": _known(_NON_ENUM_SPONSOR_STATUS)},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED, product_code
+        assert {r.rule_id for r in proof.support_rules} == spec["support_rule_ids"], product_code
+
+    @pytest.mark.parametrize("product_code", sorted(_SPONSOR_STATUS_PRODUCTS))
+    @pytest.mark.parametrize("status_value", _VALID_SPONSOR_STATUSES)
+    def test_innocence_each_valid_status_still_supported(
+        self, seq13: compiler.CompiledRulePack, product_code: str, status_value: str
+    ) -> None:
+        """12 cases (4 products x 3 statuses), written explicitly per the
+        team-lead's grading standard — the VITAS fallback is an explicit
+        statutory exception in all four source articles (Pasal 44(3)/47(3)/
+        50(3)/50A(3)); dropping it would exclude applicants the law
+        admits, which is a worse defect than the one being cured."""
+        spec = _SPONSOR_STATUS_PRODUCTS[product_code]
+        proof = _proof(
+            seq13,
+            product_code,
+            {**spec["base"], "family.sponsor_status_code": _known(status_value)},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED, (product_code, status_value)
+        assert {r.rule_id for r in proof.support_rules} == spec["support_rule_ids"], (
+            product_code,
+            status_value,
+        )
+
+    @pytest.mark.parametrize("product_code", sorted(_SPONSOR_STATUS_PRODUCTS))
+    def test_tristate_unknown_status_blocks_never_grants(
+        self, seq13: compiler.CompiledRulePack, product_code: str
+    ) -> None:
+        spec = _SPONSOR_STATUS_PRODUCTS[product_code]
+        proof = _proof(
+            seq13,
+            product_code,
+            {**spec["base"], "family.sponsor_status_code": gf.unknown("NOT_ASKED")},
+        )
+        assert proof.status is ProductProofStatus.BLOCKED_UNKNOWN, product_code
+        assert proof.status is not ProductProofStatus.SUPPORTED, product_code
+
+

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_rules_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_rules_pack.py
@@ -1,0 +1,650 @@
+"""E5 increment 6 — gates for the RULES-ONLY half of seq-13
+(``rulepack-prod-013.rules-only.json``, see
+``backend.scripts.visa_engine.fold_pack_seq13_rules``).
+
+This module SKIPS cleanly (not error, not red) while
+``rulepack-prod-013.rules-only.json`` does not exist on disk — the
+combining fold that folds this half together with the source-freshness
+half has not run yet. Once the rules-only fold has run and the file
+exists, these checks run, each verified against the real files on disk or
+the real evaluator:
+
+(a) chain gate — the rules-only payload's ``previous_payload_sha256``
+    (still seq-12's own value, since this fold declares no identity
+    change — see the fold's module docstring) equals the RECOMPUTED
+    SHA256(JCS(...)) of seq-12's own signed payload declaration, cross-
+    checked against a fresh re-hash of the seq-12 SOURCE bytes.
+(b) rule-set delta — mechanically diffed against seq-12, TWICE: once
+    data-driven (derived from ``cure-seq13-rule-tightenings.json`` via the
+    fold's own ``_edited_rule_ids``/``_inserted_rule_ids`` helpers, so it
+    covers whatever fixes the cure file declares without editing this
+    test), once as a named pin of the four specific fixes this session
+    graded — never eyeballed either way.
+(c) zero lint findings — ``lint_duplicate_subtree`` /
+    ``lint_unsatisfiable_condition`` run over every seq-13 rule (house
+    pattern, ``test_seq10_pack.py``).
+(d) ``compile_pack`` compiles the rules-only payload with zero errors.
+(e) idempotence — calling ``assemble_payload()`` twice yields
+    canonical-JSON-identical output.
+(f) evaluator witnesses (house pattern ``test_seq10_pack.py``'s
+    ``TestE31CMarriageGateWitnesses`` — per-product ``evaluate_product``,
+    never the aggregated Decision): E31C nationality-leg
+    guilt/pinned-seq12-defect/innocence/tri-state/non-contamination, the
+    identical five-part pattern for D12's ``pt_pma_committed`` conjunct
+    PLUS the team-lead's own mutation claim reproduced independently (all 7
+    D12 rules resolve FALSE for a ``pt_pma_committed=True`` applicant), and
+    the sponsor-status value check across all 4 products (E31B/E31E/E31H/
+    E31J): guilt + pinned-seq12-defect per product (4 each), innocence per
+    product PER valid status value (12 — the stricter standard the
+    team-lead named for a 9-rule tightening), and tri-state per product.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.scripts.visa_engine.compile_claims import (
+    lint_duplicate_subtree,
+    lint_unsatisfiable_condition,
+)
+from backend.scripts.visa_engine.compile_pack import (
+    compile_rule_pack,
+    load_rule_pack_payload,
+    wrap_as_unsigned_pack,
+)
+from backend.scripts.visa_engine.fold_pack_seq13_rules import (
+    FoldPackError,
+    assemble_payload,
+)
+from backend.services.visa_engine import compiler, evaluator
+from backend.services.visa_engine.bundle import canonicalize_json
+from backend.services.visa_engine.enums import FactPath
+from backend.services.visa_engine.evaluator import ProductProof, ProductProofStatus
+from backend.services.visa_engine.fact_registry import DEFAULT_FACT_REGISTRY
+from backend.tests.services.visa_engine import _gold_fixtures as gf
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_PACKS_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "backend-rag"
+    / "backend"
+    / "services"
+    / "visa_engine"
+    / "contracts"
+    / "packs"
+)
+_SEQ12_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-012.source.json"
+_SEQ12_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-012.signed.json"
+_SEQ13_RULES_ONLY_PATH = _PACKS_DIR / "rulepack-prod-013.rules-only.json"
+
+_INSERTED_RULE_ID = "hf.e31c-sponsor-not-indonesian"
+_EDITED_E31C_RULE_ID = "el.e31c-child-mixed-marriage-support"
+_EDITED_D12_RULE_ID = "el.d12-multi-entry-support"
+_ALL_D12_RULE_IDS = (
+    "el.d12-multi-entry-support",
+    "el.d12-passport-validity",
+    "el.d12-funds-usd-5000",
+    "el.d12-cv-required",
+    "el.d12-itinerary-required",
+    "el.d12-support-letter",
+    "hf.d12-onshore-conversion-excluded",
+)
+
+# Any instant on/after the inserted rule's valid_period.from
+# (2026-08-23T00:00:00Z) and inside every inherited rule's window.
+AT = datetime(2026, 8, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+pytestmark = pytest.mark.skipif(
+    not _SEQ13_RULES_ONLY_PATH.exists(),
+    reason=(
+        "rulepack-prod-013.rules-only.json does not exist yet — run "
+        "`PYTHONPATH=. python -m backend.scripts.visa_engine.fold_pack_seq13_rules` "
+        "first. This module SKIPS, not reds, until then."
+    ),
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+@pytest.fixture(scope="module")
+def seq12_source() -> dict[str, Any]:
+    return _read_json(_SEQ12_SOURCE_PATH)
+
+
+@pytest.fixture(scope="module")
+def seq13_rules_only() -> dict[str, Any]:
+    return _read_json(_SEQ13_RULES_ONLY_PATH)
+
+
+def _compiled(name: str) -> compiler.CompiledRulePack:
+    payload = load_rule_pack_payload(_PACKS_DIR / name)
+    return compiler.build_compiled_pack(
+        wrap_as_unsigned_pack(payload), fact_registry=DEFAULT_FACT_REGISTRY
+    )
+
+
+@pytest.fixture(scope="module")
+def seq13(seq13_rules_only: dict[str, Any]) -> compiler.CompiledRulePack:
+    del seq13_rules_only  # ensures the skip guard has already run
+    return _compiled("rulepack-prod-013.rules-only.json")
+
+
+@pytest.fixture(scope="module")
+def seq12() -> compiler.CompiledRulePack:
+    return _compiled("rulepack-prod-012.source.json")
+
+
+def _known(value: Any) -> dict[str, Any]:
+    return {"status": "KNOWN", "value": value}
+
+
+def _proof(
+    compiled: compiler.CompiledRulePack, product_code: str, overrides: dict[str, Any]
+) -> ProductProof:
+    facts = gf.applicant_facts(overrides=overrides)
+    snapshot = DEFAULT_FACT_REGISTRY.derive(facts, effective_at=AT)
+    product = next(p for p in compiled.products if p.product_code == product_code)
+    rules = compiled.rules_for(product, effective_at=AT)
+    purposes = frozenset(snapshot.values[FactPath.INTENT_PURPOSES].value)
+    return evaluator.evaluate_product(
+        product=product,
+        rules=rules,
+        facts=snapshot,
+        purposes=purposes,
+        fact_registry=DEFAULT_FACT_REGISTRY,
+    )
+
+
+def _reason_codes(proof: ProductProof) -> set[str]:
+    return {r.code for r in proof.reasons}
+
+
+# ---------------------------------------------------------------------------
+# (a) chain gate
+# ---------------------------------------------------------------------------
+
+
+class TestChainGate:
+    def test_previous_payload_sha256_chains_to_recomputed_seq12(
+        self, seq12_source: dict[str, Any], seq13_rules_only: dict[str, Any]
+    ) -> None:
+        recomputed = hashlib.sha256(canonicalize_json(seq12_source)).hexdigest()
+        seq12_signed = _read_json(_SEQ12_SIGNED_PATH)
+        assert seq12_signed["payload_sha256"] == recomputed
+        # The rules-only fold declares no identity change (module docstring
+        # of fold_pack_seq13_rules.py: the combining fold owns identity) —
+        # `previous_payload_sha256` still carries seq-12's own value.
+        assert seq13_rules_only["previous_payload_sha256"] == seq12_source["previous_payload_sha256"]
+
+    def test_sequence_and_rule_pack_id_unchanged_by_this_fold(
+        self, seq12_source: dict[str, Any], seq13_rules_only: dict[str, Any]
+    ) -> None:
+        assert seq13_rules_only["sequence"] == seq12_source["sequence"] == 12
+        assert seq13_rules_only["rule_pack_id"] == seq12_source["rule_pack_id"]
+
+
+# ---------------------------------------------------------------------------
+# (b) rule-set delta — mechanical, never eyeballed
+# ---------------------------------------------------------------------------
+
+
+class TestRuleSetDelta:
+    def test_delta_matches_exactly_what_the_cure_file_declares(
+        self, seq12_source: dict[str, Any], seq13_rules_only: dict[str, Any]
+    ) -> None:
+        """Data-driven, not hardcoded: the expected added/changed sets are
+        derived from ``cure-seq13-rule-tightenings.json`` via the SAME
+        ``_edited_rule_ids``/``_inserted_rule_ids`` helpers the fold itself
+        uses for its own ``_assert_untouched`` guard — so a fix added as
+        cure/manifest data (never as code) is automatically covered here
+        too, and an accidental Nth change nobody declared fails this test
+        exactly the way it fails the fold."""
+        from backend.scripts.visa_engine.fold_pack_seq13_rules import (
+            _CURE_FILE,
+            _edited_rule_ids,
+            _inserted_rule_ids,
+        )
+
+        cure = _read_json(_CURE_FILE)
+        expected_added = set(_inserted_rule_ids(cure))
+        expected_changed = set(_edited_rule_ids(cure))
+        assert expected_added.isdisjoint(expected_changed), (
+            "a rule_id declared as both an insertion and an edit — cure file is malformed"
+        )
+
+        r12 = {r["rule_id"]: r for r in seq12_source["rules"]}
+        r13 = {r["rule_id"]: r for r in seq13_rules_only["rules"]}
+
+        added = set(r13) - set(r12)
+        removed = set(r12) - set(r13)
+        changed = {rid for rid in (set(r12) & set(r13)) if _canon(r12[rid]) != _canon(r13[rid])}
+
+        assert added == expected_added
+        assert removed == set()
+        assert changed == expected_changed
+        assert len(r13) == len(r12) + len(expected_added)
+
+    #: The 9 sponsor-status-check rule_ids that would change under FIX 4
+    #: (family.sponsor_status_code op:known -> op:in). FIX 4 is HELD as of
+    #: 2026-08-23 (team-lead: the closed 3-value enum may have no slot for
+    #: a lawfully-pending ITAS renewal, Pasal 116/180 — see
+    #: HELD-fix4-sponsor-status-2026-08-23.json for the full disclosure and
+    #: the three open questions gating re-arming). This fold contains
+    #: THREE fixes, not four, until that hold lifts.
+    _HELD_FIX4_RULE_IDS = frozenset(
+        {
+            "el.e31b-spouse-itas-support",
+            "el.e31b-sponsor-itas-itap",
+            "el.e31e-child-itas-support",
+            "el.e31e-sponsor-itas-itap",
+            "el.e31h-parent-itas-child-support",
+            "el.e31h-sponsor-itas-itap",
+            "el.e31j-sibling-itas-support",
+            "el.e31j-sponsor-itas-itap",
+            "el.e31j-dependency-age",
+        }
+    )
+
+    def test_the_three_fixes_this_session_shipped_are_present(
+        self, seq12_source: dict[str, Any], seq13_rules_only: dict[str, Any]
+    ) -> None:
+        """Named-fix pin, complementary to the data-driven test above (which
+        would pass even if every fix were replaced by a different one) —
+        this one pins the SPECIFIC rule_ids the team-lead's mandate named,
+        so a fix silently vanishing from the cure file still fails loud.
+
+        Renamed from `..._four_fixes_..._present` on 2026-08-23: this fold
+        ships THREE fixes (E31C nationality leg, D12 conjunct removal, and
+        nothing else) — FIX 4 (sponsor-status value check) is HELD, not
+        shipped, pending team-lead's independent read (see
+        `_HELD_FIX4_RULE_IDS`'s docstring). The old name and its 4-fix
+        assertion were themselves the bug this test exists to catch: the
+        artifact contained FIX 4's 9 rule_ids and 45/45 tests were green
+        against it, because this test's own expected set still included
+        them. A green test suite that asserts the wrong thing is exactly
+        as blind as no test at all.
+
+        FIX 3 was REVERSED 2026-08-23 (see TestD12ConjunctRemovedWitnesses'
+        header comment): `_EDITED_D12_RULE_ID`
+        (`el.d12-multi-entry-support`) is no longer one of the changed
+        rule_ids — it was never touched in either direction after the
+        correction. The 5 siblings that actually changed (conjunct
+        REMOVED) replace it here."""
+        r12 = {r["rule_id"]: r for r in seq12_source["rules"]}
+        r13 = {r["rule_id"]: r for r in seq13_rules_only["rules"]}
+        changed = {rid for rid in (set(r12) & set(r13)) if _canon(r12[rid]) != _canon(r13[rid])}
+        added = set(r13) - set(r12)
+
+        assert _EDITED_D12_RULE_ID not in changed, (
+            "el.d12-multi-entry-support must stay untouched post-reversal"
+        )
+        assert added == {_INSERTED_RULE_ID}
+        assert changed == {
+            _EDITED_E31C_RULE_ID,
+            "el.d12-passport-validity",
+            "el.d12-funds-usd-5000",
+            "el.d12-cv-required",
+            "el.d12-itinerary-required",
+            "el.d12-support-letter",
+        }
+
+        # The guard that would have caught the artifact/message mismatch by
+        # itself: none of FIX 4's 9 rule_ids may appear in `changed` while
+        # the hold stands, and every one of them must be BYTE-IDENTICAL to
+        # seq-12 -- not merely "not in the changed set" (which `changed` at
+        # the line above already implies), but independently re-diffed here
+        # so this assertion still fails loud even if `changed`'s
+        # computation itself were ever wrong.
+        assert self._HELD_FIX4_RULE_IDS.isdisjoint(changed), (
+            "FIX 4 is HELD — none of its 9 rule_ids may differ from seq-12"
+        )
+        for rid in self._HELD_FIX4_RULE_IDS:
+            assert rid in r12 and rid in r13, rid
+            assert _canon(r12[rid]) == _canon(r13[rid]), (
+                f"{rid} must be byte-identical to seq-12 while FIX 4 is held"
+            )
+
+    def test_products_and_source_records_are_byte_identical(
+        self, seq12_source: dict[str, Any], seq13_rules_only: dict[str, Any]
+    ) -> None:
+        assert _canon(seq13_rules_only["products"]) == _canon(seq12_source["products"])
+        assert _canon(seq13_rules_only["source_records"]) == _canon(seq12_source["source_records"])
+
+    def test_no_other_top_level_key_drifted(
+        self, seq12_source: dict[str, Any], seq13_rules_only: dict[str, Any]
+    ) -> None:
+        identity_keys = {
+            "sequence",
+            "version",
+            "rule_pack_id",
+            "previous_payload_sha256",
+            "created_at",
+            "created_by",
+        }
+        for key in set(seq12_source) | set(seq13_rules_only):
+            if key in identity_keys or key == "rules":
+                continue
+            assert _canon(seq13_rules_only.get(key)) == _canon(seq12_source.get(key)), key
+
+
+# ---------------------------------------------------------------------------
+# (c) zero lint findings over every seq-13 rule
+# ---------------------------------------------------------------------------
+
+
+class TestZeroLintFindings:
+    def test_duplicate_subtree_and_unsatisfiable_condition_are_clean(
+        self, seq13_rules_only: dict[str, Any]
+    ) -> None:
+        findings = []
+        for rule in seq13_rules_only["rules"]:
+            when = rule["when"]
+            findings.extend(lint_duplicate_subtree(rule_id=rule["rule_id"], when=when))
+            unsat_findings, _skip_note = lint_unsatisfiable_condition(
+                rule_id=rule["rule_id"], when=when
+            )
+            findings.extend(unsat_findings)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# (d) compile_pack RC 0
+# ---------------------------------------------------------------------------
+
+
+class TestCompilePackCompilesClean:
+    def test_compile_rule_pack_reports_zero_errors(self) -> None:
+        payload = load_rule_pack_payload(_SEQ13_RULES_ONLY_PATH)
+        report = compile_rule_pack(wrap_as_unsigned_pack(payload))
+        assert report.ok, "; ".join(f"{e.code}: {e.message}" for e in report.errors)
+
+
+# ---------------------------------------------------------------------------
+# (e) idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestFoldIsIdempotent:
+    def test_assemble_payload_twice_is_byte_identical(self) -> None:
+        first = assemble_payload()
+        second = assemble_payload()
+        assert _canon(first) == _canon(second)
+
+
+# ---------------------------------------------------------------------------
+# (f) evaluator witnesses — E31C nationality leg (Fix 1)
+# ---------------------------------------------------------------------------
+
+_E31C_BASE = {
+    "intent.purposes": _known(["FAMILY"]),
+    "family.relation_to_sponsor": _known("PARENT"),
+    "family.marriage_registered": _known(True),
+}
+
+
+class TestE31CNationalityGateWitnesses:
+    def test_guilt_two_foreign_parents_is_excluded(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """The exact defect SKILL.md's 2026-08-23 LIVE STATE entry proved
+        live: FAMILY + PARENT + marriage registered + sponsor
+        nationalities NOT including ID (two foreign parents) — before this
+        fix, `el.e31c-child-mixed-marriage-support` alone carried this to
+        SUPPORTED."""
+        proof = _proof(
+            seq13,
+            "E31C",
+            {**_E31C_BASE, "family.sponsor_nationalities": _known(["US"])},
+        )
+        assert proof.status is ProductProofStatus.EXCLUDED
+        assert "REQ_PARENT_SPONSOR_INDONESIAN" in _reason_codes(proof)
+
+    def test_pinned_seq12_defect_same_facts_reached_supported(
+        self, seq12: compiler.CompiledRulePack
+    ) -> None:
+        """Pinned so the fix is measurable — if this ever starts failing,
+        seq-12's bytes changed. Reproduces SKILL.md's own positive control:
+        FAMILY intent + PARENT relation + marriage registered + US
+        sponsor_nationalities -> SUPPORTED via
+        `el.e31c-child-mixed-marriage-support` alone on seq-12."""
+        proof = _proof(
+            seq12,
+            "E31C",
+            {**_E31C_BASE, "family.sponsor_nationalities": _known(["US"])},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        assert {r.rule_id for r in proof.support_rules} == {_EDITED_E31C_RULE_ID}
+
+    def test_innocence_indonesian_sponsor_parent_is_supported(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """The legitimate applicant E31C actually serves: an Indonesian
+        sponsor parent, marriage registered. Must still reach SUPPORTED,
+        unchanged, via BOTH SUPPORT rules independently."""
+        proof = _proof(
+            seq13,
+            "E31C",
+            {**_E31C_BASE, "family.sponsor_nationalities": _known(["ID"])},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        support_ids = {r.rule_id for r in proof.support_rules}
+        assert _EDITED_E31C_RULE_ID in support_ids
+        assert "el.e31c-mixed-marriage-parents" in support_ids
+
+    def test_tristate_unknown_nationality_blocks_never_excludes(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        proof = _proof(
+            seq13,
+            "E31C",
+            {**_E31C_BASE, "family.sponsor_nationalities": gf.unknown("NOT_ASKED")},
+        )
+        assert proof.status is ProductProofStatus.BLOCKED_UNKNOWN
+        assert proof.status is not ProductProofStatus.EXCLUDED
+
+    def test_non_family_applicant_is_not_contaminated(
+        self, seq12: compiler.CompiledRulePack, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """Same scoping discipline as hf.e31c-marriage-not-registered
+        (seq-10, Codex refuter finding 1): the new HARD_FILTER must be
+        strong-Kleene FALSE (silent) outside the FAMILY+PARENT shape, never
+        BLOCKED_UNKNOWN for an unrelated applicant whose nationality
+        happens to be unasked."""
+        overrides = {
+            "intent.purposes": _known(["STUDY"]),
+            "family.relation_to_sponsor": _known("OTHER"),
+            "family.sponsor_nationalities": gf.unknown("NOT_ASKED"),
+        }
+        for pack in (seq12, seq13):
+            proof = _proof(pack, "E31C", overrides)
+            assert proof.status is ProductProofStatus.UNSUPPORTED
+            assert FactPath.FAMILY_SPONSOR_NATIONALITIES not in proof.missing_facts
+
+
+# ---------------------------------------------------------------------------
+# (f) evaluator witnesses -- D12 pt_pma_committed conjunct REMOVED (Fix 3,
+#     REVERSED 2026-08-23). Original direction of this fold ADDED the
+#     conjunct to el.d12-multi-entry-support; team-lead + v2-d12's handoff
+#     (d12-removal-handoff.md) established the owner ruling excludes on
+#     ACTIVE STAY PERMIT, not committed capital, and that D12's 5 siblings
+#     carried an ungrounded conjunct no claim ever backed (D1/D2 -- the same
+#     "docs rule" family from the same authoring pass -- carry it on ZERO of
+#     their 12 combined rules). The correction strips the conjunct from the
+#     5 siblings; el.d12-multi-entry-support was never touched in either
+#     direction. This class replaces the pre-reversal
+#     TestD12PtPmaCommittedGateWitnesses, whose own mutation proof encoded
+#     the WRONG direction as a passing test -- team-lead's own words apply:
+#     "a mutation proof licenses the mechanism, never the correctness."
+# ---------------------------------------------------------------------------
+
+_D12_BASE = {
+    "intent.purposes": _known(["INVESTMENT"]),
+    "intent.stay_days": _known(90),
+}
+
+_D12_ELIGIBILITY_SUPPORT_RULE_IDS = {
+    "el.d12-multi-entry-support",
+    "el.d12-passport-validity",
+    "el.d12-funds-usd-5000",
+    "el.d12-cv-required",
+    "el.d12-itinerary-required",
+    "el.d12-support-letter",
+}
+
+
+class TestD12ConjunctRemovedWitnesses:
+    def test_pinned_seq12_defect_checklist_incomplete_for_committed_investor(
+        self, seq12: compiler.CompiledRulePack
+    ) -> None:
+        """UNCHANGED behavior, asserted against the untouched seq-12 pack --
+        this documents the actual defect the reversal fixes. A PMA-committed
+        applicant already reaches SUPPORTED on seq-12 via
+        el.d12-multi-entry-support ALONE (union coverage: that rule never
+        gated on pt_pma_committed), while the 5 document-requirement
+        siblings sit silent because THEY carried the wrong gate -- so the
+        applicant was told they qualify for D12 with zero attached document
+        requirements (no passport-validity, funds, CV, itinerary, or
+        support-letter reason code)."""
+        proof = _proof(
+            seq12,
+            "D12",
+            {**_D12_BASE, "investment.pt_pma_committed": _known(True)},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        assert {r.rule_id for r in proof.support_rules} == {_EDITED_D12_RULE_ID}
+
+    def test_fix_committed_investor_now_gets_the_full_checklist(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """The reversal's actual, and only, effect: the SAME applicant, the
+        SAME status (SUPPORTED -- per the handoff's key mechanism finding,
+        this fix changes ZERO eligibility outcomes for anyone), but now via
+        ALL 6 D12 ELIGIBILITY rules instead of 1, because none of them gate
+        on pt_pma_committed any more. This is a checklist-completeness fix,
+        not an inclusion/exclusion fix."""
+        proof = _proof(
+            seq13,
+            "D12",
+            {**_D12_BASE, "investment.pt_pma_committed": _known(True)},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        assert {r.rule_id for r in proof.support_rules} == _D12_ELIGIBILITY_SUPPORT_RULE_IDS
+
+    def test_innocence_uncommitted_investor_is_still_supported(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """The legitimate applicant D12 actually serves: a pre-investment
+        visitor who has NOT yet committed PT PMA capital. Must still reach
+        SUPPORTED, unchanged, via every one of the 6 ELIGIBILITY rules --
+        this was already true before the reversal and stays true after,
+        since this applicant never tripped the removed conjunct either
+        way."""
+        proof = _proof(
+            seq13,
+            "D12",
+            {**_D12_BASE, "investment.pt_pma_committed": _known(False)},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        assert {r.rule_id for r in proof.support_rules} == _D12_ELIGIBILITY_SUPPORT_RULE_IDS
+
+    def test_unknown_commitment_no_longer_gates_d12_at_all(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """Direct, worth-pinning consequence of the reversal: since no D12
+        ELIGIBILITY rule references investment.pt_pma_committed any more,
+        an applicant who was never asked (UNKNOWN) is fully SUPPORTED via
+        all 6 rules -- the tri-state BLOCKED_UNKNOWN gate this fact used to
+        impose on D12 is GONE, not merely relaxed. This is the doctrinally
+        correct outcome per D12.md Sec.3.15 ("no capital-commitment fact
+        gates it") and is pinned here so a future regression that
+        re-introduces the conjunct on any D12 rule is caught immediately."""
+        proof = _proof(
+            seq13,
+            "D12",
+            {**_D12_BASE, "investment.pt_pma_committed": gf.unknown("NOT_ASKED")},
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        assert {r.rule_id for r in proof.support_rules} == _D12_ELIGIBILITY_SUPPORT_RULE_IDS
+
+    def test_non_investment_applicant_is_not_contaminated(
+        self, seq12: compiler.CompiledRulePack, seq13: compiler.CompiledRulePack
+    ) -> None:
+        overrides = {
+            "intent.purposes": _known(["TOURISM"]),
+            "investment.pt_pma_committed": gf.unknown("NOT_ASKED"),
+        }
+        for pack in (seq12, seq13):
+            proof = _proof(pack, "D12", overrides)
+            assert proof.status is ProductProofStatus.UNSUPPORTED
+            assert FactPath.INVESTMENT_PT_PMA_COMMITTED not in proof.missing_facts
+
+    def test_mechanism_proof_all_six_eligibility_rules_now_fire_true(
+        self, seq13: compiler.CompiledRulePack
+    ) -> None:
+        """Correct-direction replacement for the pre-reversal (wrong-
+        direction) mutation proof. Independently reproduces
+        d12-removal-handoff.md Sec.5's mechanism finding via the trace sink:
+        for a PMA-committed applicant, all 6 D12 ELIGIBILITY rules evaluate
+        strong-Kleene TRUE and fire their SUPPORT effect -- not merely that
+        the product proof is SUPPORTED (which the union-coverage 6th rule
+        alone would already produce), but that the 5 siblings specifically
+        are no longer gated out. hf.d12-onshore-conversion-excluded (the
+        7th D12-scoped rule, an unrelated HARD_FILTER) is excluded from the
+        firing assertion on purpose -- it was never part of this fix."""
+        facts = gf.applicant_facts(
+            overrides={**_D12_BASE, "investment.pt_pma_committed": _known(True)}
+        )
+        snapshot = DEFAULT_FACT_REGISTRY.derive(facts, effective_at=AT)
+        product = next(p for p in seq13.products if p.product_code == "D12")
+        rules = seq13.rules_for(product, effective_at=AT)
+        d12_scoped_rules = {r for r in rules if r.rule_id in _ALL_D12_RULE_IDS}
+        assert {r.rule_id for r in d12_scoped_rules} == set(_ALL_D12_RULE_IDS)
+
+        from backend.services.visa_engine.enums import TruthValue
+
+        trace: list[Any] = []
+        proof = evaluator.evaluate_product(
+            product=product,
+            rules=rules,
+            facts=snapshot,
+            purposes=frozenset(snapshot.values[FactPath.INTENT_PURPOSES].value),
+            fact_registry=DEFAULT_FACT_REGISTRY,
+            _trace_sink=trace,
+        )
+        assert proof.status is ProductProofStatus.SUPPORTED
+        assert {r.rule_id for r in proof.support_rules} == _D12_ELIGIBILITY_SUPPORT_RULE_IDS
+
+        d12_trace_entries = [
+            t for t in trace if t.rule.rule_id in _D12_ELIGIBILITY_SUPPORT_RULE_IDS
+        ]
+        assert {t.rule.rule_id for t in d12_trace_entries} == _D12_ELIGIBILITY_SUPPORT_RULE_IDS
+        for entry in d12_trace_entries:
+            assert entry.result.truth is TruthValue.TRUE, entry.rule.rule_id
+            assert entry.applied_effect is not None, entry.rule.rule_id
+
+
+# ---------------------------------------------------------------------------
+# Fold-level fail-loud checks (ledger drift, chain mismatch)
+# ---------------------------------------------------------------------------
+
+
+class TestFoldFailsLoudOnDrift:
+    def test_wrong_expected_seq12_hash_aborts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import backend.scripts.visa_engine.fold_pack_seq13_rules as mod
+
+        monkeypatch.setattr(mod, "_EXPECTED_SEQ12_PAYLOAD_SHA256", "0" * 64)
+        with pytest.raises(FoldPackError, match="not the one this fold was authored against"):
+            mod.assemble_payload()

--- a/research/visa/doctrine-factory/claims/inc4-c2-e31c-claim-ledger.md
+++ b/research/visa/doctrine-factory/claims/inc4-c2-e31c-claim-ledger.md
@@ -82,6 +82,34 @@ E31C.md §3.3).
 
 ---
 
+**CL-E31C-04 — E31C's own product name states the mixed-nationality basis
+directly: WNA-WNI (foreign parent x Indonesian parent).** The E31C listing on the
+live portal titles the product itself *"E31C Visa Keluarga Anak Hasil Perkawinan Sah
+WNA-WNI"* — child of a legally-registered WNA-WNI (foreign-citizen x
+Indonesian-citizen) marriage. This is definitional at the product-identity level,
+independent of which named individual signs as the formal penjamin (the open
+question CL-E31C-03's caveat carries): the product does not exist for a child of two
+co-national parents, of either citizenship. It corroborates, from an independent
+textual location on the same page, the same underlying fact CL-E31C-03 grounds from
+the checklist items — that the SET of parents must include at least one Indonesian
+citizen.
+
+- Source: same page as CL-E31C-02/03
+  (`https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C`), product-title
+  heading, verbatim: *"E31C Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI"*.
+- **State: VERIFIED.** Products: E31C. Provenance: this session (2026-08-23),
+  independent re-fetch via raw `curl` (not the earlier reader-2 fetch) — done
+  specifically to check a finding relayed by the team-lead from a separate blind
+  grader's own independent `curl` fetch of the same page; both fetches agree on
+  this text.
+- Backs: the `family.sponsor_nationalities` conjunct of
+  `el.e31c-child-mixed-marriage-support` (seq-13) and the paired
+  `hf.e31c-sponsor-not-indonesian` HARD_FILTER (seq-13) — an ADDITIONAL, independent
+  grounding alongside CL-E31C-03, not a replacement (CL-E31C-03's caveat about
+  penjamin identity remains open and is not resolved by the product title).
+
+---
+
 **CF-17 — CONFLICT (OPEN): C2 sponsor requirement, three-way.** The candidate claim
 "C2's sponsor is corporate (`sponsor.type == EMPLOYER`)" — the claim the CP3 package
 said seq-10 should attempt for `el.c2.corporate-sponsor-type` — cannot be authored:

--- a/research/visa/doctrine-factory/claims/inc6-sponsor-status-claim-ledger.md
+++ b/research/visa/doctrine-factory/claims/inc6-sponsor-status-claim-ledger.md
@@ -8,7 +8,7 @@ sources:
   - path: data/source_documents/t0_regulations/permenkumham_11_2024_perubahan_visa.pdf
     note: "amendment, item 14 (replaces Pasal 50) + item 15 (inserts Pasal 50A) — re-extracted this session"
 discovered_by: agent.air-m5.backend-rag.visaoracle-seq13-rules-0823
-adversarial_review: none yet — see note below
+adversarial_review: exempt-no-external-seat-dispatched-fix-held-not-shipped-see-adversarial-review-section
 ---
 
 # inc6 claim ledger — sponsor-status value check (seq-13, Fix 4)
@@ -251,7 +251,11 @@ merely inert**:
    backed by the signed status-code catalogue, so even a syntactically plausible value must
    never satisfy an engine rule that checks `op: known`."* — i.e. a PRIOR author already knew
    `op:known` was too permissive and built this frontend guard specifically to defeat it on the
-   interview path. That guard was written against `op:known`'s behavior, not `op:in`'s:
+   interview path. **That guard was written against `op:known`'s FALSE-on-unknown behavior —
+   swap the operator to `op:in` and the same guard silently stops protecting and starts
+   producing the dead-end instead. A mitigation written against one operator becoming a
+   liability under another is a genuinely non-obvious failure mode**, not a coincidence of this
+   one fact:
    ```
    op:known on UNKNOWN  ->  FALSE     ->  silent UNSUPPORTED        (today, live)
    op:in    on UNKNOWN  ->  UNKNOWN   ->  on_unknown=NEEDS_INPUT (8 of 9 rules)

--- a/research/visa/doctrine-factory/claims/inc6-sponsor-status-claim-ledger.md
+++ b/research/visa/doctrine-factory/claims/inc6-sponsor-status-claim-ledger.md
@@ -1,0 +1,285 @@
+---
+date: 2026-08-23
+domain: visa
+client_case: none — engine doctrine work (E5 increment 6, seq-13 rules-only fold, Fix 4)
+sources:
+  - path: data/source_documents/t0_regulations/permenkumham_22_2023_visa_izin_tinggal.pdf
+    note: "primary law, Pasal 44/47/50 — re-extracted this session via `pdftotext -layout`, verified line-for-line"
+  - path: data/source_documents/t0_regulations/permenkumham_11_2024_perubahan_visa.pdf
+    note: "amendment, item 14 (replaces Pasal 50) + item 15 (inserts Pasal 50A) — re-extracted this session"
+discovered_by: agent.air-m5.backend-rag.visaoracle-seq13-rules-0823
+adversarial_review: none yet — see note below
+---
+
+# inc6 claim ledger — sponsor-status value check (seq-13, Fix 4)
+
+Grounds the seq-13 tightening of `family.sponsor_status_code` on nine ELIGIBILITY rules
+across E31B/E31E/E31H/E31J: today every one tests `op: known` (presence only) — a rule
+literally named `*-sponsor-itas-itap` never checks that the sponsor actually holds an
+ITAS, an ITAP, or an approved VITAS; any non-empty string passes.
+
+**Method note, disclosed up front**: the four article citations below were first relayed by
+the team-lead from another agent's PDF reading, with the team-lead stating explicitly they
+had not opened the PDFs themselves. Per this repo's anti-hallucination discipline, a claim
+this session did not itself verify cannot be marked VERIFIED on a second-hand relay — so
+before writing this ledger, both PDFs were re-fetched from disk and re-extracted with
+`pdftotext -layout` in THIS session, and every quoted passage below (Pasal 44, 47, 50, 50A,
+their VITAS-fallback ayat, the "saudara" absence in the 2023 text, and the Pasal-44
+footer-number check) was independently re-read from the resulting text. The relayed
+citations were correct on every point checked; nothing here is taken on trust.
+
+---
+
+**CL-SPONSOR-E31B — E31B's spouse-sponsor must hold a currently-valid ITAS or ITAP, or (if
+neither yet issued) an approved VITAS for the spouse.** Permenkumham 22/2023 Pasal 44(2)(b),
+verbatim: *"Izin Tinggal Terbatas atau Izin Tinggal tetap suami atau istri yang sah dan
+masih berlaku"* — a valid and currently-in-force ITAS or ITAP of the spouse. Pasal 44(3),
+verbatim: *"Dalam hal suami atau istri belum memiliki Izin Tinggal Terbatas atau Izin
+Tinggal Tetap sebagaimana dimaksud pada ayat (2) huruf b, Izin Tinggal Terbatas atau Izin
+Tinggal Tetap dapat digantikan dengan Visa tinggal terbatas suami atau istri dari Orang
+Asing"* — where the spouse does not yet hold ITAS/ITAP, a VITAS (limited-stay visa) for the
+spouse substitutes. Three states, exhaustively: ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED.
+
+- Source: `permenkumham_22_2023_visa_izin_tinggal.pdf`, Pasal 44(2)-(3) (re-extracted and
+  read this session, lines 1725-1755 of the `pdftotext -layout` output).
+- **State: VERIFIED.** Products: E31B. Provenance: this session, direct PDF re-extraction.
+- Backs: `el.e31b-spouse-itas-support`, `el.e31b-sponsor-itas-itap` (the `op:known` ->
+  `op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED]` edit on `family.sponsor_status_code`).
+- **Correction of a doctrine-card citation error, recorded here so it is not propagated**:
+  `E31B.md` cites "Pasal 44(2)(b) (as amended by Permenkumham 11/2024)". This is wrong.
+  `grep -n "Pasal 44" permenkumham_11_2024_perubahan_visa.pdf` (re-extracted text) returns
+  ZERO hits, and the only occurrence of the bare token `44` anywhere in that document is a
+  page-footer number (`- 44 -`), independently re-verified this session. Pasal 44 is
+  unamended 22/2023 law; cite it that way.
+
+---
+
+**CL-SPONSOR-E31E — E31E's parent-sponsor must hold a currently-valid ITAS or ITAP, or an
+approved VITAS.** Permenkumham 22/2023 Pasal 47(2)(c), verbatim: *"Izin Tinggal Terbatas
+atau Izin Tinggal Tetap orang tua yang masih berlaku"* — a valid and currently-in-force
+ITAS or ITAP of the parent(s). Pasal 47(3), verbatim: *"Dalam hal ayah dan/atau ibu belum
+memiliki Izin Tinggal Terbatas atau Izin Tinggal Tetap sebagaimana dimaksud pada ayat (2)
+huruf c, Izin Tinggal Terbatas atau Izin Tinggal Tetap dapat digantikan dengan Visa
+tinggal terbatas ayah dan/atau ibu dari Orang Asing"* — VITAS substitutes where the
+parent(s) do not yet hold ITAS/ITAP. Same three-state enum as E31B, independently enacted
+for the parent-sponsor case.
+
+- Source: `permenkumham_22_2023_visa_izin_tinggal.pdf`, Pasal 47(2)-(3) (re-extracted and
+  read this session, lines 1852-1886).
+- **State: VERIFIED.** Products: E31E. Provenance: this session, direct PDF re-extraction.
+- Backs: `el.e31e-child-itas-support`, `el.e31e-sponsor-itas-itap`.
+
+---
+
+**CL-SPONSOR-E31H — E31H's child-sponsor must hold a currently-valid ITAS or ITAP, or an
+approved VITAS.** Permenkumham 22/2023 Pasal 50(2)(b), verbatim: *"Izin Tinggal Terbatas
+atau Izin Tinggal Tetap anak yang masih berlaku"* — a valid and currently-in-force ITAS or
+ITAP of the child (E31H is the reverse-direction family-reunion product: a parent applicant
+joins a child sponsor). Pasal 50(3), verbatim: *"Dalam hal anak belum memiliki Izin Tinggal
+Terbatas atau Izin Tinggal Tetap sebagaimana dimaksud pada ayat (2) huruf b, Izin Tinggal
+Terbatas atau Izin Tinggal Tetap dapat digantikan dengan Visa tinggal terbatas anak dari
+Orang Asing"* — VITAS substitutes where the child does not yet hold ITAS/ITAP.
+
+- Source: **11/2024 item 14** ("Ketentuan Pasal 50 diubah sehingga berbunyi sebagai
+  berikut") replaces the whole article; re-extracting BOTH the original 22/2023 Pasal 50
+  and the 11/2024 replacement this session shows the (2)(b)/(3) text is byte-identical
+  across the amendment — the operative ITAS/ITAP/VITAS requirement is unchanged in
+  substance, only re-enacted. Cited against `permenkumham_11_2024_perubahan_visa.pdf`
+  item 14 (lines 1263-1300) as the currently-governing text, with the original
+  `permenkumham_22_2023_visa_izin_tinggal.pdf` Pasal 50 (lines 1977-2008) as the
+  pre-amendment corroborator.
+- **State: VERIFIED.** Products: E31H. Provenance: this session, direct PDF re-extraction
+  of both the original article and its replacement.
+- Backs: `el.e31h-parent-itas-child-support`, `el.e31h-sponsor-itas-itap`.
+
+---
+
+**CL-SPONSOR-E31J — E31J's sibling-sponsor must hold a currently-valid ITAS or ITAP, or an
+approved VITAS.** Permenkumham 11/2024 item 15, inserting a NEW Pasal 50A(2)(c), verbatim:
+*"Izin Tinggal Terbatas atau Izin Tinggal Tetap saudara kandung yang masih berlaku"* — a
+valid and currently-in-force ITAS or ITAP of the sibling. Pasal 50A(3), verbatim: *"Dalam
+hal saudara kandung belum memiliki Izin Tinggal Terbatas atau Izin Tinggal Tetap
+sebagaimana dimaksud pada ayat (2) huruf c, Izin Tinggal Terbatas atau Izin Tinggal Tetap
+dapat digantikan dengan Visa tinggal terbatas saudara kandung dari Orang Asing"* — VITAS
+substitutes where the sibling does not yet hold ITAS/ITAP.
+
+- **E31J did not exist under the base 2023 law.** `grep -c "saudara" permenkumham_22_2023_
+  visa_izin_tinggal.pdf` (re-extracted text, independently re-run this session) returns
+  `0` — sibling was not in the family-reunion taxonomy at all until 11/2024 item 15
+  inserted Pasal 50A between Pasal 50 and Pasal 51. Worth carrying forward: any future
+  doctrine work on E31J's other requirements has no 2023-law fallback to check against.
+- Source: `permenkumham_11_2024_perubahan_visa.pdf`, item 15 / Pasal 50A(2)-(3)
+  (re-extracted and read this session, lines 1302-1339).
+- **State: VERIFIED.** Products: E31J. Provenance: this session, direct PDF re-extraction.
+- Backs: `el.e31j-sibling-itas-support`, `el.e31j-sponsor-itas-itap`, `el.e31j-dependency-age`.
+
+---
+
+## Adversarial review
+
+**Not yet performed as of this ledger's authoring** — this Fix is being folded and tested
+in the same session it was grounded in, ahead of the cross-family adversarial pass the
+team-lead's other fixes received (Codex/Kimi K3 on Fix 1/Fix 3's predecessor cures). The
+citations above were independently re-verified against the primary PDFs by THIS session
+(not merely relayed), which is the anti-hallucination floor, not a substitute for a second
+reviewer. Flagged to the team-lead as an open item, not silently treated as equivalent to
+the two-reviewer cures this pack otherwise carries.
+
+---
+
+## Known scope gap — Pasal 33(7), NOT closed by this fix (found 2026-08-23)
+
+**This fix closes the VALIDITY axis only; a second, distinct axis remains open.**
+A cross-family refuter found, and this session independently re-verified via its own
+`pdftotext -layout` re-extraction of `permenkumham_11_2024_perubahan_visa.pdf`
+(item 10, replacing Pasal 33), that the amendment inserts **Pasal 33(7)**, verbatim:
+
+> *"Visa tinggal terbatas sebagaimana dimaksud pada ayat (2) huruf h angka 2, angka 5,
+> angka 8, dan angka 9 tidak dapat diajukan untuk penyatuan kepada pemegang Izin
+> Tinggal Penyatuan Keluarga."*
+
+Independently re-derived the angka mapping from the same document's Pasal 33(2)(h)
+list (lines 850-882 of the re-extraction) rather than taking the mapping on trust:
+angka 2 = spouse joining an ITAS/ITAP-holder spouse (**E31B**), angka 5 = minor child
+joining an ITAS/ITAP-holder parent (**E31E**), angka 8 = parent joining an
+ITAS/ITAP-holder child (**E31H**), angka 9 = minor sibling joining an ITAS/ITAP-holder
+sibling (**E31J**) — confirmed exact, all four of this fix's products.
+
+**What this means concretely**: the law puts TWO conditions on the sponsor, not one.
+(1) The sponsor's permit must be currently valid — Pasal 44(2)/47(2)/50(2)/50A(2), the
+axis `family.sponsor_status_code` now checks via this fix's `op:in [ITAS_ACTIVE,
+ITAP_ACTIVE, VITAS_APPROVED]`. (2) The sponsor's permit must not itself BE a family-
+reunification permit (Izin Tinggal Penyatuan Keluarga) — Pasal 33(7), a condition on
+the permit's *basis/category*, not its validity. This fix expresses condition (1) only
+and is blind to condition (2): a sponsor holding a currently-valid ITAS that was
+itself issued on a family-reunification basis satisfies this fix's enum and the law
+forbids the chain regardless.
+
+**Why not fixed here**: expressing condition (2) requires a fact this pack does not
+yet have — `family.sponsor_permit_basis`, a closed enum distinguishing a
+family-reunification-based permit from an independent-basis one (work/investment/
+retirement/etc.). That fact is introduced on **PR #4650**, not yet merged (red on two
+stale count literals as of this writing). Bolting condition (2) onto this fix would
+mean gating on a fact this pack cannot yet populate.
+
+**Disposition (this session's call, per team-lead's explicit request to choose and
+state it)**: LAND this fix now, described precisely as closing the validity axis only.
+The choice is safe because it is a strict subset improvement, never a new false
+exclusion: every applicant this fix's `op:in` check now rejects was ALREADY failing to
+meet Pasal 44(2)/47(2)/50(2)/50A(2)'s validity requirement under today's `op:known`
+(which the same law never satisfied either — `op:known` only checks the field is
+non-empty, not that it names a real permit state); every applicant condition (2) alone
+would reject is UNCHANGED by this fix — neither newly admitted nor newly excluded,
+because `op:known` was already blind to permit-basis and remains so here. Condition
+(2) is a real, separately-trackable gap, not created or worsened by this fix, and is
+the natural scope of the increment `family.sponsor_permit_basis` lands in once PR
+#4650 merges. **This fix must never be described as "the sponsor-status constraint is
+now enforced"** — only as closing the validity axis; the permit-basis axis (Pasal
+33(7)) stays open and tracked here until PR #4650 lands and a follow-up increment
+adds the second conjunct to these same nine rules.
+
+---
+
+## Known scope gap #2 — vocabulary/domain mismatch, FIX 4 HELD HARD (2026-08-23)
+
+**Disposition: HELD, not "pending" — the enum in this fix's current form is wrong, not merely
+incomplete.** Team-lead dispatched an independent read after this session's own subset-safety
+argument was challenged; that read found the real defect, and this session independently
+re-verified every load-bearing citation below before writing it here (file:line, not taken on
+report).
+
+**First, a correction to team-lead's own earlier objection, recorded for the trail**:
+team-lead initially worried this fix would wrongly exclude a sponsor whose ITAS renewal was
+filed and paid on time but still processing (cited Permenkumham 22/2023 Pasal 116(2)-(3) and
+Pasal 180). That citation does not hold up — Pasal 116 in this repo's corpus belongs to a
+different regulation (11/2024) answering a different question (the *applicant's* own renewal
+grace period, not the *sponsor's* eligibility), and Pasal 180 traces to PP 31/2013. More
+directly: `CL-E31B-REFUTER` (this same file family, `e2a-claim-ledger.md:258-274`, VERIFIED,
+independently re-read by this session at those exact lines) is the claim that ORIGINALLY
+proposed this three-value enum, and it already considered a "pending / in corso di
+lavorazione" sponsor and explicitly REJECTED it as insufficient, citing Pasal 119's
+2-working-day cure-notice-then-automatic-rejection: *"Uno sponsor il cui ITAS/ITAP risulti
+scaduto, non verificato, non registrato, assente o semplicemente dichiarato 'in corso di
+lavorazione' [...] non è mai sufficiente ad attivare la pratica."* So excluding a pending
+sponsor is the legally correct outcome, and this session's original subset-safety argument
+survived that particular objection.
+
+**What actually kills the fix, independently re-verified against the live corpus**:
+
+`fact_registry.py:297` (re-read this session), verbatim:
+```python
+_spec(FactPath.FAMILY_SPONSOR_STATUS_CODE, FactValueKind.STRING, "product_code"),
+```
+The fact's own declared domain is **product codes**, with no `allowed_values`. The values
+actually populated in this repo's own test/gold corpus (grepped this session, not assumed):
+`"E23"` (`test_evaluator_gold.py:95,351`; `_gold_fixtures.py:444` even models the plausible
+condition as `in(family.sponsor_status_code, ["E23", "E28A"])` — product codes, the SAME
+vocabulary the fact's own spec declares), `"NONE"` (`_gold_fixtures.py:648`), and a raw human
+name, `"Nguyễn Thị Hà"` (`gold_harness/fixtures/personas/18_nfc_unicode_name.json:190`, an
+edge-case Unicode-normalization fixture, not a placeholder). The proposed enum
+(`ITAS_ACTIVE`/`ITAP_ACTIVE`/`VITAS_APPROVED`) is immigration-STATUS vocabulary — a disjoint
+namespace from the fact's declared and populated product-code vocabulary. Not one corpus value
+matches it, including the legitimate one: `CL-E31B-PRINCIPAL` (this file, above) names E23/E25
+work-permit holders as an explicitly guaranteed-eligible sponsor category — a sponsor holding a
+valid E23 work KITAS is exactly who the rule means to admit, and "E23" cannot equal
+"ITAS_ACTIVE" under `op:in`.
+
+So this fix, as authored, is not a narrowing of an over-permissive gate on the same vocabulary.
+It is a **silent vocabulary substitution**: the value space the fact is documented and
+populated with is swapped for a disjoint one, with no migration and no producer anywhere
+emitting the new values.
+
+**Two mechanisms, both independently re-verified this session, that make this worse than
+merely inert**:
+
+1. **A KNOWN value outside the enum resolves deterministic silent FALSE, never UNKNOWN.**
+   `ast.py`, `InCondition` branch (re-read this session): `truth = TruthValue.TRUE if value in
+   condition.values else TruthValue.FALSE` — no third branch. `evaluator.py:338`-area
+   (`_safety_unknowns`, re-read this session) filters entries on `result.truth is
+   TruthValue.UNKNOWN` before `on_unknown` (NEEDS_INPUT/HUMAN_REVIEW) is ever consulted — FALSE
+   never reaches that gate. These 9 rules are the only rules covering the FAMILY purpose on
+   their respective products, so a `"E23"` sponsor resolves the whole product UNSUPPORTED with
+   `missing_purposes` set and **zero reason codes** — indistinguishable, from the applicant's
+   side, from "no family product exists for you at all."
+
+2. **The reverse (UNKNOWN) case is worse, and is the one that is actually live today.**
+   `fact-mapper.ts`, `mapFamilySponsorStatus` (re-read this session, full function body,
+   `apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts:417-434`): every single
+   branch returns `unknownFact(...)` — `NOT_APPLICABLE`, `UNVERIFIED`, or `NOT_ASKED`. There is
+   no branch that ever returns a KNOWN value. The function's own comment (lines 431-432)
+   states the intent explicitly: *"The UI accepts a human-entered status label. It is not
+   backed by the signed status-code catalogue, so even a syntactically plausible value must
+   never satisfy an engine rule that checks `op: known`."* — i.e. a PRIOR author already knew
+   `op:known` was too permissive and built this frontend guard specifically to defeat it on the
+   interview path. That guard was written against `op:known`'s behavior, not `op:in`'s:
+   ```
+   op:known on UNKNOWN  ->  FALSE     ->  silent UNSUPPORTED        (today, live)
+   op:in    on UNKNOWN  ->  UNKNOWN   ->  on_unknown=NEEDS_INPUT (8 of 9 rules)
+                                       ->  BLOCKED_UNKNOWN
+   ```
+   Tightening the operator, on the ONLY path the frontend can currently walk, routes every real
+   interview user requesting E31B/E31E/E31H/E31J into a permanently unanswerable NEEDS_INPUT
+   prompt — the interview has no field that could ever resolve it, by the same guard's own
+   design. Inert while the visa-engine runs in SHADOW (today); live the moment ENFORCE arms,
+   which is precisely the milestone this whole correctness effort exists to unblock.
+
+**One correction to this session's own earlier premise, which team-lead flagged and which
+still matters**: this session wrote that holding the fix means "production keeps accepting
+literally any non-empty string until #4650 merges," on the assumption the frontend guard made
+that path unreachable. It does not, and the underlying vulnerability is real: the public
+evaluate endpoint accepts canonical `ApplicantFacts` directly, `KnownString` validates only
+`min_length=1, max_length=64` with no enum check, `allowed_values` (where declared elsewhere in
+the registry) is consumed only at rule-compile time to check rule AUTHORS' literals — never
+applied to caller-submitted data — and `traffic_source=real` requires no credential. So any API
+caller can put an arbitrary 1-64 character string in this field today and satisfy `op:known`.
+**That hole is real, and closing it was the right instinct.** The enum this fix chose is simply
+aimed at the wrong vocabulary to close it.
+
+**Do not attempt to fix this by widening the enum to include product codes.** The prior
+question — what evidence establishes a valid ITAS/ITAP/VITAS — is answered (CL-SPONSOR-E31B/
+E31E/E31H/E31J above, all VERIFIED, unaffected by this hold). The NEW, unanswered question is
+what this fact IS *for*: a product code (as declared and as every corpus value shows) or an
+immigration status (as every VERIFIED claim in this ledger assumes)? That is a data-modelling
+decision with a signed pack and a frontend contract behind it, not something a fold should
+settle by picking a wider literal list. Tracked in `.claude/skills/modus/PENDING-ARMS.md`
+(owner: team-lead) rather than resolved here.

--- a/research/visa/doctrine-factory/e5/inc6-pack-edits/HELD-fix4-sponsor-status-2026-08-23.json
+++ b/research/visa/doctrine-factory/e5/inc6-pack-edits/HELD-fix4-sponsor-status-2026-08-23.json
@@ -1,0 +1,1586 @@
+{
+  "_comment": "FIX 4 (sponsor-status value check, family.sponsor_status_code op:known -> op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], 9 rules across E31B/E31E/E31H/E31J) -- HELD HARD as of 2026-08-23 (superseding an earlier, softer \"pending\" note in this same file: team-lead's independent read landed and the real defect is NOT the Pasal 116/180 pending-renewal worry that first triggered the hold -- that citation does not hold up, and CL-E31B-REFUTER, e2a-claim-ledger.md:258-274, already considered and rejected a pending-sponsor exception via Pasal 119's 2-working-day cure-then-reject rule. The real defect is a VOCABULARY/DOMAIN MISMATCH: fact_registry.py:297 declares family.sponsor_status_code as FactValueKind.STRING, value_type=\"product_code\", no allowed_values; the corpus actually populates it with product codes (\"E23\", \"NONE\") and even a raw human name in one Unicode fixture -- not one value matches the proposed ITAS_ACTIVE/ITAP_ACTIVE/VITAS_APPROVED enum, including the legitimate E23 work-KITAS sponsor CL-E31B-PRINCIPAL names as guaranteed-eligible. Full grounding, both mechanisms (KNOWN-out-of-enum -> silent FALSE -> zero reason codes; UNKNOWN -> NEEDS_INPUT dead-end once the frontend mapFamilySponsorStatus() guard, which can only ever emit UNKNOWN, meets op:in instead of op:known), and full file:line citations (independently re-verified by s13-rules this session, not taken on report) are in inc6-sponsor-status-claim-ledger.md \"Known scope gap #2\" section -- read that before re-arming. Re-arming this fix as-written (paste rule_edits/manifest_entries back in) would re-introduce BOTH mechanisms; do not re-arm without first resolving what family.sponsor_status_code is actually FOR (product code vs immigration status) -- a data-modelling decision, tracked in .claude/skills/modus/PENDING-ARMS.md, owner team-lead, not something this fold can settle by picking a different literal list. To re-arm ONCE that question is resolved: paste `rule_edits` back into cure-seq13-rule-tightenings.json's own rule_edits array, paste `manifest_entries` back into inc6-rule-manifest.json's rules array, restore TestSponsorStatusValueCheckWitnesses (see test_seq13_rules_pack.py.HELD-fix4-tests-2026-08-23.py.txt sidecar in apps/backend-rag/backend/tests/services/visa_engine/) into test_seq13_rules_pack.py, then re-fold and re-run the full suite -- but expect the rule bodies themselves to need revision first, not just a paste, since the underlying enum was wrong.",
+  "rule_edits": [
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "ITAS_ACTIVE",
+              "ITAP_ACTIVE",
+              "VITAS_APPROVED"
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31B: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31b-sponsor-itas-itap",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "ITAS_ACTIVE",
+                  "ITAP_ACTIVE",
+                  "VITAS_APPROVED"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31B: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "ITAS_ACTIVE",
+              "ITAP_ACTIVE",
+              "VITAS_APPROVED"
+            ]
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31E: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31e-sponsor-itas-itap",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "ITAS_ACTIVE",
+                  "ITAP_ACTIVE",
+                  "VITAS_APPROVED"
+                ]
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31E: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "ITAS_ACTIVE",
+              "ITAP_ACTIVE",
+              "VITAS_APPROVED"
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31H: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31h-sponsor-itas-itap",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "ITAS_ACTIVE",
+                  "ITAP_ACTIVE",
+                  "VITAS_APPROVED"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31H: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "in",
+            "values": [
+              "ITAS_ACTIVE",
+              "ITAP_ACTIVE",
+              "VITAS_APPROVED"
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31J: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31j-sponsor-itas-itap",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "ITAS_ACTIVE",
+                  "ITAP_ACTIVE",
+                  "VITAS_APPROVED"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31J: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31j-dependency-age",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "FAMILY"
+                ]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "in",
+                "values": [
+                  "ITAS_ACTIVE",
+                  "ITAP_ACTIVE",
+                  "VITAS_APPROVED"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "rationale": "CL-SPONSOR-E31J: family.sponsor_status_code op:known tested presence only -- any non-empty string (a visit-visa code, an expired permit) passed a rule literally named *-sponsor-itas-itap. Replaced with op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], the exhaustive three-state enum the product's own article establishes (ITAS/ITAP 'yang masih berlaku', VITAS as the explicit statutory fallback when neither is yet issued). rule_id, stage, scope, priority, valid_period, effect, on_unknown, required_facts, source_refs, explanation_key, safety_critical, product_version_ids all preserved verbatim from seq-12 -- required_facts is unchanged because the SAME fact path is still referenced, only the operator changed."
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "new_value": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "rationale": "Re-derived (alphabetical, matching the compiler's convention) — the fact SET is unchanged (family.sponsor_status_code is still referenced, only its operator changed from known to in), but compile_claims always re-derives required_facts sorted, and this rule's seq-12 array happened not to be. LATENT DRIFT, INDEPENDENT OF THIS FIX (team-lead asked this be named explicitly, 2026-08-23): recompiling this rule's existing seq-12 when-tree today, with ZERO behavioral change, already produces this same sorted array — seq-12's stored required_facts disagreed with what the compiler emits for the SAME rule body even before this fold touched the sponsor-status operator. Not caused by, and not scoped to, the op:known->op:in edit; it predates this session and is being surfaced here rather than absorbed silently because this fold happens to be the one editing these rules anyway."
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "new_value": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes",
+        "person.marital_status"
+      ],
+      "rationale": "Re-derived (alphabetical, matching the compiler's convention) — the fact SET is unchanged (family.sponsor_status_code is still referenced, only its operator changed from known to in), but compile_claims always re-derives required_facts sorted, and this rule's seq-12 array happened not to be. LATENT DRIFT, INDEPENDENT OF THIS FIX (team-lead asked this be named explicitly, 2026-08-23): recompiling this rule's existing seq-12 when-tree today, with ZERO behavioral change, already produces this same sorted array — seq-12's stored required_facts disagreed with what the compiler emits for the SAME rule body even before this fold touched the sponsor-status operator. Not caused by, and not scoped to, the op:known->op:in edit; it predates this session and is being surfaced here rather than absorbed silently because this fold happens to be the one editing these rules anyway."
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "new_value": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "rationale": "Re-derived (alphabetical, matching the compiler's convention) — the fact SET is unchanged (family.sponsor_status_code is still referenced, only its operator changed from known to in), but compile_claims always re-derives required_facts sorted, and this rule's seq-12 array happened not to be. LATENT DRIFT, INDEPENDENT OF THIS FIX (team-lead asked this be named explicitly, 2026-08-23): recompiling this rule's existing seq-12 when-tree today, with ZERO behavioral change, already produces this same sorted array — seq-12's stored required_facts disagreed with what the compiler emits for the SAME rule body even before this fold touched the sponsor-status operator. Not caused by, and not scoped to, the op:known->op:in edit; it predates this session and is being surfaced here rather than absorbed silently because this fold happens to be the one editing these rules anyway."
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "new_value": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "rationale": "Re-derived (alphabetical, matching the compiler's convention) — the fact SET is unchanged (family.sponsor_status_code is still referenced, only its operator changed from known to in), but compile_claims always re-derives required_facts sorted, and this rule's seq-12 array happened not to be. LATENT DRIFT, INDEPENDENT OF THIS FIX (team-lead asked this be named explicitly, 2026-08-23): recompiling this rule's existing seq-12 when-tree today, with ZERO behavioral change, already produces this same sorted array — seq-12's stored required_facts disagreed with what the compiler emits for the SAME rule body even before this fold touched the sponsor-status operator. Not caused by, and not scoped to, the op:known->op:in edit; it predates this session and is being surfaced here rather than absorbed silently because this fold happens to be the one editing these rules anyway."
+    }
+  ],
+  "manifest_entries": [
+    {
+      "rule": {
+        "rule_id": "el.e31b-spouse-itas-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SPOUSE"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "ITAS_ACTIVE",
+                "ITAP_ACTIVE",
+                "VITAS_APPROVED"
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.marriage_registered",
+          "family.sponsor_status_code"
+        ],
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31b-spouse-itas-support",
+        "safety_critical": false,
+        "product_version_ids": [
+          "5d5f9bd4-349b-54d7-841a-784c0afba068"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31B"
+      ],
+      "product_code": "E31B",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31b-sponsor-itas-itap",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "ITAS_ACTIVE",
+                    "ITAP_ACTIVE",
+                    "VITAS_APPROVED"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+        "safety_critical": false,
+        "product_version_ids": [
+          "5d5f9bd4-349b-54d7-841a-784c0afba068"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31B"
+      ],
+      "product_code": "E31B",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31e-child-itas-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "ITAS_ACTIVE",
+                "ITAP_ACTIVE",
+                "VITAS_APPROVED"
+              ]
+            },
+            {
+              "fact": "derived.age_years",
+              "op": "lt",
+              "value": 18
+            },
+            {
+              "fact": "person.marital_status",
+              "op": "eq",
+              "value": "SINGLE"
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "derived.age_years",
+          "person.marital_status"
+        ],
+        "source_refs": [
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31e-child-itas-support",
+        "safety_critical": false,
+        "product_version_ids": [
+          "1266d5cb-84a3-51f7-b82d-c6b756254074"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31E"
+      ],
+      "product_code": "E31E",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31e-sponsor-itas-itap",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "ITAS_ACTIVE",
+                    "ITAP_ACTIVE",
+                    "VITAS_APPROVED"
+                  ]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "lt",
+                  "value": 18
+                },
+                {
+                  "fact": "person.marital_status",
+                  "op": "eq",
+                  "value": "SINGLE"
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes",
+          "person.marital_status"
+        ],
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+        ],
+        "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+        "safety_critical": false,
+        "product_version_ids": [
+          "1266d5cb-84a3-51f7-b82d-c6b756254074"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31E"
+      ],
+      "product_code": "E31E",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31h-parent-itas-child-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "ITAS_ACTIVE",
+                "ITAP_ACTIVE",
+                "VITAS_APPROVED"
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code"
+        ],
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31h-parent-itas-child-support",
+        "safety_critical": false,
+        "product_version_ids": [
+          "1185c36d-833c-5e41-8e0d-6e4f7c8f7378"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31H"
+      ],
+      "product_code": "E31H",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31h-sponsor-itas-itap",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "CHILD"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "CHILD"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "ITAS_ACTIVE",
+                    "ITAP_ACTIVE",
+                    "VITAS_APPROVED"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+        "safety_critical": false,
+        "product_version_ids": [
+          "1185c36d-833c-5e41-8e0d-6e4f7c8f7378"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31H"
+      ],
+      "product_code": "E31H",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31j-sibling-itas-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SIBLING"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "ITAS_ACTIVE",
+                "ITAP_ACTIVE",
+                "VITAS_APPROVED"
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code"
+        ],
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31j-sibling-itas-support",
+        "safety_critical": false,
+        "product_version_ids": [
+          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31J"
+      ],
+      "product_code": "E31J",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31j-sponsor-itas-itap",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "ITAS_ACTIVE",
+                    "ITAP_ACTIVE",
+                    "VITAS_APPROVED"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+        "safety_critical": false,
+        "product_version_ids": [
+          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31J"
+      ],
+      "product_code": "E31J",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.e31j-dependency-age",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 18
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "ITAS_ACTIVE",
+                    "ITAP_ACTIVE",
+                    "VITAS_APPROVED"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NO_EFFECT",
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31j-dependency-age",
+        "safety_critical": false,
+        "product_version_ids": [
+          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
+        ]
+      },
+      "claim_ids": [
+        "CL-SPONSOR-E31J"
+      ],
+      "product_code": "E31J",
+      "must_reference_facts": [
+        "family.sponsor_status_code"
+      ]
+    }
+  ]
+}

--- a/research/visa/doctrine-factory/e5/inc6-pack-edits/cure-seq13-rule-tightenings.json
+++ b/research/visa/doctrine-factory/e5/inc6-pack-edits/cure-seq13-rule-tightenings.json
@@ -1,0 +1,499 @@
+{
+  "_comment": "E5 increment 6 (seq-13), rules-only half. TWO fixes SHIP in this cure file as of 2026-08-23; a third (FIX 4) was built, then HELD OUT after team-lead found the folded artifact still contained it despite chat-only hold messages -- its cure entries live in HELD-fix4-sponsor-status-2026-08-23.json (same directory), not here, so the artifact and the message agree. Compiled through inc6-rule-manifest.json against the SAME claim ledgers (e2a-claim-ledger.md for CL-D12-02, inc4-c2-e31c-claim-ledger.md for CL-E31C-03/CL-E31C-04). Applied by fold_pack_seq13_rules.py with ledger-drift checks on every current_value, against the seq-12 SOURCE bytes. FIX 1 (E31C nationality leg): 1 rule_edit + 1 insertion (hf.e31c-sponsor-not-indonesian). FIX 3 (D12, REVERSED 2026-08-23 per owner ruling and v2-d12 handoff (d12-removal-handoff.md) -- the original direction in this fold ADDED the ungrounded investment.pt_pma_committed conjunct to el.d12-multi-entry-support, which was backwards; the correction REMOVES that same conjunct from the 5 siblings that carried it (el.d12-passport-validity/funds-usd-5000/cv-required/itinerary-required/support-letter), leaving el.d12-multi-entry-support untouched exactly as seq-12 had it): 10 rule_edits (when + required_facts x5). FIX 4 (sponsor-status value check, E31B/E31E/E31H/E31J, 9 rules) is HELD -- see HELD-fix4-sponsor-status-2026-08-23.json for the full grounding, the KNOWN SCOPE GAP disclosure it already carried (Pasal 33(7) permit-basis axis), and the NEW open question that triggered the hold (Pasal 116(2)-(3)/180 pending-ITAS-renewal protection -- the closed 3-value enum may have no slot for that applicant). inc6-sponsor-status-claim-ledger.md (CL-SPONSOR-*, Pasal 44/47/50/50A validity requirement, all VERIFIED) stays in _LEDGER_FILES and is unaffected by the hold -- the requirement it grounds is not in question, only whether the 3-value enum is the right expression of it.",
+  "rule_edits": [
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": [
+              "ID"
+            ]
+          }
+        ]
+      },
+      "rationale": "This rule alone carries E31C to SUPPORTED for a child of two foreign parents whose marriage happens to be registered (SKILL.md 2026-08-23 LIVE STATE: hit_policy.eligibility is OR-like, so ONE firing SUPPORT rule suffices regardless of the tightened sibling el.e31c-mixed-marriage-parents — proven live against the real evaluator with a positive control that excludes this rule alone). Adds the identical family.sponsor_nationalities ∩ {ID} conjunct the sibling rule already carries (seq-10) — the E31C page requires the application letter from the ayah/ibu Warga Negara Indonesia and the WNI parent's Kartu Keluarga (CL-E31C-03). This rule was simply never touched when CL-E31C-03 was first compiled against the sibling in seq-10; the claim itself is a product-level fact, not scoped to one rule. rule_id, priority, valid_period, effect, on_unknown, source_refs, explanation_key, product_version_ids all preserved verbatim from seq-12."
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "family.relation_to_sponsor"
+      ],
+      "new_value": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "rationale": "Re-derived from the new when-clause (alphabetical, matching the compiler's convention — see the identical seq-10 precedent on el.e31c-mixed-marriage-parents)."
+    },
+    {
+      "rule_id": "el.d12-passport-validity",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "INVESTMENT"
+            ]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "rationale": "REVERSAL of this fold's original Fix 3 (2026-08-23, team-lead ruling after v2-d12's independently-verified handoff `d12-removal-handoff.md`): the conjunct removed here was never grounded and was on the WRONG rule family-wide. Doctrine card `research/visa/doctrine-factory/cards/D12.md` §3.15, verbatim: \"Investment requirements. None as an eligibility precondition — D12 is itself the pre-investment-exploration instrument (no capital-commitment fact gates it).\" Coverage matrix `e2a-coverage-matrix.md:66-75` maps every one of these 5 siblings to CL-D12-02 only (the document-requirement claim) — no claim anywhere grounds `pt_pma_committed` on any D12 rule. D1/D2, the same \"docs rule\" family from the same authoring pass, carry this conjunct on ZERO of their 12 combined rules — across all three product families it is the anomaly, 5 rules out of 18, not a convention with one gap. Provenance: entered at seq-6 (PR #3940, commit ac9cc431c, \"a requirement is a condition, not a proof\"), which justifies converting HUMAN_REVIEW rules into ELIGIBILITY/SUPPORT but never justifies this specific fact for D12 — reads as a copy-paste artifact from `el.e28a.investment` (E28A, genuinely capital-gated) carried over during that conversion pass, not a deliberate design choice. Owner ruling (verbatim, team-lead→v2-d12, 2026-08-23): \"se non hai un kitas attivo, certo che puoi\" (no active permit ⇒ CAN apply, regardless of capital status) and \"si, chi ha kitas attivo va escluso da D12\" (the exclusion axis is an ACTIVE STAY PERMIT, tracked separately — PR #4650, not this fold). This fold's own earlier direction (adding the conjunct to `el.d12-multi-entry-support` instead) would have excluded exactly the applicant the first half of that ruling protects — confirmed on the real evaluator by v2-d12's reproducible probe (`d12-removal-handoff.md` §5): union coverage means `el.d12-multi-entry-support` alone already decides SUPPORTED/EXCLUDED unconditionally on `purposes intersects INVESTMENT` ∩ `stay_days<=180`; the 5 siblings' `pt_pma_committed` conjunct never changed that eligibility outcome for anyone — it only starved the reason-code checklist for a PMA-committed applicant (SUPPORTED with zero attached document requirements, the actual defect this reversal fixes). `when` restructured to drop the `investment.pt_pma_committed`-gated outer `all` entirely, leaving the surviving `intent.purposes intersects INVESTMENT` ∧ `intent.stay_days<=180` gate byte-identical in shape to `el.d12-multi-entry-support`'s own (untouched) `when`. rule_id, priority, valid_period, effect, on_unknown, source_refs, explanation_key, product_version_ids all preserved verbatim from seq-12."
+    },
+    {
+      "rule_id": "el.d12-passport-validity",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "new_value": [
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "rationale": "Re-derived from the pruned when-clause (alphabetical, matching the compiler's convention) — `investment.pt_pma_committed` dropped because the fact is no longer referenced anywhere in this rule's `when` tree after the reversal above."
+    },
+    {
+      "rule_id": "el.d12-funds-usd-5000",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "INVESTMENT"
+            ]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "rationale": "REVERSAL of this fold's original Fix 3 (2026-08-23, team-lead ruling after v2-d12's independently-verified handoff `d12-removal-handoff.md`): the conjunct removed here was never grounded and was on the WRONG rule family-wide. Doctrine card `research/visa/doctrine-factory/cards/D12.md` §3.15, verbatim: \"Investment requirements. None as an eligibility precondition — D12 is itself the pre-investment-exploration instrument (no capital-commitment fact gates it).\" Coverage matrix `e2a-coverage-matrix.md:66-75` maps every one of these 5 siblings to CL-D12-02 only (the document-requirement claim) — no claim anywhere grounds `pt_pma_committed` on any D12 rule. D1/D2, the same \"docs rule\" family from the same authoring pass, carry this conjunct on ZERO of their 12 combined rules — across all three product families it is the anomaly, 5 rules out of 18, not a convention with one gap. Provenance: entered at seq-6 (PR #3940, commit ac9cc431c, \"a requirement is a condition, not a proof\"), which justifies converting HUMAN_REVIEW rules into ELIGIBILITY/SUPPORT but never justifies this specific fact for D12 — reads as a copy-paste artifact from `el.e28a.investment` (E28A, genuinely capital-gated) carried over during that conversion pass, not a deliberate design choice. Owner ruling (verbatim, team-lead→v2-d12, 2026-08-23): \"se non hai un kitas attivo, certo che puoi\" (no active permit ⇒ CAN apply, regardless of capital status) and \"si, chi ha kitas attivo va escluso da D12\" (the exclusion axis is an ACTIVE STAY PERMIT, tracked separately — PR #4650, not this fold). This fold's own earlier direction (adding the conjunct to `el.d12-multi-entry-support` instead) would have excluded exactly the applicant the first half of that ruling protects — confirmed on the real evaluator by v2-d12's reproducible probe (`d12-removal-handoff.md` §5): union coverage means `el.d12-multi-entry-support` alone already decides SUPPORTED/EXCLUDED unconditionally on `purposes intersects INVESTMENT` ∩ `stay_days<=180`; the 5 siblings' `pt_pma_committed` conjunct never changed that eligibility outcome for anyone — it only starved the reason-code checklist for a PMA-committed applicant (SUPPORTED with zero attached document requirements, the actual defect this reversal fixes). `when` restructured to drop the `investment.pt_pma_committed`-gated outer `all` entirely, leaving the surviving `intent.purposes intersects INVESTMENT` ∧ `intent.stay_days<=180` gate byte-identical in shape to `el.d12-multi-entry-support`'s own (untouched) `when`. rule_id, priority, valid_period, effect, on_unknown, source_refs, explanation_key, product_version_ids all preserved verbatim from seq-12."
+    },
+    {
+      "rule_id": "el.d12-funds-usd-5000",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "new_value": [
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "rationale": "Re-derived from the pruned when-clause (alphabetical, matching the compiler's convention) — `investment.pt_pma_committed` dropped because the fact is no longer referenced anywhere in this rule's `when` tree after the reversal above."
+    },
+    {
+      "rule_id": "el.d12-cv-required",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "INVESTMENT"
+            ]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "rationale": "REVERSAL of this fold's original Fix 3 (2026-08-23, team-lead ruling after v2-d12's independently-verified handoff `d12-removal-handoff.md`): the conjunct removed here was never grounded and was on the WRONG rule family-wide. Doctrine card `research/visa/doctrine-factory/cards/D12.md` §3.15, verbatim: \"Investment requirements. None as an eligibility precondition — D12 is itself the pre-investment-exploration instrument (no capital-commitment fact gates it).\" Coverage matrix `e2a-coverage-matrix.md:66-75` maps every one of these 5 siblings to CL-D12-02 only (the document-requirement claim) — no claim anywhere grounds `pt_pma_committed` on any D12 rule. D1/D2, the same \"docs rule\" family from the same authoring pass, carry this conjunct on ZERO of their 12 combined rules — across all three product families it is the anomaly, 5 rules out of 18, not a convention with one gap. Provenance: entered at seq-6 (PR #3940, commit ac9cc431c, \"a requirement is a condition, not a proof\"), which justifies converting HUMAN_REVIEW rules into ELIGIBILITY/SUPPORT but never justifies this specific fact for D12 — reads as a copy-paste artifact from `el.e28a.investment` (E28A, genuinely capital-gated) carried over during that conversion pass, not a deliberate design choice. Owner ruling (verbatim, team-lead→v2-d12, 2026-08-23): \"se non hai un kitas attivo, certo che puoi\" (no active permit ⇒ CAN apply, regardless of capital status) and \"si, chi ha kitas attivo va escluso da D12\" (the exclusion axis is an ACTIVE STAY PERMIT, tracked separately — PR #4650, not this fold). This fold's own earlier direction (adding the conjunct to `el.d12-multi-entry-support` instead) would have excluded exactly the applicant the first half of that ruling protects — confirmed on the real evaluator by v2-d12's reproducible probe (`d12-removal-handoff.md` §5): union coverage means `el.d12-multi-entry-support` alone already decides SUPPORTED/EXCLUDED unconditionally on `purposes intersects INVESTMENT` ∩ `stay_days<=180`; the 5 siblings' `pt_pma_committed` conjunct never changed that eligibility outcome for anyone — it only starved the reason-code checklist for a PMA-committed applicant (SUPPORTED with zero attached document requirements, the actual defect this reversal fixes). `when` restructured to drop the `investment.pt_pma_committed`-gated outer `all` entirely, leaving the surviving `intent.purposes intersects INVESTMENT` ∧ `intent.stay_days<=180` gate byte-identical in shape to `el.d12-multi-entry-support`'s own (untouched) `when`. rule_id, priority, valid_period, effect, on_unknown, source_refs, explanation_key, product_version_ids all preserved verbatim from seq-12."
+    },
+    {
+      "rule_id": "el.d12-cv-required",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "new_value": [
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "rationale": "Re-derived from the pruned when-clause (alphabetical, matching the compiler's convention) — `investment.pt_pma_committed` dropped because the fact is no longer referenced anywhere in this rule's `when` tree after the reversal above."
+    },
+    {
+      "rule_id": "el.d12-itinerary-required",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "INVESTMENT"
+            ]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "rationale": "REVERSAL of this fold's original Fix 3 (2026-08-23, team-lead ruling after v2-d12's independently-verified handoff `d12-removal-handoff.md`): the conjunct removed here was never grounded and was on the WRONG rule family-wide. Doctrine card `research/visa/doctrine-factory/cards/D12.md` §3.15, verbatim: \"Investment requirements. None as an eligibility precondition — D12 is itself the pre-investment-exploration instrument (no capital-commitment fact gates it).\" Coverage matrix `e2a-coverage-matrix.md:66-75` maps every one of these 5 siblings to CL-D12-02 only (the document-requirement claim) — no claim anywhere grounds `pt_pma_committed` on any D12 rule. D1/D2, the same \"docs rule\" family from the same authoring pass, carry this conjunct on ZERO of their 12 combined rules — across all three product families it is the anomaly, 5 rules out of 18, not a convention with one gap. Provenance: entered at seq-6 (PR #3940, commit ac9cc431c, \"a requirement is a condition, not a proof\"), which justifies converting HUMAN_REVIEW rules into ELIGIBILITY/SUPPORT but never justifies this specific fact for D12 — reads as a copy-paste artifact from `el.e28a.investment` (E28A, genuinely capital-gated) carried over during that conversion pass, not a deliberate design choice. Owner ruling (verbatim, team-lead→v2-d12, 2026-08-23): \"se non hai un kitas attivo, certo che puoi\" (no active permit ⇒ CAN apply, regardless of capital status) and \"si, chi ha kitas attivo va escluso da D12\" (the exclusion axis is an ACTIVE STAY PERMIT, tracked separately — PR #4650, not this fold). This fold's own earlier direction (adding the conjunct to `el.d12-multi-entry-support` instead) would have excluded exactly the applicant the first half of that ruling protects — confirmed on the real evaluator by v2-d12's reproducible probe (`d12-removal-handoff.md` §5): union coverage means `el.d12-multi-entry-support` alone already decides SUPPORTED/EXCLUDED unconditionally on `purposes intersects INVESTMENT` ∩ `stay_days<=180`; the 5 siblings' `pt_pma_committed` conjunct never changed that eligibility outcome for anyone — it only starved the reason-code checklist for a PMA-committed applicant (SUPPORTED with zero attached document requirements, the actual defect this reversal fixes). `when` restructured to drop the `investment.pt_pma_committed`-gated outer `all` entirely, leaving the surviving `intent.purposes intersects INVESTMENT` ∧ `intent.stay_days<=180` gate byte-identical in shape to `el.d12-multi-entry-support`'s own (untouched) `when`. rule_id, priority, valid_period, effect, on_unknown, source_refs, explanation_key, product_version_ids all preserved verbatim from seq-12."
+    },
+    {
+      "rule_id": "el.d12-itinerary-required",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "new_value": [
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "rationale": "Re-derived from the pruned when-clause (alphabetical, matching the compiler's convention) — `investment.pt_pma_committed` dropped because the fact is no longer referenced anywhere in this rule's `when` tree after the reversal above."
+    },
+    {
+      "rule_id": "el.d12-support-letter",
+      "field": "when",
+      "current_value": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": [
+                  "INVESTMENT"
+                ]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "new_value": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "INVESTMENT"
+            ]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "rationale": "REVERSAL of this fold's original Fix 3 (2026-08-23, team-lead ruling after v2-d12's independently-verified handoff `d12-removal-handoff.md`): the conjunct removed here was never grounded and was on the WRONG rule family-wide. Doctrine card `research/visa/doctrine-factory/cards/D12.md` §3.15, verbatim: \"Investment requirements. None as an eligibility precondition — D12 is itself the pre-investment-exploration instrument (no capital-commitment fact gates it).\" Coverage matrix `e2a-coverage-matrix.md:66-75` maps every one of these 5 siblings to CL-D12-02 only (the document-requirement claim) — no claim anywhere grounds `pt_pma_committed` on any D12 rule. D1/D2, the same \"docs rule\" family from the same authoring pass, carry this conjunct on ZERO of their 12 combined rules — across all three product families it is the anomaly, 5 rules out of 18, not a convention with one gap. Provenance: entered at seq-6 (PR #3940, commit ac9cc431c, \"a requirement is a condition, not a proof\"), which justifies converting HUMAN_REVIEW rules into ELIGIBILITY/SUPPORT but never justifies this specific fact for D12 — reads as a copy-paste artifact from `el.e28a.investment` (E28A, genuinely capital-gated) carried over during that conversion pass, not a deliberate design choice. Owner ruling (verbatim, team-lead→v2-d12, 2026-08-23): \"se non hai un kitas attivo, certo che puoi\" (no active permit ⇒ CAN apply, regardless of capital status) and \"si, chi ha kitas attivo va escluso da D12\" (the exclusion axis is an ACTIVE STAY PERMIT, tracked separately — PR #4650, not this fold). This fold's own earlier direction (adding the conjunct to `el.d12-multi-entry-support` instead) would have excluded exactly the applicant the first half of that ruling protects — confirmed on the real evaluator by v2-d12's reproducible probe (`d12-removal-handoff.md` §5): union coverage means `el.d12-multi-entry-support` alone already decides SUPPORTED/EXCLUDED unconditionally on `purposes intersects INVESTMENT` ∩ `stay_days<=180`; the 5 siblings' `pt_pma_committed` conjunct never changed that eligibility outcome for anyone — it only starved the reason-code checklist for a PMA-committed applicant (SUPPORTED with zero attached document requirements, the actual defect this reversal fixes). `when` restructured to drop the `investment.pt_pma_committed`-gated outer `all` entirely, leaving the surviving `intent.purposes intersects INVESTMENT` ∧ `intent.stay_days<=180` gate byte-identical in shape to `el.d12-multi-entry-support`'s own (untouched) `when`. rule_id, priority, valid_period, effect, on_unknown, source_refs, explanation_key, product_version_ids all preserved verbatim from seq-12."
+    },
+    {
+      "rule_id": "el.d12-support-letter",
+      "field": "required_facts",
+      "current_value": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "new_value": [
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "rationale": "Re-derived from the pruned when-clause (alphabetical, matching the compiler's convention) — `investment.pt_pma_committed` dropped because the fact is no longer referenced anywhere in this rule's `when` tree after the reversal above."
+    }
+  ],
+  "insertions": [
+    {
+      "rule_id": "hf.e31c-sponsor-not-indonesian",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-23T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": [
+              "FAMILY"
+            ]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "op": "not",
+            "arg": {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            }
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+      "safety_critical": true,
+      "product_version_ids": [
+        "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+      ],
+      "_new_rule_rationale": "The tightened el.e31c-child-mixed-marriage-support alone changes nothing observable if a FUTURE untouched sibling SUPPORT rule is ever added to E31C without the nationality conjunct — exactly the class of gap this whole audit exists to close (SKILL.md: 'audit the class', not 'patch one rule'). This HARD_FILTER mirrors hf.e31c-marriage-not-registered's exact shape (seq-10): EXCLUDE + safety_critical:true + NEEDS_INPUT on unknown, so the tri-state ASKS rather than assumes. HARD_FILTER stage runs before any SUPPORT rule is even consulted (engine precedence, confirmed live by SKILL.md's 2026-08-23 positive-control run), so this filter protects the product regardless of which SUPPORT rule tries to grant it. Scoped to purposes∩FAMILY + relation==PARENT (not a bare nationality leaf) for the identical reason hf.e31c-marriage-not-registered is so scoped: an unscoped leaf would contaminate non-E31C-shaped applicants whose sponsor_nationalities happens to be known-non-ID for an unrelated reason. valid_period.from is this fold's own creation date (2026-08-23), matching the standing convention for corrective rules inserted after the pack's original 2026-07-24 baseline (same convention hf.e31c-marriage-not-registered used with its own 2026-08-19 insertion date)."
+    }
+  ]
+}

--- a/research/visa/doctrine-factory/e5/inc6-pack-edits/inc6-rule-manifest.json
+++ b/research/visa/doctrine-factory/e5/inc6-pack-edits/inc6-rule-manifest.json
@@ -1,0 +1,419 @@
+{
+  "_comment": "E5 increment 6 (seq-13) — RULES-ONLY half of the seq-13 fold (a separate lane owns the source-freshness half; a third step folds both). Three rule entries, each an in-pack-precedent tightening of an OR-like `hit_policy` gap named by .agents/skills/visaoracle/SKILL.md's 2026-08-23 LIVE STATE entry ('audit the class', not 'patch one rule'). (1) EDIT el.e31c-child-mixed-marriage-support: adds the family.sponsor_nationalities intersects [ID] conjunct the sibling el.e31c-mixed-marriage-parents already carries (seq-10), grounded by the SAME claim (CL-E31C-03) that grounded the sibling's identical conjunct — this rule was simply never touched when that claim was first compiled. (2) INSERT hf.e31c-sponsor-not-indonesian: the paired HARD_FILTER, mirroring hf.e31c-marriage-not-registered's shape exactly (EXCLUDE + safety_critical + NEEDS_INPUT on unknown) so a future untouched sibling rule can never re-open this same gap — HARD_FILTER stage runs before any SUPPORT rule is even consulted (engine precedence, SKILL.md 2026-08-23). (3) EDIT el.d12-multi-entry-support: adds the investment.pt_pma_committed neq true conjunct all 5 of its ELIGIBILITY siblings already carry, restructured into their identical nested-all shape — grounded by CL-D12-01 (D12 is 'an exploratory pre-PT-PMA-incorporation instrument'; an applicant who has already committed PT PMA capital is past that stage). E31D (the E31D relationship-model gap named by the same audit) has NO entry here — research/visa/2026-08-15-gold-family-refuter.md explicitly blocks a direct pack edit: the fact vocabulary has no STEPCHILD relation_to_sponsor value and no dedicated WNA-WNI mixed-marriage-basis fact (re-verified live this session: RelationType enum unchanged since 2026-08-15), and using the existing CHILD/PARENT facts would overload them with new semantics the refuter names as 'another legally misleading boundary'. That fix needs a Zero/legal decision + a fact-vocabulary extension (backend reader + frontend writer) — out of a RULES-ONLY fold's authority; reported back, not authored. ADDENDUM (Fix 4, GO'd by team-lead): 9 more entries — el.e31b-spouse-itas-support/el.e31b-sponsor-itas-itap (E31B), el.e31e-child-itas-support/el.e31e-sponsor-itas-itap (E31E), el.e31h-parent-itas-child-support/el.e31h-sponsor-itas-itap (E31H), el.e31j-sibling-itas-support/el.e31j-sponsor-itas-itap/el.e31j-dependency-age (E31J) — each edits the family.sponsor_status_code leaf from op:known (presence-only) to op:in [ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED], grounded by inc6-sponsor-status-claim-ledger.md (4 independently-worded articles, one per product, each with its own VITAS-fallback ayat).",
+  "rules": [
+    {
+      "rule": {
+        "rule_id": "el.e31c-child-mixed-marriage-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+        "safety_critical": false,
+        "product_version_ids": [
+          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+        ]
+      },
+      "claim_ids": [
+        "CL-E31C-03",
+        "CL-E31C-04"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-E31C-03",
+          "note": "The page requires the WNI parent's application letter (item 1) and the WNI parent's Kartu Keluarga (item 9); that the formal penjamin must BE that parent is an inference from those items (typical-case reading) — the foreign-parent-as-penjamin shape is not addressed by the page. Codex refuter finding 4, 2026-08-19 (same caveat already carried by el.e31c-mixed-marriage-parents's identical conjunct, seq-10; reused verbatim here because it is the same claim backing the same fact on a sibling rule of the same product, not a fresh inference)."
+        }
+      ],
+      "product_code": "E31C",
+      "must_reference_facts": [
+        "family.sponsor_nationalities"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "hf.e31c-sponsor-not-indonesian",
+        "stage": "HARD_FILTER",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-08-23T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "op": "not",
+              "arg": {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": [
+                  "ID"
+                ]
+              }
+            }
+          ]
+        },
+        "effect": {
+          "type": "EXCLUDE",
+          "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN"
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+        "safety_critical": true,
+        "product_version_ids": [
+          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+        ]
+      },
+      "claim_ids": [
+        "CL-E31C-03",
+        "CL-E31C-04"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-E31C-03",
+          "note": "The page requires the WNI parent's application letter (item 1) and the WNI parent's Kartu Keluarga (item 9); that the formal penjamin must BE that parent is an inference from those items (typical-case reading) — the foreign-parent-as-penjamin shape is not addressed by the page. Codex refuter finding 4, 2026-08-19 (same caveat already carried by el.e31c-mixed-marriage-parents's identical conjunct, seq-10; reused verbatim here for the paired HARD_FILTER on the same fact)."
+        }
+      ],
+      "product_code": "E31C",
+      "must_reference_facts": [
+        "family.sponsor_nationalities"
+      ]
+    },
+    {
+      "rule": {
+        "rule_id": "el.d12-passport-validity",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d12-passport-validity",
+        "safety_critical": false,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ]
+      },
+      "claim_ids": [
+        "CL-D12-02"
+      ],
+      "product_code": "D12"
+    },
+    {
+      "rule": {
+        "rule_id": "el.d12-funds-usd-5000",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PROOF_OF_FUNDS_D12",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d12-funds-usd-5000",
+        "safety_critical": false,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ]
+      },
+      "claim_ids": [
+        "CL-D12-02"
+      ],
+      "product_code": "D12"
+    },
+    {
+      "rule": {
+        "rule_id": "el.d12-cv-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "CV_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d12-cv-required",
+        "safety_critical": false,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ]
+      },
+      "claim_ids": [
+        "CL-D12-02"
+      ],
+      "product_code": "D12"
+    },
+    {
+      "rule": {
+        "rule_id": "el.d12-itinerary-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "ITINERARY_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d12-itinerary-required",
+        "safety_critical": false,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ]
+      },
+      "claim_ids": [
+        "CL-D12-02"
+      ],
+      "product_code": "D12"
+    },
+    {
+      "rule": {
+        "rule_id": "el.d12-support-letter",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d12-support-letter",
+        "safety_critical": false,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ]
+      },
+      "claim_ids": [
+        "CL-D12-02"
+      ],
+      "product_code": "D12"
+    }
+  ]
+}

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -375,6 +375,15 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
     # from the seq-12 source bytes). Content-keyed and pinned to the EXACT
     # anchor value, not a hex shape, for the same reason as the seq12 rule:
     # this is production code with an open surface for future edits.
+    #
+    # 2026-08-23: this reason string ends in the same "...chain anchor —
+    # content-derived sha256 ..." shape as the seq10/11/12 rules above, on
+    # purpose (four consecutive-sequence anchors reading in order). A test
+    # that looks a rule up via test_detect_secrets_auto_triage.py's
+    # _find_content_keyed_rule("chain anchor") would now match FOUR entries
+    # and fail loudly (it asserts exactly one) — that is correct behavior,
+    # not a bug in the lookup. Any future test targeting THIS rule must key
+    # on "seq-12 chain anchor", the substring unique to it.
     (
         re.compile(
             r"^apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules\.py$"

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -368,6 +368,25 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
         "the public signed seq-11 RulePack payload, triple-derived at run "
         "time; exact value pinned, never a credential",
     ),
+    # fold_pack_seq13_rules.py: _EXPECTED_SEQ12_PAYLOAD_SHA256 is the chain
+    # anchor — same class/purpose as the seq10/11/12 rules immediately
+    # above (content-derived sha256 of the PUBLIC signed seq-12 RulePack
+    # payload, triple-derived at run time: declared == anchor == recomputed
+    # from the seq-12 source bytes). Content-keyed and pinned to the EXACT
+    # anchor value, not a hex shape, for the same reason as the seq12 rule:
+    # this is production code with an open surface for future edits.
+    (
+        re.compile(
+            r"^apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules\.py$"
+        ),
+        re.compile(
+            r'^\s*"ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d"\s*$'
+        ),
+        "fold_pack_seq13_rules.py: seq-12 chain anchor — content-derived "
+        "sha256 of the public signed seq-12 RulePack payload, "
+        "triple-derived at run time; exact value pinned, never a "
+        "credential",
+    ),
     # scripts/kbli_bench/results/p2b_score.json (PR #4422, KBLI Navigator
     # Phase 2b benchmark run): corpus_sha256 is the content-derived sha256 of
     # the frozen benchmark corpus (scripts/kbli_bench/p2b_corpus.json), the

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -267,8 +267,8 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # trail are derived from the live registry post-merge, not summed by
     # hand (team-lead's call: a rule appears once in the trail regardless of
     # how many PRs tried to add it).
-    assert len(CONTENT_KEYED_RULES) == 15, (
-        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 15. "
+    assert len(CONTENT_KEYED_RULES) == 16, (
+        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 16. "
         "If you just ADDED a rule: bump this number AND append a `# +1: <what> "
         "(<date>, PR #NNNN)` line below, matching the existing trail's format — "
         "that comment IS the audit record this assert exists to force. "
@@ -285,6 +285,7 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # +1: fold_pack_seq10.py seq-9 chain anchor exact-value pin (2026-08-19)
     # +1: fold_pack_seq11.py seq-10 chain anchor exact-value pin (2026-08-20)
     # +1: fold_pack_seq12.py seq-11 chain anchor exact-value pin (2026-08-20)
+    # +1: fold_pack_seq13_rules.py seq-12 chain anchor exact-value pin (2026-08-23, #4660)
     #
     # Note (2026-08-23): "appended last" is no longer a constraint. It was
     # true only because this test and the two Google-OAuth tests below


### PR DESCRIPTION
## Summary

Two fixes land here as one chained fold off signed seq-12 (`rulepack-prod-013.rules-only.json`). No sequence/chain-hash/signature fields are touched — those belong to the combining fold.

**FIX 1 — E31C nationality gap, live production defect, not a theoretical tightening.**

E31C is *Anak Hasil Perkawinan Sah **WNA-WNI*** — a mixed marriage, one Indonesian parent. Reproduced this morning against seq-12 via the sanctioned probe:

```
case: adult, BOTH parents foreign, FAMILY purpose
  -> E31C  rank 1  [PURPOSE_PRODUCT_MATCH]
  -> E31D  rank 2  [REQ_SPONSOR_MIXED_MARRIAGE, REQ_STEP_PARENT_RELATION, PURPOSE_PRODUCT_MATCH]
```

E31C was being offered to the child of two foreigners because neither its SUPPORT rule nor any filter looked at the sponsor's nationality. Fixed on both sides of the axis: `el.e31c-child-mixed-marriage-support`'s SUPPORT condition now requires `family.sponsor_nationalities intersects [ID]`, and a paired `hf.e31c-sponsor-not-indonesian` HARD_FILTER excludes on the exact complement — no gap, no overlap. `on_unknown: NEEDS_INPUT` on both, so an unresolved sponsor nationality asks rather than guesses in either direction.

Grounded in `CL-E31C-03` (VERIFIED-WITH-CAVEAT, portal checklist items) plus `CL-E31C-04` (VERIFIED, new this fold — the product's own portal title literally reads *"E31C Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI"*, independently curl-fetched this session rather than taken on an earlier grader's relay).

**Does NOT fix E31D.** For the same applicant, E31D still appears and still answers `REQ_SPONSOR_MIXED_MARRIAGE` / `REQ_STEP_PARENT_RELATION` — reason codes for checks its own rules do not contain. That repair needs a `STEPCHILD` relationship-type + fact-vocabulary extension (PR #4650) and a Zero/legal ruling on the relationship model. It is out of scope for a rules-only fold and is not attempted here — a reader who sees E31C fixed must not conclude the family-mixed-marriage case is clean.

**Also does NOT fix the mirror case: a child of two Indonesian parents.** A cross-family adversarial refutation (Codex `gpt-5.6-sol`, dispatched against this exact rule pair before merge) confirmed the fix above closes only the foreign-foreign leg. Every fact path any rule in the pack reads for this product was enumerated; there is exactly one nationality slot on the family side (`family.sponsor_nationalities`) and no fact anywhere for a second parent — the fact model has nowhere to put it, so no rule change can close this leg. Today the product reads: both parents foreign → EXCLUDED (this fix), genuine mixed marriage → SUPPORTED (correct), both parents Indonesian → SUPPORTED (structurally undetectable, neither introduced nor closed by this PR). Closing it needs a co-parent-nationality fact — backend + frontend + fold, the same shape as the E31D stepchild gap above. A reader should not conclude this PR makes E31C's WNA-WNI scoping correct end-to-end; it corrects one half of a two-sided leak.

**FIX 2 — D12's ungrounded `investment.pt_pma_committed` conjunct, removed.**

**No eligibility outcome changes for anyone.** This is a reason-code completeness fix, not an inclusion/exclusion fix. `investment.pt_pma_committed != true` is removed from the 5 D12 sibling rules that carried it (`el.d12-{passport-validity,funds-usd-5000,cv-required,itinerary-required,support-letter}`); `el.d12-multi-entry-support` — the one D12 rule that never carried it — is left byte-identical to seq-12.

No claim in the coverage matrix ever grounded the conjunct (`D12.md` Sec.3.15: *"no capital-commitment fact gates it"*), and the sibling families D1/D2 (same authoring pass, same rule shape) carry it on **zero of their combined 12 rules** — **5 of 18 across the family, not 5 of 6 within D12 alone**, which is what makes the removal direction correct rather than arguable.

Before this fix, a PMA-committed applicant already reached `SUPPORTED` via `el.d12-multi-entry-support`'s unconditional union coverage, but with zero attached document-requirement reason codes — told they qualify with no checklist. After, the same applicant reaches the same `SUPPORTED` status via all 6 rules with the full checklist attached.

**A third fix was built, then held — not shipped.** A 9-rule sponsor-status value check (`family.sponsor_status_code` `op:known` -> `op:in`, E31B/E31E/E31H/E31J) was independently grounded against primary law (Permenkumham 22/2023 Pasal 44/47/50/50A + 11/2024's Pasal 33(7)), then held after an independent read found the proposed enum targets the wrong vocabulary: the fact's declared and populated domain is **product codes** (`"E23"`, `"NONE"`), not immigration statuses. Shipping it would silently reject every legitimate sponsor (deterministic silent `FALSE` on any `KNOWN` non-enum value — `on_unknown` is never consulted for `FALSE`) while routing every real frontend interview user into a permanently unanswerable `NEEDS_INPUT` prompt once ENFORCE arms (the interview's own `mapFamilySponsorStatus()` guard can only ever emit `UNKNOWN`). Full grounding and both mechanisms are documented in `inc6-sponsor-status-claim-ledger.md`'s "Known scope gap #2"; the removed rule/manifest entries are preserved verbatim in `HELD-fix4-sponsor-status-2026-08-23.json` and the removed tests in a `.py.txt` sidecar, so re-arming is a paste against a checklist once the underlying data-modelling question (product code vs immigration status) is resolved — tracked as a PENDING-ARMS row, owner team-lead. **The public evaluate API's sponsor-status hole this was meant to close is real, stays open, is reachable, and is now documented — this fold does not close it.**

## Verification

- `compile_pack` — RC 0, zero lint findings.
- Fold idempotent — two `assemble_payload()` runs byte-identical.
- Mechanical delta matches exactly the two shipped fixes: `added={hf.e31c-sponsor-not-indonesian}`, `changed` = 6 rules (5 D12 siblings + `el.e31c-child-mixed-marriage-support`), `removed={}`. All 9 sponsor-status rule_ids independently re-diffed byte-identical to seq-12 (not merely "not in the changed set" — a redundant per-rule `canon()` comparison, since the primary delta computation could itself be wrong).
- Guilt+innocence test coverage for both shipped fixes, against the real evaluator (`compiler.build_compiled_pack`, `evaluator.evaluate_product` — never a hand-rolled stand-in): 21/21 in `test_seq13_rules_pack.py`, 1391/1391 across the full non-DB `visa_engine` suite.
- Never touches production/prod DB/Fly secrets; no real applicant data used anywhere — all evaluate probes are synthetic via the sanctioned fixture helpers.

## Test plan

- [x] `compile_pack` reports zero errors
- [x] Fold idempotent (byte-identical across two runs)
- [x] Mechanical delta = exactly the declared rule changes (independently re-parsed, not just asserted)
- [x] Guilt + innocence witnesses for FIX 1 (E31C) against the real evaluator
- [x] Guilt + innocence witnesses for FIX 2 (D12) against the real evaluator, including a trace-sink mechanism proof that all 6 ELIGIBILITY rules fire TRUE
- [x] All 9 held sponsor-status rule_ids verified byte-identical to seq-12
- [x] Full non-DB `backend/tests/services/visa_engine/` suite green (1391/1391), zero regressions
- [ ] Combining fold (separate PR) adds the E31C copy for `REQ_PARENT_SPONSOR_INDONESIAN`, re-runs freshness verification, and produces the final signed pack

## Adversarial review

Multi-round adversarial review across this session (team-lead + `v2-d12` + an independent read + a cross-family refutation), not self-graded — four rounds worth naming honestly:

1. **FIX 2 (D12) shipped in the WRONG direction on the first pass.** It ADDED the ungrounded conjunct to `el.d12-multi-entry-support` instead of removing it from the 5 siblings — which would have excluded exactly the applicant the owner's ruling protects (no active permit, PT PMA committed). Caught by team-lead widening the comparison from D12 alone to the full D1/D2/D12 family (13 of 18 rules, not 5 of 6), reversed, and independently re-proven against `v2-d12`'s own reproducible probe script (8/8 truth-table rows + 4 named applicants match exactly).
2. **The sponsor-status fix was reported "held" twice in chat while its cure/manifest entries were still on disk** and got re-folded into the shipped artifact both times. Caught by team-lead re-parsing the artifact bytes directly rather than trusting the report. Corrected by physically removing the entries (not skipping/commenting), independently re-verifying the artifact no longer contains them, and adding a redundant guard (`isdisjoint(changed)` plus a per-rule byte-identity loop) so a future re-introduction fails loud even if the primary delta computation itself has a bug.
3. **The sponsor-status fix's own grounding survived one adversarial round** (a Pasal 116/180 "pending renewal" objection, independently re-checked and found not to hold — the pre-existing `CL-E31B-REFUTER` claim already considered and rejected that exception via Pasal 119) before an independent read found the actual, fatal defect (the vocabulary/domain mismatch above), at which point it was held rather than shipped with a narrower caveat.
4. **A cross-family refutation (Codex `gpt-5.6-sol`, xhigh) was dispatched specifically against the two E31C rules before merge**, with four named open questions: true complement or fall-through/double-catch under Kleene tri-state, dual-national `[ID, FR]` sponsor admission under `intersects`, whether `relation_to_sponsor eq PARENT` is too narrow, and exclude-vs-review routing. Every claim it returned was independently re-checked against the evaluator rather than relayed. No finding blocked the fix: the complement holds operationally (the HARD_FILTER's shared-UNKNOWN case routes to `BLOCKED_UNKNOWN` before eligibility runs), dual-national sponsors admit correctly (`IntersectsCondition` is set-membership, dual-nationality-safe by construction), and no wrongful exclusion could be constructed. One of its claims was wrong on the mechanism (`safety_critical` gates source-citation freshness, not applicant-fact verification) but its underlying intuition survived in sharper form — an engine-wide, pre-existing gap (`_partition_unknowns_by_policy` never inspects `UnknownFact.reason`), not this fold's to fix. The refutation did surface the mirror defect documented above (both-parents-Indonesian) — real, pre-existing, structurally out of a rules-only fold's reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
