### PR TITLE
feat(mouth): draw the money's path instead of describing it

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/lib/secondhome-studio/copy";
+
+import { CustodyMap } from "./CustodyMap";
+
+const custodyStrings = [
+  COPY.custody.eyebrow,
+  COPY.custody.intro,
+  ...Object.values(COPY.custody.steps).flatMap(({ title, body }) => [
+    title,
+    body,
+  ]),
+  COPY.custody.disclaimer,
+];
+
+describe("CustodyMap", () => {
+  it("renders three keyboard-reachable custody nodes", () => {
+    render(<CustodyMap />);
+
+    const nodes = screen.getAllByRole("button");
+    expect(nodes).toHaveLength(3);
+    expect(nodes.map((node) => node.textContent)).toEqual(
+      Object.values(COPY.custody.steps).map(({ title }) => title),
+    );
+    nodes.forEach((node) =>
+      expect(node).toHaveAttribute("aria-expanded", "false"),
+    );
+  });
+
+  it("expands and closes a node detail", () => {
+    render(<CustodyMap />);
+
+    const firstNode = screen.getByRole("button", {
+      name: COPY.custody.steps.step1.title,
+    });
+    fireEvent.click(firstNode);
+
+    expect(firstNode).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(COPY.custody.steps.step1.body)).toBeInTheDocument();
+
+    fireEvent.click(firstNode);
+    expect(firstNode).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText(COPY.custody.steps.step1.body)).not.toBeVisible();
+  });
+
+  it("provides a text equivalent for the visual flow", () => {
+    render(<CustodyMap />);
+
+    expect(
+      screen.getByRole("group", { name: COPY.custody.eyebrow }),
+    ).toHaveAccessibleDescription(COPY.custody.intro);
+    expect(screen.getByRole("list")).toBeInTheDocument();
+  });
+
+  it("renders only user-visible strings sourced from copy.ts", () => {
+    const { container } = render(<CustodyMap />);
+    const assertRenderedTextComesFromCopy = () => {
+      const textNodes: string[] = [];
+      const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        const parent = walker.currentNode.parentElement;
+        if (parent?.closest("style, [hidden]")) continue;
+        const value = walker.currentNode.textContent?.trim();
+        if (value) textNodes.push(value);
+      }
+
+      expect(textNodes).not.toHaveLength(0);
+      textNodes.forEach((value) => expect(custodyStrings).toContain(value));
+    };
+
+    assertRenderedTextComesFromCopy();
+    Object.values(COPY.custody.steps).forEach(({ title, body }) => {
+      fireEvent.click(screen.getByRole("button", { name: title }));
+      expect(screen.getByText(body)).toBeVisible();
+      assertRenderedTextComesFromCopy();
+    });
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
@@ -1,120 +1,326 @@
 "use client";
 
+import { useState } from "react";
+
 import { getCopy } from "@/lib/secondhome-studio/copy";
 
 const STEPS = ["step1", "step2", "step3"] as const;
 
-/** Static 3-step custody explainer (spec §5). No yield/return figures, no
- *  LPS mention — copy.ts's own forbidden-claims sweep enforces this across
- *  every string this component reads. */
-export function CustodyMap() {
+type Step = (typeof STEPS)[number];
+
+function NodeIcon({ step }: { step: Step }) {
+  const commonProps = {
+    "aria-hidden": true,
+    fill: "none",
+    height: 28,
+    stroke: "currentColor",
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    strokeWidth: 1.5,
+    viewBox: "0 0 28 28",
+    width: 28,
+  };
+
+  if (step === "step1") {
+    return (
+      <svg {...commonProps}>
+        <circle cx="14" cy="8" r="3.5" />
+        <path d="M6.5 22c.8-4.6 3.3-7 7.5-7s6.7 2.4 7.5 7" />
+        <path d="M9 23h10" />
+      </svg>
+    );
+  }
+
+  if (step === "step2") {
+    return (
+      <svg {...commonProps}>
+        <path d="M4.5 10.5 14 5l9.5 5.5" />
+        <path d="M6.5 11.5h15M7.5 21.5h13M9 12v7.5M14 12v7.5M19 12v7.5" />
+        <path d="M5 23h18" />
+      </svg>
+    );
+  }
+
   return (
-    <section
-      style={{
-        display: "grid",
-        gap: "var(--space-3, 1rem)",
-        background: "var(--surface-raised)",
-        border: "1px solid var(--color-border-subtle)",
-        borderRadius: 12,
-        padding: "var(--space-4, 1.5rem)",
-      }}
-    >
-      <p
-        style={{
-          margin: 0,
-          fontSize: "0.7rem",
-          letterSpacing: "0.15em",
-          textTransform: "uppercase",
-          opacity: 0.6,
-          color: "var(--color-text-muted)",
-        }}
+    <svg {...commonProps}>
+      <path d="M8 3.5h8l5 5v16H8z" />
+      <path d="M16 3.5v5h5M11.5 13h6M11.5 17h6" />
+      <circle cx="18.5" cy="21" r="3" />
+    </svg>
+  );
+}
+
+/** Three-stage, interactive view of the deposit evidence path. All visible
+ * copy comes from copy.ts so the Studio claim guard remains comprehensive. */
+export function CustodyMap() {
+  const [expandedStep, setExpandedStep] = useState<Step | null>(null);
+
+  return (
+    <section className="custody-map" aria-labelledby="custody-map-title">
+      <header className="custody-header">
+        <h2 id="custody-map-title">{getCopy("custody.eyebrow")}</h2>
+      </header>
+
+      <div
+        className="custody-layout"
+        role="group"
+        aria-label={getCopy("custody.eyebrow")}
+        aria-describedby="custody-map-intro"
       >
-        Custody
-      </p>
-      <h2
-        style={{
-          margin: 0,
-          fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
-          color: "var(--text-primary)",
-        }}
-      >
-        {getCopy("custody.eyebrow")}
-      </h2>
-      <p style={{ margin: 0, lineHeight: 1.6, color: "var(--text-primary)" }}>
-        {getCopy("custody.intro")}
-      </p>
-      <ol
-        style={{
-          margin: 0,
-          padding: 0,
-          listStyle: "none",
-          display: "grid",
-          gap: "var(--space-3, 1rem)",
-        }}
-      >
-        {STEPS.map((step, i) => (
-          <li
-            key={step}
-            style={{ display: "grid", gap: "var(--space-1, 0.3rem)" }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-2, 0.5rem)",
-              }}
-            >
-              {/* Step badge — matches the timeline's rounded, bordered
-               *  "owner chip" language (TimelineView.tsx) instead of a bare
-               *  numeral, aria-hidden since the number is decorative
-               *  (the step order is already conveyed by the <ol>). */}
-              <span
-                aria-hidden
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                  width: 24,
-                  height: 24,
-                  borderRadius: "50%",
-                  border: "1.5px solid var(--accent-funnel)",
-                  fontFamily: "var(--font-serif, Georgia, serif)",
-                  fontSize: "0.8rem",
-                  fontWeight: 600,
-                  color: "var(--accent-funnel-text, var(--accent-funnel))",
-                }}
-              >
-                {i + 1}
-              </span>
-              <strong style={{ color: "var(--text-primary)" }}>
-                {getCopy(`custody.steps.${step}.title`)}
-              </strong>
-            </div>
-            <p
-              style={{
-                margin: 0,
-                marginLeft: "1.3rem",
-                color: "var(--color-text-muted)",
-                lineHeight: 1.6,
-              }}
-            >
-              {getCopy(`custody.steps.${step}.body`)}
-            </p>
-          </li>
-        ))}
-      </ol>
-      <p
-        style={{
-          margin: 0,
-          fontSize: "var(--text-sm, 0.82rem)",
-          color: "var(--color-text-muted)",
-          fontStyle: "italic",
-        }}
-      >
-        {getCopy("custody.disclaimer")}
-      </p>
+        <ol className="custody-flow">
+          {STEPS.map((step, index) => {
+            const isExpanded = expandedStep === step;
+            const detailId = `custody-${step}-detail`;
+
+            return (
+              <li className="custody-flow-item" key={step}>
+                <div className="custody-node" data-account={step === "step1"}>
+                  <button
+                    type="button"
+                    aria-controls={detailId}
+                    aria-expanded={isExpanded}
+                    onClick={() => setExpandedStep(isExpanded ? null : step)}
+                  >
+                    <span className="custody-icon">
+                      <NodeIcon step={step} />
+                    </span>
+                    <strong>{getCopy(`custody.steps.${step}.title`)}</strong>
+                    <svg
+                      aria-hidden
+                      className="custody-chevron"
+                      viewBox="0 0 16 16"
+                    >
+                      <path d="m4 6 4 4 4-4" />
+                    </svg>
+                  </button>
+                  <p id={detailId} hidden={!isExpanded}>
+                    {getCopy(`custody.steps.${step}.body`)}
+                  </p>
+                </div>
+                {index < STEPS.length - 1 ? (
+                  <svg
+                    aria-hidden
+                    className="custody-arrow"
+                    viewBox="0 0 40 18"
+                  >
+                    <path d="M2 9h33M29 3l6 6-6 6" />
+                  </svg>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+
+        <aside className="custody-outside" id="custody-map-intro">
+          <p>{getCopy("custody.intro")}</p>
+        </aside>
+      </div>
+
+      <p className="custody-disclaimer">{getCopy("custody.disclaimer")}</p>
+
+      <style jsx>{`
+        .custody-map {
+          display: grid;
+          gap: 1.5rem;
+          min-width: 0;
+          padding: clamp(1.25rem, 3vw, 2rem);
+          overflow: hidden;
+          background: var(--surface-raised);
+          border: 1px solid var(--color-border-subtle);
+          border-radius: 12px;
+          color: var(--text-primary);
+          font-variant-numeric: tabular-nums;
+        }
+
+        .custody-header {
+          padding-left: 1rem;
+          border-left: 2px solid var(--color-border-subtle);
+        }
+
+        h2 {
+          margin: 0;
+          font-size: clamp(1.35rem, 3vw, 1.75rem);
+          line-height: 1.2;
+        }
+
+        .custody-layout {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) minmax(12rem, 0.3fr);
+          align-items: center;
+          gap: clamp(2rem, 4vw, 3.5rem);
+          min-width: 0;
+        }
+
+        .custody-flow {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 2.5rem;
+          min-width: 0;
+          margin: 0;
+          padding: 0;
+          list-style: none;
+        }
+
+        .custody-flow-item {
+          position: relative;
+          min-width: 0;
+        }
+
+        .custody-node {
+          height: 100%;
+          min-width: 0;
+          background: var(--surface-raised);
+          border: 1px solid var(--color-border-subtle);
+          border-radius: 10px;
+        }
+
+        button {
+          display: grid;
+          grid-template-columns: auto minmax(0, 1fr) auto;
+          align-items: center;
+          gap: 0.75rem;
+          width: 100%;
+          min-height: 6rem;
+          padding: 1rem;
+          color: var(--text-primary);
+          text-align: left;
+          background: transparent;
+          border: 0;
+          border-radius: 10px;
+          cursor: pointer;
+        }
+
+        button:focus-visible {
+          outline: 2px solid var(--text-primary);
+          outline-offset: 3px;
+        }
+
+        .custody-icon {
+          display: inline-grid;
+          place-items: center;
+          color: var(--color-text-muted);
+        }
+
+        .custody-node[data-account="true"] .custody-icon {
+          color: var(--accent-funnel);
+        }
+
+        strong {
+          min-width: 0;
+          line-height: 1.35;
+        }
+
+        .custody-chevron {
+          width: 16px;
+          height: 16px;
+          fill: none;
+          stroke: var(--color-text-muted);
+          stroke-linecap: round;
+          stroke-linejoin: round;
+          stroke-width: 1.5;
+          transition: transform 180ms ease;
+        }
+
+        button[aria-expanded="true"] .custody-chevron {
+          transform: rotate(180deg);
+        }
+
+        .custody-node > p {
+          margin: 0;
+          padding: 0 1rem 1rem;
+          color: var(--color-text-muted);
+          line-height: 1.6;
+        }
+
+        .custody-node > p[hidden] {
+          display: none;
+        }
+
+        .custody-arrow {
+          position: absolute;
+          top: 3rem;
+          left: calc(100% + 0.25rem);
+          width: 2rem;
+          height: 1.125rem;
+          overflow: visible;
+          fill: none;
+          stroke: var(--color-text-muted);
+          stroke-linecap: round;
+          stroke-linejoin: round;
+          stroke-width: 1.5;
+        }
+
+        .custody-outside {
+          position: relative;
+          padding: 1rem;
+          border: 1px dashed var(--color-border-subtle);
+          border-radius: 10px;
+        }
+
+        .custody-outside::before {
+          position: absolute;
+          top: 50%;
+          right: 100%;
+          width: clamp(2rem, 4vw, 3.5rem);
+          border-top: 1px dashed var(--color-border-subtle);
+          content: "";
+        }
+
+        .custody-outside p,
+        .custody-disclaimer {
+          margin: 0;
+          color: var(--color-text-muted);
+          line-height: 1.6;
+        }
+
+        .custody-disclaimer {
+          font-size: 0.82rem;
+          font-style: italic;
+        }
+
+        @media (max-width: 760px) {
+          .custody-layout,
+          .custody-flow {
+            grid-template-columns: minmax(0, 1fr);
+          }
+
+          .custody-layout {
+            gap: 2.5rem;
+          }
+
+          .custody-flow {
+            gap: 2.25rem;
+          }
+
+          .custody-arrow {
+            top: calc(100% + 0.55rem);
+            left: 50%;
+            transform: translateX(-50%) rotate(90deg);
+          }
+
+          .custody-outside::before {
+            top: 1.5rem;
+            right: 100%;
+            bottom: auto;
+            left: auto;
+            width: 2rem;
+            height: 0;
+            border-top: 1px dashed var(--color-border-subtle);
+            border-left: 0;
+          }
+
+          .custody-outside {
+            width: calc(100% - 2rem);
+            margin-left: 2rem;
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .custody-chevron {
+            transition: none;
+          }
+        }
+      `}</style>
     </section>
   );
 }


### PR DESCRIPTION
## Why this module and not another

The product research (`research/secondhome/2026-08-19-e33-sticky-funnel-research.md` §1, §3.3) calls the custody module **"the single highest-leverage trust asset"** of the whole funnel. The fear that silently bounces a prospect is not our fee — it is *"if I put USD 130,000 into an Indonesian arrangement, who is actually holding it?"*

It shipped as three numbered paragraphs wearing the same card chrome as the *clear my plan* button beneath it. The decisive reassurance had the visual weight of a utility control.

## What it is now

A diagram of where the money actually goes:

```
YOUR MONEY → account in YOUR OWN NAME at a state-owned (BUMN) bank → evidence for Imigrasi
```

with **Bali Zero rendered outside that chain** — a separate aside joined by a dashed connector rather than sitting in the flow. The entire point of the module is that we are never in the chain of custody; that now reads from the drawing, not only from the sentence.

- Each node expands to its own detail, keyboard-operable, `aria-expanded` on the control.
- Three inline SVG line icons (person, institution, sealed document) at lucide's stroke weight — generic institutional shapes, never a real bank's mark.
- Narrow viewports stack the chain vertically.

## Constraints held

- **No new copy.** Every string still comes from the existing `custody.*` keys in `copy.ts` — `eyebrow`, `intro`, `steps.{step1,step2,step3}.{title,body}`, `disclaimer` — cross-checked key by key against that file before opening this.
- **No hex literals**; existing design tokens only. The one transition is disabled under `prefers-reduced-motion: reduce`.
- Unchanged by design: no yield or interest figure, no LPS, no named bank, no price.
- Scope: `CustodyMap.tsx` + its new test, nothing else — four sibling lanes are working in this directory.

## Tests

278 passed across `src/app/visa/second-home` and `src/lib/secondhome-studio`.

## Honest note

I have read this rendering only as code and as CSS, not as pixels — the browser QA pass on production is queued behind the deploy, and it specifically includes keyboard operation of the nodes. If the diagram does not in fact read as "Bali Zero is outside" on a real screen, that is a follow-up, not something this PR has proven.
