### PR TITLE
fix(mouth): the Studio quoted one price for three different products

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/lib/secondhome-studio/sequence";
 import {
   E33_LIVE_PRICE_CATEGORY,
-  E33_LIVE_PRICE_KEY,
+  resolveSecondHomePriceKey,
 } from "@/lib/secondhome-studio/pricing-key";
 import {
   clearPlan,
@@ -464,7 +464,16 @@ export function StudioApp() {
   const [plan, setPlan] = useState<PlanState>(emptyPlan);
   const [stepIndex, setStepIndex] = useState(0);
   const hydratedOnce = useRef(false);
-  const { price } = usePricingData(E33_LIVE_PRICE_KEY, E33_LIVE_PRICE_CATEGORY);
+
+  const sequence = computeSequence(plan);
+  const isVerdictStage = stepIndex >= sequence.length;
+  const currentQuestion = isVerdictStage ? null : sequence[stepIndex];
+  const verdict = isVerdictStage ? evaluatePlan(plan) : null;
+  const priceKey = resolveSecondHomePriceKey(
+    verdict?.product ?? null,
+    plan.location,
+  );
+  const { price } = usePricingData(priceKey, E33_LIVE_PRICE_CATEGORY);
 
   // P2-3: the stage heading (QuestionCard's <h2> or VerdictPanel's <h1> —
   // only one is ever mounted at a time) is focused on a user-driven step
@@ -536,10 +545,6 @@ export function StudioApp() {
     setStepIndex(0);
   }
 
-  const sequence = computeSequence(plan);
-  const isVerdictStage = stepIndex >= sequence.length;
-  const currentQuestion = isVerdictStage ? null : sequence[stepIndex];
-  const verdict = isVerdictStage ? evaluatePlan(plan) : null;
   // P1-C9: CustodyMap only makes sense for deposit-holding routes — a
   // property or E33F (income-only, no deposit) verdict never shows it.
   const showCustodyMap =

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/pricing-key.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/pricing-key.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  E33E_LIVE_PRICE_KEY,
+  E33F_OFFSHORE_LIVE_PRICE_KEY,
+  E33F_ONSHORE_LIVE_PRICE_KEY,
+  E33_LIVE_PRICE_KEY,
+  resolveSecondHomePriceKey,
+} from "../pricing-key";
+
+describe("resolveSecondHomePriceKey", () => {
+  it("resolves base E33 to its 5-year PricingTool row", () => {
+    expect(resolveSecondHomePriceKey("E33", "abroad")).toBe(E33_LIVE_PRICE_KEY);
+  });
+
+  it("regression: resolves E33E to the senior row, never the base E33 row", () => {
+    const key = resolveSecondHomePriceKey("E33E", "in_indonesia");
+
+    expect(key).toBe(E33E_LIVE_PRICE_KEY);
+    expect(key).not.toBe(E33_LIVE_PRICE_KEY);
+  });
+
+  it("resolves E33F abroad to the offshore row", () => {
+    expect(resolveSecondHomePriceKey("E33F", "abroad")).toBe(
+      E33F_OFFSHORE_LIVE_PRICE_KEY,
+    );
+  });
+
+  it("resolves E33F in Indonesia to the Altus/onshore row", () => {
+    expect(resolveSecondHomePriceKey("E33F", "in_indonesia")).toBe(
+      E33F_ONSHORE_LIVE_PRICE_KEY,
+    );
+  });
+
+  it("abstains for E33F when location is unknown", () => {
+    expect(resolveSecondHomePriceKey("E33F", null)).toBeNull();
+  });
+
+  it("abstains when the verdict has no product", () => {
+    expect(resolveSecondHomePriceKey(null, "abroad")).toBeNull();
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/pricing-key.ts
+++ b/apps/mouth/src/lib/secondhome-studio/pricing-key.ts
@@ -11,5 +11,32 @@
  * import this module), so any drift here that changed the values would
  * fail that test.
  */
+import type { Location, Verdict } from "./types";
+
 export const E33_LIVE_PRICE_KEY = "E33 Second Home (5 Years)";
+export const E33E_LIVE_PRICE_KEY = "E33E Second Home Senior (5 Years)";
+export const E33F_OFFSHORE_LIVE_PRICE_KEY =
+  "E33F Second Home Senior (1 Year, Offshore)";
+export const E33F_ONSHORE_LIVE_PRICE_KEY =
+  "E33F Second Home Senior (1 Year, Altus/Onshore)";
 export const E33_LIVE_PRICE_CATEGORY = "kitas_permits";
+
+/** Resolve the exact PricingTool identity for the Studio verdict. */
+export function resolveSecondHomePriceKey(
+  product: Verdict["product"],
+  location: Location | null,
+): string | null {
+  switch (product) {
+    case "E33":
+      return E33_LIVE_PRICE_KEY;
+    case "E33E":
+      return E33E_LIVE_PRICE_KEY;
+    case "E33F":
+      if (location === "abroad") return E33F_OFFSHORE_LIVE_PRICE_KEY;
+      if (location === "in_indonesia") return E33F_ONSHORE_LIVE_PRICE_KEY;
+      // Offshore and onshore are distinct products: without location, abstain.
+      return null;
+    case null:
+      return null;
+  }
+}


### PR DESCRIPTION
## The defect

The Second Home Studio's verdict branches across three products — `Verdict.product` is `"E33" | "E33E" | "E33F" | null` — but the price panel resolved **one** hardcoded PricingTool identity, `E33 Second Home (5 Years)`, and printed it whatever the verdict matched.

Live on a public page since 2026-08-19, under the caption *"One figure, everything included for the main applicant"*:

| verdict | showed | real price | error |
|---|---|---|---|
| `E33` | 35.000.000 | 35.000.000 | correct |
| `E33E` | 35.000.000 | **45.000.000** | understated by 10.000.000 |
| `E33F` | 35.000.000 | **14.000.000** offshore / **16.000.000** onshore | overstated by ~20.000.000 |

A senior matched to E33E read a price ten million rupiah below what the product sells for. Found by reading a production screenshot of the verdict stage — the wizard prints `Matching product: E33E` directly above the wrong figure.

## Why every test was green

The PricingTool-only rule was obeyed at the level of the **value** — the figure always came from `usePricingData`, never a literal — and violated at the level of the **key**. A test asserting "the price renders" passes. Only a test asserting *which row was resolved, per branch* can fail. There was none.

## The fix

`resolveSecondHomePriceKey(product, location)` maps the verdict's product — and, for `E33F` only, the offshore/onshore split the wizard already knows from `plan.location` — onto the matching PricingTool row. What is mapped is the **key**; the figure still comes from the pricing snapshot.

`E33_LIVE_PRICE_KEY` keeps its exact value: `SecondHomeLanding.tsx` and its `page.test.tsx` still resolve the base E33 row through it.

### The abstain case, deliberately

When the product is `E33F` and `location` is `null`, the resolver returns `null` and the price block does not render. Offshore and onshore are genuinely different products: picking one at random would be a wrong price, and showing a range would present two products as one figure — which also collides with the owner's rule that the price is always a single all-inclusive line.

## Tests

Six cases on the pure resolver: one per branch plus both abstain paths, including a regression case that fails against the previous code (`E33E` must not resolve the base row).

Verified locally in this worktree:
- `src/lib/secondhome-studio` — 8 files, **238 passed**
- `src/app/visa/second-home` — 3 files, **42 passed**
