### PR TITLE
docs(secondhome): align base E33 price in §4 with live 35M rate

### DIFF
--- a/.agents/skills/secondhome/SKILL.md
+++ b/.agents/skills/secondhome/SKILL.md
@@ -117,7 +117,7 @@ BY DESIGN until the first real case (F4b).
   purpose guard, 23 gold personas. `RelationType.SIBLING` added for E31J.
   First signed PRODUCTION RulePack (#3090): 38 products, 110 rules,
   28 sources, seq 1, version `2026.7.25`, payload sha `47a97c32…`.
-- **Pricing**: `VisaType.E33` + dedicated rows: base 39M; E33E 45M 5-year
+- **Pricing**: `VisaType.E33` + dedicated rows: base 35M; E33E 45M 5-year
   (+ 10M extend); E33F 14M offshore / 16M onshore (+ 10M extend). Bridge
   resolves all three.
 - **Guard**: `e33_claim_guard.py` hooked in `orchestrator_core.py` step 12b


### PR DESCRIPTION
Fixes a one-word stale price in the /secondhome corner.

The SKILL.md corner contradicted itself in three places:
- §3 Owner decisions already stated base E33 = **IDR 35,000,000** (repriced from 39M on 2026-08-19).
- §4bis LIVE STATE already reported production `E33 Second Home (5 Years)` at **35.000.000 IDR** (re-probed 2026-08-24).
- §4 "What's built" still listed the stale `base 39M`.

This change updates §4 to `base 35M`. E33E/E33F pricing and extend rows are untouched (already correct after #4742). Verified live via `search_service_pricing`.

Closes: the self-contradiction in `.agents/skills/secondhome/SKILL.md`.
