### PR TITLE
fix(garuda): B1 extension max-stay guard let a 60-day difference through as ACCEPT, one day over

### DIFF
--- a/apps/backend-rag/backend/services/garuda_flow/constants.py
+++ b/apps/backend-rag/backend/services/garuda_flow/constants.py
@@ -31,6 +31,19 @@ Every number here is traceable to a governance document, NOT invented:
 - ``INTERNAL_ESCALATION_DAYS`` (D-3) / ``FINAL_CHECK_DAYS`` (D-1): internal
   Bali Zero checkpoints only (SOP §6) — never quoted to clients.
 - ``MIN_PASSPORT_VALIDITY_DAYS`` (≥6 months from entry): SOP §1 + §4 checklist.
+- ``b1_max_total_stay_exceeded()``: B1 stay is counted with the arrival day AS
+  DAY 1 — imigrasi.go.id's own B1 page states the initial stay is "maksimal 30
+  hari, dihitung sejak tanggal kedatangan" (max 30 days, counted FROM the
+  arrival date). So for a legal maximum of N days (``VISA_META[VisaType.B1]``:
+  30 + 1×30 extension = 60), day N of the stay is ``entry_date + (N - 1)``
+  days, and a printed expiry of ``entry_date + N`` days is already day N+1 —
+  one day past the maximum. The day-DIFFERENCE comparison against the max is
+  therefore inclusive (``>=``), never strict (``>``); this helper is the
+  single place that convention is expressed, so the internal preview CLI's
+  B1 max-stay guard never re-derives it from a bare comparison operator
+  (verified 2026-08-23: a previous strict-`>` inline comparison silently
+  ACCEPTed a difference exactly equal to the max, one day over the legal
+  maximum).
 
 These are the enforceable form of what the Gate-1 role-play validated by hand.
 """
@@ -47,6 +60,20 @@ FINAL_CHECK_DAYS: int = 1  # D-1 — internal final-check checkpoint
 # ── Intake ───────────────────────────────────────────────────────────
 MIN_PASSPORT_VALIDITY_DAYS: int = 180  # >= 6 months from entry (SOP §1/§4)
 
+
+def b1_max_total_stay_exceeded(day_difference: int, max_total_stay_days: int) -> bool:
+    """Whether a B1 printed-expiry day-difference exceeds the legal max stay.
+
+    ``day_difference`` is ``(printed_expiry - entry_date).days``.
+    ``max_total_stay_days`` is the legal maximum (base duration + extensions,
+    e.g. derived from ``VISA_META[VisaType.B1]``) expressed as a day COUNT,
+    not an offset. See the module docstring above for why the comparison is
+    inclusive: the arrival day counts as day 1, so a difference equal to the
+    max is already one day past it.
+    """
+    return day_difference >= max_total_stay_days
+
+
 __all__ = [
     "EXTENSION_WINDOW_OPENS_DAYS",
     "FINAL_CHECK_DAYS",
@@ -54,4 +81,5 @@ __all__ = [
     "MIN_PASSPORT_VALIDITY_DAYS",
     "PILOT_INTAKE_THRESHOLD_DAYS",
     "PUBLISHED_FILING_DEADLINE_DAYS",
+    "b1_max_total_stay_exceeded",
 ]

--- a/apps/backend-rag/backend/services/garuda_flow/internal_preview_cli.py
+++ b/apps/backend-rag/backend/services/garuda_flow/internal_preview_cli.py
@@ -24,6 +24,7 @@ from backend.services.garuda_flow.constants import (
     FINAL_CHECK_DAYS,
     INTERNAL_ESCALATION_DAYS,
     PILOT_INTAKE_THRESHOLD_DAYS,
+    b1_max_total_stay_exceeded,
 )
 from backend.services.garuda_flow.intake import (
     CaseType,
@@ -132,7 +133,9 @@ def _validate_entry_window(request: InternalPreviewRequest, *, today: date) -> N
     meta = VISA_META[VisaType.B1]
     extension_count, extension_days = meta.extensions
     max_total_stay_days = meta.duration_days + extension_count * extension_days
-    if (printed_expiry - request.entry_date).days > max_total_stay_days:
+    if b1_max_total_stay_exceeded(
+        (printed_expiry - request.entry_date).days, max_total_stay_days
+    ):
         raise PreviewInputError("extension expiry exceeds B1 maximum stay")
 
 

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_internal_preview_cli.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_internal_preview_cli.py
@@ -255,6 +255,36 @@ def test_extension_rejects_printed_expiry_beyond_b1_max_total_stay() -> None:
         build_internal_preview(request, today=_TODAY, generated_at=_NOW)
 
 
+def test_extension_rejects_printed_expiry_exactly_at_b1_max_total_stay_boundary() -> None:
+    # GUILT case: entry 2026-07-01 + 60 days (B1's inclusive-count max, day 1 = arrival
+    # day per imigrasi.go.id) lands on 2026-08-30 — that is day 61 of stay, one day
+    # PAST the legal maximum, so it must be rejected. A naive `> max_total_stay_days`
+    # comparison on the day-DIFFERENCE lets this exact boundary through as ACCEPT
+    # because the difference (60) is not strictly greater than the max (60).
+    request = _request(
+        case_type="extension",
+        entry_date="2026-07-01",
+        voa_expiry_date="2026-08-30",
+    )
+
+    with pytest.raises(ValueError, match="maximum stay"):
+        build_internal_preview(request, today=_TODAY, generated_at=_NOW)
+
+
+def test_extension_accepts_printed_expiry_one_day_inside_b1_max_total_stay_boundary() -> None:
+    # INNOCENCE case: entry 2026-07-01 + 59 days = 2026-08-29 is day 60 of stay —
+    # the legal maximum itself, still valid — and must remain ACCEPT.
+    request = _request(
+        case_type="extension",
+        entry_date="2026-07-01",
+        voa_expiry_date="2026-08-29",
+    )
+
+    response = build_internal_preview(request, today=_TODAY, generated_at=_NOW)
+
+    assert response.decision == "ACCEPT"
+
+
 def test_past_printed_expiry_reaches_engine_and_declines_as_expired() -> None:
     response = build_internal_preview(
         _request(

--- a/evidence/brief.yml
+++ b/evidence/brief.yml
@@ -1,80 +1,35 @@
-task_id: s12-c4-quickcheck
+task_id: garuda-b1-max-stay-boundary-0823
 gear: 2
-l_level: L1
+l_level: L2
 gate_class: opus
-objective: |
-  Kill mechanical red CI rounds before they reach CI. Measured the same day:
-  a red PR round whose cause is purely mechanical — a prepush-guards miss, a
-  Prettier diff, an adversarial-review gate missing its literal heading —
-  costs a lane roughly 30 minutes of wall-clock, and the diagnosis is
-  available locally in about a second.
-
-  `scripts/quickcheck.sh` runs four checks, each scoped to what actually
-  changed vs origin/main, and is wired ADVISORY-ONLY into `.husky/pre-push`.
-
-  The single hard constraint is that it must NEVER become a second blocking
-  gate. That is not a promise in a comment here — it is proven twice below,
-  by two independent mechanisms, because a pre-push hook that can block is a
-  hook that will one day block someone at the worst possible moment.
+objective: >-
+  `internal_preview_cli.py::_validate_entry_window` rejects a B1 extension's
+  printed expiry only when `(printed_expiry - entry_date).days` is STRICTLY
+  GREATER THAN the legal max-stay day count (60). Because B1 stay is counted
+  with the arrival day AS DAY 1, a difference of exactly 60 is already the
+  61st calendar day of stay — one day past the legal maximum — and the strict
+  `>` silently ACCEPTed it. Make the comparison inclusive and single-source
+  the day-counting convention in a documented helper so the next reader does
+  not have to re-derive it from a bare operator.
+why_now: >-
+  Independently reproduced and confirmed by three instruments this session
+  (cross-family red-team, cross-family refuter, Google-grounded research
+  pass): `build_internal_preview(EXTENSION, entry=2026-07-01,
+  voa_expiry=2026-08-30, today=2026-08-23)` returned `decision=ACCEPT` with a
+  published filing deadline, for a stay that is one day beyond what
+  imigrasi.go.id's own B1 page allows ("maksimal 30 hari, dihitung sejak
+  tanggal kedatangan"). The only existing boundary test used a 61-day
+  difference (clearly over) and never exercised the ==60 edge, so the gap was
+  live and undocumented.
 constraints:
-  - 'NEVER blocks a push. Guaranteed at two independent layers: the script
-    itself ends `main "$@"; exit 0` (its exit status is unconditional and
-    does not depend on what any check returned), and the call site in
-    `.husky/pre-push` invokes it as `bash ... || true`. Either layer alone
-    would suffice; both are present deliberately.'
-  - "Reuses the engines the PR lane already uses rather than inventing
-    parallel ones: `scripts/ci/impact_map.py` for test selection (never the
-    full 17k-test suite), `prettier --check` on changed files with the same
-    extension scope as package.json's own format:check, and actionlint with
-    the same auto-discovery scope as .github/workflows/actionlint.yml. A
-    local check that disagrees with CI is worse than no local check."
-  - "The R1 heading check matches the LITERAL line `## Adversarial review` —
-    exact, anchored, case-sensitive. NOT a substring match on `adversarial`:
-    superscar family #3 catalogues ~20 scars in this repo caused by exactly
-    that shortcut, and this check is guarded by guilt tests that reject the
-    bare substring and the wrong hash count."
-  - "Every check is skippable and every one degrades to a skip-with-reason,
-    never to a false pass or a hang. `QUICKCHECK_SKIP=1` disables the hook
-    entirely."
+  - "OUT of scope: safe_clock.py's estimated stay-end (entry + 30) — a documented, deliberately accepted +1-day optimism with a printed_expiry override and an existing pinning test from a 2026-07-25 grader round. Not touched."
+  - "OUT of scope: the 6-month passport rule (spec says 'from entry', already correct)."
+  - "OUT of scope: anything under apps/mouth/, apps/admin-dashboard-local/, or any non-garuda_flow path."
+  - "The fix must not touch VISA_META's B1 duration_days/extensions data — only the comparison semantics against the already-derived max_total_stay_days."
+  - "No hardcoded day-count constant that duplicates VISA_META's derived value (that would drift silently if VISA_META B1 data ever changes) — express the convention as a named helper instead."
 acceptance:
-  - "Exit code is 0 on a clean tree AND when checks find problems — measured,
-    not asserted."
-  - "A quickcheck that exits non-zero still lets the push proceed, including
-    under `sh -e` (the W101 decapitation shape)."
-  - "Runtime on the fast path is low enough to sit in front of every push."
-  - "The R1 guard rejects the substring and the wrong heading level."
-consumer_map:
-  - "`.husky/pre-push` — the call site. Advisory, existence-guarded,
-    kill-switched. This PR DOES wire it (see dissent: that deviates from the
-    gate's own instruction and was accepted on measured merit, not waved
-    through)."
-  - "`scripts/ci/impact_map.py` — reused, not reimplemented."
-  - "`.github/workflows/actionlint.yml` — scope mirrored, not duplicated."
-risks:
-  - "An advisory check that is always green teaches people to ignore it. The
-    mitigation here is scope, not severity: it only speaks when the diff
-    actually touches the surface each check covers, and says
-    `skipped — <reason>` otherwise, so a silent run means 'nothing to say',
-    not 'nothing checked'."
-  - "The R1 heading matcher is STRICTLY NARROWER than CI's: quickcheck wants
-    `^## Adversarial review` exactly and case-sensitively, while
-    `scripts/check_adversarial_review.py` accepts `^#{2,}\\s+Adversarial
-    review\\b` case-insensitively. So quickcheck can cry MISSING on a body CI
-    would pass. Kept deliberately — the direction is safe (a false alarm sends
-    you to the real gate; it can never produce a false all-clear) — but it is
-    a real divergence, not a duplicate, and it is named rather than left to be
-    rediscovered in anger."
-  - "`actionlint` is not installed on this host, so that branch of the script
-    was never exercised end-to-end here. Correct by inspection only. It was
-    deliberately NOT auto-downloaded into a hook: CI's pinned binary is
-    linux_amd64 and shipping an unpinned download inside a pre-push hook is a
-    supply-chain shortcut this repo does not take."
-grader: |
-  Independent verification by the S12 conductor (Opus 5), which did not write
-  any of the 497 lines: the diff scope was read, the deviation from the
-  no-install instruction was caught by reading `.husky/pre-push` rather than
-  taken from the implementer's report, both advisory guarantees were proven
-  by execution, the runtime was timed, the deterministic floor was recomputed
-  from the diff, and the test suite was re-run.
-budget: 1 implementer lane + conductor gate; no council (a local advisory script)
-pii: none
+  - "A printed expiry at entry_date + 60 days (arrival-day-inclusive day 61) is REJECTED with a 'maximum stay' ValueError."
+  - "A printed expiry at entry_date + 59 days (day 60, the legal maximum itself) is still ACCEPTED."
+  - "The pre-existing 61-day-difference boundary test (test_extension_rejects_printed_expiry_beyond_b1_max_total_stay) still passes unchanged."
+  - "The day-counting convention (arrival day = day 1, hence inclusive >= comparison) is documented once, in constants.py, next to the existing MIN_PASSPORT_VALIDITY_DAYS/PUBLISHED_FILING_DEADLINE_DAYS sourcing comments, not re-derived inline."
+  - "Full backend/tests/services/garuda_flow/ suite passes after the change (measured before and after)."

--- a/evidence/pack.yml
+++ b/evidence/pack.yml
@@ -1,198 +1,50 @@
 brief_ref: evidence/brief.yml
-plan_ref: "S12/C4 — advisory pre-push quickcheck (mandate ~/sessioni-2026-08-23/S12-mini-ship-accelerators.md, Mini, 2026-08-23)"
-lanes:
-  - lane: s12-c4
-    role: build
-    seat: "claude-sonnet-5 (implementer subagent, Mini)"
-  - lane: s12-c4-gate
-    role: review
-    seat: "claude-opus-5 (S12 conductor — generator != grader, wrote none of the 497 lines)"
-seat_diversity: degraded
-seat_diversity_note: >-
-  Both lanes are Anthropic seats. Only one build lane, so the D3 rule's own
-  floor (>=2 build lanes) does not fire, but the absence is real and is
-  declared rather than left to read as satisfied. Roster state measured this
-  session: codex AUTH_DEAD (401, refresh token revoked), glm CRED_UNAVAILABLE,
-  kimi LIVE but spent on S12/C1 (larger blast radius), and agy — contrary to
-  an earlier reading — was ALIVE and reachable from Pro the whole time. So
-  for this lane the missing cross-family review is a CHOICE made under time
-  pressure, not an unavailable-seat constraint.
+plan_ref: "BUILD LANE B1 mandate (team-lead, GARUDA VOA engine) — B1 max-stay boundary off-by-one, garuda-b1-max-stay-boundary-0823"
 diff:
-  net_lines: >-
-    3 files, +497/-0: scripts/quickcheck.sh (358), scripts/tests/test_quickcheck.sh
-    (109), .husky/pre-push (+30). Deterministic gear floor RECOMPUTED from the
-    diff by the gate = 1 (.husky/pre-push is NOT a hot-zone path). Declared
-    Gear 2 because it is a new 358-line script that runs on every developer's
-    push, not because the floor demanded it.
-  behaviour_change: >-
-    Every `git push` in this repo now runs an advisory check first. Nothing
-    can newly fail: the hook cannot block (proven twice below), and
-    QUICKCHECK_SKIP=1 disables it.
+  net_lines: "Three files: constants.py (+28/-0, new documented helper b1_max_total_stay_exceeded() plus its sourcing comment), internal_preview_cli.py (+4/-1, swaps the inline strict comparison for the helper call), test_internal_preview_cli.py (+30/-0, one GUILT test at the ==60 boundary and one INNOCENCE test at ==59). Net +61 across the real diff (evidence/*.yml excluded, they are PR scratch)."
+  behaviour_change: "The B1 extension max-stay guard now REJECTS a printed expiry whose day-difference from entry_date is exactly the legal max (60), not only strictly above it. Nothing else changes: VISA_META's B1 duration_days/extensions data is untouched, the derivation of max_total_stay_days is untouched, every other validation branch in _validate_entry_window is untouched, and safe_clock.py's separate estimated-stay-end approximation is explicitly out of scope and untouched."
 receipts:
-  - claim: "Exit code is 0 and the fast path is ~1 second"
-    cmd: "time bash scripts/quickcheck.sh   (clean tree, 3 changed files vs origin/main)"
-    result: >-
-      EXIT=0; real 1.011s (0.09s user, 0.06s system). Output named each
-      skipped check with its reason (no backend .py in diff, no
-      ts/js/json/md/yml in diff, no open PR for the branch) rather than
-      printing a bare green.
+  - claim: "The mandate's exact reproduction reproduces on truly unmodified source (fix stashed via `git stash push` on only the two source files, re-run, then popped back) — decision=ACCEPT for a 60-day difference, one day past the B1 legal maximum — and after popping the fix back, the SAME call REJECTS"
+    cmd: 'PYTHONPATH=. python3 -c "...InternalPreviewRequest+build_internal_preview(EXTENSION, entry=2026-07-01, voa_expiry=2026-08-30, today=2026-08-23)...": before fix -> ''decision= ACCEPT published_filing_deadline= 2026-08-23''; after fix (same call, PreviewInputError caught) -> "REJECTED: extension expiry exceeds B1 maximum stay"'
     exit: 0
-    ts: "2026-08-23T12:14Z"
-    seat: "session (mini, conductor/gate)"
-  - claim: "GUARANTEE 1 — the script's own exit status is unconditional, independent of what any check returned"
-    cmd: "tail -12 scripts/quickcheck.sh"
-    result: >-
-      The entrypoint is `main \"$@\"` followed by a bare `exit 0` on the next
-      line — main's return value is discarded by construction. Read from the
-      file, not from the header's claim about itself.
+    ts: "2026-08-23T13:12:00Z"
+    seat: "opus-5"
+  - claim: "Guilt test (==60 boundary) was RED on unmodified code, not written after the fact"
+    cmd: "PYTHONPATH=. pytest backend/tests/services/garuda_flow/test_internal_preview_cli.py -k b1_max_total_stay_boundary -v -> test_extension_rejects_printed_expiry_exactly_at_b1_max_total_stay_boundary FAILED (Failed: DID NOT RAISE <class 'ValueError'>); test_extension_accepts_printed_expiry_one_day_inside_b1_max_total_stay_boundary PASSED. 1 failed, 1 passed."
+    exit: 1
+    ts: "2026-08-23T13:03:00Z"
+    seat: "opus-5"
+  - claim: "After the fix, the guilt test, the innocence test, and the pre-existing 61-day-difference boundary test all pass together"
+    cmd: 'PYTHONPATH=. pytest backend/tests/services/garuda_flow/test_internal_preview_cli.py -k "b1_max_total_stay_boundary or beyond_b1_max_total_stay" -v -> 3 passed, 20 deselected'
     exit: 0
-    ts: "2026-08-23T12:15Z"
-    seat: "session (mini, conductor/gate)"
-  - claim: "GUARANTEE 2 — a quickcheck that exits 1 STILL lets the push proceed, including under `sh -e` (the W101 decapitation shape)"
-    cmd: 'sh -e -c ''bash <stub-that-prints-and-exits-1> || true; echo "PUSH PROCEEDS (rc=$?)"'''
-    result: >-
-      'SIMULATED FAILURE' then 'PUSH PROCEEDS (rc=0)', outer rc=0. Exercised
-      against a stub that hard-exits 1, because the real script cannot be made
-      to exit non-zero — which is exactly why the call site needed testing
-      SEPARATELY from the script. Two independent layers, either sufficient.
+    ts: "2026-08-23T13:07:00Z"
+    seat: "opus-5"
+  - claim: "The full garuda_flow suite is green after the change, and the count moved by exactly the 2 tests added (no collateral breakage, no collateral skip)"
+    cmd: "PYTHONPATH=. pytest backend/tests/services/garuda_flow/ -> before: 125 passed; after: 127 passed"
     exit: 0
-    ts: "2026-08-23T12:15Z"
-    seat: "session (mini, conductor/gate)"
-  - claim: "The R1 heading guard has real guilt tests — it is not a substring match on 'adversarial'"
-    cmd: "bash scripts/tests/test_quickcheck.sh"
-    result: >-
-      ALL PASS, including the three guilt cases: rejects 'Adversarial review'
-      with no hashes, rejects the bare substring 'adversarial' with no
-      heading, rejects '### Adversarial review' (wrong hash count).
+    ts: "2026-08-23T13:08:00Z"
+    seat: "opus-5"
+  - claim: "The wider GARUDA surface (garuda_flow/ + the two garuda_voa router test files) is green and matches the mandate's known-good baseline of 162 plus the 2 tests this PR adds"
+    cmd: "PYTHONPATH=. pytest backend/tests/services/garuda_flow/ backend/tests/app/routers/test_garuda_voa.py backend/tests/app/routers/test_garuda_voa_no_internal_leak.py -> 164 passed"
     exit: 0
-    ts: "2026-08-23T12:16Z"
-    seat: "session (mini, conductor/gate)"
-  - claim: "The deterministic gear floor is 1 — recomputed by the gate from the actual diff, not taken from the brief"
-    cmd: "git diff --name-only origin/main...HEAD > /tmp/c4-changed.txt; evidence_pack_lint.py --print-floor --changed-files-file /tmp/c4-changed.txt"
-    result: "1 (.husky/pre-push, scripts/quickcheck.sh, scripts/tests/test_quickcheck.sh — no hot-zone hit)"
+    ts: "2026-08-23T13:09:00Z"
+    seat: "opus-5"
+  - claim: "The dependency-injection import chain is unbroken by this change"
+    cmd: 'python -c "from backend.app.dependencies import get_current_user; print(''OK'')" -> OK'
     exit: 0
-    ts: "2026-08-23T12:16Z"
-    seat: "session (mini, conductor/gate)"
-  - claim: "SLOW path measured too — scoped pytest actually runs and names the broken test"
-    cmd: "time bash scripts/quickcheck.sh (deliberately-broken test committed, diff isolated via the script's own QUICKCHECK_BASE_REF override)"
-    result: >-
-      3.38s user 0.24s system 53% cpu, 6.811s total — names
-      test_quickcheck_probe_deliberately_broken with its AssertionError.
-      Measured by the IMPLEMENTER and reported to the gate; recorded here
-      attributed to it, not reproduced as if the gate ran it. The isolation is
-      necessary and self-cancelling: against real origin/main this PR's diff
-      is mixed, impact_map fails open on out-of-scope paths by its own
-      contract, and the fast path fires instead (0.87s) — an artifact of
-      testing the check inside the PR that introduces it, gone once merged.
-    exit: 0
-    ts: "2026-08-23T11:54Z"
-    seat: "s12-c4 implementer (claude-sonnet-5)"
-  - claim: "ADVISORY proven by a REAL `git push`, not only by a stub: a failing quickcheck does not block a push"
-    cmd: "git push /tmp/quickcheck-fake-remote-XXXXX.git HEAD:refs/heads/proof-isolated   (throwaway LOCAL bare repo, never origin, broken test committed)"
-    result: >-
-      quickcheck reported '[pytest] scoped suite reported failures (advisory,
-      rc=1)' and named the AssertionError; the push still completed —
-      '* [new branch] HEAD -> proof-isolated', EXIT_CODE=0 — and the object
-      was verified present in the bare repo. Same push in the unmodified state
-      also EXIT_CODE=0. Bare repo destroyed, probe reverted, `git remote -v`
-      back to origin/pro/m5 only. Measured by the IMPLEMENTER; this is a
-      stronger proof than the gate's own `sh -e` stub test, which is retained
-      above because the two exercise different layers.
-    exit: 0
-    ts: "2026-08-23T11:54Z"
-    seat: "s12-c4 implementer (claude-sonnet-5)"
-pii_scan: clean
-dissent:
-  - seat: "the implementer, against the gate — and the implementer was RIGHT"
-    objection: >-
-      An earlier draft of this pack recorded the `.husky/pre-push` wiring as a
-      CONFIRMED deviation from an explicit gate instruction, and stated that
-      the gate caught it by reading the diff "NOT from the implementer's
-      report". The implementer contested both claims. On re-checking the
-      primary sources rather than the gate's memory of them, BOTH gate claims
-      were false.
-    status: RETRACTED
-    note: >-
-      Retracted in full, and the retraction is kept in the record rather than
-      the entry being deleted. (1) The wiring was ORDERED, not deviated from —
-      the S12 mandate, line 38, verbatim: "Wire into `.husky/pre-push` as
-      **advisory** (WARN, never a second blocking gate ...)". The gate's later
-      question ("confirm you have NOT wired it into .git/hooks/pre-push or any
-      installed hook") was about a different layer, the machine-level
-      git-hooks mechanism, and the implementer answered it correctly and
-      completely: `.git/hooks/` untouched, `core.hooksPath=.husky/_`
-      pre-existing and not installed by it, no `husky install` run. (2) It was
-      disclosed UPFRONT — the first line of the implementer's first report
-      names ".husky/pre-push wired via `bash scripts/quickcheck.sh || true`"
-      as one of three headline deliverables. The gate did not discover it; it
-      was told, and later mis-remembered being told. (3) The gate also wrote
-      that the implementer "went quiet before sending the numbers" — also
-      false: the numbers were sent (fast/slow `time` output, two real pushes
-      with captured exit codes, a CI-overlap audit) and arrived while the gate
-      was already mid-gate. That is message ordering, not silence, and the
-      gate should have said so. This entry stays because a gate that
-      mis-states a teammate's conduct in a permanent record is a worse defect
-      than the one it thought it had found, and deleting the accusation would
-      hide the correction along with it.
-  - seat: "the implementer (named finding the gate had not caught), on R1 vs CI"
-    objection: >-
-      The R1 heading matcher DISAGREES with CI and is strictly narrower.
-      quickcheck matches `^## Adversarial review` (exact, case-sensitive); CI's
-      `scripts/check_adversarial_review.py` matches
-      `^#{2,}\s+Adversarial review\b` (case-INsensitive, 2+ hashes, flexible
-      whitespace). So quickcheck reports MISSING on bodies CI would PASS —
-      `### Adversarial review`, two spaces after the hashes, or lowercase.
-    status: CONFIRMED
-    note: >-
-      Verified by the gate by reading both regexes, not accepted on assertion.
-      Left as-is deliberately: the disagreement direction is the safe one (a
-      false alarm sends you to look at the real gate; it can never produce a
-      false all-clear), and this is an advisory check whose failure mode is
-      annoyance. But it IS a real divergence, not a duplicate of CI, and it is
-      named here rather than left for someone to rediscover when quickcheck
-      cries about a heading CI is perfectly happy with. Found and reported by
-      the implementer, not by the gate.
-  - seat: "S12 conductor (gate), on the slow-path measurement"
-    objection: >-
-      An earlier draft claimed only the FAST path had been timed. The
-      implementer had in fact measured both, and its caveat is more
-      interesting than the numbers.
-    status: RETRACTED
-    note: >-
-      Both paths are measured (see receipts). The caveat that matters, in the
-      implementer's own framing: to reach the slow path at all it had to
-      isolate the diff with `QUICKCHECK_BASE_REF`, because measured against
-      real origin/main this PR's diff is MIXED (it contains quickcheck's own
-      non-.py files), and `impact_map.py` fails open on any out-of-scope path
-      by its own declared contract — so pytest never runs and the fast path
-      fires instead (0.87s). That is a structural artifact of testing a check
-      inside the PR that introduces it, and it disappears once merged: a
-      normal single-concern PR will not carry `scripts/quickcheck.sh` in its
-      own diff. 6.811s is what a real future backend-touching PR sees.
+    ts: "2026-08-23T13:09:30Z"
+    seat: "opus-5"
 tests:
-  - "scripts/tests/test_quickcheck.sh — ALL PASS, re-run by the gate rather than trusted from the implementer's report. Guilt on the R1 guard: bare substring rejected, wrong hash count rejected, heading-without-hashes rejected."
+  - "backend/tests/services/garuda_flow/test_internal_preview_cli.py::test_extension_rejects_printed_expiry_exactly_at_b1_max_total_stay_boundary — new GUILT test, red on unmodified code, green after fix"
+  - "backend/tests/services/garuda_flow/test_internal_preview_cli.py::test_extension_accepts_printed_expiry_one_day_inside_b1_max_total_stay_boundary — new INNOCENCE test, green throughout"
+  - "backend/tests/services/garuda_flow/test_internal_preview_cli.py::test_extension_rejects_printed_expiry_beyond_b1_max_total_stay — pre-existing 61-day boundary test, unchanged, still green"
+  - "backend/tests/services/garuda_flow/ (full dir) — 127 passed (was 125)"
+  - "backend/tests/services/garuda_flow/ + test_garuda_voa.py + test_garuda_voa_no_internal_leak.py — 164 passed (matches mandate's 162 baseline + 2 new tests)"
 static:
-  - "bash -n scripts/quickcheck.sh -> clean"
-  - "pre-commit hooks pass, none bypassed"
-notes:
-  - >-
-    An earlier commit on this branch (a deliberately-broken test used to probe
-    the acceptance) was correctly reverted by the implementer before this pack
-    was written; the branch head carries only the feature commit. Verified by
-    the gate reading git log, not by asking.
-  - >-
-    PROCESS FINDING, more useful than anything else in this pack. The gate
-    wrote three false statements about the implementer's conduct into an
-    earlier draft — that it deviated from an instruction, that the gate caught
-    the deviation by reading the diff, and that it "went quiet". All three
-    came from the gate reasoning over its own recollection of the mandate and
-    of the message order, instead of re-reading the mandate file and its own
-    inbox. The implementer contested them with citations; every citation held.
-    The mechanism is exactly the anti-hallucination rule this repo already has
-    ("never cite a tool's output without having run it THIS turn") applied to
-    a surface it is usually not applied to: a claim about a COLLEAGUE'S
-    conduct is a claim about world-state and needs a primary source in the
-    same turn, at least as much as a file path does. Cheap to prevent
-    (`grep` the mandate, re-read the message), expensive to leave standing —
-    an evidence pack is permanent and this one would have libelled a
-    teammate's process on main forever.
+  - "python -c 'from backend.app.dependencies import get_current_user; print(OK)' -> OK (import chain smoke, CLAUDE.md §11 pre-deploy step)"
+lanes:
+  - lane: "garuda-b1-boundary-build"
+    role: build
+    seat: "opus-5"
+pii_scan: clean
+dissent: []


### PR DESCRIPTION
## What

`internal_preview_cli.py::_validate_entry_window` rejected a B1 extension's printed expiry only when `(printed_expiry - entry_date).days` was STRICTLY GREATER THAN the legal max-stay day count (60). B1 stay is counted with the arrival day AS DAY 1 (imigrasi.go.id: "maksimal 30 hari, dihitung sejak tanggal kedatangan"), so a difference of exactly 60 is already day 61 of stay — one day past the legal maximum (30 base + 1×30 extension) — and the strict `>` silently ACCEPTed it.

## Production impact: NONE — this does not reach the Fly-deployed runtime

The live Fly router `apps/backend-rag/backend/app/routers/garuda_voa.py` imports only `eligibility.DeclineCode` and `intake.CaseType` (enums) plus the repository. It never calls `build_verdict`, `eligibility.screen`, or `build_internal_preview` — those names appear in that file only in comments/docstrings. The only live consumer of `internal_preview_cli.py` is the owner-local admin cockpit, which spawns it as a subprocess from the local checkout (loopback-only, operator-controlled SSH access — see the module's own docstring). **This PR changes zero production runtime behaviour and requires no Fly deploy.**

## Reproduction (before the fix, on unmodified source)

```
build_internal_preview(EXTENSION, entry=2026-07-01, voa_expiry=2026-08-30, today=2026-08-23)
-> decision=ACCEPT, published_filing_deadline=2026-08-23
```

Same call after the fix:

```
-> PreviewInputError: extension expiry exceeds B1 maximum stay
```

## Fix

Added `constants.b1_max_total_stay_exceeded()`, a documented helper expressing the inclusive-day-counting convention (`>=`, not `>`), and swapped it in for the inline comparison. Deliberately **not** a hardcoded day-count constant — that would duplicate `VISA_META`'s derived value (`meta.duration_days + extension_count * extension_days`) and could drift silently if B1's duration/extension data ever changes.

## Tests

- `test_extension_rejects_printed_expiry_exactly_at_b1_max_total_stay_boundary` (GUILT, difference==60) — confirmed **red** on unmodified code (`Failed: DID NOT RAISE <class 'ValueError'>`), green after the fix.
- `test_extension_accepts_printed_expiry_one_day_inside_b1_max_total_stay_boundary` (INNOCENCE, difference==59) — green throughout.
- The pre-existing difference==61 boundary test is untouched and stays green.

Suite: `backend/tests/services/garuda_flow/` 125 → 127 passed. Wider surface (+ `test_garuda_voa.py` + `test_garuda_voa_no_internal_leak.py`): 164 passed, matching the mandate's 162 baseline + 2 new tests.

## End-to-end verification through the actual CLI entrypoint (not just unit tests)

Ran `python -m backend.services.garuda_flow.internal_preview_cli` as a real subprocess with JSON on stdin — the exact way the owner-local cockpit invokes it — for both edges (entry `2026-08-01`, chosen so the printed expiry sits safely in the future relative to the real system clock and doesn't trip the separate, unrelated `EXPIRES_TOO_SOON` business decline):

```
$ echo '{"case_type":"extension",...,"entry_date":"2026-08-01","voa_expiry_date":"2026-09-30",...}' \
    | PYTHONPATH=. python3 -m backend.services.garuda_flow.internal_preview_cli   # difference==60
{"ok":false,"error":"invalid_request"}
exit 2

$ echo '{"case_type":"extension",...,"entry_date":"2026-08-01","voa_expiry_date":"2026-09-29",...}' \
    | PYTHONPATH=. python3 -m backend.services.garuda_flow.internal_preview_cli   # difference==59
{"decision":"ACCEPT","reason_codes":[],...}
exit 0
```

The CLI deliberately genericizes every validation failure to `{"ok":false,"error":"invalid_request"}` (its own docstring: "emits no input in logs or errors"), so `exit 2` + that body is the correct, by-design shape for the rejected case — it is not distinguishable from other validation errors by design, and the unit test (which asserts on the underlying `PreviewInputError` message directly) is what pins the specific "maximum stay" reason.

## Out of scope (deliberately untouched)

- `safe_clock.py`'s estimated stay-end (`entry + 30`) — a separate documented +1-day optimism with its own pinning test from a 2026-07-25 grader round.
- The 6-month passport rule (spec says "from entry", already correct).
- Anything under `apps/mouth/`, `apps/admin-dashboard-local/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
