### PR TITLE
fix(secondhome): stop naming a land title our own source does not state, on a USD 1M route

### DIFF
--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -322,7 +322,7 @@
       "b": {
         "title": "Route B — Property",
         "amount": "USD 1,000,000",
-        "body": "A completed strata-title property (hak milik atas satuan rumah susun) worth at least USD 1,000,000.",
+        "body": "A completed strata unit (rumah susun or apartment) worth at least USD 1,000,000.",
         "note": "Completed strata-title only — off-plan purchases and leasehold do not qualify."
       }
     },
@@ -383,7 +383,7 @@
       "q1": "What is the E33 Second Home Visa for Indonesia?",
       "a1": "The E33 Second Home Visa is a long-term residence permit for financially established applicants. The first grant is up to 5 years and it is renewable, with a 10-year cumulative cap. It is a pure residence permit and does not authorize employment in Indonesia.",
       "q2": "How do I qualify for the Second Home Visa?",
-      "a2": "Two qualifying routes: a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata-title property (hak milik atas satuan rumah susun). Off-plan and leasehold property do not qualify.",
+      "a2": "Two qualifying routes: a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata unit (rumah susun or apartment). Off-plan and leasehold property do not qualify.",
       "q3": "Can I work in Indonesia on a Second Home Visa?",
       "a3": "No. The E33 is a residence permit only — it does not authorize employment. Paid work in Indonesia requires a separate work permit/KITAS.",
       "q4": "Is there a senior option for the Second Home Visa?",

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -322,7 +322,7 @@
       "b": {
         "title": "Jalur B — Properti",
         "amount": "USD 1.000.000",
-        "body": "Properti strata-title yang sudah selesai dibangun (hak milik atas satuan rumah susun) senilai minimal USD 1.000.000.",
+        "body": "Unit rumah susun atau apartemen yang sudah selesai dibangun dengan nilai minimal USD 1.000.000.",
         "note": "Hanya strata-title yang sudah selesai — pembelian off-plan dan leasehold tidak memenuhi syarat."
       }
     },
@@ -383,7 +383,7 @@
       "q1": "Apa itu Visa Second Home E33 Indonesia?",
       "a1": "Visa Second Home E33 adalah izin tinggal jangka panjang bagi pemohon dengan kondisi finansial mapan. Izin pertama hingga 5 tahun dan dapat diperpanjang, dengan batas kumulatif 10 tahun. Ini murni izin tinggal dan tidak memberikan hak bekerja di Indonesia.",
       "q2": "Bagaimana cara memenuhi syarat Visa Second Home?",
-      "a2": "Dua jalur kualifikasi: deposito USD 130.000 atas nama Anda sendiri di bank BUMN Indonesia, atau properti strata-title yang sudah selesai dibangun senilai USD 1.000.000 (hak milik atas satuan rumah susun). Properti off-plan dan leasehold tidak memenuhi syarat.",
+      "a2": "Dua jalur kualifikasi: deposito USD 130.000 atas nama Anda sendiri di bank BUMN Indonesia, atau unit rumah susun atau apartemen yang sudah selesai dibangun senilai USD 1.000.000. Properti off-plan dan leasehold tidak memenuhi syarat.",
       "q3": "Apakah saya bisa bekerja di Indonesia dengan Visa Second Home?",
       "a3": "Tidak. E33 hanyalah izin tinggal — tidak memberikan hak bekerja. Pekerjaan berbayar di Indonesia memerlukan izin kerja/KITAS terpisah.",
       "q4": "Apakah ada opsi senior untuk Visa Second Home?",

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -322,7 +322,7 @@
       "b": {
         "title": "Percorso B — Proprietà",
         "amount": "USD 1.000.000",
-        "body": "Una proprietà strata-title completata (hak milik atas satuan rumah susun) del valore di almeno USD 1.000.000.",
+        "body": "Un'unità completata in un rumah susun o appartamento del valore di almeno USD 1.000.000.",
         "note": "Solo strata-title completata — acquisti off-plan e leasehold non sono validi."
       }
     },
@@ -383,7 +383,7 @@
       "q1": "Cos'è il visto Second Home E33 per l'Indonesia?",
       "a1": "Il visto Second Home E33 è un permesso di soggiorno a lungo termine per richiedenti con solide disponibilità economiche. Il primo rilascio dura fino a 5 anni ed è rinnovabile, con un limite cumulativo di 10 anni. È un puro permesso di soggiorno e non autorizza il lavoro in Indonesia.",
       "q2": "Come ci si qualifica per il visto Second Home?",
-      "a2": "Due percorsi: un deposito di USD 130.000 intestato a te presso una banca statale indonesiana (BUMN), oppure una proprietà strata-title completata del valore di USD 1.000.000 (hak milik atas satuan rumah susun). Off-plan e leasehold non sono validi.",
+      "a2": "Due percorsi: un deposito di USD 130.000 intestato a te presso una banca statale indonesiana (BUMN), oppure un'unità completata in un rumah susun o appartamento del valore di USD 1.000.000. Off-plan e leasehold non sono validi.",
       "q3": "Posso lavorare in Indonesia con il visto Second Home?",
       "a3": "No. L'E33 è solo un permesso di soggiorno — non autorizza il lavoro. Il lavoro retribuito in Indonesia richiede un permesso di lavoro/KITAS separato.",
       "q4": "Esiste un'opzione senior per il visto Second Home?",

--- a/research/secondhome/e33-fact-registry.json
+++ b/research/secondhome/e33-fact-registry.json
@@ -33,12 +33,22 @@
     {
       "id": "e33_base_property_alternative",
       "topic": "Base E33 qualifying basis — property alternative",
-      "value": "USD 1,000,000 qualifying property — completed strata-title (hak milik atas satuan rumah susun) only; off-plan/leasehold do NOT qualify",
+      "value": "USD 1,000,000 qualifying property — completed strata unit (rumah susun / apartment) only; off-plan/leasehold do NOT qualify",
       "status": "confirmed",
       "confidence": "BERSYARAT",
-      "source": "live imigrasi.go.id E33 page fetch 2026-07-19; research/curated-qa-corrections-2026-07-21/visa-second-home-variants.jsonl Q2",
-      "source_date": "2026-07-19",
-      "notes": "BERSYARAT: the strata-title-only condition must always travel with the claim. How immigration validates the property (appraisal standard) is unknown (property_validation_standard)."
+      "source": "live imigrasi.go.id E33 page fetch 2026-07-19; research/curated-qa-corrections-2026-07-21/visa-second-home-variants.jsonl Q2; Ditjen Imigrasi E33 index page re-fetch 2026-08-23 states only 'properti berupa rumah susun atau apartemen' and is silent on title type",
+      "source_date": "2026-08-23",
+      "notes": "BERSYARAT: the completed-strata-unit condition must always travel with the claim. The Ditjen Imigrasi page is silent on title type; PP 18/2021 points to Hak Pakai for foreign holders, but the qualifying title type remains unresolved and must not be asserted. This is not covered by letters 001-006; the tracker has zero questions on the property route. How immigration validates the property (appraisal standard) is unknown (property_validation_standard)."
+    },
+    {
+      "id": "e33_base_property_title_type",
+      "topic": "Base E33 property route — qualifying title type",
+      "value": "Which legal title type qualifies for the USD 1,000,000 completed-strata-unit property route",
+      "status": "unknown",
+      "confidence": "BELUM_DIATUR_PUBLIK",
+      "source": "Ditjen Imigrasi E33 index page re-fetch 2026-08-23 (states only 'properti berupa rumah susun atau apartemen' and is silent on title type); PP 18/2021 review (points to Hak Pakai for foreign holders)",
+      "source_date": "2026-08-23",
+      "notes": "Unresolved: do not assert a qualifying title type. Not covered by letters 001-006; the tracker has zero questions on the property route. Candidate for a follow-up letter or addendum."
     },
     {
       "id": "e33_first_grant_duration",


### PR DESCRIPTION
The fact registry carried `e33_base_property_alternative` as **`status: confirmed`**, citing the official Ditjen Imigrasi E33 index page, with the value:

> "USD 1,000,000 qualifying property — completed strata-title **(hak milik atas satuan rumah susun)** only; off-plan/leasehold do NOT qualify"

That page, re-fetched 2026-08-23 by a cross-family refuter, says only **"properti berupa rumah susun atau apartemen"**. It is **silent on the title type**. The registry attributed to its own cited source a precision the source does not carry — and six client-facing strings repeated it, in three languages, on a **USD 1,000,000** route.

Not a harmless over-precision: under **PP 18/2021** a foreign national generally holds a strata unit in **Hak Pakai**, not Hak Milik. We were naming the one title a foreigner usually cannot hold.

## What was deliberately NOT done

**No substitution with "hak pakai".** Replacing one unsourced title with another is the identical defect facing the other way. The correct state is that we assert no title type and record why.

## What survives, because each has its own support

The USD 1,000,000 minimum · the **completed**-strata requirement · the **off-plan and leasehold exclusion**. Verified present in all three locales after the rewrite.

| locale | before | after |
|---|---|---|
| en | "A completed strata-title property (hak milik atas satuan rumah susun) worth at least USD 1,000,000." | "A completed strata unit (rumah susun or apartment) worth at least USD 1,000,000." |
| it | "Una proprietà strata-title completata (hak milik…) del valore di almeno USD 1.000.000." | "Un’unità completata in un rumah susun o appartamento del valore di almeno USD 1.000.000." |
| id | "Properti strata-title yang sudah selesai dibangun (hak milik…) senilai minimal USD 1.000.000." | "Unit rumah susun atau apartemen yang sudah selesai dibangun dengan nilai minimal USD 1.000.000." |

(plus the `a2` FAQ answer in each of the three, same treatment)

## The gap now has an honest home

A new registry fact **`e33_base_property_title_type`** — `status: unknown`, `confidence: BELUM_DIATUR_PUBLIK`, following the shape the file already uses for `property_validation_standard` — recording that the Ditjen page is silent, that PP 18/2021 points elsewhere, and this:

> **none of letters 001–006 asks it.** The tracker has **zero** questions touching the property route (grepped `propert|title|sertifikat|hak|strata|rumah susun|apartemen` — no hits). Waiting for those replies would never have answered this, which is why the fix is a source correction and not a blocked item.

The existing fact keeps `status: confirmed` for its **reduced** claim, keeps `BERSYARAT`, and its `source` now records the 2026-08-23 re-fetch and what the page actually says.

## Verification

- all four JSON files parse
- `grep -rn "hak milik"` across the registry and the three locales → **0**
- each locale still carries USD 1,000,000, the completed-strata requirement, and the off-plan/leasehold exclusion — checked per language

Built on the **Codex** seat (`seat_build.sh`, xhigh, 150s). 4 files, +21/−11.