### PR TITLE
feat(mouth): differentiate VerdictPanel by fit band

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { Verdict, VerdictBand } from "@/lib/secondhome-studio/types";
+import { VerdictPanel } from "./VerdictPanel";
+
+const baseVerdict = (band: VerdictBand): Verdict => ({
+  band,
+  product: band === "not_eligible" || band === "edge_case" ? null : "E33",
+  reasons: [],
+  humanReviewNote: null,
+});
+
+/** Read the inline border style written by the component. */
+function getPanelBorder(section: HTMLElement): {
+  width: number;
+  color: string;
+} {
+  const border = section.style.border;
+  const match = border.match(/^(\d+)px solid (.+)$/);
+  if (!match) {
+    throw new Error(`Unexpected border style: ${border}`);
+  }
+  return { width: Number(match[1]), color: match[2] };
+}
+
+describe("VerdictPanel", () => {
+  it.each([
+    ["strong_fit", "strong match"],
+    ["likely_fit", "likely match"],
+    ["edge_case", "needs human review"],
+    ["not_eligible", "does not fit"],
+  ] as const)("renders the %s verdict heading", (band, textMatch) => {
+    render(<VerdictPanel verdict={baseVerdict(band)} />);
+    expect(
+      screen.getByRole("heading", { name: new RegExp(textMatch, "i") }),
+    ).toBeInTheDocument();
+  });
+
+  it("strong_fit and not_eligible receive visibly different panel treatments", () => {
+    const { rerender, container } = render(
+      <VerdictPanel verdict={baseVerdict("strong_fit")} />,
+    );
+    const strongSection = container.querySelector(
+      '[data-verdict-band="strong_fit"]',
+    ) as HTMLElement;
+    const strongBorder = getPanelBorder(strongSection);
+
+    rerender(<VerdictPanel verdict={baseVerdict("not_eligible")} />);
+    const notEligibleSection = container.querySelector(
+      '[data-verdict-band="not_eligible"]',
+    ) as HTMLElement;
+    const notEligibleBorder = getPanelBorder(notEligibleSection);
+
+    // Color is different.
+    expect(strongBorder.color).not.toBe(notEligibleBorder.color);
+    // Weight is different (strong_fit is emphasized).
+    expect(strongBorder.width).not.toBe(notEligibleBorder.width);
+  });
+
+  it("does not rely on colour alone: every band carries a distinct icon", () => {
+    const seenPaths = new Set<string>();
+
+    for (const band of [
+      "strong_fit",
+      "likely_fit",
+      "edge_case",
+      "not_eligible",
+    ] as VerdictBand[]) {
+      const { container } = render(
+        <VerdictPanel verdict={baseVerdict(band)} />,
+      );
+      const section = container.querySelector(
+        `[data-verdict-band="${band}"]`,
+      ) as HTMLElement;
+      expect(section).toBeInTheDocument();
+
+      const icon = section.querySelector('svg[aria-hidden="true"]');
+      expect(icon).toBeInTheDocument();
+
+      // Use the first path's "d" as a fingerprint for the icon shape.
+      const firstPath = icon?.querySelector("path");
+      expect(firstPath).toHaveAttribute("d");
+      const d = firstPath?.getAttribute("d") ?? "";
+      expect(seenPaths.has(d)).toBe(false);
+      seenPaths.add(d);
+    }
+
+    expect(seenPaths.size).toBe(4);
+  });
+
+  it("renders the verdict title larger than secondary card titles would be", () => {
+    render(<VerdictPanel verdict={baseVerdict("strong_fit")} />);
+    const heading = screen.getByRole("heading", { name: /strong match/i });
+    expect(heading.style.fontSize).toBe("clamp(2.2rem, 6vw, 3.5rem)");
+  });
+
+  it("never renders a numeric score or probability", () => {
+    render(<VerdictPanel verdict={baseVerdict("strong_fit")} />);
+    expect(screen.queryByText(/\d+%/)).toBeNull();
+    expect(screen.queryByText(/probability/i)).toBeNull();
+    expect(screen.queryByText(/score/i)).toBeNull();
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { Ref } from "react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
-import type { Verdict } from "@/lib/secondhome-studio/types";
+import type { Verdict, VerdictBand } from "@/lib/secondhome-studio/types";
 
 export interface VerdictPanelProps {
   verdict: Verdict;
@@ -13,6 +13,112 @@ export interface VerdictPanelProps {
   headingRef?: Ref<HTMLHeadingElement>;
 }
 
+interface BandStyle {
+  borderColor: string;
+  borderWidth: number;
+  icon: React.ReactNode;
+  background: string;
+}
+
+const CHECK_ICON = (
+  <svg
+    aria-hidden="true"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+);
+
+const INFO_ICON = (
+  <svg
+    aria-hidden="true"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 16v-4" />
+    <path d="M12 8h.01" />
+  </svg>
+);
+
+const WARNING_ICON = (
+  <svg
+    aria-hidden="true"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+    <path d="M12 9v4" />
+    <path d="M12 17h.01" />
+  </svg>
+);
+
+const CLOSE_ICON = (
+  <svg
+    aria-hidden="true"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+);
+
+const BAND_STYLES: Record<VerdictBand, BandStyle> = {
+  strong_fit: {
+    borderColor: "var(--state-success)",
+    borderWidth: 3,
+    icon: CHECK_ICON,
+    background: "color-mix(in srgb, var(--state-success) 6%, transparent)",
+  },
+  likely_fit: {
+    borderColor: "var(--state-info)",
+    borderWidth: 2,
+    icon: INFO_ICON,
+    background: "color-mix(in srgb, var(--state-info) 6%, transparent)",
+  },
+  edge_case: {
+    borderColor: "var(--state-warning)",
+    borderWidth: 2,
+    icon: WARNING_ICON,
+    background: "color-mix(in srgb, var(--state-warning) 6%, transparent)",
+  },
+  not_eligible: {
+    // Deliberately neutral rather than --state-danger: a clear, respectful
+    // "no" for a 55+ risk-averse audience. The signal is carried by the
+    // icon shape and border weight in addition to the muted tone.
+    borderColor: "var(--text-secondary)",
+    borderWidth: 2,
+    icon: CLOSE_ICON,
+    background: "color-mix(in srgb, var(--text-secondary) 8%, transparent)",
+  },
+};
+
 /** Renders the fit-check result: band heading/body (verbatim from copy.ts,
  *  which guarantees "the final decision rests with Imigrasi" is present),
  *  the reason list, and the human-review disclosure when present.
@@ -20,16 +126,19 @@ export interface VerdictPanelProps {
 export function VerdictPanel({ verdict, headingRef }: VerdictPanelProps) {
   const heading = getCopy(`verdict.bands.${verdict.band}.heading`);
   const body = getCopy(`verdict.bands.${verdict.band}.body`);
+  const style = BAND_STYLES[verdict.band];
 
   return (
     <section
+      data-verdict-band={verdict.band}
       style={{
         display: "grid",
         gap: "var(--space-3, 1rem)",
-        background: "var(--surface-raised)",
-        border: "2px solid var(--accent-funnel)",
+        background: style.background,
+        border: `${style.borderWidth}px solid ${style.borderColor}`,
         borderRadius: 12,
         padding: "var(--space-4, 1.5rem)",
+        fontVariantNumeric: "tabular-nums",
       }}
     >
       <p
@@ -44,13 +153,29 @@ export function VerdictPanel({ verdict, headingRef }: VerdictPanelProps) {
       >
         Your fit-check result
       </p>
+      <div
+        aria-hidden="true"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 44,
+          height: 44,
+          borderRadius: "50%",
+          color: style.borderColor,
+          background: "color-mix(in srgb, currentColor 10%, transparent)",
+        }}
+      >
+        {style.icon}
+      </div>
       <h1
         ref={headingRef}
         tabIndex={-1}
         style={{
           margin: 0,
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.6rem, 4vw, 2.2rem)",
+          fontSize: "clamp(2.2rem, 6vw, 3.5rem)",
+          lineHeight: 1.1,
           color: "var(--text-primary)",
         }}
       >
@@ -91,7 +216,7 @@ export function VerdictPanel({ verdict, headingRef }: VerdictPanelProps) {
           style={{
             margin: 0,
             padding: "var(--space-2, 0.5rem)",
-            borderLeft: "3px solid var(--accent-funnel)",
+            borderLeft: `3px solid ${style.borderColor}`,
             fontSize: "var(--text-sm, 0.88rem)",
             color: "var(--text-primary)",
           }}


### PR DESCRIPTION
VerdictPanel now renders a visually distinct treatment for each of the four fit-check bands, using existing semantic state tokens and without adding new copy or numeric scores.

### Changes
- `strong_fit` → success green, 3px border, check icon
- `likely_fit` → info blue, 2px border, info icon
- `edge_case` → warning amber, 2px border, warning icon
- `not_eligible` → neutral grey, 2px border, close icon (sober, not alarming)
- Verdict title enlarged to `clamp(2.2rem, 6vw, 3.5rem)`
- `font-variant-numeric: tabular-nums` on the panel
- Signal is carried by icon shape and border weight in addition to colour

### Tests
- 4 band-specific renders
- Regression: `strong_fit` and `not_eligible` differ in both colour and border weight
- Signal is not colour-only: every band has a distinct icon
- No numeric score/probability is rendered

### Compliance
- No new copy introduced
- No animations or emoji
- No modifications to off-limits files