### PR TITLE
fix(backend-rag): stop ColoredFormatter mutating the caller's LogRecord

### DIFF
--- a/apps/backend-rag/backend/app/core/logging_config.py
+++ b/apps/backend-rag/backend/app/core/logging_config.py
@@ -12,6 +12,7 @@ Provides configurable logging with:
 import logging
 import sys
 import time
+from copy import copy
 from datetime import datetime, timezone
 from typing import Any
 
@@ -66,6 +67,8 @@ class ColoredFormatter(logging.Formatter):
     }
 
     def format(self, record: Any) -> Any:
+        record = copy(record)
+
         if ENVIRONMENT == "development":
             color = self.COLORS.get(record.levelname, self.COLORS["RESET"])
             record.levelname = f"{color}{record.levelname}{self.COLORS['RESET']}"

--- a/apps/backend-rag/backend/tests/unit/app/core/test_logging_config.py
+++ b/apps/backend-rag/backend/tests/unit/app/core/test_logging_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+import sys
+from importlib import import_module
+
+import pytest
+
+
+class _ReferenceCaptureHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def test_colored_formatter_colours_output_without_mutating_shared_record(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root_logger = logging.getLogger()
+    original_root_handlers = root_logger.handlers[:]
+    original_root_level = root_logger.level
+    child_logger = logging.getLogger("backend.tests.colored_formatter.shared_record")
+    original_child_handlers = child_logger.handlers[:]
+    original_child_level = child_logger.level
+    original_child_propagate = child_logger.propagate
+    original_child_disabled = child_logger.disabled
+
+    try:
+        logging_config = import_module("backend.app.core.logging_config")
+
+        root_logger.handlers.clear()
+        root_logger.setLevel(getattr(logging, logging_config.LOG_LEVEL))
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setFormatter(
+            logging_config.ColoredFormatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            ),
+        )
+        root_logger.addHandler(console_handler)
+
+        reference_handler = _ReferenceCaptureHandler()
+        child_logger.handlers.clear()
+        child_logger.addHandler(reference_handler)
+        child_logger.setLevel(logging.ERROR)
+        child_logger.propagate = True
+        child_logger.disabled = False
+
+        child_logger.error("shared-record probe")
+        rendered_output = capsys.readouterr().out
+        stored_records = reference_handler.records[:]
+    finally:
+        root_logger.handlers[:] = original_root_handlers
+        root_logger.setLevel(original_root_level)
+        child_logger.handlers[:] = original_child_handlers
+        child_logger.setLevel(original_child_level)
+        child_logger.propagate = original_child_propagate
+        child_logger.disabled = original_child_disabled
+
+    assert "\x1b[31mERROR\x1b[0m" in rendered_output
+    assert len(stored_records) == 1
+    assert stored_records[0].levelname == "ERROR"
+    assert "\x1b" not in stored_records[0].levelname


### PR DESCRIPTION
Root cause of a test failure that blocked the Research OS P04-D1 packet all day. Cures the class, not the symptom.

`base: 1c647c020e5bc1bab0aba8df482a1d3fd0e66a16`

## The defect

`ColoredFormatter.format()` reassigned `record.levelname` — and `record.name`, when a `component` attribute is present — **on the record object handed to it**. `Logger.callHandlers()` visits the originating logger's handlers first, then walks up to root's, synchronously inside the same `.error()` call, passing the **same object**. A handler that stored the record by reference found `levelname` rewritten to `'\x1b[31mERROR\x1b[0m'` moments later, so a downstream `record.levelname == "ERROR"` was False.

`setup_logging()` runs as a bare module-level call (`:219`), so importing anything that reaches this module installs the mutating root handler for the whole process.

## Why nobody found it by searching

Three independent searches swept the "who suppresses a record" API surface — `logging.disable`, `manager.disable`, `addFilter`, `addLevelName` — and the corpus was genuinely clean. The mutator is **none of those APIs**: it is an attribute reassignment inside a bespoke `format()`. The record was never suppressed; it was emitted, captured correctly, and then **edited**. `levelno` stayed 40 while `levelname` was ANSI-wrapped — the identity was intact and only the rendered string was wrong.

Compounding it, the visible evidence was clean in both directions: pytest strips ANSI in its own displays (`_remove_ansi_escape_sequences`), so every rendered log looked correct while the compared *attribute* carried the escape codes.

## What this was NOT

Measured, not assumed: the failure reproduces **sequentially, with no `pytest-xdist` at all** (`rc=1`), and **in either file order** (`rc=1`). So it is not a concurrency, worker-scheduling or ordering effect, and it is not a flake — it is deterministic given the file selection. The poisoning happens at **import/collection time**, before any test body runs. Positional test sharding was never the cause; it merely changed which files share a session. Every "reproduce it locally" attempt that ran the target file alone was guaranteed to pass.

## The fix

Format a copy. This is exactly what `uvicorn.logging.ColourizedFormatter.formatMessage` does (`recordcopy = copy(record)`), for this same reason. The copy is taken before **both** mutations, so the `component` rewrite of `record.name` is covered too. Rendered output is unchanged; only the side effect on the caller's record disappears.

## Verification (return codes captured on the command itself, never after a pipe)

- **Guilt test arms**: with the fix `rc=0`; with the single `record = copy(record)` line removed `rc=1`, failing as `AssertionError: assert '\x1b[31mERROR\x1b[0m' == 'ERROR'` — the literal original failure mode.
- **Innocence**: the test also asserts the rendered output still contains the colour codes, so nobody later "fixes" this by silently dropping colour.
- **End-to-end**: the minimal pair that fails on `main` in both orders (`test_monitoring_rag.py` + `test_prompt_manager.py`) passes here in both orders, `rc=0`.

## Provenance

Built by a Codex seat (`scripts/seat_build.sh --seat codex`, per the arsenal routing floor); the wrapper ships nothing. Diff, guilt proof and end-to-end proof were re-run independently by the grading session before publishing — generator and grader are different.

## Reported separately, deliberately not fixed here

1. `:23` — `ENVIRONMENT = getattr(__import__("os").environ, "ENVIRONMENT", "development")` reads an *attribute* off the `os._Environ` mapping, which never has one, so it always yields `"development"`. Verified with `ENVIRONMENT=production` genuinely exported. Consequence: **production logs carry raw ANSI**. Its own concern, its own PR.
2. Whether anything live stores `LogRecord` by reference and later reads `.levelname` — the `ring_handler` near `app/setup/logging_config.py:209` is the specific thing to check. If a live buffer holds records, this bug corrupted operational data, not only a test.
