### PR TITLE
feat(visa-engine): seq-13 signed bundle — Ed25519, kid prod-2026-07-1

### DIFF
--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.signed.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.signed.json
@@ -24,9 +24,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "INVESTMENT"
-        ],
+        "covered_purposes": ["INVESTMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -37,9 +35,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "B211"
-        ],
+        "legacy_codes": ["B211"],
         "legacy_slugs": [],
         "names": {
           "en": "Investor Visa (E28A)",
@@ -55,12 +51,8 @@
           "operational_work_beyond_management_and_ownership"
         ],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "INVESTMENT"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -79,9 +71,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "INVESTMENT"
-        ],
+        "covered_purposes": ["INVESTMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -101,16 +91,10 @@
         "pricing_key": null,
         "product_code": "E28B",
         "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
-        "prohibited_activities": [
-          "operational_work"
-        ],
+        "prohibited_activities": ["operational_work"],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "INVESTMENT"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -129,9 +113,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "INVESTMENT"
-        ],
+        "covered_purposes": ["INVESTMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -160,9 +142,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -181,9 +161,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "INVESTMENT"
-        ],
+        "covered_purposes": ["INVESTMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -207,12 +185,8 @@
           "operational_work_outside_managing_subsidiary"
         ],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "INVESTMENT"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -231,9 +205,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "INVESTMENT"
-        ],
+        "covered_purposes": ["INVESTMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -253,16 +225,10 @@
         "pricing_key": null,
         "product_code": "E28F",
         "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
-        "prohibited_activities": [
-          "operational_work"
-        ],
+        "prohibited_activities": ["operational_work"],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "INVESTMENT"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INVESTMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -281,10 +247,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "SECOND_HOME",
-          "TOURISM"
-        ],
+        "covered_purposes": ["SECOND_HOME", "TOURISM"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -318,9 +281,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -339,11 +300,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "EMPLOYMENT",
-          "TOURISM",
-          "FAMILY"
-        ],
+        "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -373,9 +330,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "GOVERNMENT"
-        ],
+        "sponsor_types": ["GOVERNMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -430,9 +385,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -486,9 +439,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "GOVERNMENT"
-        ],
+        "sponsor_types": ["GOVERNMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -507,12 +458,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "RETIREMENT",
-          "SECOND_HOME",
-          "TOURISM",
-          "FAMILY"
-        ],
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -523,9 +469,7 @@
           "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
           "status": "UNKNOWN"
         },
-        "legacy_codes": [
-          "E311A"
-        ],
+        "legacy_codes": ["E311A"],
         "legacy_slugs": [],
         "names": {
           "en": "Second Home Golden Visa \u2014 Elderly 5-Year (E33E)",
@@ -548,9 +492,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -585,9 +527,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "E311A"
-        ],
+        "legacy_codes": ["E311A"],
         "legacy_slugs": [],
         "names": {
           "en": "Second Home Visa \u2014 Elderly 1-Year (E33F)",
@@ -609,9 +549,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -630,11 +568,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "REMOTE_WORK",
-          "TOURISM",
-          "FAMILY"
-        ],
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -668,9 +602,7 @@
           "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
           "9248b1d7-9172-54d9-ad61-251e83a2285b"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -689,10 +621,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "TOURISM",
-          "TRANSIT"
-        ],
+        "covered_purposes": ["TOURISM", "TRANSIT"],
         "entry_policy": {
           "entry_count": "SINGLE"
         },
@@ -722,12 +651,8 @@
           "journalism"
         ],
         "public_catalog": true,
-        "source_refs": [
-          "808d691c-374e-5581-8186-9eb54d0ca7ab"
-        ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -746,9 +671,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "TOURISM"
-        ],
+        "covered_purposes": ["TOURISM"],
         "entry_policy": {
           "entry_count": "SINGLE"
         },
@@ -759,9 +682,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "B213"
-        ],
+        "legacy_codes": ["B213"],
         "legacy_slugs": [],
         "names": {
           "en": "Visa on Arrival \u2014 Tourism (B1)",
@@ -780,12 +701,8 @@
           "journalism"
         ],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -804,10 +721,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "TOURISM",
-          "FAMILY"
-        ],
+        "covered_purposes": ["TOURISM", "FAMILY"],
         "entry_policy": {
           "entry_count": "SINGLE"
         },
@@ -818,9 +732,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "B211A"
-        ],
+        "legacy_codes": ["B211A"],
         "legacy_slugs": [],
         "names": {
           "en": "Tourist Visit Visa (C1)",
@@ -838,14 +750,8 @@
           "journalism"
         ],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "NONE",
-          "INDIVIDUAL",
-          "EMPLOYER"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -864,10 +770,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "BUSINESS_MEETINGS",
-          "INVESTMENT"
-        ],
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
         "entry_policy": {
           "entry_count": "SINGLE"
         },
@@ -878,10 +781,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "B211B",
-          "B211A"
-        ],
+        "legacy_codes": ["B211B", "B211A"],
         "legacy_slugs": [],
         "names": {
           "en": "Business Visit Visa (C2)",
@@ -893,16 +793,10 @@
         },
         "product_code": "C2",
         "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "EMPLOYER"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["EMPLOYER"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -921,9 +815,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "OTHER"
-        ],
+        "covered_purposes": ["OTHER"],
         "entry_policy": {
           "entry_count": "SINGLE"
         },
@@ -934,9 +826,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "B211A"
-        ],
+        "legacy_codes": ["B211A"],
         "legacy_slugs": [],
         "names": {
           "en": "Social Activity Visit Visa (C6)",
@@ -948,18 +838,10 @@
         },
         "product_code": "C6",
         "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
-        "prohibited_activities": [
-          "paid_employment",
-          "business_meetings"
-        ],
+        "prohibited_activities": ["paid_employment", "business_meetings"],
         "public_catalog": true,
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
-        "sponsor_types": [
-          "INDIVIDUAL",
-          "EMPLOYER"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+        "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -978,9 +860,7 @@
           "available": false,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "OTHER"
-        ],
+        "covered_purposes": ["OTHER"],
         "entry_policy": {
           "entry_count": "NOT_APPLICABLE"
         },
@@ -1013,9 +893,7 @@
           "3da72c7b-783e-51e3-9168-6c54bce709ed",
           "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1034,9 +912,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "EMPLOYMENT"
-        ],
+        "covered_purposes": ["EMPLOYMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1065,12 +941,8 @@
           "passive_investment_management"
         ],
         "public_catalog": true,
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
-        "sponsor_types": [
-          "EMPLOYER"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "sponsor_types": ["EMPLOYER"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1089,9 +961,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "EMPLOYMENT"
-        ],
+        "covered_purposes": ["EMPLOYMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1111,16 +981,10 @@
         "pricing_key": null,
         "product_code": "E23U",
         "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
-        "prohibited_activities": [
-          "work_for_non_diplomat_employer"
-        ],
+        "prohibited_activities": ["work_for_non_diplomat_employer"],
         "public_catalog": true,
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1139,9 +1003,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "EMPLOYMENT"
-        ],
+        "covered_purposes": ["EMPLOYMENT"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1161,16 +1023,10 @@
         "pricing_key": null,
         "product_code": "E23V",
         "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
-        "prohibited_activities": [
-          "work_for_standard_corporate_employers"
-        ],
+        "prohibited_activities": ["work_for_standard_corporate_employers"],
         "public_catalog": true,
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
-        "sponsor_types": [
-          "GOVERNMENT"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+        "sponsor_types": ["GOVERNMENT"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1189,9 +1045,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1202,9 +1056,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "C317"
-        ],
+        "legacy_codes": ["C317"],
         "legacy_slugs": [],
         "names": {
           "en": "Family Visa \u2014 Spouse of Indonesian Citizen (E31A)",
@@ -1223,9 +1075,7 @@
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1244,9 +1094,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1257,9 +1105,7 @@
           "reason_code": null,
           "status": "VERIFIED"
         },
-        "legacy_codes": [
-          "C318"
-        ],
+        "legacy_codes": ["C318"],
         "legacy_slugs": [],
         "names": {
           "en": "Family Visa \u2014 Spouse of ITAS/ITAP Holder (E31B)",
@@ -1271,18 +1117,14 @@
         },
         "product_code": "E31B",
         "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "570f2bc4-5120-561f-90ba-58fcd9507514",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1301,9 +1143,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1326,18 +1166,14 @@
         },
         "product_code": "E31C",
         "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "40523028-431b-5ae0-a937-277882f0f243",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1356,9 +1192,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1381,18 +1215,14 @@
         },
         "product_code": "E31D",
         "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1411,9 +1241,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1436,18 +1264,14 @@
         },
         "product_code": "E31E",
         "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1466,9 +1290,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1491,18 +1313,14 @@
         },
         "product_code": "E31F",
         "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "f9306203-0bdc-5dd8-9603-554e7eefedc8",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1521,9 +1339,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1546,18 +1362,14 @@
         },
         "product_code": "E31G",
         "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "86880290-68c2-5220-8f9e-2350678e5f09",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1576,9 +1388,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1601,18 +1411,14 @@
         },
         "product_code": "E31H",
         "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "153beca1-a24b-5440-bac0-b46c3d19da6f",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1631,9 +1437,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "FAMILY"
-        ],
+        "covered_purposes": ["FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1656,18 +1460,14 @@
         },
         "product_code": "E31J",
         "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
-        "prohibited_activities": [
-          "paid_employment"
-        ],
+        "prohibited_activities": ["paid_employment"],
         "public_catalog": true,
         "source_refs": [
           "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1723,9 +1523,7 @@
           "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
           "e3572ad2-08a9-55bd-b818-353b3e9db715"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1744,11 +1542,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "BUSINESS_MEETINGS",
-          "TOURISM",
-          "FAMILY"
-        ],
+        "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1781,9 +1575,7 @@
           "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
           "e3572ad2-08a9-55bd-b818-353b3e9db715"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1802,11 +1594,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "INVESTMENT",
-          "TOURISM",
-          "FAMILY"
-        ],
+        "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1838,9 +1626,7 @@
           "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
           "e3572ad2-08a9-55bd-b818-353b3e9db715"
         ],
-        "sponsor_types": [
-          "NONE"
-        ],
+        "sponsor_types": ["NONE"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1859,9 +1645,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "STUDY"
-        ],
+        "covered_purposes": ["STUDY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1892,10 +1676,7 @@
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "EDUCATION",
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "VARIABLE_BY_GRANT",
@@ -1914,9 +1695,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "STUDY"
-        ],
+        "covered_purposes": ["STUDY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -1951,10 +1730,7 @@
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "EDUCATION",
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -1973,9 +1749,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "STUDY"
-        ],
+        "covered_purposes": ["STUDY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -2011,10 +1785,7 @@
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
           "31850f85-8d19-58df-bb66-b04968c9aff0"
         ],
-        "sponsor_types": [
-          "EDUCATION",
-          "INDIVIDUAL"
-        ],
+        "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "FIXED_DAYS",
@@ -2033,9 +1804,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "STUDY"
-        ],
+        "covered_purposes": ["STUDY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -2066,9 +1835,7 @@
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "EDUCATION"
-        ],
+        "sponsor_types": ["EDUCATION"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "VARIABLE_BY_GRANT",
@@ -2087,9 +1854,7 @@
           "available": true,
           "checkpoints": []
         },
-        "covered_purposes": [
-          "STUDY"
-        ],
+        "covered_purposes": ["STUDY"],
         "entry_policy": {
           "entry_count": "MULTIPLE"
         },
@@ -2120,9 +1885,7 @@
           "e3572ad2-08a9-55bd-b818-353b3e9db715",
           "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
         ],
-        "sponsor_types": [
-          "EDUCATION"
-        ],
+        "sponsor_types": ["EDUCATION"],
         "status": "ACTIVE",
         "stay_policy": {
           "kind": "VARIABLE_BY_GRANT",
@@ -2147,15 +1910,11 @@
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
         "product_version_ids": null,
-        "required_facts": [
-          "derived.has_indonesian_citizenship"
-        ],
+        "required_facts": ["derived.has_indonesian_citizenship"],
         "rule_id": "hf.citizen",
         "safety_critical": true,
         "scope": "GLOBAL",
-        "source_refs": [
-          "e76bf823-2b36-522f-b2f7-e51eb7715e44"
-        ],
+        "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2176,15 +1935,11 @@
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
         "product_version_ids": null,
-        "required_facts": [
-          "immigration.overstay_days"
-        ],
+        "required_facts": ["immigration.overstay_days"],
         "rule_id": "hf.overstay-exceeds-60-days",
         "safety_critical": true,
         "scope": "GLOBAL",
-        "source_refs": [
-          "e76bf823-2b36-522f-b2f7-e51eb7715e44"
-        ],
+        "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2205,15 +1960,11 @@
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
         "product_version_ids": null,
-        "required_facts": [
-          "person.nationalities"
-        ],
+        "required_facts": ["person.nationalities"],
         "rule_id": "review.calling-visa",
         "safety_critical": true,
         "scope": "GLOBAL",
-        "source_refs": [
-          "bc309fa9-d14e-5625-b914-72fe4a68c19d"
-        ],
+        "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2222,14 +1973,7 @@
         "when": {
           "fact": "person.nationalities",
           "op": "intersects",
-          "values": [
-            "AF",
-            "IL",
-            "KP",
-            "LR",
-            "NG",
-            "SO"
-          ]
+          "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
         }
       },
       {
@@ -2241,15 +1985,11 @@
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
         "product_version_ids": null,
-        "required_facts": [
-          "immigration.overstay_days"
-        ],
+        "required_facts": ["immigration.overstay_days"],
         "rule_id": "review.active-overstay",
         "safety_critical": true,
         "scope": "GLOBAL",
-        "source_refs": [
-          "e76bf823-2b36-522f-b2f7-e51eb7715e44"
-        ],
+        "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2269,18 +2009,12 @@
         "explanation_key": "explain.hf.a1.not-bvk-nationality",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "aee1a12d-3285-526e-8a6f-3d8467fe5d72"
-        ],
-        "required_facts": [
-          "person.nationalities"
-        ],
+        "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"],
+        "required_facts": ["person.nationalities"],
         "rule_id": "hf.a1.not-bvk-nationality",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "808d691c-374e-5581-8186-9eb54d0ca7ab"
-        ],
+        "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2317,19 +2051,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "TOURISM",
-            "TRANSIT"
-          ],
+          "covered_purposes": ["TOURISM", "TRANSIT"],
           "reason_code": "A1_BVK_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.a1.tourism",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "aee1a12d-3285-526e-8a6f-3d8467fe5d72"
-        ],
+        "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"],
         "required_facts": [
           "intent.purposes",
           "intent.stay_days",
@@ -2338,9 +2067,7 @@
         "rule_id": "el.a1.tourism",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "808d691c-374e-5581-8186-9eb54d0ca7ab"
-        ],
+        "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2351,10 +2078,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "TOURISM",
-                "TRANSIT"
-              ]
+              "values": ["TOURISM", "TRANSIT"]
             },
             {
               "fact": "person.nationalities",
@@ -2392,18 +2116,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "TOURISM"
-          ],
+          "covered_purposes": ["TOURISM"],
           "reason_code": "B1_VOA_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.b1.tourism",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "4e30cbe0-c4bf-59be-9bf8-513e66946e44"
-        ],
+        "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"],
         "required_facts": [
           "intent.purposes",
           "intent.stay_days",
@@ -2426,9 +2146,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "TOURISM"
-              ]
+              "values": ["TOURISM"]
             },
             {
               "fact": "intent.stay_days",
@@ -2544,29 +2262,19 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "TOURISM",
-            "FAMILY"
-          ],
+          "covered_purposes": ["TOURISM", "FAMILY"],
           "reason_code": "C1_VISIT_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.c1.tourism-family",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "7a07cbb0-564f-5c3f-9720-6ad62c4789cd"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.c1.tourism-family",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2577,10 +2285,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "TOURISM",
-                "FAMILY"
-              ]
+              "values": ["TOURISM", "FAMILY"]
             },
             {
               "fact": "intent.stay_days",
@@ -2593,19 +2298,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS",
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
           "reason_code": "C2_BUSINESS_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.c2.business",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "de433757-f7af-5762-ad65-41bc16bc2ae1"
-        ],
+        "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"],
         "required_facts": [
           "family.sponsor_confirmed",
           "intent.purposes",
@@ -2614,9 +2314,7 @@
         "rule_id": "el.c2.business",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2627,10 +2325,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS",
-                "INVESTMENT"
-              ]
+              "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
             },
             {
               "fact": "family.sponsor_confirmed",
@@ -2648,18 +2343,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "OTHER"
-          ],
+          "covered_purposes": ["OTHER"],
           "reason_code": "C6_SOCIAL_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.c6.social",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "8cf5e09b-6e02-536f-aeca-4aaecaca09c7"
-        ],
+        "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"],
         "required_facts": [
           "family.sponsor_confirmed",
           "intent.purposes",
@@ -2668,9 +2359,7 @@
         "rule_id": "el.c6.social",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2681,9 +2370,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "OTHER"
-              ]
+              "values": ["OTHER"]
             },
             {
               "fact": "family.sponsor_confirmed",
@@ -2707,18 +2394,12 @@
         "explanation_key": "explain.hf.e28a.paid-capital-below-min",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "c8277316-c29d-5fde-bf9f-2611099a0029"
-        ],
-        "required_facts": [
-          "investment.paid_up_capital_idr"
-        ],
+        "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"],
+        "required_facts": ["investment.paid_up_capital_idr"],
         "rule_id": "hf.e28a.paid-capital-below-min",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2738,18 +2419,12 @@
         "explanation_key": "explain.hf.e28a.total-investment-below-min",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "c8277316-c29d-5fde-bf9f-2611099a0029"
-        ],
-        "required_facts": [
-          "investment.investment_capital_idr"
-        ],
+        "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"],
+        "required_facts": ["investment.investment_capital_idr"],
         "rule_id": "hf.e28a.total-investment-below-min",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2763,18 +2438,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "E28A_INVESTMENT_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e28a.investment",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "c8277316-c29d-5fde-bf9f-2611099a0029"
-        ],
+        "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"],
         "required_facts": [
           "intent.purposes",
           "investment.investment_capital_idr",
@@ -2785,9 +2456,7 @@
         "rule_id": "el.e28a.investment",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2798,9 +2467,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "investment.pt_pma_committed",
@@ -2810,10 +2477,7 @@
             {
               "fact": "investment.proposed_role",
               "op": "in",
-              "values": [
-                "SHAREHOLDER_DIRECTOR",
-                "SHAREHOLDER_COMMISSIONER"
-              ]
+              "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
             },
             {
               "fact": "investment.paid_up_capital_idr",
@@ -2837,19 +2501,12 @@
         "explanation_key": "explain.review.e28b.usd-threshold-manual",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "ca8c1177-ad94-5261-82a6-68bc912d31bb"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e28b.usd-threshold-manual",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2860,9 +2517,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -2881,19 +2536,12 @@
         "explanation_key": "explain.review.e28c.usd-threshold-manual",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "b074270f-fa7c-598b-a728-81ca89432364"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e28c.usd-threshold-manual",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2904,9 +2552,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -2925,19 +2571,12 @@
         "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "ee4fef98-3497-507c-8486-225932364e26"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e28d.usd-threshold-turnover-manual",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2948,9 +2587,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -2969,19 +2606,12 @@
         "explanation_key": "explain.review.e28f.ikn-threshold-manual",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "2df6f723-7fc3-585a-b26f-0e8c060a2d8d"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e28f.ikn-threshold-manual",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -2992,9 +2622,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -3007,19 +2635,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "SECOND_HOME",
-            "TOURISM"
-          ],
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
           "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e33.deposit-basis",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
-        ],
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
         "required_facts": [
           "intent.purposes",
           "secondhome.bank_deposit_at_state_bank",
@@ -3043,9 +2666,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "SECOND_HOME"
-              ]
+              "values": ["SECOND_HOME"]
             },
             {
               "fact": "secondhome.bank_deposit_usd",
@@ -3068,19 +2689,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "SECOND_HOME",
-            "TOURISM"
-          ],
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
           "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e33.property-basis",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
-        ],
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
         "required_facts": [
           "intent.purposes",
           "secondhome.qualifying_property_value_usd"
@@ -3102,9 +2718,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "SECOND_HOME"
-              ]
+              "values": ["SECOND_HOME"]
             },
             {
               "fact": "secondhome.qualifying_property_value_usd",
@@ -3117,19 +2731,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "SECOND_HOME",
-            "TOURISM"
-          ],
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
           "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e33.property-qualification",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
-        ],
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
         "required_facts": [
           "intent.purposes",
           "secondhome.bank_deposit_at_state_bank",
@@ -3156,9 +2765,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "SECOND_HOME"
-                  ]
+                  "values": ["SECOND_HOME"]
                 },
                 {
                   "fact": "secondhome.qualifying_property_value_usd",
@@ -3175,9 +2782,7 @@
                     {
                       "fact": "intent.purposes",
                       "op": "intersects",
-                      "values": [
-                        "SECOND_HOME"
-                      ]
+                      "values": ["SECOND_HOME"]
                     },
                     {
                       "fact": "secondhome.bank_deposit_usd",
@@ -3202,9 +2807,7 @@
                     {
                       "fact": "intent.purposes",
                       "op": "intersects",
-                      "values": [
-                        "SECOND_HOME"
-                      ]
+                      "values": ["SECOND_HOME"]
                     },
                     {
                       "fact": "secondhome.qualifying_property_value_usd",
@@ -3223,19 +2826,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "SECOND_HOME",
-            "TOURISM"
-          ],
+          "covered_purposes": ["SECOND_HOME", "TOURISM"],
           "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e33.guarantee-maintenance",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
-        ],
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
         "required_facts": [
           "intent.purposes",
           "secondhome.bank_deposit_at_state_bank",
@@ -3262,9 +2860,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "SECOND_HOME"
-                  ]
+                  "values": ["SECOND_HOME"]
                 },
                 {
                   "args": [
@@ -3291,9 +2887,7 @@
                     {
                       "fact": "intent.purposes",
                       "op": "intersects",
-                      "values": [
-                        "SECOND_HOME"
-                      ]
+                      "values": ["SECOND_HOME"]
                     },
                     {
                       "fact": "secondhome.bank_deposit_usd",
@@ -3318,9 +2912,7 @@
                     {
                       "fact": "intent.purposes",
                       "op": "intersects",
-                      "values": [
-                        "SECOND_HOME"
-                      ]
+                      "values": ["SECOND_HOME"]
                     },
                     {
                       "fact": "secondhome.qualifying_property_value_usd",
@@ -3345,18 +2937,12 @@
         "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
-        ],
-        "required_facts": [
-          "intent.purposes"
-        ],
+        "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"],
+        "required_facts": ["intent.purposes"],
         "rule_id": "review.e33.work-rangkap-kegiatan",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3367,16 +2953,12 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "SECOND_HOME"
-              ]
+              "values": ["SECOND_HOME"]
             },
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "EMPLOYMENT"
-              ]
+              "values": ["EMPLOYMENT"]
             }
           ],
           "op": "all"
@@ -3390,19 +2972,12 @@
         "explanation_key": "explain.review.e33a.central-government-invitation",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5c18e265-ddb2-5010-8d24-a2f19df89850"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e33a.central-government-invitation",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3413,9 +2988,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "EMPLOYMENT"
-              ]
+              "values": ["EMPLOYMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -3434,19 +3007,12 @@
         "explanation_key": "explain.review.e33b.expertise-qualification",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "32b6fb5f-5a24-5763-95f9-0b77be18353c"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e33b.expertise-qualification",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3457,9 +3023,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "EMPLOYMENT"
-              ]
+              "values": ["EMPLOYMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -3478,19 +3042,12 @@
         "explanation_key": "explain.review.e33c.central-government-invitation",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e33c.central-government-invitation",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3501,9 +3058,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -3522,18 +3077,12 @@
         "explanation_key": "explain.hf.e33e.age-below-55",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"
-        ],
-        "required_facts": [
-          "derived.age_years"
-        ],
+        "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"],
+        "required_facts": ["derived.age_years"],
         "rule_id": "hf.e33e.age-below-55",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3559,9 +3108,7 @@
         "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"
-        ],
+        "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"],
         "required_facts": [
           "derived.age_years",
           "intent.purposes",
@@ -3589,9 +3136,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "RETIREMENT"
-                  ]
+                  "values": ["RETIREMENT"]
                 },
                 {
                   "fact": "derived.age_years",
@@ -3607,9 +3152,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "RETIREMENT"
-                  ]
+                  "values": ["RETIREMENT"]
                 },
                 {
                   "fact": "derived.age_years",
@@ -3662,9 +3205,7 @@
         "explanation_key": "explain.el.e33e.retirement",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"
-        ],
+        "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"],
         "required_facts": [
           "derived.age_years",
           "intent.purposes",
@@ -3690,9 +3231,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "RETIREMENT"
-              ]
+              "values": ["RETIREMENT"]
             },
             {
               "fact": "derived.age_years",
@@ -3736,18 +3275,12 @@
         "explanation_key": "explain.hf.e33f.sponsor-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "7c1da88f-f7cd-571a-95c2-7da32463d3e6"
-        ],
-        "required_facts": [
-          "family.sponsor_confirmed"
-        ],
+        "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"],
+        "required_facts": ["family.sponsor_confirmed"],
         "rule_id": "hf.e33f.sponsor-required",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3773,9 +3306,7 @@
         "explanation_key": "explain.el.e33f.retirement",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "7c1da88f-f7cd-571a-95c2-7da32463d3e6"
-        ],
+        "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"],
         "required_facts": [
           "family.sponsor_confirmed",
           "intent.purposes",
@@ -3798,9 +3329,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "RETIREMENT"
-              ]
+              "values": ["RETIREMENT"]
             },
             {
               "fact": "secondhome.passive_monthly_income_usd",
@@ -3824,18 +3353,12 @@
         "explanation_key": "explain.hf.e33g.indonesian-employer",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "51e023ea-3229-5233-b88f-cb204b5df713"
-        ],
-        "required_facts": [
-          "work.employer_is_indonesian_entity"
-        ],
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["work.employer_is_indonesian_entity"],
         "rule_id": "hf.e33g.indonesian-employer",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3855,18 +3378,12 @@
         "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "51e023ea-3229-5233-b88f-cb204b5df713"
-        ],
-        "required_facts": [
-          "work.indonesia_source_compensation"
-        ],
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["work.indonesia_source_compensation"],
         "rule_id": "hf.e33g.indonesian-source-compensation",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3886,19 +3403,12 @@
         "explanation_key": "explain.review.e33g.local-market",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "51e023ea-3229-5233-b88f-cb204b5df713"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "work.serves_indonesian_clients"
-        ],
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
         "rule_id": "review.e33g.local-market",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3909,9 +3419,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "REMOTE_WORK"
-              ]
+              "values": ["REMOTE_WORK"]
             },
             {
               "fact": "work.serves_indonesian_clients",
@@ -3930,19 +3438,12 @@
         "explanation_key": "explain.review.e33g.local-company-ownership",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "51e023ea-3229-5233-b88f-cb204b5df713"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "investment.pt_pma_committed"
-        ],
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
+        "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
         "rule_id": "review.e33g.local-company-ownership",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -3953,9 +3454,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "REMOTE_WORK"
-              ]
+              "values": ["REMOTE_WORK"]
             },
             {
               "fact": "investment.pt_pma_committed",
@@ -3968,20 +3467,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "REMOTE_WORK",
-            "TOURISM",
-            "FAMILY"
-          ],
+          "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
           "reason_code": "REMOTE_WORK_ELIGIBLE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e33g.remote-work",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "51e023ea-3229-5233-b88f-cb204b5df713"
-        ],
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
         "required_facts": [
           "intent.purposes",
           "work.employer_is_indonesian_entity",
@@ -3991,9 +3484,7 @@
         "rule_id": "el.e33g.remote-work",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4004,9 +3495,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "REMOTE_WORK"
-              ]
+              "values": ["REMOTE_WORK"]
             },
             {
               "fact": "work.employer_is_indonesian_entity",
@@ -4035,18 +3524,12 @@
         "explanation_key": "explain.hf.bridging.offshore",
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
-        "required_facts": [
-          "immigration.currently_in_indonesia"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["immigration.currently_in_indonesia"],
         "rule_id": "hf.bridging.offshore",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4066,12 +3549,8 @@
         "explanation_key": "explain.hf.bridging.from-visit-itk",
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
-        "required_facts": [
-          "immigration.current_status_code"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["immigration.current_status_code"],
         "rule_id": "hf.bridging.from-visit-itk",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -4106,18 +3585,12 @@
         "explanation_key": "explain.hf.bridging.to-bridging",
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
-        "required_facts": [
-          "immigration.current_status_code"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["immigration.current_status_code"],
         "rule_id": "hf.bridging.to-bridging",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4131,18 +3604,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "OTHER"
-          ],
+          "covered_purposes": ["OTHER"],
           "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.bridging.t3-window-manual",
         "on_unknown": "NO_EFFECT",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
         "required_facts": [
           "immigration.current_status_expiry",
           "immigration.currently_in_indonesia",
@@ -4152,9 +3621,7 @@
         "rule_id": "el.bridging.t3-window-manual",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4181,9 +3648,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "OTHER"
-                  ]
+                  "values": ["OTHER"]
                 },
                 {
                   "fact": "intent.requested_product_code",
@@ -4199,18 +3664,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "OTHER"
-          ],
+          "covered_purposes": ["OTHER"],
           "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.bridging.overstay-shield-payment",
         "on_unknown": "NO_EFFECT",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
         "required_facts": [
           "immigration.current_status_expiry",
           "immigration.currently_in_indonesia",
@@ -4220,9 +3681,7 @@
         "rule_id": "el.bridging.overstay-shield-payment",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4249,9 +3708,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "OTHER"
-                  ]
+                  "values": ["OTHER"]
                 },
                 {
                   "fact": "intent.requested_product_code",
@@ -4267,18 +3724,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "OTHER"
-          ],
+          "covered_purposes": ["OTHER"],
           "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.bridging.source-status-verify",
         "on_unknown": "NO_EFFECT",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
         "required_facts": [
           "immigration.current_status_code",
           "immigration.currently_in_indonesia",
@@ -4288,9 +3741,7 @@
         "rule_id": "el.bridging.source-status-verify",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4317,9 +3768,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "OTHER"
-                  ]
+                  "values": ["OTHER"]
                 },
                 {
                   "fact": "intent.requested_product_code",
@@ -4341,9 +3790,7 @@
         "explanation_key": "explain.review.bridging.adverse-history",
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
         "required_facts": [
           "immigration.currently_in_indonesia",
           "immigration.violation_history"
@@ -4351,9 +3798,7 @@
         "rule_id": "review.bridging.adverse-history",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4382,28 +3827,19 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "OTHER"
-          ],
+          "covered_purposes": ["OTHER"],
           "reason_code": "BRIDGING_DESTINATION_STATED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.bridging.destination-stated",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "760025cf-d51d-5687-9e98-b921010b9018"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "el.bridging.destination-stated",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "9248b1d7-9172-54d9-ad61-251e83a2285b"
-        ],
+        "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4414,9 +3850,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "OTHER"
-              ]
+              "values": ["OTHER"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -4429,18 +3863,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "EMPLOYMENT"
-          ],
+          "covered_purposes": ["EMPLOYMENT"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e23-employment-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "e1d761e9-56c5-57c3-9c01-986d3c333157"
-        ],
+        "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"],
         "required_facts": [
           "intent.purposes",
           "work.employer_is_indonesian_entity",
@@ -4449,9 +3879,7 @@
         "rule_id": "el.e23-employment-support",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4462,9 +3890,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "EMPLOYMENT"
-              ]
+              "values": ["EMPLOYMENT"]
             },
             {
               "fact": "work.employer_is_indonesian_entity",
@@ -4482,18 +3908,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "EMPLOYMENT"
-          ],
+          "covered_purposes": ["EMPLOYMENT"],
           "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e23-operational-work-boundary",
         "on_unknown": "NO_EFFECT",
         "priority": 100,
-        "product_version_ids": [
-          "e1d761e9-56c5-57c3-9c01-986d3c333157"
-        ],
+        "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"],
         "required_facts": [
           "intent.purposes",
           "investment.proposed_role",
@@ -4503,9 +3925,7 @@
         "rule_id": "el.e23-operational-work-boundary",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4518,17 +3938,12 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "EMPLOYMENT"
-                  ]
+                  "values": ["EMPLOYMENT"]
                 },
                 {
                   "fact": "investment.proposed_role",
                   "op": "in",
-                  "values": [
-                    "SHAREHOLDER_DIRECTOR",
-                    "SHAREHOLDER_COMMISSIONER"
-                  ]
+                  "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
                 }
               ],
               "op": "all"
@@ -4538,9 +3953,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "EMPLOYMENT"
-                  ]
+                  "values": ["EMPLOYMENT"]
                 },
                 {
                   "fact": "work.employer_is_indonesian_entity",
@@ -4561,18 +3974,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31a-spouse-wni-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
-        ],
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -4596,9 +4005,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -4608,9 +4015,7 @@
             {
               "fact": "family.sponsor_nationalities",
               "op": "intersects",
-              "values": [
-                "ID"
-              ]
+              "values": ["ID"]
             },
             {
               "fact": "family.marriage_registered",
@@ -4623,18 +4028,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_FUNDS_2000",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31a-funds-2000",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
-        ],
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
         "required_facts": [
           "family.marriage_registered",
           "family.relation_to_sponsor",
@@ -4660,9 +4061,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -4672,9 +4071,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 }
               ],
               "op": "all"
@@ -4684,9 +4081,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -4696,9 +4091,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 },
                 {
                   "fact": "family.marriage_registered",
@@ -4714,18 +4107,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31a-spousal-work-article-61",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
-        ],
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
         "required_facts": [
           "family.marriage_registered",
           "family.relation_to_sponsor",
@@ -4735,9 +4124,7 @@
         "rule_id": "el.e31a-spousal-work-article-61",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "5a0d367b-bf64-535d-83e4-f40c45de2008"
-        ],
+        "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4750,9 +4137,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -4762,9 +4147,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 }
               ],
               "op": "all"
@@ -4774,9 +4157,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -4786,9 +4167,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 },
                 {
                   "fact": "family.marriage_registered",
@@ -4804,18 +4183,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31a-kitap-prerequisites",
         "on_unknown": "NO_EFFECT",
         "priority": 100,
-        "product_version_ids": [
-          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
-        ],
+        "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"],
         "required_facts": [
           "family.marriage_registered",
           "family.relation_to_sponsor",
@@ -4826,9 +4201,7 @@
         "rule_id": "el.e31a-kitap-prerequisites",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "5a0d367b-bf64-535d-83e4-f40c45de2008"
-        ],
+        "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
         "stage": "ELIGIBILITY",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -4846,9 +4219,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -4858,9 +4229,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 },
                 {
                   "fact": "family.marriage_registered",
@@ -4876,18 +4245,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31b-spouse-itas-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5d5f9bd4-349b-54d7-841a-784c0afba068"
-        ],
+        "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -4911,9 +4276,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -4935,18 +4298,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_SPONSOR_ITAS_ITAP",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31b-sponsor-itas-itap",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5d5f9bd4-349b-54d7-841a-784c0afba068"
-        ],
+        "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"],
         "required_facts": [
           "family.marriage_registered",
           "family.relation_to_sponsor",
@@ -4972,9 +4331,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -4989,9 +4346,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5016,18 +4371,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
-        ],
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
         "required_facts": [
           "family.relation_to_sponsor",
           "family.sponsor_nationalities",
@@ -5050,9 +4401,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5062,9 +4411,7 @@
             {
               "fact": "family.sponsor_nationalities",
               "op": "intersects",
-              "values": [
-                "ID"
-              ]
+              "values": ["ID"]
             }
           ],
           "op": "all"
@@ -5072,18 +4419,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31c-mixed-marriage-parents",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
-        ],
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
         "required_facts": [
           "family.marriage_registered",
           "family.relation_to_sponsor",
@@ -5107,9 +4450,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5119,9 +4460,7 @@
             {
               "fact": "family.sponsor_nationalities",
               "op": "intersects",
-              "values": [
-                "ID"
-              ]
+              "values": ["ID"]
             },
             {
               "fact": "family.marriage_registered",
@@ -5134,21 +4473,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31d-stepchild-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "3204e973-59da-5da1-bad0-06a7172e5b2c"
-        ],
-        "required_facts": [
-          "intent.purposes"
-        ],
+        "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"],
+        "required_facts": ["intent.purposes"],
         "rule_id": "el.e31d-stepchild-support",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -5166,9 +4499,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             }
           ],
           "op": "all"
@@ -5176,21 +4507,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_STEP_PARENT_RELATION",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31d-step-parent-relation",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "3204e973-59da-5da1-bad0-06a7172e5b2c"
-        ],
-        "required_facts": [
-          "intent.purposes"
-        ],
+        "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"],
+        "required_facts": ["intent.purposes"],
         "rule_id": "el.e31d-step-parent-relation",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -5208,18 +4533,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 }
               ],
               "op": "all"
@@ -5230,21 +4551,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "3204e973-59da-5da1-bad0-06a7172e5b2c"
-        ],
-        "required_facts": [
-          "intent.purposes"
-        ],
+        "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"],
+        "required_facts": ["intent.purposes"],
         "rule_id": "el.e31d-sponsor-mixed-marriage",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -5262,18 +4577,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 }
               ],
               "op": "all"
@@ -5290,18 +4601,12 @@
         "explanation_key": "explain.hf.e31e-adult-excluded",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "1266d5cb-84a3-51f7-b82d-c6b756254074"
-        ],
-        "required_facts": [
-          "derived.age_years"
-        ],
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
+        "required_facts": ["derived.age_years"],
         "rule_id": "hf.e31e-adult-excluded",
         "safety_critical": true,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
-        ],
+        "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -5321,18 +4626,12 @@
         "explanation_key": "explain.hf.e31e-married-excluded",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "1266d5cb-84a3-51f7-b82d-c6b756254074"
-        ],
-        "required_facts": [
-          "person.marital_status"
-        ],
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
+        "required_facts": ["person.marital_status"],
         "rule_id": "hf.e31e-married-excluded",
         "safety_critical": true,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
-        ],
+        "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -5346,18 +4645,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31e-child-itas-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "1266d5cb-84a3-51f7-b82d-c6b756254074"
-        ],
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -5382,9 +4677,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5411,18 +4704,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_SPONSOR_ITAS_ITAP",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31e-sponsor-itas-itap",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "1266d5cb-84a3-51f7-b82d-c6b756254074"
-        ],
+        "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"],
         "required_facts": [
           "derived.age_years",
           "family.relation_to_sponsor",
@@ -5449,9 +4738,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5466,9 +4753,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5498,18 +4783,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31f-child-wni-parent-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"
-        ],
+        "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -5532,9 +4813,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5544,9 +4823,7 @@
             {
               "fact": "family.sponsor_nationalities",
               "op": "intersects",
-              "values": [
-                "ID"
-              ]
+              "values": ["ID"]
             }
           ],
           "op": "all"
@@ -5554,18 +4831,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31f-adult-age-review",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"
-        ],
+        "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"],
         "required_facts": [
           "derived.age_years",
           "family.relation_to_sponsor",
@@ -5591,9 +4864,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5603,9 +4874,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 },
                 {
                   "fact": "derived.age_years",
@@ -5620,9 +4889,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5632,9 +4899,7 @@
                 {
                   "fact": "family.sponsor_nationalities",
                   "op": "intersects",
-                  "values": [
-                    "ID"
-                  ]
+                  "values": ["ID"]
                 }
               ],
               "op": "all"
@@ -5645,18 +4910,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31g-parent-wni-child-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "fbc980d5-47b6-5f16-974d-25158dfffc06"
-        ],
+        "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -5679,9 +4940,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5691,9 +4950,7 @@
             {
               "fact": "family.sponsor_nationalities",
               "op": "intersects",
-              "values": [
-                "ID"
-              ]
+              "values": ["ID"]
             }
           ],
           "op": "all"
@@ -5701,18 +4958,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31h-parent-itas-child-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "1185c36d-833c-5e41-8e0d-6e4f7c8f7378"
-        ],
+        "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -5735,9 +4988,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5754,18 +5005,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_SPONSOR_ITAS_ITAP",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31h-sponsor-itas-itap",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "1185c36d-833c-5e41-8e0d-6e4f7c8f7378"
-        ],
+        "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"],
         "required_facts": [
           "family.relation_to_sponsor",
           "family.sponsor_status_code",
@@ -5790,9 +5037,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5807,9 +5052,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5829,18 +5072,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31j-sibling-itas-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
-        ],
+        "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"],
         "required_facts": [
           "intent.purposes",
           "family.relation_to_sponsor",
@@ -5863,9 +5102,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -5882,18 +5119,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "REQ_SPONSOR_ITAS_ITAP",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31j-sponsor-itas-itap",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
-        ],
+        "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"],
         "required_facts": [
           "family.relation_to_sponsor",
           "family.sponsor_status_code",
@@ -5918,9 +5151,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5935,9 +5166,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -5957,18 +5186,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "FAMILY"
-          ],
+          "covered_purposes": ["FAMILY"],
           "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e31j-dependency-age",
         "on_unknown": "NO_EFFECT",
         "priority": 100,
-        "product_version_ids": [
-          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
-        ],
+        "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"],
         "required_facts": [
           "derived.age_years",
           "family.relation_to_sponsor",
@@ -5994,9 +5219,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -6016,9 +5239,7 @@
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "FAMILY"
-                  ]
+                  "values": ["FAMILY"]
                 },
                 {
                   "fact": "family.relation_to_sponsor",
@@ -6050,9 +5271,7 @@
         "explanation_key": "explain.el.d1-multi-entry-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "374e79e0-f0bf-5291-8cba-974e794e210a"
-        ],
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
         "required_facts": [
           "intent.purposes",
           "intent.stay_days",
@@ -6115,9 +5334,7 @@
         "explanation_key": "explain.el.d1-passport-validity",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "374e79e0-f0bf-5291-8cba-974e794e210a"
-        ],
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
         "required_facts": [
           "intent.entry_pattern",
           "intent.purposes",
@@ -6205,9 +5422,7 @@
         "explanation_key": "explain.el.d1-funds-usd-2000",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "374e79e0-f0bf-5291-8cba-974e794e210a"
-        ],
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
         "required_facts": [
           "intent.entry_pattern",
           "intent.purposes",
@@ -6295,9 +5510,7 @@
         "explanation_key": "explain.el.d1-cv-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "374e79e0-f0bf-5291-8cba-974e794e210a"
-        ],
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
         "required_facts": [
           "intent.entry_pattern",
           "intent.purposes",
@@ -6385,9 +5598,7 @@
         "explanation_key": "explain.el.d1-itinerary-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "374e79e0-f0bf-5291-8cba-974e794e210a"
-        ],
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
         "required_facts": [
           "intent.entry_pattern",
           "intent.purposes",
@@ -6475,9 +5686,7 @@
         "explanation_key": "explain.el.d1-support-letter",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "374e79e0-f0bf-5291-8cba-974e794e210a"
-        ],
+        "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"],
         "required_facts": [
           "intent.entry_pattern",
           "intent.purposes",
@@ -6553,22 +5762,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d2-multi-entry-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "306725c1-7269-5c45-a4b8-188265fcf4d8"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d2-multi-entry-support",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6586,9 +5788,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS"
-              ]
+              "values": ["BUSINESS_MEETINGS"]
             },
             {
               "fact": "intent.stay_days",
@@ -6601,22 +5801,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS"],
           "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d2-passport-validity",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "306725c1-7269-5c45-a4b8-188265fcf4d8"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d2-passport-validity",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6634,18 +5827,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS"
-              ]
+              "values": ["BUSINESS_MEETINGS"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "BUSINESS_MEETINGS"
-                  ]
+                  "values": ["BUSINESS_MEETINGS"]
                 },
                 {
                   "fact": "intent.stay_days",
@@ -6661,22 +5850,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS"],
           "reason_code": "PROOF_OF_FUNDS_D2",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d2-funds-usd-2000",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "306725c1-7269-5c45-a4b8-188265fcf4d8"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d2-funds-usd-2000",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6694,18 +5876,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS"
-              ]
+              "values": ["BUSINESS_MEETINGS"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "BUSINESS_MEETINGS"
-                  ]
+                  "values": ["BUSINESS_MEETINGS"]
                 },
                 {
                   "fact": "intent.stay_days",
@@ -6721,22 +5899,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS"],
           "reason_code": "CV_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d2-cv-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "306725c1-7269-5c45-a4b8-188265fcf4d8"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d2-cv-required",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6754,18 +5925,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS"
-              ]
+              "values": ["BUSINESS_MEETINGS"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "BUSINESS_MEETINGS"
-                  ]
+                  "values": ["BUSINESS_MEETINGS"]
                 },
                 {
                   "fact": "intent.stay_days",
@@ -6781,22 +5948,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS"],
           "reason_code": "ITINERARY_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d2-itinerary-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "306725c1-7269-5c45-a4b8-188265fcf4d8"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d2-itinerary-required",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6814,18 +5974,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS"
-              ]
+              "values": ["BUSINESS_MEETINGS"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "BUSINESS_MEETINGS"
-                  ]
+                  "values": ["BUSINESS_MEETINGS"]
                 },
                 {
                   "fact": "intent.stay_days",
@@ -6841,22 +5997,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "BUSINESS_MEETINGS"
-          ],
+          "covered_purposes": ["BUSINESS_MEETINGS"],
           "reason_code": "SUPPORT_LETTER_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d2-support-letter",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "306725c1-7269-5c45-a4b8-188265fcf4d8"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d2-support-letter",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6874,18 +6023,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "BUSINESS_MEETINGS"
-              ]
+              "values": ["BUSINESS_MEETINGS"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "BUSINESS_MEETINGS"
-                  ]
+                  "values": ["BUSINESS_MEETINGS"]
                 },
                 {
                   "fact": "intent.stay_days",
@@ -6901,22 +6046,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d12-multi-entry-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d12-multi-entry-support",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6934,9 +6072,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.stay_days",
@@ -6949,22 +6085,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d12-passport-validity",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d12-passport-validity",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -6982,9 +6111,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.stay_days",
@@ -6997,22 +6124,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "PROOF_OF_FUNDS_D12",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d12-funds-usd-5000",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d12-funds-usd-5000",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -7030,9 +6150,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.stay_days",
@@ -7045,22 +6163,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "CV_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d12-cv-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d12-cv-required",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -7078,9 +6189,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.stay_days",
@@ -7093,22 +6202,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "ITINERARY_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d12-itinerary-required",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d12-itinerary-required",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -7126,9 +6228,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.stay_days",
@@ -7141,22 +6241,15 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "INVESTMENT"
-          ],
+          "covered_purposes": ["INVESTMENT"],
           "reason_code": "SUPPORT_LETTER_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.d12-support-letter",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.stay_days"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["intent.purposes", "intent.stay_days"],
         "rule_id": "el.d12-support-letter",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -7174,9 +6267,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "INVESTMENT"
-              ]
+              "values": ["INVESTMENT"]
             },
             {
               "fact": "intent.stay_days",
@@ -7195,18 +6286,12 @@
         "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
-        ],
-        "required_facts": [
-          "process.wants_onshore_conversion"
-        ],
+        "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"],
+        "required_facts": ["process.wants_onshore_conversion"],
         "rule_id": "hf.d12-onshore-conversion-excluded",
         "safety_critical": true,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"
-        ],
+        "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -7220,9 +6305,7 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
@@ -7256,9 +6339,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "fact": "study.admission_confirmed",
@@ -7276,18 +6357,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "LIVING_COST_USD2000",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30-living-cost-2000.e30",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "94d26bed-b3ba-5b9a-9c6c-9c137854293c"
-        ],
+        "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7312,18 +6389,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7344,18 +6417,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "LIVING_COST_USD2000",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30-living-cost-2000.e30a",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f"
-        ],
+        "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7380,18 +6449,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7412,18 +6477,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "LIVING_COST_USD2000",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30-living-cost-2000.e30b",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
-        ],
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7448,18 +6509,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7480,18 +6537,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30-passport-validity.e30",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "94d26bed-b3ba-5b9a-9c6c-9c137854293c"
-        ],
+        "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7516,18 +6569,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7548,18 +6597,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30-passport-validity.e30a",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f"
-        ],
+        "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7584,18 +6629,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7616,18 +6657,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30-passport-validity.e30b",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
-        ],
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7652,18 +6689,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7690,19 +6723,12 @@
         "explanation_key": "explain.hf.e30a-level-band",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "study.level"
-        ],
+        "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"],
+        "required_facts": ["intent.purposes", "study.level"],
         "rule_id": "hf.e30a-level-band",
         "safety_critical": true,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -7713,17 +6739,12 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "fact": "study.level",
               "op": "not_in",
-              "values": [
-                "PRIMARY",
-                "SECONDARY"
-              ]
+              "values": ["PRIMARY", "SECONDARY"]
             }
           ],
           "op": "all"
@@ -7737,19 +6758,12 @@
         "explanation_key": "explain.hf.e30b-level-band",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "study.level"
-        ],
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
+        "required_facts": ["intent.purposes", "study.level"],
         "rule_id": "hf.e30b-level-band",
         "safety_critical": true,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "e3572ad2-08a9-55bd-b818-353b3e9db715"
-        ],
+        "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -7760,18 +6774,12 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "fact": "study.level",
               "op": "not_in",
-              "values": [
-                "VOCATIONAL",
-                "UNDERGRADUATE",
-                "POSTGRADUATE"
-              ]
+              "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
             }
           ],
           "op": "all"
@@ -7779,18 +6787,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "STUDY_PERMIT_KEMDIKBUD",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30b-izin-belajar",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
-        ],
+        "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"],
         "required_facts": [
           "intent.purposes",
           "study.admission_confirmed",
@@ -7814,18 +6818,14 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "args": [
                 {
                   "fact": "intent.purposes",
                   "op": "intersects",
-                  "values": [
-                    "STUDY"
-                  ]
+                  "values": ["STUDY"]
                 },
                 {
                   "fact": "study.admission_confirmed",
@@ -7852,18 +6852,12 @@
         "explanation_key": "explain.hf.b1.not-voa-nationality",
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
-        "product_version_ids": [
-          "4e30cbe0-c4bf-59be-9bf8-513e66946e44"
-        ],
-        "required_facts": [
-          "person.nationalities"
-        ],
+        "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"],
+        "required_facts": ["person.nationalities"],
         "rule_id": "hf.b1.not-voa-nationality",
         "safety_critical": true,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "38a6cb08-041f-51e4-86e4-9e73243acd3a"
-        ],
+        "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
         "stage": "HARD_FILTER",
         "valid_period": {
           "from": "2026-07-24T00:00:00Z",
@@ -7985,9 +6979,7 @@
         "on_unknown": "HUMAN_REVIEW",
         "priority": 100,
         "product_version_ids": null,
-        "required_facts": [
-          "person.nationalities"
-        ],
+        "required_facts": ["person.nationalities"],
         "rule_id": "review.citizenship-conflict",
         "safety_critical": true,
         "scope": "GLOBAL",
@@ -8273,14 +7265,7 @@
                 {
                   "fact": "person.nationalities",
                   "op": "intersects",
-                  "values": [
-                    "AF",
-                    "IL",
-                    "KP",
-                    "LR",
-                    "NG",
-                    "SO"
-                  ]
+                  "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
                 },
                 {
                   "fact": "person.nationalities",
@@ -8547,16 +7532,11 @@
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
         "product_version_ids": null,
-        "required_facts": [
-          "derived.is_minor",
-          "family.sponsor_confirmed"
-        ],
+        "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
         "rule_id": "review.minor-without-guardian",
         "safety_critical": true,
         "scope": "GLOBAL",
-        "source_refs": [
-          "38242587-f4da-5c31-b0ea-662f7fdc475c"
-        ],
+        "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-08-09T00:00:00Z",
@@ -8586,12 +7566,8 @@
         "explanation_key": "explain.hf.e33f.age-below-55",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "7c1da88f-f7cd-571a-95c2-7da32463d3e6"
-        ],
-        "required_facts": [
-          "derived.age_years"
-        ],
+        "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"],
+        "required_facts": ["derived.age_years"],
         "rule_id": "hf.e33f.age-below-55",
         "safety_critical": false,
         "scope": "PRODUCTS",
@@ -8618,9 +7594,7 @@
         "explanation_key": "explain.review.e33g.income-evidence",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "51e023ea-3229-5233-b88f-cb204b5df713"
-        ],
+        "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"],
         "required_facts": [
           "intent.purposes",
           "work.employer_is_indonesian_entity",
@@ -8644,9 +7618,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "REMOTE_WORK"
-              ]
+              "values": ["REMOTE_WORK"]
             },
             {
               "fact": "work.employer_is_indonesian_entity",
@@ -8669,18 +7641,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30e-student-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "19e3ea6c-95c6-5998-b9d7-efc77f583589"
-        ],
+        "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"],
         "required_facts": [
           "intent.purposes",
           "sponsor.type",
@@ -8705,9 +7673,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "fact": "study.admission_confirmed",
@@ -8722,10 +7688,7 @@
             {
               "fact": "sponsor.type",
               "op": "in",
-              "values": [
-                "EDUCATION",
-                "INDIVIDUAL"
-              ]
+              "values": ["EDUCATION", "INDIVIDUAL"]
             }
           ],
           "op": "all"
@@ -8733,18 +7696,14 @@
       },
       {
         "effect": {
-          "covered_purposes": [
-            "STUDY"
-          ],
+          "covered_purposes": ["STUDY"],
           "reason_code": "PURPOSE_PRODUCT_MATCH",
           "type": "SUPPORT"
         },
         "explanation_key": "explain.el.e30f-student-support",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
-        ],
+        "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"],
         "required_facts": [
           "intent.purposes",
           "sponsor.type",
@@ -8768,9 +7727,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "STUDY"
-              ]
+              "values": ["STUDY"]
             },
             {
               "fact": "study.admission_confirmed",
@@ -8799,12 +7756,8 @@
         "explanation_key": "explain.hf.e33a.sponsor-not-government",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "5c18e265-ddb2-5010-8d24-a2f19df89850"
-        ],
-        "required_facts": [
-          "sponsor.type"
-        ],
+        "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"],
+        "required_facts": ["sponsor.type"],
         "rule_id": "hf.e33a.sponsor-not-government",
         "safety_critical": true,
         "scope": "PRODUCTS",
@@ -8831,12 +7784,8 @@
         "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "32b6fb5f-5a24-5763-95f9-0b77be18353c"
-        ],
-        "required_facts": [
-          "sponsor.type"
-        ],
+        "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"],
+        "required_facts": ["sponsor.type"],
         "rule_id": "hf.e33b.sponsor-not-government-or-none",
         "safety_critical": true,
         "scope": "PRODUCTS",
@@ -8852,10 +7801,7 @@
         "when": {
           "fact": "sponsor.type",
           "op": "not_in",
-          "values": [
-            "GOVERNMENT",
-            "NONE"
-          ]
+          "values": ["GOVERNMENT", "NONE"]
         }
       },
       {
@@ -8866,12 +7812,8 @@
         "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"
-        ],
-        "required_facts": [
-          "sponsor.type"
-        ],
+        "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"],
+        "required_facts": ["sponsor.type"],
         "rule_id": "hf.e33c.sponsor-not-government-or-none",
         "safety_critical": true,
         "scope": "PRODUCTS",
@@ -8887,10 +7829,7 @@
         "when": {
           "fact": "sponsor.type",
           "op": "not_in",
-          "values": [
-            "GOVERNMENT",
-            "NONE"
-          ]
+          "values": ["GOVERNMENT", "NONE"]
         }
       },
       {
@@ -8901,19 +7840,12 @@
         "explanation_key": "explain.review.e23u.requested-product",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "fa143e97-b444-5ae4-9b05-6365f15e3ec7"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e23u.requested-product",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-08-19T00:00:00Z",
@@ -8924,9 +7856,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "EMPLOYMENT"
-              ]
+              "values": ["EMPLOYMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -8945,19 +7875,12 @@
         "explanation_key": "explain.review.e23v.requested-product",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "e8a1d738-daa7-5c99-a0c6-800b25579129"
-        ],
-        "required_facts": [
-          "intent.purposes",
-          "intent.requested_product_code"
-        ],
+        "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"],
+        "required_facts": ["intent.purposes", "intent.requested_product_code"],
         "rule_id": "review.e23v.requested-product",
         "safety_critical": false,
         "scope": "PRODUCTS",
-        "source_refs": [
-          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
-        ],
+        "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
         "stage": "HUMAN_REVIEW",
         "valid_period": {
           "from": "2026-08-19T00:00:00Z",
@@ -8968,9 +7891,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "EMPLOYMENT"
-              ]
+              "values": ["EMPLOYMENT"]
             },
             {
               "fact": "intent.requested_product_code",
@@ -8989,9 +7910,7 @@
         "explanation_key": "explain.hf.e31c-marriage-not-registered",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
-        ],
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
         "required_facts": [
           "family.marriage_registered",
           "family.relation_to_sponsor",
@@ -9014,9 +7933,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -9040,9 +7957,7 @@
         "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
         "on_unknown": "NEEDS_INPUT",
         "priority": 100,
-        "product_version_ids": [
-          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
-        ],
+        "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"],
         "required_facts": [
           "family.relation_to_sponsor",
           "family.sponsor_nationalities",
@@ -9065,9 +7980,7 @@
             {
               "fact": "intent.purposes",
               "op": "intersects",
-              "values": [
-                "FAMILY"
-              ]
+              "values": ["FAMILY"]
             },
             {
               "fact": "family.relation_to_sponsor",
@@ -9078,9 +7991,7 @@
               "arg": {
                 "fact": "family.sponsor_nationalities",
                 "op": "intersects",
-                "values": [
-                  "ID"
-                ]
+                "values": ["ID"]
               },
               "op": "not"
             }

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.signed.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-013.signed.json
@@ -1,0 +1,10157 @@
+{
+  "canonicalization": "RFC8785",
+  "payload": {
+    "created_at": "2026-08-23T13:00:00Z",
+    "created_by": "agent.air-m5.backend-rag.visa-seq13-source-join.fold-2026-08-23",
+    "decision_domain": "IMMIGRATION_VISA",
+    "engine_contract_version": "1.0.0",
+    "engine_max_version": "1.0.0",
+    "engine_min_version": "1.0.0",
+    "environment": "PRODUCTION",
+    "hit_policy": {
+      "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+      "hard_filter": "COLLECT_ALL",
+      "human_review": "COLLECT_ALL",
+      "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+    },
+    "jurisdiction": "ID",
+    "previous_payload_sha256": "ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d",
+    "products": [
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 100,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "B211"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Visa (E28A)",
+          "id": "Visa Investor (E28A)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Investor KITAS 2 Years (Offshore)"
+        },
+        "product_code": "E28A",
+        "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+        "prohibited_activities": [
+          "operational_work_beyond_management_and_ownership"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "INVESTMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 730,
+          "minimum_days": 730
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 Company Establishment (E28B)",
+          "id": "Visa Investor Pendirian Perusahaan (E28B)"
+        },
+        "pricing_key": null,
+        "product_code": "E28B",
+        "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+        "prohibited_activities": [
+          "operational_work"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "INVESTMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 Capital Market (E28C)",
+          "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+        },
+        "pricing_key": null,
+        "product_code": "E28C",
+        "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+        "prohibited_activities": [
+          "operational_work",
+          "corporate_establishment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 Branch or Subsidiary (E28D)",
+          "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+        },
+        "pricing_key": null,
+        "product_code": "E28D",
+        "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+        "prohibited_activities": [
+          "operational_work_outside_managing_subsidiary"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "INVESTMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Investor Golden Visa \u2014 New Capital (IKN) Subsidiary (E28F)",
+          "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+        },
+        "pricing_key": null,
+        "product_code": "E28F",
+        "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+        "prohibited_activities": [
+          "operational_work"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "INVESTMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "SECOND_HOME",
+          "TOURISM"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa (E33)",
+          "id": "Visa Rumah Kedua (E33)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E33 Second Home (5 Years)"
+        },
+        "product_code": "E33",
+        "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services",
+          "guarantee_value_below_commitment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 1825,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "EMPLOYMENT",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa \u2014 Special-Expertise Government Invitation (E33A)",
+          "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+        },
+        "pricing_key": null,
+        "product_code": "E33A",
+        "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "GOVERNMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "EMPLOYMENT",
+          "BUSINESS_MEETINGS",
+          "INVESTMENT",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Golden Visa \u2014 Special-Expertise Collaboration (E33B)",
+          "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+        },
+        "pricing_key": null,
+        "product_code": "E33B",
+        "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Golden Visa \u2014 World-Figure Government Invitation (E33C)",
+          "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+        },
+        "pricing_key": null,
+        "product_code": "E33C",
+        "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "GOVERNMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 3650,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "RETIREMENT",
+          "SECOND_HOME",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [
+          "E311A"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Golden Visa \u2014 Elderly 5-Year (E33E)",
+          "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Retirement (Offshore)"
+        },
+        "product_code": "E33E",
+        "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services",
+          "deposit_value_below_commitment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 1825,
+          "minimum_days": 1825
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "E311A"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa \u2014 Elderly 1-Year (E33F)",
+          "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+        },
+        "product_code": "E33F",
+        "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+        "prohibited_activities": [
+          "overstay",
+          "work_inconsistent_with_permit",
+          "sale_of_goods_or_services"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "REMOTE_WORK",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Second Home Visa \u2014 Remote Worker (E33G)",
+          "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E33G Remote Worker (Offshore)"
+        },
+        "product_code": "E33G",
+        "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+        "prohibited_activities": [
+          "work_for_indonesian_entity",
+          "indonesian_source_compensation_including_in_kind",
+          "indonesian_company_ownership",
+          "sale_of_goods_or_services_beyond_remote_work"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "TOURISM",
+          "TRANSIT"
+        ],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visa-Free Tourism Visit (A1)",
+          "id": "Bebas Visa Kunjungan Wisata (A1)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "A1 Visa-Free Tourism"
+        },
+        "product_code": "A1",
+        "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings",
+          "study",
+          "journalism"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "808d691c-374e-5581-8186-9eb54d0ca7ab"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 30,
+          "minimum_days": 30
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "TOURISM"
+        ],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 30,
+          "maximum_extensions": 1,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "B213"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visa on Arrival \u2014 Tourism (B1)",
+          "id": "Visa Saat Kedatangan Wisata (B1)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "B1 Visa on Arrival (VOA)"
+        },
+        "product_code": "B1",
+        "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings",
+          "study",
+          "journalism"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 30,
+          "minimum_days": 30
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "B211A"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Tourist Visit Visa (C1)",
+          "id": "Visa Kunjungan Wisata (C1)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "C1 Tourism"
+        },
+        "product_code": "C1",
+        "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings",
+          "journalism"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "NONE",
+          "INDIVIDUAL",
+          "EMPLOYER"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "INVESTMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "B211B",
+          "B211A"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Business Visit Visa (C2)",
+          "id": "Visa Kunjungan Bisnis (C2)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "C2 Business"
+        },
+        "product_code": "C2",
+        "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "EMPLOYER"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "SHORT_STAY",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "OTHER"
+        ],
+        "entry_policy": {
+          "entry_count": "SINGLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "B211A"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Social Activity Visit Visa (C6)",
+          "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "C6 Social Activity"
+        },
+        "product_code": "C6",
+        "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+        "prohibited_activities": [
+          "paid_employment",
+          "business_meetings"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL",
+          "EMPLOYER"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "OTHER",
+        "clock_policy": {
+          "anchor": "NOT_APPLICABLE",
+          "available": false,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "OTHER"
+        ],
+        "entry_policy": {
+          "entry_count": "NOT_APPLICABLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Bridging Visa \u2014 Transitional Stay Permit",
+          "id": "Izin Tinggal Peralihan"
+        },
+        "pricing_key": {
+          "category": "single_entry_visas",
+          "item_key": "Bridging Visa"
+        },
+        "product_code": "BRIDGING",
+        "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+        "prohibited_activities": [
+          "employment_relationship",
+          "exit_terminates_permit"
+        ],
+        "public_catalog": false,
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b",
+          "3da72c7b-783e-51e3-9168-6c54bce709ed",
+          "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "EMPLOYMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 1,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Working Visa (E23)",
+          "id": "Visa Kerja (E23)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Working KITAS (Offshore)"
+        },
+        "product_code": "E23",
+        "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+        "prohibited_activities": [
+          "work_for_non_sponsor_entity",
+          "hr_personnel_positions",
+          "passive_investment_management"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": [
+          "EMPLOYER"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "EMPLOYMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Working Visa \u2014 Foreign Diplomat House Assistant (E23U)",
+          "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+        },
+        "pricing_key": null,
+        "product_code": "E23U",
+        "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+        "prohibited_activities": [
+          "work_for_non_diplomat_employer"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "EMPLOYMENT"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Working Visa \u2014 Trade and Economic Office (E23V)",
+          "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+        },
+        "pricing_key": null,
+        "product_code": "E23V",
+        "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+        "prohibited_activities": [
+          "work_for_standard_corporate_employers"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": [
+          "GOVERNMENT"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "C317"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Spouse of Indonesian Citizen (E31A)",
+          "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Spouse 1 Year (Offshore)"
+        },
+        "product_code": "E31A",
+        "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+        "prohibited_activities": [],
+        "public_catalog": true,
+        "source_refs": [
+          "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 730,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [
+          "C318"
+        ],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Spouse of ITAS/ITAP Holder (E31B)",
+          "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31B",
+        "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child of Legal Mixed Marriage (E31C)",
+          "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31C",
+        "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+          "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31D",
+        "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child of ITAS/ITAP Holder (E31E)",
+          "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31E",
+        "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child of Indonesian Citizen Parent (E31F)",
+          "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31F",
+        "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Parent of Indonesian Citizen Child (E31G)",
+          "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31G",
+        "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "86880290-68c2-5220-8f9e-2350678e5f09",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Parent of Child ITAS/ITAP Holder (E31H)",
+          "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31H",
+        "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 365,
+          "maximum_extensions": 5,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Family Visa \u2014 Child Joining Sibling ITAS/ITAP Holder (E31J)",
+          "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "Dependent 1 Year (Offshore)"
+        },
+        "product_code": "E31J",
+        "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+        "prohibited_activities": [
+          "paid_employment"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 365,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "MULTIPLE_ENTRY",
+        "clock_policy": {
+          "anchor": "ENTRY_DATE",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visit Visa Tourism \u2014 Multiple Entry (D1)",
+          "id": "Visa Kunjungan Wisata \u2014 Beberapa Kali Perjalanan (D1)"
+        },
+        "pricing_key": {
+          "category": "multiple_entry_visas",
+          "item_key": "D1 Tourism (1 Year)"
+        },
+        "product_code": "D1",
+        "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+        "prohibited_activities": [
+          "selling_goods_services",
+          "indonesian_source_remuneration"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "MULTIPLE_ENTRY",
+        "clock_policy": {
+          "anchor": "ENTRY_DATE",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 60,
+          "maximum_extensions": 2,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visit Visa Business \u2014 Multiple Entry (D2)",
+          "id": "Visa Kunjungan Bisnis (D2)"
+        },
+        "pricing_key": {
+          "category": "multiple_entry_visas",
+          "item_key": "D2 Business (1 Year)"
+        },
+        "product_code": "D2",
+        "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+        "prohibited_activities": [
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "continuous_supervision_production_sales"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 60,
+          "minimum_days": 60
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "MULTIPLE_ENTRY",
+        "clock_policy": {
+          "anchor": "ENTRY_DATE",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "INVESTMENT",
+          "TOURISM",
+          "FAMILY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": true,
+          "days_per_extension": 180,
+          "maximum_extensions": 1,
+          "reason_code": null,
+          "status": "VERIFIED"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Visit Visa Pre-Investment \u2014 Multiple Entry (D12)",
+          "id": "Visa Kunjungan Pra-Investasi (D12)"
+        },
+        "pricing_key": {
+          "category": "multiple_entry_visas",
+          "item_key": "D12 Business Investigation (1 Year)"
+        },
+        "product_code": "D12",
+        "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+        "prohibited_activities": [
+          "selling_goods_services",
+          "indonesian_source_remuneration"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "sponsor_types": [
+          "NONE"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 180,
+          "minimum_days": 180
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "STUDY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Education Visa (E30)",
+          "id": "Visa Pendidikan (E30)"
+        },
+        "pricing_key": null,
+        "product_code": "E30",
+        "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": false,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "EDUCATION",
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "VARIABLE_BY_GRANT",
+          "maximum_days": null,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "STUDY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Primary/Secondary Education Visa (E30A)",
+          "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E30A Education Visa (1 Year)"
+        },
+        "product_code": "E30A",
+        "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "EDUCATION",
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 730,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "STUDY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Higher Education Visa (E30B)",
+          "id": "Visa Pendidikan Tinggi (E30B)"
+        },
+        "pricing_key": {
+          "category": "kitas_permits",
+          "item_key": "E30B Higher Education (1 Year)"
+        },
+        "product_code": "E30B",
+        "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "31850f85-8d19-58df-bb66-b04968c9aff0"
+        ],
+        "sponsor_types": [
+          "EDUCATION",
+          "INDIVIDUAL"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "FIXED_DAYS",
+          "maximum_days": 1460,
+          "minimum_days": 365
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "STUDY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "SEZ Education Visa (E30E)",
+          "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+        },
+        "pricing_key": null,
+        "product_code": "E30E",
+        "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "EDUCATION"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "VARIABLE_BY_GRANT",
+          "maximum_days": null,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      },
+      {
+        "category": "LIMITED_STAY",
+        "clock_policy": {
+          "anchor": "PERMIT_ISSUED_AT",
+          "available": true,
+          "checkpoints": []
+        },
+        "covered_purposes": [
+          "STUDY"
+        ],
+        "entry_policy": {
+          "entry_count": "MULTIPLE"
+        },
+        "extension_policy": {
+          "allowed": false,
+          "days_per_extension": null,
+          "maximum_extensions": 0,
+          "reason_code": "EXTENSION_POLICY_NOT_VERIFIED",
+          "status": "UNKNOWN"
+        },
+        "legacy_codes": [],
+        "legacy_slugs": [],
+        "names": {
+          "en": "Student Exchange Visa (E30F)",
+          "id": "Visa Pertukaran Pelajar (E30F)"
+        },
+        "pricing_key": null,
+        "product_code": "E30F",
+        "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+        "prohibited_activities": [
+          "paid_employment",
+          "selling_goods_services",
+          "indonesian_source_remuneration",
+          "political_activity"
+        ],
+        "public_catalog": true,
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "sponsor_types": [
+          "EDUCATION"
+        ],
+        "status": "ACTIVE",
+        "stay_policy": {
+          "kind": "VARIABLE_BY_GRANT",
+          "maximum_days": null,
+          "minimum_days": null
+        },
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        }
+      }
+    ],
+    "rollback_of_payload_sha256": null,
+    "rule_pack_id": "79b62b85-829e-59f8-a058-c38c065b8cb5",
+    "rules": [
+      {
+        "effect": {
+          "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.citizen",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": [
+          "derived.has_indonesian_citizenship"
+        ],
+        "rule_id": "hf.citizen",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "e76bf823-2b36-522f-b2f7-e51eb7715e44"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.has_indonesian_citizenship",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "OVERSTAY_EXCEEDS_60_DAYS",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.overstay-exceeds-60-days",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": [
+          "immigration.overstay_days"
+        ],
+        "rule_id": "hf.overstay-exceeds-60-days",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "e76bf823-2b36-522f-b2f7-e51eb7715e44"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.overstay_days",
+          "op": "gt",
+          "value": 60
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "CALLING_VISA_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.calling-visa",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": [
+          "person.nationalities"
+        ],
+        "rule_id": "review.calling-visa",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "person.nationalities",
+          "op": "intersects",
+          "values": [
+            "AF",
+            "IL",
+            "KP",
+            "LR",
+            "NG",
+            "SO"
+          ]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "ACTIVE_OVERSTAY",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.active-overstay",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": [
+          "immigration.overstay_days"
+        ],
+        "rule_id": "review.active-overstay",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "e76bf823-2b36-522f-b2f7-e51eb7715e44"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.overstay_days",
+          "op": "gt",
+          "value": 0
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BVK_NATIONALITY_ONLY",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.a1.not-bvk-nationality",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "aee1a12d-3285-526e-8a6f-3d8467fe5d72"
+        ],
+        "required_facts": [
+          "person.nationalities"
+        ],
+        "rule_id": "hf.a1.not-bvk-nationality",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "808d691c-374e-5581-8186-9eb54d0ca7ab"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "arg": {
+            "fact": "person.nationalities",
+            "op": "intersects",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          "op": "not"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "A1_BVK_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.a1.tourism",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "aee1a12d-3285-526e-8a6f-3d8467fe5d72"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days",
+          "person.nationalities"
+        ],
+        "rule_id": "el.a1.tourism",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "808d691c-374e-5581-8186-9eb54d0ca7ab"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "TOURISM",
+                "TRANSIT"
+              ]
+            },
+            {
+              "fact": "person.nationalities",
+              "op": "intersects",
+              "values": [
+                "BN",
+                "MY",
+                "TH",
+                "SG",
+                "PH",
+                "KH",
+                "LA",
+                "MM",
+                "VN",
+                "TL",
+                "SR",
+                "CO",
+                "HK",
+                "TR",
+                "BR",
+                "PE",
+                "MO",
+                "KZ",
+                "BY"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 30
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "TOURISM"
+          ],
+          "reason_code": "B1_VOA_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.b1.tourism",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "4e30cbe0-c4bf-59be-9bf8-513e66946e44"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days",
+          "person.nationalities"
+        ],
+        "rule_id": "el.b1.tourism",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "TOURISM"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 30
+            },
+            {
+              "fact": "person.nationalities",
+              "op": "intersects",
+              "values": [
+                "ZA",
+                "AL",
+                "US",
+                "AD",
+                "SA",
+                "AR",
+                "AM",
+                "AU",
+                "AT",
+                "AZ",
+                "BH",
+                "NL",
+                "BY",
+                "BE",
+                "BR",
+                "BN",
+                "BA",
+                "BG",
+                "CZ",
+                "CL",
+                "DK",
+                "EC",
+                "EE",
+                "PH",
+                "FI",
+                "GT",
+                "HK",
+                "HU",
+                "IN",
+                "GB",
+                "IE",
+                "IT",
+                "IS",
+                "JP",
+                "DE",
+                "KH",
+                "CA",
+                "KZ",
+                "KE",
+                "CO",
+                "KR",
+                "HR",
+                "KW",
+                "LA",
+                "LV",
+                "LI",
+                "LT",
+                "LU",
+                "MV",
+                "MY",
+                "MT",
+                "MA",
+                "MU",
+                "MX",
+                "EG",
+                "MC",
+                "MN",
+                "MZ",
+                "MM",
+                "NO",
+                "OM",
+                "PS",
+                "PG",
+                "FR",
+                "PE",
+                "PL",
+                "PT",
+                "QA",
+                "RO",
+                "RU",
+                "RW",
+                "NZ",
+                "RS",
+                "SC",
+                "SG",
+                "CY",
+                "SK",
+                "SI",
+                "ES",
+                "SR",
+                "SE",
+                "CH",
+                "TW",
+                "TZ",
+                "TH",
+                "TL",
+                "CN",
+                "TN",
+                "TR",
+                "AE",
+                "UZ",
+                "UA",
+                "VA",
+                "VE",
+                "VN",
+                "JO",
+                "GR"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "TOURISM",
+            "FAMILY"
+          ],
+          "reason_code": "C1_VISIT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.c1.tourism-family",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "7a07cbb0-564f-5c3f-9720-6ad62c4789cd"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.c1.tourism-family",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "TOURISM",
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 60
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "INVESTMENT"
+          ],
+          "reason_code": "C2_BUSINESS_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.c2.business",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "de433757-f7af-5762-ad65-41bc16bc2ae1"
+        ],
+        "required_facts": [
+          "family.sponsor_confirmed",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.c2.business",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS",
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 60
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "OTHER"
+          ],
+          "reason_code": "C6_SOCIAL_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.c6.social",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "8cf5e09b-6e02-536f-aeca-4aaecaca09c7"
+        ],
+        "required_facts": [
+          "family.sponsor_confirmed",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.c6.social",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "OTHER"
+              ]
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 60
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "c8277316-c29d-5fde-bf9f-2611099a0029"
+        ],
+        "required_facts": [
+          "investment.paid_up_capital_idr"
+        ],
+        "rule_id": "hf.e28a.paid-capital-below-min",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "investment.paid_up_capital_idr",
+          "op": "lt",
+          "value": 2500000000
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e28a.total-investment-below-min",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "c8277316-c29d-5fde-bf9f-2611099a0029"
+        ],
+        "required_facts": [
+          "investment.investment_capital_idr"
+        ],
+        "rule_id": "hf.e28a.total-investment-below-min",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "investment.investment_capital_idr",
+          "op": "lt",
+          "value": 10000000000
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e28a.investment",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "c8277316-c29d-5fde-bf9f-2611099a0029"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "investment.investment_capital_idr",
+          "investment.paid_up_capital_idr",
+          "investment.proposed_role",
+          "investment.pt_pma_committed"
+        ],
+        "rule_id": "el.e28a.investment",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "investment.pt_pma_committed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "investment.proposed_role",
+              "op": "in",
+              "values": [
+                "SHAREHOLDER_DIRECTOR",
+                "SHAREHOLDER_COMMISSIONER"
+              ]
+            },
+            {
+              "fact": "investment.paid_up_capital_idr",
+              "op": "gte",
+              "value": 2500000000
+            },
+            {
+              "fact": "investment.investment_capital_idr",
+              "op": "gte",
+              "value": 10000000000
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28b.usd-threshold-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "ca8c1177-ad94-5261-82a6-68bc912d31bb"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e28b.usd-threshold-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28B"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28c.usd-threshold-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "b074270f-fa7c-598b-a728-81ca89432364"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e28c.usd-threshold-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28C"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "ee4fef98-3497-507c-8486-225932364e26"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e28d.usd-threshold-turnover-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28D"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "2df6f723-7fc3-585a-b26f-0e8c060a2d8d"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e28f.ikn-threshold-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E28F"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "SECOND_HOME",
+            "TOURISM"
+          ],
+          "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.deposit-basis",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd"
+        ],
+        "rule_id": "el.e33.deposit-basis",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "SECOND_HOME"
+              ]
+            },
+            {
+              "fact": "secondhome.bank_deposit_usd",
+              "op": "gte",
+              "value": 130000
+            },
+            {
+              "fact": "secondhome.bank_deposit_at_state_bank",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "secondhome.bank_deposit_in_own_name",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "SECOND_HOME",
+            "TOURISM"
+          ],
+          "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.property-basis",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "rule_id": "el.e33.property-basis",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "SECOND_HOME"
+              ]
+            },
+            {
+              "fact": "secondhome.qualifying_property_value_usd",
+              "op": "gte",
+              "value": 1000000
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "SECOND_HOME",
+            "TOURISM"
+          ],
+          "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.property-qualification",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "rule_id": "el.e33.property-qualification",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "SECOND_HOME"
+                  ]
+                },
+                {
+                  "fact": "secondhome.qualifying_property_value_usd",
+                  "op": "gte",
+                  "value": 1000000
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "SECOND_HOME"
+                      ]
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 130000
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "op": "eq",
+                      "value": true
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "op": "eq",
+                      "value": true
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "SECOND_HOME"
+                      ]
+                    },
+                    {
+                      "fact": "secondhome.qualifying_property_value_usd",
+                      "op": "gte",
+                      "value": 1000000
+                    }
+                  ],
+                  "op": "all"
+                }
+              ],
+              "op": "any"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "SECOND_HOME",
+            "TOURISM"
+          ],
+          "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33.guarantee-maintenance",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.qualifying_property_value_usd"
+        ],
+        "rule_id": "el.e33.guarantee-maintenance",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "SECOND_HOME"
+                  ]
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 130000
+                    },
+                    {
+                      "fact": "secondhome.qualifying_property_value_usd",
+                      "op": "gte",
+                      "value": 1000000
+                    }
+                  ],
+                  "op": "any"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "SECOND_HOME"
+                      ]
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 130000
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "op": "eq",
+                      "value": true
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "op": "eq",
+                      "value": true
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "SECOND_HOME"
+                      ]
+                    },
+                    {
+                      "fact": "secondhome.qualifying_property_value_usd",
+                      "op": "gte",
+                      "value": 1000000
+                    }
+                  ],
+                  "op": "all"
+                }
+              ],
+              "op": "any"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "cf4d7f3d-1253-5036-8953-79ab3d3e7009"
+        ],
+        "required_facts": [
+          "intent.purposes"
+        ],
+        "rule_id": "review.e33.work-rangkap-kegiatan",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "SECOND_HOME"
+              ]
+            },
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "EMPLOYMENT"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "GOVT_INVITATION_REQUIRED",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33a.central-government-invitation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5c18e265-ddb2-5010-8d24-a2f19df89850"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e33a.central-government-invitation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "EMPLOYMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E33A"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33b.expertise-qualification",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "32b6fb5f-5a24-5763-95f9-0b77be18353c"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e33b.expertise-qualification",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "EMPLOYMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E33B"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "GOVT_INVITATION_REQUIRED",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33c.central-government-invitation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e33c.central-government-invitation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E33C"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "AGE_BELOW_55",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33e.age-below-55",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"
+        ],
+        "required_facts": [
+          "derived.age_years"
+        ],
+        "rule_id": "hf.e33e.age-below-55",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "lt",
+          "value": 55
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY",
+            "RETIREMENT",
+            "SECOND_HOME",
+            "TOURISM"
+          ],
+          "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"
+        ],
+        "required_facts": [
+          "derived.age_years",
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "rule_id": "el.e33e.age-55-59-disputed-band",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "RETIREMENT"
+                  ]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "lower": 55,
+                  "op": "between",
+                  "upper": 59
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "RETIREMENT"
+                  ]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 55
+                },
+                {
+                  "args": [
+                    {
+                      "fact": "secondhome.bank_deposit_usd",
+                      "op": "gte",
+                      "value": 50000
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_at_state_bank",
+                      "op": "eq",
+                      "value": true
+                    },
+                    {
+                      "fact": "secondhome.bank_deposit_in_own_name",
+                      "op": "eq",
+                      "value": true
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "secondhome.passive_monthly_income_usd",
+                  "op": "gte",
+                  "value": 3000
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "RETIREMENT",
+            "SECOND_HOME",
+            "TOURISM",
+            "FAMILY"
+          ],
+          "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33e.retirement",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"
+        ],
+        "required_facts": [
+          "derived.age_years",
+          "intent.purposes",
+          "secondhome.bank_deposit_at_state_bank",
+          "secondhome.bank_deposit_in_own_name",
+          "secondhome.bank_deposit_usd",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "rule_id": "el.e33e.retirement",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "RETIREMENT"
+              ]
+            },
+            {
+              "fact": "derived.age_years",
+              "op": "gte",
+              "value": 55
+            },
+            {
+              "args": [
+                {
+                  "fact": "secondhome.bank_deposit_usd",
+                  "op": "gte",
+                  "value": 50000
+                },
+                {
+                  "fact": "secondhome.bank_deposit_at_state_bank",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "secondhome.bank_deposit_in_own_name",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "secondhome.passive_monthly_income_usd",
+              "op": "gte",
+              "value": 3000
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "SPONSOR_REQUIRED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33f.sponsor-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "7c1da88f-f7cd-571a-95c2-7da32463d3e6"
+        ],
+        "required_facts": [
+          "family.sponsor_confirmed"
+        ],
+        "rule_id": "hf.e33f.sponsor-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "family.sponsor_confirmed",
+          "op": "eq",
+          "value": false
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "RETIREMENT",
+            "BUSINESS_MEETINGS",
+            "TOURISM",
+            "FAMILY"
+          ],
+          "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33f.retirement",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "7c1da88f-f7cd-571a-95c2-7da32463d3e6"
+        ],
+        "required_facts": [
+          "family.sponsor_confirmed",
+          "intent.purposes",
+          "secondhome.passive_monthly_income_usd"
+        ],
+        "rule_id": "el.e33f.retirement",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "RETIREMENT"
+              ]
+            },
+            {
+              "fact": "secondhome.passive_monthly_income_usd",
+              "op": "gte",
+              "value": 3000
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33g.indonesian-employer",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "51e023ea-3229-5233-b88f-cb204b5df713"
+        ],
+        "required_facts": [
+          "work.employer_is_indonesian_entity"
+        ],
+        "rule_id": "hf.e33g.indonesian-employer",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "work.employer_is_indonesian_entity",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "51e023ea-3229-5233-b88f-cb204b5df713"
+        ],
+        "required_facts": [
+          "work.indonesia_source_compensation"
+        ],
+        "rule_id": "hf.e33g.indonesian-source-compensation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "work.indonesia_source_compensation",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33g.local-market",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "51e023ea-3229-5233-b88f-cb204b5df713"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "work.serves_indonesian_clients"
+        ],
+        "rule_id": "review.e33g.local-market",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "REMOTE_WORK"
+              ]
+            },
+            {
+              "fact": "work.serves_indonesian_clients",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33g.local-company-ownership",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "51e023ea-3229-5233-b88f-cb204b5df713"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "investment.pt_pma_committed"
+        ],
+        "rule_id": "review.e33g.local-company-ownership",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "REMOTE_WORK"
+              ]
+            },
+            {
+              "fact": "investment.pt_pma_committed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "REMOTE_WORK",
+            "TOURISM",
+            "FAMILY"
+          ],
+          "reason_code": "REMOTE_WORK_ELIGIBLE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e33g.remote-work",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "51e023ea-3229-5233-b88f-cb204b5df713"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "work.employer_is_indonesian_entity",
+          "work.indonesia_source_compensation",
+          "work.serves_indonesian_clients"
+        ],
+        "rule_id": "el.e33g.remote-work",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "REMOTE_WORK"
+              ]
+            },
+            {
+              "fact": "work.employer_is_indonesian_entity",
+              "op": "eq",
+              "value": false
+            },
+            {
+              "fact": "work.serves_indonesian_clients",
+              "op": "eq",
+              "value": false
+            },
+            {
+              "fact": "work.indonesia_source_compensation",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_ONSHORE_ONLY",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.bridging.offshore",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.currently_in_indonesia"
+        ],
+        "rule_id": "hf.bridging.offshore",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.currently_in_indonesia",
+          "op": "eq",
+          "value": false
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.bridging.from-visit-itk",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.current_status_code"
+        ],
+        "rule_id": "hf.bridging.from-visit-itk",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b",
+          "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.current_status_code",
+          "op": "in",
+          "values": [
+            "ITK_FROM_BVK",
+            "ITK_FROM_VISIT_C",
+            "ITK_FROM_VISIT_D",
+            "A1",
+            "C1",
+            "C2",
+            "C6"
+          ]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.bridging.to-bridging",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.current_status_code"
+        ],
+        "rule_id": "hf.bridging.to-bridging",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "immigration.current_status_code",
+          "op": "eq",
+          "value": "ITK_PERALIHAN"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "OTHER"
+          ],
+          "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.t3-window-manual",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.current_status_expiry",
+          "immigration.currently_in_indonesia",
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.t3-window-manual",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "immigration.currently_in_indonesia",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "immigration.current_status_expiry",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "OTHER"
+                  ]
+                },
+                {
+                  "fact": "intent.requested_product_code",
+                  "op": "neq",
+                  "value": "BRIDGING"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "OTHER"
+          ],
+          "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.overstay-shield-payment",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.current_status_expiry",
+          "immigration.currently_in_indonesia",
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.overstay-shield-payment",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "immigration.currently_in_indonesia",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "immigration.current_status_expiry",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "OTHER"
+                  ]
+                },
+                {
+                  "fact": "intent.requested_product_code",
+                  "op": "neq",
+                  "value": "BRIDGING"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "OTHER"
+          ],
+          "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.source-status-verify",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.current_status_code",
+          "immigration.currently_in_indonesia",
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.source-status-verify",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "immigration.currently_in_indonesia",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "immigration.current_status_code",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "OTHER"
+                  ]
+                },
+                {
+                  "fact": "intent.requested_product_code",
+                  "op": "neq",
+                  "value": "BRIDGING"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "BRIDGING_ADVERSE_HISTORY",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.bridging.adverse-history",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "immigration.currently_in_indonesia",
+          "immigration.violation_history"
+        ],
+        "rule_id": "review.bridging.adverse-history",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "immigration.currently_in_indonesia",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "immigration.violation_history",
+              "op": "intersects",
+              "values": [
+                "OVERSTAY",
+                "DEPORTATION",
+                "BLACKLIST",
+                "IMMIGRATION_INVESTIGATION"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "OTHER"
+          ],
+          "reason_code": "BRIDGING_DESTINATION_STATED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.bridging.destination-stated",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "760025cf-d51d-5687-9e98-b921010b9018"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "el.bridging.destination-stated",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "OTHER"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "neq",
+              "value": "BRIDGING"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "EMPLOYMENT"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e23-employment-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "e1d761e9-56c5-57c3-9c01-986d3c333157"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "work.employer_is_indonesian_entity",
+          "work.indonesian_work_sponsor_confirmed"
+        ],
+        "rule_id": "el.e23-employment-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "EMPLOYMENT"
+              ]
+            },
+            {
+              "fact": "work.employer_is_indonesian_entity",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "work.indonesian_work_sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "EMPLOYMENT"
+          ],
+          "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e23-operational-work-boundary",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": [
+          "e1d761e9-56c5-57c3-9c01-986d3c333157"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "investment.proposed_role",
+          "work.employer_is_indonesian_entity",
+          "work.indonesian_work_sponsor_confirmed"
+        ],
+        "rule_id": "el.e23-operational-work-boundary",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "EMPLOYMENT"
+                  ]
+                },
+                {
+                  "fact": "investment.proposed_role",
+                  "op": "in",
+                  "values": [
+                    "SHAREHOLDER_DIRECTOR",
+                    "SHAREHOLDER_COMMISSIONER"
+                  ]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "EMPLOYMENT"
+                  ]
+                },
+                {
+                  "fact": "work.employer_is_indonesian_entity",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "work.indonesian_work_sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-spouse-wni-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "family.marriage_registered"
+        ],
+        "rule_id": "el.e31a-spouse-wni-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SPOUSE"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_FUNDS_2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-funds-2000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
+        ],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31a-funds-2000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-spousal-work-article-61",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
+        ],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31a-spousal-work-article-61",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5a0d367b-bf64-535d-83e4-f40c45de2008"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31a-kitap-prerequisites",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": [
+          "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"
+        ],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes",
+          "process.wants_onshore_conversion"
+        ],
+        "rule_id": "el.e31a-kitap-prerequisites",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5a0d367b-bf64-535d-83e4-f40c45de2008"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "process.wants_onshore_conversion",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31b-spouse-itas-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5d5f9bd4-349b-54d7-841a-784c0afba068"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.marriage_registered",
+          "family.sponsor_status_code"
+        ],
+        "rule_id": "el.e31b-spouse-itas-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SPOUSE"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5d5f9bd4-349b-54d7-841a-784c0afba068"
+        ],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31b-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+        ],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31c-child-mixed-marriage-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+        ],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31c-mixed-marriage-parents",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31d-stepchild-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "required_facts": [
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31d-stepchild-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_STEP_PARENT_RELATION",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31d-step-parent-relation",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "required_facts": [
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31d-step-parent-relation",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "required_facts": [
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31d-sponsor-mixed-marriage",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_UNDER_18",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31e-adult-excluded",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "1266d5cb-84a3-51f7-b82d-c6b756254074"
+        ],
+        "required_facts": [
+          "derived.age_years"
+        ],
+        "rule_id": "hf.e31e-adult-excluded",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "gte",
+          "value": 18
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_UNMARRIED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31e-married-excluded",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "1266d5cb-84a3-51f7-b82d-c6b756254074"
+        ],
+        "required_facts": [
+          "person.marital_status"
+        ],
+        "rule_id": "hf.e31e-married-excluded",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "person.marital_status",
+          "op": "neq",
+          "value": "SINGLE"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31e-child-itas-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "1266d5cb-84a3-51f7-b82d-c6b756254074"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "derived.age_years",
+          "person.marital_status"
+        ],
+        "rule_id": "el.e31e-child-itas-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "known"
+            },
+            {
+              "fact": "derived.age_years",
+              "op": "lt",
+              "value": 18
+            },
+            {
+              "fact": "person.marital_status",
+              "op": "eq",
+              "value": "SINGLE"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "1266d5cb-84a3-51f7-b82d-c6b756254074"
+        ],
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes",
+          "person.marital_status"
+        ],
+        "rule_id": "el.e31e-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "known"
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "lt",
+                  "value": 18
+                },
+                {
+                  "fact": "person.marital_status",
+                  "op": "eq",
+                  "value": "SINGLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31f-child-wni-parent-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities"
+        ],
+        "rule_id": "el.e31f-child-wni-parent-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31f-adult-age-review",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"
+        ],
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31f-adult-age-review",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 18
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "PARENT"
+                },
+                {
+                  "fact": "family.sponsor_nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ID"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31g-parent-wni-child-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "fbc980d5-47b6-5f16-974d-25158dfffc06"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities"
+        ],
+        "rule_id": "el.e31g-parent-wni-child-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "86880290-68c2-5220-8f9e-2350678e5f09",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            },
+            {
+              "fact": "family.sponsor_nationalities",
+              "op": "intersects",
+              "values": [
+                "ID"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31h-parent-itas-child-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "1185c36d-833c-5e41-8e0d-6e4f7c8f7378"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code"
+        ],
+        "rule_id": "el.e31h-parent-itas-child-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "1185c36d-833c-5e41-8e0d-6e4f7c8f7378"
+        ],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31h-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "153beca1-a24b-5440-bac0-b46c3d19da6f",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "CHILD"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "CHILD"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31j-sibling-itas-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code"
+        ],
+        "rule_id": "el.e31j-sibling-itas-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SIBLING"
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "known"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
+        ],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31j-sponsor-itas-itap",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "FAMILY"
+          ],
+          "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e31j-dependency-age",
+        "on_unknown": "NO_EFFECT",
+        "priority": 100,
+        "product_version_ids": [
+          "4a4a0f7c-a6a0-5835-acd6-8a096342ef68"
+        ],
+        "required_facts": [
+          "derived.age_years",
+          "family.relation_to_sponsor",
+          "family.sponsor_status_code",
+          "intent.purposes"
+        ],
+        "rule_id": "el.e31j-dependency-age",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "derived.age_years",
+                  "op": "gte",
+                  "value": 18
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SIBLING"
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "known"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "TOURISM",
+            "FAMILY",
+            "TRANSIT",
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-multi-entry-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days",
+          "intent.entry_pattern"
+        ],
+        "rule_id": "el.d1-multi-entry-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "fact": "intent.entry_pattern",
+              "op": "eq",
+              "value": "MULTIPLE"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-passport-validity",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-passport-validity",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "PROOF_OF_FUNDS_D1",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-funds-usd-2000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-funds-usd-2000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "CV_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-cv-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-cv-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "ITINERARY_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-itinerary-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-itinerary-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ],
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d1-support-letter",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "required_facts": [
+          "intent.entry_pattern",
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d1-support-letter",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ],
+                  "op": "all"
+                },
+                {
+                  "fact": "intent.entry_pattern",
+                  "op": "eq",
+                  "value": "MULTIPLE"
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-multi-entry-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d2-multi-entry-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 60
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-passport-validity",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d2-passport-validity",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "PROOF_OF_FUNDS_D2",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-funds-usd-2000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d2-funds-usd-2000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "CV_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-cv-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d2-cv-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "ITINERARY_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-itinerary-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d2-itinerary-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ],
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d2-support-letter",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d2-support-letter",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-multi-entry-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d12-multi-entry-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-passport-validity",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d12-passport-validity",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "PROOF_OF_FUNDS_D12",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-funds-usd-5000",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d12-funds-usd-5000",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "CV_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-cv-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d12-cv-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "ITINERARY_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-itinerary-required",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d12-itinerary-required",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "INVESTMENT"
+          ],
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.d12-support-letter",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.stay_days"
+        ],
+        "rule_id": "el.d12-support-letter",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "D12_NOT_CONVERTIBLE",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "required_facts": [
+          "process.wants_onshore_conversion"
+        ],
+        "rule_id": "hf.d12-onshore-conversion-excluded",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "process.wants_onshore_conversion",
+          "op": "eq",
+          "value": true
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-student-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-student-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "fact": "study.admission_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "study.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "LIVING_COST_USD2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-living-cost-2000.e30",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "94d26bed-b3ba-5b9a-9c6c-9c137854293c"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-living-cost-2000.e30",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "LIVING_COST_USD2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-living-cost-2000.e30a",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "LIVING_COST_USD2000",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-living-cost-2000.e30b",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-passport-validity.e30",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "94d26bed-b3ba-5b9a-9c6c-9c137854293c"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-passport-validity.e30",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-passport-validity.e30a",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-passport-validity.e30a",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30-passport-validity.e30b",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30-passport-validity.e30b",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c",
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "LEVEL_BAND_DASMEN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e30a-level-band",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5028908f-25be-5ef1-91b9-0d6bccfc0e1f"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.level"
+        ],
+        "rule_id": "hf.e30a-level-band",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "fact": "study.level",
+              "op": "not_in",
+              "values": [
+                "PRIMARY",
+                "SECONDARY"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "LEVEL_BAND_DIKTI",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e30b-level-band",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.level"
+        ],
+        "rule_id": "hf.e30b-level-band",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "fact": "study.level",
+              "op": "not_in",
+              "values": [
+                "VOCATIONAL",
+                "UNDERGRADUATE",
+                "POSTGRADUATE"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30b-izin-belajar",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30b-izin-belajar",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "STUDY"
+                  ]
+                },
+                {
+                  "fact": "study.admission_confirmed",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "study.sponsor_confirmed",
+                  "op": "eq",
+                  "value": true
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "VOA_NATIONALITY_ONLY",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.b1.not-voa-nationality",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": [
+          "4e30cbe0-c4bf-59be-9bf8-513e66946e44"
+        ],
+        "required_facts": [
+          "person.nationalities"
+        ],
+        "rule_id": "hf.b1.not-voa-nationality",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "arg": {
+            "fact": "person.nationalities",
+            "op": "intersects",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          },
+          "op": "not"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "CITIZENSHIP_LIST_DIVERGENCE",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.citizenship-conflict",
+        "on_unknown": "HUMAN_REVIEW",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": [
+          "person.nationalities"
+        ],
+        "rule_id": "review.citizenship-conflict",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+          "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "args": [
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "ZA",
+                    "AL",
+                    "US",
+                    "AD",
+                    "SA",
+                    "AR",
+                    "AM",
+                    "AU",
+                    "AT",
+                    "AZ",
+                    "BH",
+                    "NL",
+                    "BY",
+                    "BE",
+                    "BR",
+                    "BN",
+                    "BA",
+                    "BG",
+                    "CZ",
+                    "CL",
+                    "DK",
+                    "EC",
+                    "EE",
+                    "PH",
+                    "FI",
+                    "GT",
+                    "HK",
+                    "HU",
+                    "IN",
+                    "GB",
+                    "IE",
+                    "IT",
+                    "IS",
+                    "JP",
+                    "DE",
+                    "KH",
+                    "CA",
+                    "KZ",
+                    "KE",
+                    "CO",
+                    "KR",
+                    "HR",
+                    "KW",
+                    "LA",
+                    "LV",
+                    "LI",
+                    "LT",
+                    "LU",
+                    "MV",
+                    "MY",
+                    "MT",
+                    "MA",
+                    "MU",
+                    "MX",
+                    "EG",
+                    "MC",
+                    "MN",
+                    "MZ",
+                    "MM",
+                    "NO",
+                    "OM",
+                    "PS",
+                    "PG",
+                    "FR",
+                    "PE",
+                    "PL",
+                    "PT",
+                    "QA",
+                    "RO",
+                    "RU",
+                    "RW",
+                    "NZ",
+                    "RS",
+                    "SC",
+                    "SG",
+                    "CY",
+                    "SK",
+                    "SI",
+                    "ES",
+                    "SR",
+                    "SE",
+                    "CH",
+                    "TW",
+                    "TZ",
+                    "TH",
+                    "TL",
+                    "CN",
+                    "TN",
+                    "TR",
+                    "AE",
+                    "UZ",
+                    "UA",
+                    "VA",
+                    "VE",
+                    "VN",
+                    "JO",
+                    "GR"
+                  ]
+                },
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "AF",
+                    "AG",
+                    "AI",
+                    "AO",
+                    "AQ",
+                    "AS",
+                    "AW",
+                    "AX",
+                    "BB",
+                    "BD",
+                    "BF",
+                    "BI",
+                    "BJ",
+                    "BL",
+                    "BM",
+                    "BO",
+                    "BQ",
+                    "BS",
+                    "BT",
+                    "BV",
+                    "BW",
+                    "BZ",
+                    "CC",
+                    "CD",
+                    "CF",
+                    "CG",
+                    "CI",
+                    "CK",
+                    "CM",
+                    "CR",
+                    "CU",
+                    "CV",
+                    "CW",
+                    "CX",
+                    "DJ",
+                    "DM",
+                    "DO",
+                    "DZ",
+                    "EH",
+                    "ER",
+                    "ET",
+                    "FJ",
+                    "FK",
+                    "FM",
+                    "FO",
+                    "GA",
+                    "GD",
+                    "GE",
+                    "GF",
+                    "GG",
+                    "GH",
+                    "GI",
+                    "GL",
+                    "GM",
+                    "GN",
+                    "GP",
+                    "GQ",
+                    "GS",
+                    "GU",
+                    "GW",
+                    "GY",
+                    "HM",
+                    "HN",
+                    "HT",
+                    "ID",
+                    "IL",
+                    "IM",
+                    "IO",
+                    "IQ",
+                    "IR",
+                    "JE",
+                    "JM",
+                    "KG",
+                    "KI",
+                    "KM",
+                    "KN",
+                    "KP",
+                    "KY",
+                    "LB",
+                    "LC",
+                    "LK",
+                    "LR",
+                    "LS",
+                    "LY",
+                    "MD",
+                    "ME",
+                    "MF",
+                    "MG",
+                    "MH",
+                    "MK",
+                    "ML",
+                    "MO",
+                    "MP",
+                    "MQ",
+                    "MR",
+                    "MS",
+                    "MW",
+                    "NA",
+                    "NC",
+                    "NE",
+                    "NF",
+                    "NG",
+                    "NI",
+                    "NP",
+                    "NR",
+                    "NU",
+                    "PA",
+                    "PF",
+                    "PK",
+                    "PM",
+                    "PN",
+                    "PR",
+                    "PW",
+                    "PY",
+                    "RE",
+                    "SB",
+                    "SD",
+                    "SH",
+                    "SJ",
+                    "SL",
+                    "SM",
+                    "SN",
+                    "SO",
+                    "SS",
+                    "ST",
+                    "SV",
+                    "SX",
+                    "SY",
+                    "SZ",
+                    "TC",
+                    "TD",
+                    "TF",
+                    "TG",
+                    "TJ",
+                    "TK",
+                    "TM",
+                    "TO",
+                    "TT",
+                    "TV",
+                    "UG",
+                    "UM",
+                    "UY",
+                    "VC",
+                    "VG",
+                    "VI",
+                    "VU",
+                    "WF",
+                    "WS",
+                    "YE",
+                    "YT",
+                    "ZM",
+                    "ZW"
+                  ]
+                }
+              ],
+              "op": "all"
+            },
+            {
+              "args": [
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "AF",
+                    "IL",
+                    "KP",
+                    "LR",
+                    "NG",
+                    "SO"
+                  ]
+                },
+                {
+                  "fact": "person.nationalities",
+                  "op": "intersects",
+                  "values": [
+                    "AD",
+                    "AE",
+                    "AG",
+                    "AI",
+                    "AL",
+                    "AM",
+                    "AO",
+                    "AQ",
+                    "AR",
+                    "AS",
+                    "AT",
+                    "AU",
+                    "AW",
+                    "AX",
+                    "AZ",
+                    "BA",
+                    "BB",
+                    "BD",
+                    "BE",
+                    "BF",
+                    "BG",
+                    "BH",
+                    "BI",
+                    "BJ",
+                    "BL",
+                    "BM",
+                    "BN",
+                    "BO",
+                    "BQ",
+                    "BR",
+                    "BS",
+                    "BT",
+                    "BV",
+                    "BW",
+                    "BY",
+                    "BZ",
+                    "CA",
+                    "CC",
+                    "CD",
+                    "CF",
+                    "CG",
+                    "CH",
+                    "CI",
+                    "CK",
+                    "CL",
+                    "CM",
+                    "CN",
+                    "CO",
+                    "CR",
+                    "CU",
+                    "CV",
+                    "CW",
+                    "CX",
+                    "CY",
+                    "CZ",
+                    "DE",
+                    "DJ",
+                    "DK",
+                    "DM",
+                    "DO",
+                    "DZ",
+                    "EC",
+                    "EE",
+                    "EG",
+                    "EH",
+                    "ER",
+                    "ES",
+                    "ET",
+                    "FI",
+                    "FJ",
+                    "FK",
+                    "FM",
+                    "FO",
+                    "FR",
+                    "GA",
+                    "GB",
+                    "GD",
+                    "GE",
+                    "GF",
+                    "GG",
+                    "GH",
+                    "GI",
+                    "GL",
+                    "GM",
+                    "GN",
+                    "GP",
+                    "GQ",
+                    "GR",
+                    "GS",
+                    "GT",
+                    "GU",
+                    "GW",
+                    "GY",
+                    "HK",
+                    "HM",
+                    "HN",
+                    "HR",
+                    "HT",
+                    "HU",
+                    "ID",
+                    "IE",
+                    "IM",
+                    "IN",
+                    "IO",
+                    "IQ",
+                    "IR",
+                    "IS",
+                    "IT",
+                    "JE",
+                    "JM",
+                    "JO",
+                    "JP",
+                    "KE",
+                    "KG",
+                    "KH",
+                    "KI",
+                    "KM",
+                    "KN",
+                    "KR",
+                    "KW",
+                    "KY",
+                    "KZ",
+                    "LA",
+                    "LB",
+                    "LC",
+                    "LI",
+                    "LK",
+                    "LS",
+                    "LT",
+                    "LU",
+                    "LV",
+                    "LY",
+                    "MA",
+                    "MC",
+                    "MD",
+                    "ME",
+                    "MF",
+                    "MG",
+                    "MH",
+                    "MK",
+                    "ML",
+                    "MM",
+                    "MN",
+                    "MO",
+                    "MP",
+                    "MQ",
+                    "MR",
+                    "MS",
+                    "MT",
+                    "MU",
+                    "MV",
+                    "MW",
+                    "MX",
+                    "MY",
+                    "MZ",
+                    "NA",
+                    "NC",
+                    "NE",
+                    "NF",
+                    "NI",
+                    "NL",
+                    "NO",
+                    "NP",
+                    "NR",
+                    "NU",
+                    "NZ",
+                    "OM",
+                    "PA",
+                    "PE",
+                    "PF",
+                    "PG",
+                    "PH",
+                    "PK",
+                    "PL",
+                    "PM",
+                    "PN",
+                    "PR",
+                    "PS",
+                    "PT",
+                    "PW",
+                    "PY",
+                    "QA",
+                    "RE",
+                    "RO",
+                    "RS",
+                    "RU",
+                    "RW",
+                    "SA",
+                    "SB",
+                    "SC",
+                    "SD",
+                    "SE",
+                    "SG",
+                    "SH",
+                    "SI",
+                    "SJ",
+                    "SK",
+                    "SL",
+                    "SM",
+                    "SN",
+                    "SR",
+                    "SS",
+                    "ST",
+                    "SV",
+                    "SX",
+                    "SY",
+                    "SZ",
+                    "TC",
+                    "TD",
+                    "TF",
+                    "TG",
+                    "TH",
+                    "TJ",
+                    "TK",
+                    "TL",
+                    "TM",
+                    "TN",
+                    "TO",
+                    "TR",
+                    "TT",
+                    "TV",
+                    "TW",
+                    "TZ",
+                    "UA",
+                    "UG",
+                    "UM",
+                    "US",
+                    "UY",
+                    "UZ",
+                    "VA",
+                    "VC",
+                    "VE",
+                    "VG",
+                    "VI",
+                    "VN",
+                    "VU",
+                    "WF",
+                    "WS",
+                    "YE",
+                    "YT",
+                    "ZA",
+                    "ZM",
+                    "ZW"
+                  ]
+                }
+              ],
+              "op": "all"
+            }
+          ],
+          "op": "any"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.minor-without-guardian",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": null,
+        "required_facts": [
+          "derived.is_minor",
+          "family.sponsor_confirmed"
+        ],
+        "rule_id": "review.minor-without-guardian",
+        "safety_critical": true,
+        "scope": "GLOBAL",
+        "source_refs": [
+          "38242587-f4da-5c31-b0ea-662f7fdc475c"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-09T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "derived.is_minor",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.sponsor_confirmed",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "AGE_BELOW_55",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33f.age-below-55",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "7c1da88f-f7cd-571a-95c2-7da32463d3e6"
+        ],
+        "required_facts": [
+          "derived.age_years"
+        ],
+        "rule_id": "hf.e33f.age-below-55",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "lt",
+          "value": 55
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33G_INCOME_EVIDENCE_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e33g.income-evidence",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "51e023ea-3229-5233-b88f-cb204b5df713"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "work.employer_is_indonesian_entity",
+          "work.indonesia_source_compensation",
+          "work.serves_indonesian_clients"
+        ],
+        "rule_id": "review.e33g.income-evidence",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "REMOTE_WORK"
+              ]
+            },
+            {
+              "fact": "work.employer_is_indonesian_entity",
+              "op": "eq",
+              "value": false
+            },
+            {
+              "fact": "work.serves_indonesian_clients",
+              "op": "eq",
+              "value": false
+            },
+            {
+              "fact": "work.indonesia_source_compensation",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30e-student-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "19e3ea6c-95c6-5998-b9d7-efc77f583589"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "sponsor.type",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30e-student-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "fact": "study.admission_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "study.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "sponsor.type",
+              "op": "in",
+              "values": [
+                "EDUCATION",
+                "INDIVIDUAL"
+              ]
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "covered_purposes": [
+            "STUDY"
+          ],
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "type": "SUPPORT"
+        },
+        "explanation_key": "explain.el.e30f-student-support",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "sponsor.type",
+          "study.admission_confirmed",
+          "study.sponsor_confirmed"
+        ],
+        "rule_id": "el.e30f-student-support",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "ELIGIBILITY",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "STUDY"
+              ]
+            },
+            {
+              "fact": "study.admission_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "study.sponsor_confirmed",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "sponsor.type",
+              "op": "eq",
+              "value": "EDUCATION"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33a.sponsor-not-government",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "5c18e265-ddb2-5010-8d24-a2f19df89850"
+        ],
+        "required_facts": [
+          "sponsor.type"
+        ],
+        "rule_id": "hf.e33a.sponsor-not-government",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "sponsor.type",
+          "op": "neq",
+          "value": "GOVERNMENT"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "32b6fb5f-5a24-5763-95f9-0b77be18353c"
+        ],
+        "required_facts": [
+          "sponsor.type"
+        ],
+        "rule_id": "hf.e33b.sponsor-not-government-or-none",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "sponsor.type",
+          "op": "not_in",
+          "values": [
+            "GOVERNMENT",
+            "NONE"
+          ]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"
+        ],
+        "required_facts": [
+          "sponsor.type"
+        ],
+        "rule_id": "hf.e33c.sponsor-not-government-or-none",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+          "9248b1d7-9172-54d9-ad61-251e83a2285b"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "sponsor.type",
+          "op": "not_in",
+          "values": [
+            "GOVERNMENT",
+            "NONE"
+          ]
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e23u.requested-product",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "fa143e97-b444-5ae4-9b05-6365f15e3ec7"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e23u.requested-product",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "EMPLOYMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E23U"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW",
+          "type": "REQUIRE_REVIEW"
+        },
+        "explanation_key": "explain.review.e23v.requested-product",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "e8a1d738-daa7-5c99-a0c6-800b25579129"
+        ],
+        "required_facts": [
+          "intent.purposes",
+          "intent.requested_product_code"
+        ],
+        "rule_id": "review.e23v.requested-product",
+        "safety_critical": false,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "6f5135f2-1f77-571f-88ed-26d1d2b9efba"
+        ],
+        "stage": "HUMAN_REVIEW",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "EMPLOYMENT"
+              ]
+            },
+            {
+              "fact": "intent.requested_product_code",
+              "op": "eq",
+              "value": "E23V"
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31c-marriage-not-registered",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+        ],
+        "required_facts": [
+          "family.marriage_registered",
+          "family.relation_to_sponsor",
+          "intent.purposes"
+        ],
+        "rule_id": "hf.e31c-marriage-not-registered",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-19T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": false
+            }
+          ],
+          "op": "all"
+        }
+      },
+      {
+        "effect": {
+          "reason_code": "REQ_PARENT_SPONSOR_INDONESIAN",
+          "type": "EXCLUDE"
+        },
+        "explanation_key": "explain.hf.e31c-sponsor-not-indonesian",
+        "on_unknown": "NEEDS_INPUT",
+        "priority": 100,
+        "product_version_ids": [
+          "62ab2d13-1d7e-5048-9cf7-9622c0098439"
+        ],
+        "required_facts": [
+          "family.relation_to_sponsor",
+          "family.sponsor_nationalities",
+          "intent.purposes"
+        ],
+        "rule_id": "hf.e31c-sponsor-not-indonesian",
+        "safety_critical": true,
+        "scope": "PRODUCTS",
+        "source_refs": [
+          "40523028-431b-5ae0-a937-277882f0f243",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "stage": "HARD_FILTER",
+        "valid_period": {
+          "from": "2026-08-23T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "PARENT"
+            },
+            {
+              "arg": {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": [
+                  "ID"
+                ]
+              },
+              "op": "not"
+            }
+          ],
+          "op": "all"
+        }
+      }
+    ],
+    "sequence": 13,
+    "source_records": [
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+        "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+        "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28A"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28B"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28C"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28D"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E28F"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33A"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33B"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33C"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33E"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33F"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/E33G"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/B1"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/C1"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/C2"
+          },
+          {
+            "kind": "PAGE",
+            "value": "/wna/daftar-visa-indonesia/C6"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+        "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Kepmen M.IP-08.GR.01.01/2025 \u2014 Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+        "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+        "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2024-04-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 33(2)(j)"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 61"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 62"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 63"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 86A"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 94A"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 94B"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 113"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 185"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 39"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 40"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 57"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 58"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 59"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+        "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 \u2014 Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+        "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+        "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-09T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+        "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permen Imipas 10/2026 \u2014 Daftar Negara Bebas Visa Kunjungan (BVK)",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "PRIMARY_LAW",
+        "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+        "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+        "document_number": "UU 6/2011 jo. UU 63/2024",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+        "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian \u2014 kewarganegaraan dan ketentuan overstay",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+        "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "SECTION",
+            "value": "Calling Visa country list; national Ditjen Imigrasi display"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi-calling-visa-country-list",
+        "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+        "title": "Daftar Negara Calling Visa \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+        "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2024-04-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+        "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+        "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 \u2014 Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+        "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+        "document_number": "Permen Imipas 5/2025",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-02-07T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 1"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "permen-imipas-5-2025-penjamin-revocation",
+        "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permen Imipas 5/2025 \u2014 Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a1",
+        "version": 1
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+        "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi-alih-status-itk-itas-service-page",
+        "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+        "title": "Layanan Alih Status \u2014 Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+        "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+        "document_number": "M.IP-08.GR.01.01/2025",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "SECTION",
+            "value": "Lampiran"
+          }
+        ],
+        "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+        "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+        "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+        "document_number": "22/2023",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2023-08-22T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 42"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 105"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 113"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 33"
+          }
+        ],
+        "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+        "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "IMPLEMENTING_REGULATION",
+        "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+        "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+        "document_number": "11/2024",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2024-04-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 105 ayat (7)"
+          }
+        ],
+        "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+        "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "PRIMARY_LAW",
+        "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+        "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+        "document_number": "UU 6/2011",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2011-05-05T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 60 ayat (2)"
+          },
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 61"
+          }
+        ],
+        "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+        "recorded_period": {
+          "from": "2026-08-10T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-10T00:00:00Z",
+        "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+        "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Pasal 60 ayat (2) dan Pasal 61",
+        "verified_at": "2026-08-10T00:00:00Z",
+        "verified_by": "agent.air-m5.visa-seq6-semantics",
+        "version": 1
+      },
+      {
+        "authority_type": "PRIMARY_LAW",
+        "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+        "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+        "document_number": "UU 6/2011",
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 31536000
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2011-05-05T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "ARTICLE",
+            "value": "Pasal 61"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-07-24T00:00:00Z",
+        "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+        "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+        "verified_at": "2026-07-24T00:00:00Z",
+        "verified_by": "agent.m5.visa-authoring-a2",
+        "version": 1
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+        "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+        "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+        "title": "Visa Keluarga Suami/Istri WNI (E31A) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+        "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+        "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+        "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+        "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+        "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+        "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+        "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+        "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+        "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+        "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+        "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+        "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+        "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+        "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+        "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+        "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+        "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+        "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+        "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+        "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+        "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+        "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+        "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+        "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+        "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+        "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+        "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+        "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+        "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+        "title": "Visa Kunjungan Bisnis (D2) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+        "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+        "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+        "title": "Visa Kunjungan Pra-Investasi (D12) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+        "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+        "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+        "title": "Visa Pendidikan Dasar dan Menengah (E30A) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+        "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2025-06-01T00:00:00Z",
+          "to": null
+        },
+        "locators": [],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-06T06:19:49Z",
+        "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+        "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+        "title": "Visa Pendidikan Tinggi (E30B) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 2
+      },
+      {
+        "authority_type": "OFFICIAL_PORTAL",
+        "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+        "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+        "document_number": null,
+        "freshness_policy": {
+          "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+          "max_age_seconds": 604800
+        },
+        "jurisdiction": "ID",
+        "language": "id",
+        "legal_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "locators": [
+          {
+            "kind": "SECTION",
+            "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+          }
+        ],
+        "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+        "recorded_period": {
+          "from": "2026-08-08T00:00:00Z",
+          "to": null
+        },
+        "retrieved_at": "2026-08-08T00:00:00Z",
+        "source_key": "imigrasi-voa-country-list",
+        "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "status": "VERIFIED",
+        "supersedes_source_record_id": null,
+        "title": "Daftar Negara Subjek Visa on Arrival (VoA) \u2014 Direktorat Jenderal Imigrasi",
+        "verified_at": "2026-08-23T10:44:48Z",
+        "verified_by": "agent.s13-fresh.backend-rag.visa-freshness-reader.qw5-recheck-2026-08-23",
+        "version": 1
+      }
+    ],
+    "valid_period": {
+      "from": "2026-07-25T00:00:00Z",
+      "to": null
+    },
+    "version": "2026.8.23"
+  },
+  "payload_sha256": "b9edb809930ab486e49a4af7804fbae7f072caa3b6459b78a94ecb7f6bfe14f8",
+  "protected": {
+    "alg": "Ed25519",
+    "domain": "balizero.visa-rulepack.v1",
+    "environment": "PRODUCTION",
+    "kid": "prod-2026-07-1",
+    "schema_version": "1.0.0",
+    "signed_at": "2026-08-23T14:53:27.345445Z"
+  },
+  "signature": "1T5ehvPM2vvrDuQdYHTUfb4c54PZEFLeYHcqdYjDxUcl960Ha77V6DLK2oQ6HXnTR1ZEmdzH1yv1RTtUS5wTAA"
+}


### PR DESCRIPTION
Signed bundle for RulePack **seq-13**, produced by the offline signing ceremony on M5. **Bundle-only** — no rule, engine, or source-pack bytes change in this PR.

## Provenance

Every value below was **re-measured this turn against the merged bytes on `origin/main`**, not carried forward from the fold lane's pre-merge report. The fold branch was force-pushed twice after those numbers were first quoted, so a carried-forward hash would have described an artifact that no longer existed.

| | |
|---|---|
| source file sha256 | `309a7b3c90703179cb5e15e54fec4472f922ec8346ec5188bd2f08cdbeedf8f1` |
| `compile_pack` | **RC 0** — zero compilation errors |
| `payload_sha256` | `b9edb809930ab486e49a4af7804fbae7f072caa3b6459b78a94ecb7f6bfe14f8` |
| `previous_payload_sha256` | `ff43d55e79e833a91820c4b68dd9ffdd086e7969b3b3a44dbd80747aa451406d` |
| kid / alg / canonicalization | `prod-2026-07-1` / Ed25519 / RFC8785 |
| `signed_at` | `2026-08-23T14:53:27.345445Z` |
| contents | 111 rules · 28 source records · `environment: PRODUCTION` |

`compile_pack` was run from a worktree synced to `origin/main`, **not** from the local main checkout, which is deliberately hundreds of commits behind — a stale validator can return a pass built on a schema that no longer applies.

Exit code was captured explicitly rather than inferred from the `OK — zero compilation errors` line. The message and the return code derive from the same value here, but a printed word is not a measurement.

## Two independent confirmations

**1. The signer and the fold agree.** `sign_pack`'s own `payload_sha256` equals the canonical hash `fold_pack_seq13_source.py` computed. Two programs, two code paths, one value. This matters because the fold lane had already caught itself using an ad-hoc `json.dumps(sort_keys=True)` in place of the module's real `canonicalize_json` — the two agree on most inputs, which is exactly what makes a disagreement dangerous. This confirms the shipped bytes were canonicalized by the real function.

**2. The chain anchor has five derivations, one with no shared ancestor.** `ff43d55e…451406d` is confirmed by the declared value, `rulepack-prod-012.signed.json`, the pinned constant, an independent recomputation from seq-12's bytes — and by a **live synthetic probe of production**, which reported it as the currently ACTIVE pack's `payload_sha256`. The first four all read files on disk; the fifth asked the running engine. A file-only agreement proves consistent parsing, not correctness.

`sign_pack` self-verified the signature before writing the bundle.

## Not in this PR

**Activation.** It is a separate, deliberately gated step: `activate_pack` defaults to a dry run and requires two distinct database credentials — one that may write an immutable pack, one that may make it active. Neither alone completes the operation. That step is run after this merges, and `SHADOW` posture is unchanged by it.

**ENFORCE remains NO-GO.** Nothing here touches it.