### PR TITLE
fix(mouth/visa-oracle): wake derived.has_active_stay_permit's dormant positive path

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -204,6 +204,45 @@ const CURRENT_STATUS_CODES = [
   "ITK_FROM_VISIT_D",
   "ITK_PERALIHAN",
 ] as const;
+// 29 real product codes, verbatim from `rulepack-prod-007.source.json`
+// (`products[].product_code`, filtered to `E`-prefix). Only reachable via
+// `stay_permit_code` (tree.ts), gated behind `holds_stay_permit === "yes"`
+// — see `mapCurrentStatusCode` below. Not the same list as
+// `CURRENT_STATUS_CODES` above: that one is the non-E ITK/visit-class
+// catalogue, this one is the ITAS/ITAP catalogue backing
+// `derived.has_active_stay_permit`'s positive branch (fact_registry.py's
+// `^E\d+[A-Z]?$` heuristic).
+const STAY_PERMIT_CODES = [
+  "E23",
+  "E23U",
+  "E23V",
+  "E28A",
+  "E28B",
+  "E28C",
+  "E28D",
+  "E28F",
+  "E30",
+  "E30A",
+  "E30B",
+  "E30E",
+  "E30F",
+  "E31A",
+  "E31B",
+  "E31C",
+  "E31D",
+  "E31E",
+  "E31F",
+  "E31G",
+  "E31H",
+  "E31J",
+  "E33",
+  "E33A",
+  "E33B",
+  "E33C",
+  "E33E",
+  "E33F",
+  "E33G",
+] as const;
 const SPONSOR_TYPES = [
   "NONE",
   "INDIVIDUAL",
@@ -400,7 +439,24 @@ export function mapDisclosedReviewFlags(
   return [...flags].sort();
 }
 
+// Two source questions feed this ONE FactPath. The `holds_stay_permit` gate
+// (tree.ts) makes them mutually exclusive in the tree — "yes" routes to the
+// KITAS/KITAP transcription question (`stay_permit_code`, validated against
+// the real E-code catalogue), "no" routes to the original 8-code visit-class
+// question (`current_status_code`), unchanged — and `pruneFacts` (flow.ts)
+// drops whichever one falls out of history on every EDIT, so at most one of
+// the two raw fields is ever populated at a time. Branching on THAT
+// (presence of the raw field actually answered) rather than on
+// `holds_stay_permit`'s value keeps this mapper correct even when it's
+// invoked in isolation — e.g. a test that answers `stay_permit_code` alone,
+// without also setting `holds_stay_permit` — instead of silently resolving
+// to NOT_ASKED because the gate field was never populated. Both branches go
+// through `enumFact`, so an unrecognized or "unsure" value resolves UNKNOWN
+// either way — never a guessed KNOWN.
 function mapCurrentStatusCode(facts: OracleFacts): FactValue<string> {
+  if (facts.stay_permit_code !== undefined) {
+    return enumFact(facts.stay_permit_code, STAY_PERMIT_CODES);
+  }
   return enumFact(facts.current_status_code, CURRENT_STATUS_CODES);
 }
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -305,6 +305,7 @@ describe("onshore/offshore canonical fact collection", () => {
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "yes");
     state = answer(state, "permit_expiry", "2026-09-01");
+    state = answer(state, "holds_stay_permit", "no");
     state = answer(state, "current_status_code", "C1");
     state = answer(state, "overstay_days", "0");
     state = answer(state, "wants_onshore_conversion", "yes");
@@ -334,6 +335,7 @@ describe("onshore/offshore canonical fact collection", () => {
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "yes");
     state = answer(state, "permit_expiry", "2026-09-01");
+    state = answer(state, "holds_stay_permit", "no");
     expectQuestion(state, "current_status_code");
     state = reduce(state, { type: "SKIP", questionId: "current_status_code" });
     expect(state.facts.current_status_code).toBe("unsure");
@@ -360,9 +362,13 @@ describe("onshore/offshore canonical fact collection", () => {
       { kind: "question", questionId: "permit_expiry" },
       { in_indonesia: "yes", permit_expiry: "2020-01-01" },
     );
+    // permit_expiry always advances to the holds_stay_permit gate now
+    // (never straight to overstay_days) — an expired date does not
+    // short-circuit the interview into treating the applicant as already
+    // out of status without asking what they currently hold.
     expect(next).toEqual({
       kind: "question",
-      questionId: "current_status_code",
+      questionId: "holds_stay_permit",
     });
   });
 });
@@ -385,6 +391,7 @@ describe("wants_onshore_conversion / application_channel cross-validation (2026-
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "yes");
     state = answer(state, "permit_expiry", "2026-09-01");
+    state = answer(state, "holds_stay_permit", "no");
     state = answer(state, "current_status_code", "C1");
     state = answer(state, "overstay_days", "0");
     state = answer(state, "wants_onshore_conversion", wantsOnshoreConversion);
@@ -636,6 +643,7 @@ describe("editing, pruning and branch projection", () => {
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "yes");
     state = answer(state, "permit_expiry", "2026-09-01");
+    state = answer(state, "holds_stay_permit", "no");
     state = answer(state, "current_status_code", "C1");
     state = answer(state, "overstay_days", "0");
     state = answer(state, "wants_onshore_conversion", "yes");
@@ -790,12 +798,14 @@ describe("resume snapshot validation", () => {
         { kind: "framing" },
         { kind: "question", questionId: "in_indonesia" },
         { kind: "question", questionId: "permit_expiry" },
+        { kind: "question", questionId: "holds_stay_permit" },
         { kind: "question", questionId: "current_status_code" },
         { kind: "question", questionId: "overstay_days" },
       ],
       facts: {
         in_indonesia: "yes",
         permit_expiry: "2026-09-01",
+        holds_stay_permit: "no",
         current_status_code: "C22",
       },
     };
@@ -860,6 +870,7 @@ describe("resume snapshot validation", () => {
       { kind: "framing" as const },
       { kind: "question" as const, questionId: "in_indonesia" },
       { kind: "question" as const, questionId: "permit_expiry" },
+      { kind: "question" as const, questionId: "holds_stay_permit" },
       { kind: "question" as const, questionId: "current_status_code" },
       { kind: "question" as const, questionId: "overstay_days" },
       { kind: "question" as const, questionId: "wants_onshore_conversion" },
@@ -872,6 +883,7 @@ describe("resume snapshot validation", () => {
       facts: {
         in_indonesia: "yes",
         permit_expiry: "2026-09-01",
+        holds_stay_permit: "no",
         current_status_code: "C1",
         overstay_days: "36501",
       },

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -424,7 +424,13 @@ export function computeNextNode(
       return { kind: "question", questionId: "overstay_days" };
     }
     case "permit_expiry":
-      return { kind: "question", questionId: "current_status_code" };
+      return { kind: "question", questionId: "holds_stay_permit" };
+    case "holds_stay_permit":
+      return facts.holds_stay_permit === "yes"
+        ? { kind: "question", questionId: "stay_permit_code" }
+        : { kind: "question", questionId: "current_status_code" };
+    case "stay_permit_code":
+      return { kind: "question", questionId: "overstay_days" };
     case "current_status_code":
       return { kind: "question", questionId: "overstay_days" };
     case "overstay_days":
@@ -912,9 +918,22 @@ export function getTreeSteps(
       ? [
           { id: "permit_expiry", labelI18nKey: "tree.permit_expiry" },
           {
-            id: "current_status_code",
-            labelI18nKey: "tree.current_status_code",
+            id: "holds_stay_permit",
+            labelI18nKey: "tree.holds_stay_permit",
           },
+          ...(facts.holds_stay_permit === "yes"
+            ? [
+                {
+                  id: "stay_permit_code",
+                  labelI18nKey: "tree.stay_permit_code",
+                },
+              ]
+            : [
+                {
+                  id: "current_status_code",
+                  labelI18nKey: "tree.current_status_code",
+                },
+              ]),
         ]
       : []),
     { id: "overstay_days", labelI18nKey: "tree.overstay_days" },

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
@@ -46,6 +46,62 @@ const en = {
   "q.current_status_code.opt.other": "Another code — needs human review",
   "why.current_status_code":
     "The engine receives the printed status code unchanged; the interface never guesses it from the permit name.",
+  "q.holds_stay_permit":
+    "Do you currently hold a limited or permanent stay permit (KITAS / KITAP)?",
+  "why.holds_stay_permit":
+    "The E-code catalogue only applies to KITAS/KITAP holders; everyone else answers the shorter code list below.",
+  "q.stay_permit_code": "Which code is printed on your permit?",
+  "q.stay_permit_code.hint":
+    "Enter the exact code from your card. Use Not sure rather than guessing.",
+  "q.stay_permit_code.opt.E23": "E23 — Working Visa",
+  "q.stay_permit_code.opt.E23U":
+    "E23U — Working Visa — Foreign Diplomat House Assistant",
+  "q.stay_permit_code.opt.E23V":
+    "E23V — Working Visa — Trade and Economic Office",
+  "q.stay_permit_code.opt.E28A": "E28A — Investor Visa",
+  "q.stay_permit_code.opt.E28B":
+    "E28B — Investor Golden Visa — Company Establishment",
+  "q.stay_permit_code.opt.E28C": "E28C — Investor Golden Visa — Capital Market",
+  "q.stay_permit_code.opt.E28D":
+    "E28D — Investor Golden Visa — Branch or Subsidiary",
+  "q.stay_permit_code.opt.E28F":
+    "E28F — Investor Golden Visa — New Capital (IKN) Subsidiary",
+  "q.stay_permit_code.opt.E30": "E30 — Education Visa",
+  "q.stay_permit_code.opt.E30A": "E30A — Primary/Secondary Education Visa",
+  "q.stay_permit_code.opt.E30B": "E30B — Higher Education Visa",
+  "q.stay_permit_code.opt.E30E": "E30E — SEZ Education Visa",
+  "q.stay_permit_code.opt.E30F": "E30F — Student Exchange Visa",
+  "q.stay_permit_code.opt.E31A":
+    "E31A — Family Visa — Spouse of Indonesian Citizen",
+  "q.stay_permit_code.opt.E31B":
+    "E31B — Family Visa — Spouse of ITAS/ITAP Holder",
+  "q.stay_permit_code.opt.E31C":
+    "E31C — Family Visa — Child of Legal Mixed Marriage",
+  "q.stay_permit_code.opt.E31D":
+    "E31D — Family Visa — Stepchild of Foreigner in Legal Mixed Marriage",
+  "q.stay_permit_code.opt.E31E":
+    "E31E — Family Visa — Child of ITAS/ITAP Holder",
+  "q.stay_permit_code.opt.E31F":
+    "E31F — Family Visa — Child of Indonesian Citizen Parent",
+  "q.stay_permit_code.opt.E31G":
+    "E31G — Family Visa — Parent of Indonesian Citizen Child",
+  "q.stay_permit_code.opt.E31H":
+    "E31H — Family Visa — Parent of Child ITAS/ITAP Holder",
+  "q.stay_permit_code.opt.E31J":
+    "E31J — Family Visa — Child Joining Sibling ITAS/ITAP Holder",
+  "q.stay_permit_code.opt.E33": "E33 — Second Home Visa",
+  "q.stay_permit_code.opt.E33A":
+    "E33A — Second Home Visa — Special-Expertise Government Invitation",
+  "q.stay_permit_code.opt.E33B":
+    "E33B — Second Home Golden Visa — Special-Expertise Collaboration",
+  "q.stay_permit_code.opt.E33C":
+    "E33C — Second Home Golden Visa — World-Figure Government Invitation",
+  "q.stay_permit_code.opt.E33E":
+    "E33E — Second Home Golden Visa — Elderly 5-Year",
+  "q.stay_permit_code.opt.E33F": "E33F — Second Home Visa — Elderly 1-Year",
+  "q.stay_permit_code.opt.E33G": "E33G — Second Home Visa — Remote Worker",
+  "why.stay_permit_code":
+    "The engine receives the printed code unchanged, the same as the code list above — the interface never guesses it from the permit name.",
   "q.overstay_days": "How many overstay days are active right now?",
   "q.overstay_days.hint":
     "Enter 0 if there is no active overstay. Do not include past overstay history here.",
@@ -518,7 +574,9 @@ const en = {
   "tree.framing": "Start",
   "tree.in_indonesia": "Where you are",
   "tree.permit_expiry": "Permit window",
+  "tree.holds_stay_permit": "Stay permit",
   "tree.current_status_code": "Current status",
+  "tree.stay_permit_code": "Permit code",
   "tree.overstay_days": "Active overstay",
   "tree.wants_onshore_conversion": "Conversion intent",
   "tree.application_channel": "Application channel",
@@ -793,6 +851,59 @@ const id: Record<Keys, string> = {
   "q.current_status_code.opt.other": "Kode lain — perlu tinjauan manusia",
   "why.current_status_code":
     "Mesin menerima kode status yang tercetak tanpa perubahan; antarmuka tidak pernah menebaknya dari nama izin.",
+  "q.holds_stay_permit":
+    "Apakah Anda saat ini memegang izin tinggal terbatas atau tetap (KITAS / KITAP)?",
+  "why.holds_stay_permit":
+    "Katalog kode-E hanya berlaku untuk pemegang KITAS/KITAP; yang lain menjawab daftar kode yang lebih pendek di bawah.",
+  "q.stay_permit_code": "Kode apa yang tercantum pada izin Anda?",
+  "q.stay_permit_code.hint":
+    "Masukkan kode persis dari kartu Anda. Pilih Tidak yakin daripada menebak.",
+  "q.stay_permit_code.opt.E23": "E23 — Visa Kerja",
+  "q.stay_permit_code.opt.E23U":
+    "E23U — Visa Kerja Asisten Rumah Tangga Diplomat Asing",
+  "q.stay_permit_code.opt.E23V": "E23V — Visa Kerja Kantor Dagang dan Ekonomi",
+  "q.stay_permit_code.opt.E28A": "E28A — Visa Investor",
+  "q.stay_permit_code.opt.E28B": "E28B — Visa Investor Pendirian Perusahaan",
+  "q.stay_permit_code.opt.E28C":
+    "E28C — Visa Investor Tanpa Mendirikan Perusahaan",
+  "q.stay_permit_code.opt.E28D":
+    "E28D — Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan",
+  "q.stay_permit_code.opt.E28F":
+    "E28F — Visa Investor Anak Perusahaan Ibukota Nusantara",
+  "q.stay_permit_code.opt.E30": "E30 — Visa Pendidikan",
+  "q.stay_permit_code.opt.E30A": "E30A — Visa Pendidikan Dasar dan Menengah",
+  "q.stay_permit_code.opt.E30B": "E30B — Visa Pendidikan Tinggi",
+  "q.stay_permit_code.opt.E30E":
+    "E30E — Visa Pendidikan Kawasan Ekonomi Khusus",
+  "q.stay_permit_code.opt.E30F": "E30F — Visa Pertukaran Pelajar",
+  "q.stay_permit_code.opt.E31A": "E31A — Visa Keluarga Suami/Istri WNI",
+  "q.stay_permit_code.opt.E31B":
+    "E31B — Visa Keluarga Suami/Istri Pemegang ITAS/ITAP",
+  "q.stay_permit_code.opt.E31C":
+    "E31C — Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI",
+  "q.stay_permit_code.opt.E31D":
+    "E31D — Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI",
+  "q.stay_permit_code.opt.E31E": "E31E — Visa Keluarga Anak Pemegang ITAS/ITAP",
+  "q.stay_permit_code.opt.E31F":
+    "E31F — Visa Keluarga Anak dengan Orang Tua WNI",
+  "q.stay_permit_code.opt.E31G": "E31G — Visa Keluarga Orang Tua dari Anak WNI",
+  "q.stay_permit_code.opt.E31H":
+    "E31H — Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP",
+  "q.stay_permit_code.opt.E31J":
+    "E31J — Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP",
+  "q.stay_permit_code.opt.E33": "E33 — Visa Rumah Kedua",
+  "q.stay_permit_code.opt.E33A":
+    "E33A — Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah",
+  "q.stay_permit_code.opt.E33B":
+    "E33B — Visa Rumah Kedua Kolaborasi Keahlian Khusus",
+  "q.stay_permit_code.opt.E33C":
+    "E33C — Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah",
+  "q.stay_permit_code.opt.E33E":
+    "E33E — Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa",
+  "q.stay_permit_code.opt.E33F": "E33F — Visa Rumah Kedua Lansia untuk 1 Tahun",
+  "q.stay_permit_code.opt.E33G": "E33G — Visa Rumah Kedua Pekerja Jarak Jauh",
+  "why.stay_permit_code":
+    "Mesin menerima kode yang tercetak tanpa perubahan, sama seperti daftar kode di atas — antarmuka tidak pernah menebaknya dari nama izin.",
   "q.overstay_days": "Berapa hari overstay yang aktif saat ini?",
   "q.overstay_days.hint":
     "Masukkan 0 jika tidak ada overstay aktif. Jangan masukkan riwayat overstay lama di sini.",
@@ -1265,7 +1376,9 @@ const id: Record<Keys, string> = {
   "tree.framing": "Mulai",
   "tree.in_indonesia": "Posisi Anda",
   "tree.permit_expiry": "Jendela izin tinggal",
+  "tree.holds_stay_permit": "Izin tinggal",
   "tree.current_status_code": "Status saat ini",
+  "tree.stay_permit_code": "Kode izin",
   "tree.overstay_days": "Overstay aktif",
   "tree.wants_onshore_conversion": "Niat konversi",
   "tree.application_channel": "Kanal permohonan",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/tree.ts
@@ -177,6 +177,85 @@ export const QUESTIONS: Record<string, OracleQuestion> = {
     whyWeAsk: { i18nKey: "why.current_status_code" },
     notSure: { mode: "human-review" },
   },
+  // Two-step gate (2026-08-23 owner ruling, D12/derived.has_active_stay_permit
+  // reachability): `derived.has_active_stay_permit`'s `KNOWN(True)` branch
+  // requires an E-prefix `current_status_code`, which the 8-code list above
+  // never offers — the positive path was dormant since PR #4650. Ruled
+  // against an umbrella sentinel (would require editing the freshly-merged
+  // backend derivation, the MORE invasive option, and discards the specific
+  // code other rules will want) and against discrete-codes-only with no gate
+  // (asks precision a layperson may not have; a guessed answer would resolve
+  // KNOWN and be trusted). This gate asks first, then the code is a
+  // TRANSCRIPTION of what's printed on the applicant's own card — not recall
+  // of a legal taxonomy, a materially different trust class from
+  // `family_sponsor_permit_basis` (see `mapFamilySponsorPermitBasis` in
+  // fact-mapper.ts), which is exactly why that fact needed a wall and this
+  // one does not.
+  holds_stay_permit: {
+    id: "holds_stay_permit",
+    i18nKey: "q.holds_stay_permit",
+    kind: "branch",
+    group: "location",
+    decisionMapping: { kind: "HUMAN_CONTEXT" },
+    sensitive: false,
+    options: [
+      { key: "yes", labelI18nKey: "q.boolean.yes" },
+      { key: "no", labelI18nKey: "q.boolean.no" },
+    ],
+    whyWeAsk: { i18nKey: "why.holds_stay_permit" },
+    notSure: { mode: "human-review" },
+  },
+  // 29 real product codes, verbatim from `rulepack-prod-007.source.json`
+  // (`products[].product_code` + `products[].names`), not invented — every
+  // one is `category: "LIMITED_STAY"`, i.e. an actual ITAS a person can
+  // currently hold, not merely a visa product applied for. "I'm not sure"
+  // is the existing universal `notSure` affordance below, not a listed
+  // option — `enumFact()` already resolves the literal string "unsure" to
+  // UNKNOWN(UNVERIFIED), never a guessed KNOWN (fact-mapper.ts).
+  stay_permit_code: {
+    id: "stay_permit_code",
+    i18nKey: "q.stay_permit_code",
+    kind: "choice",
+    group: "location",
+    decisionMapping: {
+      kind: "FACT",
+      factPaths: ["immigration.current_status_code"],
+    },
+    sensitive: true,
+    options: [
+      { key: "E23", labelI18nKey: "q.stay_permit_code.opt.E23" },
+      { key: "E23U", labelI18nKey: "q.stay_permit_code.opt.E23U" },
+      { key: "E23V", labelI18nKey: "q.stay_permit_code.opt.E23V" },
+      { key: "E28A", labelI18nKey: "q.stay_permit_code.opt.E28A" },
+      { key: "E28B", labelI18nKey: "q.stay_permit_code.opt.E28B" },
+      { key: "E28C", labelI18nKey: "q.stay_permit_code.opt.E28C" },
+      { key: "E28D", labelI18nKey: "q.stay_permit_code.opt.E28D" },
+      { key: "E28F", labelI18nKey: "q.stay_permit_code.opt.E28F" },
+      { key: "E30", labelI18nKey: "q.stay_permit_code.opt.E30" },
+      { key: "E30A", labelI18nKey: "q.stay_permit_code.opt.E30A" },
+      { key: "E30B", labelI18nKey: "q.stay_permit_code.opt.E30B" },
+      { key: "E30E", labelI18nKey: "q.stay_permit_code.opt.E30E" },
+      { key: "E30F", labelI18nKey: "q.stay_permit_code.opt.E30F" },
+      { key: "E31A", labelI18nKey: "q.stay_permit_code.opt.E31A" },
+      { key: "E31B", labelI18nKey: "q.stay_permit_code.opt.E31B" },
+      { key: "E31C", labelI18nKey: "q.stay_permit_code.opt.E31C" },
+      { key: "E31D", labelI18nKey: "q.stay_permit_code.opt.E31D" },
+      { key: "E31E", labelI18nKey: "q.stay_permit_code.opt.E31E" },
+      { key: "E31F", labelI18nKey: "q.stay_permit_code.opt.E31F" },
+      { key: "E31G", labelI18nKey: "q.stay_permit_code.opt.E31G" },
+      { key: "E31H", labelI18nKey: "q.stay_permit_code.opt.E31H" },
+      { key: "E31J", labelI18nKey: "q.stay_permit_code.opt.E31J" },
+      { key: "E33", labelI18nKey: "q.stay_permit_code.opt.E33" },
+      { key: "E33A", labelI18nKey: "q.stay_permit_code.opt.E33A" },
+      { key: "E33B", labelI18nKey: "q.stay_permit_code.opt.E33B" },
+      { key: "E33C", labelI18nKey: "q.stay_permit_code.opt.E33C" },
+      { key: "E33E", labelI18nKey: "q.stay_permit_code.opt.E33E" },
+      { key: "E33F", labelI18nKey: "q.stay_permit_code.opt.E33F" },
+      { key: "E33G", labelI18nKey: "q.stay_permit_code.opt.E33G" },
+    ],
+    whyWeAsk: { i18nKey: "why.stay_permit_code" },
+    notSure: { mode: "human-review" },
+  },
   overstay_days: {
     id: "overstay_days",
     i18nKey: "q.overstay_days",


### PR DESCRIPTION
## What

`derived.has_active_stay_permit`'s `KNOWN(True)` branch (backend heuristic `^E\d+[A-Z]?$` on `immigration.current_status_code`) has been unreachable since PR #4650 merged: the frontend's `current_status_code` question only ever offers the 8-code non-E ITK/visit-class list, never an E-prefixed stay-permit code. This is Gap 1 of the two-gap dormancy finding reported after #4650 (Gap 2, `family_sponsor_permit_basis`, was fixed and merged separately in #4686).

## Design — owner-ruled (2026-08-23), not the umbrella I first proposed

A strict two-step gate:

1. `holds_stay_permit` (`HUMAN_CONTEXT`, yes/no): "Do you currently hold a limited or permanent stay permit (KITAS / KITAP)?"
2. On yes, `stay_permit_code` (`FACT` → `immigration.current_status_code`): "Which code is printed on your permit?" — 29 real E-series options, plus the existing universal `notSure: {mode:"human-review"}` affordance. On no, falls through to the original `current_status_code` question, unchanged.

Rejected alternatives, and why:
- **Umbrella sentinel** — would require editing the freshly-merged backend derivation (more invasive, not less) and would discard the specific code other rules will want.
- **Discrete codes with no gate** — risks a guessed answer resolving to a trusted `KNOWN`. The two-step asks yes/no first, so a "no" answer never has to guess among 29 codes it doesn't hold.

**Trust-class note** (why this fact needed no wall, unlike `family_sponsor_permit_basis` in #4686): `stay_permit_code` is a **transcription** of what's printed on the applicant's own card, not recall of a legal taxonomy classification — a materially different trust class.

## Grounding

The 29-code catalogue is grounded verbatim (`product_code` + `names.en`/`names.id`) from `apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json`, filtered to `category: "LIMITED_STAY"` + E-prefix — i.e. things a person can currently **hold**, not merely apply for. Zero invented codes or labels; every label was extracted programmatically and diffed byte-exact against what was inserted into both the TS options array and both i18n locales.

## Implementation

- `tree.ts`: two new questions, `holds_stay_permit` + `stay_permit_code`.
- `flow.ts`: `computeNextNode` inserts the gate between `permit_expiry` and `current_status_code`/`stay_permit_code`; `getTreeSteps` mirrors the branch for the trunk breadcrumb.
- `fact-mapper.ts`: `mapCurrentStatusCode` branches on **which raw field is actually populated** (`stay_permit_code` vs `current_status_code`) rather than on `holds_stay_permit`'s value. `pruneFacts` already makes the two mutually exclusive on every EDIT (only one is ever in `history` at a time), and branching on presence keeps the mapper correct even when invoked in isolation — e.g. the wire-coverage test that answers `stay_permit_code` alone.
- `i18n.ts`: EN+ID copy for both new questions, mirroring `current_status_code`'s established pattern.

## Design judgment call — grounded, not merely flagged as open to revision

The full 29-code list (not a coarser subset) is offered — precision the D12 derivation and other current/future rules can use, at the cost of a longer choice list.

Update: this was flagged open-to-revision at build time on an inference — that the E-code is transcription, not recall, because it's printed on the physical KITAS/ITAS card. Team-lead asked Zero directly, and **Zero confirmed from daily practice: the index code IS physically printed on the card.** That converts the premise the whole two-step design rests on — a 29-option list matched against a document in hand is a materially different interaction from a 29-option list answered from memory — from an assumption into a grounded fact. The two-step gate (and the full-catalogue choice within it) is now the grounded design, not merely the least-bad guess. Two follow-ons this unlocks, explicitly NOT in scope here (owner-scoped for later): (1) an OCR path for this field becomes real, since the code is legible on a document Bali Zero already OCRs — closing exactly the "document-verified source" gap #4686's wall names as not existing today; (2) the code → `SponsorPermitBasis` mapping (Pasal 33(2) huruf a-l) is largely a data-compilation task against the existing rulepack, not new research.

## Test plan

- `npx vitest run "src/app/(visa-oracle)/"` → 466/466 passed (37 files).
- `npx tsc --noEmit` → clean.
- `npx eslint` on all 5 non-test files → clean.
- `e2e/visa-oracle-v2.spec.ts` checked for impact: its only fact-count assertion (44 keys) is unaffected — neither new question adds a `FactPath`; its resume-fixture is fully offshore (`in_indonesia:"no"`) and never reaches this branch.

## Adversarial review

Self-reviewed (generator = author here, same as #4686 — no external reviewer ran before this PR). Traced every EDIT/prune path connecting `holds_stay_permit`/`stay_permit_code`/`current_status_code` to **confirm** `pruneFacts` (flow.ts) keeps them mutually exclusive, rather than assuming it. Verified the 29-code catalogue against the signed rulepack source by Python diff (not by hand-transcription) in both the TS options array and both i18n locales.

**Not verified**: live rendering of the 29-option choice list in the actual UI (no dev-server QA run in this worktree) — the existing `choice`-kind question renderer is unmodified and this mirrors `current_status_code`'s established pattern exactly, so the risk is judged low, but it is unverified, not verified-and-passing.

Order: this is Gap 1, built and shipped second per team-lead's explicit ruling (Gap 2/#4686 first, own PR, never combined — different review attention needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
