### PR TITLE
fix(visa-oracle): offshore applicants can now reach the permit-status chain (P0)

### DIFF
--- a/apps/backend-rag/backend/services/visa_engine/fact_registry.py
+++ b/apps/backend-rag/backend/services/visa_engine/fact_registry.py
@@ -71,21 +71,6 @@ _MINOR_AGE_THRESHOLD = 18
 #: describes an EXTERNAL taxonomy fact about these specific strings, not a
 #: FactPath-level closed vocabulary.
 #:
-#: ``NO_STAY_PERMIT`` (added 2026-08-24, P0 offshore-reachability fix,
-#: team-lead funnel-cost review) is NOT one of the 8 real option keys above
-#: and is never offered as a UI choice — it is a synthesized sentinel
-#: ``apps/mouth``'s ``fact-mapper.ts`` emits directly when an OFFSHORE
-#: applicant answers the (already-existing) ``holds_stay_permit`` question
-#: "no", instead of asking the granular ``current_status_code`` question a
-#: second time for a fact its own answer already fully determines. This is
-#: not a guess: it is the literal, honest translation of what the applicant
-#: told us, distinct from every real document-derived code, and it belongs
-#: in this frozenset (not `_STAY_PERMIT_STATUS_CODE_SHAPE`) for the exact
-#: same reason a real visit-class code does — it is definitively NOT a
-#: residence permit, so no need to consult expiry either. See
-#: ``flow.ts::computeNextNode``'s offshore branch for the frontend routing
-#: that produces it, and the funnel-cost measurement in PR #4727 for why
-#: this exists instead of unconditionally asking the full onshore chain.
 _VISIT_CLASS_STATUS_CODES: frozenset[str] = frozenset(
     {
         "A1",
@@ -96,9 +81,31 @@ _VISIT_CLASS_STATUS_CODES: frozenset[str] = frozenset(
         "ITK_FROM_VISIT_C",
         "ITK_FROM_VISIT_D",
         "ITK_PERALIHAN",
-        "NO_STAY_PERMIT",
     }
 )
+
+#: Synthesized sentinel (added 2026-08-24, P0 offshore-reachability fix,
+#: PR #4727) — NOT one of the 8 real ``current_status_code`` option keys and
+#: never offered as a UI choice. ``apps/mouth``'s ``fact-mapper.ts`` emits it
+#: directly when an OFFSHORE applicant answers the (already-existing)
+#: ``holds_stay_permit`` question "no", instead of asking the granular
+#: ``current_status_code`` question a second time for a fact its own answer
+#: already fully determines. This is not a guess: it is the literal, honest
+#: translation of what the applicant told us.
+#:
+#: Deliberately kept OUT of ``_VISIT_CLASS_STATUS_CODES`` (team-lead review,
+#: 2026-08-24): that set is a two-sided grounding of REAL document-derived
+#: codes — every member appears on an actual permit/visa document. A synthetic
+#: "holds nothing at all" sentinel is not a visit-class code, it is the
+#: ABSENCE of one, and folding it in would corrupt what the set's name says
+#: it means — especially now that F4 (ruling 2, renewal-in-process) is about
+#: to re-examine ``ITK_PERALIHAN``'s membership in this exact set. Checked
+#: explicitly and early in ``_derive_has_active_stay_permit`` instead, so the
+#: sentinel's semantics never couple to whatever F4 does to the real-code set.
+#: See ``flow.ts::computeNextNode``'s offshore branch for the frontend
+#: routing that produces it, and the funnel-cost measurement in PR #4727 for
+#: why this exists instead of unconditionally asking the full onshore chain.
+NO_STAY_PERMIT = "NO_STAY_PERMIT"
 
 #: ``derived.has_active_stay_permit`` grounding, side 2 of 2: the SHAPE of a
 #: LIMITED_STAY/PERMANENT_STAY (ITAS/ITAP-class) product code in the current
@@ -708,6 +715,12 @@ class FactRegistry:
             return UnknownFact(reason=code.reason)
 
         code_value = str(code.value)
+        if code_value == NO_STAY_PERMIT:
+            # The applicant told us directly they hold nothing at all
+            # (offshore P0 fix, PR #4727) — checked first and explicitly,
+            # never folded into _VISIT_CLASS_STATUS_CODES (see that
+            # constant's docstring for why).
+            return KnownFact(value=False)
         if code_value in _VISIT_CLASS_STATUS_CODES:
             # A visit-class code is definitively not a residence permit,
             # regardless of its own expiry — no need to consult

--- a/apps/backend-rag/backend/services/visa_engine/fact_registry.py
+++ b/apps/backend-rag/backend/services/visa_engine/fact_registry.py
@@ -54,7 +54,8 @@ JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dic
 _INDONESIA_COUNTRY_CODE = "ID"
 _MINOR_AGE_THRESHOLD = 18
 
-#: ``derived.has_active_stay_permit`` grounding, side 1 of 2 (2026-08-23):
+#: ``derived.has_active_stay_permit`` grounding, side 1 of 2 (2026-08-23,
+#: extended 2026-08-24 with a 9th, synthesized value — see below):
 #: the exact 8 option keys ``apps/mouth``'s ``current_status_code`` question
 #: offers today (the only values the live frontend can ever send as KNOWN —
 #: an "other" answer is filtered to UNKNOWN client-side, see that question's
@@ -69,6 +70,22 @@ _MINOR_AGE_THRESHOLD = 18
 #: kept a separate frozenset (not derived from the enum registry) because it
 #: describes an EXTERNAL taxonomy fact about these specific strings, not a
 #: FactPath-level closed vocabulary.
+#:
+#: ``NO_STAY_PERMIT`` (added 2026-08-24, P0 offshore-reachability fix,
+#: team-lead funnel-cost review) is NOT one of the 8 real option keys above
+#: and is never offered as a UI choice — it is a synthesized sentinel
+#: ``apps/mouth``'s ``fact-mapper.ts`` emits directly when an OFFSHORE
+#: applicant answers the (already-existing) ``holds_stay_permit`` question
+#: "no", instead of asking the granular ``current_status_code`` question a
+#: second time for a fact its own answer already fully determines. This is
+#: not a guess: it is the literal, honest translation of what the applicant
+#: told us, distinct from every real document-derived code, and it belongs
+#: in this frozenset (not `_STAY_PERMIT_STATUS_CODE_SHAPE`) for the exact
+#: same reason a real visit-class code does — it is definitively NOT a
+#: residence permit, so no need to consult expiry either. See
+#: ``flow.ts::computeNextNode``'s offshore branch for the frontend routing
+#: that produces it, and the funnel-cost measurement in PR #4727 for why
+#: this exists instead of unconditionally asking the full onshore chain.
 _VISIT_CLASS_STATUS_CODES: frozenset[str] = frozenset(
     {
         "A1",
@@ -79,6 +96,7 @@ _VISIT_CLASS_STATUS_CODES: frozenset[str] = frozenset(
         "ITK_FROM_VISIT_C",
         "ITK_FROM_VISIT_D",
         "ITK_PERALIHAN",
+        "NO_STAY_PERMIT",
     }
 )
 

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_fact_registry.py
@@ -782,6 +782,29 @@ class TestDeriveHasActiveStayPermit:
         snapshot = self._snapshot(self._known("C1"), self._unknown())
         assert snapshot.values[FactPath.DERIVED_HAS_ACTIVE_STAY_PERMIT] == KnownFact(value=False)
 
+    # -- grounding: NO_STAY_PERMIT, the offshore convergence sentinel ------
+
+    def test_no_stay_permit_sentinel_is_a_definite_false_the_reachability_proof_for_pr_4727(
+        self,
+    ) -> None:
+        # This is the backend half of the P0 offshore-reachability fix's
+        # own reachability proof (team-lead review, PR #4727): NOT one of
+        # tree.ts's 8 real current_status_code options — it is a value
+        # apps/mouth's fact-mapper.ts synthesizes directly, without asking
+        # a question, when an OFFSHORE applicant answers the existing
+        # `holds_stay_permit` gate "no" (flow.test.ts and
+        # fact-mapper.test.ts on that PR prove the frontend reaches this
+        # value with zero further questions). This test proves the OTHER
+        # half: the wire value the frontend actually sends resolves the
+        # fact DEFINITELY on the real derivation, not to UNKNOWN — the
+        # exact failure mode the original P0 exposed at the flow-graph
+        # level with no backend fact ever reachable at all. Expiry is
+        # irrelevant here for the same reason as every other visit-class
+        # code: a NO_STAY_PERMIT applicant was never a residence-permit
+        # holder in the first place.
+        snapshot = self._snapshot(self._known("NO_STAY_PERMIT"), self._unknown())
+        assert snapshot.values[FactPath.DERIVED_HAS_ACTIVE_STAY_PERMIT] == KnownFact(value=False)
+
     # -- grounding: an unclassifiable code is honestly UNKNOWN, never a guess --
 
     @pytest.mark.parametrize("code", ["XYZ", "other", "B211", "NONE_ISSUED"])

--- a/apps/mouth/e2e/visa-oracle-v2.spec.ts
+++ b/apps/mouth/e2e/visa-oracle-v2.spec.ts
@@ -12,6 +12,12 @@ const SCREENSHOT_DIR = path.resolve(
 );
 const VERDICT_FACTS = {
   in_indonesia: "no",
+  // Added 2026-08-24 (P0 offshore-reachability fix, PR #4727): offshore now
+  // gates on this question before converging on overstay_days — see
+  // flow.ts::computeNextNode's "in_indonesia" case. "no" here means the
+  // synthesized NO_STAY_PERMIT sentinel resolves the derived fact without a
+  // further question (fact-mapper.ts::mapCurrentStatusCode).
+  holds_stay_permit: "no",
   overstay_days: "0",
   nationalities: "US",
   birth_date: "1990-01-01",
@@ -24,6 +30,9 @@ const VERDICT_FACTS = {
 const VERDICT_HISTORY = [
   { kind: "framing" },
   { kind: "question", questionId: "in_indonesia" },
+  // Added 2026-08-24 alongside VERDICT_FACTS.holds_stay_permit above — see
+  // that constant's comment.
+  { kind: "question", questionId: "holds_stay_permit" },
   { kind: "question", questionId: "overstay_days" },
   { kind: "question", questionId: "nationalities" },
   { kind: "question", questionId: "birth_date" },
@@ -335,6 +344,11 @@ test.describe("Visa Oracle v2 integration — page Page", () => {
     await page.getByRole("button", { name: /^start$/i }).click();
     await page.getByRole("button", { name: /no, i.m planning ahead/i }).click();
 
+    // Added 2026-08-24 (P0 offshore-reachability fix, PR #4727): offshore
+    // now gates on holds_stay_permit before overstay_days — see
+    // VERDICT_FACTS.holds_stay_permit's comment above for the mechanism.
+    await page.getByRole("button", { name: "No", exact: true }).click();
+
     await page.getByRole("spinbutton").fill("0");
     await page.getByRole("button", { name: /^continue$/i }).click();
 
@@ -455,6 +469,20 @@ test.describe("Visa Oracle v2 integration — page Page", () => {
         page,
         page.getByRole("button", {
           name: translate(language, "q.in_indonesia.opt.no"),
+          exact: true,
+        }),
+      );
+      // Added 2026-08-24 (P0 offshore-reachability fix, PR #4727) — see
+      // VERDICT_FACTS.holds_stay_permit's comment above for the mechanism.
+      await expectFocusedHeading(
+        page,
+        translate(language, "q.holds_stay_permit"),
+      );
+
+      await keyboardActivate(
+        page,
+        page.getByRole("button", {
+          name: translate(language, "q.boolean.no"),
           exact: true,
         }),
       );

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
@@ -30,12 +30,11 @@ import { OracleShell } from "./OracleShell";
 
 const ANSWERS = [
   ["in_indonesia", "no"],
-  // Offshore now enters the same permit-status chain as onshore (fixed
-  // 2026-08-24, D12 offshore-reachability P0) — answered "no" to preserve
-  // this fixture's original downstream intent.
-  ["permit_expiry", "2026-09-01"],
+  // Offshore now asks a single permit-status gate question, converging
+  // immediately on "no" (fixed 2026-08-24, D12 offshore-reachability P0,
+  // then re-fixed same day after a funnel-cost review) — answered "no"
+  // to preserve this fixture's original downstream intent.
   ["holds_stay_permit", "no"],
-  ["current_status_code", "C1"],
   ["overstay_days", "0"],
   ["nationalities", "US"],
   ["birth_date", "1990-01-01"],
@@ -99,16 +98,17 @@ async function completeFreshInterview(): Promise<void> {
     await screen.findByRole("button", { name: /planning ahead/i }),
   );
 
-  // Offshore now enters the same permit-status chain as onshore (fixed
-  // 2026-08-24, D12 offshore-reachability P0) before reaching overstay_days.
-  await screen.findByRole("heading", { name: /current stay permit expire/i });
-  const permitExpiryDate =
-    document.querySelector<HTMLInputElement>('input[type="date"]');
-  expect(permitExpiryDate).not.toBeNull();
-  fireEvent.change(permitExpiryDate!, { target: { value: "2026-09-01" } });
-  fireEvent.click(screen.getByRole("button", { name: /see my options/i }));
+  // Offshore now asks a single permit-status gate question before
+  // converging (fixed 2026-08-24, D12 offshore-reachability P0, then
+  // re-fixed same day after a funnel-cost review — see flow.ts's
+  // `in_indonesia`/`holds_stay_permit` cases). "no" here converges
+  // straight to overstay_days with no further permit questions — the
+  // fact resolves from this answer alone via fact-mapper.ts's
+  // synthesized NO_STAY_PERMIT (see fact-mapper.test.ts for that proof).
+  await screen.findByRole("heading", {
+    name: /do you currently hold a limited or permanent stay permit/i,
+  });
   fireEvent.click(await screen.findByRole("button", { name: /^no$/i }));
-  fireEvent.click(await screen.findByRole("button", { name: /^c1$/i }));
 
   fireEvent.change(await screen.findByRole("spinbutton"), {
     target: { value: "0" },

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
@@ -30,6 +30,12 @@ import { OracleShell } from "./OracleShell";
 
 const ANSWERS = [
   ["in_indonesia", "no"],
+  // Offshore now enters the same permit-status chain as onshore (fixed
+  // 2026-08-24, D12 offshore-reachability P0) — answered "no" to preserve
+  // this fixture's original downstream intent.
+  ["permit_expiry", "2026-09-01"],
+  ["holds_stay_permit", "no"],
+  ["current_status_code", "C1"],
   ["overstay_days", "0"],
   ["nationalities", "US"],
   ["birth_date", "1990-01-01"],
@@ -92,6 +98,17 @@ async function completeFreshInterview(): Promise<void> {
   fireEvent.click(
     await screen.findByRole("button", { name: /planning ahead/i }),
   );
+
+  // Offshore now enters the same permit-status chain as onshore (fixed
+  // 2026-08-24, D12 offshore-reachability P0) before reaching overstay_days.
+  await screen.findByRole("heading", { name: /current stay permit expire/i });
+  const permitExpiryDate =
+    document.querySelector<HTMLInputElement>('input[type="date"]');
+  expect(permitExpiryDate).not.toBeNull();
+  fireEvent.change(permitExpiryDate!, { target: { value: "2026-09-01" } });
+  fireEvent.click(screen.getByRole("button", { name: /see my options/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /^no$/i }));
+  fireEvent.click(await screen.findByRole("button", { name: /^c1$/i }));
 
   fireEvent.change(await screen.findByRole("spinbutton"), {
     target: { value: "0" },

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -276,6 +276,53 @@ describe("mapCurrentStatusExpiry — permit_expiry -> immigration.current_status
   });
 });
 
+describe("mapCurrentStatusCode — the synthesized NO_STAY_PERMIT sentinel (2026-08-24 P0 fix)", () => {
+  // mapCurrentStatusCode is not exported (internal to mapOracleFactsToApplicantFacts);
+  // reached here through the same `immigration.current_status_code` wire key
+  // every other test in this file uses for the exported facts, mapper.ts's
+  // own convention.
+  it("stay_permit_code answered -> KNOWN with the E-code, unaffected by holds_stay_permit", () => {
+    expect(
+      mapFacts({
+        stay_permit_code: "E28A",
+        holds_stay_permit: "yes",
+      }).facts["immigration.current_status_code"],
+    ).toEqual({ status: "KNOWN", value: "E28A" });
+  });
+
+  it("current_status_code answered (onshore 'no' path) -> KNOWN with the real visit-class code, never the sentinel", () => {
+    expect(
+      mapFacts({
+        current_status_code: "C1",
+        holds_stay_permit: "no",
+      }).facts["immigration.current_status_code"],
+    ).toEqual({ status: "KNOWN", value: "C1" });
+  });
+
+  it("neither raw field answered, holds_stay_permit='no' (offshore convergence) -> KNOWN NO_STAY_PERMIT, no question asked", () => {
+    expect(
+      mapFacts({ holds_stay_permit: "no" }).facts[
+        "immigration.current_status_code"
+      ],
+    ).toEqual({ status: "KNOWN", value: "NO_STAY_PERMIT" });
+  });
+
+  it("neither raw field answered, holds_stay_permit='yes' -> UNKNOWN NOT_ASKED (still waiting on stay_permit_code)", () => {
+    expect(
+      mapFacts({ holds_stay_permit: "yes" }).facts[
+        "immigration.current_status_code"
+      ],
+    ).toEqual({ status: "UNKNOWN", reason: "NOT_ASKED" });
+  });
+
+  it("nothing answered at all -> UNKNOWN NOT_ASKED", () => {
+    expect(mapFacts({}).facts["immigration.current_status_code"]).toEqual({
+      status: "UNKNOWN",
+      reason: "NOT_ASKED",
+    });
+  });
+});
+
 describe("mapSponsorType — sponsor_category -> sponsor.type", () => {
   it("never asked -> UNKNOWN NOT_ASKED (the pre-existing default value)", () => {
     expect(mapSponsorType({})).toEqual({

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -453,11 +453,34 @@ export function mapDisclosedReviewFlags(
 // to NOT_ASKED because the gate field was never populated. Both branches go
 // through `enumFact`, so an unrecognized or "unsure" value resolves UNKNOWN
 // either way — never a guessed KNOWN.
+//
+// A THIRD case (added 2026-08-24, P0 offshore-reachability fix): an
+// OFFSHORE applicant (`in_indonesia === "no"`) who answers
+// `holds_stay_permit === "no"` is never asked `current_status_code` at all
+// — `flow.ts::computeNextNode`'s offshore branch converges straight to
+// `overstay_days` instead, specifically to avoid paying a redundant
+// question for a fact `holds_stay_permit`'s own answer already fully
+// determines (measured funnel-cost review, PR #4727: asking it anyway
+// would cost every offshore applicant of every product 3 questions to
+// serve one product's rule). When neither raw field is populated but
+// `holds_stay_permit` is explicitly "no", emit the synthesized
+// `NO_STAY_PERMIT` sentinel directly (see `fact_registry.py`'s
+// `_VISIT_CLASS_STATUS_CODES` docstring for why this is honest, not a
+// guess) rather than falling through to NOT_ASKED. This branch can never
+// fire for onshore: onshore always asks the real `current_status_code`
+// question on "no" (unchanged), so that raw field is already populated by
+// the time this mapper runs and the second branch above wins first.
 function mapCurrentStatusCode(facts: OracleFacts): FactValue<string> {
   if (facts.stay_permit_code !== undefined) {
     return enumFact(facts.stay_permit_code, STAY_PERMIT_CODES);
   }
-  return enumFact(facts.current_status_code, CURRENT_STATUS_CODES);
+  if (facts.current_status_code !== undefined) {
+    return enumFact(facts.current_status_code, CURRENT_STATUS_CODES);
+  }
+  if (facts.holds_stay_permit === "no") {
+    return known("NO_STAY_PERMIT");
+  }
+  return unknownFact(NOT_ASKED);
 }
 
 /**

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -40,13 +40,15 @@ function startOffshore(category?: string): FlowState {
   let state = initialFlowState("en");
   state = reduce(state, { type: "ADVANCE" });
   state = answer(state, "in_indonesia", "no");
-  // Offshore now enters the same permit-status chain as onshore (fixed
-  // 2026-08-24, D12 offshore-reachability P0) — answered "no" here to
-  // preserve every downstream test's original intent (none of them are
-  // about permit status).
-  state = answer(state, "permit_expiry", "2026-09-01");
+  // Offshore now asks a single permit-status gate question before
+  // converging (fixed 2026-08-24, D12 offshore-reachability P0, then
+  // re-fixed same day after a funnel-cost review — see `computeNextNode`'s
+  // `in_indonesia`/`holds_stay_permit` cases). "no" here converges
+  // straight to `overstay_days` with no further questions (the fact
+  // resolves from this answer alone via `fact-mapper.ts`'s synthesized
+  // `NO_STAY_PERMIT`) — preserved here to keep every downstream test's
+  // original intent (none of them are about permit status).
   state = answer(state, "holds_stay_permit", "no");
-  state = answer(state, "current_status_code", "C1");
   state = answer(state, "overstay_days", "0");
   state = answer(state, "nationalities", "IT");
   state = answer(state, "birth_date", "1990-02-03");
@@ -326,26 +328,57 @@ describe("onshore/offshore canonical fact collection", () => {
     });
   });
 
-  it("asks the permit-status chain offshore too, then converges on overstay_days and skips the onshore-conversion-only fields", () => {
-    // Fixed 2026-08-24 (D12 offshore-reachability P0): before this fix, "no"
-    // skipped straight to overstay_days, so an offshore applicant's
-    // current-status/permit facts could never be collected — including the
-    // exact person the D12 owner ruling names (someone abroad holding an
-    // unlapsed KITAS). wants_onshore_conversion/application_channel remain
+  it("offshore + holds a permit: gates on holds_stay_permit first, then asks the full chain, then converges", () => {
+    // Fixed 2026-08-24 (D12 offshore-reachability P0, then re-fixed same
+    // day after a funnel-cost review): before the P0 fix, "no" skipped
+    // straight to overstay_days, so an offshore applicant's
+    // current-status/permit facts could never be collected — including
+    // the exact person the D12 owner ruling names (someone abroad holding
+    // an unlapsed KITAS). The first fix mirrored the onshore order
+    // unconditionally (permit_expiry asked before knowing whether the
+    // applicant even holds a permit); this version gates on
+    // holds_stay_permit FIRST for offshore instead, to avoid paying the
+    // full chain for applicants who don't hold one (see the sibling test
+    // below). wants_onshore_conversion/application_channel remain
     // onshore-only, unchanged by this fix.
     let state = initialFlowState("en");
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "no");
-    expectQuestion(state, "permit_expiry");
-    state = answer(state, "permit_expiry", "2026-09-01");
     expectQuestion(state, "holds_stay_permit");
     state = answer(state, "holds_stay_permit", "yes");
+    expectQuestion(state, "permit_expiry");
+    state = answer(state, "permit_expiry", "2026-09-01");
     expectQuestion(state, "stay_permit_code");
     state = answer(state, "stay_permit_code", "E28A");
     expectQuestion(state, "overstay_days");
     state = answer(state, "overstay_days", "0");
     expectQuestion(state, "nationalities");
     expect(state.facts.stay_permit_code).toBe("E28A");
+    expect(state.facts.application_channel).toBeUndefined();
+  });
+
+  it("offshore + no permit: converges on overstay_days after exactly one gate question, no code/expiry asked", () => {
+    // The funnel-cost half of the same 2026-08-24 fix: an offshore
+    // applicant who does not hold a permit pays exactly ONE extra
+    // question (holds_stay_permit itself), not the full 3-question
+    // chain — permit_expiry/stay_permit_code/current_status_code are
+    // never reached at all. Reachability of
+    // derived.has_active_stay_permit from this path (the synthesized
+    // NO_STAY_PERMIT sentinel resolving to a definite False) is proven
+    // at the backend in fact-mapper.test.ts and
+    // test_d12_active_stay_permit_exclusion.py, not here — this test
+    // only proves the frontend never asks the redundant questions.
+    let state = initialFlowState("en");
+    state = reduce(state, { type: "ADVANCE" });
+    state = answer(state, "in_indonesia", "no");
+    expectQuestion(state, "holds_stay_permit");
+    state = answer(state, "holds_stay_permit", "no");
+    expectQuestion(state, "overstay_days");
+    state = answer(state, "overstay_days", "0");
+    expectQuestion(state, "nationalities");
+    expect(state.facts.permit_expiry).toBeUndefined();
+    expect(state.facts.stay_permit_code).toBeUndefined();
+    expect(state.facts.current_status_code).toBeUndefined();
     expect(state.facts.application_channel).toBeUndefined();
   });
 
@@ -657,14 +690,18 @@ describe("editing, pruning and branch projection", () => {
     expectQuestion(state, "trip_scope");
   });
 
-  it("editing in_indonesia prunes stale answers and re-enters the (now shared) permit-status chain", () => {
-    // Renamed and updated 2026-08-24 (D12 offshore-reachability P0 fix):
-    // permit_expiry/current_status_code are no longer onshore-only — both
-    // branches ask them now, so switching to "no" re-enters that same
-    // chain instead of skipping to overstay_days. application_channel
-    // remains genuinely onshore-only (only reachable after
-    // wants_onshore_conversion, which stays gated on in_indonesia==="yes"),
-    // so it is still correctly pruned and unreachable here.
+  it("editing in_indonesia prunes stale answers and re-enters the (now shared, differently-ordered) permit-status chain", () => {
+    // Renamed and updated 2026-08-24 (D12 offshore-reachability P0 fix,
+    // then re-fixed same day after a funnel-cost review): the fact is no
+    // longer onshore-only-reachable — both branches can reach it now —
+    // but the OFFSHORE order gates on holds_stay_permit first (funnel-cost
+    // minimization: a "no" answer converges immediately, see the
+    // dedicated tests above), so switching to "no" re-enters a
+    // differently-shaped chain, not the identical onshore one.
+    // application_channel remains genuinely onshore-only (only reachable
+    // after wants_onshore_conversion, which stays gated on
+    // in_indonesia==="yes"), so it is still correctly pruned and
+    // unreachable here.
     let state = initialFlowState("en");
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "yes");
@@ -680,14 +717,16 @@ describe("editing, pruning and branch projection", () => {
     expect(state.facts.permit_expiry).toBeUndefined();
     expect(state.facts.current_status_code).toBeUndefined();
     expect(state.facts.application_channel).toBeUndefined();
-    expectQuestion(state, "permit_expiry");
+    expectQuestion(state, "holds_stay_permit");
 
     // Prove the chain is genuinely reachable now, not just present in
-    // history — answer it through to convergence.
-    state = answer(state, "permit_expiry", "2026-09-01");
+    // history — answer it through to convergence via BOTH offshore
+    // sub-branches are covered by the dedicated tests above; here, prove
+    // re-entry specifically converges correctly on the "no" path.
     state = answer(state, "holds_stay_permit", "no");
-    state = answer(state, "current_status_code", "C1");
     expectQuestion(state, "overstay_days");
+    expect(state.facts.permit_expiry).toBeUndefined();
+    expect(state.facts.current_status_code).toBeUndefined();
     expect(state.facts.application_channel).toBeUndefined();
   });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -40,6 +40,13 @@ function startOffshore(category?: string): FlowState {
   let state = initialFlowState("en");
   state = reduce(state, { type: "ADVANCE" });
   state = answer(state, "in_indonesia", "no");
+  // Offshore now enters the same permit-status chain as onshore (fixed
+  // 2026-08-24, D12 offshore-reachability P0) — answered "no" here to
+  // preserve every downstream test's original intent (none of them are
+  // about permit status).
+  state = answer(state, "permit_expiry", "2026-09-01");
+  state = answer(state, "holds_stay_permit", "no");
+  state = answer(state, "current_status_code", "C1");
   state = answer(state, "overstay_days", "0");
   state = answer(state, "nationalities", "IT");
   state = answer(state, "birth_date", "1990-02-03");
@@ -319,14 +326,26 @@ describe("onshore/offshore canonical fact collection", () => {
     });
   });
 
-  it("asks active overstay offshore but skips onshore-only status fields", () => {
+  it("asks the permit-status chain offshore too, then converges on overstay_days and skips the onshore-conversion-only fields", () => {
+    // Fixed 2026-08-24 (D12 offshore-reachability P0): before this fix, "no"
+    // skipped straight to overstay_days, so an offshore applicant's
+    // current-status/permit facts could never be collected — including the
+    // exact person the D12 owner ruling names (someone abroad holding an
+    // unlapsed KITAS). wants_onshore_conversion/application_channel remain
+    // onshore-only, unchanged by this fix.
     let state = initialFlowState("en");
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "no");
+    expectQuestion(state, "permit_expiry");
+    state = answer(state, "permit_expiry", "2026-09-01");
+    expectQuestion(state, "holds_stay_permit");
+    state = answer(state, "holds_stay_permit", "yes");
+    expectQuestion(state, "stay_permit_code");
+    state = answer(state, "stay_permit_code", "E28A");
     expectQuestion(state, "overstay_days");
     state = answer(state, "overstay_days", "0");
     expectQuestion(state, "nationalities");
-    expect(state.facts.current_status_code).toBeUndefined();
+    expect(state.facts.stay_permit_code).toBe("E28A");
     expect(state.facts.application_channel).toBeUndefined();
   });
 
@@ -638,7 +657,14 @@ describe("editing, pruning and branch projection", () => {
     expectQuestion(state, "trip_scope");
   });
 
-  it("editing in_indonesia prunes every onshore descendant", () => {
+  it("editing in_indonesia prunes stale answers and re-enters the (now shared) permit-status chain", () => {
+    // Renamed and updated 2026-08-24 (D12 offshore-reachability P0 fix):
+    // permit_expiry/current_status_code are no longer onshore-only — both
+    // branches ask them now, so switching to "no" re-enters that same
+    // chain instead of skipping to overstay_days. application_channel
+    // remains genuinely onshore-only (only reachable after
+    // wants_onshore_conversion, which stays gated on in_indonesia==="yes"),
+    // so it is still correctly pruned and unreachable here.
     let state = initialFlowState("en");
     state = reduce(state, { type: "ADVANCE" });
     state = answer(state, "in_indonesia", "yes");
@@ -654,7 +680,15 @@ describe("editing, pruning and branch projection", () => {
     expect(state.facts.permit_expiry).toBeUndefined();
     expect(state.facts.current_status_code).toBeUndefined();
     expect(state.facts.application_channel).toBeUndefined();
+    expectQuestion(state, "permit_expiry");
+
+    // Prove the chain is genuinely reachable now, not just present in
+    // history — answer it through to convergence.
+    state = answer(state, "permit_expiry", "2026-09-01");
+    state = answer(state, "holds_stay_permit", "no");
+    state = answer(state, "current_status_code", "C1");
     expectQuestion(state, "overstay_days");
+    expect(state.facts.application_channel).toBeUndefined();
   });
 
   it("back is a real history step and prunes the removed answer", () => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -418,27 +418,65 @@ export function computeNextNode(
 
   switch (current.questionId) {
     case "in_indonesia": {
-      // BOTH branches now enter the same permit-status chain (fixed
-      // 2026-08-24, Kimi refuter P0 finding on the D12 offshore-reachability
-      // gap): before this fix, `"no"` skipped straight to `overstay_days`,
-      // so `permit_expiry`/`holds_stay_permit`/`stay_permit_code`/
+      // Fixed 2026-08-24 (Kimi refuter P0 finding on the D12
+      // offshore-reachability gap, then re-fixed same day after a
+      // team-lead funnel-cost review rejected the first version): before
+      // the P0 fix, `"no"` skipped straight to `overstay_days`, so
+      // `permit_expiry`/`holds_stay_permit`/`stay_permit_code`/
       // `current_status_code` were structurally unreachable for every
       // offshore applicant — D12's own target population, including the
       // exact person the owner's D12 ruling names (someone abroad holding
       // an unlapsed KITAS). #4695 fixed the codes on offer but never the
-      // reachability of the gate itself; this closes the other half. The
-      // chain converges back to `overstay_days` exactly as it always did
-      // (see the `stay_permit_code`/`current_status_code` cases below), so
-      // nothing downstream of that convergence point changes for either
-      // branch.
-      return { kind: "question", questionId: "permit_expiry" };
+      // reachability of the gate itself.
+      //
+      // The FIRST fix mirrored the onshore chain unconditionally (ask
+      // `permit_expiry` first, same as onshore) — team-lead measured that
+      // as a flat 3-question cost added to EVERY offshore applicant of
+      // EVERY product (~38), to serve exactly one product's rule (grepped
+      // the live signed pack: no product other than D12 reads these facts
+      // for an offshore applicant — the only other consumer, `BRIDGING`,
+      // is itself onshore-only). This version instead asks
+      // `holds_stay_permit` FIRST for offshore — a single gate question —
+      // and only expands into the full `permit_expiry`/`stay_permit_code`
+      // chain on "yes". A "no" answer converges straight to
+      // `overstay_days`: `fact-mapper.ts::mapCurrentStatusCode` derives
+      // `immigration.current_status_code` directly from that "no" (the
+      // synthesized `NO_STAY_PERMIT` sentinel — see its docstring and
+      // `fact_registry.py`'s `_VISIT_CLASS_STATUS_CODES`), so the fact
+      // still resolves definitely without a redundant extra question.
+      // Onshore is completely unchanged — see the `permit_expiry` and
+      // `holds_stay_permit` cases below for how the two orders coexist
+      // without looping.
+      return facts.in_indonesia === "yes"
+        ? { kind: "question", questionId: "permit_expiry" }
+        : { kind: "question", questionId: "holds_stay_permit" };
     }
     case "permit_expiry":
-      return { kind: "question", questionId: "holds_stay_permit" };
-    case "holds_stay_permit":
+      // Onshore always arrives here FIRST (before `holds_stay_permit`,
+      // the pre-existing order — deliberately not redesigned by this fix).
+      // Offshore arrives here ONLY after `holds_stay_permit === "yes"`
+      // (see that case below), so routing offshore straight to
+      // `stay_permit_code` here — instead of back to `holds_stay_permit` —
+      // is required to avoid an infinite loop, not an inconsistency.
+      return facts.in_indonesia === "yes"
+        ? { kind: "question", questionId: "holds_stay_permit" }
+        : { kind: "question", questionId: "stay_permit_code" };
+    case "holds_stay_permit": {
+      if (facts.in_indonesia === "yes") {
+        // Onshore: unchanged pre-existing behavior.
+        return facts.holds_stay_permit === "yes"
+          ? { kind: "question", questionId: "stay_permit_code" }
+          : { kind: "question", questionId: "current_status_code" };
+      }
+      // Offshore: this is the gate question itself (asked before
+      // `permit_expiry`, unlike onshore). "yes" still needs the real
+      // code+expiry chain; "no" converges directly — see the
+      // `fact-mapper.ts` comment above for why no further question is
+      // needed to resolve the fact.
       return facts.holds_stay_permit === "yes"
-        ? { kind: "question", questionId: "stay_permit_code" }
-        : { kind: "question", questionId: "current_status_code" };
+        ? { kind: "question", questionId: "permit_expiry" }
+        : { kind: "question", questionId: "overstay_days" };
+    }
     case "stay_permit_code":
       return { kind: "question", questionId: "overstay_days" };
     case "current_status_code":
@@ -921,35 +959,54 @@ export function getTreeSteps(
   current: OracleNode,
   facts: OracleFacts,
 ): { trunk: TreeStep[]; categoryLeaves: TreeCategoryLeaf[] | null } {
+  // The permit-status chain has TWO distinct shapes depending on
+  // `in_indonesia` (fixed 2026-08-24 — see `computeNextNode`'s
+  // `in_indonesia`/`permit_expiry`/`holds_stay_permit` cases for the
+  // routing this mirrors, and the funnel-cost review that produced it).
+  // Onshore always shows the full 3-node chain in the pre-existing order
+  // (`permit_expiry` → `holds_stay_permit` → one of the two code
+  // questions) the moment `in_indonesia` has a value. Offshore shows
+  // `holds_stay_permit` FIRST, alone, until it too has a value — a "no"
+  // answer converges with NO further permit-chain steps (the fact
+  // resolves from that answer alone, see `fact-mapper.ts`), a "yes"
+  // answer then adds `permit_expiry` + `stay_permit_code`.
+  const permitChainSteps: { id: string; labelI18nKey: string }[] =
+    facts.in_indonesia === "yes"
+      ? [
+          { id: "permit_expiry", labelI18nKey: "tree.permit_expiry" },
+          { id: "holds_stay_permit", labelI18nKey: "tree.holds_stay_permit" },
+          facts.holds_stay_permit === "yes"
+            ? { id: "stay_permit_code", labelI18nKey: "tree.stay_permit_code" }
+            : {
+                id: "current_status_code",
+                labelI18nKey: "tree.current_status_code",
+              },
+        ]
+      : facts.in_indonesia === "no"
+        ? [
+            {
+              id: "holds_stay_permit",
+              labelI18nKey: "tree.holds_stay_permit",
+            },
+            ...(facts.holds_stay_permit === "yes"
+              ? [
+                  {
+                    id: "permit_expiry",
+                    labelI18nKey: "tree.permit_expiry",
+                  },
+                  {
+                    id: "stay_permit_code",
+                    labelI18nKey: "tree.stay_permit_code",
+                  },
+                ]
+              : []),
+          ]
+        : [];
+
   const order = [
     { id: "framing", labelI18nKey: "tree.framing" },
     { id: "in_indonesia", labelI18nKey: "tree.in_indonesia" },
-    // Both "yes" and "no" now enter the permit-status chain (fixed
-    // 2026-08-24, matching the `computeNextNode` fix above) — gated on
-    // "answered at all", not on the "yes" value specifically, so the tree
-    // doesn't show these steps before `in_indonesia` itself has a value.
-    ...(facts.in_indonesia !== undefined
-      ? [
-          { id: "permit_expiry", labelI18nKey: "tree.permit_expiry" },
-          {
-            id: "holds_stay_permit",
-            labelI18nKey: "tree.holds_stay_permit",
-          },
-          ...(facts.holds_stay_permit === "yes"
-            ? [
-                {
-                  id: "stay_permit_code",
-                  labelI18nKey: "tree.stay_permit_code",
-                },
-              ]
-            : [
-                {
-                  id: "current_status_code",
-                  labelI18nKey: "tree.current_status_code",
-                },
-              ]),
-        ]
-      : []),
+    ...permitChainSteps,
     { id: "overstay_days", labelI18nKey: "tree.overstay_days" },
     ...(facts.in_indonesia === "yes"
       ? [

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -418,10 +418,20 @@ export function computeNextNode(
 
   switch (current.questionId) {
     case "in_indonesia": {
-      if (facts.in_indonesia === "yes") {
-        return { kind: "question", questionId: "permit_expiry" };
-      }
-      return { kind: "question", questionId: "overstay_days" };
+      // BOTH branches now enter the same permit-status chain (fixed
+      // 2026-08-24, Kimi refuter P0 finding on the D12 offshore-reachability
+      // gap): before this fix, `"no"` skipped straight to `overstay_days`,
+      // so `permit_expiry`/`holds_stay_permit`/`stay_permit_code`/
+      // `current_status_code` were structurally unreachable for every
+      // offshore applicant — D12's own target population, including the
+      // exact person the owner's D12 ruling names (someone abroad holding
+      // an unlapsed KITAS). #4695 fixed the codes on offer but never the
+      // reachability of the gate itself; this closes the other half. The
+      // chain converges back to `overstay_days` exactly as it always did
+      // (see the `stay_permit_code`/`current_status_code` cases below), so
+      // nothing downstream of that convergence point changes for either
+      // branch.
+      return { kind: "question", questionId: "permit_expiry" };
     }
     case "permit_expiry":
       return { kind: "question", questionId: "holds_stay_permit" };
@@ -914,7 +924,11 @@ export function getTreeSteps(
   const order = [
     { id: "framing", labelI18nKey: "tree.framing" },
     { id: "in_indonesia", labelI18nKey: "tree.in_indonesia" },
-    ...(facts.in_indonesia === "yes"
+    // Both "yes" and "no" now enter the permit-status chain (fixed
+    // 2026-08-24, matching the `computeNextNode` fix above) — gated on
+    // "answered at all", not on the "yes" value specifically, so the tree
+    // doesn't show these steps before `in_indonesia` itself has a value.
+    ...(facts.in_indonesia !== undefined
       ? [
           { id: "permit_expiry", labelI18nKey: "tree.permit_expiry" },
           {


### PR DESCRIPTION
## Summary

Fixes the P0 offshore-reachability defect (Kimi K3 R1 adversarial review, dispatched by team-lead): `computeNextNode`'s `in_indonesia === "no"` branch skipped straight to `overstay_days`, so `permit_expiry`/`holds_stay_permit`/`stay_permit_code`/`current_status_code` — everything `derived.has_active_stay_permit` depends on — were reachable only for onshore applicants. D12 is offshore-applied by definition, so the future D12 EXCLUDE would have been unreachable for its entire target market.

**Revision history on this branch**: the first commit mirrored the onshore chain unconditionally (3 extra questions for every offshore applicant). team-lead's funnel-cost review rejected that: counted in `computeNextNode`, it's a flat 3-question cost added to EVERY offshore applicant of every product (~38), and a grep of the live signed pack (`rulepack-prod-013.source.json`, 111 rules) found no product other than D12 reads `current_status_code`/`current_status_expiry`/`has_active_stay_permit` for an offshore applicant — the only other consumer, `BRIDGING` (Izin Tinggal Peralihan), is itself onshore-only by definition.

## Design (current)

Offshore now gates on the existing `holds_stay_permit` question FIRST:
- **"no" (expected majority)**: converges straight to `overstay_days` — **zero** extra questions beyond the one gate. The backend fact still resolves definitely: `fact-mapper.ts` synthesizes a new `NO_STAY_PERMIT` sentinel directly from the "no" answer (honest translation of what the applicant told us, not a guess).
- **"yes"**: expands into `permit_expiry` → `stay_permit_code` (2 more questions), same total cost as the rejected first version, paid only by the minority it matters for.

Onshore is completely unchanged.

**Follow-up structural fix (team-lead review)**: `NO_STAY_PERMIT` was initially added as a member of `fact_registry.py`'s `_VISIT_CLASS_STATUS_CODES` frozenset — but every other member of that set is a REAL code that appears on a real document, and the sentinel means "holds nothing at all" (the absence of a code, not a code). Folding it in would have coupled "the user told us they have nothing" to F4's upcoming re-examination of whether `ITK_PERALIHAN` belongs in that same set. Cured: the sentinel is now a bare module constant, checked explicitly and first in `_derive_has_active_stay_permit`, before either bucket is consulted — same behavior, no coupling.

**E2E follow-up (root-caused via `gh run view --log-failed`, not rerun blind)**: `apps/mouth/e2e/visa-oracle-v2.spec.ts` hardcoded the pre-fix offshore shape in four places — the shared `VERDICT_FACTS`/`VERDICT_HISTORY` resume-seed fixtures (10 of 13 CI failures, via `seedVerdictResume`'s localStorage seed, which the app validates against the current flow shape and resets to start if stale), the "real EN/ID journey" test's scripted click sequence, and the keyboard-only EN/ID journey's assertions — all updated to insert the `holds_stay_permit` gate step. One separate, pre-existing flake surfaced and ruled out during investigation (not caused by this PR, not fixed here): a WCAG color-contrast check on `.oracle-tree__leaf[data-status="pending"]` (`--oracle-ink-faint`, `oracle.css` — zero diff on this branch) failed once under load, passed clean on an isolated rerun.

## Reachability proof (per review requirement — not merely "a question exists")

- `flow.test.ts`: two new tests walk both offshore branches end-to-end and assert the exact question sequence + convergence point + which facts stay `undefined`.
- `fact-mapper.test.ts`: new `describe` block proves the wire value `mapCurrentStatusCode` produces for every combination (E-code, real visit-class code, the new sentinel, not-yet-answered).
- `test_fact_registry.py`: new `test_no_stay_permit_sentinel_is_a_definite_false_the_reachability_proof_for_pr_4727` proves the real backend derivation resolves `NO_STAY_PERMIT` to `KnownFact(value=False)`, not `UnknownFact` — the failure mode the original P0 exposed one layer down.

## Test plan
- [x] 472/472 visa-oracle vitest suite green
- [x] `tsc --noEmit` clean
- [x] eslint clean (source files; test files are eslint-ignored by config)
- [x] prettier clean
- [x] 21/21 `TestDeriveHasActiveStayPermit` backend tests green, 91/91 `test_fact_registry.py`
- [x] ruff clean
- [x] 18/18 `e2e/visa-oracle-v2.spec.ts` (chromium) green, run locally after root-causing the CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
