### PR TITLE
feat(mouth): add minimal stroke-icon vocabulary to Second Home Studio

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Landmark, Home, Scale } from "lucide-react";
+import { QuestionCard, OptionButton } from "./QuestionCard";
+
+describe("QuestionCard > OptionButton icon support", () => {
+  it("renders an icon when the icon prop is provided", () => {
+    const { container } = render(
+      <OptionButton
+        label="Bank deposit"
+        selected={false}
+        onSelect={vi.fn()}
+        variant="radio"
+        icon={Landmark}
+      />,
+    );
+
+    const icon = container.querySelector("svg[aria-hidden='true']");
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("keeps the label text when an icon is present", () => {
+    render(
+      <OptionButton
+        label="Completed strata-title property"
+        selected={false}
+        onSelect={vi.fn()}
+        variant="radio"
+        icon={Home}
+      />,
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Completed strata-title property" }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks the icon aria-hidden so the accessible name comes from the label", () => {
+    const { container } = render(
+      <OptionButton
+        label="I am not sure yet"
+        selected={false}
+        onSelect={vi.fn()}
+        variant="radio"
+        icon={Scale}
+      />,
+    );
+
+    const icon = container.querySelector("svg");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("does not render an icon when the icon prop is omitted", () => {
+    const { container } = render(
+      <OptionButton
+        label="Under 55"
+        selected={false}
+        onSelect={vi.fn()}
+        variant="radio"
+      />,
+    );
+
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+  });
+
+  it("does not add icons to non-route QuestionCard options by default", () => {
+    const { container } = render(
+      <QuestionCard
+        heading="First, how old are you?"
+        body="Age helps determine routes."
+        why="Regulation uses different thresholds."
+        options={[
+          <OptionButton
+            key="under_55"
+            label="Under 55"
+            selected={false}
+            onSelect={vi.fn()}
+            variant="radio"
+          />,
+          <OptionButton
+            key="60_plus"
+            label="60 or over"
+            selected={false}
+            onSelect={vi.fn()}
+            variant="radio"
+          />,
+        ]}
+      >
+        <button type="button">Continue</button>
+      </QuestionCard>,
+    );
+
+    expect(container.querySelectorAll("svg").length).toBe(1); // only the chevron in <details>
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useId, type ReactNode, type Ref } from "react";
+import type { LucideIcon } from "lucide-react";
 import { ChevronRight } from "lucide-react";
 
 export interface QuestionCardProps {
@@ -168,6 +169,9 @@ export interface OptionButtonProps {
    *  a future enhancement — Tab-order navigation between options still
    *  works today; only the announced role/state changed here. */
   variant?: "radio" | "toggle";
+  /** Optional leading icon for route-style options. Rendered `aria-hidden`
+   *  because the textual label already carries the meaning. */
+  icon?: LucideIcon;
 }
 
 /** Decorative leading affordance for a radio-variant option: an empty ring
@@ -246,6 +250,7 @@ export function OptionButton({
   selected,
   onSelect,
   variant = "toggle",
+  icon: Icon,
 }: OptionButtonProps) {
   const isRadio = variant === "radio";
   return (
@@ -276,6 +281,17 @@ export function OptionButton({
       ) : (
         <CheckAffordance selected={selected} />
       )}
+      {Icon ? (
+        <Icon
+          size={18}
+          strokeWidth={1.5}
+          aria-hidden
+          style={{
+            flexShrink: 0,
+            color: "var(--color-text-muted)",
+          }}
+        />
+      ) : null}
       <span>{label}</span>
     </button>
   );

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouteComparator } from "./RouteComparator";
+
+describe("RouteComparator", () => {
+  it("renders the three column headings with their text labels", () => {
+    render(<RouteComparator />);
+
+    expect(screen.getByText("Deposit route")).toBeInTheDocument();
+    expect(screen.getByText("Property route")).toBeInTheDocument();
+    expect(screen.getByText("Senior route (55+)")).toBeInTheDocument();
+  });
+
+  it("renders an aria-hidden icon next to each column heading", () => {
+    const { container } = render(<RouteComparator />);
+
+    const headings = container.querySelectorAll(
+      "th > span > svg[aria-hidden='true']",
+    );
+    expect(headings.length).toBe(3);
+  });
+
+  it("does not remove the accessible column text when icons are present", () => {
+    render(<RouteComparator highlight />);
+
+    const depositHeading = screen.getByText("Deposit route").closest("th");
+    expect(depositHeading).toBeInTheDocument();
+    const icon = depositHeading?.querySelector("svg");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { Home, Landmark, Scale } from "lucide-react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 
 const COLUMNS = ["deposit", "property", "senior"] as const;
+
+const COLUMN_ICONS = {
+  deposit: Landmark,
+  property: Home,
+  senior: Scale,
+} as const;
 const ROWS = [
   "capital",
   "liquidity",
@@ -48,20 +55,40 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
           <thead>
             <tr>
               <th scope="col" style={{ padding: "var(--space-2, 0.5rem)" }} />
-              {COLUMNS.map((c) => (
-                <th
-                  key={c}
-                  scope="col"
-                  style={{
-                    textAlign: "left",
-                    padding: "var(--space-2, 0.5rem)",
-                    color: "var(--text-primary)",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {getCopy(`routeComparator.columns.${c}.title`)}
-                </th>
-              ))}
+              {COLUMNS.map((c) => {
+                const ColumnIcon = COLUMN_ICONS[c];
+                return (
+                  <th
+                    key={c}
+                    scope="col"
+                    style={{
+                      textAlign: "left",
+                      padding: "var(--space-2, 0.5rem)",
+                      color: "var(--text-primary)",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: "var(--space-2, 0.5rem)",
+                      }}
+                    >
+                      <ColumnIcon
+                        size={18}
+                        strokeWidth={1.5}
+                        aria-hidden
+                        style={{
+                          flexShrink: 0,
+                          color: "var(--color-text-muted)",
+                        }}
+                      />
+                      {getCopy(`routeComparator.columns.${c}.title`)}
+                    </span>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody>

--- a/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TimelineView } from "./TimelineView";
+
+describe("TimelineView", () => {
+  it("renders owner chips with their text labels", () => {
+    render(
+      <TimelineView
+        horizon="exploring"
+        location="in_indonesia"
+        route="deposit"
+        product="E33"
+      />,
+    );
+
+    expect(screen.getAllByText("You").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Bali Zero").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Imigrasi")).toBeInTheDocument();
+  });
+
+  it("renders an aria-hidden icon inside every owner chip", () => {
+    const { container } = render(
+      <TimelineView
+        horizon="exploring"
+        location="in_indonesia"
+        route="deposit"
+        product="E33"
+      />,
+    );
+
+    const chips = container.querySelectorAll("span > svg[aria-hidden='true']");
+    expect(chips.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps the text label as the accessible name and does not duplicate it via icon", () => {
+    render(
+      <TimelineView
+        horizon="asap"
+        location="abroad"
+        route="property"
+        product="E33"
+      />,
+    );
+
+    const youChips = screen.getAllByText("You");
+    expect(youChips.length).toBeGreaterThanOrEqual(1);
+    const firstYouChip = youChips[0]!.closest("span");
+    expect(firstYouChip).toBeInTheDocument();
+    const icon = firstYouChip?.querySelector("svg");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Building2, Landmark, User } from "lucide-react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 import { buildTimeline } from "@/lib/secondhome-studio/timeline";
 import type {
@@ -8,6 +9,12 @@ import type {
   TimelineHorizon,
   Verdict,
 } from "@/lib/secondhome-studio/types";
+
+const OWNER_ICONS = {
+  you: User,
+  balizero: Building2,
+  imigrasi: Landmark,
+} as const;
 
 export interface TimelineViewProps {
   horizon: TimelineHorizon;
@@ -84,6 +91,9 @@ export function TimelineView({
               </strong>
               <span
                 style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "var(--space-1, 0.3rem)",
                   fontSize: "0.68rem",
                   letterSpacing: "0.08em",
                   textTransform: "uppercase",
@@ -94,6 +104,17 @@ export function TimelineView({
                   whiteSpace: "nowrap",
                 }}
               >
+                {(() => {
+                  const OwnerIcon = OWNER_ICONS[step.ownerKey];
+                  return OwnerIcon ? (
+                    <OwnerIcon
+                      size={12}
+                      strokeWidth={1.5}
+                      aria-hidden
+                      style={{ flexShrink: 0 }}
+                    />
+                  ) : null;
+                })()}
                 {getCopy(`timeline.ownerLabels.${step.ownerKey}`)}
               </span>
             </div>


### PR DESCRIPTION
Adds a small, consistent set of lucide-react stroke icons to the three visual anchor points identified in the audit:

- TimelineView: distinct owner chip icons for You / Bali Zero / Imigrasi (User, Building2, Landmark). Text labels remain; icons are aria-hidden.
- RouteComparator: matching deposit/property/senior column header icons (Landmark, Home, Scale). Text labels remain; icons are aria-hidden.
- QuestionCard: OptionButton now accepts an optional icon prop, so the route question can receive icons from its caller without fragile string matching inside the generic card component.

All icons use existing color tokens (--color-text-muted), keep the textual label as the accessible name, and are imported as individual glyphs to avoid bundle growth.

No new dependencies. StudioApp.tsx was left untouched per the rigid file boundary, so the route-question icons are wired in OptionButton but not yet passed by the caller; this is flagged in the delivery report.