### PR TITLE
feat(mouth): scenario toggle — preview your answers on the other route

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -6,6 +6,7 @@ import {
   emptyPlan,
   encodePlanFragment,
   savePlan,
+  PLAN_STORAGE_KEY,
 } from "@/lib/secondhome-studio/plan-codec";
 import type { PlanState } from "@/lib/secondhome-studio/types";
 import { StudioApp } from "./StudioApp";
@@ -425,6 +426,34 @@ describe("StudioApp", () => {
       render(<StudioApp />);
       await screen.findByRole("heading", { name: /strong match/i });
       expect(screen.getByText("Your money stays yours")).toBeInTheDocument();
+    });
+  });
+
+  describe("ScenarioToggle — saved-plan immutability", () => {
+    it("opening the route preview does not mutate the saved plan in localStorage", async () => {
+      const saved = fullPlan({
+        route: "deposit",
+        capital: "ready_130k",
+      });
+      savePlan(saved);
+
+      const fragmentPlan = fullPlan({
+        route: "property",
+        capital: null,
+        property: "none",
+      });
+      window.location.hash = `#p=${encodePlanFragment(fragmentPlan)}`;
+
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /needs human review/i });
+
+      fireEvent.click(screen.getByRole("button", { name: /other route/i }));
+      expect(screen.getByTestId("scenario-toggle-preview")).toBeInTheDocument();
+
+      const stored = JSON.parse(
+        window.localStorage.getItem(PLAN_STORAGE_KEY) ?? "null",
+      );
+      expect(stored).toEqual(saved);
     });
   });
 });

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -41,6 +41,7 @@ import { TimelineView } from "./components/TimelineView";
 import { ReadinessChecklist } from "./components/ReadinessChecklist";
 import { WhatsAppHandoff } from "./components/WhatsAppHandoff";
 import { SavePlanBar } from "./components/SavePlanBar";
+import { ScenarioToggle } from "./components/ScenarioToggle";
 
 /**
  * Second Home Studio — the wizard state machine (spec §4).
@@ -604,6 +605,7 @@ export function StudioApp() {
           <VerdictPanel verdict={verdict} headingRef={stageHeadingRef} />
           {showCustodyMap ? <CustodyMap /> : null}
           <RouteComparator highlight={plan.route === "unsure"} />
+          <ScenarioToggle plan={plan} />
           <TimelineView
             horizon={plan.horizon ?? "exploring"}
             location={plan.location ?? "in_indonesia"}

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePricingData } from "@/hooks/usePricingData";
+import { emptyPlan } from "@/lib/secondhome-studio/plan-codec";
+import {
+  E33F_OFFSHORE_LIVE_PRICE_KEY,
+  E33_LIVE_PRICE_KEY,
+} from "@/lib/secondhome-studio/pricing-key";
+import type { PlanState } from "@/lib/secondhome-studio/types";
+
+import {
+  ScenarioToggle,
+  buildScenarioPreview,
+  otherRoute,
+} from "./ScenarioToggle";
+
+vi.mock("@/hooks/usePricingData", () => ({
+  usePricingData: vi.fn(),
+}));
+
+function basePlan(overrides: Partial<PlanState> = {}): PlanState {
+  return { ...emptyPlan(), ...overrides };
+}
+
+describe("ScenarioToggle", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.mocked(usePricingData).mockReturnValue({
+      price: null,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  it("renders the control label when closed", () => {
+    render(<ScenarioToggle plan={basePlan({ route: "deposit" })} />);
+    expect(
+      screen.getByRole("button", { name: /other route/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the preview when the control is clicked and closes it with the back button", () => {
+    render(<ScenarioToggle plan={basePlan({ route: "deposit" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /other route/i }));
+    expect(screen.getByTestId("scenario-toggle-preview")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Back to your result/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Back to your result/i }),
+    );
+    expect(screen.queryByTestId("scenario-toggle-preview")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /other route/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when the plan has no route yet", () => {
+    const { container } = render(<ScenarioToggle plan={basePlan()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not write to localStorage", () => {
+    const plan = basePlan({
+      route: "deposit",
+      age: "under_55",
+      capital: "ready_130k",
+    });
+    render(<ScenarioToggle plan={plan} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /other route/i }));
+    expect(window.localStorage.length).toBe(0);
+  });
+});
+
+describe("otherRoute", () => {
+  it("swaps deposit and property, and treats unsure as property", () => {
+    expect(otherRoute("deposit")).toBe("property");
+    expect(otherRoute("property")).toBe("deposit");
+    expect(otherRoute("unsure")).toBe("property");
+  });
+});
+
+describe("buildScenarioPreview", () => {
+  it("passes the copy through relevantPlan — capital is nulled when switching from deposit to property", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+      property: "owns_qualifying_strata",
+    });
+    const { previewPlan } = buildScenarioPreview(plan, "property");
+
+    expect(previewPlan.capital).toBeNull();
+    expect(previewPlan.property).toBe("owns_qualifying_strata");
+    expect(previewPlan.route).toBe("property");
+  });
+
+  it("lists missing reachable questions for the other route", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    });
+    const { missingQuestions } = buildScenarioPreview(plan, "property");
+
+    expect(missingQuestions).toContain("property");
+    expect(missingQuestions).not.toContain("capital");
+  });
+
+  it("shows the missing-answer copy for an unanswered property question", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    });
+    render(<ScenarioToggle plan={plan} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /other route/i }));
+    expect(
+      screen.getByText(/what property position you hold/i),
+    ).toBeInTheDocument();
+  });
+
+  it("preview price follows the preview product, not the real verdict product", () => {
+    vi.mocked(usePricingData).mockImplementation((serviceKey) => ({
+      price: serviceKey,
+      isLoading: false,
+      isError: false,
+    }));
+
+    const plan = basePlan({
+      age: "60_plus",
+      route: "property",
+      property: "none",
+      seniorFunding: "income_only_3k",
+      location: "abroad",
+    });
+    render(<ScenarioToggle plan={plan} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /other route/i }));
+    expect(screen.getByText(E33F_OFFSHORE_LIVE_PRICE_KEY)).toBeInTheDocument();
+    expect(screen.queryByText(E33_LIVE_PRICE_KEY)).toBeNull();
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowLeft, GitCompare } from "lucide-react";
+
+import { usePricingData } from "@/hooks/usePricingData";
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import {
+  E33_LIVE_PRICE_CATEGORY,
+  resolveSecondHomePriceKey,
+} from "@/lib/secondhome-studio/pricing-key";
+import { evaluatePlan } from "@/lib/secondhome-studio/rules";
+import {
+  computeSequence,
+  relevantPlan,
+  type QuestionId,
+} from "@/lib/secondhome-studio/sequence";
+import type {
+  PlanState,
+  RouteIntent,
+  Verdict,
+} from "@/lib/secondhome-studio/types";
+
+import { TimelineView } from "./TimelineView";
+import { VerdictPanel } from "./VerdictPanel";
+
+export function otherRoute(route: RouteIntent): RouteIntent {
+  return route === "property" ? "deposit" : "property";
+}
+
+function isQuestionMissing(p: PlanState, q: QuestionId): boolean {
+  switch (q) {
+    case "age":
+      return p.age == null;
+    case "route":
+      return p.route == null;
+    case "capital":
+      return p.capital == null;
+    case "seniorFunding":
+      return p.seniorFunding == null;
+    case "property":
+      return p.property == null;
+    case "family":
+      return false;
+    case "horizon":
+      return p.horizon == null;
+    case "location":
+      return p.location == null;
+  }
+}
+
+export interface ScenarioPreview {
+  previewPlan: PlanState;
+  previewVerdict: Verdict;
+  missingQuestions: QuestionId[];
+}
+
+/**
+ * Build a temporary preview of `plan` evaluated on a different `route`.
+ *
+ * The copy is run through `relevantPlan()` BEFORE evaluation so that answers
+ * from an abandoned branch (e.g. `capital` left over from a deposit route)
+ * are nulled when the preview switches to the property route. This keeps the
+ * preview honest: it only ever evaluates states the wizard sequence could
+ * actually produce.
+ */
+export function buildScenarioPreview(
+  plan: PlanState,
+  route: RouteIntent,
+): ScenarioPreview {
+  const draft: PlanState = { ...plan, route };
+  const previewPlan = relevantPlan(draft);
+  const previewVerdict = evaluatePlan(previewPlan);
+  const reachable = computeSequence(previewPlan);
+  const missingQuestions = reachable.filter((q) =>
+    isQuestionMissing(previewPlan, q),
+  );
+  return { previewPlan, previewVerdict, missingQuestions };
+}
+
+interface ScenarioToggleProps {
+  plan: PlanState;
+}
+
+/**
+ * Second Home Studio — temporary "what if I took the other route?" preview.
+ *
+ * Purely client-side and state-only: the saved plan (`localStorage`, URL
+ * fragment, and parent `plan` state) is never mutated. The preview copy is
+ * sanitized through `relevantPlan()` before evaluation so the verdict is
+ * always computed on a reachable wizard state, and any unreachable answers
+ * are surfaced as "we would need to know X" instead of being invented.
+ */
+export function ScenarioToggle({ plan }: ScenarioToggleProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const route = plan.route;
+  const altRoute = route ? otherRoute(route) : null;
+
+  // Hooks must run before any early return.
+  const preview =
+    isOpen && altRoute ? buildScenarioPreview(plan, altRoute) : null;
+  const previewPriceKey = preview
+    ? resolveSecondHomePriceKey(
+        preview.previewVerdict.product,
+        preview.previewPlan.location,
+      )
+    : null;
+  const { price: previewPrice } = usePricingData(
+    previewPriceKey,
+    E33_LIVE_PRICE_CATEGORY,
+  );
+
+  if (!route) return null;
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="bz-shs-scenario-toggle-trigger"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "var(--space-2, 0.5rem)",
+          padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
+          borderRadius: 8,
+          border: "1px solid var(--accent-funnel)",
+          background: "transparent",
+          color: "var(--accent-funnel)",
+          cursor: "pointer",
+          fontWeight: 600,
+          minHeight: 44,
+        }}
+      >
+        <GitCompare size={18} strokeWidth={1.5} aria-hidden />
+        {getCopy("scenarioToggle.controlLabel")}
+      </button>
+    );
+  }
+
+  const { previewPlan, previewVerdict, missingQuestions } = preview!;
+  const horizon = previewPlan.horizon ?? "exploring";
+  const location = previewPlan.location ?? "in_indonesia";
+
+  return (
+    <section
+      aria-label={getCopy("scenarioToggle.previewEyebrow")}
+      data-testid="scenario-toggle-preview"
+      className="bz-shs-scenario-toggle-preview"
+      style={{
+        display: "grid",
+        gap: "var(--space-4, 1.5rem)",
+        background: "var(--surface-raised)",
+        border: "2px dashed var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-2, 0.5rem)",
+          padding: "var(--space-2, 0.5rem) var(--space-3, 0.75rem)",
+          borderLeft: "3px solid var(--state-info)",
+          background: "color-mix(in srgb, var(--state-info) 8%, transparent)",
+          color: "var(--text-primary)",
+          fontSize: "var(--text-sm, 0.88rem)",
+        }}
+      >
+        <GitCompare
+          size={16}
+          strokeWidth={1.5}
+          aria-hidden
+          style={{ flexShrink: 0 }}
+        />
+        {getCopy("scenarioToggle.banner")}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setIsOpen(false)}
+        className="bz-shs-scenario-toggle-back"
+        style={{
+          justifySelf: "start",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "var(--space-2, 0.5rem)",
+          padding: "6px 14px",
+          borderRadius: 8,
+          border: "1px solid var(--color-border-subtle)",
+          background: "transparent",
+          color: "var(--text-primary)",
+          cursor: "pointer",
+          minHeight: 44,
+        }}
+      >
+        <ArrowLeft size={16} strokeWidth={1.5} aria-hidden />
+        {getCopy("scenarioToggle.back")}
+      </button>
+
+      <VerdictPanel verdict={previewVerdict} />
+
+      {missingQuestions.length > 0 ? (
+        <div
+          style={{
+            display: "grid",
+            gap: "var(--space-2, 0.5rem)",
+            padding: "var(--space-3, 0.75rem)",
+            border: "1px solid var(--color-border-subtle)",
+            borderRadius: 8,
+            background:
+              "color-mix(in srgb, var(--state-warning) 6%, transparent)",
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontWeight: 600,
+              color: "var(--text-primary)",
+            }}
+          >
+            {getCopy("scenarioToggle.missingAnswer.heading")}
+          </p>
+          <ul
+            style={{
+              margin: 0,
+              paddingLeft: "1.2rem",
+              color: "var(--text-primary)",
+            }}
+          >
+            {missingQuestions.map((q) => (
+              <li key={q}>{getCopy(`scenarioToggle.missingAnswer.${q}`)}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <TimelineView
+        horizon={horizon}
+        location={location}
+        route={previewPlan.route}
+        product={previewVerdict.product}
+      />
+
+      {previewPrice ? (
+        <section
+          style={{
+            display: "grid",
+            gap: "var(--space-1, 0.3rem)",
+            background: "var(--surface-raised)",
+            border: "1px solid var(--accent-funnel)",
+            borderRadius: 12,
+            padding: "var(--space-4, 1.5rem)",
+            textAlign: "center",
+            justifyItems: "center",
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontSize: "0.7rem",
+              letterSpacing: "0.15em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {getCopy("price.label")}
+          </p>
+          <div
+            style={{
+              fontFamily: "var(--font-serif, Georgia, serif)",
+              fontSize: "clamp(1.8rem, 4.5vw, 2.4rem)",
+              color: "var(--accent-funnel-text, var(--accent-funnel))",
+            }}
+          >
+            {previewPrice}
+          </div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.88rem)",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {getCopy("price.note")}
+          </p>
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.85rem)",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {getCopy("price.dependentsNote")}
+          </p>
+        </section>
+      ) : null}
+
+      <style>{`
+        .bz-shs-scenario-toggle-trigger,
+        .bz-shs-scenario-toggle-back {
+          transition: transform 120ms ease, box-shadow 120ms ease;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .bz-shs-scenario-toggle-preview *,
+          .bz-shs-scenario-toggle-trigger,
+          .bz-shs-scenario-toggle-back {
+            transition: none !important;
+            animation: none !important;
+          }
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -278,6 +278,21 @@ export const COPY = {
     },
   },
 
+  scenarioToggle: {
+    controlLabel: "What if I took the other route?",
+    banner:
+      "You are comparing a different route. Your saved plan has not changed.",
+    back: "Back to your result",
+    previewEyebrow: "Route preview",
+    missingAnswer: {
+      heading:
+        "To give an honest fit-check result for this route, we would need to know:",
+      capital: "how much capital you could place in the required deposit",
+      property: "what property position you hold",
+      seniorFunding: "which senior funding profile matches you",
+    },
+  },
+
   timeline: {
     ownerLabels: {
       you: "You",


### PR DESCRIPTION
## What

At the verdict stage the Studio shows a **static** three-column "Compare the routes" table that never reflects the visitor's own answers. Someone who lands there on the deposit route has no way to ask the one question that actually precedes a USD 130,000 commitment: *and if I took the other road?* Today the only way to find out is to go back and redo the interview, losing the result you were reading.

This adds a control at the verdict stage that evaluates **the visitor's own answers** against the other route, without disturbing the plan they have saved.

## The defect a cross-family refuter found in this idea before it was built — and how it is cured

Kimi K3, reviewing the spec, objected that `evaluatePlan` would be asked to reason about states the wizard can never produce: patch `route` from `deposit` to `property` while `capital: "ready_130k"` is still populated, and you evaluate a combination the interview could not generate — so the preview verdict could be a lie.

The cure uses a function the package already had: `relevantPlan()` in `sequence.ts` nulls every branch answer unreachable in the current sequence. The copied plan is passed through it **before** evaluation (`ScenarioToggle.tsx:72-73`), and a test fails if that step is ever removed.

The honest consequence is handled rather than hidden: after sanitising, the other route usually has missing answers, so its preview states what it would need to know instead of inventing values.

## Constraints honoured

- The preview price resolves through `resolveSecondHomePriceKey(product, location)` — it does **not** repeat the one-key-for-three-products defect cured by #4747.
- Verdict bands only, never a numeric score or anything readable as approval probability.
- The saved plan is never mutated: no `localStorage` write, no `#p=` fragment change, no wizard state change. Pinned by a test.
- No price decomposition; one all-inclusive figure.
- No new dependency; the Studio stays fully client-side.

## Verification

`vitest run src/app/visa/second-home src/lib/secondhome-studio` — **19 files, 328 tests passing**, re-run independently by the conductor on this branch rather than taken from the build seat's report.

Built on a non-Anthropic seat (Kimi); reviewed, tested, published and armed by the conductor — generator is not grader.