### PR TITLE
feat(pricing): E33E Second Home Senior 5y — one all-inclusive row at 45.000.000 IDR (owner ruling)

### DIFF
--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -348,24 +348,14 @@
         "description_en": "Second Home Visa / KITAS (E33) for foreigners who hold a qualifying USD 130,000 deposit in their own name at a state-owned Indonesian bank (or a USD 1,000,000 qualifying property). Valid 5 years, renewable; non-working residency. Bali Zero manages document preparation, submission, and the 90-day post-grant commitment gate; the deposit always remains in the client's own account.",
         "icon_id": "kitas-investor"
       },
-      "E33E Second Home Senior (5 Years, Offshore)": {
-        "name": "E33E Second Home Senior (5 Years, Offshore)",
-        "price": "14.000.000 IDR",
+      "E33E Second Home Senior (5 Years)": {
+        "name": "E33E Second Home Senior (5 Years)",
+        "price": "45.000.000 IDR",
         "tier_range": null,
         "duration": "",
         "validity": "5 years",
-        "notes": "All-inclusive price. Senior 55+ route: USD 50,000 deposit at a state-owned Indonesian bank plus USD 3,000/month passive income. Aligned to the de-facto senior pricing pending owner review.",
-        "description_en": "Second Home Visa / KITAS senior route (E33E) for applicants 55+ holding a USD 50,000 deposit in their own name at a state-owned Indonesian bank plus proven USD 3,000/month passive income. Valid 5 years; non-working residency. Offshore process for applicants outside Indonesia.",
-        "icon_id": "kitas-investor"
-      },
-      "E33E Second Home Senior (5 Years, Altus/Onshore)": {
-        "name": "E33E Second Home Senior (5 Years, Altus/Onshore)",
-        "price": "16.000.000 IDR",
-        "tier_range": null,
-        "duration": "",
-        "validity": "5 years",
-        "notes": "All-inclusive price. Senior 55+ route: USD 50,000 deposit at a state-owned Indonesian bank plus USD 3,000/month passive income. Aligned to the de-facto senior pricing pending owner review.",
-        "description_en": "Second Home Visa / KITAS senior route (E33E) for applicants 55+ holding a USD 50,000 deposit in their own name at a state-owned Indonesian bank plus proven USD 3,000/month passive income. Valid 5 years; non-working residency. Onshore process via Altus.",
+        "notes": "All-inclusive price. Senior 55+ route: USD 50,000 deposit at a state-owned Indonesian bank plus USD 3,000/month passive income.",
+        "description_en": "Second Home Visa / KITAS senior route (E33E) for applicants 55+ holding a USD 50,000 deposit in their own name at a state-owned Indonesian bank plus proven USD 3,000/month passive income. Valid 5 years; non-working residency.",
         "icon_id": "kitas-investor"
       },
       "E33E Second Home Senior (Extend)": {

--- a/apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py
+++ b/apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py
@@ -1481,7 +1481,7 @@ VISA_TYPES = [
         "name": "Second Home Visa Elderly for 5 Years Golden Visa",
         "category": "KITAS/Limited Stay",
         "duration": "See details",
-        "cost_visa": "IDR 14.000.000 (Offshore) / 16.000.000 (Onshore)",
+        "cost_visa": "Contact for Quote",
         "requirements": [],
         "description": "Official title: Second Home Visa Elderly for 5 Years Golden Visa",
         "metadata": {

--- a/apps/backend-rag/backend/services/compliance/renewal_rules.py
+++ b/apps/backend-rag/backend/services/compliance/renewal_rules.py
@@ -286,7 +286,7 @@ RENEWAL_RULES: dict[str, RenewalRule] = {
         processing_days=30,
         lead_time_days=120,
         recommended_start_days=150,
-        renewal_pricing_key="E33E Second Home Senior (5 Years, Altus/Onshore)",
+        renewal_pricing_key="E33E Second Home Senior (5 Years)",
         required_docs=(
             "valid_passport",
             "current_itas_card",

--- a/apps/backend-rag/backend/services/visa_check/pricing_bridge.py
+++ b/apps/backend-rag/backend/services/visa_check/pricing_bridge.py
@@ -60,7 +60,7 @@ _SEARCH_HINTS: dict[VisaType, tuple[str, ...]] = {
         "Family",
     ),
     VisaType.E33: ("E33 Second Home (5 Years)", "E33 Second Home"),
-    VisaType.E33E: ("E33E Second Home Senior (5 Years, Offshore)", "E33E Second Home Senior"),
+    VisaType.E33E: ("E33E Second Home Senior (5 Years)", "E33E Second Home Senior"),
     VisaType.E33F: ("E33F Second Home Senior (1 Year, Offshore)", "E33F Second Home Senior"),
     VisaType.E33G: ("E33G Remote Worker (Offshore)", "E33G Remote Worker"),
 }

--- a/apps/backend-rag/backend/tests/services/compliance/test_renewal_rules.py
+++ b/apps/backend-rag/backend/tests/services/compliance/test_renewal_rules.py
@@ -185,7 +185,7 @@ class TestE33SeniorRoutes:
 
     def test_e33e_full_pricing_name_matches_by_code_not_prose(self) -> None:
         # The code wins even though the string also contains "second home senior".
-        rule = match_rule("kitas", "E33E Second Home Senior (5 Years, Offshore)")
+        rule = match_rule("kitas", "E33E Second Home Senior (5 Years)")
         assert rule.rule_id == "e33e_senior_renewal"
 
     def test_e33f_extend_pricing_name_matches(self) -> None:

--- a/apps/backend-rag/scripts/brochure/brochure_en.html
+++ b/apps/backend-rag/scripts/brochure/brochure_en.html
@@ -220,7 +220,7 @@
       <tr><td>Freelance E23</td><td>Offshore</td><td>{{PRICE_E23_OFF}}</td></tr>
       <tr><td>Retirement</td><td>Offshore</td><td>{{PRICE_RET_OFF}}</td></tr>
       <tr><td>Spouse or dependent, 1 year</td><td>Offshore</td><td>{{PRICE_SPOUSE_OFF}}</td></tr>
-      <tr><td>E33E Second Home Senior, 5 years</td><td>Offshore</td><td>{{PRICE_E33E_OFF}}</td></tr>
+      <tr><td>E33E Second Home Senior, 5 years</td><td>Offshore / onshore</td><td>{{PRICE_E33E}}</td></tr>
     </tbody>
   </table>
 

--- a/apps/backend-rag/scripts/generate_brochure.py
+++ b/apps/backend-rag/scripts/generate_brochure.py
@@ -228,7 +228,7 @@ PRICE_MAP: dict[str, tuple[tuple[str, ...], str]] = {
     "PRICE_E23_OFF":       (('kitas_permits', 'Freelance E23 (Offshore)'), 'Freelance E23 (Offshore)'),
     "PRICE_RET_OFF":       (('kitas_permits', 'Retirement (Offshore)'), 'Retirement (Offshore)'),
     "PRICE_SPOUSE_OFF":    (('kitas_permits', 'Spouse 1 Year (Offshore)'), 'Spouse 1 Year (Offshore)'),
-    "PRICE_E33E_OFF":      (('kitas_permits', 'E33E Second Home Senior (5 Years, Offshore)'), 'E33E Second Home Senior (5 Years, Offshore)'),
+    "PRICE_E33E":          (('kitas_permits', 'E33E Second Home Senior (5 Years)'), 'E33E Second Home Senior (5 Years)'),
     "PRICE_KITAP_INV":     (('kitap_permits', 'Investor KITAP + MERP'), 'Investor KITAP + MERP'),
     "PRICE_KITAP_RET":     (('kitap_permits', 'Retirement KITAP + MERP'), 'Retirement KITAP + MERP'),
     "PRICE_NEWCO":         (('company_services', 'New Company (PT PMA)'), 'New Company (PT PMA)'),

--- a/apps/mouth/data/bali-zero-prices.json
+++ b/apps/mouth/data/bali-zero-prices.json
@@ -387,26 +387,15 @@
         "description_en": "Second Home Visa / KITAS (E33) for foreigners who hold a qualifying USD 130,000 deposit in their own name at a state-owned Indonesian bank (or a USD 1,000,000 qualifying property). Valid 5 years, renewable; non-working residency. Bali Zero manages document preparation, submission, and the 90-day post-grant commitment gate; the deposit always remains in the client's own account.",
         "icon_id": "kitas-investor"
       },
-      "E33E Second Home Senior (5 Years, Offshore)": {
+      "E33E Second Home Senior (5 Years)": {
         "category": "kitas_permits",
-        "key": "E33E Second Home Senior (5 Years, Offshore)",
-        "name": "E33E Second Home Senior (5 Years, Offshore)",
-        "price": "14.000.000 IDR",
+        "key": "E33E Second Home Senior (5 Years)",
+        "name": "E33E Second Home Senior (5 Years)",
+        "price": "45.000.000 IDR",
         "duration": "",
         "validity": "5 years",
-        "notes": "All-inclusive price. Senior 55+ route: USD 50,000 deposit at a state-owned Indonesian bank plus USD 3,000/month passive income. Aligned to the de-facto senior pricing pending owner review.",
-        "description_en": "Second Home Visa / KITAS senior route (E33E) for applicants 55+ holding a USD 50,000 deposit in their own name at a state-owned Indonesian bank plus proven USD 3,000/month passive income. Valid 5 years; non-working residency. Offshore process for applicants outside Indonesia.",
-        "icon_id": "kitas-investor"
-      },
-      "E33E Second Home Senior (5 Years, Altus/Onshore)": {
-        "category": "kitas_permits",
-        "key": "E33E Second Home Senior (5 Years, Altus/Onshore)",
-        "name": "E33E Second Home Senior (5 Years, Altus/Onshore)",
-        "price": "16.000.000 IDR",
-        "duration": "",
-        "validity": "5 years",
-        "notes": "All-inclusive price. Senior 55+ route: USD 50,000 deposit at a state-owned Indonesian bank plus USD 3,000/month passive income. Aligned to the de-facto senior pricing pending owner review.",
-        "description_en": "Second Home Visa / KITAS senior route (E33E) for applicants 55+ holding a USD 50,000 deposit in their own name at a state-owned Indonesian bank plus proven USD 3,000/month passive income. Valid 5 years; non-working residency. Onshore process via Altus.",
+        "notes": "All-inclusive price. Senior 55+ route: USD 50,000 deposit at a state-owned Indonesian bank plus USD 3,000/month passive income.",
+        "description_en": "Second Home Visa / KITAS senior route (E33E) for applicants 55+ holding a USD 50,000 deposit in their own name at a state-owned Indonesian bank plus proven USD 3,000/month passive income. Valid 5 years; non-working residency.",
         "icon_id": "kitas-investor"
       },
       "E33E Second Home Senior (Extend)": {

--- a/apps/mouth/src/lib/pricing-snapshot.test.ts
+++ b/apps/mouth/src/lib/pricing-snapshot.test.ts
@@ -109,7 +109,7 @@ describe("generated PricingTool snapshot", () => {
         (count, rows) => count + Object.keys(rows).length,
         0,
       ),
-    ).toBe(114);
+    ).toBe(113);
   });
 
   it.each(selectedRows)("keeps %s:%s in parity", (category, key) => {

--- a/research/secondhome/README.md
+++ b/research/secondhome/README.md
@@ -56,6 +56,9 @@ Pasal 33(10)(d) still reads **60** — operate on 55, disclose the ambiguity
   decompose into PNBP + service fee in any client-facing material (org rule:
   single all-inclusive price; Fable-5 gate item 4.5). Repriced from 39M on
   2026-08-19 (Zero ruling D2 — match Flado).
+- **E33E pricing (2026-08-24)** → **IDR 45,000,000 all-inclusive** for the
+  5-year first grant, carried by one PricingTool row with no offshore/onshore
+  split. E33E Extend remains IDR 10,000,000.
 - **Branch merge** → the content-freeze and fact-registry branches are
   approved for Claude-session review & merge (master list item 0.1).
 - **Dependent pricing** → **start price-alignment work now** (no final number


### PR DESCRIPTION
**Owner ruling, Zero 2026-08-24 (SYMBIOSIS Legge 5).** Not a proposal — the decision is made; this PR applies it.

## Why the ruling exists

This session measured a margin inversion and put the arithmetic in front of Zero. E33E (5 years) and E33F (1 year) were selling at the **same** 14M offshore / 16M onshore, while their PNBP differs almost 2×:

| product | PNBP (Ditjen index page, `Biaya` field) | was | over PNBP |
|---|---|---|---|
| E33E — 5 years | Rp 13,000,000 | 14M / 16M | **+1M** offshore |
| E33F — 1 year | Rp 7,000,000 | 14M / 16M | +7M / +9M |

E33E offshore cleared one million rupiah over the regulator’s own fee. The best product in the line was the one that did not earn.

## What changes

```
E33E Second Home Senior (5 Years, Offshore)       14.000.000  ->  removed
E33E Second Home Senior (5 Years, Altus/Onshore)  16.000.000  ->  removed
E33E Second Home Senior (5 Years)                                 45.000.000
```

One row, all-inclusive, no offshore/onshore split — the shape `E33 Second Home (5 Years)` (35.000.000) already uses. Never decomposed into PNBP + service fee anywhere client-facing.

## What is deliberately NOT changed

**`E33 Second Home (5 Years)` stays 35.000.000, so E33E now costs MORE than the flagship base product** — which carries the heavier requirement (USD 130k deposit or USD 1M property, no age limit) against E33E’s USD 50k + income for 55+. Zero was shown this inversion explicitly, in those terms, and chose to keep the base where it is. **It is a decision, not an oversight — do not "fix" it in a later PR.**

Also untouched: `E33F` keeps its two-row 14/16M shape · `E33E Extend` stays 10M · `E33G` and `Retirement` are not involved.

## Consumers — nine, and three were missed by the first map

The conductor’s consumer-map found six. The build seat found three more: the **seed migration script**, the **brochure HTML template**, and the **corner README**. Both price files matter equally — `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json` (SSOT) and `apps/mouth/data/bali-zero-prices.json` (frontend copy) — and must never diverge.

The brochure placeholder was `PRICE_E33E_OFF`, named for "offshore". With one row that name lies, so it is `PRICE_E33E` now, in both the generator and the template.

## Verification — run by the grader, not reported by the builder

- both JSON files parse, and their E33-family row sets are **identical**, price for price
- **zero** occurrences of either old string remain outside git history
- `pytest backend/tests/services/compliance/test_renewal_rules.py backend/tests/services/visa_check` → **rc=0**
- `ruff check` clean on all five touched `.py` files
- pre-commit and pre-push hooks ran and passed

Built on the **Codex** seat (`seat_build.sh`, xhigh, 571s). 9 files, +20/−38.

Closes the `operator[business]` PENDING-ARMS row opened in #4693 (senior pricing E33E/E33F parity) — a follow-up will mark it ruled and update the corner’s §3 owner-decisions block.