### PR TITLE
fix(tests): stop index-anchoring CONTENT_KEYED_RULES in secret-triage tests

### DIFF
--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -214,6 +214,41 @@ KBLI_GOLD_SENTENCE_SHA256_REAL_LINES = [
 ]
 
 
+def _find_content_keyed_rule(
+    reason_substring: str,
+) -> tuple[re.Pattern[str], re.Pattern[str], str]:
+    """Locate one CONTENT_KEYED_RULES entry by a substring unique to its
+    reason string, rather than by list position.
+
+    2026-08-23: three tests in this file indexed into CONTENT_KEYED_RULES
+    positionally (CONTENT_KEYED_RULES[1]/[13]/[14]) instead of by identity.
+    detect_secrets_auto_triage.py's own header comment above the list
+    documents why the list had become append-only-by-convention: "inserting
+    a rule mid-list shifts every later index and breaks the per-rule
+    registration tests (measured the hard way 2026-08-21: 8 red from one
+    mid-list insert)." That is the index-anchoring naming the symptom, not
+    a reason the list itself needs positional stability — nothing in
+    classify()'s matching loop depends on order for correctness (it returns
+    on first content+path match; two rules covering the same file+line
+    would only change WHICH reason string is reported, never whether the
+    line is approved). Looking a rule up by what makes it unique — a
+    substring of its own reason — removes the coupling instead of
+    documenting around it: a rule can be inserted anywhere in the list
+    without touching this file.
+
+    Fails loudly on zero or more than one match rather than silently
+    returning the wrong rule — a lookup that can return the wrong entry
+    without raising is not an improvement on the index it replaces.
+    """
+    matches = [rule for rule in CONTENT_KEYED_RULES if reason_substring in rule[2]]
+    assert len(matches) == 1, (
+        f"expected exactly 1 CONTENT_KEYED_RULES entry with reason containing "
+        f"{reason_substring!r}, found {len(matches)}: "
+        f"{[rule[2] for rule in matches] if matches else [rule[2] for rule in CONTENT_KEYED_RULES]}"
+    )
+    return matches[0]
+
+
 def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     """Sanity: the KBLI gold-set rule is path-scoped to kbli-gold-all.json
     only — not the other KBLI files, which stay on the closed-writer-set
@@ -244,13 +279,21 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # +1: apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py public_key (2026-08-13)
     # +1: research/visa/2026-08-12-gold-replay-live-report.json payload_sha256 (2026-08-13)
     # +1: scripts/kbli_bench/results/p2b_score.json corpus_sha256 (2026-08-21, #4422 via main merge)
-    # +2: scripts/lint_google_oauth_credentials.py KNOWN_COMPROMISED fingerprints + selftest fragment (2026-08-21, appended last — this list is positionally indexed)
+    # +2: scripts/lint_google_oauth_credentials.py KNOWN_COMPROMISED fingerprints + selftest fragment (2026-08-21)
     # +1: scripts/lint_telegram_tokens.py KNOWN_COMPROMISED sha256[:16] key (2026-08-14)
     # +1: traffic-source fail-closed proof identity/integrity anchors (2026-08-15)
     # +1: fold_pack_seq10.py seq-9 chain anchor exact-value pin (2026-08-19)
     # +1: fold_pack_seq11.py seq-10 chain anchor exact-value pin (2026-08-20)
     # +1: fold_pack_seq12.py seq-11 chain anchor exact-value pin (2026-08-20)
-    path_pat, _content_pat, reason = CONTENT_KEYED_RULES[1]
+    #
+    # Note (2026-08-23): "appended last" is no longer a constraint. It was
+    # true only because this test and the two Google-OAuth tests below
+    # indexed into the list positionally; all three now look their rule up
+    # by content instead (see _find_content_keyed_rule above), so a new
+    # rule may be inserted anywhere in CONTENT_KEYED_RULES without breaking
+    # a registration test. The count assert immediately above is unaffected
+    # by this - it counts entries, not positions, and stays deliberate.
+    path_pat, _content_pat, reason = _find_content_keyed_rule("KBLI gold-set")
     assert path_pat.search(KBLI_GOLD_ALL)
     assert not path_pat.search("apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
     assert not path_pat.search("data/kbli-filiera/some_manifest.json")
@@ -1250,10 +1293,15 @@ GOOGLE_OAUTH_LINT = "scripts/lint_google_oauth_credentials.py"
 
 
 def test_google_oauth_known_compromised_rule_registered() -> None:
-    """Appended-last rule (this list is positionally indexed): approves only
-    the 16-hex dict-key lines carrying the exact 2026-08-21 publication
-    marker, only in the OAuth guard's own file."""
-    path_pat, content_pat, reason = CONTENT_KEYED_RULES[13]
+    """Looks its rule up by content (a substring unique to its reason), not
+    by list position (2026-08-23 - previously CONTENT_KEYED_RULES[13], the
+    exact positional coupling s13-rules' mid-list insert broke elsewhere in
+    this file the same day). Approves only the 16-hex dict-key lines
+    carrying the exact 2026-08-21 publication marker, only in the OAuth
+    guard's own file."""
+    path_pat, content_pat, reason = _find_content_keyed_rule(
+        "Google OAuth gate: KNOWN_COMPROMISED"
+    )
     assert path_pat.search(GOOGLE_OAUTH_LINT)
     assert not path_pat.search("scripts/lint_telegram_tokens.py")
     assert "never key material" in reason
@@ -1265,7 +1313,10 @@ def test_google_oauth_known_compromised_rule_registered() -> None:
 
 
 def test_google_oauth_selftest_fragment_rule_registered() -> None:
-    path_pat, content_pat, _reason = CONTENT_KEYED_RULES[14]
+    """Same content-based lookup as the test above, not by list position."""
+    path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "OAuth guard selftest fixture fragment"
+    )
     assert path_pat.search(GOOGLE_OAUTH_LINT)
     frag = '    ref_body = "0c" + "defghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-abcd"'
     assert content_pat.match(frag)


### PR DESCRIPTION
## The pattern

Two independent lanes hit the same defect shape today, in unrelated code:

1. **`scripts/pending_arms_report.py`** extracted the PENDING-ARMS ledger's
   owner field by position (`parts[-2]`). A row with an extra field put the
   proof text where the owner should be, so a genuinely phantom `owner:
   operator` row passed the phantom-operator gate silently. Fixed in #4662
   by anchoring on the `owner:` label instead of the slot.
2. **`scripts/tests/test_detect_secrets_auto_triage.py`** (this PR) asserted
   on `CONTENT_KEYED_RULES[13]` and `[14]` by index. `s13-rules` inserted a
   new rule mid-list in #4660 and shifted everything after it, turning two
   unrelated Google-OAuth tests red with a confusing failure.

Same root: **identifying a thing by where it sits rather than by what it
is.**

## Fix

`test_google_oauth_known_compromised_rule_registered` and
`test_google_oauth_selftest_fragment_rule_registered` were the two named
instances (`CONTENT_KEYED_RULES[13]`/`[14]`). While fixing them, found a
**third, unnamed instance of the identical defect in the same file**:
`test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file` also
indexed `CONTENT_KEYED_RULES[1]` for its own path-scoping assertions
(separate from its count assert — see below). Fixed all three.

A new `_find_content_keyed_rule(reason_substring)` helper looks a rule up
by a substring unique to its own reason string, and fails loudly on zero
or more than one match. All three tests use it instead of a raw index.
Nothing in `classify()`'s matching loop depends on list order for
correctness — it returns on first content+path match, so two overlapping
rules would only change which reason string surfaces, never whether a
line is approved. This removes the coupling instead of documenting around
it: a rule can now be inserted anywhere in `CONTENT_KEYED_RULES` without
touching a test.

## The count assert — kept, unchanged

`test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file` also
asserts `len(CONTENT_KEYED_RULES) == 15`. That is a **different, orthogonal
property** — a deliberate, already well-documented speed bump against
silent rule-list growth (its own comment cites the 2026-08-21 audit: a
directory-wide rule had forgiven a real Google OAuth secret for months).
The count doesn't care about position, only total, so it needed no
structural change — kept as-is.

## Append-last convention — retired, cited why

`detect_secrets_auto_triage.py`'s own header comment above
`CONTENT_KEYED_RULES` names the reason for append-only-by-convention
verbatim: *"inserting a rule mid-list shifts every later index and breaks
the per-rule registration tests."* That reason is gone once the tests stop
indexing — updated one stale in-repo comment (in the test file only) that
called the list "positionally indexed" and required "appended last."
**Not touching `detect_secrets_auto_triage.py` itself** per instruction —
its own header comment still states the now-superseded rationale; flagging
that as a follow-up rather than fixing it here (see below).

## Verification (the falsifiability check, not just a green run)

1. Ran the suite **before** touching anything: 84 passed (baseline).
2. After the fix: 84 passed (same count — 3 tests modified, one non-test
   helper added).
3. **The check that's the actual point**: temporarily inserted a dummy
   `CONTENT_KEYED_RULES` entry mid-list directly in
   `detect_secrets_auto_triage.py` (after the KBLI rule, before the next
   entry) — the exact operation that broke things on #4660. Result: the
   two Google-OAuth tests and the KBLI test's own by-content lookup all
   **still passed**; the KBLI test's count assert correctly went red
   (`16 != 15`) — the deliberate guard doing its job, not a regression.
   **15 other tests in the same file — not part of this PR's scope —
   failed from the identical index shift**, confirming this pattern is far
   more widespread in this file than the three instances fixed here (full
   list of names available on request; all follow the same
   `_registered_and_scoped_to_..._file` / guilt-innocence shape and would
   take the same `_find_content_keyed_rule` fix).
4. Reverted the dummy rule via `git checkout --` immediately after
   (confirmed 0-diff on `detect_secrets_auto_triage.py`) and re-ran clean:
   84 passed.

## Scope

`scripts/tests/test_detect_secrets_auto_triage.py` only.
`detect_secrets_auto_triage.py` itself untouched — the rules are fine,
only the tests were fragile. `s13-rules`' new rule entry in #4660 is
untouched; that PR is armed and frozen.

## Two things surfaced, not silently acted on

- **15 more index-anchored tests in this same file**, found via the
  mid-list-insert verification above. Same defect class, same fix shape
  (`_find_content_keyed_rule` is already in the file, ready to reuse) —
  deliberately not folded into this PR to keep it to the assigned scope
  and roughly 60 lines.
- `detect_secrets_auto_triage.py:392-395`'s own "APPEND-ONLY from here"
  comment now states a rationale this PR retires on the test side. Left
  untouched per instruction (do not touch that file); worth a follow-up
  line updating it once/if the other 15 tests are fixed too.

## Adversarial review

This PR fixes a pattern named by the directing agent, not a bug I found —
credit for the underlying insight belongs to their independent discovery
of the identical shape in `pending_arms_report.py` (#4662) the same day.
My own contribution here: the third unnamed instance (KBLI test's index-1
access) and the falsifiability check quantifying how much of this file
still shares the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)