### PR TITLE
fix(visa-oracle): wall family.sponsor_permit_basis to UNKNOWN — self-declared, not document-verified

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -180,6 +180,7 @@ describe("question registry -> wire coverage", () => {
     ["investment_vehicle", "property", "ACTIVITY_BOUNDARY"],
     ["retirement_basis", "property", "ACTIVITY_BOUNDARY"],
     ["family_sponsor_status_code", "FOO", "AMBIGUOUS_SPONSOR"],
+    ["family_sponsor_permit_basis", "EXPERT", "AMBIGUOUS_SPONSOR"],
     ["diaspora_connection", "former_citizen", "ACTIVITY_BOUNDARY"],
     ["diaspora_documents", "passport", "ACTIVITY_BOUNDARY"],
     ["other_purpose", "medical", "ACTIVITY_BOUNDARY"],
@@ -613,6 +614,50 @@ describe("family sponsor status — unverified human context", () => {
       reason: "UNVERIFIED",
     });
     expect(result.disclosed_review_flags).toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  // 2026-08-23: `family.sponsor_permit_basis` shipped in PR #4650 wired to
+  // `enumFact()` directly — a self-declared choice resolved straight to
+  // KNOWN, missing the parallel to the sibling test immediately above.
+  // Corrected to mirror it exactly: collected, flagged, never trusted.
+  it("never turns a self-declared permit-basis category into a KNOWN signed fact", () => {
+    const result = mapFacts({
+      family_sponsor_confirmed: "yes",
+      family_sponsor_permit_basis: "EXPERT",
+    });
+    expect(result.facts["family.sponsor_permit_basis"]).toEqual({
+      status: "UNKNOWN",
+      reason: "UNVERIFIED",
+    });
+    expect(result.disclosed_review_flags).toContain("AMBIGUOUS_SPONSOR");
+  });
+
+  it("resolves NOT_APPLICABLE for both sponsor facts when no sponsor is confirmed", () => {
+    const result = mapFacts({
+      family_sponsor_confirmed: "no",
+      family_sponsor_status_code: "E28B",
+      family_sponsor_permit_basis: "EXPERT",
+    });
+    expect(result.facts["family.sponsor_status_code"]).toEqual({
+      status: "UNKNOWN",
+      reason: "NOT_APPLICABLE",
+    });
+    expect(result.facts["family.sponsor_permit_basis"]).toEqual({
+      status: "UNKNOWN",
+      reason: "NOT_APPLICABLE",
+    });
+  });
+
+  it("resolves NOT_ASKED for both sponsor facts on an empty interview", () => {
+    const result = mapFacts({});
+    expect(result.facts["family.sponsor_status_code"]).toEqual({
+      status: "UNKNOWN",
+      reason: "NOT_ASKED",
+    });
+    expect(result.facts["family.sponsor_permit_basis"]).toEqual({
+      status: "UNKNOWN",
+      reason: "NOT_ASKED",
+    });
   });
 });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -40,7 +40,6 @@ type ProposedRole = KnownValue<"investment.proposed_role">;
 type FamilyRelation = KnownValue<"family.relation_to_sponsor">;
 type StudyLevel = KnownValue<"study.level">;
 type SponsorTypeValue = KnownValue<"sponsor.type">;
-type SponsorPermitBasisValue = KnownValue<"family.sponsor_permit_basis">;
 
 const NOT_ASKED: UnknownReasonWire = "NOT_ASKED";
 const UNVERIFIED: UnknownReasonWire = "UNVERIFIED";
@@ -213,23 +212,6 @@ const SPONSOR_TYPES = [
   "INVESTMENT",
   "GOVERNMENT",
 ] as const satisfies readonly SponsorTypeValue[];
-// Mirrors the closed `SponsorPermitBasis` enum 1:1 (2026-08-23 owner
-// ruling — Permenkumham 11/2024 Pasal 33 ayat (2) huruf a-l).
-const SPONSOR_PERMIT_BASES = [
-  "EXPERT",
-  "WORKER",
-  "MARITIME_CREW",
-  "CLERGY",
-  "FOREIGN_INVESTMENT",
-  "SCIENTIFIC_RESEARCH",
-  "EDUCATION",
-  "FAMILY_REUNIFICATION",
-  "REPATRIATION",
-  "SECOND_HOME",
-  "MEDICAL_TREATMENT",
-  "WORKING_HOLIDAY",
-  "OTHER",
-] as const satisfies readonly SponsorPermitBasisValue[];
 
 export const CATEGORY_TO_PURPOSE: Partial<Record<CategoryKey, Purpose>> = {
   tourism: "TOURISM",
@@ -409,7 +391,10 @@ export function mapDisclosedReviewFlags(
   ) {
     flags.add("ACTIVITY_BOUNDARY");
   }
-  if (facts.family_sponsor_status_code !== undefined) {
+  if (
+    facts.family_sponsor_status_code !== undefined ||
+    facts.family_sponsor_permit_basis !== undefined
+  ) {
     flags.add("AMBIGUOUS_SPONSOR");
   }
   return [...flags].sort();
@@ -452,6 +437,40 @@ function mapFamilySponsorStatus(facts: OracleFacts): FactValue<string> {
   // The UI accepts a human-entered status label. It is not backed by the
   // signed status-code catalogue, so even a syntactically plausible value
   // must never satisfy an engine rule that checks `op: known`.
+  return unknownFact(UNVERIFIED);
+}
+
+/**
+ * `family.sponsor_permit_basis` shipped in PR #4650 wired straight to
+ * `enumFact()` — self-declaration resolving directly to `KNOWN`. That
+ * missed the parallel to its sibling immediately above: the applicant/
+ * sponsor is asked to classify the sponsor's OWN permit into one of 13
+ * Pasal 33 ayat (2) huruf a-l legal categories, a taxonomy they are no
+ * more likely to know precisely than a signed status code. Ruling 2's
+ * whole purpose is Pasal 33 ayat (7), an EXCLUSIONARY gate — a wrong
+ * self-declared category does not just fail to help, it can wrongly
+ * exclude an eligible applicant. Mirrors `mapFamilySponsorStatus` exactly:
+ * collected, flagged for human review (`AMBIGUOUS_SPONSOR`, below), never
+ * trusted for `op: known`, until a document-verified source (e.g. an
+ * OCR'd sponsor permit card cross-checked against the signed catalogue —
+ * which does not exist yet for `sponsor_status_code` either) supplies one.
+ */
+function mapFamilySponsorPermitBasis(
+  facts: OracleFacts,
+): FactValue<KnownValue<"family.sponsor_permit_basis">> {
+  if (facts.family_sponsor_confirmed === "no") {
+    return unknownFact(NOT_APPLICABLE);
+  }
+  if (facts.family_sponsor_confirmed === "unsure") {
+    return unknownFact(UNVERIFIED);
+  }
+  if (facts.family_sponsor_confirmed !== "yes") {
+    return facts.family_sponsor_permit_basis === undefined
+      ? unknownFact(NOT_ASKED)
+      : unknownFact(UNVERIFIED);
+  }
+  const value = facts.family_sponsor_permit_basis;
+  if (value === undefined) return unknownFact(NOT_ASKED);
   return unknownFact(UNVERIFIED);
 }
 
@@ -531,10 +550,7 @@ export function mapOracleFactsToApplicantFacts(
     "family.stepchild_birth_certificate_confirmed": booleanFact(
       facts.family_stepchild_birth_certificate_confirmed,
     ),
-    "family.sponsor_permit_basis": enumFact(
-      facts.family_sponsor_permit_basis,
-      SPONSOR_PERMIT_BASES,
-    ),
+    "family.sponsor_permit_basis": mapFamilySponsorPermitBasis(facts),
     "family.sponsor_confirmed": booleanFact(facts.family_sponsor_confirmed),
     "study.level": enumFact(facts.study_level, STUDY_LEVELS),
     "study.admission_confirmed": booleanFact(facts.study_admission_confirmed),

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
@@ -309,7 +309,7 @@ const en = {
   "q.family_sponsor_permit_basis.opt.WORKING_HOLIDAY": "Working holiday",
   "q.family_sponsor_permit_basis.opt.OTHER": "Another basis",
   "why.family_sponsor_permit_basis":
-    "Some permit bases block a family-reunification permit from being layered on top of them; the engine checks this directly.",
+    "Some permit bases block a family-reunification permit from being layered on top of them. We can't verify your answer automatically, so our team reviews it directly rather than the system deciding on its own.",
   "q.family_marriage_registered": "Is the marriage officially registered?",
   "q.family_marriage_registered.hint":
     "If your sponsor is your parent, this asks about your parents' marriage. Choose Not applicable if the family relationship involves no marriage.",
@@ -1062,7 +1062,7 @@ const id: Record<Keys, string> = {
   "q.family_sponsor_permit_basis.opt.WORKING_HOLIDAY": "Working holiday",
   "q.family_sponsor_permit_basis.opt.OTHER": "Dasar lain",
   "why.family_sponsor_permit_basis":
-    "Beberapa dasar izin dapat menghalangi penerbitan izin penyatuan keluarga di atasnya; mesin memeriksa ini secara langsung.",
+    "Beberapa dasar izin dapat menghalangi penerbitan izin penyatuan keluarga di atasnya. Kami tidak dapat memverifikasi jawaban Anda secara otomatis, sehingga tim kami yang meninjau langsung, bukan sistem yang memutuskan sendiri.",
   "q.family_marriage_registered": "Apakah pernikahan tercatat secara resmi?",
   "q.family_marriage_registered.hint":
     "Jika sponsor Anda adalah orang tua, pertanyaan ini mengenai pernikahan orang tua Anda. Pilih Tidak berlaku jika hubungan keluarga tidak melibatkan pernikahan.",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.test.ts
@@ -80,6 +80,18 @@ describe("tree.ts — interview decision boundary", () => {
     });
   });
 
+  // 2026-08-23: `family_sponsor_permit_basis` shipped as FACT in PR #4650,
+  // one increment before this fix — self-declaring a Pasal 33(2) legal
+  // category into engine trust, the same defect this file's sibling
+  // assertion above exists to prevent. Corrected to mirror
+  // `family_sponsor_status_code` exactly. See `mapFamilySponsorPermitBasis`
+  // in fact-mapper.ts for the full reasoning.
+  it("keeps self-declared sponsor permit basis outside engine facts too", () => {
+    expect(QUESTIONS.family_sponsor_permit_basis.decisionMapping).toEqual({
+      kind: "HUMAN_CONTEXT",
+    });
+  });
+
   it("does not carry the 2 dead legacy nodes (E4 slice — question-registry-audit.md §2)", () => {
     // Both were unreachable in the live graph (flow.ts's dispatch never
     // routed to them from any FIXED_CATEGORY_QUESTIONS or dynamic branch

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
@@ -794,14 +794,21 @@ export const QUESTIONS: Record<string, OracleQuestion> = {
   // free-form STRING and can only express validity, never purpose. Options
   // mirror the closed `SponsorPermitBasis` enum 1:1 — 13 values grounded in
   // Pasal 33 ayat (2) huruf a-l, verbatim quote in `why.family_sponsor_permit_basis`.
+  //
+  // HUMAN_CONTEXT, not FACT (corrected 2026-08-23, one increment after
+  // this question shipped as FACT in PR #4650): this asks the applicant/
+  // sponsor to classify the sponsor's OWN permit into this same legal
+  // taxonomy, the identical trust problem `family_sponsor_status_code`
+  // (immediately above) already solved by staying out of engine facts.
+  // Mirrors that sibling exactly — see `mapFamilySponsorPermitBasis` in
+  // fact-mapper.ts for the full reasoning.
   family_sponsor_permit_basis: {
     id: "family_sponsor_permit_basis",
     i18nKey: "q.family_sponsor_permit_basis",
     kind: "choice",
     group: "details",
     decisionMapping: {
-      kind: "FACT",
-      factPaths: ["family.sponsor_permit_basis"],
+      kind: "HUMAN_CONTEXT",
     },
     sensitive: true,
     options: [


### PR DESCRIPTION
## Summary

Corrective fix, one increment after `#4650` (this session) shipped the defect it fixes. Author's note up front: **I shipped `family.sponsor_permit_basis` the wrong way, and I am the one fixing it — I do not grade this diff myself.** See Adversarial review below for what independent verification this went through.

## The defect

`#4650` added `family.sponsor_permit_basis` — a closed 13-value enum classifying the sponsor's OWN permit into a Pasal 33(2) huruf a-l category — wired to trust self-declaration: `decisionMapping: {kind: "FACT"}` in `tree.ts`, plain `enumFact()` in `fact-mapper.ts`. Answering the question resolved straight to `KNOWN`.

This missed the parallel to its sibling fact, `family.sponsor_status_code`, already in this exact file with two independent walls against precisely this trust problem:
- `decisionMapping: {kind: "HUMAN_CONTEXT"}` — the tree-level schema itself says this question doesn't feed engine facts.
- `mapFamilySponsorStatus()` forces `unknownFact(UNVERIFIED)` on every branch regardless of input, with an explicit comment: *"even a syntactically plausible value must never satisfy an engine rule that checks `op: known`."*

Both facts ask the applicant/sponsor to classify the sponsor's own permit into a legal taxonomy they are unlikely to know precisely. For `sponsor_permit_basis` this is more urgent, not less: Ruling 2's whole purpose is Permenkumham 11/2024 Pasal 33 ayat (7), an **exclusionary** gate. A wrong self-declared category doesn't just fail to help — it wrongly excludes an eligible applicant. For a client-facing tool that is the worst direction of error, and the one a person is least able to detect or contest.

## The fix

Mirrors `mapFamilySponsorStatus` exactly:
- `tree.ts`: `family_sponsor_permit_basis.decisionMapping` → `{kind: "HUMAN_CONTEXT"}`.
- `fact-mapper.ts`: new `mapFamilySponsorPermitBasis()` — same 4-branch structure (`NOT_APPLICABLE` / `UNVERIFIED` / `NOT_ASKED`), never `KNOWN`. Removed the now-unused `SPONSOR_PERMIT_BASES` const and `SponsorPermitBasisValue` type (the mapper no longer validates against them since it never constructs a `KNOWN` value).
- Extended the existing `AMBIGUOUS_SPONSOR` review flag (shared with `sponsor_status_code`) to also fire when `family_sponsor_permit_basis` is answered — so the self-declared answer routes to human review instead of being silently discarded.
- `i18n.ts` (EN+ID): the "why we ask" copy said *"the engine checks this directly"* — no longer true, and would have actively misled applicants about what happens with their answer. Corrected to explain the human-review path honestly.

The fact **stays in the vocabulary** — it's real vocabulary, per the original owner ruling. It just can't satisfy `op:known` until a document-verified source exists (e.g. an OCR'd sponsor permit card cross-checked against the signed catalogue), which doesn't exist yet for `sponsor_status_code` either.

## Sequencing consequence

**No rule may consume `family.sponsor_permit_basis` as trusted `KNOWN` until this lands.** Checked `#4660`'s diff before writing this: it references `family.sponsor_permit_basis` twice, but only as forward-referenced future scope ("the natural scope of the increment... once PR #4650 lands and a follow-up increment") — never as a rule input. Nothing is load-bearing yet, which is exactly why this is cheap now and would have been a client-facing wrong-exclusion later if a Pasal 33(7) rule had shipped against the untrusted version first.

## Consequence: Pasal 33(7) has no enforceable rule today

Permenkumham 11/2024 Pasal 33 ayat (7) forbids E31B/E31E/E31H/E31J from being used to reunify onto a Family-Reunification-permit holder — verified, cited, real, and a *permit basis* constraint, a different axis from validity. `family.sponsor_permit_basis` was added by `#4650` precisely to express it. This PR walls that fact to UNKNOWN, correctly, because a self-declared legal category cannot satisfy `op:known`.

The consequence, stated plainly: **the Pasal 33(7) rule is unenforceable today, and stays unenforceable until a document-verified source exists** — an OCR'd sponsor permit cross-checked against the signed catalogue. That source does not exist for `sponsor_status_code` either, so this is not a regression this PR introduces; it is the honest current state, made visible here for the first time (this fact only existed since `#4650`, one increment earlier — there was never a moment it was safely enforceable).

This is a statement about consequence, not sequencing. The sequencing note above says "wait for this PR, then write the rule" — that is not the correct conclusion. The correct conclusion is: **do not write a Pasal 33(7) exclusion rule against `family.sponsor_permit_basis` at all, until the input is document-verified.** A future author who finds a populated enum and writes the exclusion against it reintroduces exactly the wrong-exclusion risk this PR exists to prevent — on an exclusionary gate, where the error removes a path from an eligible applicant.

## Scope check

Touches only `tree.ts` / `fact-mapper.ts` / their test files / `i18n.ts`. Verified `OracleShell.tsx`, `shadow-parity.ts`, `preview-adapter.ts` are untouched. Checked `gold-oracle-baseline.ts` (team-lead granted access to it if needed) — its doc comment lists `AMBIGUOUS_SPONSOR` among flags it deliberately does NOT try to pin ("this baseline has not verified the ordering/merge behaviour for" — non-exhaustive by design), and reusing the existing flag name rather than inventing a new one means that file needed no edit. Also verified this change doesn't touch the E4 slice's `TIER_B_LANE_IDS` (`e4-tier-fence.ts`) — that's a fixed, doc-frozen 4-lane list from an unrelated CP2-approved reform, and my new HUMAN_CONTEXT lane isn't one of the 4 named lanes.

## Test plan

- [x] `npx vitest run "src/app/(visa-oracle)/"` → 466 passed (37 files) — 461 baseline + 5 new (1 tree.test.ts assertion, 1 fact-mapper.test.ts `it.each` row, 3 fact-mapper.test.ts describe-block cases mirroring the sibling's coverage: never-KNOWN, NOT_APPLICABLE-when-no-sponsor, NOT_ASKED-when-empty)
- [x] `npx tsc --noEmit` → clean (caught and fixed one real type error mid-build: the mapper's return type needed to match `KnownValue<"family.sponsor_permit_basis">`, not a generic `string`, even though every branch only ever returns UNKNOWN — same pattern `mapFamilySponsorStatus` already uses against `family.sponsor_status_code`'s `string` type)
- [x] `npx eslint` on all 5 changed non-test files → clean
- [x] Confirmed via `gh pr diff 4660` that no in-flight rule consumes this fact as trusted `KNOWN` yet

## Adversarial review

No external LLM seat dispatched. Given I authored the original defect, independent verification here means: (1) reading the actual sibling implementation line-by-line rather than trusting my own PR's description of it, (2) checking the live in-flight PR (#4660) for whether this fact is already load-bearing before writing "nothing depends on this yet" as a claim, (3) tracing every file that references `HUMAN_CONTEXT`/`decisionMapping.kind` in this directory (9 files) rather than assuming the two I already knew about were the whole surface — this is how the E4 `TIER_B_LANE_IDS` fence and the `gold-oracle-baseline.ts` non-exhaustive flag list were found and ruled out as needing changes, instead of being missed. This PR is still subject to this repo's real generator≠grader gates (R1 adversarial-review gate, CI test suite, Subhi-surface verification) same as any other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
