### PR TITLE
fix(mouth): the printed plan lost the money-path diagram

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
@@ -54,6 +54,20 @@ describe("CustodyMap", () => {
     expect(screen.getByRole("list")).toBeInTheDocument();
   });
 
+  it("prints every node body and removes the interactive chevrons", () => {
+    const { container } = render(<CustodyMap />);
+    const css = Array.from(container.querySelectorAll("style"))
+      .map((style) => style.textContent ?? "")
+      .join("\n");
+
+    expect(css).toMatch(
+      /@media print\s*{[\s\S]*?\.custody-node > p\[data-collapsed="true"\]\s*{[\s\S]*?display: block !important;/,
+    );
+    expect(css).toMatch(
+      /@media print\s*{[\s\S]*?\.custody-chevron\s*{[\s\S]*?display: none !important;/,
+    );
+  });
+
   it("renders only user-visible strings sourced from copy.ts", () => {
     const { container } = render(<CustodyMap />);
     const assertRenderedTextComesFromCopy = () => {
@@ -61,7 +75,7 @@ describe("CustodyMap", () => {
       const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
       while (walker.nextNode()) {
         const parent = walker.currentNode.parentElement;
-        if (parent?.closest("style, [hidden]")) continue;
+        if (parent?.closest('style, [data-collapsed="true"]')) continue;
         const value = walker.currentNode.textContent?.trim();
         if (value) textNodes.push(value);
       }

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
@@ -93,7 +93,7 @@ export function CustodyMap() {
                       <path d="m4 6 4 4 4-4" />
                     </svg>
                   </button>
-                  <p id={detailId} hidden={!isExpanded}>
+                  <p id={detailId} data-collapsed={!isExpanded}>
                     {getCopy(`custody.steps.${step}.body`)}
                   </p>
                 </div>
@@ -232,7 +232,7 @@ export function CustodyMap() {
           line-height: 1.6;
         }
 
-        .custody-node > p[hidden] {
+        .custody-node > p[data-collapsed="true"] {
           display: none;
         }
 
@@ -276,6 +276,16 @@ export function CustodyMap() {
         .custody-disclaimer {
           font-size: 0.82rem;
           font-style: italic;
+        }
+
+        @media print {
+          .custody-node > p[data-collapsed="true"] {
+            display: block !important;
+          }
+
+          .custody-chevron {
+            display: none !important;
+          }
         }
 
         @media (max-width: 760px) {

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -57,7 +57,7 @@ describe("SavePlanBar print action", () => {
     ).not.toThrow();
   });
 
-  it("ships the global print rules for document colors, panels, controls, and the WhatsApp contact", () => {
+  it("ships targeted print rules without hiding content buttons globally", () => {
     const { container } = render(
       <SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />,
     );
@@ -67,7 +67,10 @@ describe("SavePlanBar print action", () => {
     // intentionally verify only that the browser-facing rules are emitted.
     expect(css).toContain("@media print");
     expect(css).toContain("--surface-base: #ffffff");
-    expect(css).toContain("button,");
+    expect(css).toContain(".bz-shs-save-plan-bar,");
+    expect(css).toContain(".bz-shs-option,");
+    expect(css).toContain(".bz-shs-scenario-toggle-trigger,");
+    expect(css).not.toMatch(/(?:^|[,{])\s*button\s*(?=[,{])/);
     expect(css).toContain("break-inside: avoid");
     expect(css).toContain('input[type="checkbox"]');
     expect(css).toContain('a[href^="https://wa.me"]::after');

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -43,9 +43,11 @@ const PRINT_STYLES = `
     }
 
     nav,
-    button,
     .fixed.bottom-0.left-0.right-0.z-50,
-    .bz-shs-save-plan-bar {
+    .bz-shs-save-plan-bar,
+    .bz-shs-option,
+    .bz-shs-scenario-toggle-trigger,
+    .bz-shs-scenario-toggle-back {
       display: none !important;
     }
 


### PR DESCRIPTION
## The regression

Two PRs from the same wave collided.

- **#4751** added the Studio's print stylesheet, whose blanket rule hid every `button` — written to hide Save / Copy / Print / Clear.
- **#4753** then rewrote the custody map so each of its three chain nodes **is** a `<button aria-expanded>`.

Consequence on promoted production: printing the plan drops the three custody nodes entirely. Only the connecting arrows and the "not a payment to Bali Zero" aside survive — arrows around an empty space. Found under `page.emulateMedia({media:'print'})` and confirmed by computed style, not by eye.

This matters because the printed plan is the artefact a prospect carries to their bank or their family. The custody diagram is the page's highest-leverage trust asset: the whole point is showing the money never enters Bali Zero's hands.

## The fix — inverted, not patched

Print now hides **named controls** (`.bz-shs-save-plan-bar`, `.bz-shs-option`, the scenario-toggle trigger and back control) instead of every `button` with a growing list of `:not()` exceptions. A blanket selector with exceptions is exactly how this bug was born; the next content-bearing button someone adds would have hit it too.

After the inversion, a content button added tomorrow prints by default. The worst new failure mode is a stray control on paper — cosmetic — rather than missing content.

Custody bodies now print expanded regardless of their on-screen state: paper has no interaction, and a collapsed node would print a heading stripped of the sentence that explains it. The collapse moves from the `hidden` attribute to `data-collapsed` so the print rule can override it. Chevrons are hidden — they afford a click that cannot happen on paper.

## Audit of the same class

Every `<button>` in the studio components was censused: custody node (content — now prints), question option, four save-bar controls, two scenario-toggle controls (all named and hidden). `ReadinessChecklist` uses `<input>` and was never affected.

## Regression net

A test fails if a bare `button` selector ever returns to the print block:

```js
expect(css).not.toMatch(/(?:^|[,{])\s*button\s*(?=[,{])/);
```

`vitest run src/app/visa/second-home src/lib/secondhome-studio` — **19 files, 329 tests passing**, re-run independently by the conductor on this branch rather than taken from the build seat's report.

Built on the Codex seat (non-Anthropic); graded, tested, published and armed by the conductor — generator is not grader.