### PR TITLE
docs(cicatrix): W125 — hand-resolving conflict markers is not `--ours`; clean merges inside a conflicted file survive it

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -1286,3 +1286,42 @@ _Scoperto 2026-08-23 su M5, lane visa-oracle fact-vocabulary, su PR #4650, dopo 
 **GOTCHA.** Non fidarti nemmeno del `check-suite` "completato": un `completed`/`success` prematuro su un sottoinsieme striminzito (qui: 3-4 check contro i ~40 attesi) è esso stesso il segnale che qualcosa non è partito, non la prova che tutto sia a posto — va incrociato col CONTEGGIO atteso (`branch protection required_status_checks`), non letto da solo.
 
 **Famiglia: superscar #2 (Esiste ≠ Armato / cron theater).** Variante "check-suite theater": il gate non mente sul proprio esito, mente per omissione — dichiara fatto ciò che non ha nemmeno tentato.
+
+### 🐛 W125 (2026-08-23): risolvere i marker A MANO non è `--ours` — git fonde in silenzio le righe non contese dentro un file conflittuale, e la resa «tengo il mio» se le porta dietro
+
+_Scoperto 2026-08-23 su Mini, lane S12 (ship-accelerators), sull'evidence pack di cinque PR che si sono contese gli stessi due path fissi. Severity: **P2** (nessun dato perso — la contaminazione è stata vista prima del commit; ma è invisibile per costruzione, e il file contaminato è quello che il gate legge per decidere la marcia di una PR)._
+
+**Famiglia: superscar #9 (state-schema drift / stato letto via PROXY).** Il proxy, qui, è _«ci sono marker di conflitto?»_: si legge la presenza dei marker come se fosse la mappa di ciò che il merge ha toccato. Non lo è. I marker mappano solo ciò che git **non ha saputo** decidere; ciò che ha deciso da solo non lascia traccia.
+
+**TRAUMA.** `evidence/brief.yml` e `evidence/pack.yml` vivono a due path FISSI nella radice, quindi due PR Gear≥2 qualsiasi collidono per costruzione. Su cinque PR S12, in una sessione, ho contato **11 commit `Merge remote-tracking branch 'origin/main'`** (verificabile: `gh pr view <n> --json commits`) — undici passaggi dentro la finestra. In uno di questi il pack della C1 è arrivato in working tree con `l_level: L2` in testa al file, **fuori da qualsiasi marker**, mentre i marker stavano dieci righe più sotto attorno a `objective:`. `L2` non era mai stato un valore della C1 (che dichiara `l_level: L1`): apparteneva al brief della C6, «De-serialize the Evidence Pack», il cui gear è davvero 2. Nessun marker, nessun avviso, nessun check rosso — e `l_level` è precisamente il campo su cui il gate decide quanta cerimonia pretendere da quella PR.
+
+**MECCANISMO — riprodotto, non dedotto.** Un conflitto è per HUNK, non per FILE. Se «loro» toccano due regioni separate da ≥3 righe di contesto e io ne ho toccata una sola, git mette i marker sulla regione contesa e applica l'altra **in silenzio**. Riproduzione minima, 9 righe con sei filler a separare le due regioni:
+
+```text
+PRE-MERGE HEAD:   l_level: L1 · objective: MINE
+DOPO IL MERGE:    1  l_level: L2          <- nessun marker
+                  9  <<<<<<< HEAD
+                 10  objective: MINE
+                 11  =======
+                 12  objective: THEIRS
+                 13  >>>>>>> theirs
+```
+
+Le due rese **non sono equivalenti**, misurato sullo stesso working tree:
+
+| gesto di resa                             | `l_level` risultante | identico all'HEAD pre-merge? |
+| ----------------------------------------- | -------------------- | ---------------------------- |
+| risolvo i marker a mano, «tengo il mio»   | **`L2`**             | **NO — contaminato**         |
+| `git checkout --ours -- <path>`           | `L1`                 | SÌ                           |
+
+`--ours` ripristina lo _stage 2_, cioè il file INTERO come stava in HEAD, e quindi annulla anche le fusioni pulite. Editare i marker no: tocca soltanto ciò che i marker delimitano. La differenza è tutta qui, ed è invisibile finché non la si misura.
+
+**CURA.** Per un file di cui la mia PR è l'UNICA proprietaria — l'evidence pack lo è: la versione su `main` appartiene a un'altra PR e lì dentro non c'è nulla che io voglia — la resa corretta è `git checkout --ours -- <path>`, mai l'editing a mano dei marker. E comunque, **prima di `git add`**:
+
+```bash
+git show "HEAD:evidence/pack.yml" | diff -q - evidence/pack.yml   # deve essere VUOTO
+```
+
+Vuoto = ho davvero tenuto il mio. Non vuoto = qualcosa è entrato dalla porta di servizio, e adesso lo vedo.
+
+**GOTCHA.** «Byte-identico all'HEAD pre-merge» vale per questa CLASSE di file (interamente miei), non per un merge qualunque: in un merge normale il contenuto altrui DEVE entrare, e un diff vuoto sarebbe il bug. Prima di applicare la cura, chiediti se il file ha un solo proprietario. E la vigilanza non è la cura strutturale: quella è togliere i path fissi — `scripts/ci/evidence_paths.py` è già su `main` (#4678) ma non ancora adottato dai produttori dei pack, e finché non lo è la finestra si riapre a ogni PR Gear≥2.

--- a/.claude/rules/cicatrix-superscar.md
+++ b/.claude/rules/cicatrix-superscar.md
@@ -204,7 +204,7 @@ CONTENUTO (diff vuoto/subset), mai patch-equivalenza/SHA-ancestor/timestamp.
 contenuto post-squash) · W102 (two-dot diff accusa PR dei file di main) · W106 (proxy congelato sceglie
 credenziale morta) · W106b (il checkout stesso è il proxy) · W109b (2 PR che si bloccano a vicenda) ·
 W111 (`gh run rerun` rigioca merge-ref stantio) · W114 (fake e codice condividono l'immaginazione) ·
-W118 (3 proxy merge-queue che mentono).
+W118 (3 proxy merge-queue che mentono) · W125 (fusione pulita senza marker, la resa a mano la tiene).
 **→ dettaglio:** cicatrix-scars.md (resto) + archive (W53/W54/W61)
 **PR-1 landing** (corpo in `PENDING-ARMS.md`): la mergeability GitHub non onora `merge=union`;
 `autoMergeRequest` non sopravvive a un transito CONFLICTING — va riarmato via GraphQL.


### PR DESCRIPTION
## Why

A git conflict is per **hunk**, not per **file**. When the other side touches two regions separated by ≥3 context lines and this side touched only one, git marks the contested region and applies the other one **silently** — no marker, no warning, no red check. Reading "are there conflict markers?" as the map of what the merge changed is a proxy, and it is wrong in exactly the direction that hurts.

## Measured, not asserted

**Live artifact (S12, 2026-08-23).** The C1 evidence pack arrived in the working tree carrying `l_level: L2` at the top of the file, **outside any marker**, while the markers sat ten lines below around `objective:`. `L2` was never a C1 value — C1 declares `L1`; `L2` came from the C6 brief ("De-serialize the Evidence Pack"). `l_level` is the field the harness gate reads to decide how much ceremony a PR owes.

**Exposure.** `gh pr view <n> --json commits` across the five S12 PRs: **11** `Merge remote-tracking branch 'origin/main'` commits in one session — eleven passes through that window. (Eleven *passes*, not eleven contaminations; the pack was the conflicting surface because it lives at two fixed root paths, which is what #4678 exists to remove.)

**Reproduction.** Nine lines, six filler lines separating the two regions, both resolution gestures measured on the same working tree:

| gesture | resulting `l_level` | byte-identical to pre-merge HEAD? |
| --- | --- | --- |
| hand-resolve the markers, keep my side | **`L2`** | **NO — silent contamination** |
| `git checkout --ours -- <path>` | `L1` | YES |

`--ours` restores **stage 2** — the whole file as it stood in HEAD — so it undoes the clean merge too. Editing markers touches only what the markers delimit. That is the entire difference, and it is invisible until measured.

## Cure

For a file this PR **solely owns** (the evidence pack is one: main's copy belongs to another PR and contains nothing wanted here), resolve with `git checkout --ours -- <path>`, never by hand-editing markers. Either way, before `git add`:

```bash
git show "HEAD:evidence/pack.yml" | diff -q - evidence/pack.yml   # must be EMPTY
```

Family **#9** (state read through a proxy). The structural cure is de-serializing the fixed paths — `scripts/ci/evidence_paths.py` is already on main (#4678) but not yet adopted by the pack producers — not this vigilance.

## Adversarial review

Four attacks, run against the entry before opening:

1. **"The antidote is wrong in general."** Correct, and it would be a real defect if left unqualified — in a normal merge the other side's content *must* land, and an empty diff would be the bug. The entry's GOTCHA states the scope explicitly (this file **class**: single-owner files) and tells the reader to check ownership first. Not silently over-general.
2. **"`--ours` can silently drop a shared schema change."** Real risk, and it is the strongest argument against the recommended gesture — if a required field were added to the pack schema on main, `--ours` would discard it. But that failure mode is **loud**: `scripts/evidence_pack_lint.py` fails the PR red. The failure mode of hand-editing markers is **silent**. The recommendation trades a loud failure for a silent one in the right direction, which is the point.
3. **"The reproduction is an artifact of the synthetic fixture, not real git."** The reproduced layout matches the live artifact line for line — contaminated field at the top with no marker, markers ten lines below around `objective:`. Two independent observations of the same shape, one synthetic and one from production.
4. **"11 is inflated — those merges weren't all evidence conflicts."** Granted, and the entry says so: eleven *passes through the window*, from `gh pr view --json commits`, not eleven contaminations. The count measures exposure, and it is labelled as exposure.

Guards run locally: `test_superscar_budget.py` + `test_cicatrix_scar_pointer_integrity.py`, **18 passed**. Superscar file 13,696 → 13,759 bytes, **241 bytes** under the 14,000 budget. All three cicatrix files are in `.prettierignore` (lines 134-136), so W112 does not apply.

Diff is 2 files, docs-only — deterministic gear floor **1**, same shape as #4683 (W124) and #4665 (W123), which shipped without an evidence pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
