### PR TITLE
feat(visa-engine): RulePack seq-13 JOIN — combine rules + freshness halves into rulepack-prod-013.source.json

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
@@ -26,27 +26,44 @@ Every other top-level key must equal seq-12 canonically. If either half
 smuggled a change outside its own lane, this fold aborts rather than
 silently carrying it forward.
 
-**On the freshness half's identical-timestamp shape.** All 18 restamps in
-the freshness input currently carry the SAME ``verified_at`` value — a
-disclosed pass-level proxy timestamp (see that file's own
-``verified_at_caveat``), not 18 independently observed per-source fetch
-times (none were logged). This fold does **not** reject that shape: it is
-the same pattern seq-12's own restamp batch already used (2 groups of
-4/14 identical-second stamps in ``source-restamp-edits.json`` — see
-``test_seq12_pack.py``'s restamp-parity gate, which asserts monotonic
-advance per record, never distinctness across records). The per-source
-evidentiary backing for "this page is still what it says" lives in the
-QW-5 verbatim-quote report, not in how many distinct clock values the
-batch happens to carry — a script cannot manufacture 18 honest
-independent timestamps out of one that were never captured, and inventing
-artificial jitter would be *less* honest, not more. What this fold DOES
-enforce mechanically, per record: the new ``verified_at`` strictly
-advances past the value it replaces (a real ledger-drift guard, checked
-against the freshness file's own declared prior value AND cross-checked
-against seq-12's actual bytes), and is not later than this pack's own
-``created_at`` (no fabricated future attestation). Batching is FLAGGED —
-a non-fatal note on stdout, mechanically testable — never silently
-absorbed and never blocked.
+**On the freshness half's identical-timestamp shape — and the trend behind
+it.** All 18 restamps in the freshness input currently carry the SAME
+``verified_at`` value — a disclosed pass-level proxy timestamp (see that
+file's own ``verified_at_caveat``), not 18 independently observed
+per-source fetch times (none were logged). This fold does **not** reject
+that shape: a script cannot manufacture 18 honest independent timestamps
+out of one that were never captured, and inventing artificial jitter
+would be *less* honest, not more.
+
+But "seq-12 did the same thing" — this module's own first-draft framing,
+corrected by the team-lead reading the actual bytes rather than trusting
+that claim — is the wrong reference point. ``source-restamp-edits.json``
+(seq-12's own restamp ledger) shows a DESCENDING staircase, not a stable
+convention: the batch seq-12 itself replaced (inherited from seq-10/
+seq-11) carried **7 distinct, second-precision values** — real per-fetch
+times (``2026-08-18T21:41:23Z`` through ``2026-08-19T04:31:03Z``, verified
+by reading the file directly). seq-12's own fold then rounded that down to
+**2** (4 records at ``06:14:00Z``, 14 at ``06:15:00Z``). This freshness
+input proposes **1**. Each restamp has been coarser than the last, and
+nothing in this fold family has ever noticed, because every gate asserts
+*advance*, never *resolution*. "What good looks like" is seq-10's 7
+distinct values, not seq-12's 2 — citing seq-12 as the bar would enshrine
+one step of degradation as acceptable practice.
+
+What this fold DOES enforce mechanically, per record: the new
+``verified_at`` strictly advances past the value it replaces (a real
+ledger-drift guard, checked against the freshness file's own declared
+prior value AND cross-checked against seq-12's actual bytes), and is not
+later than this pack's own ``created_at`` (no fabricated future
+attestation). Those are real teeth; distinctness-across-records is not,
+and a guard that pretended otherwise would be worse engineering than
+naming the gap plainly. So the shape is FLAGGED, never rejected and never
+silently absorbed: a non-fatal note on stderr, mechanically testable,
+that reports the actual three-point resolution trend (this pass vs. the
+batch it replaces vs. the batch seq-12 itself replaced, the last read
+best-effort from ``source-restamp-edits.json`` — informational only,
+never a hard dependency of this fold; its absence degrades the note, not
+the join).
 
 **``content_sha256`` is never touched, never recomputed, never
 "verified" here.** Ditjen pages embed a per-request CSRF token, so two
@@ -111,6 +128,21 @@ _SEQ13_SOURCE_OUT = _PACKS_DIR / "rulepack-prod-013.source.json"
 # not yet committed as of this module's authoring.
 _FRESHNESS_INPUT = _REPO_ROOT / "research" / "visa" / "2026-08-23-seq13-restamp-source-records.json"
 
+# Informational only, never a hard dependency: seq-12's OWN restamp ledger,
+# read purely to report the resolution-trend NOTE (see module docstring).
+# Its absence degrades the note (that segment is simply omitted), never the
+# join — this path is deliberately not run through `_load_json`'s
+# raise-on-missing behavior.
+_SEQ12_RESTAMP_HISTORY = (
+    _REPO_ROOT
+    / "research"
+    / "visa"
+    / "doctrine-factory"
+    / "e5"
+    / "inc5-pack-edits"
+    / "source-restamp-edits.json"
+)
+
 _PRETTIER_BIN = _REPO_ROOT / "node_modules" / ".bin" / "prettier"
 
 # ---------------------------------------------------------------------------
@@ -168,6 +200,29 @@ def _load_json(path: Path, *, what: str) -> Any:
 
 def _canon(obj: Any) -> str:
     return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _historical_restamp_distinct_count(record_ids: set[str]) -> int | None:
+    """Best-effort, informational only: how many distinct ``verified_at``
+    values the batch seq-12 ITSELF replaced (``source-restamp-edits.json``'s
+    own ``current_verified_at`` — inherited from seq-10/seq-11) carried,
+    restricted to ``record_ids``. Returns ``None`` on anything short of a
+    clean read (missing file, unexpected shape, empty overlap) — this feeds
+    the resolution-trend NOTE only, never a guard, and must never become a
+    third hard dependency of this fold."""
+
+    try:
+        if not _SEQ12_RESTAMP_HISTORY.exists():
+            return None
+        data = json.loads(_SEQ12_RESTAMP_HISTORY.read_text(encoding="utf-8"))
+        values = {
+            e["current_verified_at"]
+            for e in data["restamps"]
+            if e.get("source_record_id") in record_ids
+        }
+        return len(values) if values else None
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None
 
 
 def _parse_utc(value: str) -> datetime:
@@ -320,6 +375,7 @@ def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> s
 
     created_at_dt = _parse_utc(_SEQ13_CREATED_AT)
     new_stamps: list[str] = []
+    replaced_stamps: list[str] = []
 
     for fresh_record_raw in records:
         sid = fresh_record_raw["source_record_id"]
@@ -381,21 +437,40 @@ def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> s
         baseline["verified_at"] = new_verified_at
         baseline["verified_by"] = new_verified_by
         new_stamps.append(new_verified_at)
+        replaced_stamps.append(prior_verified_at)
 
     # FLAGGED, not rejected — see module docstring for the reasoning. A
     # batch of identical-to-the-second stamps is a disclosed pass-level
-    # proxy, the same pattern seq-12's own restamp already used; the
-    # per-record guards above (advance + not-future + ledger-drift) are
-    # the actual evidentiary teeth, not timestamp cardinality.
-    distinct = set(new_stamps)
-    if len(distinct) < len(new_stamps):
+    # proxy, not per-source observation; the per-record guards above
+    # (advance + not-future + ledger-drift) are the actual evidentiary
+    # teeth, not timestamp cardinality. But this fold family's resolution
+    # has been getting COARSER, not holding steady — report the trend, not
+    # just the current number, so a reader sees the coarsening rather than
+    # mistaking a prior degradation for an established convention.
+    current_distinct = len(set(new_stamps))
+    if current_distinct < len(new_stamps):
+        replaced_distinct = len(set(replaced_stamps))
+        historical_distinct = _historical_restamp_distinct_count(restamp_ids)
+
+        trend = [f"{current_distinct} now"]
+        trend.append(f"{replaced_distinct} in the batch this replaces (seq-12's own restamp)")
+        if historical_distinct is not None:
+            trend.append(
+                f"{historical_distinct} in the batch seq-12 itself replaced "
+                "(inherited from seq-10/seq-11, real second-precision per-fetch times)"
+            )
+
         print(
-            f"NOTE: {len(new_stamps)} freshness restamps carry only {len(distinct)} "
+            f"NOTE: {len(new_stamps)} freshness restamps carry only {current_distinct} "
             "distinct verified_at value(s) — a disclosed pass-level proxy timestamp, "
-            "not independently observed per-source fetch times. Flagged, not "
-            "rejected: seq-12's own restamp batch used the same pattern. Evidentiary "
-            "backing for each source is the QW-5 verbatim-quote report, not "
-            "timestamp cardinality.",
+            "not independently observed per-source fetch times. Flagged, not rejected: "
+            "a script cannot manufacture per-source fetch times that were never "
+            "captured. But this is a DESCENDING resolution trend, not a stable "
+            f"convention — distinct-verified_at-count, newest first: {' <- '.join(trend)}. "
+            "What good looks like is the oldest figure in that chain, not the most "
+            "recent one. Evidentiary backing for each source is the QW-5 "
+            "verbatim-quote report, not timestamp cardinality — but the coarsening "
+            "itself is worth naming, not just excusing.",
             file=sys.stderr,
         )
 

--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
@@ -5,6 +5,42 @@ re-attestation of the OFFICIAL_PORTAL ``source_records``, the seq-12
 pattern applied to seq-13) into the actual, signable
 ``rulepack-prod-013.source.json``.
 
+**The freshness half's input contract is the EDIT-PAIR shape** — the same
+schema seq-12's own ``source-restamp-edits.json`` uses: each restamp
+carries ``source_record_id``, ``source_key`` (cross-checked against
+seq-12's actual record, not just trusted — an id/key mismatch aborts),
+``field`` (must read exactly ``"verified_at+verified_by"`` — this fold
+refuses to consume an edit-pair claiming to touch anything else),
+``current_verified_at``/``current_verified_by``, and
+``new_verified_at``/``new_verified_by`` — 7 fields, verified against the
+real ``inc5``/``inc7`` files on disk, not assumed from a routing message
+(the first draft of this contract assumed 5). Not a full-record blob.
+Settled 2026-08-23 (team-lead, after a same-day architecture fork — see
+the "seq-14" note below): the edit-pair shape is
+strictly better for a joiner, not merely consistent with family
+convention — it lets this fold assert the declared PRIOR against seq-12's
+ACTUAL bytes before mutating (a real ledger-drift gate), where a
+full-record blob only asks to be trusted for what it claims to contain.
+It also makes "content_sha256 never touched" true BY CONSTRUCTION rather
+than by comparison: the edit-pair schema has no slot for content fields
+at all, so there is nothing for a freshness input to smuggle even if it
+tried — this fold's own field-scoped mutation (`verified_at`/
+`verified_by` only, nothing else ever assigned) is the second, redundant
+half of that guarantee.
+
+**A same-day architecture fork, caught before it shipped.** Mid-build, the
+freshness lane's worktree independently produced an uncommitted
+``fold_pack_seq14.py`` that chained directly off seq-12 (same signed
+hash), skipping seq-13 entirely — freshness-only, with NO rules-only
+fixes (no E31C nationality-gap close, no D12 removal). Two children of one
+parent, one signed active pack: had it shipped, the fixes would have
+silently lost with nothing going red. The team-lead ruled it out
+(traced to a routing-message race on their end, not a decision anyone
+made) — **seq-13 combined is the path, seq-14 is stopped.** Left here
+because the failure mode is worth knowing: a freshness-only re-attestation
+convenience fold is easy to reach for and easy to get structurally wrong
+when a rules-fix lane is mid-flight on the same parent.
+
 Two lanes, two disjoint concerns, one join. Neither half's own fold owns
 identity (``sequence``/``version``/``rule_pack_id``/
 ``previous_payload_sha256``/``created_at``/``created_by``) — both leave it
@@ -70,10 +106,14 @@ the join).
 fetches of unchanged content hash differently — there is no
 canonical-extraction script in this repo. Verification of those 18
 sources is by verbatim quotation (the QW-5 report), not by hash
-recomputation. This fold's only hash-side check on ``content_sha256`` is
-that it rides through byte-identical from seq-12 on every restamped
-record — the same "did anything besides the declared field change"
-guard every sibling fold in this family runs.
+recomputation. Two independent guarantees, not one: the edit-pair input
+schema has no field for content at all (nothing to smuggle even if the
+freshness lane tried), AND this fold's own final byte-invariance sweep
+(``_assert_untouched``) asserts every restamped record rides through
+byte-identical from seq-12 outside ``verified_at``/``verified_by`` — the
+same "did anything besides the declared field change" guard every
+sibling fold in this family runs, now redundant-by-design rather than
+the sole line of defense.
 
 Every input is read from disk at run time. The chain hash is read LIVE
 from ``rulepack-prod-012.signed.json`` and asserted against the expected
@@ -83,8 +123,9 @@ fold. Deterministic: fixed timestamps, no ``datetime.now()`` — re-running
 is byte-identical. Both input halves are read from disk at fixed paths;
 either being absent raises a clear ``FoldPackError``, never an unhandled
 crash — the rules-only half ships in PR #4660 (not yet merged as of this
-module's authoring) and the freshness half is still being corrected by
-its own lane as of this module's authoring.
+module's authoring) and the freshness half's exact commit path was still
+being coordinated directly with its lane as of this module's authoring
+(see ``_FRESHNESS_INPUT``'s own comment).
 
 Usage::
 
@@ -121,12 +162,23 @@ _SEQ12_SIGNED = _PACKS_DIR / "rulepack-prod-012.signed.json"
 _SEQ13_RULES_ONLY = _PACKS_DIR / "rulepack-prod-013.rules-only.json"
 _SEQ13_SOURCE_OUT = _PACKS_DIR / "rulepack-prod-013.source.json"
 
-# Where the s13-fresh lane's re-attestation lands. Matches the file already
-# on disk in that lane's own worktree at the time this fold was authored
-# (research/visa/2026-08-23-seq13-restamp-source-records.json) — a research
-# capture next to its own report (2026-08-23-freshness-restamp-seq13.md),
-# not yet committed as of this module's authoring.
-_FRESHNESS_INPUT = _REPO_ROOT / "research" / "visa" / "2026-08-23-seq13-restamp-source-records.json"
+# Where the s13-fresh lane's re-attestation lands: the edit-pair shape
+# (see module docstring), same schema and same directory convention as
+# seq-12's own inc5-pack-edits/source-restamp-edits.json, one increment
+# later. Matches what is staged (uncommitted) in that lane's own worktree
+# at the time this fold was authored — coordinated directly with that
+# lane per the team-lead's instruction (this is a two-lane integration
+# detail, not something adjudicated from outside). If the committed path
+# ends up different, this is the one constant to repoint.
+_FRESHNESS_INPUT = (
+    _REPO_ROOT
+    / "research"
+    / "visa"
+    / "doctrine-factory"
+    / "e5"
+    / "inc7-pack-edits"
+    / "source-restamp-edits.json"
+)
 
 # Informational only, never a hard dependency: seq-12's OWN restamp ledger,
 # read purely to report the resolution-trend NOTE (see module docstring).
@@ -326,30 +378,65 @@ def _apply_rules(payload: dict[str, Any], seq12_source: dict[str, Any]) -> dict[
 # ---------------------------------------------------------------------------
 
 
+#: The only top-level keys the edit-pair freshness input may carry. A
+#: whitelist, not a blacklist: any key outside this set — including,
+#: but not limited to, a "rules"/"products" fragment that would smuggle
+#: a change outside the freshness lane's territory — aborts the fold.
+_FRESHNESS_INPUT_ALLOWED_KEYS = frozenset({"_comment", "restamps"})
+
+#: The exact fields one restamp edit in the edit-pair shape carries —
+#: verified against the REAL inc5/inc7 files on disk (not assumed from a
+#: routing message): 7 fields, not 5. ``source_key``/``field`` are
+#: descriptive metadata this fold cross-checks (entity consistency /
+#: scope), not merely tolerated passthrough. Extra or missing keys abort
+#: — a whitelist so a future accidental field (e.g. a stray
+#: content_sha256) is caught by construction, not by remembering to check
+#: for it.
+_RESTAMP_EDIT_FIELDS = frozenset(
+    {
+        "source_record_id",
+        "source_key",
+        "field",
+        "current_verified_at",
+        "current_verified_by",
+        "new_verified_at",
+        "new_verified_by",
+    }
+)
+_RESTAMP_EDIT_EXPECTED_FIELD_VALUE = "verified_at+verified_by"
+
+
 def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> set[str]:
     freshness = _load_json(_FRESHNESS_INPUT, what="seq-13 freshness restamp JSON")
 
-    # The freshness input is a bespoke research-capture document, not a
-    # RulePackPayload fragment — it must not carry rule/product edits at
-    # all. This is the complement half of the rules-fold cross-check above:
-    # each half is refused the other's territory even if its SHAPE changed
-    # to make that possible.
-    for forbidden_key in ("rules", "products"):
-        if forbidden_key in freshness:
-            raise FoldPackError(
-                f"the freshness input declares a {forbidden_key!r} key — the "
-                "freshness lane owns only source_records; refusing to consume "
-                "a change outside its territory"
-            )
+    extra_keys = set(freshness) - _FRESHNESS_INPUT_ALLOWED_KEYS
+    if extra_keys:
+        raise FoldPackError(
+            f"the freshness input declares unexpected top-level key(s) {sorted(extra_keys)} "
+            f"— only {sorted(_FRESHNESS_INPUT_ALLOWED_KEYS)} are allowed in the edit-pair "
+            "shape; refusing to consume a change outside the freshness lane's territory"
+        )
 
-    records = freshness.get("restamped_source_records")
+    records = freshness.get("restamps")
     if records is None:
-        raise FoldPackError("freshness input is missing 'restamped_source_records'")
+        raise FoldPackError("freshness input is missing 'restamps'")
     if len(records) != _EXPECTED_RESTAMP_COUNT:
         raise FoldPackError(
             f"expected exactly {_EXPECTED_RESTAMP_COUNT} restamps, freshness input "
             f"carries {len(records)}"
         )
+
+    for edit in records:
+        extra = set(edit) - _RESTAMP_EDIT_FIELDS
+        missing = _RESTAMP_EDIT_FIELDS - set(edit)
+        if extra or missing:
+            raise FoldPackError(
+                f"restamp edit {edit.get('source_record_id')!r} has "
+                f"{'unexpected field(s) ' + str(sorted(extra)) if extra else ''}"
+                f"{' and ' if extra and missing else ''}"
+                f"{'missing field(s) ' + str(sorted(missing)) if missing else ''} "
+                f"— must carry exactly {sorted(_RESTAMP_EDIT_FIELDS)}"
+            )
 
     payload_records_by_id = {r["source_record_id"]: r for r in payload["source_records"]}
 
@@ -365,66 +452,62 @@ def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> s
     if len(restamp_ids) != len(records):
         raise FoldPackError("freshness input names a duplicate source_record_id")
     if restamp_ids != portal_ids:
-        missing = sorted(portal_ids - restamp_ids)
-        extra = sorted(restamp_ids - portal_ids)
+        missing_ids = sorted(portal_ids - restamp_ids)
+        extra_ids = sorted(restamp_ids - portal_ids)
         raise FoldPackError(
             "freshness restamp set is not exactly the OFFICIAL_PORTAL set — "
-            f"portal records not restamped: {missing}; "
-            f"restamps naming non-portal/unknown records: {extra}"
+            f"portal records not restamped: {missing_ids}; "
+            f"restamps naming non-portal/unknown records: {extra_ids}"
         )
 
     created_at_dt = _parse_utc(_SEQ13_CREATED_AT)
     new_stamps: list[str] = []
     replaced_stamps: list[str] = []
 
-    for fresh_record_raw in records:
-        sid = fresh_record_raw["source_record_id"]
+    for edit in records:
+        sid = edit["source_record_id"]
         baseline = payload_records_by_id.get(sid)
         if baseline is None:
             raise FoldPackError(f"freshness restamp names unknown source_record_id {sid!r}")
 
-        prior_verified_at = fresh_record_raw.get("_prior_verified_at")
-        prior_verified_by = fresh_record_raw.get("_prior_verified_by")
-        if prior_verified_at is None or prior_verified_by is None:
+        if edit["field"] != _RESTAMP_EDIT_EXPECTED_FIELD_VALUE:
             raise FoldPackError(
-                f"freshness record {sid!r} is missing _prior_verified_at/_prior_verified_by "
-                "— cannot ledger-drift-check a restamp without its declared prior value"
+                f"restamp edit {sid!r} declares field={edit['field']!r}, expected "
+                f"{_RESTAMP_EDIT_EXPECTED_FIELD_VALUE!r} — this fold only ever restamps "
+                "verified_at+verified_by; any other declared field is out of scope"
             )
-        if baseline.get("verified_at") != prior_verified_at or baseline.get("verified_by") != prior_verified_by:
+        if edit["source_key"] != baseline.get("source_key"):
+            raise FoldPackError(
+                f"restamp edit {sid!r} declares source_key={edit['source_key']!r}, but "
+                f"seq-12's actual record {sid!r} has source_key={baseline.get('source_key')!r} "
+                "— id/key mismatch, refusing to apply against the wrong record"
+            )
+
+        current_verified_at = edit["current_verified_at"]
+        current_verified_by = edit["current_verified_by"]
+
+        # Ledger-drift guard: the edit-pair's declared "current" value must
+        # match seq-12's ACTUAL bytes — this is the exact strengthening the
+        # edit-pair shape buys over a full-record blob (team-lead, on
+        # adopting this contract): a claim about what is being replaced,
+        # checked against reality, not merely trusted.
+        if baseline.get("verified_at") != current_verified_at or baseline.get("verified_by") != current_verified_by:
             raise FoldPackError(
                 f"source_record {sid!r}: seq-12's actual verified_at/verified_by "
                 f"({baseline.get('verified_at')!r}, {baseline.get('verified_by')!r}) does not "
-                f"match the freshness input's declared prior value ({prior_verified_at!r}, "
-                f"{prior_verified_by!r}) — ledger drift, refusing to apply blind"
+                f"match the freshness input's declared current value ({current_verified_at!r}, "
+                f"{current_verified_by!r}) — ledger drift, refusing to apply blind"
             )
 
-        # Full-content parity: strip verified_at/verified_by (the only
-        # fields a restamp may change) AND the leading-underscore ledger
-        # metadata (not part of the pack schema) from the freshness
-        # record, then require canonical equality against seq-12's own
-        # record. This is what makes "content_sha256 never touched" a
-        # mechanical guard rather than a promise: any drift on
-        # content_sha256, title, locators, etc. fails here, loud.
-        cleaned = {
-            k: v for k, v in fresh_record_raw.items() if k not in _RESTAMP_FIELDS and not k.startswith("_")
-        }
-        baseline_stripped = {k: v for k, v in baseline.items() if k not in _RESTAMP_FIELDS}
-        if _canon(cleaned) != _canon(baseline_stripped):
-            raise FoldPackError(
-                f"freshness record {sid!r} changed beyond verified_at/verified_by — "
-                "content_sha256 and every other field must ride through untouched "
-                "on a pure re-stamp"
-            )
-
-        new_verified_at = fresh_record_raw["verified_at"]
-        new_verified_by = fresh_record_raw["verified_by"]
+        new_verified_at = edit["new_verified_at"]
+        new_verified_by = edit["new_verified_by"]
 
         new_dt = _parse_utc(new_verified_at)
-        prior_dt = _parse_utc(prior_verified_at)
-        if not new_dt > prior_dt:
+        current_dt = _parse_utc(current_verified_at)
+        if not new_dt > current_dt:
             raise FoldPackError(
                 f"source_record {sid!r}: new verified_at {new_verified_at!r} does not "
-                f"advance past the prior {prior_verified_at!r} — a re-stamp that moves "
+                f"advance past the current {current_verified_at!r} — a re-stamp that moves "
                 "time backward or holds it still is not an attestation"
             )
         if new_dt > created_at_dt:
@@ -434,10 +517,17 @@ def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> s
                 "attest to a fetch that (per this pack's own clock) hasn't happened yet"
             )
 
+        # content_sha256 and every other field are untouched BY
+        # CONSTRUCTION here — the edit-pair schema has no slot for them,
+        # and only these two fields are ever assigned onto `baseline`.
+        # No comparison is needed; there is nothing for the input to have
+        # smuggled. `_assert_untouched` below re-derives the same
+        # guarantee independently from the final payload, for defense in
+        # depth against a bug in THIS function.
         baseline["verified_at"] = new_verified_at
         baseline["verified_by"] = new_verified_by
         new_stamps.append(new_verified_at)
-        replaced_stamps.append(prior_verified_at)
+        replaced_stamps.append(current_verified_at)
 
     # FLAGGED, not rejected — see module docstring for the reasoning. A
     # batch of identical-to-the-second stamps is a disclosed pass-level

--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
@@ -1,0 +1,525 @@
+"""fold_pack_seq13_source.py — the seq-13 JOIN: combine the RULES-ONLY half
+(``rulepack-prod-013.rules-only.json``, ``fold_pack_seq13_rules.py``) with
+the source-freshness half (an 18-record ``verified_at``/``verified_by``
+re-attestation of the OFFICIAL_PORTAL ``source_records``, the seq-12
+pattern applied to seq-13) into the actual, signable
+``rulepack-prod-013.source.json``.
+
+Two lanes, two disjoint concerns, one join. Neither half's own fold owns
+identity (``sequence``/``version``/``rule_pack_id``/
+``previous_payload_sha256``/``created_at``/``created_by``) — both leave it
+at seq-12's own values by design (see each fold's module docstring). This
+module is where identity is actually assigned and where the chain anchors
+to seq-12's SIGNED payload hash.
+
+**Complement-of-the-rules-fold's guard.** ``fold_pack_seq13_rules.py``'s
+own ``_assert_untouched`` holds ``products``/``source_records`` (and every
+top-level key outside its declared rule edits) to whole-collection
+equality with seq-12 — the rules-only lane owns neither. This module
+enforces the complement: ``rules`` comes ONLY from the rules-only half
+(taken wholesale, cross-checked that the rules-only payload's own
+non-``rules`` content is untouched from seq-12 — i.e. the rules lane kept
+its promise), and ``source_records`` comes ONLY from the freshness half
+(the restamp applied to seq-12's own source_records, entity-derived as
+the OFFICIAL_PORTAL set — never a frozen id list, the seq-12 pattern).
+Every other top-level key must equal seq-12 canonically. If either half
+smuggled a change outside its own lane, this fold aborts rather than
+silently carrying it forward.
+
+**On the freshness half's identical-timestamp shape.** All 18 restamps in
+the freshness input currently carry the SAME ``verified_at`` value — a
+disclosed pass-level proxy timestamp (see that file's own
+``verified_at_caveat``), not 18 independently observed per-source fetch
+times (none were logged). This fold does **not** reject that shape: it is
+the same pattern seq-12's own restamp batch already used (2 groups of
+4/14 identical-second stamps in ``source-restamp-edits.json`` — see
+``test_seq12_pack.py``'s restamp-parity gate, which asserts monotonic
+advance per record, never distinctness across records). The per-source
+evidentiary backing for "this page is still what it says" lives in the
+QW-5 verbatim-quote report, not in how many distinct clock values the
+batch happens to carry — a script cannot manufacture 18 honest
+independent timestamps out of one that were never captured, and inventing
+artificial jitter would be *less* honest, not more. What this fold DOES
+enforce mechanically, per record: the new ``verified_at`` strictly
+advances past the value it replaces (a real ledger-drift guard, checked
+against the freshness file's own declared prior value AND cross-checked
+against seq-12's actual bytes), and is not later than this pack's own
+``created_at`` (no fabricated future attestation). Batching is FLAGGED —
+a non-fatal note on stdout, mechanically testable — never silently
+absorbed and never blocked.
+
+**``content_sha256`` is never touched, never recomputed, never
+"verified" here.** Ditjen pages embed a per-request CSRF token, so two
+fetches of unchanged content hash differently — there is no
+canonical-extraction script in this repo. Verification of those 18
+sources is by verbatim quotation (the QW-5 report), not by hash
+recomputation. This fold's only hash-side check on ``content_sha256`` is
+that it rides through byte-identical from seq-12 on every restamped
+record — the same "did anything besides the declared field change"
+guard every sibling fold in this family runs.
+
+Every input is read from disk at run time. The chain hash is read LIVE
+from ``rulepack-prod-012.signed.json`` and asserted against the expected
+anchor; the seq-12 source bytes are additionally re-hashed (RFC 8785 JCS)
+and must equal that same value — a source/signed mismatch aborts the
+fold. Deterministic: fixed timestamps, no ``datetime.now()`` — re-running
+is byte-identical. Both input halves are read from disk at fixed paths;
+either being absent raises a clear ``FoldPackError``, never an unhandled
+crash — the rules-only half ships in PR #4660 (not yet merged as of this
+module's authoring) and the freshness half is still being corrected by
+its own lane as of this module's authoring.
+
+Usage::
+
+    PYTHONPATH=. python -m backend.scripts.visa_engine.fold_pack_seq13_source
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from backend.services.visa_engine.bundle import canonicalize_json
+from backend.services.visa_engine.models import RulePackPayload
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_THIS_FILE = Path(__file__).resolve()
+_BACKEND_ROOT = _THIS_FILE.parents[2]  # apps/backend-rag/backend
+_REPO_ROOT = _THIS_FILE.parents[5]
+
+_PACKS_DIR = _BACKEND_ROOT / "services" / "visa_engine" / "contracts" / "packs"
+_SEQ12_SOURCE = _PACKS_DIR / "rulepack-prod-012.source.json"
+_SEQ12_SIGNED = _PACKS_DIR / "rulepack-prod-012.signed.json"
+_SEQ13_RULES_ONLY = _PACKS_DIR / "rulepack-prod-013.rules-only.json"
+_SEQ13_SOURCE_OUT = _PACKS_DIR / "rulepack-prod-013.source.json"
+
+# Where the s13-fresh lane's re-attestation lands. Matches the file already
+# on disk in that lane's own worktree at the time this fold was authored
+# (research/visa/2026-08-23-seq13-restamp-source-records.json) — a research
+# capture next to its own report (2026-08-23-freshness-restamp-seq13.md),
+# not yet committed as of this module's authoring.
+_FRESHNESS_INPUT = _REPO_ROOT / "research" / "visa" / "2026-08-23-seq13-restamp-source-records.json"
+
+_PRETTIER_BIN = _REPO_ROOT / "node_modules" / ".bin" / "prettier"
+
+# ---------------------------------------------------------------------------
+# seq-13 identity (the uuid5 anchor is verified, never assumed)
+# ---------------------------------------------------------------------------
+
+_SEQ13_SEQUENCE = 13
+_SEQ13_VERSION = "2026.8.23"
+_SEQ13_RULE_PACK_ID_URL = (
+    "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/13"
+)
+_EXPECTED_SEQ13_RULE_PACK_ID = uuid.UUID("79b62b85-829e-59f8-a058-c38c065b8cb5")
+
+# The signed seq-12 payload hash this pack must chain to. Read LIVE from the
+# signed file at run time AND asserted equal to this anchor AND equal to the
+# recomputed canonical hash of the seq-12 SOURCE bytes — three independent
+# derivations of one value, any mismatch aborts. Same anchor
+# fold_pack_seq13_rules.py chains against (both halves fold off the same
+# seq-12 baseline).
+_EXPECTED_SEQ12_PAYLOAD_SHA256 = (
+    "ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d"
+)
+
+# Fixed (not datetime.now()) so re-running this script is byte-identical,
+# and so the freshness half's "not in the future" guard has a fixed
+# reference rather than depending on wall-clock at run time.
+_SEQ13_CREATED_AT = "2026-08-23T20:00:00Z"
+_SEQ13_CREATED_BY = "agent.air-m5.backend-rag.visa-seq13-source-join.fold-2026-08-23"
+
+# Drift tripwire on the restamp batch size — same convention as seq-12's
+# fold: a different count means this fold was authored against a different
+# world and must abort, not adapt.
+_EXPECTED_RESTAMP_COUNT = 18
+_PORTAL_AUTHORITY_TYPE = "OFFICIAL_PORTAL"
+
+_IDENTITY_KEYS = frozenset(
+    {"sequence", "version", "rule_pack_id", "previous_payload_sha256", "created_at", "created_by"}
+)
+_RESTAMP_FIELDS = frozenset({"verified_at", "verified_by"})
+_UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+class FoldPackError(RuntimeError):
+    """A fail-loud gate inside the fold tripped — never silently degrade."""
+
+
+def _load_json(path: Path, *, what: str) -> Any:
+    if not path.exists():
+        raise FoldPackError(
+            f"{what} not found at {path} — this join cannot run without it. "
+            "Merge/land that lane's artifact first, then re-run this fold."
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _parse_utc(value: str) -> datetime:
+    try:
+        return datetime.strptime(value, _UTC_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        raise FoldPackError(f"timestamp {value!r} is not the fixed UTC shape {_UTC_FORMAT!r}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Identity + chain
+# ---------------------------------------------------------------------------
+
+
+def _verify_rule_pack_id() -> uuid.UUID:
+    computed = uuid.uuid5(uuid.NAMESPACE_URL, _SEQ13_RULE_PACK_ID_URL)
+    if computed != _EXPECTED_SEQ13_RULE_PACK_ID:
+        raise FoldPackError(
+            f"seq-13 rule_pack_id convention drifted: uuid5(NAMESPACE_URL, "
+            f"{_SEQ13_RULE_PACK_ID_URL!r}) = {computed}, expected "
+            f"{_EXPECTED_SEQ13_RULE_PACK_ID} — do not hand-adjust either side"
+        )
+    return computed
+
+
+def _chain_hash(seq12_source: dict[str, Any]) -> str:
+    signed = _load_json(_SEQ12_SIGNED, what="rulepack-prod-012.signed.json")
+    declared = signed.get("payload_sha256")
+    if declared != _EXPECTED_SEQ12_PAYLOAD_SHA256:
+        raise FoldPackError(
+            f"{_SEQ12_SIGNED} declares payload_sha256={declared!r}, expected "
+            f"{_EXPECTED_SEQ12_PAYLOAD_SHA256!r} — the signed seq-12 on disk is "
+            "not the one this fold was authored against"
+        )
+    recomputed = hashlib.sha256(canonicalize_json(seq12_source)).hexdigest()
+    if recomputed != declared:
+        raise FoldPackError(
+            f"seq-12 SOURCE bytes re-hash to {recomputed}, but the signed file "
+            f"declares {declared} — source/signed mismatch, refusing to chain"
+        )
+    return declared
+
+
+def _apply_identity(payload: dict[str, Any], seq12_source: dict[str, Any]) -> None:
+    payload["sequence"] = _SEQ13_SEQUENCE
+    payload["version"] = _SEQ13_VERSION
+    payload["rule_pack_id"] = str(_verify_rule_pack_id())
+    payload["previous_payload_sha256"] = _chain_hash(seq12_source)
+    payload["created_at"] = _SEQ13_CREATED_AT
+    payload["created_by"] = _SEQ13_CREATED_BY
+    # rollback_of_payload_sha256 stays null; top-level valid_period untouched
+    # (not in _IDENTITY_KEYS, so the byte-invariance sweep asserts it equals
+    # seq-12's).
+
+
+# ---------------------------------------------------------------------------
+# Rules half — taken wholesale, cross-checked that it kept its own promise
+# ---------------------------------------------------------------------------
+
+
+def _apply_rules(payload: dict[str, Any], seq12_source: dict[str, Any]) -> dict[str, Any]:
+    rules_only = _load_json(_SEQ13_RULES_ONLY, what="rulepack-prod-013.rules-only.json")
+
+    # The rules-only fold's own docstring promises it changes NOTHING but
+    # `rules` — identity stays at seq-12's own values, products and
+    # source_records are untouched. Verify that promise was kept before
+    # trusting its `rules` at all: a rules-only artifact that silently
+    # smuggled a product or source_record edit must abort here, not ride
+    # into the combined pack disguised as "the rules half".
+    for key in _IDENTITY_KEYS:
+        if rules_only.get(key) != seq12_source.get(key):
+            raise FoldPackError(
+                f"rulepack-prod-013.rules-only.json's {key!r} = "
+                f"{rules_only.get(key)!r} differs from seq-12's {seq12_source.get(key)!r} "
+                "— the rules-only fold declares no identity change; this artifact "
+                "does not match its own contract"
+            )
+    for key in ("products", "source_records"):
+        if _canon(rules_only.get(key)) != _canon(seq12_source.get(key)):
+            raise FoldPackError(
+                f"rulepack-prod-013.rules-only.json's {key!r} drifted from seq-12 — "
+                "the rules-only lane owns neither products nor source_records; "
+                "this join refuses to inherit a change outside that lane's own "
+                "declared territory"
+            )
+    for key in set(seq12_source) | set(rules_only):
+        if key in _IDENTITY_KEYS or key in ("rules", "products", "source_records"):
+            continue
+        if _canon(rules_only.get(key)) != _canon(seq12_source.get(key)):
+            raise FoldPackError(
+                f"rulepack-prod-013.rules-only.json's top-level key {key!r} drifted "
+                "from seq-12 outside its declared rules-only edit"
+            )
+
+    payload["rules"] = copy.deepcopy(rules_only["rules"])
+    return rules_only
+
+
+# ---------------------------------------------------------------------------
+# Freshness half — 18-record OFFICIAL_PORTAL restamp, entity-derived
+# ---------------------------------------------------------------------------
+
+
+def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> set[str]:
+    freshness = _load_json(_FRESHNESS_INPUT, what="seq-13 freshness restamp JSON")
+
+    # The freshness input is a bespoke research-capture document, not a
+    # RulePackPayload fragment — it must not carry rule/product edits at
+    # all. This is the complement half of the rules-fold cross-check above:
+    # each half is refused the other's territory even if its SHAPE changed
+    # to make that possible.
+    for forbidden_key in ("rules", "products"):
+        if forbidden_key in freshness:
+            raise FoldPackError(
+                f"the freshness input declares a {forbidden_key!r} key — the "
+                "freshness lane owns only source_records; refusing to consume "
+                "a change outside its territory"
+            )
+
+    records = freshness.get("restamped_source_records")
+    if records is None:
+        raise FoldPackError("freshness input is missing 'restamped_source_records'")
+    if len(records) != _EXPECTED_RESTAMP_COUNT:
+        raise FoldPackError(
+            f"expected exactly {_EXPECTED_RESTAMP_COUNT} restamps, freshness input "
+            f"carries {len(records)}"
+        )
+
+    payload_records_by_id = {r["source_record_id"]: r for r in payload["source_records"]}
+
+    # Entity check, not a frozen id list — the restamped set must be exactly
+    # the set of OFFICIAL_PORTAL records already in the payload (seq-12's,
+    # untouched at this point). The seq-12 pattern, one generation later.
+    portal_ids = {
+        sid
+        for sid, r in payload_records_by_id.items()
+        if r.get("authority_type") == _PORTAL_AUTHORITY_TYPE
+    }
+    restamp_ids = {r["source_record_id"] for r in records}
+    if len(restamp_ids) != len(records):
+        raise FoldPackError("freshness input names a duplicate source_record_id")
+    if restamp_ids != portal_ids:
+        missing = sorted(portal_ids - restamp_ids)
+        extra = sorted(restamp_ids - portal_ids)
+        raise FoldPackError(
+            "freshness restamp set is not exactly the OFFICIAL_PORTAL set — "
+            f"portal records not restamped: {missing}; "
+            f"restamps naming non-portal/unknown records: {extra}"
+        )
+
+    created_at_dt = _parse_utc(_SEQ13_CREATED_AT)
+    new_stamps: list[str] = []
+
+    for fresh_record_raw in records:
+        sid = fresh_record_raw["source_record_id"]
+        baseline = payload_records_by_id.get(sid)
+        if baseline is None:
+            raise FoldPackError(f"freshness restamp names unknown source_record_id {sid!r}")
+
+        prior_verified_at = fresh_record_raw.get("_prior_verified_at")
+        prior_verified_by = fresh_record_raw.get("_prior_verified_by")
+        if prior_verified_at is None or prior_verified_by is None:
+            raise FoldPackError(
+                f"freshness record {sid!r} is missing _prior_verified_at/_prior_verified_by "
+                "— cannot ledger-drift-check a restamp without its declared prior value"
+            )
+        if baseline.get("verified_at") != prior_verified_at or baseline.get("verified_by") != prior_verified_by:
+            raise FoldPackError(
+                f"source_record {sid!r}: seq-12's actual verified_at/verified_by "
+                f"({baseline.get('verified_at')!r}, {baseline.get('verified_by')!r}) does not "
+                f"match the freshness input's declared prior value ({prior_verified_at!r}, "
+                f"{prior_verified_by!r}) — ledger drift, refusing to apply blind"
+            )
+
+        # Full-content parity: strip verified_at/verified_by (the only
+        # fields a restamp may change) AND the leading-underscore ledger
+        # metadata (not part of the pack schema) from the freshness
+        # record, then require canonical equality against seq-12's own
+        # record. This is what makes "content_sha256 never touched" a
+        # mechanical guard rather than a promise: any drift on
+        # content_sha256, title, locators, etc. fails here, loud.
+        cleaned = {
+            k: v for k, v in fresh_record_raw.items() if k not in _RESTAMP_FIELDS and not k.startswith("_")
+        }
+        baseline_stripped = {k: v for k, v in baseline.items() if k not in _RESTAMP_FIELDS}
+        if _canon(cleaned) != _canon(baseline_stripped):
+            raise FoldPackError(
+                f"freshness record {sid!r} changed beyond verified_at/verified_by — "
+                "content_sha256 and every other field must ride through untouched "
+                "on a pure re-stamp"
+            )
+
+        new_verified_at = fresh_record_raw["verified_at"]
+        new_verified_by = fresh_record_raw["verified_by"]
+
+        new_dt = _parse_utc(new_verified_at)
+        prior_dt = _parse_utc(prior_verified_at)
+        if not new_dt > prior_dt:
+            raise FoldPackError(
+                f"source_record {sid!r}: new verified_at {new_verified_at!r} does not "
+                f"advance past the prior {prior_verified_at!r} — a re-stamp that moves "
+                "time backward or holds it still is not an attestation"
+            )
+        if new_dt > created_at_dt:
+            raise FoldPackError(
+                f"source_record {sid!r}: new verified_at {new_verified_at!r} is after "
+                f"this pack's own created_at {_SEQ13_CREATED_AT!r} — a re-stamp cannot "
+                "attest to a fetch that (per this pack's own clock) hasn't happened yet"
+            )
+
+        baseline["verified_at"] = new_verified_at
+        baseline["verified_by"] = new_verified_by
+        new_stamps.append(new_verified_at)
+
+    # FLAGGED, not rejected — see module docstring for the reasoning. A
+    # batch of identical-to-the-second stamps is a disclosed pass-level
+    # proxy, the same pattern seq-12's own restamp already used; the
+    # per-record guards above (advance + not-future + ledger-drift) are
+    # the actual evidentiary teeth, not timestamp cardinality.
+    distinct = set(new_stamps)
+    if len(distinct) < len(new_stamps):
+        print(
+            f"NOTE: {len(new_stamps)} freshness restamps carry only {len(distinct)} "
+            "distinct verified_at value(s) — a disclosed pass-level proxy timestamp, "
+            "not independently observed per-source fetch times. Flagged, not "
+            "rejected: seq-12's own restamp batch used the same pattern. Evidentiary "
+            "backing for each source is the QW-5 verbatim-quote report, not "
+            "timestamp cardinality.",
+            file=sys.stderr,
+        )
+
+    return restamp_ids
+
+
+# ---------------------------------------------------------------------------
+# Byte-invariance sweep — everything not declared touched must match seq-12
+# ---------------------------------------------------------------------------
+
+
+def _assert_untouched(
+    payload: dict[str, Any], seq12: dict[str, Any], restamped_ids: set[str]
+) -> None:
+    for key in set(seq12) | set(payload):
+        if key in _IDENTITY_KEYS or key in ("rules", "source_records"):
+            continue
+        if _canon(payload.get(key)) != _canon(seq12.get(key)):
+            raise FoldPackError(
+                f"top-level payload key {key!r} drifted from seq-12 — this join "
+                "declares no edit there"
+            )
+
+    seq12_records = {r["source_record_id"]: r for r in seq12["source_records"]}
+    new_records = {r["source_record_id"]: r for r in payload["source_records"]}
+    if set(new_records) != set(seq12_records):
+        raise FoldPackError(
+            "source_record set (by source_record_id) drifted from seq-12 — this "
+            "join declares no record add/remove/drop"
+        )
+    for sid, record in new_records.items():
+        baseline = seq12_records[sid]
+        if sid in restamped_ids:
+            b = {k: v for k, v in baseline.items() if k not in _RESTAMP_FIELDS}
+            c = {k: v for k, v in record.items() if k not in _RESTAMP_FIELDS}
+            if _canon(b) != _canon(c):
+                raise FoldPackError(
+                    f"source_record {sid!r} changed beyond verified_at/verified_by "
+                    "— content_sha256 and every other field must ride through "
+                    "untouched on a pure re-stamp"
+                )
+        elif _canon(record) != _canon(baseline):
+            raise FoldPackError(
+                f"source_record {sid!r} drifted from seq-12 outside the declared "
+                "restamp set"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Write (atomic + prettier — fold_pack.py's Codex-finding-7 shape)
+# ---------------------------------------------------------------------------
+
+
+def _write_pack(payload: dict[str, Any], out_path: Path) -> None:
+    if not _PRETTIER_BIN.exists():
+        raise FoldPackError(
+            f"prettier binary not found at {_PRETTIER_BIN} — run `npm install` at repo root"
+        )
+
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"{out_path.stem}.tmp.", suffix=out_path.suffix, dir=str(out_path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with open(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        result = subprocess.run(
+            [str(_PRETTIER_BIN), "--write", str(tmp_path)],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise FoldPackError(
+                f"prettier --write {tmp_path} failed (rc={result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        tmp_path.replace(out_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def assemble_payload() -> dict[str, Any]:
+    seq12_original = _load_json(_SEQ12_SOURCE, what="rulepack-prod-012.source.json")
+    payload = copy.deepcopy(seq12_original)
+
+    _apply_identity(payload, seq12_original)
+    _apply_rules(payload, seq12_original)
+    restamped_ids = _apply_freshness(payload, seq12_original)
+    _assert_untouched(payload, seq12_original, restamped_ids)
+
+    try:
+        RulePackPayload.model_validate(payload)
+    except Exception as exc:  # re-raised loud with context
+        raise FoldPackError(
+            f"assembled seq-13 payload failed RulePackPayload validation: {exc}"
+        ) from exc
+
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # no CLI flags — deterministic single-purpose script
+    try:
+        payload = assemble_payload()
+    except FoldPackError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    _write_pack(payload, _SEQ13_SOURCE_OUT)
+    print(
+        f"wrote {_SEQ13_SOURCE_OUT} — {len(payload['rules'])} rule(s), "
+        f"{len(payload['products'])} product(s), {len(payload['source_records'])} source_record(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
@@ -221,7 +221,22 @@ _EXPECTED_SEQ12_PAYLOAD_SHA256 = (
 # Fixed (not datetime.now()) so re-running this script is byte-identical,
 # and so the freshness half's "not in the future" guard has a fixed
 # reference rather than depending on wall-clock at run time.
-_SEQ13_CREATED_AT = "2026-08-23T20:00:00Z"
+#
+# 2026-08-23, corrected: the original value here (20:00:00Z) was picked
+# when this module was first written, at ~10:29 UTC that day — already
+# ~9.5h in the future at write-time, with no comment justifying the choice.
+# It was carried unchanged through every later revision (the NOTE-trend
+# fix, the edit-pair schema adopt, the post-merge rebase re-run) because
+# it's a hardcoded literal, not a computed value — the two-consecutive-run
+# determinism proof this fold reports cannot see this class of defect,
+# since a hardcoded wrong value is exactly as deterministic as a hardcoded
+# right one. Caught by a reviewer comparing this field to real measured
+# UTC, not by anything in this module. Fixed to the most recently-elapsed
+# round hour as of actually finalizing this pack (13:54:25Z measured,
+# 13:00:00Z chosen so it is unambiguously in the past by the time this
+# commits) — matching seq-12's own convention (a nominal round-hour stamp,
+# not a measured instant) without repeating the "guessed forward" mistake.
+_SEQ13_CREATED_AT = "2026-08-23T13:00:00Z"
 _SEQ13_CREATED_BY = "agent.air-m5.backend-rag.visa-seq13-source-join.fold-2026-08-23"
 
 # Drift tripwire on the restamp batch size — same convention as seq-12's

--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py
@@ -587,6 +587,71 @@ def _apply_freshness(payload: dict[str, Any], seq12_source: dict[str, Any]) -> s
 # ---------------------------------------------------------------------------
 
 
+def _real_now_utc() -> datetime:
+    """The actual wall clock, read once per fold run — deliberately NOT
+    baked into the payload (``_SEQ13_CREATED_AT`` stays fixed for
+    determinism; see that constant's own comment). This is a VALIDATION
+    reference only, isolated into its own function so a test can
+    monkeypatch it without touching the stdlib.
+
+    A separate seam matters here specifically: ``_apply_freshness``'s
+    guard above checks every restamp against ``_SEQ13_CREATED_AT`` — but
+    both that guard's subject (the restamp) and its reference
+    (``_SEQ13_CREATED_AT``) live in files this fold's own author controls.
+    2026-08-23 (team-lead, after finding ``_SEQ13_CREATED_AT`` was
+    hardcoded 6h into the future and had sat that way through every
+    revision including a determinism-proved rebase re-run): "a check
+    whose reference is derived from its subject ... goes green by
+    construction, and the green is indistinguishable from the real
+    thing." Real wall-clock is a reference the author cannot pre-arrange
+    to agree with a wrong ``_SEQ13_CREATED_AT`` — which is the whole
+    point of adding it.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _assert_wall_clock_sanity(payload: dict[str, Any]) -> None:
+    """Independent of the `_apply_freshness` restamp-vs-`_SEQ13_CREATED_AT`
+    guard: that guard proves a restamp doesn't outrun this pack's own
+    declared clock, but cannot catch `_SEQ13_CREATED_AT` itself being
+    wrong, since both live in this one file. This function's reference —
+    real wall-clock via `_real_now_utc()` — is not something the fold's
+    author can get wrong in the same way a hardcoded constant can: it is
+    read fresh every run, not carried forward from whatever it was set to
+    when someone last edited this file.
+
+    Deliberately checks ALL 28 `source_records`' `verified_at`, not only
+    the 18 just-restamped ones — a non-restamped record's stamp is
+    inherited from seq-12 and already known-good, but "known-good" is
+    exactly the kind of claim this function exists to stop trusting
+    without checking.
+    """
+    real_now = _real_now_utc()
+
+    created_at_dt = _parse_utc(_SEQ13_CREATED_AT)
+    if created_at_dt > real_now:
+        raise FoldPackError(
+            f"this pack's own created_at {_SEQ13_CREATED_AT!r} is in the future "
+            f"relative to real wall-clock ({real_now.strftime(_UTC_FORMAT)}) — a "
+            "pack cannot declare it was created after it actually was. Fix "
+            "_SEQ13_CREATED_AT; do not silence this check."
+        )
+
+    for record in payload.get("source_records", []):
+        verified_at = record.get("verified_at")
+        if verified_at is None:
+            continue
+        verified_dt = _parse_utc(verified_at)
+        if verified_dt > real_now:
+            raise FoldPackError(
+                f"source_record {record.get('source_record_id')!r}: verified_at "
+                f"{verified_at!r} is in the future relative to real wall-clock "
+                f"({real_now.strftime(_UTC_FORMAT)}) — independent of the "
+                "_SEQ13_CREATED_AT-relative check in _apply_freshness, which "
+                "cannot catch _SEQ13_CREATED_AT itself being wrong"
+            )
+
+
 def _assert_untouched(
     payload: dict[str, Any], seq12: dict[str, Any], restamped_ids: set[str]
 ) -> None:
@@ -673,6 +738,7 @@ def assemble_payload() -> dict[str, Any]:
     _apply_identity(payload, seq12_original)
     _apply_rules(payload, seq12_original)
     restamped_ids = _apply_freshness(payload, seq12_original)
+    _assert_wall_clock_sanity(payload)
     _assert_untouched(payload, seq12_original, restamped_ids)
 
     try:

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.source.json
@@ -1,5 +1,5 @@
 {
-  "created_at": "2026-08-23T20:00:00Z",
+  "created_at": "2026-08-23T13:00:00Z",
   "created_by": "agent.air-m5.backend-rag.visa-seq13-source-join.fold-2026-08-23",
   "decision_domain": "IMMIGRATION_VISA",
   "engine_contract_version": "1.0.0",

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.source.json
@@ -1,0 +1,9005 @@
+{
+  "created_at": "2026-08-23T20:00:00Z",
+  "created_by": "agent.air-m5.backend-rag.visa-seq13-source-join.fold-2026-08-23",
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_contract_version": "1.0.0",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "environment": "PRODUCTION",
+  "hit_policy": {
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL",
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+  },
+  "jurisdiction": "ID",
+  "previous_payload_sha256": "ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d",
+  "rollback_of_payload_sha256": null,
+  "products": [
+    {
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "product_code": "E28A",
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 730,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 100,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Investor KITAS 2 Years (Offshore)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "product_code": "E28B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "product_code": "E28C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work", "corporate_establishment"],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "product_code": "E28D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "product_code": "E28F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "product_code": "E33",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33 Second Home (5 Years)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "product_code": "E33A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "product_code": "E33B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "product_code": "E33C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "product_code": "E33E",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Retirement (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "product_code": "E33F",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "product_code": "E33G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33G Remote Worker (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "product_code": "A1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "A1 Visa-Free Tourism"
+      },
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "product_code": "B1",
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa on Arrival — Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 30,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "B1 Visa on Arrival (VOA)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "product_code": "C1",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C1 Tourism"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "product_code": "C2",
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C2 Business"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "product_code": "C6",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": ["paid_employment", "business_meetings"],
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C6 Social Activity"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "product_code": "BRIDGING",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Bridging Visa — Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "category": "OTHER",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": null,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "Bridging Visa"
+      },
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "product_code": "E23",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "product_code": "E23U",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_non_diplomat_employer"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "product_code": "E23V",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_standard_corporate_employers"],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "product_code": "E31A",
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": [],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "product_code": "E31B",
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "product_code": "E31C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "product_code": "E31D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "product_code": "E31E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "product_code": "E31F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "product_code": "E31G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "product_code": "E31H",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "product_code": "E31J",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "product_code": "D1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Tourism — Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata — Beberapa Kali Perjalanan (D1)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "product_code": "D2",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Business — Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "product_code": "D12",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Pre-Investment — Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 180,
+        "maximum_days": 180
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 180,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "product_code": "E30",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "product_code": "E30A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30A Education Visa (1 Year)"
+      },
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "product_code": "E30B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 1460
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30B Higher Education (1 Year)"
+      },
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "product_code": "E30E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "product_code": "E30F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hf.citizen",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.calling-visa",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.active-overstay",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.a1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.b1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "el.c1.tourism-family",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "rule_id": "el.c2.business",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "el.c6.social",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.investment_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "el.e28a.investment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "rule_id": "el.e33.deposit-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-qualification",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.guarantee-maintenance",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "any",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33a.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "review.e33b.expertise-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "review.e33c.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "hf.e33e.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.age-55-59-disputed-band",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "between",
+                "fact": "derived.age_years",
+                "lower": 55,
+                "upper": 59
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "gte",
+                "fact": "derived.age_years",
+                "value": 55
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 50000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.passive_monthly_income_usd",
+                "value": 3000
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY", "RETIREMENT", "SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "hf.e33f.sponsor-required",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["family.sponsor_confirmed"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "el.e33f.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-employer",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.indonesia_source_compensation"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-market",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-company-ownership",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e33g.remote-work",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.bridging.offshore",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.from-visit-itk",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.to-bridging",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.t3-window-manual",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.overstay-shield-payment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.source-status-verify",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_code"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.adverse-history",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.destination-stated",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.e23-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.employer_is_indonesian_entity",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e23-operational-work-boundary",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "investment.proposed_role",
+                "op": "in",
+                "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "work.employer_is_indonesian_entity",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "work.indonesian_work_sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.proposed_role",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e31a-spouse-wni-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-funds-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_FUNDS_2000",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-spousal-work-article-61",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-spousal-work-article-61",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-kitap-prerequisites",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "process.wants_onshore_conversion",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes",
+        "process.wants_onshore_conversion"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-kitap-prerequisites",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31b-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31c-mixed-marriage-parents",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31d-stepchild-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-step-parent-relation",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_STEP_PARENT_RELATION",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-step-parent-relation",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-sponsor-mixed-marriage",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hf.e31e-adult-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "derived.age_years",
+        "op": "gte",
+        "value": 18
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hf.e31e-married-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "person.marital_status",
+        "op": "neq",
+        "value": "SINGLE"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.marital_status"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+      ],
+      "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31f-adult-age-review",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+      ],
+      "explanation_key": "explain.el.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31h-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-dependency-age",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.d1-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D1",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d2-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D2",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d12-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-funds-usd-5000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D12",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.e30-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+      ]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.e30a-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["PRIMARY", "SECONDARY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hf.e30b-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30b-izin-belajar",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.b1.not-voa-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "review.citizenship-conflict",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.minor-without-guardian",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-09T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "derived.is_minor",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.review.minor-without-guardian",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.e33f.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33f.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "review.e33g.income-evidence",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_INCOME_EVIDENCE_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.review.e33g.income-evidence",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e30e-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "values": ["EDUCATION", "INDIVIDUAL"],
+            "op": "in"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e30e-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "rule_id": "el.e30f-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "value": "EDUCATION",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30f-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "rule_id": "hf.e33a.sponsor-not-government",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "value": "GOVERNMENT",
+        "op": "neq"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33a.sponsor-not-government",
+      "safety_critical": true,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "hf.e33b.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "hf.e33c.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "review.e23u.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23U",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23u.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "review.e23v.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23V",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23v.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hf.e31c-marriage-not-registered",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["FAMILY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT",
+            "op": "eq"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "value": false,
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-marriage-not-registered",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "hf.e31c-sponsor-not-indonesian",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-23T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["FAMILY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT",
+            "op": "eq"
+          },
+          {
+            "op": "not",
+            "arg": {
+              "fact": "family.sponsor_nationalities",
+              "values": ["ID"],
+              "op": "intersects"
+            }
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    }
+  ],
+  "rule_pack_id": "79b62b85-829e-59f8-a058-c38c065b8cb5",
+  "sequence": 13,
+  "version": "2026.8.23",
+  "valid_period": {
+    "from": "2026-07-25T00:00:00Z",
+    "to": null
+  },
+  "source_records": [
+    {
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Kepmen M.IP-08.GR.01.01/2025 — Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "language": "id",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 — Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "language": "id",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 39"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 40"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 57"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 58"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 59"
+        }
+      ],
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 10/2026 — Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "language": "id",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "locators": [],
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "legal_period": {
+        "from": "2026-07-09T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian — kewarganegaraan dan ketentuan overstay",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "language": "id",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "locators": [],
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Calling Visa — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 — Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "legal_period": {
+        "from": "2024-04-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 5/2025 — Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "language": "id",
+      "document_number": "Permen Imipas 5/2025",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "legal_period": {
+        "from": "2025-02-07T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Layanan Alih Status — Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "language": "id",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "language": "id",
+      "document_number": "22/2023",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33"
+        }
+      ],
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "legal_period": {
+        "from": "2023-08-22T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "language": "id",
+      "document_number": "11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+      "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Pasal 60 ayat (2) dan Pasal 61",
+      "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+      "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 60 ayat (2)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-10T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-10T00:00:00Z",
+      "verified_at": "2026-08-10T00:00:00Z",
+      "verified_by": "agent.air-m5.visa-seq6-semantics",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Bisnis (D2) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Pra-Investasi (D12) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Tinggi (E30B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "version": 1,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-08T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "verified_at": "2026-08-23T10:44:48Z",
+      "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    }
+  ]
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_cure_forward_guard.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_cure_forward_guard.py
@@ -272,6 +272,49 @@ class TestHardFilterShape:
         assert ("family.relation_to_sponsor", "eq", "PARENT") in conjuncts
 
 
+# =============================================================================
+# CURED (was: KNOWN-OPEN GAP) — E31C's nationality leg. Closed by PR #4660
+# (seq-13 rules-only fold, merged 2026-08-23): `el.e31c-child-mixed-
+# marriage-support` gained a `family.sponsor_nationalities intersects
+# [ID]` conjunct, and a paired `hf.e31c-sponsor-not-indonesian` HARD_FILTER
+# was inserted. Confirmed deliberate against PR #4660's own body (FIX 1)
+# before this section was rewritten — this is the exact migration the
+# banner that used to live here scripted in advance (see git history on
+# this file, or `test_cure_forward_guard.py` in PR #4667, for the four-step
+# instructions this rewrite followed). What used to be a KNOWN-OPEN pin is
+# now `TestNationalityGapCuredShape` (structural, grouped with the other
+# structural classes above) and `TestNationalityGapCuredWitnesses`
+# (behavioural, grouped with `TestE31CForwardWitnesses` below).
+# =============================================================================
+
+_NATIONALITY_GAP_RULE_ID = "el.e31c-child-mixed-marriage-support"
+_NATIONALITY_GAP_CURED_CONJUNCTS = frozenset(
+    {
+        ("intent.purposes", "intersects", ("FAMILY",)),
+        ("family.relation_to_sponsor", "eq", "PARENT"),
+        ("family.sponsor_nationalities", "intersects", ("ID",)),
+    }
+)
+
+
+class TestNationalityGapCuredShape:
+    """Structural half of the cure (mirrors `TestE31CSupportRuleShape` /
+    `TestHardFilterShape` above) — pins `el.e31c-child-mixed-marriage-
+    support`'s new 3-conjunct shape now that PR #4660 closed the
+    nationality leg. If this goes red, the rule's conjuncts drifted from
+    the shape the cure shipped; re-derive from the real pack, do not
+    just widen the assertion."""
+
+    def test_present_with_exact_three_conjuncts(self, highest_source: dict[str, Any]) -> None:
+        rule = _find_rule(highest_source["rules"], _NATIONALITY_GAP_RULE_ID)
+        assert _conjuncts(rule["when"]) == _NATIONALITY_GAP_CURED_CONJUNCTS
+
+    def test_stage_and_effect(self, highest_source: dict[str, Any]) -> None:
+        rule = _find_rule(highest_source["rules"], _NATIONALITY_GAP_RULE_ID)
+        assert rule["stage"] == "ELIGIBILITY"
+        assert rule["effect"]["type"] == "SUPPORT"
+
+
 # ---------------------------------------------------------------------------
 # positive control — prove the semantic checker is not vacuous
 # ---------------------------------------------------------------------------
@@ -413,6 +456,59 @@ class TestE31CForwardWitnesses:
         assert FactPath.FAMILY_MARRIAGE_REGISTERED not in proof.missing_facts
 
 
+class TestNationalityGapCuredWitnesses:
+    """Behavioural half of the cure (mirrors `TestE31CForwardWitnesses`
+    above), driven against the real evaluator on the highest pack. Sponsor
+    nationality is the discriminator: US (no Indonesian nationality
+    anywhere) must no longer reach SUPPORTED via
+    `el.e31c-child-mixed-marriage-support`; ID must still reach it, and
+    must ALSO still fire the properly-scoped sibling
+    `el.e31c-mixed-marriage-parents` (the discrimination control that used
+    to live in the deleted `TestE31CNationalityGapKnownOpen` class — kept
+    here because it still proves the fix targets nationality specifically,
+    not "E31C always excluded now")."""
+
+    def test_us_nationality_no_longer_reaches_supported_via_this_rule(
+        self, highest_compiled: compiler.CompiledRulePack
+    ) -> None:
+        """Cured direction. Marriage IS registered — the registration
+        leg's cure (hf.e31c-marriage-not-registered) does not fire here,
+        because that HARD_FILTER only excludes on
+        `marriage_registered eq False`. This is the nationality leg
+        specifically, not a retest of the registration cure above."""
+        overrides = {
+            "intent.purposes": _known(["FAMILY"]),
+            "family.relation_to_sponsor": _known("PARENT"),
+            "family.sponsor_nationalities": _known(["US"]),
+            "family.marriage_registered": _known(True),
+        }
+        proof = _proof(highest_compiled, "E31C", overrides)
+        assert _NATIONALITY_GAP_RULE_ID not in {r.rule_id for r in proof.support_rules}
+        assert proof.status is not ProductProofStatus.SUPPORTED
+
+    def test_indonesian_nationality_control_fires_both_sibling_rules(
+        self, highest_compiled: compiler.CompiledRulePack
+    ) -> None:
+        """Discrimination control: the SAME fact pattern but with an
+        Indonesian sponsor nationality reaches SUPPORTED via BOTH sibling
+        rules — the properly-scoped `el.e31c-mixed-marriage-parents` fires
+        too. Proves the fix above is not simply "E31C never SUPPORTED
+        regardless of facts": it specifically requires ID nationality on
+        both the previously nationality-blind sibling and the always-
+        scoped one."""
+        overrides = {
+            "intent.purposes": _known(["FAMILY"]),
+            "family.relation_to_sponsor": _known("PARENT"),
+            "family.sponsor_nationalities": _known(["ID"]),
+            "family.marriage_registered": _known(True),
+        }
+        proof = _proof(highest_compiled, "E31C", overrides)
+        assert proof.status is ProductProofStatus.SUPPORTED
+        support_rule_ids = {r.rule_id for r in proof.support_rules}
+        assert _NATIONALITY_GAP_RULE_ID in support_rule_ids
+        assert _EDITED_RULE_ID in support_rule_ids
+
+
 def _write_temp_pack(source: dict[str, Any]) -> Path:
     """Writes ``source`` to a fresh temp file and returns its path — the
     ONLY way ``load_rule_pack_payload``/``_compiled_from_path`` can build a
@@ -425,152 +521,15 @@ def _write_temp_pack(source: dict[str, Any]) -> Path:
     return Path(name)
 
 
-# =============================================================================
-# KNOWN-OPEN GAP — E31C's nationality leg is UNENFORCED (a PIN, NOT an
-# endorsement). Everything above this banner asserts the CURE (the
-# registration leg, closed seq-10, enforced fail-closed by
-# hf.e31c-marriage-not-registered). Everything below pins a DIFFERENT,
-# still-open defect in a THIRD rule scoped to the same E31C
-# product_version_id — kept in its own section, its own class names, and
-# its own docstrings so nobody mistakes a passing pin for a clean bill of
-# health.
-# =============================================================================
-#
-# E31C ("Child of Legal Mixed Marriage") exists because ONE parent is
-# Indonesian. `el.e31c-child-mixed-marriage-support` (ELIGIBILITY/SUPPORT,
-# same product_version_id as the two cured rules above) has only 2
-# conjuncts — `intent.purposes intersects [FAMILY]` and
-# `family.relation_to_sponsor eq PARENT` — no nationality conjunct, no
-# marriage conjunct. Because the evaluator's ELIGIBILITY hit-policy is
-# `COVER_ALL_DECLARED_PURPOSES` (models.py, OR-like: ANY firing SUPPORT
-# rule is sufficient for that purpose), this sibling alone is enough to
-# reach SUPPORTED — the properly-scoped `el.e31c-mixed-marriage-parents`
-# (4 conjuncts, including the nationality check) never gets a chance to
-# shield the applicant, because nothing requires it to also fail.
-# Empirically confirmed against the REAL evaluator on the real seq-12
-# payload: a FAMILY+PARENT applicant with sponsor nationality ["US"]
-# (no Indonesian nationality anywhere) and a REGISTERED marriage reaches
-# SUPPORTED via `el.e31c-child-mixed-marriage-support` alone. Pre-existing
-# since seq-9; seq-10's cure closed the REGISTRATION leg only.
-#
-# IF THE TEST BELOW STARTS FAILING: that is GOOD NEWS, not a regression.
-# It means a future pack finally added a nationality (or equivalent) gate
-# to `el.e31c-child-mixed-marriage-support` (or retired/rescoped it), and
-# the US-nationality fact pattern no longer reaches SUPPORTED via that
-# rule alone. When that happens:
-#   1. Confirm it was DELIBERATE — check the fold's own PR/doctrine note
-#      for an intentional nationality-leg cure, not an accidental rule
-#      deletion or an unrelated evaluator change.
-#   2. DELETE this class — the gap it pins no longer exists.
-#   3. ADD a witness next to `TestE31CForwardWitnesses` above, asserting
-#      the CURED behavior (US-nationality FAMILY+PARENT no longer
-#      SUPPORTED via this rule — EXCLUDED/BLOCKED_UNKNOWN/UNSUPPORTED per
-#      whatever the cure's own design intends).
-#   4. ADD a structural check (mirroring `TestHardFilterShape` /
-#      `TestE31CSupportRuleShape` above) pinning the cured rule's new
-#      conjunct shape, the same way `TestE31CSupportRuleShape` pins
-#      `el.e31c-mixed-marriage-parents` today.
-# Do NOT simply widen or delete the assertion to make it pass again —
-# that would silently re-open exactly the gap this class exists to keep
-# visible. This is the same registration-leg transition the mandate
-# originally wanted for c2/e31c, applied forward to the nationality leg.
-
-_NATIONALITY_GAP_RULE_ID = "el.e31c-child-mixed-marriage-support"
-_NATIONALITY_GAP_CONJUNCTS = frozenset(
-    {
-        ("intent.purposes", "intersects", ("FAMILY",)),
-        ("family.relation_to_sponsor", "eq", "PARENT"),
-    }
-)
-
-
-class TestE31CNationalityGapKnownOpen:
-    """PIN of a known-open defect — see the module-level banner comment
-    directly above for the full mechanism, the evidence, and (most
-    importantly) the exact instructions for what to do when this class
-    starts failing. House pattern: `_KNOWN_PRE_EXISTING_LINT_RESIDUALS` in
-    `test_pack_chain_and_pricing.py` — a test that asserts the CURRENT,
-    DEFECTIVE reality so the gap is executable, not a comment someone can
-    miss."""
-
-    def test_gap_rule_has_exactly_two_conjuncts_no_nationality_no_marriage(
-        self, highest_source: dict[str, Any]
-    ) -> None:
-        """Structural half. If a future fold adds a nationality or
-        marriage conjunct to this rule, this goes red FIRST — before
-        anyone even has to drive the evaluator."""
-        rule = _find_rule(highest_source["rules"], _NATIONALITY_GAP_RULE_ID)
-        assert _conjuncts(rule["when"]) == _NATIONALITY_GAP_CONJUNCTS
-        assert rule["stage"] == "ELIGIBILITY"
-        assert rule["effect"]["type"] == "SUPPORT"
-
-    def test_foreign_foreign_parent_with_registered_marriage_still_reaches_supported(
-        self, highest_compiled: compiler.CompiledRulePack
-    ) -> None:
-        """Behavioural half, driven against the real evaluator. Sponsor
-        nationality is US (no Indonesian nationality anywhere in the fact
-        pattern), marriage IS registered — the registration leg's cure
-        (hf.e31c-marriage-not-registered) does not fire here, because that
-        HARD_FILTER only excludes on `marriage_registered eq False`. This
-        is the nationality leg specifically, not a retest of the
-        registration cure above."""
-        overrides = {
-            "intent.purposes": _known(["FAMILY"]),
-            "family.relation_to_sponsor": _known("PARENT"),
-            "family.sponsor_nationalities": _known(["US"]),
-            "family.marriage_registered": _known(True),
-        }
-        proof = _proof(highest_compiled, "E31C", overrides)
-        assert proof.status is ProductProofStatus.SUPPORTED, (
-            "KNOWN-OPEN GAP PIN: a red here may mean the E31C nationality "
-            "leg was CURED — read the banner above "
-            "TestE31CNationalityGapKnownOpen before touching this assertion."
-        )
-        # Membership, not equality (Kimi K3 refuter finding, 2026-08-23):
-        # the pinned defect is "the gap rule fires on a US-nationality fact
-        # pattern", not "the gap rule is the ONLY support rule that fires".
-        # A future fold that adds a legitimately-scoped support rule (e.g.
-        # one requiring `marriage_registered eq True`) would fire here too
-        # and turn a set-equality assertion red while the nationality gap
-        # is still open — a false red on a pin whose own banner says do
-        # NOT simply widen or delete the assertion.
-        assert _NATIONALITY_GAP_RULE_ID in {r.rule_id for r in proof.support_rules}
-
-    def test_indonesian_nationality_control_fires_both_sibling_rules(
-        self, highest_compiled: compiler.CompiledRulePack
-    ) -> None:
-        """Discrimination control: the SAME fact pattern but with an
-        Indonesian sponsor nationality reaches SUPPORTED via BOTH sibling
-        rules — the properly-scoped `el.e31c-mixed-marriage-parents` fires
-        too. Proves the gap test above is not simply "E31C always
-        SUPPORTED regardless of facts": it is specifically that the
-        nationality-blind sibling fires alone on a fact pattern the
-        properly-scoped rule would reject outright (no ID nationality)."""
-        overrides = {
-            "intent.purposes": _known(["FAMILY"]),
-            "family.relation_to_sponsor": _known("PARENT"),
-            "family.sponsor_nationalities": _known(["ID"]),
-            "family.marriage_registered": _known(True),
-        }
-        proof = _proof(highest_compiled, "E31C", overrides)
-        assert proof.status is ProductProofStatus.SUPPORTED
-        # Membership, not equality — same rationale as the US-nationality
-        # case above: this must not go red merely because a future,
-        # legitimately-scoped support rule also fires on this pattern.
-        support_rule_ids = {r.rule_id for r in proof.support_rules}
-        assert _NATIONALITY_GAP_RULE_ID in support_rule_ids
-        assert _EDITED_RULE_ID in support_rule_ids
-
-
 class TestNationalityGapPinIsNotVacuous:
     """Positive control (same discipline as `TestConjunctCheckerIsNotVacuous`
-    above): proves the pin in `TestE31CNationalityGapKnownOpen` is actually
-    discriminating on `el.e31c-child-mixed-marriage-support`'s presence —
-    not asserting something that would be true of E31C regardless.
-    Operates on a TEMP COPY of the highest pack (`_write_temp_pack`) —
-    never a file on disk. Answers "what would make the pin fail?":
-    removing (or properly scoping) this one rule does, and this test
-    proves it does, right now, against the real evaluator."""
+    above): proves `el.e31c-child-mixed-marriage-support`'s presence is
+    what makes a mismatched-nationality applicant fail to reach SUPPORTED
+    via this rule — not asserting something that would be true of E31C
+    regardless. Operates on a TEMP COPY of the highest pack
+    (`_write_temp_pack`) — never a file on disk. Answers "what would make
+    this rule's contribution to E31C fail?": removing it does, and this
+    test proves it does, right now, against the real evaluator."""
 
     def test_removing_the_gap_rule_flips_the_us_case_to_unsupported(
         self, highest_source: dict[str, Any]

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
@@ -1,0 +1,545 @@
+"""seq-13 JOIN — gates for the assembled ``rulepack-prod-013.source.json``
+(see ``backend.scripts.visa_engine.fold_pack_seq13_source``).
+
+This module SKIPS cleanly (not error, not red) unless BOTH of this fold's
+inputs exist on disk: ``rulepack-prod-013.rules-only.json`` (PR #4660,
+``fold_pack_seq13_rules.py``) and the s13-fresh lane's freshness restamp
+JSON. Neither is guaranteed to be present in every checkout of this
+branch — the rules-only half ships in a separate, independently-armed PR,
+and the freshness half is a research capture from a third lane. An absent
+input here is a legitimate pre-join state, not a defect (contrast
+``test_seq12_pack.py``, which does NOT skip: seq-12 ships its pack in the
+same PR as its single-source fold).
+
+Checks, each verified against the real files on disk or a fresh
+``assemble_payload()`` call — never eyeballed:
+
+(a) chain gate — ``previous_payload_sha256`` equals the RECOMPUTED
+    SHA256(JCS(...)) of seq-12's own SIGNED payload declaration, itself
+    cross-checked against a fresh re-hash of the seq-12 SOURCE bytes.
+    identity — ``sequence == 13``, ``rule_pack_id`` matches the uuid5
+    convention recomputed in-test (never imported from the fold module as
+    a trusted constant).
+(b) complement-of-the-rules-fold — ``rules`` in the combined pack equals
+    the rules-only artifact's ``rules`` byte-for-byte, and everything
+    OUTSIDE ``rules`` in the rules-only artifact equals seq-12
+    byte-for-byte (the rules lane kept its own promise); the freshness
+    input carries no ``rules``/``products`` key at all.
+(c) restamp parity — exactly 18 source_records differ from seq-12, each
+    ONLY in ``verified_at``/``verified_by``; the restamped set is exactly
+    the OFFICIAL_PORTAL set (entity, not a frozen id list); every restamp
+    advances the clock past what the freshness input declares as the
+    PRIOR value, cross-checked against seq-12's actual bytes (ledger
+    drift); no restamp is timestamped after the pack's own
+    ``created_at``; ``content_sha256`` is byte-identical on all 28
+    records.
+(d) byte-invariance — products and the 10 non-restamped source_records
+    are fully identical to seq-12; every top-level key outside the
+    identity set is identical.
+(e) regeneration parity — the disk file is canonically identical to what
+    ``fold_pack_seq13_source.assemble_payload()`` produces right now, and
+    calling it twice in a row is canonically identical (idempotence).
+(f) guard mutation tests — for each hard guard in the fold, a
+    deliberately-broken input is shown to raise ``FoldPackError`` with
+    the module's OWN (re-imported, not re-implemented) machinery, proving
+    the guard is reachable and not vacuously green. Also covers the
+    identical-timestamp NOTE: fires on a batch with fewer distinct stamps
+    than records, does not fire once every record's stamp is distinct.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.services.visa_engine.bundle import canonicalize_json
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_PACKS_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "backend-rag"
+    / "backend"
+    / "services"
+    / "visa_engine"
+    / "contracts"
+    / "packs"
+)
+_SEQ12_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-012.source.json"
+_SEQ12_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-012.signed.json"
+_SEQ13_RULES_ONLY_PATH = _PACKS_DIR / "rulepack-prod-013.rules-only.json"
+_SEQ13_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-013.source.json"
+_FRESHNESS_INPUT_PATH = (
+    _REPO_ROOT / "research" / "visa" / "2026-08-23-seq13-restamp-source-records.json"
+)
+
+_EXPECTED_RESTAMP_COUNT = 18
+_PORTAL_AUTHORITY_TYPE = "OFFICIAL_PORTAL"
+_RESTAMP_FIELDS = frozenset({"verified_at", "verified_by"})
+_IDENTITY_KEYS = frozenset(
+    {"sequence", "version", "rule_pack_id", "previous_payload_sha256", "created_at", "created_by"}
+)
+
+pytestmark = pytest.mark.skipif(
+    not (_SEQ13_RULES_ONLY_PATH.exists() and _FRESHNESS_INPUT_PATH.exists()),
+    reason=(
+        "seq-13 join needs BOTH rulepack-prod-013.rules-only.json (PR #4660) and "
+        "the s13-fresh freshness restamp JSON on disk — at least one is missing. "
+        "This module SKIPS, not reds, until both land."
+    ),
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _differs_only_in_restamp_fields(baseline: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    b = {k: v for k, v in baseline.items() if k not in _RESTAMP_FIELDS}
+    c = {k: v for k, v in candidate.items() if k not in _RESTAMP_FIELDS}
+    return _canon(b) == _canon(c)
+
+
+@pytest.fixture(scope="module")
+def seq12_source() -> dict[str, Any]:
+    return _read_json(_SEQ12_SOURCE_PATH)
+
+
+@pytest.fixture(scope="module")
+def rules_only() -> dict[str, Any]:
+    return _read_json(_SEQ13_RULES_ONLY_PATH)
+
+
+@pytest.fixture(scope="module")
+def freshness_input() -> dict[str, Any]:
+    return _read_json(_FRESHNESS_INPUT_PATH)
+
+
+@pytest.fixture(scope="module")
+def seq13_source() -> dict[str, Any]:
+    return _read_json(_SEQ13_SOURCE_PATH)
+
+
+# ---------------------------------------------------------------------------
+# (a) chain + identity
+# ---------------------------------------------------------------------------
+
+
+class TestChainGate:
+    def test_pack_file_exists(self) -> None:
+        assert _SEQ13_SOURCE_PATH.exists(), (
+            "rulepack-prod-013.source.json is missing — run "
+            "`PYTHONPATH=. python -m backend.scripts.visa_engine.fold_pack_seq13_source` "
+            "once both inputs are present"
+        )
+
+    def test_previous_payload_sha256_chains_to_recomputed_seq12(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        recomputed = hashlib.sha256(canonicalize_json(seq12_source)).hexdigest()
+        seq12_signed = _read_json(_SEQ12_SIGNED_PATH)
+        assert recomputed == seq12_signed["payload_sha256"]
+        assert seq13_source["previous_payload_sha256"] == recomputed
+
+    def test_sequence_is_13(self, seq13_source: dict[str, Any]) -> None:
+        assert seq13_source["sequence"] == 13
+
+    def test_rule_pack_id_matches_uuid5_convention(self, seq13_source: dict[str, Any]) -> None:
+        expected = uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/13",
+        )
+        assert seq13_source["rule_pack_id"] == str(expected)
+
+
+# ---------------------------------------------------------------------------
+# (b) complement-of-the-rules-fold
+# ---------------------------------------------------------------------------
+
+
+class TestComplementOfRulesFold:
+    def test_rules_taken_wholesale_from_rules_only(
+        self, rules_only: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        assert _canon(seq13_source["rules"]) == _canon(rules_only["rules"])
+
+    def test_rules_only_non_rules_content_matches_seq12(
+        self, seq12_source: dict[str, Any], rules_only: dict[str, Any]
+    ) -> None:
+        for key in set(seq12_source) | set(rules_only):
+            if key in _IDENTITY_KEYS or key == "rules":
+                continue
+            assert _canon(rules_only.get(key)) == _canon(seq12_source.get(key)), (
+                f"rules-only artifact's {key!r} drifted from seq-12 — the rules lane "
+                "broke its own contract"
+            )
+        for key in _IDENTITY_KEYS:
+            assert rules_only[key] == seq12_source[key], (
+                f"rules-only artifact's {key!r} differs from seq-12's own value — "
+                "identity is not the rules lane's to change"
+            )
+
+    def test_freshness_input_carries_no_rule_or_product_key(
+        self, freshness_input: dict[str, Any]
+    ) -> None:
+        assert "rules" not in freshness_input
+        assert "products" not in freshness_input
+
+
+# ---------------------------------------------------------------------------
+# (c) restamp parity
+# ---------------------------------------------------------------------------
+
+
+class TestRestampParity:
+    def test_exactly_18_records_differ_and_only_in_restamp_fields(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        seq12_by_id = {r["source_record_id"]: r for r in seq12_source["source_records"]}
+        changed = []
+        illegal = []
+        for record in seq13_source["source_records"]:
+            baseline = seq12_by_id[record["source_record_id"]]
+            if _canon(record) == _canon(baseline):
+                continue
+            changed.append(record["source_record_id"])
+            if not _differs_only_in_restamp_fields(baseline, record):
+                illegal.append(record["source_record_id"])
+        assert len(changed) == _EXPECTED_RESTAMP_COUNT
+        assert illegal == []
+
+    def test_restamped_set_is_exactly_the_official_portal_set(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        seq12_by_id = {r["source_record_id"]: r for r in seq12_source["source_records"]}
+        changed = {
+            r["source_record_id"]
+            for r in seq13_source["source_records"]
+            if _canon(r) != _canon(seq12_by_id[r["source_record_id"]])
+        }
+        portal = {
+            r["source_record_id"]
+            for r in seq13_source["source_records"]
+            if r.get("authority_type") == _PORTAL_AUTHORITY_TYPE
+        }
+        assert changed == portal
+        assert len(portal) == _EXPECTED_RESTAMP_COUNT
+
+    def test_every_restamp_advances_past_freshness_declared_prior(
+        self, seq13_source: dict[str, Any], freshness_input: dict[str, Any]
+    ) -> None:
+        seq13_by_id = {r["source_record_id"]: r for r in seq13_source["source_records"]}
+        for fr in freshness_input["restamped_source_records"]:
+            sid = fr["source_record_id"]
+            pack_record = seq13_by_id[sid]
+            assert pack_record["verified_at"] == fr["verified_at"]
+            assert pack_record["verified_by"] == fr["verified_by"]
+            assert fr["verified_at"] > fr["_prior_verified_at"], (
+                f"{sid!r}: freshness input's own declared new/prior stamps do not advance"
+            )
+
+    def test_no_restamp_is_after_pack_created_at(self, seq13_source: dict[str, Any]) -> None:
+        created_at = seq13_source["created_at"]
+        for record in seq13_source["source_records"]:
+            if record.get("authority_type") != _PORTAL_AUTHORITY_TYPE:
+                continue
+            assert record["verified_at"] <= created_at, (
+                f"{record['source_record_id']!r}: verified_at {record['verified_at']!r} "
+                f"is after the pack's own created_at {created_at!r}"
+            )
+
+    def test_content_sha256_untouched_on_all_records(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        seq12_by_id = {r["source_record_id"]: r for r in seq12_source["source_records"]}
+        drifted = []
+        for record in seq13_source["source_records"]:
+            baseline = seq12_by_id[record["source_record_id"]]
+            if record.get("content_sha256") != baseline.get("content_sha256"):
+                drifted.append(record["source_record_id"])
+        assert len(seq13_source["source_records"]) == len(seq12_source["source_records"])
+        assert drifted == []
+
+
+# ---------------------------------------------------------------------------
+# (d) byte-invariance — products, non-restamped records, top-level keys
+# ---------------------------------------------------------------------------
+
+
+class TestByteInvariance:
+    def test_products_canonically_identical_to_seq12(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        assert len(seq13_source["products"]) == len(seq12_source["products"])
+        assert _canon(seq13_source["products"]) == _canon(seq12_source["products"])
+
+    def test_source_record_set_unchanged(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        seq12_ids = {r["source_record_id"] for r in seq12_source["source_records"]}
+        seq13_ids = {r["source_record_id"] for r in seq13_source["source_records"]}
+        assert seq12_ids == seq13_ids
+        assert len(seq13_source["source_records"]) == len(seq12_source["source_records"])
+
+    def test_non_restamped_records_fully_identical(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any], freshness_input: dict[str, Any]
+    ) -> None:
+        restamped_ids = {r["source_record_id"] for r in freshness_input["restamped_source_records"]}
+        seq12_by_id = {r["source_record_id"]: r for r in seq12_source["source_records"]}
+        drifted = []
+        checked = 0
+        for record in seq13_source["source_records"]:
+            if record["source_record_id"] in restamped_ids:
+                continue
+            checked += 1
+            if _canon(record) != _canon(seq12_by_id[record["source_record_id"]]):
+                drifted.append(record["source_record_id"])
+        assert checked == len(seq13_source["source_records"]) - _EXPECTED_RESTAMP_COUNT
+        assert drifted == []
+
+    def test_top_level_keys_other_than_identity_unchanged(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        for key in set(seq12_source) | set(seq13_source):
+            if key in _IDENTITY_KEYS or key in ("rules", "source_records"):
+                continue
+            assert _canon(seq13_source.get(key)) == _canon(seq12_source.get(key)), (
+                f"top-level key {key!r} drifted from seq-12"
+            )
+
+
+# ---------------------------------------------------------------------------
+# (e) regeneration parity + idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerationParity:
+    def test_disk_pack_equals_freshly_assembled_payload(self, seq13_source: dict[str, Any]) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source
+
+        regenerated = fold_pack_seq13_source.assemble_payload()
+        assert (
+            hashlib.sha256(canonicalize_json(regenerated)).hexdigest()
+            == hashlib.sha256(canonicalize_json(seq13_source)).hexdigest()
+        )
+
+    def test_two_consecutive_runs_are_byte_identical(self) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source
+
+        first = fold_pack_seq13_source.assemble_payload()
+        second = fold_pack_seq13_source.assemble_payload()
+        assert canonicalize_json(first) == canonicalize_json(second)
+
+
+# ---------------------------------------------------------------------------
+# (f) guard mutation tests — red-then-green on each hard guard, using the
+# module's OWN functions (never a reimplementation) against deliberately
+# broken in-memory copies of the real inputs.
+# ---------------------------------------------------------------------------
+
+
+class TestGuardsFireOnMutation:
+    def test_chain_hash_guard_fires_on_wrong_expected_anchor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        monkeypatch.setattr(m, "_EXPECTED_SEQ12_PAYLOAD_SHA256", "0" * 64)
+        with pytest.raises(m.FoldPackError, match="the signed seq-12 on disk is not"):
+            m.assemble_payload()
+
+    def test_rule_pack_id_guard_fires_on_wrong_expected_uuid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        monkeypatch.setattr(m, "_EXPECTED_SEQ13_RULE_PACK_ID", uuid.uuid4())
+        with pytest.raises(m.FoldPackError, match="rule_pack_id convention drifted"):
+            m.assemble_payload()
+
+    def test_rules_only_identity_drift_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, rules_only: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(rules_only)
+        mutated["created_by"] = "someone.who.should.not.touch.identity"
+        bad_path = tmp_path / "rulepack-prod-013.rules-only.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_SEQ13_RULES_ONLY", bad_path)
+        with pytest.raises(m.FoldPackError, match="declares no identity change"):
+            m.assemble_payload()
+
+    def test_rules_only_products_drift_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, rules_only: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(rules_only)
+        mutated["products"] = list(mutated["products"])[:-1]  # drop one product
+        bad_path = tmp_path / "rulepack-prod-013.rules-only.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_SEQ13_RULES_ONLY", bad_path)
+        with pytest.raises(m.FoldPackError, match="owns neither products nor source_records"):
+            m.assemble_payload()
+
+    def test_freshness_forbidden_key_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["products"] = []
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match="owns only source_records"):
+            m.assemble_payload()
+
+    def test_freshness_wrong_record_count_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamped_source_records"] = mutated["restamped_source_records"][:-1]
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match=f"expected exactly {_EXPECTED_RESTAMP_COUNT} restamps"):
+            m.assemble_payload()
+
+    def test_freshness_ledger_drift_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamped_source_records"][0]["_prior_verified_at"] = "2099-01-01T00:00:00Z"
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match="ledger drift"):
+            m.assemble_payload()
+
+    def test_freshness_content_drift_guard_fires_on_content_sha256_change(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamped_source_records"][0]["content_sha256"] = "f" * 64
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match="changed beyond verified_at/verified_by"):
+            m.assemble_payload()
+
+    def test_freshness_backward_stamp_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        rec = mutated["restamped_source_records"][0]
+        rec["verified_at"] = rec["_prior_verified_at"]  # holds time still
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match="does not advance past the prior"):
+            m.assemble_payload()
+
+    def test_freshness_future_stamp_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamped_source_records"][0]["verified_at"] = "2099-01-01T00:00:00Z"
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match="is after this pack's own created_at"):
+            m.assemble_payload()
+
+    def test_freshness_entity_mismatch_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamped_source_records"] = mutated["restamped_source_records"][1:]
+        extra = copy.deepcopy(freshness_input["restamped_source_records"][0])
+        extra["source_record_id"] = str(uuid.uuid4())
+        extra["_prior_verified_at"] = "2020-01-01T00:00:00Z"
+        extra["_prior_verified_by"] = "nobody"
+        mutated["restamped_source_records"].append(extra)
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        with pytest.raises(m.FoldPackError, match="not exactly the OFFICIAL_PORTAL set"):
+            m.assemble_payload()
+
+    def test_missing_rules_only_input_raises_clear_error_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        monkeypatch.setattr(m, "_SEQ13_RULES_ONLY", tmp_path / "does-not-exist.json")
+        with pytest.raises(m.FoldPackError, match="not found at"):
+            m.assemble_payload()
+
+    def test_missing_freshness_input_raises_clear_error_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", tmp_path / "does-not-exist.json")
+        with pytest.raises(m.FoldPackError, match="not found at"):
+            m.assemble_payload()
+
+
+class TestIdenticalTimestampNote:
+    """The identical-timestamp shape is FLAGGED, not rejected (see the
+    fold module's docstring for the reasoning). These prove the flag is
+    reachable (fires on the real, current batch of 18 identical stamps)
+    and precise (does NOT fire once every stamp in the batch is made
+    distinct) — a guard never exercised in both directions is not
+    verified."""
+
+    def test_note_fires_on_the_real_identical_batch(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        m.assemble_payload()
+        captured = capsys.readouterr()
+        assert "distinct verified_at value(s)" in captured.err
+
+    def test_note_does_not_fire_once_every_stamp_is_distinct(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        freshness_input: dict[str, Any],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        assert len(mutated["restamped_source_records"]) <= 60, "helper below assumes < 60 records"
+        for i, rec in enumerate(mutated["restamped_source_records"]):
+            # Still a legal UTC-Z shape, still after _prior_verified_at,
+            # still not after created_at — only made pairwise distinct via
+            # the seconds field.
+            rec["verified_at"] = f"2026-08-23T06:14:{i:02d}Z"
+        bad_path = tmp_path / "freshness.json"
+        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+
+        m.assemble_payload()
+        captured = capsys.readouterr()
+        assert "distinct verified_at value(s)" not in captured.err

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
@@ -507,18 +507,33 @@ class TestGuardsFireOnMutation:
 
 class TestIdenticalTimestampNote:
     """The identical-timestamp shape is FLAGGED, not rejected (see the
-    fold module's docstring for the reasoning). These prove the flag is
-    reachable (fires on the real, current batch of 18 identical stamps)
-    and precise (does NOT fire once every stamp in the batch is made
-    distinct) — a guard never exercised in both directions is not
-    verified."""
+    fold module's docstring for the reasoning — and its correction: the
+    reference point for "what good looks like" is seq-10's 7 distinct
+    second-precision values, not seq-12's already-degraded 2, because the
+    fold family's resolution has been a DESCENDING staircase, not a
+    stable convention). These prove the flag is reachable (fires on the
+    real, current batch of 18 identical stamps, with the real 1<-2<-7
+    trend), precise (does NOT fire once every stamp in the batch is made
+    distinct), and degrades gracefully when its purely-informational
+    third data point is unavailable — a guard never exercised in every
+    direction is not verified."""
 
-    def test_note_fires_on_the_real_identical_batch(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_note_fires_on_the_real_identical_batch_with_the_real_trend(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         m.assemble_payload()
         captured = capsys.readouterr()
         assert "distinct verified_at value(s)" in captured.err
+        assert "DESCENDING resolution trend" in captured.err
+        # The actual, independently-verified trend (read directly from
+        # source-restamp-edits.json in this same test module — see
+        # TestHistoricalTrendHelper below): 1 now <- 2 (seq-12's own
+        # restamp) <- 7 (what seq-12 itself replaced).
+        assert "1 now" in captured.err
+        assert "2 in the batch this replaces" in captured.err
+        assert "7 in the batch seq-12 itself replaced" in captured.err
 
     def test_note_does_not_fire_once_every_stamp_is_distinct(
         self,
@@ -543,3 +558,83 @@ class TestIdenticalTimestampNote:
         m.assemble_payload()
         captured = capsys.readouterr()
         assert "distinct verified_at value(s)" not in captured.err
+
+    def test_note_degrades_gracefully_when_historical_file_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The third, purely-informational trend point is best-effort: its
+        absence must never crash the fold or silently swallow the rest of
+        the note — only that one clause is omitted."""
+
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        monkeypatch.setattr(m, "_SEQ12_RESTAMP_HISTORY", tmp_path / "does-not-exist.json")
+        m.assemble_payload()  # must not raise
+        captured = capsys.readouterr()
+        assert "distinct verified_at value(s)" in captured.err
+        assert "DESCENDING resolution trend" in captured.err
+        assert "1 now" in captured.err
+        assert "2 in the batch this replaces" in captured.err
+        assert "in the batch seq-12 itself replaced" not in captured.err
+
+    def test_note_degrades_gracefully_on_malformed_historical_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        bad_path = tmp_path / "malformed.json"
+        bad_path.write_text("{not valid json", encoding="utf-8")
+        monkeypatch.setattr(m, "_SEQ12_RESTAMP_HISTORY", bad_path)
+        m.assemble_payload()  # must not raise
+        captured = capsys.readouterr()
+        assert "in the batch seq-12 itself replaced" not in captured.err
+
+
+class TestHistoricalTrendHelper:
+    """Independently re-derives the historical-distinct-count figure the
+    NOTE reports, straight from source-restamp-edits.json's own bytes —
+    never by importing the fold's helper — so a bug in
+    ``_historical_restamp_distinct_count`` itself would show up as a
+    mismatch here, not just as an internally-consistent wrong number."""
+
+    def test_seq12_restamp_history_carries_seven_distinct_prior_stamps(
+        self, seq12_source: dict[str, Any]
+    ) -> None:
+        history_path = (
+            _REPO_ROOT
+            / "research"
+            / "visa"
+            / "doctrine-factory"
+            / "e5"
+            / "inc5-pack-edits"
+            / "source-restamp-edits.json"
+        )
+        data = _read_json(history_path)
+        portal_ids = {
+            r["source_record_id"]
+            for r in seq12_source["source_records"]
+            if r.get("authority_type") == _PORTAL_AUTHORITY_TYPE
+        }
+        restamps = [e for e in data["restamps"] if e["source_record_id"] in portal_ids]
+        assert len(restamps) == _EXPECTED_RESTAMP_COUNT
+        distinct_current = {e["current_verified_at"] for e in restamps}
+        distinct_new = {e["new_verified_at"] for e in restamps}
+        # The exact staircase the team-lead's correction is grounded on:
+        # 7 real second-precision values inherited from seq-10/seq-11,
+        # rounded down to 2 by seq-12's own fold.
+        assert len(distinct_current) == 7
+        assert len(distinct_new) == 2
+
+    def test_helper_matches_this_independent_recomputation(
+        self, seq12_source: dict[str, Any], seq13_source: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine.fold_pack_seq13_source import (
+            _historical_restamp_distinct_count,
+        )
+
+        portal_ids = {
+            r["source_record_id"]
+            for r in seq13_source["source_records"]
+            if r.get("authority_type") == _PORTAL_AUTHORITY_TYPE
+        }
+        assert _historical_restamp_distinct_count(portal_ids) == 7

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
@@ -4,12 +4,15 @@
 This module SKIPS cleanly (not error, not red) unless BOTH of this fold's
 inputs exist on disk: ``rulepack-prod-013.rules-only.json`` (PR #4660,
 ``fold_pack_seq13_rules.py``) and the s13-fresh lane's freshness restamp
-JSON. Neither is guaranteed to be present in every checkout of this
-branch — the rules-only half ships in a separate, independently-armed PR,
-and the freshness half is a research capture from a third lane. An absent
-input here is a legitimate pre-join state, not a defect (contrast
-``test_seq12_pack.py``, which does NOT skip: seq-12 ships its pack in the
-same PR as its single-source fold).
+edit-pair JSON (``inc7-pack-edits/source-restamp-edits.json``, the same
+schema as seq-12's own ``inc5-pack-edits/source-restamp-edits.json``).
+Neither is guaranteed to be present in every checkout of this branch — the
+rules-only half ships in a separate, independently-armed PR, and the
+freshness half is coordinated directly with its own lane (see the fold
+module's ``_FRESHNESS_INPUT`` comment). An absent input here is a
+legitimate pre-join state, not a defect (contrast ``test_seq12_pack.py``,
+which does NOT skip: seq-12 ships its pack in the same PR as its
+single-source fold).
 
 Checks, each verified against the real files on disk or a fresh
 ``assemble_payload()`` call — never eyeballed:
@@ -24,15 +27,17 @@ Checks, each verified against the real files on disk or a fresh
     the rules-only artifact's ``rules`` byte-for-byte, and everything
     OUTSIDE ``rules`` in the rules-only artifact equals seq-12
     byte-for-byte (the rules lane kept its own promise); the freshness
-    input carries no ``rules``/``products`` key at all.
+    input carries no top-level key outside ``{"_comment", "restamps"}``
+    (whitelist, not a blacklist).
 (c) restamp parity — exactly 18 source_records differ from seq-12, each
     ONLY in ``verified_at``/``verified_by``; the restamped set is exactly
     the OFFICIAL_PORTAL set (entity, not a frozen id list); every restamp
     advances the clock past what the freshness input declares as the
-    PRIOR value, cross-checked against seq-12's actual bytes (ledger
+    CURRENT value, cross-checked against seq-12's actual bytes (ledger
     drift); no restamp is timestamped after the pack's own
     ``created_at``; ``content_sha256`` is byte-identical on all 28
-    records.
+    records (true by construction here — the edit-pair schema has no
+    slot for it at all).
 (d) byte-invariance — products and the 10 non-restamped source_records
     are fully identical to seq-12; every top-level key outside the
     identity set is identical.
@@ -44,7 +49,9 @@ Checks, each verified against the real files on disk or a fresh
     the module's OWN (re-imported, not re-implemented) machinery, proving
     the guard is reachable and not vacuously green. Also covers the
     identical-timestamp NOTE: fires on a batch with fewer distinct stamps
-    than records, does not fire once every record's stamp is distinct.
+    than records (reporting the real 1<-2<-7 resolution trend), does not
+    fire once every record's stamp is distinct, degrades gracefully when
+    its purely-informational third trend point is unavailable.
 """
 
 from __future__ import annotations
@@ -76,7 +83,22 @@ _SEQ12_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-012.signed.json"
 _SEQ13_RULES_ONLY_PATH = _PACKS_DIR / "rulepack-prod-013.rules-only.json"
 _SEQ13_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-013.source.json"
 _FRESHNESS_INPUT_PATH = (
-    _REPO_ROOT / "research" / "visa" / "2026-08-23-seq13-restamp-source-records.json"
+    _REPO_ROOT
+    / "research"
+    / "visa"
+    / "doctrine-factory"
+    / "e5"
+    / "inc7-pack-edits"
+    / "source-restamp-edits.json"
+)
+_INC5_HISTORY_PATH = (
+    _REPO_ROOT
+    / "research"
+    / "visa"
+    / "doctrine-factory"
+    / "e5"
+    / "inc5-pack-edits"
+    / "source-restamp-edits.json"
 )
 
 _EXPECTED_RESTAMP_COUNT = 18
@@ -85,13 +107,24 @@ _RESTAMP_FIELDS = frozenset({"verified_at", "verified_by"})
 _IDENTITY_KEYS = frozenset(
     {"sequence", "version", "rule_pack_id", "previous_payload_sha256", "created_at", "created_by"}
 )
+_RESTAMP_EDIT_FIELDS = frozenset(
+    {
+        "source_record_id",
+        "source_key",
+        "field",
+        "current_verified_at",
+        "current_verified_by",
+        "new_verified_at",
+        "new_verified_by",
+    }
+)
 
 pytestmark = pytest.mark.skipif(
     not (_SEQ13_RULES_ONLY_PATH.exists() and _FRESHNESS_INPUT_PATH.exists()),
     reason=(
         "seq-13 join needs BOTH rulepack-prod-013.rules-only.json (PR #4660) and "
-        "the s13-fresh freshness restamp JSON on disk — at least one is missing. "
-        "This module SKIPS, not reds, until both land."
+        "the s13-fresh freshness restamp edit-pair JSON on disk — at least one is "
+        "missing. This module SKIPS, not reds, until both land."
     ),
 )
 
@@ -189,11 +222,22 @@ class TestComplementOfRulesFold:
                 "identity is not the rules lane's to change"
             )
 
-    def test_freshness_input_carries_no_rule_or_product_key(
+    def test_freshness_input_carries_only_whitelisted_top_level_keys(
         self, freshness_input: dict[str, Any]
     ) -> None:
+        assert set(freshness_input) <= {"_comment", "restamps"}
         assert "rules" not in freshness_input
         assert "products" not in freshness_input
+
+    def test_every_restamp_edit_carries_only_whitelisted_fields(
+        self, freshness_input: dict[str, Any]
+    ) -> None:
+        for edit in freshness_input["restamps"]:
+            assert set(edit) == _RESTAMP_EDIT_FIELDS, (
+                f"restamp edit {edit.get('source_record_id')!r} has fields "
+                f"{sorted(edit)}, expected exactly {sorted(_RESTAMP_EDIT_FIELDS)}"
+            )
+            assert edit["field"] == "verified_at+verified_by"
 
 
 # ---------------------------------------------------------------------------
@@ -235,17 +279,17 @@ class TestRestampParity:
         assert changed == portal
         assert len(portal) == _EXPECTED_RESTAMP_COUNT
 
-    def test_every_restamp_advances_past_freshness_declared_prior(
+    def test_every_restamp_advances_past_freshness_declared_current(
         self, seq13_source: dict[str, Any], freshness_input: dict[str, Any]
     ) -> None:
         seq13_by_id = {r["source_record_id"]: r for r in seq13_source["source_records"]}
-        for fr in freshness_input["restamped_source_records"]:
-            sid = fr["source_record_id"]
+        for edit in freshness_input["restamps"]:
+            sid = edit["source_record_id"]
             pack_record = seq13_by_id[sid]
-            assert pack_record["verified_at"] == fr["verified_at"]
-            assert pack_record["verified_by"] == fr["verified_by"]
-            assert fr["verified_at"] > fr["_prior_verified_at"], (
-                f"{sid!r}: freshness input's own declared new/prior stamps do not advance"
+            assert pack_record["verified_at"] == edit["new_verified_at"]
+            assert pack_record["verified_by"] == edit["new_verified_by"]
+            assert edit["new_verified_at"] > edit["current_verified_at"], (
+                f"{sid!r}: freshness input's own declared new/current stamps do not advance"
             )
 
     def test_no_restamp_is_after_pack_created_at(self, seq13_source: dict[str, Any]) -> None:
@@ -294,7 +338,7 @@ class TestByteInvariance:
     def test_non_restamped_records_fully_identical(
         self, seq12_source: dict[str, Any], seq13_source: dict[str, Any], freshness_input: dict[str, Any]
     ) -> None:
-        restamped_ids = {r["source_record_id"] for r in freshness_input["restamped_source_records"]}
+        restamped_ids = {e["source_record_id"] for e in freshness_input["restamps"]}
         seq12_by_id = {r["source_record_id"]: r for r in seq12_source["source_records"]}
         drifted = []
         checked = 0
@@ -348,6 +392,12 @@ class TestRegenerationParity:
 # ---------------------------------------------------------------------------
 
 
+def _write_freshness(tmp_path: Path, mutated: dict[str, Any]) -> Path:
+    path = tmp_path / "freshness.json"
+    path.write_text(json.dumps(mutated), encoding="utf-8")
+    return path
+
+
 class TestGuardsFireOnMutation:
     def test_chain_hash_guard_fires_on_wrong_expected_anchor(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
@@ -389,17 +439,15 @@ class TestGuardsFireOnMutation:
         with pytest.raises(m.FoldPackError, match="owns neither products nor source_records"):
             m.assemble_payload()
 
-    def test_freshness_forbidden_key_guard_fires(
+    def test_freshness_unexpected_top_level_key_guard_fires(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
     ) -> None:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
         mutated["products"] = []
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
-        with pytest.raises(m.FoldPackError, match="owns only source_records"):
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
+        with pytest.raises(m.FoldPackError, match="unexpected top-level key"):
             m.assemble_payload()
 
     def test_freshness_wrong_record_count_guard_fires(
@@ -408,11 +456,58 @@ class TestGuardsFireOnMutation:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
-        mutated["restamped_source_records"] = mutated["restamped_source_records"][:-1]
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        mutated["restamps"] = mutated["restamps"][:-1]
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
         with pytest.raises(m.FoldPackError, match=f"expected exactly {_EXPECTED_RESTAMP_COUNT} restamps"):
+            m.assemble_payload()
+
+    def test_freshness_edit_missing_field_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        del mutated["restamps"][0]["source_key"]
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
+        with pytest.raises(m.FoldPackError, match="missing field"):
+            m.assemble_payload()
+
+    def test_freshness_edit_extra_field_guard_fires_on_content_sha256_smuggle_attempt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        """The class of attack the old full-record shape needed a
+        content-parity comparison to catch — smuggling a content field
+        through the freshness input — is now caught by the field
+        whitelist instead, before the record is ever touched."""
+
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamps"][0]["content_sha256"] = "f" * 64
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
+        with pytest.raises(m.FoldPackError, match="unexpected field"):
+            m.assemble_payload()
+
+    def test_freshness_edit_wrong_field_value_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamps"][0]["field"] = "content_sha256"
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
+        with pytest.raises(m.FoldPackError, match="this fold only ever restamps"):
+            m.assemble_payload()
+
+    def test_freshness_source_key_mismatch_guard_fires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        mutated = copy.deepcopy(freshness_input)
+        mutated["restamps"][0]["source_key"] = "not-the-real-source-key"
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
+        with pytest.raises(m.FoldPackError, match="id/key mismatch"):
             m.assemble_payload()
 
     def test_freshness_ledger_drift_guard_fires(
@@ -421,24 +516,9 @@ class TestGuardsFireOnMutation:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
-        mutated["restamped_source_records"][0]["_prior_verified_at"] = "2099-01-01T00:00:00Z"
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        mutated["restamps"][0]["current_verified_at"] = "2099-01-01T00:00:00Z"
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
         with pytest.raises(m.FoldPackError, match="ledger drift"):
-            m.assemble_payload()
-
-    def test_freshness_content_drift_guard_fires_on_content_sha256_change(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
-    ) -> None:
-        from backend.scripts.visa_engine import fold_pack_seq13_source as m
-
-        mutated = copy.deepcopy(freshness_input)
-        mutated["restamped_source_records"][0]["content_sha256"] = "f" * 64
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
-        with pytest.raises(m.FoldPackError, match="changed beyond verified_at/verified_by"):
             m.assemble_payload()
 
     def test_freshness_backward_stamp_guard_fires(
@@ -447,12 +527,10 @@ class TestGuardsFireOnMutation:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
-        rec = mutated["restamped_source_records"][0]
-        rec["verified_at"] = rec["_prior_verified_at"]  # holds time still
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
-        with pytest.raises(m.FoldPackError, match="does not advance past the prior"):
+        edit = mutated["restamps"][0]
+        edit["new_verified_at"] = edit["current_verified_at"]  # holds time still
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
+        with pytest.raises(m.FoldPackError, match="does not advance past the current"):
             m.assemble_payload()
 
     def test_freshness_future_stamp_guard_fires(
@@ -461,10 +539,8 @@ class TestGuardsFireOnMutation:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
-        mutated["restamped_source_records"][0]["verified_at"] = "2099-01-01T00:00:00Z"
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        mutated["restamps"][0]["new_verified_at"] = "2099-01-01T00:00:00Z"
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
         with pytest.raises(m.FoldPackError, match="is after this pack's own created_at"):
             m.assemble_payload()
 
@@ -474,15 +550,13 @@ class TestGuardsFireOnMutation:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
-        mutated["restamped_source_records"] = mutated["restamped_source_records"][1:]
-        extra = copy.deepcopy(freshness_input["restamped_source_records"][0])
+        mutated["restamps"] = mutated["restamps"][1:]
+        extra = copy.deepcopy(freshness_input["restamps"][0])
         extra["source_record_id"] = str(uuid.uuid4())
-        extra["_prior_verified_at"] = "2020-01-01T00:00:00Z"
-        extra["_prior_verified_by"] = "nobody"
-        mutated["restamped_source_records"].append(extra)
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+        extra["current_verified_at"] = "2020-01-01T00:00:00Z"
+        extra["current_verified_by"] = "nobody"
+        mutated["restamps"].append(extra)
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
         with pytest.raises(m.FoldPackError, match="not exactly the OFFICIAL_PORTAL set"):
             m.assemble_payload()
 
@@ -545,15 +619,13 @@ class TestIdenticalTimestampNote:
         from backend.scripts.visa_engine import fold_pack_seq13_source as m
 
         mutated = copy.deepcopy(freshness_input)
-        assert len(mutated["restamped_source_records"]) <= 60, "helper below assumes < 60 records"
-        for i, rec in enumerate(mutated["restamped_source_records"]):
-            # Still a legal UTC-Z shape, still after _prior_verified_at,
+        assert len(mutated["restamps"]) <= 60, "helper below assumes < 60 records"
+        for i, edit in enumerate(mutated["restamps"]):
+            # Still a legal UTC-Z shape, still after current_verified_at,
             # still not after created_at — only made pairwise distinct via
             # the seconds field.
-            rec["verified_at"] = f"2026-08-23T06:14:{i:02d}Z"
-        bad_path = tmp_path / "freshness.json"
-        bad_path.write_text(json.dumps(mutated), encoding="utf-8")
-        monkeypatch.setattr(m, "_FRESHNESS_INPUT", bad_path)
+            edit["new_verified_at"] = f"2026-08-23T06:14:{i:02d}Z"
+        monkeypatch.setattr(m, "_FRESHNESS_INPUT", _write_freshness(tmp_path, mutated))
 
         m.assemble_payload()
         captured = capsys.readouterr()
@@ -600,16 +672,7 @@ class TestHistoricalTrendHelper:
     def test_seq12_restamp_history_carries_seven_distinct_prior_stamps(
         self, seq12_source: dict[str, Any]
     ) -> None:
-        history_path = (
-            _REPO_ROOT
-            / "research"
-            / "visa"
-            / "doctrine-factory"
-            / "e5"
-            / "inc5-pack-edits"
-            / "source-restamp-edits.json"
-        )
-        data = _read_json(history_path)
+        data = _read_json(_INC5_HISTORY_PATH)
         portal_ids = {
             r["source_record_id"]
             for r in seq12_source["source_records"]

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq13_source_pack.py
@@ -544,6 +544,86 @@ class TestGuardsFireOnMutation:
         with pytest.raises(m.FoldPackError, match="is after this pack's own created_at"):
             m.assemble_payload()
 
+    def test_wall_clock_sanity_created_at_future_relative_to_real_now_guard_fires(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard the future-stamp test above CANNOT exercise: a wrong
+        _SEQ13_CREATED_AT itself, caught against a reference (real
+        wall-clock, via _real_now_utc) the fold's own author does not
+        control — as opposed to the _apply_freshness guard, whose
+        reference IS _SEQ13_CREATED_AT, so it cannot see this class of
+        defect. No freshness-input mutation here at all — this fires purely
+        because the mocked "now" is before the pack's own created_at,
+        proving the two guards are independent."""
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        created_at_dt = m._parse_utc(m._SEQ13_CREATED_AT)
+        before_created_at = created_at_dt.replace(
+            year=created_at_dt.year - 1
+        )  # unambiguously earlier, no DST/leap edge cases
+        monkeypatch.setattr(m, "_real_now_utc", lambda: before_created_at)
+        with pytest.raises(m.FoldPackError, match="is in the future relative to real wall-clock"):
+            m.assemble_payload()
+
+    def test_wall_clock_sanity_verified_at_future_relative_to_real_now_guard_fires(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct unit test of _assert_wall_clock_sanity, bypassing
+        assemble_payload() entirely — end-to-end this check is unreachable
+        on ITS OWN failure mode: _SEQ13_CREATED_AT is, by construction, the
+        latest timestamp anywhere in the payload (it's stamped after every
+        input), so whenever real-now is early enough to make some
+        source_record's verified_at look future, real-now is ALSO before
+        created_at, and the created_at check above fires first (algebra:
+        verified_at <= created_at, so created_at <= now implies
+        verified_at <= now too — the per-record check can only ever add
+        value once created_at itself is untrustworthy in some way THIS
+        payload's construction doesn't allow, or for the 10 of 28
+        source_records _apply_freshness never touches at all, which this
+        payload's ordering also always covers). A direct unit test proves
+        the per-record check is real and independently reachable, not
+        dead code kept only for its comment."""
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        payload = {
+            "created_at": "2026-08-23T13:00:00Z",  # passes the created_at check
+            "source_records": [
+                {"source_record_id": "sr-1", "verified_at": "2026-08-23T12:00:00Z"},
+                {"source_record_id": "sr-2", "verified_at": "2099-01-01T00:00:00Z"},  # the violator
+            ],
+        }
+        mocked_now = m._parse_utc("2026-08-23T13:30:00Z")  # after created_at, before sr-2
+        monkeypatch.setattr(m, "_real_now_utc", lambda: mocked_now)
+        monkeypatch.setattr(m, "_SEQ13_CREATED_AT", payload["created_at"])
+        with pytest.raises(
+            m.FoldPackError,
+            match=r"source_record 'sr-2': verified_at .* is in the future relative to real wall-clock",
+        ):
+            m._assert_wall_clock_sanity(payload)
+
+    def test_wall_clock_sanity_passes_when_real_now_is_after_everything(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The positive direction team-lead asked for explicitly: a past
+        stamp (relative to the mocked clock) must NOT raise. Mocks "now"
+        to something safely after created_at and every real restamp,
+        proving the new guard doesn't fire on the actual, correct data —
+        this is effectively re-proven by every other passing test in this
+        file (they all run with the real, unmocked wall-clock, which is
+        already after everything here), but this test pins the exact
+        boundary explicitly rather than leaving it implicit."""
+        from backend.scripts.visa_engine import fold_pack_seq13_source as m
+
+        safely_after_everything = m._parse_utc("2026-08-24T00:00:00Z")
+        monkeypatch.setattr(m, "_real_now_utc", lambda: safely_after_everything)
+        payload = m.assemble_payload()
+        assert payload["created_at"] == m._SEQ13_CREATED_AT, (
+            "assemble_payload() must complete and return the real assembled "
+            "payload, not merely avoid raising — proves the guard ran (it's "
+            "unconditionally called from assemble_payload()) and cleared, "
+            "rather than the test accidentally not exercising it at all"
+        )
+
     def test_freshness_entity_mismatch_guard_fires(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, freshness_input: dict[str, Any]
     ) -> None:

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -380,10 +380,14 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
     # content-derived sha256 ..." shape as the seq10/11/12 rules above, on
     # purpose (four consecutive-sequence anchors reading in order). A test
     # that looks a rule up via test_detect_secrets_auto_triage.py's
-    # _find_content_keyed_rule("chain anchor") would now match FOUR entries
+    # _find_content_keyed_rule("chain anchor") would now match FIVE entries
+    # (a fifth landed the same day: fold_pack_seq13_source.py, the JOIN
+    # fold, also chains off seq-12 and so also reads "seq-12 chain anchor")
     # and fail loudly (it asserts exactly one) — that is correct behavior,
-    # not a bug in the lookup. Any future test targeting THIS rule must key
-    # on "seq-12 chain anchor", the substring unique to it.
+    # not a bug in the lookup. "seq-12 chain anchor" alone is no longer
+    # unique either, now that two files share it; a lookup for THIS rule
+    # must key on the file-qualified reason prefix, e.g.
+    # "fold_pack_seq13_rules.py: seq-12 chain anchor".
     (
         re.compile(
             r"^apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules\.py$"
@@ -392,6 +396,39 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
             r'^\s*"ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d"\s*$'
         ),
         "fold_pack_seq13_rules.py: seq-12 chain anchor — content-derived "
+        "sha256 of the public signed seq-12 RulePack payload, "
+        "triple-derived at run time; exact value pinned, never a "
+        "credential",
+    ),
+    # fold_pack_seq13_source.py: _EXPECTED_SEQ12_PAYLOAD_SHA256 is the chain
+    # anchor — the content-derived sha256 of the PUBLIC signed seq-12
+    # RulePack payload (same value class as the three fold_pack_seq1{0,1,2}
+    # rules above: hashes of public legal documents, never credentials). This
+    # JOIN fold pins it so the seq-13 chain link is triple-derived at run
+    # time (declared == anchor == recomputed from the seq-12 source bytes)
+    # and any mismatch aborts the fold.
+    #
+    # Content-keyed and pinned to the EXACT anchor value, not a hex shape:
+    # this is production code with an open surface for future edits — a real
+    # credential pasted anywhere else in the file (or even another 64-hex
+    # value on this line) stays flagged. The approved line is the bare
+    # continuation-string line of the parenthesized assignment, end-anchored.
+    #
+    # 2026-08-23: this fold and fold_pack_seq13_rules.py (the rule
+    # immediately above) both chain off seq-12 and so both read "seq-12
+    # chain anchor" in their reason string — deliberately not disambiguated
+    # by inventing a different anchor description for the same value. A
+    # lookup by that substring alone is ambiguous by construction; use the
+    # file-qualified prefix, e.g. "fold_pack_seq13_source.py: seq-12 chain
+    # anchor", to select this one specifically.
+    (
+        re.compile(
+            r"^apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source\.py$"
+        ),
+        re.compile(
+            r'^\s*"ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d"\s*$'
+        ),
+        "fold_pack_seq13_source.py: seq-12 chain anchor — content-derived "
         "sha256 of the public signed seq-12 RulePack payload, "
         "triple-derived at run time; exact value pinned, never a "
         "credential",

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -267,8 +267,8 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # trail are derived from the live registry post-merge, not summed by
     # hand (team-lead's call: a rule appears once in the trail regardless of
     # how many PRs tried to add it).
-    assert len(CONTENT_KEYED_RULES) == 16, (
-        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 16. "
+    assert len(CONTENT_KEYED_RULES) == 17, (
+        f"CONTENT_KEYED_RULES now has {len(CONTENT_KEYED_RULES)} entries, not 17. "
         "If you just ADDED a rule: bump this number AND append a `# +1: <what> "
         "(<date>, PR #NNNN)` line below, matching the existing trail's format — "
         "that comment IS the audit record this assert exists to force. "
@@ -286,6 +286,7 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     # +1: fold_pack_seq11.py seq-10 chain anchor exact-value pin (2026-08-20)
     # +1: fold_pack_seq12.py seq-11 chain anchor exact-value pin (2026-08-20)
     # +1: fold_pack_seq13_rules.py seq-12 chain anchor exact-value pin (2026-08-23, #4660)
+    # +1: fold_pack_seq13_source.py seq-12 chain anchor exact-value pin (2026-08-23, #4667)
     #
     # Note (2026-08-23): "appended last" is no longer a constraint. It was
     # true only because this test and the two Google-OAuth tests below
@@ -1288,6 +1289,114 @@ def test_innocence_fold_seq12_keyed_assignment_not_approved() -> None:
     _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[11]
     keyed_line = f'    "payload_sha256": "{FOLD_PACK_SEQ12_ANCHOR}",'
     assert content_pat.match(keyed_line) is None
+
+
+# ---------------------------------------------------------------------------
+# fold_pack_seq13_source.py — seq-12 chain anchor exact-value pin (2026-08-23, #4667)
+# ---------------------------------------------------------------------------
+# The seq-13 JOIN fold. Same value as fold_pack_seq13_rules.py's own rule
+# above (both chain off seq-12), in a DIFFERENT file — pins the anchor to
+# the exact value, in exactly this one path. Looked up by content (a
+# substring unique to its reason once file-qualified), not by list
+# position, per the 2026-08-23 policy note above: a new rule may be
+# inserted anywhere in CONTENT_KEYED_RULES without breaking a registration
+# test — this entry is itself an example, inserted between the seq12 and
+# p2b_score.json rules without touching any positional test in this file.
+
+FOLD_PACK_SEQ13_SOURCE = (
+    "apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_source.py"
+)
+FOLD_PACK_SEQ13_SOURCE_ANCHOR = (
+    "ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d"
+)
+
+
+def test_fold_seq13_source_rule_registered_and_scoped_to_exactly_one_file() -> None:
+    path_pat, _content_pat, reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    assert path_pat.search(FOLD_PACK_SEQ13_SOURCE)
+    assert not path_pat.search(FOLD_PACK_SEQ12)
+    assert not path_pat.search(
+        "apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules.py"
+    )
+    assert not path_pat.search(
+        "scripts/detect_secrets_auto_triage.py"
+    )
+    assert "credential" in reason
+
+
+def test_guilt_fold_seq13_source_real_finding_approved() -> None:
+    """The exact real line 218 in the fold script must be approved — read
+    live off disk, so this fails if the file and rule ever drift, not
+    merely if someone edits a string literal in this test."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    lines = Path(FOLD_PACK_SEQ13_SOURCE).read_text(encoding="utf-8").splitlines()
+    real_line = lines[217]  # line 218, 1-indexed
+    assert real_line == f'    "{FOLD_PACK_SEQ13_SOURCE_ANCHOR}"'
+    assert content_pat.match(real_line), f"should be approved: {real_line!r}"
+
+
+def test_innocence_fold_seq13_source_other_hex_value_not_approved() -> None:
+    """A DIFFERENT 64-hex bare string line must not be approved — proves the
+    rule is pinned to the exact anchor value, not merely to the shape."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    other_hex_line = '    "' + "a" * 64 + '"'
+    assert content_pat.match(other_hex_line) is None
+
+
+def test_innocence_fold_seq13_source_uppercase_not_approved() -> None:
+    """The same value uppercased must not be approved — the anchor is
+    lowercase hex, matching hashlib.hexdigest's own output."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    uppercase_line = f'    "{FOLD_PACK_SEQ13_SOURCE_ANCHOR.upper()}"'
+    assert content_pat.match(uppercase_line) is None
+
+
+def test_innocence_fold_seq13_source_ride_along_statement_not_approved() -> None:
+    """The value followed by a second statement or token on the same line
+    must not launder the ride-along — end-anchored, same discipline as every
+    other rule in this list."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    for compound in (
+        f'    "{FOLD_PACK_SEQ13_SOURCE_ANCHOR}"; import os',
+        f'    "{FOLD_PACK_SEQ13_SOURCE_ANCHOR}" "second_token"',
+    ):
+        assert content_pat.match(compound) is None, f"must NOT be approved: {compound!r}"
+
+
+def test_innocence_fold_seq13_source_keyed_assignment_not_approved() -> None:
+    """A JSON-style keyed line carrying the same value must not be approved —
+    the rule approves only the bare continuation-string shape of the
+    parenthesized assignment, never a `"key": "value"` shape."""
+    _path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    keyed_line = f'    "payload_sha256": "{FOLD_PACK_SEQ13_SOURCE_ANCHOR}",'
+    assert content_pat.match(keyed_line) is None
+
+
+def test_fold_seq13_source_rule_does_not_launder_via_seq13_rules_path() -> None:
+    """The two seq-13 chain-anchor rules share the identical anchor VALUE
+    (both fold scripts chain off seq-12) but must stay path-scoped: this
+    rule's path pattern must reject fold_pack_seq13_rules.py even though
+    the content pattern alone would match a line copy-pasted from it."""
+    path_pat, content_pat, _reason = _find_content_keyed_rule(
+        "fold_pack_seq13_source.py: seq-12 chain anchor"
+    )
+    real_line = f'    "{FOLD_PACK_SEQ13_SOURCE_ANCHOR}"'
+    assert content_pat.match(real_line)  # content alone matches...
+    assert not path_pat.search(  # ...but path must not, for the sibling file
+        "apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq13_rules.py"
+    )
 
 
 GOOGLE_OAUTH_LINT = "scripts/lint_google_oauth_credentials.py"


### PR DESCRIPTION
RulePack seq-13 was architected as two halves and a third step nobody had written: the JOIN that takes `rulepack-prod-013.rules-only.json` (rules half, PR #4660) + the s13-fresh lane's 18-record OFFICIAL_PORTAL re-attestation (freshness half) and produces the actual, signable `rulepack-prod-013.source.json`. No such script existed anywhere in the repo or any worktree before this PR.

**This PR now ships the real, committed pack** — `rulepack-prod-013.source.json` is generated and committed, run against the real bytes of both dependency lanes (not a reconstruction). Chain anchor and NOTE output are below.

**Both dependency halves are now merged to `origin/main`**: #4660 (rules half) merged 11:27:27Z (after resolving its own CONFLICTING state via a rebase unrelated to this fold's content — see team-lead's note), #4670 (freshness half) merged 11:13:52Z with an independent codex adversarial review (SHIP verdict). This PR was rebased onto that merged `origin/main` afterward — see point 6 in Adversarial review below for what that rebase actually changed and the two conflicts it surfaced. Both input files were re-read from the merged bytes and confirmed byte-identical to what had been copied in earlier (`diff` against `origin/main` came back empty for both), then the fold was re-run against them rather than trusting the pre-rebase run. `test_seq13_source_pack.py` skips cleanly (not red) when either input is absent — proved on the first push, which landed with neither file present and correctly failed CI's `Prove each shard reported executed tests` gate on "41 collected, 0 executed, 41 skipped" rather than silently passing.

## What it does

`fold_pack_seq13_source.py` assigns seq-13's identity (sequence/version/rule_pack_id/previous_payload_sha256/created_at/created_by — neither half owns this, by both their own module docstrings), then:

1. Takes `rules` wholesale from the rules-only half — but only after cross-checking that half kept its own promise: its identity fields, `products`, and `source_records` must all be byte-identical to seq-12 (the rules lane owns rules only). A drift on any of those aborts the join rather than silently inheriting a change outside that lane's declared territory.
2. Applies the freshness half's 18-record restamp onto seq-12's own `source_records`, entity-derived as the OFFICIAL_PORTAL set (never a frozen id list). The freshness input uses the **edit-pair schema** — 7 whitelisted fields per record (`source_record_id`, `source_key`, `field`, `current_verified_at`, `current_verified_by`, `new_verified_at`, `new_verified_by`), matching seq-12's own restamp-ledger convention rather than a full-record blob. This shape makes "content never touched" true by construction (there is no slot for content fields in an edit-pair record — a `content_sha256` smuggle attempt is an *unexpected field*, caught before any comparison logic runs) rather than by post-hoc comparison. Any top-level key on the freshness file outside `{_comment, restamps}`, any record missing/adding a field, `field != "verified_at+verified_by"`, or a `source_key` that doesn't match seq-12's actual record all abort the join.
3. Per restamped record: ledger-drift check (the edit's declared `current_verified_at`/`current_verified_by` must match seq-12's actual bytes — refuses to apply blind against a stale premise), advance check (new > current), not-in-future check (new <= this pack's own `created_at`).
4. A final byte-invariance sweep holds every top-level key outside `{identity, rules, source_records}` to whole-collection equality with seq-12, and every non-restamped `source_record` to full equality.

`content_sha256` is never recomputed or re-verified anywhere in this fold — the Ditjen portal pages carry a per-request CSRF token, so two fetches of the same unchanged page hash differently by construction. Verification of those 18 sources is by verbatim quotation (the freshness lane's QW-5 report), not hash.

## The identical-timestamp question

All 18 restamps carry the same `new_verified_at` (`2026-08-23T10:44:48Z`, a live reading team-lead independently confirmed against the freshness file's own mtime) — a disclosed pass-level proxy, not 18 independently observed per-source fetch times. **My call: flag, don't reject.**

Reasoning, corrected once during this build (see Adversarial review below for the correction itself):
- **A script can't manufacture honesty.** No per-source fetch timestamps were captured this pass. Interpolating 18 artificial distinct values would make the pack *look* like it has finer-grained evidence than it does — less honest, not more. (Proven reachable, not just asserted: `test_note_does_not_fire_once_every_stamp_is_distinct` constructs exactly that shape and confirms the flag stops firing.)
- **It is a real, worsening trend — not a stable convention to defer to.** Distinct-`verified_at`-count, newest first: **1 now <- 2 in the batch this replaces (seq-12's own restamp) <- 7 in the batch seq-12 itself replaced** (inherited from seq-10/seq-11, real second-precision per-source fetch times). What good looks like is the **oldest** figure in that chain (seq-10's 7), not the most recent one (seq-12's 2) — citing seq-12 as precedent would be citing an already-degraded step as the bar. The fold prints this full three-point trend on every run, not just the current count.
- **The real evidentiary weight isn't in timestamp cardinality anyway.** It's in the QW-5 verbatim-quote report — a separate document with per-source content. The pack's `verified_at` field has always meant "attested as of this clock reading," not "independently fetched at this exact instant."
- **What I DO gate mechanically** are the properties that actually matter: does every stamp genuinely advance past what it replaces (checked against the freshness file's own declared `current_verified_at` AND independently against seq-12's real bytes — a copy-paste restamp that doesn't touch a real prior value fails this), and is nothing attested in the future relative to the pack's own creation. Those are real teeth; distinctness-across-records is not.

The flag: a non-fatal `NOTE:` on stderr, mechanically testable (`TestIdenticalTimestampNote`, 4 tests — fires on the real batch with the real trend text, does not fire once mutated pairwise-distinct, degrades gracefully when the historical seq-12 ledger file is absent or malformed). It does not block `main()`'s exit code.

## Verification

- **Idempotence**: two `assemble_payload()` runs against the real committed inputs produce byte-identical canonical JSON (re-verified after the real run, not just during development).
- **Chain anchor** (four-way match, all independently checked): `previous_payload_sha256 = ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d` == `rulepack-prod-012.signed.json`'s declared `payload_sha256` == the pinned constant in this module == recomputed `SHA256(JCS(rulepack-prod-012.source.json))` independently.
- **This pack's own canonical payload sha256** (via the module's real `canonicalize_json`, `backend.services.visa_engine.bundle` — the same function every prior sibling fold uses for its own chain hash, and the one a future seq-14 would need): `ac3f0a6d576e4d7bcbc21469491de02fff04add29e9e738c985e6d987b71ddc7`. Verified deterministic across two independent regenerate runs (both produced this exact value, plus a matching on-disk file sha256 `2f2531719e718c42846c244698123902aa68944f0f177b32466a87a3939ee90b` both times). 111 rules, 38 products, 28 source_records.
  - Correction (2026-08-23, post-rebase): an earlier revision of this PR body reported `07a95cd4ad70a5f88005e1e7c7aabbcf6b4f2464ebe29c587bd065a61be9d470` for this field — that value came from an ad-hoc `json.dumps(sort_keys=True)` canonicalization in my own verification script, not the module's real JCS `canonicalize_json`. Caught while re-deriving the anchor post-rebase; the two prior confirmations of the *chain anchor itself* (`previous_payload_sha256`, above) were unaffected since those were always read from the module's real function.
  - **seq-13 identity, live**: `sequence=13`, `version="2026.8.23"`, `rule_pack_id=79b62b85-829e-59f8-a058-c38c065b8cb5`, `created_at="2026-08-23T13:00:00Z"` (corrected — see point 8 below; canonical payload sha256 `b9edb809930ab486e49a4af7804fbae7f072caa3b6459b78a94ecb7f6bfe14f8`, file sha256 `309a7b3c90703179cb5e15e54fec4472f922ec8346ec5188bd2f08cdbeedf8f1` — re-measured on the final armed head `9fc10b129`, two fresh runs, both identical: adding the wall-clock guard in point 9 below did not touch payload bytes, empirically, not by assumption).
- Red-then-green on every hard guard (13 mutation tests in `TestGuardsFireOnMutation`, each against the module's own functions on a deliberately-broken in-memory copy of the real input, never a reimplementation): chain-hash anchor mismatch, rule_pack_id convention mismatch, rules-only identity drift, rules-only products drift, freshness unexpected top-level key, freshness wrong record count, freshness edit missing field, freshness edit extra field (the `content_sha256` smuggle attempt), freshness edit wrong `field` value, freshness `source_key` mismatch, freshness ledger drift, freshness backward/held-still stamp, freshness future stamp, freshness entity-set mismatch, missing rules-only input, missing freshness input. All fire on the mutation and pass clean on the real input.
- **Full 41-test suite passes against the real, committed artifacts** (not reconstructed data): `PYTHONPATH=. pytest backend/tests/services/visa_engine/test_seq13_source_pack.py -v` → 41 passed.
- Never touches production/prod DB/Fly secrets; no real applicant data.

## Test plan

- [x] Fold idempotent (byte-identical across two runs, verified on the real committed inputs)
- [x] Chain anchor four-way verified (declared/recomputed/pinned/signed-pack)
- [x] 41/41 tests pass against the real committed pack
- [x] 13/13 guard-mutation tests red-then-green
- [x] Identical-timestamp NOTE fires with the real 1<-2<-7 trend on the real batch; does not fire once mutated distinct; degrades gracefully with historical ledger absent/malformed
- [x] Real pack committed: `rulepack-prod-013.source.json`, 111 rules / 38 products / 28 source_records

## Adversarial review

Self-reviewed against the team-lead's brief; the team-lead also read real bytes directly at two points below rather than taking my word for it, and both corrections are reflected in the code, not just noted here.

1. **My first NOTE reasoning was wrong, and team-lead caught it by reading the ledger directly.** I initially justified "flag, don't reject" partly by citing seq-12's own restamp batch as "the same pattern, not new" — implying a stable 2-value convention. Team-lead checked `source-restamp-edits.json` and found what seq-12 replaced (seq-10's stamps) had **7** distinct second-precision values — a real descending staircase, not a convention. I re-verified the exact numbers independently and rewrote the reasoning and the NOTE text to cite seq-10's 7 as "what good looks like" and print the full three-point trend, never citing seq-12's 2 as a precedent to emulate.
2. **My own schema assumption was wrong before I shipped it, and I caught it myself.** I was told the freshness input would use an "edit-pair shape matching seq-12's own convention" and assumed 5 fields from the paraphrase. Before finalizing I read the real bytes of both the already-merged inc5 ledger and the actual staged inc7 artifact and found both carry **7** fields, adding `source_key` and `field`. Fixed by widening the whitelist and turning both extras into real guards (`field` value check, `source_key` cross-check against seq-12's actual bytes) rather than silently accepting or ignoring them — the `content_sha256`-smuggle mutation test specifically exercises that this schema catches a content field earlier (as an unexpected key) than the old full-record-comparison approach would have (as a byte mismatch).
3. **A competing, unreviewed seq-14 fold existed in a sibling worktree, forked from seq-12 directly — it would have silently dropped the rules-half fixes.** Found it mid-build while inspecting the freshness lane's worktree for the corrected input. Did not touch it, did not build on it — reported it immediately. Team-lead ruled seq-13-combined stands and seq-14 is stopped; root cause was on team-lead's own routing side. The seq-14 architecture-fork failure mode is documented in this module's docstring as a named historical note, not left implicit.
4. **A `rm -rf` mistake, fully disclosed, zero net effect.** While building a scratch fixture I ran `rm -rf` against a path that turned out to include this worktree's entire tracked `research/` directory (1366 files), including the ledger this fold's historical-trend helper reads. Caught immediately via `git status --porcelain`, recovered via `git checkout -- research/`, re-verified the fold still produced the correct trend. Disclosed in full to team-lead rather than hidden.
5. **Files from two other lanes are committed into this PR, not pulled via their own PRs, because neither exists cleanly yet.** #4660 (rules half) is open but `mergeStateStatus=CONFLICTING` — that conflict belongs to that lane, not this fold, and is called out here rather than silently absorbed. The freshness half has no PR at all — s13-fresh's artifact is copied in directly with attribution in the commit message. This is a deliberate deadline-driven call (2026-08-27T06:14Z freshness-window expiry), not a normal cross-PR dependency pattern; flagging it explicitly so it isn't mistaken for this fold's own output.

6. **Rebased after both dependency PRs merged, not before — and it mattered.** #4660 and #4670 both merged (11:13Z and 11:27Z respectively) after this PR's earlier revisions were already pushed against pre-merge branch copies. Per the team-lead's explicit instruction, rebased onto fresh `origin/main` before regenerating anything, re-read both input files from the merged bytes (confirmed byte-identical to what I'd copied earlier — `diff` against `origin/main` came back empty for both), and re-ran the fold rather than trusting the earlier run. Two real conflicts surfaced during the rebase, both resolved by combining rather than picking a side:
   - `freshness-restamp-2026-08-23.md`: an add/add conflict where main's merged copy (from #4670) had gained a full adversarial-review section my earlier commit didn't have — took main's version wholesale (verified byte-identical to `origin/main` after resolving).
   - `scripts/detect_secrets_auto_triage.py`: #4660's own rebase-fix had, four minutes before my push, added a sibling content-keyed rule for `fold_pack_seq13_rules.py`'s identical seq-12 chain-anchor value — a real second rule, not a duplicate of mine (different file, same value, since both fold scripts chain off seq-12). Combined both tuples rather than dropping either, bumped the registry's `assert len(...) == 17` count and trail comment, and — since the two rules' reason strings now share the substring "seq-12 chain anchor" — added a disambiguating note to both comments and wrote my own rule's tests against the file-qualified lookup key rather than the ambiguous one. Added a full test block (registration, guilt, four innocence variants, one file-scoping cross-check) rather than relying on #4660's rule having none of its own.
7. **My own earlier canonical-hash figure was wrong, caught while re-deriving it post-rebase.** The very first version of this PR body reported `07a95cd4...` as "this pack's own payload sha256", computed with an ad-hoc `json.dumps(sort_keys=True, separators=(',',':'))` in a throwaway verification script — not the module's real `canonicalize_json` (RFC-8785-style JCS, imported from `backend.services.visa_engine.bundle`, the same function every sibling fold uses for its own chain hash). The real value is `ac3f0a6d...` (now in Verification above, with a two-run determinism proof using the actual function). The chain anchor itself (`previous_payload_sha256`, this pack's link back to seq-12) was never affected — that was always read via the module's real machinery, both before and after this correction.

8. **`created_at` was 6 hours in the future — caught by team-lead comparing it to real measured UTC, not by anything in this module.** `_SEQ13_CREATED_AT` was hardcoded to `"2026-08-23T20:00:00Z"` when this module was first written at ~10:29 UTC that day (git author timestamp on the introducing commit) — already ~9.5h in the future at write-time, undocumented. It survived every later revision unchanged because it's a hardcoded literal, not a computed value: the two-consecutive-run determinism proof this fold reports **cannot** see this class of defect, since a hardcoded wrong value is exactly as deterministic as a hardcoded right one — a real blind spot in that proof, named explicitly rather than left implicit. Investigated "local WITA (UTC+8) time mislabeled as UTC" as a specific hypothesis team-lead raised and ruled it out: local time at the write-time commit was 18:28, not close enough to the chosen 20:00 to be a clean transposition — more likely an arbitrary round-hour guess with no clock check behind it. Consumer check, both parts requested explicitly: `gold_replay_driver.py`'s `_OFFLINE_AT` lives in its *test* file, derived from `signed_at` across `*.signed.json` bundles only, never reads an unsigned pack's `created_at` — and this pack has no `.signed.json` yet, so it was invisible to that mechanism today. `sign_pack.py`'s `signed_at` defaults to `datetime.now(timezone.utc)` at sign time, independent of `created_at`. `models.py`'s `created_at` validator (`_check_utc`) only checks timezone-awareness and zero UTC offset, never future-dating. Net: harmless today given default signing behavior, but a real defect regardless — an untrue claim baked into a payload people will read. Fixed to `2026-08-23T13:00:00Z`, the most recently-elapsed round hour as of actually finalizing this pack, unambiguously in the past. Re-verified after the fix: NOTE text byte-identical, chain anchor unaffected, 41/41 tests pass, two fresh consecutive-run hashes match each other.

9. **The `created_at` fix corrected the value but not the disease — team-lead found it, not me.** Point 8 fixed `_SEQ13_CREATED_AT` from a wrong value to a right one, but the guard that's supposed to catch a fabricated future attestation (`_apply_freshness`'s restamp-vs-`created_at` check) reads its ceiling from `_SEQ13_CREATED_AT` — a constant in the same file, under the same author's control. A wrong `created_at` and the guard meant to catch a wrong restamp can be wrong together and still agree; that's exactly what happened, and it's the same disease as the sorter correction in point 7 and three other findings team-lead named the same day: **a check whose reference is derived from its subject.**

   Added `_real_now_utc()` (a monkeypatchable seam, not a direct `datetime.now()` call scattered around) and `_assert_wall_clock_sanity()`, called from `assemble_payload()`. Two checks against real wall-clock, independent of `_SEQ13_CREATED_AT`: (a) `_SEQ13_CREATED_AT` itself must not be future — the exact check that would have caught today's defect at fold time; (b) every one of the 28 `source_records`' `verified_at` must not be future — not only the 18 just-restamped ones, since the 10 untouched records have no other guard against them at all.

   Payload determinism unaffected — `_SEQ13_CREATED_AT` stays fixed in the output bytes; only the *validation* reads real time. Team-lead's framing, verbatim: "The OUTPUT must be deterministic ... The CHECK does not have to be deterministic. It is a validation, not an output." Three new tests: the created-future direction moves the **mocked clock** (`_real_now_utc`), not `_SEQ13_CREATED_AT` — the real production constant is exercised unmodified against a reference set one year earlier, with **no freshness-input mutation at all**, proving independence from the existing `_apply_freshness` guard. A **direct unit test** of `_assert_wall_clock_sanity()` proves the per-record check is real and reachable. Its actual reach is broader than what was asked: end-to-end through `assemble_payload()`, checking the 18 just-restamped records is algebraically redundant with the two guards already in place (`created_at ≤ now` and `restamp ≤ created_at` together force `restamp ≤ now`) — but the check runs over all **28** `source_records`, and for the **10 records `_apply_freshness` never touches**, there is no other guard anywhere in this fold. For those 10, reachability is real and in-principle, not algebra: it does not fire today only because seq-12's inherited data happens to be sound, and it is the sole thing standing between a future-dated inherited record and a signed pack. The positive direction (past stamp, must not raise) is asserted against the actual returned payload, not merely "did not raise" — this repo's own anti-reward-hacking pre-commit lint caught my first draft of that test on exactly that gap (`RH005`) before it ever reached CI.

   Also investigated, read-only, explicitly out of scope to touch: whether seq-12's own `created_at` (`"2026-08-20T07:00:00Z"`) carries the same defect, since these fold scripts get copied sibling-to-sibling. It does not — `git log` shows the introducing commit (`457bf725d`) authored `2026-08-20T07:12:04Z`, recorded natively in UTC (not WITA +08:00, unlike my own commits), 12 minutes *after* the declared `created_at` — consistent with a real `date -u` reading floored to the hour, the honest form of the round-hour convention. seq-12 is a signed, activated production pack; even a real defect there would be a different and much larger action than this PR's scope.

10. **This fold's own required CI check went genuinely red — `el.e31c-child-mixed-marriage-support`'s nationality-gap PIN, and it was the exact "GOOD NEWS" case its own author scripted for.** `test_cure_forward_guard.py::TestE31CNationalityGapKnownOpen` was a deliberate PIN of a known-open defect (E31C's nationality-blind sibling rule reaching `SUPPORTED` for a foreign-foreign-parent applicant), written months ago with its own module-level banner giving four explicit migration steps for exactly the moment its underlying gap closes. #4660's FIX 1 (E31C nationality gap, merged onto `origin/main` before this PR) closed it — `el.e31c-child-mixed-marriage-support` gained a `family.sponsor_nationalities intersects [ID]` conjunct. Since this fold's output becomes the highest-sequence pack on disk, the PIN's own `highest_source` fixture picked it up and both its assertions went red on CI (`Backend Shard 1` / `Backend Tests (Python)`, blocking `--auto` merge with a genuinely failing required check, not a flake). Followed the banner's own four steps rather than inventing a fix: (1) confirmed the cure was deliberate by reading #4660's PR body directly (its FIX 1 section describes exactly this conjunct addition); (2) deleted the `TestE31CNationalityGapKnownOpen` class; (3) added `TestNationalityGapCuredWitnesses` (behavioural — US-nationality no longer reaches `SUPPORTED` via this rule; an ID-nationality control, carried over from the deleted class's third method, still fires both sibling rules) grouped with `TestE31CForwardWitnesses`; (4) added `TestNationalityGapCuredShape` (structural — pins the new 3-conjunct shape) grouped with the file's other structural classes (`TestE31CSupportRuleShape`/`TestHardFilterShape`), correcting a first-pass misplacement of my own (initially landed in the behavioural section, caught by re-checking my own docstring's claim of where it was "grouped" against where it actually was). No rule/engine code touched anywhere in this fix — test-file assertions only, catching up with an already-shipped, already-reviewed cure from a sibling PR. Verified against two local-environment red herrings before committing: `test_bundle_verify.py`'s `TestDateTimeFormatCheckIsReal` fails locally because this worktree's `.venv` is missing the optional `rfc3339-validator` package that `requirements-prod.txt` declares (confirmed by direct reproduction — `jsonschema.FormatChecker()`'s date-time check silently no-ops without it); `test_write_substrate.py`/`test_repository.py`/etc. fail locally on `role "nuzantara" does not exist` (no local Postgres test role in this worktree). Neither is touched by this branch's diff, neither appeared in CI's Shard 2/3 (which passed), and both are orthogonal local-venv gaps, not regressions. 21/21 in `test_cure_forward_guard.py`, 91/91 in `test_detect_secrets_auto_triage.py`, unaffected.

No contradiction found between the brief and what's actually on disk once the schema correction (point 2), the trend correction (point 1), the `created_at` correction (point 8), the independent wall-clock guard (point 9), and the nationality-gap PIN retirement (point 10) were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





