### PR TITLE
fix(backend-rag): harden _capture_module_errors against ambient logging suppression

### DIFF
--- a/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
@@ -251,8 +251,11 @@ class TestPromptManagerFailLoudOnUnknownVersion:
           and it only ever *un*-mutes (`logging.disable(logging.NOTSET)`),
           saving and restoring around it. This capture is therefore
           hardening of the promise this docstring already makes —
-          "independently of the global logging config" — not the diagnosis
-          of whatever CI failure motivated it, which remains unreproduced.
+          "independently of the global logging config" — not a claimed cure
+          for the CI failure that motivated it: that failure has since been
+          reproduced deterministically (3/3 runs, real `pytest-xdist -n auto
+          --dist loadfile` against the failing corpus) but is not yet
+          root-caused.
         * this logger's own `.filters` — `Logger.filter()` runs before
           `callHandlers()`, so a drop-everything filter attached directly to
           `backend.llm.prompt_manager` (by this test file or any other) would

--- a/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
@@ -219,14 +219,50 @@ class TestPromptManagerFailLoudOnUnknownVersion:
     @staticmethod
     def _capture_module_errors(reload_target):
         """Capture ERROR records emitted DURING an import, independently of the
-        global logging config.
+        global logging config AND of any ambient suppression already in effect
+        when this runs.
 
         `caplog` reaches this logger only while propagation to the root handler
         is intact — and in a full-suite run an earlier import can leave
         propagation off or the root reconfigured, so the same assertion passed
         alone and failed in batch (order-dependent, i.e. it would fail in CI and
         pass locally). Attaching a handler to THIS logger removes the dependency
-        on anything global.
+        on propagation — but level/handlers/disabled alone are not enough: two
+        OTHER knobs are process-global (or at least logger-persistent) and are
+        not scoped to "this test":
+
+        * `logging.Logger.manager.disable` — the process-global mute set by
+          `logging.disable(N)`. `Logger.isEnabledFor()` checks it BEFORE this
+          logger's own level or handlers are ever consulted, so a suppressed
+          level never even constructs a record — no handler, including ours,
+          gets a chance to see it. pytest's own `caplog.set_level()`/
+          `at_level()` manipulate this exact global under the hood
+          (`_pytest/logging.py::_force_enable_logging`), and third-party code
+          does too (e.g. `sentence_transformers.util.misc.disable_logging`).
+          Any of them running earlier in the SAME process — CI runs this suite
+          under `pytest-xdist --dist loadfile`, which puts many files through
+          one worker process — can leave it elevated if interrupted between
+          set and restore, or simply outlive a test that never expected to
+          share a process with this one.
+        * this logger's own `.filters` — `Logger.filter()` runs before
+          `callHandlers()`, so a drop-everything filter attached directly to
+          `backend.llm.prompt_manager` (by this test file or any other) would
+          silently eat the record before our sink ever sees it, exactly like
+          the propagation gap this helper already existed to close.
+
+        Both are saved and neutralised on entry, and both are restored in
+        `finally` — a failing assertion here must never leak either into the
+        next test, which is how one broken test becomes a shard-wide outbreak
+        (cicatrix-superscar #2, "esiste != armato").
+
+        `importlib.reload()` (not a plain `import`) is what makes the
+        module-scope `logger.error()` call happen HERE, inside the capture
+        window, regardless of whether some earlier test in this process
+        already imported/reloaded the module: reload always re-executes the
+        module body against the CURRENT env var, it never short-circuits on
+        `sys.modules` already having an entry — so a prior successful import
+        with a different (or valid) `ZANTARA_PROMPT_VERSION` cannot suppress a
+        later fail-loud capture.
         """
         records: list[logging.LogRecord] = []
 
@@ -236,7 +272,13 @@ class TestPromptManagerFailLoudOnUnknownVersion:
 
         logger = logging.getLogger("backend.llm.prompt_manager")
         sink = _Sink(level=logging.ERROR)
-        previous_level, previous_disabled = logger.level, logger.disabled
+        previous_level = logger.level
+        previous_disabled = logger.disabled
+        previous_filters = list(logger.filters)
+        previous_manager_disable = logging.root.manager.disable
+
+        logger.filters = []
+        logging.disable(logging.NOTSET)  # neutralise any ambient global mute
         logger.addHandler(sink)
         logger.setLevel(logging.ERROR)
         logger.disabled = False
@@ -246,6 +288,8 @@ class TestPromptManagerFailLoudOnUnknownVersion:
             logger.removeHandler(sink)
             logger.setLevel(previous_level)
             logger.disabled = previous_disabled
+            logger.filters = previous_filters
+            logging.root.manager.disable = previous_manager_disable
         return records
 
     def test_unrecognized_explicit_value_logs_error(self, monkeypatch):
@@ -274,6 +318,82 @@ class TestPromptManagerFailLoudOnUnknownVersion:
         )
         assert pm.ZANTARA_MASTER_TEMPLATE == pm._TEMPLATE_V1
         assert pm.PROMPT_VERSION_ACTIVE == "v1"
+
+    def test_capture_survives_a_pre_existing_global_logging_disable(self, monkeypatch):
+        """GUILT: a process-global mute (exactly what `logging.disable(N)` sets,
+        and what pytest's own `caplog.set_level()`/`at_level()` toggle under the
+        hood — `_pytest/logging.py::_force_enable_logging`) must not blind the
+        capture. Simulates a sibling test/module in the SAME process (CI runs
+        this suite under `pytest-xdist --dist loadfile`, many files per worker)
+        leaving `logging.Logger.manager.disable` elevated when this test starts.
+        """
+        import backend.llm.prompt_manager as pm
+
+        logging.disable(logging.CRITICAL)
+        try:
+            monkeypatch.setenv("ZANTARA_PROMPT_VERSION", "v9")
+            error_records = [
+                r for r in self._capture_module_errors(pm) if r.levelname == "ERROR"
+            ]
+        finally:
+            logging.disable(logging.NOTSET)
+        assert error_records, (
+            "a pre-existing logging.disable(CRITICAL) must not suppress the "
+            "fail-loud ERROR record — the capture must neutralise it"
+        )
+        assert any("v9" in r.getMessage() for r in error_records)
+
+    def test_capture_survives_a_drop_everything_filter_on_the_logger(self, monkeypatch):
+        """GUILT: a filter attached directly to `backend.llm.prompt_manager`
+        runs (via `Logger.filter()`) BEFORE any handler — including our own
+        sink — ever sees the record. A filter left behind by an unrelated test
+        (or a defensive "quiet this logger during tests" helper elsewhere)
+        must not make this capture read as silence.
+        """
+        import backend.llm.prompt_manager as pm
+
+        logger = logging.getLogger("backend.llm.prompt_manager")
+
+        class _DropEverything(logging.Filter):
+            def filter(self, record: logging.LogRecord) -> bool:
+                return False
+
+        drop_all = _DropEverything()
+        logger.addFilter(drop_all)
+        try:
+            monkeypatch.setenv("ZANTARA_PROMPT_VERSION", "v9")
+            error_records = [
+                r for r in self._capture_module_errors(pm) if r.levelname == "ERROR"
+            ]
+        finally:
+            logger.removeFilter(drop_all)
+        assert error_records, (
+            "a pre-existing drop-everything filter on the logger must not "
+            "suppress the fail-loud ERROR record — the capture must clear it"
+        )
+        assert any("v9" in r.getMessage() for r in error_records)
+
+    def test_capture_stays_silent_for_known_versions_under_a_prior_global_mute(
+        self, monkeypatch
+    ):
+        """INNOCENCE: neutralising ambient suppression must not manufacture a
+        false ERROR for a legitimate version — the cure only removes noise
+        that would otherwise hide a real record, it never adds one.
+        """
+        import backend.llm.prompt_manager as pm
+
+        logging.disable(logging.CRITICAL)
+        try:
+            monkeypatch.setenv("ZANTARA_PROMPT_VERSION", "v2")
+            error_records = [
+                r for r in self._capture_module_errors(pm) if r.levelname == "ERROR"
+            ]
+        finally:
+            logging.disable(logging.NOTSET)
+        assert error_records == [], (
+            "a valid version must never trip the fail-loud path, ambient mute "
+            "or not"
+        )
 
     def test_known_versions_never_log_the_unrecognised_error(self, monkeypatch, caplog):
         import backend.llm.prompt_manager as pm

--- a/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
@@ -236,14 +236,23 @@ class TestPromptManagerFailLoudOnUnknownVersion:
           logger's own level or handlers are ever consulted, so a suppressed
           level never even constructs a record — no handler, including ours,
           gets a chance to see it. pytest's own `caplog.set_level()`/
-          `at_level()` manipulate this exact global under the hood
-          (`_pytest/logging.py::_force_enable_logging`), and third-party code
-          does too (e.g. `sentence_transformers.util.misc.disable_logging`).
-          Any of them running earlier in the SAME process — CI runs this suite
-          under `pytest-xdist --dist loadfile`, which puts many files through
-          one worker process — can leave it elevated if interrupted between
-          set and restore, or simply outlive a test that never expected to
-          share a process with this one.
+          `at_level()` do touch this exact global under the hood
+          (`_pytest/logging.py::_force_enable_logging`) — but only ever to
+          LOOSEN it: that helper's two write paths either lower the
+          threshold (`logging.disable(max(level - 10, logging.NOTSET))`) or
+          clear it outright (`logging.disable(logging.NOTSET)`), and
+          `at_level()` restores the pre-existing value in a `finally`. So
+          pytest is not a suppression source for this knob — cited here for
+          the direction it moves it, not as a threat. No producer of an
+          elevated global mute exists in this repo today: across the whole
+          `backend/` tree, all 21 `conftest.py` included, the only site that
+          touches `manager.disable` at all is
+          `backend/tests/core/test_telegram_token_never_reaches_a_log.py`,
+          and it only ever *un*-mutes (`logging.disable(logging.NOTSET)`),
+          saving and restoring around it. This capture is therefore
+          hardening of the promise this docstring already makes —
+          "independently of the global logging config" — not the diagnosis
+          of whatever CI failure motivated it, which remains unreproduced.
         * this logger's own `.filters` — `Logger.filter()` runs before
           `callHandlers()`, so a drop-everything filter attached directly to
           `backend.llm.prompt_manager` (by this test file or any other) would
@@ -320,12 +329,17 @@ class TestPromptManagerFailLoudOnUnknownVersion:
         assert pm.PROMPT_VERSION_ACTIVE == "v1"
 
     def test_capture_survives_a_pre_existing_global_logging_disable(self, monkeypatch):
-        """GUILT: a process-global mute (exactly what `logging.disable(N)` sets,
-        and what pytest's own `caplog.set_level()`/`at_level()` toggle under the
-        hood — `_pytest/logging.py::_force_enable_logging`) must not blind the
-        capture. Simulates a sibling test/module in the SAME process (CI runs
-        this suite under `pytest-xdist --dist loadfile`, many files per worker)
-        leaving `logging.Logger.manager.disable` elevated when this test starts.
+        """GUILT: a process-global mute — whatever calls `logging.disable(N)` —
+        must not blind the capture. pytest's own `caplog.set_level()`/
+        `at_level()` do touch this exact global (`_pytest/logging.py::
+        _force_enable_logging`), but only ever to LOOSEN it, never to raise
+        it — so this is not a reproduction of pytest's own behaviour. It is a
+        synthetic worst case: simulates a sibling test/module in the SAME
+        process (CI runs this suite under `pytest-xdist --dist loadfile`,
+        many files per worker) leaving `logging.Logger.manager.disable`
+        elevated by SOME OTHER means when this test starts, so the capture
+        stays defensive even though no such producer is known to exist in
+        this repo today.
         """
         import backend.llm.prompt_manager as pm
 

--- a/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py
@@ -251,11 +251,8 @@ class TestPromptManagerFailLoudOnUnknownVersion:
           and it only ever *un*-mutes (`logging.disable(logging.NOTSET)`),
           saving and restoring around it. This capture is therefore
           hardening of the promise this docstring already makes —
-          "independently of the global logging config" — not a claimed cure
-          for the CI failure that motivated it: that failure has since been
-          reproduced deterministically (3/3 runs, real `pytest-xdist -n auto
-          --dist loadfile` against the failing corpus) but is not yet
-          root-caused.
+          "independently of the global logging config" — not the diagnosis
+          of the CI failure that motivated it.
         * this logger's own `.filters` — `Logger.filter()` runs before
           `callHandlers()`, so a drop-everything filter attached directly to
           `backend.llm.prompt_manager` (by this test file or any other) would


### PR DESCRIPTION
base: 88faa0e0450a4986730829b8d2990229b11bf216

## What

`TestPromptManagerFailLoudOnUnknownVersion::test_unrecognized_explicit_value_logs_error`
fails deterministically in CI (`assert []`) and has ejected #4643 from the
merge queue twice and suspended #4653. This PR hardens the test file's own
`_capture_module_errors` helper so the promise its docstring already makes —
"independently of the global logging config" — actually holds.

## Diagnosis

> Recorded as it stood when this PR was written. The investigation continues in a separate lane; this PR hardens the capture helper and does not claim to close it.

The helper attaches a `logging.Handler` directly to the
`backend.llm.prompt_manager` logger and forces `disabled=False` before
`importlib.reload()`-ing the module. That covers propagation/level/handlers,
but leaves **two other suppression knobs** untouched, neither scoped to a
single test:

- `logging.Logger.manager.disable` — the process-global mute `logging.disable(N)`
  sets. `Logger.isEnabledFor()` checks it **before** this logger's own level or
  handlers are ever consulted, so a suppressed level never constructs a record
  at all. **Correction** (verified by reading the installed `_pytest/logging.py`
  in `.venv`): pytest's own `caplog.set_level()`/`at_level()` DO touch this
  exact global under the hood (`_pytest/logging.py::_force_enable_logging`),
  but only ever to **loosen** it — that function's two write paths either
  lower the threshold (`logging.disable(max(level - 10, logging.NOTSET))`) or
  clear it outright (`logging.disable(logging.NOTSET)`), and `at_level()`
  restores the original value in a `finally`. So pytest is not a plausible
  producer of an elevated mute; it's cited here for the mechanism it shares,
  not as a threat. Measured across the whole `backend/` tree (all 21
  `conftest.py` included): the only site that touches `manager.disable` at
  all is `test_telegram_token_never_reaches_a_log.py`, and it only ever
  un-mutes, saving/restoring around it. No producer of an elevated mute is
  known to exist in this repo today — this hardening closes a theoretical
  gap the docstring already promised to cover; it is not the diagnosis of
  the CI failure above.
- the logger's own `.filters` — `Logger.filter()` runs before `callHandlers()`,
  so a drop-everything filter attached directly to `backend.llm.prompt_manager`
  by any other test would silently eat the record before this test's sink ever
  sees it.

CI runs this suite under `pytest-xdist -n auto --dist loadfile` (confirmed in
`tests.yml`), which puts many test files through one worker **process** —
process-global logging state genuinely can leak between files that happen to
share a worker, and which files share a worker is a scheduling detail that
depends on runtime timing, not just on `scripts/ci/shard_tests.py`'s file→shard
assignment (S11, landed 10:20:01Z, changed the corpus each shard job sees,
which is the causal correlate reported for this flake starting today).

**Reproduction attempts, all negative** (I ran the *actual* CI command, not a
guess at one):
- Full real shard-2 chunk (477 files, from `scripts/ci/shard_tests.py chunk`)
  under `-n auto` (14 workers) and `-n 4` (matching `ubuntu-latest`'s vCPU
  count) — 0 failures both times.
- Sequential single-process run: every test file in the corpus that touches
  `caplog.set_level`/`at_level`/`logging.root.manager.disable` (9 files,
  grepped for the exact patterns) run immediately before
  `test_prompt_manager.py` in one process — 0 failures.

So I could not force the exact interleaving CI apparently hit — consistent
with the task's own note (5 local attempts, none reproduced). This is most
plausibly a **timing-dependent xdist worker-composition race**, not something
a fast, many-core dev machine reproduces on demand.

**The competing import-order hypothesis does not hold up under inspection**:
`importlib.reload(reload_target)` unconditionally re-executes the module body
against whatever `ZANTARA_PROMPT_VERSION` is set to *right now*, regardless of
`sys.modules` already having an entry from an earlier test/import. There is no
conditional/idempotency guard in `prompt_manager.py` that could make a reload
a no-op. I did not add the "import-order guilt test" from the mandate's Step 3
for this reason: I could not construct a version of it that fails against the
*unfixed* helper (a fake guilt test that always passes proves nothing, so
per the "prove it's a real arm" instruction I left it out rather than pad the
suite with theater).

## The cure

`_capture_module_errors` now additionally, on entry:
- saves `logging.root.manager.disable`, then neutralizes it (`logging.disable(logging.NOTSET)`)
- saves the logger's own `.filters`, then clears them

and restores **both** in `finally`, alongside the pre-existing level/handler/
disabled save-restore — so a failing assertion here can never leak either
suppression mechanism into the next test in the same worker process
(cicatrix-superscar #2, "esiste != armato": a broken test becoming a
shard-wide outbreak is exactly that family).

## Tests added (3)

- **GUILT** `test_capture_survives_a_pre_existing_global_logging_disable` —
  sets `logging.disable(logging.CRITICAL)` before capturing. **Verified**: rc=1
  (`AssertionError: assert []`) against the unfixed helper, rc=0 against the
  fixed one.
- **GUILT** `test_capture_survives_a_drop_everything_filter_on_the_logger` —
  attaches a filter that returns `False` directly to the
  `backend.llm.prompt_manager` logger before capturing. **Verified**: rc=1
  against the unfixed helper (same combined run, both failed together), rc=0
  against the fixed one.
- **INNOCENCE** `test_capture_stays_silent_for_known_versions_under_a_prior_global_mute` —
  a valid version (`v2`) under the same ambient mute still logs nothing; the
  cure only removes noise that would hide a real record, it never manufactures
  a false one.

Verification method: copied the test file to `/tmp`, swapped in the *old*
(unfixed) helper body while keeping the new tests, ran the 3 new tests —
2 failed (rc=1) exactly as expected, 1 passed (the innocence test is
orthogonal to the fix). Then ran the same 3 against the real fixed file —
all 3 passed (rc=0). Full file: 25/25 pass both before-merge and after
merging fresh `origin/main`.

## Verification

- `backend/tests/unit/llm/test_prompt_manager.py`: 25/25 pass (was 22, +3).
- Full real shard-2 chunk (`scripts/ci/shard_tests.py chunk --shards 3 --shard 2`,
  477 files) under `-n auto` and `-n 4 --dist loadfile`: 0 failures, both before
  documenting and after the fix.
- `ruff check` on the changed file: clean.
- Deterministic gear floor for this diff (`evidence_pack_lint.py --print-floor`):
  **1** — no evidence pack required.
- Pre-commit + pre-push hooks: all green (anti-reward-hacking lint, secrets
  scan, import-chain smoke, scoped pytest quickcheck).

## Scope

One file: `apps/backend-rag/backend/tests/unit/llm/test_prompt_manager.py`.
Did not touch `packages/research-os-core/`, `scripts/wr3_*`,
`docs/wr3/contracts/`, or `scripts/ci/shard_tests.py` per mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



