### PR TITLE
feat(mouth): let the plan leave the screen — print / save as PDF

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { emptyPlan } from "@/lib/secondhome-studio/plan-codec";
+import { SavePlanBar } from "./SavePlanBar";
+
+const originalPrintDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "print",
+);
+
+describe("SavePlanBar print action", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (originalPrintDescriptor) {
+      Object.defineProperty(window, "print", originalPrintDescriptor);
+    }
+  });
+
+  it("is keyboard-accessible by its visible name and calls window.print without a network request", () => {
+    const print = vi.fn();
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      value: print,
+    });
+
+    render(<SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />);
+
+    const printButton = screen.getByRole("button", {
+      name: "Print / Save as PDF",
+    });
+    expect(printButton).toHaveAttribute("type", "button");
+
+    printButton.focus();
+    expect(printButton).toHaveFocus();
+    fireEvent.click(printButton);
+
+    expect(print).toHaveBeenCalledOnce();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("is a safe no-op when the browser print API is unavailable", () => {
+    Object.defineProperty(window, "print", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />);
+
+    expect(() =>
+      fireEvent.click(
+        screen.getByRole("button", { name: "Print / Save as PDF" }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("ships the global print rules for document colors, panels, controls, and the WhatsApp contact", () => {
+    const { container } = render(
+      <SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />,
+    );
+    const css = container.querySelector("style")?.textContent ?? "";
+
+    // jsdom cannot paginate or emulate a print preview. These assertions
+    // intentionally verify only that the browser-facing rules are emitted.
+    expect(css).toContain("@media print");
+    expect(css).toContain("--surface-base: #ffffff");
+    expect(css).toContain("button,");
+    expect(css).toContain("break-inside: avoid");
+    expect(css).toContain('input[type="checkbox"]');
+    expect(css).toContain('a[href^="https://wa.me"]::after');
+    expect(css).toContain('content: " (" attr(href) ")"');
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -11,6 +11,106 @@ import type { PlanState } from "@/lib/secondhome-studio/types";
 
 const STUDIO_PATH = "/visa/second-home/studio";
 
+const PRINT_STYLES = `
+  @page {
+    margin: 14mm;
+  }
+
+  @media print {
+    :root,
+    [data-theme],
+    [data-funnel="visa"] {
+      --background: #ffffff;
+      --foreground: #172033;
+      --surface-base: #ffffff;
+      --surface-raised: #ffffff;
+      --surface-sunken: #f4f6f8;
+      --text-primary: #172033;
+      --text-secondary: #334155;
+      --text-tertiary: #475569;
+      --color-text-muted: #475569;
+      --color-border-subtle: #cbd5e1;
+      --accent-funnel: #8f1d2c;
+      --accent-funnel-text: #8f1d2c;
+      --bz-elevated: #ffffff;
+      --tx-secondary: #334155;
+    }
+
+    html,
+    body {
+      background: #ffffff !important;
+      color: #172033 !important;
+    }
+
+    nav,
+    button,
+    .fixed.bottom-0.left-0.right-0.z-50,
+    .bz-shs-save-plan-bar {
+      display: none !important;
+    }
+
+    .mx-auto.max-w-6xl,
+    [data-funnel="visa"] {
+      max-width: none !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+
+    [data-funnel="visa"] section,
+    [data-funnel="visa"] table,
+    [data-funnel="visa"] tr,
+    [data-funnel="visa"] li {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+
+    [data-funnel="visa"] section {
+      box-shadow: none !important;
+    }
+
+    [data-funnel="visa"] section > div {
+      overflow: visible !important;
+    }
+
+    [data-funnel="visa"] table {
+      width: 100% !important;
+      font-size: 9pt;
+    }
+
+    [data-funnel="visa"] th,
+    [data-funnel="visa"] td {
+      white-space: normal !important;
+    }
+
+    [data-funnel="visa"] input[type="checkbox"] {
+      appearance: auto;
+      print-color-adjust: exact;
+      -webkit-print-color-adjust: exact;
+    }
+
+    a[href^="https://wa.me"] {
+      display: inline !important;
+      min-height: 0 !important;
+      padding: 0 !important;
+      border: 0 !important;
+      background: transparent !important;
+      color: #172033 !important;
+      font-weight: 600;
+      text-decoration: none !important;
+    }
+
+    a[href^="https://wa.me"] svg {
+      display: none !important;
+    }
+
+    a[href^="https://wa.me"]::after {
+      content: " (" attr(href) ")";
+      font-weight: 400;
+      overflow-wrap: anywhere;
+    }
+  }
+`;
+
 export interface SavePlanBarProps {
   plan: PlanState;
   /** Clears localStorage (plan-codec's clearPlan) and resets the wizard to
@@ -64,8 +164,16 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
     }
   }
 
+  function handlePrint() {
+    if (typeof window === "undefined" || typeof window.print !== "function") {
+      return;
+    }
+    window.print();
+  }
+
   return (
     <section
+      className="bz-shs-save-plan-bar"
       style={{
         display: "grid",
         gap: "var(--space-3, 1rem)",
@@ -100,6 +208,9 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
         </button>
         <button type="button" onClick={handleCopyLink} style={buttonStyle}>
           {getCopy("savePlanBar.copyLinkButton")}
+        </button>
+        <button type="button" onClick={handlePrint} style={buttonStyle}>
+          {getCopy("savePlanBar.printButton")}
         </button>
         <button
           type="button"
@@ -146,6 +257,7 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
       >
         {getCopy("savePlanBar.linkWarning")}
       </p>
+      <style>{PRINT_STYLES}</style>
     </section>
   );
 }

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -445,6 +445,7 @@ export const COPY = {
     savedConfirmation: "Plan saved on this device",
     copyLinkButton: "Copy plan link",
     copiedConfirmation: "Plan link copied",
+    printButton: "Print / Save as PDF",
     linkWarning:
       "Anyone who receives the link may be able to view the answers it contains.",
     clearButton: "Clear saved plan",


### PR DESCRIPTION
## Why

A cross-family refuter (Kimi K3) reviewing the Studio's product plan named this **the gravest omission**: the research capture admits no printable artifact of the plan exists, and then schedules none of the eleven planned PRs to build one.

The audience is 55+, deciding on USD 130,000 or 1,000,000. They do not decide at the screen — they print, and carry the sheet to a spouse, an accountant, a lawyer. Until now the only way to take the plan away was *Copy plan link*, which assumes the other person opens a browser and trusts a URL.

## What

A **Print / Save as PDF** action in the save bar, calling `window.print()`. No PDF library, no new dependency, no network call — every browser already prints to PDF. `window.print` is SSR-guarded the same way the package already guards `localStorage`.

The print stylesheet turns the verdict stage into a document:

- **Colours** — the page is navy-on-dark; printed as-is it is a black rectangle that eats a cartridge. Rather than overriding every rule, the design tokens are **redefined inside `@media print`**: one block, and every component follows.
- **Hidden** — navigation, consent banner, every button (this bar included).
- **Kept** — verdict and matched product, custody, route comparison, timeline, the readiness checklist *with the boxes as the user left them*, and the price.
- **The WhatsApp link survives print as text** — its icon is dropped and the `href` is appended after the label. A printed plan with no way to reach us is a dead end.
- `break-inside: avoid` on the panels, so a table or the checklist does not split across pages.

## What it deliberately is not

Not a quote, not a legal document: no "Offer" heading, no signature block, no reference number. It is a fit-check plan and it should read as one. The price stays a single all-inclusive figure, never decomposed.

## Privacy

Nothing leaves the device. `window.print()` is local and the component makes no `fetch`, no beacon, no telemetry — verified by grep, 0 hits.

## Notes for the reviewer

- One new copy key, `savePlanBar.printButton`: a single added line in `copy.ts`, no other change to that file (other lanes are working in it).
- The consent banner is hidden via its Tailwind class selector (`.fixed.bottom-0.left-0.right-0.z-50`). That is brittle if those utility classes change — flagging it rather than hiding it, since a print-only rule failing silently is exactly the kind of thing nobody notices.

## Tests

277 passed across `src/app/visa/second-home` and `src/lib/secondhome-studio`.
