### PR TITLE
fix(bot): the throughput sentinel counted a Meta TEST payload as traffic and went blind for 48h

### DIFF
--- a/scripts/tests/test_wa_bot_throughput_sentinel.py
+++ b/scripts/tests/test_wa_bot_throughput_sentinel.py
@@ -645,3 +645,90 @@ if __name__ == "__main__":
     import pytest
 
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+# ------------------------------------------------- routing phone_number_id (incident 2026-08-23)
+
+
+def test_inbound_sql_filters_on_the_routing_phone_number_id():
+    """GUILT for the 2026-08-23 incident: three hours after this organ was armed, a
+    "Test" click in the Meta app dashboard delivered a sample payload carrying the
+    documentation placeholders (phone_number_id 123456123). whatsapp_chat.py ignored
+    it correctly; this sentinel counted it as traffic, reset inbound freshness from
+    589h to 0.5h, and suppressed dead_channel for 48h. The query must be narrowed to
+    what the PRODUCT routes on, and must be parameterised rather than interpolated."""
+    assert "phone_number_id" in wbts.INBOUND_SQL
+    assert "$1" in wbts.INBOUND_SQL, "the id must be a bound parameter, never inlined"
+    assert wbts.ROUTING_PHONE_NUMBER_ID not in wbts.INBOUND_SQL
+
+
+def test_history_sql_stays_unfiltered_so_wrong_database_stays_distinguishable():
+    """INNOCENCE for the asymmetry: HISTORY_SQL answers "does this database hold ANY
+    WhatsApp history", which is how a mispointed DSN is told apart from a real
+    outage. Narrowing it too would make a database that merely lacks OUR traffic
+    report as empty, i.e. a config fault announced where an outage lives."""
+    assert "phone_number_id" not in wbts.HISTORY_SQL
+    assert "channel = 'whatsapp'" in wbts.HISTORY_SQL
+
+
+def test_tick_actually_binds_the_routing_id_not_merely_declares_it():
+    """A filter in the query text proves nothing if the parameter is never passed.
+
+    REWRITTEN after the first version SURVIVED its own mutation: it called
+    `conn.fetchrow(INBOUND_SQL, ROUTING_PHONE_NUMBER_ID)` itself and then asserted
+    on the arguments it had just supplied — a check that derives its reference from
+    its subject, which always agrees. Deleting the real binding in _tick left it
+    green. This version drives the SENTINEL's own code path and inspects what the
+    sentinel passed.
+    """
+    import asyncio
+
+    seen = {}
+
+    class _RecordingConn:
+        async def fetchrow(self, query, *args, **kwargs):
+            if "inbound_webhooks" in query and "phone_number_id" in query:
+                seen["inbound_args"] = args
+                return {"newest": None}
+            if "wa_outbox" in query and "count(" in query:
+                return {"outbox_rows": 1, "inbound_rows": 1}
+            if "wa_outbox" in query:
+                return {"newest": None}
+            if "inbound_webhooks" in query:
+                return {"outbox_rows": 1, "inbound_rows": 1}
+            raise AssertionError(f"unexpected query: {query}")
+
+    now_wita = datetime(2026, 8, 24, 10, 0, tzinfo=wbts.WITA)
+    asyncio.run(wbts._tick(_RecordingConn(), now_wita, dry_run=True))
+
+    assert "inbound_args" in seen, "_tick never issued the filtered inbound query"
+    assert seen["inbound_args"] == (wbts.ROUTING_PHONE_NUMBER_ID,), (
+        f"_tick bound {seen['inbound_args']!r}, not the routing id"
+    )
+
+
+def test_routing_id_matches_the_products_own_constant_or_this_organ_watches_a_ghost():
+    """SSOT drift guard. ROUTING_PHONE_NUMBER_ID is duplicated from
+    wa_outbox_worker.META_INBOX_PHONE_NUMBER_ID because this script runs outside the
+    backend package (its launcher execs it with no backend PYTHONPATH), so it cannot
+    import it. A duplicated constant that nothing compares is a constant that drifts:
+    if the product is ever re-pointed at a new WhatsApp number and this is not, the
+    sentinel goes quiet on a live channel and nothing turns red. Parse the product's
+    file rather than trusting a comment."""
+    import ast
+    import pathlib
+
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    src = repo / "apps/backend-rag/backend/services/integrations/wa_outbox_worker.py"
+    assert src.is_file(), f"product module not found at {src}"
+    tree = ast.parse(src.read_text(encoding="utf-8"))
+    found = None
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "META_INBOX_PHONE_NUMBER_ID":
+                    found = ast.literal_eval(node.value)
+    assert found is not None, "META_INBOX_PHONE_NUMBER_ID no longer a module-level literal — re-anchor this guard"
+    assert wbts.ROUTING_PHONE_NUMBER_ID == found, (
+        f"sentinel routes on {wbts.ROUTING_PHONE_NUMBER_ID} but the product routes on {found}"
+    )

--- a/scripts/wa_bot_throughput_sentinel.py
+++ b/scripts/wa_bot_throughput_sentinel.py
@@ -118,7 +118,26 @@ _PY3_CANDIDATES: tuple[str, ...] = (
 # records every generated reply, 'done' meaning it actually went out. Both
 # SELECT-only, both scoped to the BOT product's own writers — never the
 # wa-mirror tables wa_mirror_freshness_liveness.py already watches.
-INBOUND_SQL = "SELECT max(received_at) AS newest FROM inbound_webhooks WHERE channel = 'whatsapp'"
+# The product routes on the phone_number_id, and so must this sentinel — MEASURED
+# 2026-08-23, three hours after this organ was armed. Someone pressed "Test" in the
+# Meta app dashboard; Meta delivered a sample payload carrying the documentation
+# placeholders (phone_number_id 123456123, display 16505551111). whatsapp_chat.py
+# correctly IGNORED it — it routes only its own number — but this sentinel counted
+# it as inbound traffic, reset its freshness clock from 589h to 0.5h, and so
+# suppressed dead_channel for the next 48 hours. One click on a test button blinded
+# the organ to the very outage it exists to watch, and nothing went red.
+#
+# So: count only the webhooks the PRODUCT would act on. Measured blast radius on
+# prod before changing this — 244 rows carry our id, 1 carries the placeholder, and
+# the JSON path is present on 100% of 245 rows, so the filter narrows the query
+# without risking the empty-result branch. A sentinel whose input set is wider than
+# its subject's is not measuring its subject.
+ROUTING_PHONE_NUMBER_ID = "1104946272705747"  # SSOT: wa_outbox_worker.META_INBOX_PHONE_NUMBER_ID
+_PNID_JSON_PATH = "payload->'entry'->0->'changes'->0->'value'->'metadata'->>'phone_number_id'"
+INBOUND_SQL = (
+    "SELECT max(received_at) AS newest FROM inbound_webhooks "
+    "WHERE channel = 'whatsapp' AND " + _PNID_JSON_PATH + " = $1"
+)
 OUTBOUND_SQL = "SELECT max(created_at) AS newest FROM wa_outbox WHERE status = 'done'"
 # Discriminator, measured 2026-08-23: the LOCAL dev database carries both tables
 # with ZERO rows, so a run against the default DSN would read NULL on both signals
@@ -126,6 +145,13 @@ OUTBOUND_SQL = "SELECT max(created_at) AS newest FROM wa_outbox WHERE status = '
 # alarm that always fires is an alarm nobody reads, which is worse than none. So
 # "this table has never held a row" is separated from "its newest row is old":
 # the first is a misconfiguration (wrong DSN / unprovisioned DB), never an outage.
+# DELIBERATELY NOT filtered by phone_number_id, unlike INBOUND_SQL above, and the
+# asymmetry is the point rather than an oversight: this query answers "does this
+# database hold ANY WhatsApp history at all", which is how a mispointed DSN is told
+# apart from a real outage. Narrowing it to our own number would make a database
+# that merely lacks OUR traffic indistinguishable from an empty one, and the
+# sentinel would announce a config fault where there is an outage. Do not "tidy"
+# these two into agreement.
 HISTORY_SQL = "SELECT (SELECT count(*) FROM wa_outbox) AS outbox_rows, (SELECT count(*) FROM inbound_webhooks WHERE channel = 'whatsapp') AS inbound_rows"
 
 
@@ -343,7 +369,7 @@ async def _tick(conn: Any, now_wita: datetime, *, dry_run: bool) -> int:
     end_hour = int(os.getenv("WA_BOT_BUSINESS_END", "20"))
     business_days = _business_days_from_env()
 
-    inbound_row = await conn.fetchrow(INBOUND_SQL, timeout=30)
+    inbound_row = await conn.fetchrow(INBOUND_SQL, ROUTING_PHONE_NUMBER_ID, timeout=30)
     outbound_row = await conn.fetchrow(OUTBOUND_SQL, timeout=30)
     inbound_newest = inbound_row["newest"]
     outbound_newest = outbound_row["newest"]


### PR DESCRIPTION
## What happened

Three hours after `pro.wa_bot_throughput_sentinel` was armed (#4682), a **"Test" click in the Meta app dashboard** delivered a sample payload carrying Meta's documentation placeholders — `phone_number_id 123456123`, `display_phone_number 16505551111`.

`whatsapp_chat.py` **ignored it correctly**: it routes only its own number (`META_INBOX_PHONE_NUMBER_ID`). The sentinel did not. It counted the row as inbound traffic, reset its freshness clock from 589h to 0.5h, and thereby **suppressed `dead_channel` for the next 48 hours** — on a channel that has produced no answer since 2026-07-30.

One click on a test button blinded the organ to the exact outage it exists to watch, and nothing went red. Superscar #2, inside the organ built against superscar #2.

## Evidence — same moment, same database

| | `condition` | `raw_inbound_h` |
|---|---|---|
| armed in prod today | `None` | 1.2 |
| with this fix | `dead_channel` | **591.6** |

Blast radius measured on prod before changing anything: **244** rows carry our routing id, **1** carries the placeholder, and the JSON path is present on **100% of 245** rows — so the filter narrows the query without reaching the empty-result branch.

## The asymmetry, documented in place

`HISTORY_SQL` stays **unfiltered** on purpose: it answers *"does this database hold ANY WhatsApp history"*, which is how a mispointed DSN is told apart from a real outage. Narrowing it too would make a database that merely lacks **our** traffic report as empty — a config fault announced where an outage lives. There is a test pinning each side so the two are not "tidied" into agreement.

## Verification

Three guards, each **mutation-verified red** (a guard you cannot make fail is decorative):

| mutation | result |
|---|---|
| revert the filter (the original defect) | 2 failed |
| drift the id away from the product's constant | 1 failed |
| drop the bound parameter in `_tick` | 1 failed |

Restored: **49 passed**, file byte-identical.

The drift guard **ast-parses** `wa_outbox_worker.META_INBOX_PHONE_NUMBER_ID` rather than trusting a comment — this script runs outside the backend package (its launcher execs it with no backend `PYTHONPATH`), so it cannot import the constant, and a duplicated constant that nothing compares is one that drifts.

## Process note

The binding guard's **first version survived its own mutation**: it called `fetchrow` itself and then asserted on the arguments it had just supplied — a check that derives its reference from its subject, so it always agrees. Rewritten to drive `_tick` and inspect what the sentinel actually passed.

## Scope

Deterministic gear floor for this diff: **1**. Two files, no hot-zone path, no evidence pack required.
