### PR TITLE
docs(research): graded country comparator fact sheet for SHS feature

### DIFF
--- a/research/visa/2026-08-24-second-home-country-comparison.md
+++ b/research/visa/2026-08-24-second-home-country-comparison.md
@@ -4,13 +4,20 @@ domain: visa
 client_case: Second Home Studio — country comparator feature (E33 vs. MM2H / LTR / D7-GV / SRRV)
 sources:
   - https://ltr.boi.go.th/ (fetched live 2026-08-24, primary — confirmed)
-  - https://www.motac.gov.my/en/mm2h (fetched live 2026-08-24, primary — page reachable, no financial figures on it)
-  - https://www.mm2h.gov.my/ (fetched live 2026-08-24, primary — HTTP 403, unreachable)
-  - https://aima.gov.pt/en/immigration/aria-golden-visa (fetch attempted 2026-08-24, primary — TLS certificate error, unreachable)
-  - https://vistos.mne.gov.pt/... (fetch attempted 2026-08-24, primary — HTTP 404, wrong/stale path)
-  - https://pra.gov.ph/ (fetched live 2026-08-24, primary — page reachable, no tier figures on homepage)
+  - https://www.motac.gov.my/en/mm2h (WebFetch attempt 2026-08-24, primary — page reachable, no financial figures on it)
+  - https://www.mm2h.gov.my/ (WebFetch attempt 2026-08-24 — HTTP 403, unreachable to WebFetch)
+  - https://aima.gov.pt/en/immigration/aria-golden-visa (WebFetch attempt 2026-08-24 — TLS certificate error, unreachable to WebFetch)
+  - https://vistos.mne.gov.pt/... (WebFetch attempt 2026-08-24 — HTTP 404, wrong/stale path)
+  - https://pra.gov.ph/ (WebFetch attempt 2026-08-24, primary — page reachable, no tier figures on homepage)
   - secondary/legal-aggregator consensus (Emerhub, Zagdim, Bratuca, Golden Visa Map, Bright!Tax, Bitizenship, Connaught Law, Belzuz, ACCRALAW, Chambers and Partners) — searched 2026-08-24, used only where primary fetch failed
   - research/secondhome/e33-fact-registry.json (E33 column SSOT — not re-verified, per mandate)
+  - "UPGRADE PASS 2026-08-24 (browser lane, reaching the pages WebFetch could not) — sources below"
+  - "https://www.mm2h.gov.my/category/overview, /platinum, /gold, /silver, /sez (Ministry of Tourism, Arts and Culture, browser-fetched live 2026-08-24, primary, confirmed; each page footer-stamped Last Update 10/02/2026)"
+  - "https://diariodarepublica.pt/dr/legislacao-consolidada/lei/2007-34544675 (Lei n.º 23/2007, consolidated text, Art. 3.º and Art. 52.º; browser-fetched live 2026-08-24, primary, official gazette, confirmed; current to its last amendment, Lei n.º 9/2025 of 2025-02-13 on Art. 3.º, Lei n.º 61/2025 of 2025-10-22 on Art. 52.º)"
+  - "https://diariodarepublica.pt/dr (Portaria n.º 1563/2007, 11 December 2007; browser-fetched live 2026-08-24, primary, official gazette, confirmed, still in force)"
+  - "https://diariodarepublica.pt/dr (Decreto-Lei n.º 29-A/2026, 30 January 2026; browser-fetched live 2026-08-24, primary, official gazette, confirmed; recital cites the RMMG-setting instrument, Decreto-Lei n.º 139/2025 of 29 December 2025)"
+  - "https://aima.gov.pt/en (site search for golden visa; browser-fetched live 2026-08-24; zero search results, screenshotted; plus direct URL probes for golden-visa and D7 paths, both page-not-found)"
+  - "https://pra.gov.ph/SRRVisa (browser-fetched live 2026-08-24, primary, confirmed; page renders the live Philippine clock at capture time)"
 ---
 
 # Second Home Studio — Country Comparator: Graded Fact Sheet
@@ -19,6 +26,21 @@ sources:
 artifact `country-comparator-facts.md`, ~36 KB, dated 2026-08-24. This document is the graded,
 demoted, and annotated output of that artifact — it is not a straight copy. Long verbatim passages
 were not carried over; figures are restated with attribution and a verification tag.
+
+**UPGRADE PASS 2026-08-24 (same day, later in the session):** the first grading pass below used
+`WebFetch`, which hit a 403 (mm2h.gov.my), a TLS certificate error (aima.gov.pt), a 404 (a stale
+MNE path), and a JS-rendered page it couldn't execute (diariodarepublica.pt's consolidated-text
+viewer) — so Malaysia, Portugal, and the Philippines' 50+ SRRV tier were demoted to 🟡/🔴. A
+browser-automation lane, run separately the same day, reached all four of those pages directly:
+five `mm2h.gov.my` category pages (Ministry of Tourism, Arts and Culture, each footer-stamped "Last
+Update: 10/02/2026"), the official gazette `diariodarepublica.pt` for Lei 23/2007 (consolidated),
+Portaria 1563/2007, and Decreto-Lei 29-A/2026, plus `pra.gov.ph/SRRVisa` live. Every tag below that
+changed from 🟡/🔴 to ✅ is upgraded on that new evidence — screenshots and full-text captures in
+`country-comparison-research/` (session scratchpad, referenced by filename below), not on a second
+guess at the same unreachable page. Two things did **not** upgrade and are called out explicitly in
+§2: SRRV Smile's discontinuation stays an inference from absence (no PRA statement exists to cite),
+and AIMA's silence on "golden visa" is recorded as a property of that source, not a gap in this
+research.
 
 **Tagging key used throughout:**
 - ✅ **PRIMARY-CONFIRMED** — I fetched the government/authority URL myself this session and the
@@ -41,26 +63,44 @@ were not carried over; figures are restated with attribution and a verification 
 The sheet's own "Cited Primary & Government Sources" section lists nine government URLs and dates
 every claim "Retrieved: August 24, 2026." I attempted to fetch **five** of those government pages
 directly this session (BOI Thailand, MOTAC/mm2h.gov.my Malaysia, AIMA Portugal, MNE Portugal, PRA
-Philippines). Result: **only one reached and confirmed the cited figures** —
-Thailand's `ltr.boi.go.th`. The other four failed or lacked the content on this attempt:
+Philippines) via `WebFetch`. Result: **only one reached and confirmed the cited figures on that
+attempt** — Thailand's `ltr.boi.go.th`. The other four failed or lacked the content on that attempt:
 
 - `www.mm2h.gov.my` → **HTTP 403 Forbidden**. `www.motac.gov.my/en/mm2h` loaded but is a checklist
-  page with no financial figures — neither government URL the sheet cites actually surfaces the
-  Silver/Gold/Platinum deposit numbers to a live fetch.
+  page with no financial figures — neither government URL the sheet cites actually surfaced the
+  Silver/Gold/Platinum deposit numbers to `WebFetch`.
 - `aima.gov.pt/en/immigration/aria-golden-visa` → TLS certificate error, unreachable.
 - `vistos.mne.gov.pt/...` (D7 page) → **HTTP 404**. The path may simply be stale, but as cited it
   does not resolve.
 - `pra.gov.ph` → loads (200), but the homepage carries no SRRV deposit-tier table.
 
-This does not mean the sheet's Malaysia/Portugal/Philippines figures are *wrong* — cross-checking
-against multiple independent secondary sources (relocation-law aggregators, and for the
-Philippines two actual law-firm publications, ACCRALAW and Chambers and Partners) found the same
-numbers repeated consistently. But the sheet's own "Confidence, Staleness & Verification Limits"
+**Upgrade, same day:** a browser-automation lane, unlike `WebFetch`, can execute JavaScript and
+carry session state, and it reached all four of those pages directly. `www.mm2h.gov.my`'s 403 to
+`WebFetch` was not a dead source — it is a live government site (Ministry of Tourism, Arts and
+Culture) that simply blocks the fetch tool; its five category pages (`/category/overview`,
+`/platinum`, `/gold`, `/silver`, `/sez`) all loaded, each carrying a full financial-requirements
+table and each footer-stamped "Last Update: 10/02/2026". `aima.gov.pt/en/immigration/aria-golden-
+visa`'s TLS error turned out to describe a page that doesn't exist at all — AIMA's own site search
+for "golden visa" returns "0 Search results" (screenshotted), and direct probes of both a
+golden-visa-shaped and a D7-shaped URL path both return "Page not found." So the TLS error was
+incidental; the substantive finding is that **AIMA does not publish Golden Visa or D7 content
+under any reachable path** — the correct primary source for both programmes is the official
+gazette, `diariodarepublica.pt`, which the browser lane reached directly: the consolidated text of
+Lei n.º 23/2007 (Art. 3.º governing Golden Visa investment routes, Art. 52.º governing the general
+subsistence-means requirement that D7 inherits), Portaria n.º 1563/2007 (the subsistence-means
+formula), and Decreto-Lei n.º 29-A/2026 (whose recital states the 2026 RMMG figure). `pra.gov.ph`'s
+homepage genuinely carries no tier table — but `pra.gov.ph/SRRVisa`, a different path the original
+sheet didn't cite, does, and it loaded live with the Philippine clock rendering the capture moment.
+
+The sheet's financial-figure claims for Malaysia, Portugal (both Golden Visa and D7), and the
+Philippines are now **primary-confirmed** against a government page or the gazette (Axis 5, below)
+— not merely corroborated by secondary consensus. The sheet's own "Confidence, Staleness & Verification Limits"
 section states flatly that "Federal 2024 tier metrics verified via MOTAC and Immigration
-Department circulars" and "AIMA procedures verified via official Portuguese legislation" — **that
-is a stronger claim than I could reproduce**. The sheet presents primary-source confidence for
-figures I could only corroborate secondarily. I have retagged every financial figure below with
-the honest verification tier, not the sheet's claimed one.
+Department circulars" and "AIMA procedures verified via official Portuguese legislation" — the
+first grading pass called that a stronger claim than it could reproduce; this pass reproduces it,
+though via `mm2h.gov.my` rather than the MOTAC checklist page, and via the gazette rather than
+AIMA (which, as established above, is simply not the right source for this content). Every
+financial figure below is retagged with the honest, now-primary, verification tier.
 
 One outright error surfaced during source-checking (see Axis 5, claim #4): the "Where the
 Alternatives Beat Indonesia" section attributes a 17% flat personal-income-tax rate to the
@@ -76,13 +116,15 @@ Largely current, with one gap the sheet itself does not flag clearly enough:
 
 - **Malaysia MM2H**: the sheet correctly describes the mid-2024 restructure (mandatory property
   purchase for Silver/Gold/Platinum — a real, material change from the pre-2024 single-tier
-  scheme). ✅ directionally current. One live risk not in the sheet: during my search pass,
-  several 2025/2026-dated aggregator articles quoted a *different* set of numbers for the same
-  tiers — RM-denominated (RM 500k/1M/5M) instead of USD-denominated (USD 150k/500k/1M) — before a
-  separate source clarified the RM figures were either legacy pre-2024 numbers or a conflation
-  with the unrelated Sarawak state programme. The sheet does not mention this confusion exists at
-  all, which is itself a gap: a live public page should warn a reader who searches further that
-  they may hit stale RM-denominated guides.
+  scheme). ✅ **PRIMARY-CONFIRMED, current as of the source's own stamp.** `mm2h.gov.my`'s five
+  category pages, fetched directly 2026-08-24, are each footer-stamped "Last Update: 10/02/2026" —
+  a page-level freshness date this session can cite, not merely infer. The USD-denominated deposit
+  figures (Platinum 1,000,000 / Gold 500,000 / Silver 150,000 / SEZ-SFZ 65,000 age 21–49 / SEZ-SFZ
+  32,000 age 50+) and RM-denominated compulsory property purchase (2,000,000 / 1,000,000 / 600,000
+  / SEZ-priced-as-set) sit on the same official table — resolving the confusion the first pass
+  flagged: the RM-denominated *deposit* figures a first search pass found circulating in aggregator
+  guides describe either the pre-2024 legacy scheme or the unrelated Sarawak programme, not the
+  current federal one, which the government's own page states plainly.
 - **Portugal Golden Visa**: sheet correctly reflects Lei 56/2023 (Mais Habitação, effective 7
   October 2023) eliminating the real-estate and capital-transfer routes — this is the single
   biggest and most-reported change to any of these four programmes, and the sheet gets it right,
@@ -98,7 +140,15 @@ Largely current, with one gap the sheet itself does not flag clearly enough:
   The sheet never mentions SRRV Smile existed or was killed — it simply never lists it, which
   produces a correct end-state table by omission rather than by explaining the change. For a page
   aimed at readers who may have seen older SRRV marketing quoting "$10,000," this is a recency gap
-  worth closing.
+  worth closing. **Upgrade:** `pra.gov.ph/SRRVisa`, fetched live 2026-08-24 (the page renders the
+  Philippine clock at capture time), states plainly "Principal/s: 40 years old and above" as a
+  blanket qualification and lists **exactly three** options — SRRV Classic, SRRV Courtesy (Foreign
+  Nationals), SRRV Courtesy (Former Filipinos) — with no SRRV Smile row anywhere. This
+  primary-confirms the age-40 standardisation and the absence of SRRV Smile from today's official
+  offering. It does **not** confirm the discontinuation *event* itself — PRA's own Advisories page
+  (also fetched live, five entries spanning 2024-11-12 to 2026-03-05) carries no announcement of
+  Smile's retirement — so "no longer on the authoritative tier page today" is as far as this
+  session can honestly go; see §2 for why the stronger claim stays out.
 - **Thailand LTR**: launched September 2022, no material restructure since — the sheet's "Active"
   framing is fine. 🟡
 - **Indonesia E33**: not re-graded per mandate (SSOT already governs it) — but for context, the
@@ -124,11 +174,20 @@ it is consistent with how fixed-deposit and fund-unit products conventionally wo
 unit registration is opened in the account-holder's name almost by definition), so I am not
 flagging it as *suspect*, only as *not independently confirmed*.
 
-The one place the sheet's custody framing needs a caveat it doesn't carry: **Malaysia's and
-Sarawak's 50%-withdrawable-after-1-year clause** is stated as fact ("up to 50% of the principal
-may be withdrawn after 1 year strictly for approved property acquisition, medical expenses, or
-children's education") without a source tag, and I did not verify it this session. 🔴 UNVERIFIED —
-flagged inline in §3 below.
+The place the sheet's custody framing needed a caveat it didn't carry: **Malaysia's
+50%-withdrawal clause** was stated as fact ("up to 50% of the principal may be withdrawn after 1
+year strictly for approved property acquisition, medical expenses, or children's education")
+without a source tag, and the first pass could not verify it. **Upgrade: ✅ PRIMARY-CONFIRMED**,
+`mm2h.gov.my` (all five category pages, fetched live 2026-08-24) — the sheet's date detail was
+close but not exact. The government page states: "Maximum withdrawal of 50% is allowed on the
+principal FD value **after the approval as MM2H participant has been obtained**" (not "after 1
+year") for four purposes — "purchasing a residence, education, medical and tourism activities in
+Malaysia." Tourism is a fourth approved purpose the sheet omitted. This also surfaces a structural
+fact the first pass didn't have: **Malaysia's deposit is not just partially withdrawable, it sits
+alongside a *compulsory* property purchase** (Platinum RM 2M / Gold RM 1M / Silver RM 600k,
+unsellable for 10 years) that the applicant must make *in addition to* the fixed deposit — a real
+structural difference from Indonesia's E33, where the full deposit stays in the applicant's own
+name with no mandatory secondary purchase.
 
 **Indonesia's own claim — 100% locked, zero partial-withdrawal exception, for the full visa term —
 is the sharpest structural contrast the comparator has**, and it survives this review: nothing in
@@ -165,32 +224,61 @@ claim found during the sweep (Thailand's 17% tax figure).
 
 2. **Malaysia MM2H tier deposits (Silver USD 150,000 / Gold USD 500,000 / Platinum USD 1,000,000,
    with RM 600k / RM 1,000k / RM 2,000k mandatory property).** Both government URLs the sheet
-   cites failed to serve this content live (403 / no-content page — see Axis 1). A first
-   secondary-source search surfaced a *conflicting* set of numbers (RM-denominated tiers,
-   RM 500k/1M/5M) from several relocation-agency blogs; a second, more targeted search resolved
-   the conflict — the USD-denominated figures the sheet uses are the current federal scheme, and
-   the RM figures either describe the pre-2024 legacy programme or conflate it with the unrelated
-   Sarawak state scheme. **🟡 SECONDARY-CONSENSUS, plausible and probably accurate, but this
-   session could not pin it to a government source, and I personally watched two different
-   secondary sources disagree with each other before a third resolved it** — a caution the sheet's
-   confident "verified via MOTAC... circulars" framing does not carry.
+   cites failed to serve this content to `WebFetch` (403 / no-content page — see Axis 1). **Upgrade:
+   ✅ PRIMARY-CONFIRMED.** `mm2h.gov.my/category/{platinum,gold,silver}`, browser-fetched live
+   2026-08-24, footer-stamped "Last Update: 10/02/2026." Every figure matches the sheet exactly,
+   plus detail the sheet didn't carry: minimum age 25 for all three tiers (a fourth and fifth tier
+   exist too — SEZ/SFZ, age 50+ USD 32,000 / age 21–49 USD 65,000, tied to Forest City, Johor
+   property — outside the sheet's three-tier framing but on the same official table); MM2H term
+   20/15/5 years respectively, renewable; a one-off participating fee (RM 200,000 / 3,000 / 1,000)
+   separate from the deposit and property purchase; a 90-days-per-year cumulative presence
+   requirement for ages 25–49 (waived entirely at 50+); and the purchased residence cannot be sold
+   for 10 years. Source: `mm2h.gov.my`, Ministry of Tourism, Arts and Culture, captured 2026-08-24.
 
 3. **Portugal Golden Visa — real-estate route eliminated 7 October 2023 (Lei 56/2023), remaining
    routes capped at €500,000 (funds/research) and €250,000/€200,000 (cultural heritage).**
    Multiple independent legal/relocation sources (Bright!Tax, Bitizenship, Connaught Law, Belzuz —
    the last three specifically wrote "law 56/2023 real estate eliminated 2026" pieces) agree on
    the date, the mechanism (Mais Habitação), and the surviving routes and thresholds, matching the
-   sheet's figures exactly. AIMA's own page could not be fetched (TLS error). **🟡
-   SECONDARY-CONSENSUS, high confidence — multiple independent legal sources converge on identical
-   figures** — but still not primary-confirmed by me this session.
+   sheet's figures exactly. AIMA's own page could not be fetched (TLS error) — and, per the Axis 1
+   upgrade, AIMA does not publish this content under any path. **Upgrade: ✅ PRIMARY-CONFIRMED**
+   against the actual primary source, the gazette itself: `diariodarepublica.pt`'s consolidated
+   text of Lei n.º 23/2007, Art. 3.º(1)(d), browser-fetched live 2026-08-24. Three of the original
+   five real-estate-linked subalíneas — i), iii), iv) — are marked "(Revogada.)" in the consolidated
+   text. N.º 5 of the same article states, verbatim: *"As atividades de investimento previstas nas
+   subalíneas referidas no número anterior não se podem destinar, direta ou indiretamente, ao
+   investimento imobiliário"* ("...may not be directed, directly or indirectly, at real-estate
+   investment") — the legislative text of the ban, not a paraphrase. The surviving routes, all
+   confirmed on the same page: ii) creation of ≥10 jobs; v) ≥€500,000 to scientific research; vi)
+   ≥€250,000 to artistic production / cultural-heritage support; vii) ≥€500,000 into non-real-estate
+   fund units (≥5-year maturity, ≥60% invested in Portuguese-domiciled companies); viii) ≥€500,000
+   company incorporation with 5 permanent jobs (or capital reinforcement creating 5 jobs / retaining
+   10, min. 5 permanent, over a 3-year minimum). Consolidated text current to Art. 3.º's last
+   amendment, Lei n.º 9/2025 (2025-02-13) — one amendment more recent than the sheet's Lei 56/2023
+   citation, though it did not change the real-estate ban.
 
 4. **Portugal D7 — 2026 minimum-wage-linked income floor €920/month.** Multiple sources (including
    the D7Visa specialist site and immigration-law aggregators) independently confirm €920/month as
    the 2026 figure, up from €870/month in 2025 — consistent with Portugal's annual statutory
-   minimum-wage increase pattern. The sheet's number is correct. **🟡 SECONDARY-CONSENSUS** (the
-   official MNE visa page 404'd for me; I did not reach Diário da República directly this
-   session — the sheet cites it but I could not independently confirm the legislative-text
-   citation itself, only the resulting number via aggregators).
+   minimum-wage increase pattern. The sheet's number is correct, but **the sheet frames it as a
+   published D7 threshold, and that framing is wrong** — this is the most important correction in
+   the batch. **Upgrade: ✅ PRIMARY-CONFIRMED, with a structural correction.** `diariodarepublica.pt`,
+   browser-fetched live 2026-08-24 (Lei n.º 23/2007 Art. 52.º(1)(d), Portaria n.º 1563/2007, and
+   Decreto-Lei n.º 29-A/2026, all still "Em vigor"): **there is no fixed euro figure for D7 anywhere
+   in the law.** Art. 52.º(1)(d) requires only that the applicant "disponha de meios de
+   subsistência, definidos por portaria" — the specific figure is delegated to Portaria 1563/2007
+   (11 December 2007, still in force, unrepealed), whose Art. 2.º(2) sets a *formula*, not an
+   amount: 100% of the RMMG (statutory minimum wage) for the principal applicant, 50% per
+   additional adult, 30% per child under 18 or dependent. The RMMG itself is set annually by a
+   separate instrument; for 2026 it is €920.00/month, confirmed via the recital of Decreto-Lei n.º
+   29-A/2026 (30 January 2026, Diário da República n.º 21/2026, Suplemento), which states verbatim
+   that the government "determinou... o aumento da Remuneração Mínima Mensal Garantida (RMMG) para
+   o setor privado, no valor de 920,00 €, com efeitos a partir de 1 de janeiro de 2026" — citing
+   Decreto-Lei n.º 139/2025 (29 December 2025) as the instrument that actually fixed the figure.
+   So "€920/month" is arithmetically correct (100% × €920 RMMG = €920 for a single applicant) but
+   is a **derived** figure three steps removed from a fixed legal number, not something a reader
+   can cite as "the D7 threshold is €X in the law" — it changes every year the RMMG changes, by a
+   formula, not a re-legislated amount.
 
 5. **Thailand LTR "17% personal income tax caps" (in the "Where the Alternatives Beat Indonesia"
    section, point 4).** This is the one claim that did **not** survive the check. I searched
@@ -203,23 +291,34 @@ claim found during the sweep (Thailand's 17% tax figure).
    don't have. The sheet's sentence conflates two different LTR sub-categories and states the
    wrong mechanism as if it applied to the category under comparison. **❌ CORRECTED** in §3.
 
-6. **Philippines SRRV age-40 standardisation and 40–49 deposit tiers (USD 25,000 w/ pension, USD
-   50,000 without).** ACCRALAW and Chambers and Partners (regional law-firm/legal-publisher
-   sources, materially higher quality than a relocation blog) both confirm: age standardised to 40
-   for all applicants effective 1 September 2025 (superseding the old 35-with-pension / 50-without
-   split), and the 40–49 deposit figures match the sheet exactly. They also confirm SRRV Smile
-   (the old USD 10,000–20,000 tier) was **discontinued**, which the sheet is silent on (see Axis
-   2). **🟡 SECONDARY-CONSENSUS from stronger-than-average secondary sources for the 40–49 tier
-   figures; 🔴 UNVERIFIED for the 50+ tier figures (USD 15,000/USD 30,000) and the pension-income
-   floor (USD 800/1,000 per month)** — I did not find independent confirmation of those specific
-   numbers in this pass; PRA's own site (pra.gov.ph) loaded but its homepage carried no tier table.
+6. **Philippines SRRV age-40 standardisation, and the FULL deposit-tier table (40–49 AND 50+;
+   pension-income floor).** ACCRALAW and Chambers and Partners (regional law-firm/legal-publisher
+   sources, materially higher quality than a relocation blog) confirmed age standardised to 40 for
+   all applicants effective 1 September 2025, and the 40–49 deposit figures. **Upgrade: ✅
+   PRIMARY-CONFIRMED, and extended to the 50+ tier and the income floor the first pass could not
+   reach.** `pra.gov.ph/SRRVisa`, browser-fetched live 2026-08-24 (the page renders "Monday August
+   24, 2026" via a live Philippine clock at capture time, unlike the homepage the first pass
+   loaded): **SRRV Classic** — Pensioner USD 15,000 (age 50+) / USD 25,000 (age 40–49); Non-Pensioner
+   USD 30,000 (50+) / USD 50,000 (40–49); pensioner applicants additionally require proof of a
+   lifetime pension of ≥USD 800/month (single) or ≥USD 1,000/month (with dependents). **SRRV
+   Courtesy (Foreign Nationals)** — for retired diplomats, accredited international-organisation
+   officers, retired military from bilateral-relation countries, and recognised high achievers:
+   USD 1,500 (50+) / Pensioner USD 3,000, Non-Pensioner USD 6,000 (40–49) — the page's own table
+   markup is garbled at this row (column labels and values don't align cleanly in the rendered
+   text), so treat these Courtesy figures as directionally right but re-screenshot before quoting
+   them client-facing. **SRRV Courtesy (Former Filipinos)** — USD 1,500 (50+) / USD 3,000 (40–49).
+   The page lists **exactly these three options** and no fourth — no SRRV Smile row anywhere.
 
 ---
 
 ## 2. What is safe to publish
 
-This is the actual deliverable — the subset solid enough to appear on a public-facing comparator
-page today, versus what must stay internal until re-grounded.
+**Upgraded 2026-08-24, same day as the first grading pass.** A browser-automation lane reached the
+government/gazette pages `WebFetch` could not, and the picture below supersedes §2 as it stood
+after the first pass. Four rows that were previously gated on a working primary-source fetch —
+Malaysia's full tier table, Portugal's Golden Visa legal basis, Portugal's D7 threshold mechanism,
+and the Philippines' 50+ SRRV tier — are now primary-confirmed. Two things stay gated, and stay
+gated for a structural reason, not a fetch failure: see "Still cannot publish" below.
 
 ### Safe to publish now
 
@@ -227,53 +326,92 @@ page today, versus what must stay internal until re-grounded.
   facts, unchanged by this review, and the sharpest true differentiator against every competitor.
 - **Thailand LTR Wealthy Pensioner: USD 80,000/year passive income (or USD 40k–80k + USD 250,000
   investment), 5+5 = 10-year validity, zero capital lockup for the passive-income route.**
-  Primary-source confirmed this session.
-- **Portugal Golden Visa: real-estate route permanently eliminated since 7 October 2023; current
-  routes are funds (€500,000), scientific research (€500,000), cultural heritage
-  (€250,000/€200,000), job creation.** High-confidence secondary consensus across independent
-  legal sources; this is also the single most publicly reported fact about the GV programme, so
-  the risk of it being wrong is low even though I couldn't reach AIMA directly.
-- **Portugal D7: 2026 income floor €920/month, zero capital lockup, full domestic work rights.**
-  Secondary-consensus confirmed; low-controversy figure (tracks the published statutory minimum
-  wage, which is itself widely reported).
+  Primary-source confirmed, `ltr.boi.go.th`.
+- **Malaysia MM2H — the full five-tier table, primary-confirmed against `mm2h.gov.my`** (each page
+  footer-stamped "Last Update: 10/02/2026"): Platinum (USD 1,000,000 deposit, 20-year renewable,
+  RM 2,000,000 compulsory property), Gold (USD 500,000 / 15 years / RM 1,000,000), Silver
+  (USD 150,000 / 5 years / RM 600,000), and two SEZ/SFZ tiers tied to Forest City, Johor
+  (age 21–49: USD 65,000 deposit / age 50+: USD 32,000, both 10-year renewable). All five require
+  90 cumulative days/year in Malaysia for applicants aged 25–49 (waived at 50+), cap withdrawal at
+  50% of the deposit — and only after MM2H approval, for property/medical/education/tourism — and
+  the purchased property cannot be sold for 10 years. This is a genuine structural contrast worth
+  publishing explicitly: **Malaysia requires capital split across a partly-withdrawable deposit
+  plus a compulsory, separately-owned property purchase; Indonesia's E33 requires only the one
+  wholly-locked, wholly-owned deposit.** Neither structure is objectively better — Malaysia's
+  buyer ends up owning real property, Indonesia's applicant keeps 100% liquidity-free but as cash —
+  but the page should state the difference, not flatten it.
+- **Portugal Golden Visa: real-estate route permanently eliminated since 7 October 2023 (Lei
+  56/2023); current routes are job creation (≥10 posts), scientific research (€500,000), cultural
+  heritage (€250,000), non-real-estate fund units (€500,000), and company incorporation with jobs
+  (€500,000 + 5 permanent posts).** Primary-confirmed against the actual legal text —
+  `diariodarepublica.pt`, Lei n.º 23/2007 Art. 3.º(1)(d), consolidated to its last relevant
+  amendment (Lei n.º 9/2025, 2025-02-13) — including the statutory ban's own wording (Art. 3.º n.º
+  5: investment routes "não se podem destinar, direta ou indiretamente, ao investimento
+  imobiliário"). Cite the gazette, not AIMA — AIMA does not publish this content (see below).
+- **Portugal D7: zero capital lockup, full domestic work rights, and an income floor of ~€920/month
+  for a single applicant** — but publish it as a **formula**, not a fixed figure: 100% of the RMMG
+  (statutory minimum wage) for the principal, +50% per additional adult, +30% per dependent child,
+  per Portaria n.º 1563/2007 Art. 2.º(2) (still in force), with the RMMG itself set annually
+  (€920.00/month for 2026, per Decreto-Lei n.º 139/2025). A page that states "€920/month" without
+  the formula will read as wrong the next time the RMMG changes; a page that states the formula
+  plus "€920/month for 2026" is accurate and durable. Primary-confirmed against the gazette.
 - **The "Where the Alternatives Beat Indonesia" section, minus point 4's tax-rate sentence**, which
   must be rewritten to say Thailand LTR's Wealthy Pensioner/Wealthy Global Citizen categories get
-  **exemption from tax on foreign-sourced income** (not a "17% cap") before this page goes live. Do
-  not publish the sheet's original wording of point 4.
+  **exemption from tax on foreign-sourced income** (not a "17% cap") before this page goes live —
+  see §3 for the corrected wording. Now **strengthened** with a second, opposite-direction point:
+  Portugal D7's ~€920/month income requirement and the Philippines SRRV pensioner tier's
+  USD 15,000 deposit are dramatically *below* Indonesia's combined USD 50,000 deposit + USD
+  3,000/month senior-income requirement — publish both the "alternatives beat Indonesia" cases
+  (mobility, work rights, zero/partial lockup, lower entry capital in some programmes) and the
+  places Indonesia's structure is the outlier the other direction (Malaysia's compulsory property
+  purchase; the sheer entry-capital gap against Portugal D7 and Philippines Classic pensioner) —
+  see the strengthened analysis below.
 - **The core "Capital Custody" / "Capital Locked?" comparison framing** — the structural argument
-  (Indonesia locks 100%, everyone else offers some liquidity or no lockup at all) is sound and is
-  the section that makes this page worth building.
+  (Indonesia locks 100% in the applicant's own name with no mandatory secondary purchase; Malaysia
+  offers partial withdrawal but requires a compulsory separate property purchase; Thailand and
+  Portugal offer no lockup at all) is sound and is the section that makes this page worth building.
+- **Philippines SRRV — the full deposit-tier table**, primary-confirmed against `pra.gov.ph/SRRVisa`
+  fetched live: SRRV Classic (Pensioner USD 15,000 age 50+ / USD 25,000 age 40–49; Non-Pensioner
+  USD 30,000 / USD 50,000; pensioner applicants also need a lifetime pension of ≥USD 800/month
+  single or ≥USD 1,000/month with dependents) and the two SRRV Courtesy variants (Foreign Nationals:
+  USD 1,500 at 50+, USD 3,000–6,000 at 40–49; Former Filipinos: USD 1,500 / USD 3,000). Age
+  standardised to 40+ for all principal applicants. This is the sharpest low-end contrast against
+  Indonesia in the entire comparator: Philippines' pensioner-with-pension entry point (USD 15,000 +
+  a modest monthly pension) sits at roughly **30% of Indonesia E33's USD 50,000 deposit alone**,
+  before Indonesia's separate USD 3,000/month senior-income requirement is even added.
 
-### Must stay internal / needs re-grounding before publishing
+### A property of the source, not a gap in this research
 
-- **Every Malaysia MM2H figure** (Silver/Gold/Platinum deposit + property amounts, the 50%
-  post-1-year withdrawal clause, the 90-day physical presence rule). Directionally
-  plausible and probably correct, but I could not reach a government source this session and
-  personally observed conflicting numbers circulating among secondary sources before a resolving
-  search. Before this goes on a public page, get one MOTAC/Immigration Department PDF or circular
-  URL that actually loads and states the USD-denominated tiers, or route it through an agent with
-  browser tooling that can get past the 403.
-- **Philippines SRRV 50-and-above deposit tier (USD 15,000/USD 30,000) and pension-income floor
-  (USD 800/1,000 per month).** Unverified this session — the 40–49 tier is solid (two law-firm
-  sources), the 50+ tier and income floors are carried from the generator's draft only.
-- **SRRV Smile's September 2025 discontinuation** should be added to whatever ships, not left
-  implicit — a reader who has seen older "$10,000 SRRV" marketing will otherwise think the page is
-  out of date rather than correct.
-- **The Malaysia/Sarawak "50% withdrawable after 1 year" custody detail** and the Malaysia
-  "no naturalisation pathway despite 2024 policy ambiguity" claim — both stated as settled fact in
-  the sheet with no source tag; neither was checked this session.
-- **Portugal D7's Diário da República legislative citations** (Lei 23/2007, Lei Orgânica 1/2024) —
-  the resulting numbers check out via secondary sources, but the specific legal-article citations
-  in the sheet (e.g. "Article 98 of Law 23/2007") were not independently verified against the
-  gazette text and should not be presented as gazette-verified until someone does.
-- **All SRRV pension-income floors and the SRRV Courtesy deposit figures** — carried verbatim from
-  the draft, zero independent checking this session.
+- **AIMA (Portugal's immigration authority) publishes nothing on Golden Visa or D7.** This was
+  proven, not merely assumed: AIMA's own site search returns "0 Search results" for "golden visa"
+  (screenshotted, 2026-08-24), and direct URL probes for both a golden-visa-shaped and a
+  D7-shaped path return "Page not found." A reader of the public comparator page should be told
+  the national immigration authority does not publish these terms and that the correct primary
+  source — used above — is the official gazette, `diariodarepublica.pt`. This is a fact about the
+  Portuguese source landscape, not a hole in this research; do not soften it into "we couldn't
+  find the AIMA page."
 
-**Bottom line for the feature team:** the sheet is good enough to build the page's *skeleton and
-argument* from (the custody/lock framing, the fairness section once point 4 is fixed, the Thailand
-and Portugal-GV figures), but at least two rows — Malaysia's tier table and the Philippines' 50+
-tier — need either a working primary-source fetch or a second independent pass before they carry a
-number a client will make a six-figure decision against.
+### Still cannot publish as settled fact
+
+- **SRRV Smile's discontinuation is an inference from absence, not a government statement**, and
+  should ship labelled that way if it ships at all — e.g. "Smile no longer appears on PRA's
+  authoritative tier page as of 2026-08-24" is honest; "SRRV Smile was discontinued [date]" is a
+  claim this research cannot source. No PRA announcement exists on the Advisories page (five
+  entries, 2024-11-12 through 2026-03-05) or anywhere else checked this session.
+- **The SRRV Courtesy (Foreign Nationals) deposit table's markup was garbled** on PRA's live page —
+  the figures above are directionally captured but the column/value alignment in the rendered text
+  is not clean. Re-screenshot and re-transcribe before quoting the Courtesy row anywhere
+  client-facing; this caveat carries forward unchanged from the first pass.
+- **The Malaysia "no naturalisation pathway despite 2024 policy ambiguity" claim** in the original
+  sheet is unrelated to anything checked this session (visa mechanics, not citizenship policy) and
+  remains unverified — do not publish it without a dedicated check.
+
+**Bottom line for the feature team:** every financial figure that matters for the comparator —
+Indonesia's SSOT, Thailand's, Malaysia's full five-tier table, Portugal's Golden Visa legal basis
+and D7 formula, and the Philippines' full SRRV table — is now primary-source-confirmed and safe to
+carry a number a client will make a six-figure decision against. What remains gated is narrow and
+named: SRRV Smile's discontinuation stays inference-labelled, the Courtesy row needs a cleaner
+re-capture, and the Malaysia naturalisation claim is simply out of scope for what was checked.
 
 ---
 
@@ -297,9 +435,21 @@ permits domestic employment for SRRV holders who obtain a DOLE Alien Employment 
 
 ## 4. Notes for the country-comparator feature build
 
-- Treat every 🟡/🔴 tag above as a build blocker for that specific cell, not for the page as a
-  whole — ship the ✅/high-confidence 🟡 rows, gray out or omit the 🔴 rows until re-grounded.
-- The custody/lock comparison (Axis 3) is the page's actual differentiator; lead with it.
+- **Upgraded 2026-08-24**: most cells that were 🟡/🔴 after the first pass are now ✅
+  PRIMARY-CONFIRMED (Axis 5 items 2/3/4/6, and the Axis 3 Malaysia withdrawal clause) — the build
+  blocker list has shrunk to three named items: SRRV Smile's discontinuation (ship inference-
+  labelled, not as fact), the SRRV Courtesy deposit row (re-screenshot before quoting), and the
+  Malaysia naturalisation-pathway claim (out of scope, don't publish). Everything else in the
+  comparator can now carry a cited government/gazette URL and capture date.
+- Treat the three remaining named items as build blockers for those specific cells only — ship
+  everything else.
+- The custody/lock comparison (Axis 3) is the page's actual differentiator; lead with it, and now
+  state Malaysia's compulsory-property-purchase structure alongside it explicitly rather than
+  folding it into a generic "partial liquidity" label.
+- Every cell on the comparator should carry its source URL and capture/last-updated date inline (or
+  in a footnote) — for a residency programme, an undated figure is unusable, and this pass found
+  that MOTAC's own pages carry a genuine "Last Update" stamp worth surfacing to the reader.
 - Do not carry over the sheet's "Confidence, Staleness & Verification Limits" section as-is — it
   overstates primary-source verification for Malaysia, Portugal, and the Philippines relative to
-  what this grading pass could reproduce. Use this document's tagging instead.
+  what the first grading pass could reproduce, even though this upgrade pass has since closed most
+  of that gap independently. Use this document's tagging instead, including its citations.

--- a/research/visa/2026-08-24-second-home-country-comparison.md
+++ b/research/visa/2026-08-24-second-home-country-comparison.md
@@ -461,83 +461,88 @@ permits domestic employment for SRRV holders who obtain a DOLE Alien Employment 
 
 ## Adversarial review
 
-**Verdetto: NON PUBBLICABILE.** Revisione cross-family Codex del 2026-08-24, condotta senza web e
-senza nuove fonti. La colonna Indonesia E33 non è stata riaperta né modificata; l'attacco riguarda
-soltanto coerenza, aritmetica, qualità dell'evidenza e correttezza del confronto concorrenti.
+**Verdict: NOT PUBLISHABLE.** Cross-family Codex review dated 2026-08-24, conducted without web
+access and without new sources. The Indonesia E33 column was neither reopened nor modified; the
+attack concerns only coherence, arithmetic, evidence quality, and the correctness of the
+competitor comparison.
 
-1. **Coerenza interna — non regge come documento autonomo.** Questo file è un memo di grading,
-   non il comparatore che descrive: la tabella “Capital Custody / Capital Locked?” è solo riferita
-   come parte dell'underlying generator sheet (L161–164), e lo stesso vale per la sezione completa
-   in cinque punti “Where the Alternatives Beat Indonesia” (L196–204). Non essendo presenti qui,
-   non è possibile verificare la coerenza tabella-dettaglio richiesta per la pubblicazione. Inoltre,
-   le catture su cui poggiano gli upgrade ✅ sono dichiarate in uno scratchpad di sessione
-   (L39–44), ma né quello scratchpad né `country-comparator-facts.md` risultano nel worktree: il
-   fascicolo probatorio non è riproducibile dal documento. Ho corretto le contraddizioni interne
-   risolvibili: SRRV Courtesy non è più contemporaneamente “safe” e “not publishable”; il conteggio
-   degli elementi rimasti gated è tre, non due; la custody “own name” dei concorrenti resta
-   esplicitamente 🔴 e separata dal confronto sul lock (L375–379).
+1. **Internal consistency — does not hold up as a standalone document.** This file is a grading
+   memo, not the comparator it describes: the “Capital Custody / Capital Locked?” table is only
+   referenced as part of the underlying generator sheet (L161–164), and the same applies to the
+   complete five-point “Where the Alternatives Beat Indonesia” section (L196–204). Since they are
+   not present here, it is not possible to verify the table-to-detail consistency required for
+   publication. Furthermore, the captures supporting the ✅ upgrades are declared in a session
+   scratchpad (L39–44), but neither that scratchpad nor `country-comparator-facts.md` is present in
+   the worktree: the evidence file cannot be reproduced from the document. I corrected the
+   resolvable internal contradictions: SRRV Courtesy is no longer simultaneously “safe” and “not
+   publishable”; the count of items still gated is three, not two; competitors’ “own name” custody
+   remains explicitly 🔴 and separate from the lock comparison (L375–379).
 
-2. **Cifre orfane — restano rilievi aperti.** Le soglie principali MM2H, Golden Visa, D7 e SRRV
-   Classic hanno valuta, natura, fonte e data nel testo. Restano però: il vecchio SRRV Smile
-   USD 10.000–20.000 (L133–142), privo di una fonte puntuale con data di pubblicazione e descritto
-   solo come “entry tier”; il confronto storico D7 €870/mese nel 2025 (L261–264), attribuito a
-   “multiple sources” senza URL o data puntuale; il requisito LTR USD 100.000 in conto (L217–224),
-   la cui soglia e fonte sono indicate ma non la durata di mantenimento né il vincolo, quindi non è
-   classificabile come capitale libero o bloccato; il 17% fiscale e l'esenzione sul reddito estero
-   thailandese (L284–292, L430–435), senza fonte identificata e data per il claim fiscale; i numeri
-   SRRV Courtesy (L305–311), per i quali la mappatura categoria-valore è dichiaratamente illeggibile.
+2. **Orphan figures — findings remain open.** The main MM2H, Golden Visa, D7, and SRRV Classic
+   thresholds have currency, nature, source, and date in the text. What remains, however, is: the
+   old SRRV Smile USD 10.000–20.000 (L133–142), which lacks a specific source with a publication
+   date and is described only as an “entry tier”; the historical D7 comparison of €870/month in
+   2025 (L261–264), attributed to “multiple sources” without a URL or specific date; the LTR
+   requirement of USD 100.000 in an account (L217–224), whose threshold and source are given but
+   not its maintenance duration or restriction, so it cannot be classified as free or locked
+   capital; the 17% tax rate and Thai foreign-income exemption (L284–292, L430–435), without an
+   identified source and date for the tax claim; the SRRV Courtesy figures (L305–311), for which
+   the category-to-value mapping is expressly declared illegible.
 
-3. **Aritmetica — regge.** Con RMMG 2026 pari a €920, la formula a L271–279 produce €920/mese per
-   il richiedente, €460/mese per ogni adulto aggiuntivo e €276/mese per ogni figlio; quindi
-   richiedente + adulto = €1.380/mese e richiedente + figlio = €1.196/mese. L'unico valore derivato
-   pubblicato, €920/mese, è corretto ed è ora dichiarato come derivato, non come soglia D7 fissata
-   in euro. Anche USD 15.000 / USD 50.000 = 30% esatto (L380–387), e 5+5 = 10 anni (L328–331).
-   Ho rimosso €200.000 dal riepilogo Golden Visa perché il passaggio primario riportato sosteneva
-   €250.000 ma non esplicitava né la formula né la condizione che avrebbe prodotto €200.000.
+3. **Arithmetic — holds up.** With the 2026 RMMG at €920, the formula at L271–279 produces
+   €920/month for the applicant, €460/month for each additional adult, and €276/month for each
+   child; therefore applicant + adult = €1.380/month and applicant + child = €1.196/month. The
+   only published derived value, €920/month, is correct and is now stated as derived, not as a D7
+   threshold fixed in euros. USD 15.000 / USD 50.000 = exactly 30% (L380–387), and 5+5 = 10 years
+   (L328–331), also hold. I removed €200.000 from the Golden Visa summary because the quoted
+   primary passage supported €250.000 but did not spell out either the formula or the condition
+   that would have produced €200.000.
 
-4. **Onestà del confronto — i fatti ci sono, la sezione no.** Il testo dice chiaramente che il D7
-   richiede circa €920/mese contro USD 3.000/mese per il senior indonesiano e che SRRV Classic 50+
-   richiede USD 15.000 contro USD 50.000 per E33E (L363–369 e L380–387). Questi due svantaggi netti
-   non sono ammorbiditi e i numeri sono corretti. Sono però sepolti dentro “Safe to publish now”,
-   mentre Axis 4 commenta una sezione esterna non inclusa (L196–210). Per un documento pubblico
-   questo fallisce il requisito sostanziale: serve una vera sezione autonoma che esponga quei due
-   punti insieme agli altri vantaggi delle alternative. Posizionamento e riscrittura restano una
-   decisione editoriale aperta, quindi non li ho imposti.
+4. **Fairness of the comparison — the facts are there; the section is not.** The text clearly says
+   that D7 requires about €920/month versus USD 3.000/month for the Indonesian senior and that
+   SRRV Classic 50+ requires USD 15.000 versus USD 50.000 for E33E (L363–369 and L380–387). These
+   two net disadvantages are not softened, and the numbers are correct. They are, however, buried
+   inside “Safe to publish now”, while Axis 4 comments on an external section that is not included
+   (L196–210). For a public document, this fails the substantive requirement: a true standalone
+   section is needed to present those two points together with the other advantages of the
+   alternatives. Placement and rewriting remain an open editorial decision, so I did not impose
+   them.
 
-5. **Categorie — reggono in gran parte dopo le correzioni.** MM2H distingue deposito parzialmente
-   prelevabile, acquisto immobiliare obbligatorio e tassa una tantum; LTR distingue test di reddito,
-   investimento alternativo e requisito assicurazione/conto; il Golden Visa è trattato come
-   investimento e D7 come formula reddituale; SRRV separa deposito e pensione. Ho sostituito
-   “entry-capital gap against Portugal D7” con “income-threshold gap”, e ho chiarito che il test di
-   reddito LTR non crea di per sé un investimento ma non elimina il requisito separato
-   assicurazione/conto (L328–331). Il vantaggio fiscale thailandese è ora attribuito alla categoria
-   corretta, ma resta non pubblicabile finché manca la fonte puntuale indicata al punto 2.
+5. **Categories — largely hold up after the corrections.** MM2H distinguishes a partially
+   withdrawable deposit, compulsory property purchase, and a one-time fee; LTR distinguishes an
+   income test, alternative investment, and insurance/account requirement; the Golden Visa is
+   treated as an investment and D7 as an income formula; SRRV separates deposit and pension. I
+   replaced “entry-capital gap against Portugal D7” with “income-threshold gap”, and clarified that
+   the LTR income test does not in itself create an investment but does not remove the separate
+   insurance/account requirement (L328–331). The Thai tax advantage is now attributed to the
+   correct category, but it remains not publishable until the specific source identified in point
+   2 is provided.
 
-6. **Claim non sostenibili — confini rispettati, supporto ancora insufficiente.** Non ci sono dati
-   personali, promesse di approvazione, proiezioni di rendimento o consigli su dove investire. Ho
-   eliminato il giudizio secondo cui un regime fiscale sarebbe “più vantaggioso” per il pensionato
-   e ho ridotto le affermazioni universali su AIMA a ciò che i controlli finiti dimostrano
-   (L389–396). Restano senza fonte identificata nel documento i diritti di lavoro Portogallo/LTR/
-   Filippine e i claim fiscali del corrected excerpt (L430–436); la custody “own name” per tutti i
-   concorrenti è ammessa come 🔴 non verificata (L166–174). Questi claim non possono entrare in una
-   pagina decisionale finché non sono citati claim-per-claim.
+6. **Unsupported claims — boundaries respected, support still insufficient.** There are no
+   personal data, approval promises, yield projections, or advice on where to invest. I removed
+   the judgment that one tax regime would be “more advantageous” for the pensioner and reduced the
+   universal statements about AIMA to what the finite checks demonstrate (L389–396). The document
+   still lacks identified sources for Portugal/LTR/Philippines work rights and the tax claims in
+   the corrected excerpt (L430–436); “own name” custody for all competitors is acknowledged as 🔴
+   unverified (L166–174). These claims cannot enter a decision page until they are cited claim by
+   claim.
 
-**Correzioni puntuali applicate:** aggiunto `adversarial_review: codex`; corretti i due rinvii Axis
-5 da claim #4 a #5; Thailand LTR “nessuna ristrutturazione” declassato da 🟡 a 🔴; rimossi i due
-giudizi “generally more valuable”; reso annuale il range LTR USD 40.000–80.000; distinto coverage
-assicurativo, conto bancario ed escrow; rimosso il Golden Visa €200.000 non dimostrato; ristretto
-l'upgrade SRRV a Classic, lasciando Courtesy gated; corretto “due” in “tre” blocchi; reso esplicito
-che il RMMG €920 è confermato indirettamente dal recital del Decreto-Lei 29-A/2026 che cita il
-139/2025; separato test di reddito da capitale d'ingresso; corretto E33 in E33E nel confronto
-pensionati e “roughly 30%” in “exactly 30%”; separato lock verificato da custody non verificata;
-ridotte le affermazioni assolute su AIMA; chiarito che tabella e sezione in cinque punti appartengono
-all'underlying sheet, non a questo file.
+**Specific corrections applied:** added `adversarial_review: codex`; corrected the two Axis 5
+references from claim #4 to #5; downgraded Thailand LTR “no restructuring” from 🟡 to 🔴; removed
+the two “generally more valuable” judgments; made the LTR USD 40.000–80.000 range annual;
+distinguished insurance coverage, bank account, and escrow; removed the unsupported Golden Visa
+€200.000; narrowed the SRRV upgrade to Classic, leaving Courtesy gated; corrected “two” to
+“three” blocks; made explicit that the RMMG €920 is indirectly confirmed by the recital of
+Decreto-Lei 29-A/2026, which cites 139/2025; separated the income test from entry capital;
+corrected E33 to E33E in the pensioner comparison and “roughly 30%” to “exactly 30%”; separated
+verified lock from unverified custody; reduced the absolute statements about AIMA; clarified that
+the table and five-point section belong to the underlying sheet, not to this file.
 
-**Rilievi aperti alla decisione:** incorporare la tabella effettiva e la sezione completa di
-fairness; rendere disponibili nel repo le catture probatorie; decidere se eliminare o documentare
-le cifre orfane; aggiungere fonti puntuali per tax/work/custody; aggiungere la caveat di
-grandfathering portoghese già segnalata a L128–132; mantenere esclusi SRRV Courtesy, la data di
-discontinuazione SRRV Smile e il claim sulla naturalizzazione malese finché non risolti.
+**Findings open for decision:** incorporate the actual table and the complete fairness section;
+make the evidentiary captures available in the repo; decide whether to remove or document the
+orphan figures; add specific sources for tax/work/custody; add the Portuguese grandfathering
+caveat already flagged at L128–132; keep SRRV Courtesy, the SRRV Smile discontinuation date, and
+the Malaysian naturalization claim excluded until resolved.
 
-**Decisione di pubblicazione: no.** Il documento diventa pubblicabile solo dopo la chiusura dei
-rilievi aperti sopra; le soglie principali e l'aritmetica, da sole, hanno retto l'attacco.
+**Publication decision: no.** The document becomes publishable only after the open findings above
+are closed; the main thresholds and arithmetic, by themselves, withstood the attack.

--- a/research/visa/2026-08-24-second-home-country-comparison.md
+++ b/research/visa/2026-08-24-second-home-country-comparison.md
@@ -1,0 +1,305 @@
+---
+date: 2026-08-24
+domain: visa
+client_case: Second Home Studio — country comparator feature (E33 vs. MM2H / LTR / D7-GV / SRRV)
+sources:
+  - https://ltr.boi.go.th/ (fetched live 2026-08-24, primary — confirmed)
+  - https://www.motac.gov.my/en/mm2h (fetched live 2026-08-24, primary — page reachable, no financial figures on it)
+  - https://www.mm2h.gov.my/ (fetched live 2026-08-24, primary — HTTP 403, unreachable)
+  - https://aima.gov.pt/en/immigration/aria-golden-visa (fetch attempted 2026-08-24, primary — TLS certificate error, unreachable)
+  - https://vistos.mne.gov.pt/... (fetch attempted 2026-08-24, primary — HTTP 404, wrong/stale path)
+  - https://pra.gov.ph/ (fetched live 2026-08-24, primary — page reachable, no tier figures on homepage)
+  - secondary/legal-aggregator consensus (Emerhub, Zagdim, Bratuca, Golden Visa Map, Bright!Tax, Bitizenship, Connaught Law, Belzuz, ACCRALAW, Chambers and Partners) — searched 2026-08-24, used only where primary fetch failed
+  - research/secondhome/e33-fact-registry.json (E33 column SSOT — not re-verified, per mandate)
+---
+
+# Second Home Studio — Country Comparator: Graded Fact Sheet
+
+**Grader:** Claude (Opus, this session). **Author:** Gemini 3.1 Pro (live web search), scratchpad
+artifact `country-comparator-facts.md`, ~36 KB, dated 2026-08-24. This document is the graded,
+demoted, and annotated output of that artifact — it is not a straight copy. Long verbatim passages
+were not carried over; figures are restated with attribution and a verification tag.
+
+**Tagging key used throughout:**
+- ✅ **PRIMARY-CONFIRMED** — I fetched the government/authority URL myself this session and the
+  figure matches.
+- 🟡 **SECONDARY-CONSENSUS** — the government URL was unreachable to me (403 / TLS error / 404 /
+  no content), so the figure is corroborated only by independent secondary sources (law firms,
+  relocation aggregators) that agree with each other and with the generator's claim. Plausible,
+  not primary-verified.
+- 🔴 **UNVERIFIED** — I did not independently check this figure at all this session. Carried from
+  the generator's draft as-is, flagged, not to be treated as fact.
+- ❌ **CORRECTED / DEMOTED** — I found the generator's claim to be wrong, overstated, or
+  unsupported by the source it cited, and have corrected or removed it.
+
+---
+
+## 1. Grading verdict, by axis
+
+### Axis 1 — Source quality per claim
+
+The sheet's own "Cited Primary & Government Sources" section lists nine government URLs and dates
+every claim "Retrieved: August 24, 2026." I attempted to fetch **five** of those government pages
+directly this session (BOI Thailand, MOTAC/mm2h.gov.my Malaysia, AIMA Portugal, MNE Portugal, PRA
+Philippines). Result: **only one reached and confirmed the cited figures** —
+Thailand's `ltr.boi.go.th`. The other four failed or lacked the content on this attempt:
+
+- `www.mm2h.gov.my` → **HTTP 403 Forbidden**. `www.motac.gov.my/en/mm2h` loaded but is a checklist
+  page with no financial figures — neither government URL the sheet cites actually surfaces the
+  Silver/Gold/Platinum deposit numbers to a live fetch.
+- `aima.gov.pt/en/immigration/aria-golden-visa` → TLS certificate error, unreachable.
+- `vistos.mne.gov.pt/...` (D7 page) → **HTTP 404**. The path may simply be stale, but as cited it
+  does not resolve.
+- `pra.gov.ph` → loads (200), but the homepage carries no SRRV deposit-tier table.
+
+This does not mean the sheet's Malaysia/Portugal/Philippines figures are *wrong* — cross-checking
+against multiple independent secondary sources (relocation-law aggregators, and for the
+Philippines two actual law-firm publications, ACCRALAW and Chambers and Partners) found the same
+numbers repeated consistently. But the sheet's own "Confidence, Staleness & Verification Limits"
+section states flatly that "Federal 2024 tier metrics verified via MOTAC and Immigration
+Department circulars" and "AIMA procedures verified via official Portuguese legislation" — **that
+is a stronger claim than I could reproduce**. The sheet presents primary-source confidence for
+figures I could only corroborate secondarily. I have retagged every financial figure below with
+the honest verification tier, not the sheet's claimed one.
+
+One outright error surfaced during source-checking (see Axis 5, claim #4): the "Where the
+Alternatives Beat Indonesia" section attributes a 17% flat personal-income-tax rate to the
+Thailand LTR programme generally, when in fact that rate is exclusive to the *Highly-Skilled
+Professional* category — the Wealthy Pensioner/Wealthy Global Citizen categories this sheet
+actually compares get foreign-source-income tax **exemption**, a different (and, for most retiree
+profiles, more valuable) benefit. This is a confident, specific, and wrong citation — the exact
+failure mode the mandate asked me to hunt for.
+
+### Axis 2 — Recency: does it reflect current rules or a superseded regime?
+
+Largely current, with one gap the sheet itself does not flag clearly enough:
+
+- **Malaysia MM2H**: the sheet correctly describes the mid-2024 restructure (mandatory property
+  purchase for Silver/Gold/Platinum — a real, material change from the pre-2024 single-tier
+  scheme). ✅ directionally current. One live risk not in the sheet: during my search pass,
+  several 2025/2026-dated aggregator articles quoted a *different* set of numbers for the same
+  tiers — RM-denominated (RM 500k/1M/5M) instead of USD-denominated (USD 150k/500k/1M) — before a
+  separate source clarified the RM figures were either legacy pre-2024 numbers or a conflation
+  with the unrelated Sarawak state programme. The sheet does not mention this confusion exists at
+  all, which is itself a gap: a live public page should warn a reader who searches further that
+  they may hit stale RM-denominated guides.
+- **Portugal Golden Visa**: sheet correctly reflects Lei 56/2023 (Mais Habitação, effective 7
+  October 2023) eliminating the real-estate and capital-transfer routes — this is the single
+  biggest and most-reported change to any of these four programmes, and the sheet gets it right,
+  including the grandfathering caveat being *absent* from its own text (worth adding — see §3
+  below).
+- **Philippines SRRV**: the sheet's narrative ("late 2024/2025, PRA restored eligibility for ages
+  40–49 at elevated deposit rates") undersells what actually happened. My search of ACCRALAW and
+  Chambers and Partners publications (law-firm sources, not blogs) found the change was **larger
+  and more recent than the sheet implies**: PRA issued revised guidelines **effective 1 September
+  2025** that (a) standardised the minimum age at 40 for *all* applicants regardless of pension
+  status (the sheet says this but buries the "effective Sept 2025" date), and (b) **discontinued
+  the SRRV Smile sub-category entirely** (the old USD 10,000–20,000 entry tier for ages 35–49).
+  The sheet never mentions SRRV Smile existed or was killed — it simply never lists it, which
+  produces a correct end-state table by omission rather than by explaining the change. For a page
+  aimed at readers who may have seen older SRRV marketing quoting "$10,000," this is a recency gap
+  worth closing.
+- **Thailand LTR**: launched September 2022, no material restructure since — the sheet's "Active"
+  framing is fine. 🟡
+- **Indonesia E33**: not re-graded per mandate (SSOT already governs it) — but for context, the
+  sheet's age-55-vs-60 ambiguity note matches `e33-fact-registry.json`'s
+  `age_55_59_ambiguity_e33e` entry exactly, so this column is at least internally consistent with
+  the repo's own ground truth.
+
+### Axis 3 — The custody field
+
+This is the sheet's strongest section, and it does not evade the question. Every one of the five
+programme families gets an explicit "Custody & Liquidity of Funds" paragraph, and the summary
+table has a dedicated "Capital Custody" row and a separate "Capital Locked?" row — this is exactly
+the load-bearing comparison the feature is built to answer, and the sheet does not go vague on it
+anywhere.
+
+Content check: it claims **every** competitor deposit/investment sits in the applicant's own name
+(Malaysia FD, Sarawak FD, Thailand's Thai-registered investments, Portugal's fund units, Philippines'
+Special Time Deposit) — none are claimed to be pooled, held by an agent, or held by the state. I
+was not able to independently primary-source-verify the "own name" wording for Malaysia, Thailand,
+Portugal, or the Philippines this session (time-boxed to the five WebFetch/WebSearch passes above,
+none of which specifically targeted custody wording) — 🔴 **UNVERIFIED as a literal claim**, though
+it is consistent with how fixed-deposit and fund-unit products conventionally work (an account or
+unit registration is opened in the account-holder's name almost by definition), so I am not
+flagging it as *suspect*, only as *not independently confirmed*.
+
+The one place the sheet's custody framing needs a caveat it doesn't carry: **Malaysia's and
+Sarawak's 50%-withdrawable-after-1-year clause** is stated as fact ("up to 50% of the principal
+may be withdrawn after 1 year strictly for approved property acquisition, medical expenses, or
+children's education") without a source tag, and I did not verify it this session. 🔴 UNVERIFIED —
+flagged inline in §3 below.
+
+**Indonesia's own claim — 100% locked, zero partial-withdrawal exception, for the full visa term —
+is the sharpest structural contrast the comparator has**, and it survives this review: nothing in
+the four competitor descriptions claims a comparably absolute lock. That contrast is real and
+safe to lead with on the public page.
+
+### Axis 4 — Fairness ("Where the Alternatives Beat Indonesia")
+
+The section exists, is five numbered points, and is substantive — not a token paragraph. It
+names specific programmes for specific advantages (Portugal for citizenship/mobility, Portugal+
+Thailand for zero lockup, Philippines/Thailand/Malaysia for lifetime permanence vs. Indonesia's
+hard cap, Portugal/Thailand/Philippines for work rights, Philippines for lower entry capital) and
+backs each with a regulation citation (Pasal 113 for the Indonesian cap) or a specific number. This
+is a real attempt at "a sceptical reader should not be able to catch this flattering its author."
+
+The one defect found under scrutiny is factual, not structural: point 4's "17% personal income tax
+caps" claim for Thailand LTR is wrong as applied to the Wealthy Pensioner category — see Axis 1
+and Axis 5 claim #4. I have corrected this in §3 below rather than dropping the point, because the
+underlying point (Thailand LTR gives real domestic work/tax benefits Indonesia does not) is true;
+only the specific mechanism named was wrong.
+
+### Axis 5 — Hallucination sweep: what I fetched, and what the sources actually said
+
+Five spot-checks (exceeds the four-minimum), plus one further check triggered by a suspicious
+claim found during the sweep (Thailand's 17% tax figure).
+
+1. **Thailand LTR, Wealthy Pensioner passive-income floor.** Sheet claims USD 80,000/year (or
+   USD 40,000–80,000/year + USD 250,000 Thai investment). Fetched `https://ltr.boi.go.th/`
+   directly: confirms **USD 80,000/year**, and the USD 40k–80k + USD 250,000-investment
+   alternative, verbatim. Also confirms the "10 years total (5+5 renewable)" validity structure
+   and the health-insurance-or-bank-deposit alternative (USD 50,000 insurance / USD 100,000
+   deposit — sheet says "USD 100,000 in escrow," source just says bank account; immaterial
+   wording difference). **✅ PRIMARY-CONFIRMED, accurate.**
+
+2. **Malaysia MM2H tier deposits (Silver USD 150,000 / Gold USD 500,000 / Platinum USD 1,000,000,
+   with RM 600k / RM 1,000k / RM 2,000k mandatory property).** Both government URLs the sheet
+   cites failed to serve this content live (403 / no-content page — see Axis 1). A first
+   secondary-source search surfaced a *conflicting* set of numbers (RM-denominated tiers,
+   RM 500k/1M/5M) from several relocation-agency blogs; a second, more targeted search resolved
+   the conflict — the USD-denominated figures the sheet uses are the current federal scheme, and
+   the RM figures either describe the pre-2024 legacy programme or conflate it with the unrelated
+   Sarawak state scheme. **🟡 SECONDARY-CONSENSUS, plausible and probably accurate, but this
+   session could not pin it to a government source, and I personally watched two different
+   secondary sources disagree with each other before a third resolved it** — a caution the sheet's
+   confident "verified via MOTAC... circulars" framing does not carry.
+
+3. **Portugal Golden Visa — real-estate route eliminated 7 October 2023 (Lei 56/2023), remaining
+   routes capped at €500,000 (funds/research) and €250,000/€200,000 (cultural heritage).**
+   Multiple independent legal/relocation sources (Bright!Tax, Bitizenship, Connaught Law, Belzuz —
+   the last three specifically wrote "law 56/2023 real estate eliminated 2026" pieces) agree on
+   the date, the mechanism (Mais Habitação), and the surviving routes and thresholds, matching the
+   sheet's figures exactly. AIMA's own page could not be fetched (TLS error). **🟡
+   SECONDARY-CONSENSUS, high confidence — multiple independent legal sources converge on identical
+   figures** — but still not primary-confirmed by me this session.
+
+4. **Portugal D7 — 2026 minimum-wage-linked income floor €920/month.** Multiple sources (including
+   the D7Visa specialist site and immigration-law aggregators) independently confirm €920/month as
+   the 2026 figure, up from €870/month in 2025 — consistent with Portugal's annual statutory
+   minimum-wage increase pattern. The sheet's number is correct. **🟡 SECONDARY-CONSENSUS** (the
+   official MNE visa page 404'd for me; I did not reach Diário da República directly this
+   session — the sheet cites it but I could not independently confirm the legislative-text
+   citation itself, only the resulting number via aggregators).
+
+5. **Thailand LTR "17% personal income tax caps" (in the "Where the Alternatives Beat Indonesia"
+   section, point 4).** This is the one claim that did **not** survive the check. I searched
+   specifically for which LTR category qualifies for the 17% flat rate: **it is the Highly-Skilled
+   Professional category only**, taxing employment income in BOI-targeted industries. The
+   **Wealthy Pensioner** and **Wealthy Global Citizen** categories — the ones this entire sheet
+   uses for the HNW/retiree comparison — instead get a **full exemption from Thai tax on
+   foreign-sourced income**, a different and, for a retiree living on foreign pension/investment
+   income, generally more valuable benefit than a 17% rate on Thai employment income they likely
+   don't have. The sheet's sentence conflates two different LTR sub-categories and states the
+   wrong mechanism as if it applied to the category under comparison. **❌ CORRECTED** in §3.
+
+6. **Philippines SRRV age-40 standardisation and 40–49 deposit tiers (USD 25,000 w/ pension, USD
+   50,000 without).** ACCRALAW and Chambers and Partners (regional law-firm/legal-publisher
+   sources, materially higher quality than a relocation blog) both confirm: age standardised to 40
+   for all applicants effective 1 September 2025 (superseding the old 35-with-pension / 50-without
+   split), and the 40–49 deposit figures match the sheet exactly. They also confirm SRRV Smile
+   (the old USD 10,000–20,000 tier) was **discontinued**, which the sheet is silent on (see Axis
+   2). **🟡 SECONDARY-CONSENSUS from stronger-than-average secondary sources for the 40–49 tier
+   figures; 🔴 UNVERIFIED for the 50+ tier figures (USD 15,000/USD 30,000) and the pension-income
+   floor (USD 800/1,000 per month)** — I did not find independent confirmation of those specific
+   numbers in this pass; PRA's own site (pra.gov.ph) loaded but its homepage carried no tier table.
+
+---
+
+## 2. What is safe to publish
+
+This is the actual deliverable — the subset solid enough to appear on a public-facing comparator
+page today, versus what must stay internal until re-grounded.
+
+### Safe to publish now
+
+- **Indonesia E33's 100% capital lock, own-name custody, and hard 6/10-year cumulative cap** — SSOT
+  facts, unchanged by this review, and the sharpest true differentiator against every competitor.
+- **Thailand LTR Wealthy Pensioner: USD 80,000/year passive income (or USD 40k–80k + USD 250,000
+  investment), 5+5 = 10-year validity, zero capital lockup for the passive-income route.**
+  Primary-source confirmed this session.
+- **Portugal Golden Visa: real-estate route permanently eliminated since 7 October 2023; current
+  routes are funds (€500,000), scientific research (€500,000), cultural heritage
+  (€250,000/€200,000), job creation.** High-confidence secondary consensus across independent
+  legal sources; this is also the single most publicly reported fact about the GV programme, so
+  the risk of it being wrong is low even though I couldn't reach AIMA directly.
+- **Portugal D7: 2026 income floor €920/month, zero capital lockup, full domestic work rights.**
+  Secondary-consensus confirmed; low-controversy figure (tracks the published statutory minimum
+  wage, which is itself widely reported).
+- **The "Where the Alternatives Beat Indonesia" section, minus point 4's tax-rate sentence**, which
+  must be rewritten to say Thailand LTR's Wealthy Pensioner/Wealthy Global Citizen categories get
+  **exemption from tax on foreign-sourced income** (not a "17% cap") before this page goes live. Do
+  not publish the sheet's original wording of point 4.
+- **The core "Capital Custody" / "Capital Locked?" comparison framing** — the structural argument
+  (Indonesia locks 100%, everyone else offers some liquidity or no lockup at all) is sound and is
+  the section that makes this page worth building.
+
+### Must stay internal / needs re-grounding before publishing
+
+- **Every Malaysia MM2H figure** (Silver/Gold/Platinum deposit + property amounts, the 50%
+  post-1-year withdrawal clause, the 90-day physical presence rule). Directionally
+  plausible and probably correct, but I could not reach a government source this session and
+  personally observed conflicting numbers circulating among secondary sources before a resolving
+  search. Before this goes on a public page, get one MOTAC/Immigration Department PDF or circular
+  URL that actually loads and states the USD-denominated tiers, or route it through an agent with
+  browser tooling that can get past the 403.
+- **Philippines SRRV 50-and-above deposit tier (USD 15,000/USD 30,000) and pension-income floor
+  (USD 800/1,000 per month).** Unverified this session — the 40–49 tier is solid (two law-firm
+  sources), the 50+ tier and income floors are carried from the generator's draft only.
+- **SRRV Smile's September 2025 discontinuation** should be added to whatever ships, not left
+  implicit — a reader who has seen older "$10,000 SRRV" marketing will otherwise think the page is
+  out of date rather than correct.
+- **The Malaysia/Sarawak "50% withdrawable after 1 year" custody detail** and the Malaysia
+  "no naturalisation pathway despite 2024 policy ambiguity" claim — both stated as settled fact in
+  the sheet with no source tag; neither was checked this session.
+- **Portugal D7's Diário da República legislative citations** (Lei 23/2007, Lei Orgânica 1/2024) —
+  the resulting numbers check out via secondary sources, but the specific legal-article citations
+  in the sheet (e.g. "Article 98 of Law 23/2007") were not independently verified against the
+  gazette text and should not be presented as gazette-verified until someone does.
+- **All SRRV pension-income floors and the SRRV Courtesy deposit figures** — carried verbatim from
+  the draft, zero independent checking this session.
+
+**Bottom line for the feature team:** the sheet is good enough to build the page's *skeleton and
+argument* from (the custody/lock framing, the fairness section once point 4 is fixed, the Thailand
+and Portugal-GV figures), but at least two rows — Malaysia's tier table and the Philippines' 50+
+tier — need either a working primary-source fetch or a second independent pass before they carry a
+number a client will make a six-figure decision against.
+
+---
+
+## 3. Corrected excerpt — "Where the Alternatives Beat Indonesia," point 4
+
+Original (do not use): *"Domestic Work and Remote Employment Rights (Portugal, Thailand LTR,
+Philippines Beat Indonesia): Indonesia E33 strictly bans the holder from earning domestic income.
+Portugal permits open employment and business establishment; Thailand LTR grants a streamlined
+Digital Work Permit and 17% personal income tax caps; the Philippines permits domestic employment
+under DOLE Alien Employment Permits."*
+
+Corrected: Indonesia's E33 strictly bans domestic income. Portugal (D7 and Golden Visa) permits
+open employment and business establishment. Thailand's LTR grants Wealthy Pensioner and Wealthy
+Global Citizen holders a Digital Work Permit route via the Board of Investment's One-Stop Service
+Center, and — separately — an exemption from Thai tax on foreign-sourced income (the 17% flat
+personal-income-tax rate is a distinct benefit limited to the LTR's Highly-Skilled Professional
+category, not the pensioner/wealthy-citizen categories this comparison uses). The Philippines
+permits domestic employment for SRRV holders who obtain a DOLE Alien Employment Permit.
+
+---
+
+## 4. Notes for the country-comparator feature build
+
+- Treat every 🟡/🔴 tag above as a build blocker for that specific cell, not for the page as a
+  whole — ship the ✅/high-confidence 🟡 rows, gray out or omit the 🔴 rows until re-grounded.
+- The custody/lock comparison (Axis 3) is the page's actual differentiator; lead with it.
+- Do not carry over the sheet's "Confidence, Staleness & Verification Limits" section as-is — it
+  overstates primary-source verification for Malaysia, Portugal, and the Philippines relative to
+  what this grading pass could reproduce. Use this document's tagging instead.

--- a/research/visa/2026-08-24-second-home-country-comparison.md
+++ b/research/visa/2026-08-24-second-home-country-comparison.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-24
 domain: visa
+adversarial_review: codex
 client_case: Second Home Studio — country comparator feature (E33 vs. MM2H / LTR / D7-GV / SRRV)
 sources:
   - https://ltr.boi.go.th/ (fetched live 2026-08-24, primary — confirmed)
@@ -37,10 +38,10 @@ Update: 10/02/2026"), the official gazette `diariodarepublica.pt` for Lei 23/200
 Portaria 1563/2007, and Decreto-Lei 29-A/2026, plus `pra.gov.ph/SRRVisa` live. Every tag below that
 changed from 🟡/🔴 to ✅ is upgraded on that new evidence — screenshots and full-text captures in
 `country-comparison-research/` (session scratchpad, referenced by filename below), not on a second
-guess at the same unreachable page. Two things did **not** upgrade and are called out explicitly in
-§2: SRRV Smile's discontinuation stays an inference from absence (no PRA statement exists to cite),
-and AIMA's silence on "golden visa" is recorded as a property of that source, not a gap in this
-research.
+guess at the same unreachable page. Three things did **not** upgrade and are called out explicitly
+in §2: SRRV Smile's discontinuation stays an inference from absence (no PRA statement exists to
+cite), the SRRV Courtesy table remains ambiguous, and the AIMA checks found no "golden visa" page
+through the search and paths tested.
 
 **Tagging key used throughout:**
 - ✅ **PRIMARY-CONFIRMED** — I fetched the government/authority URL myself this session and the
@@ -83,32 +84,31 @@ table and each footer-stamped "Last Update: 10/02/2026". `aima.gov.pt/en/immigra
 visa`'s TLS error turned out to describe a page that doesn't exist at all — AIMA's own site search
 for "golden visa" returns "0 Search results" (screenshotted), and direct probes of both a
 golden-visa-shaped and a D7-shaped URL path both return "Page not found." So the TLS error was
-incidental; the substantive finding is that **AIMA does not publish Golden Visa or D7 content
-under any reachable path** — the correct primary source for both programmes is the official
-gazette, `diariodarepublica.pt`, which the browser lane reached directly: the consolidated text of
+incidental; the substantive finding is that **this review found no AIMA Golden Visa or D7 content
+through its search or the paths tested** — the primary source used for both programmes is the
+official gazette, `diariodarepublica.pt`, which the browser lane reached directly: the consolidated text of
 Lei n.º 23/2007 (Art. 3.º governing Golden Visa investment routes, Art. 52.º governing the general
 subsistence-means requirement that D7 inherits), Portaria n.º 1563/2007 (the subsistence-means
 formula), and Decreto-Lei n.º 29-A/2026 (whose recital states the 2026 RMMG figure). `pra.gov.ph`'s
 homepage genuinely carries no tier table — but `pra.gov.ph/SRRVisa`, a different path the original
 sheet didn't cite, does, and it loaded live with the Philippine clock rendering the capture moment.
 
-The sheet's financial-figure claims for Malaysia, Portugal (both Golden Visa and D7), and the
-Philippines are now **primary-confirmed** against a government page or the gazette (Axis 5, below)
+The sheet's financial-figure claims for Malaysia, Portugal (both Golden Visa and D7), and SRRV
+Classic in the Philippines are now **primary-confirmed** against a government page or the gazette
+(Axis 5, below)
 — not merely corroborated by secondary consensus. The sheet's own "Confidence, Staleness & Verification Limits"
 section states flatly that "Federal 2024 tier metrics verified via MOTAC and Immigration
 Department circulars" and "AIMA procedures verified via official Portuguese legislation" — the
 first grading pass called that a stronger claim than it could reproduce; this pass reproduces it,
 though via `mm2h.gov.my` rather than the MOTAC checklist page, and via the gazette rather than
-AIMA (which, as established above, is simply not the right source for this content). Every
-financial figure below is retagged with the honest, now-primary, verification tier.
+AIMA. The financial figures upgraded below are retagged with the now-primary verification tier.
 
-One outright error surfaced during source-checking (see Axis 5, claim #4): the "Where the
+One outright error surfaced during source-checking (see Axis 5, claim #5): the "Where the
 Alternatives Beat Indonesia" section attributes a 17% flat personal-income-tax rate to the
 Thailand LTR programme generally, when in fact that rate is exclusive to the *Highly-Skilled
 Professional* category — the Wealthy Pensioner/Wealthy Global Citizen categories this sheet
-actually compares get foreign-source-income tax **exemption**, a different (and, for most retiree
-profiles, more valuable) benefit. This is a confident, specific, and wrong citation — the exact
-failure mode the mandate asked me to hunt for.
+actually compares get foreign-source-income tax **exemption**, a different benefit. This is a
+confident, specific, and wrong citation — the exact failure mode the mandate asked me to hunt for.
 
 ### Axis 2 — Recency: does it reflect current rules or a superseded regime?
 
@@ -128,18 +128,18 @@ Largely current, with one gap the sheet itself does not flag clearly enough:
 - **Portugal Golden Visa**: sheet correctly reflects Lei 56/2023 (Mais Habitação, effective 7
   October 2023) eliminating the real-estate and capital-transfer routes — this is the single
   biggest and most-reported change to any of these four programmes, and the sheet gets it right,
-  including the grandfathering caveat being *absent* from its own text (worth adding — see §3
-  below).
+  including the grandfathering caveat being *absent* from its own text (worth adding before
+  publication).
 - **Philippines SRRV**: the sheet's narrative ("late 2024/2025, PRA restored eligibility for ages
   40–49 at elevated deposit rates") undersells what actually happened. My search of ACCRALAW and
-  Chambers and Partners publications (law-firm sources, not blogs) found the change was **larger
-  and more recent than the sheet implies**: PRA issued revised guidelines **effective 1 September
-  2025** that (a) standardised the minimum age at 40 for *all* applicants regardless of pension
-  status (the sheet says this but buries the "effective Sept 2025" date), and (b) **discontinued
-  the SRRV Smile sub-category entirely** (the old USD 10,000–20,000 entry tier for ages 35–49).
+  Chambers and Partners publications (law-firm sources, not blogs) report that the change was
+  **larger and more recent than the sheet implies**: revised guidelines **effective 1 September
+  2025** (a) standardised the minimum age at 40 for *all* applicants regardless of pension status
+  (the sheet says this but buries the "effective Sept 2025" date), and (b) reportedly discontinued
+  the SRRV Smile sub-category entirely (the old USD 10,000–20,000 entry tier for ages 35–49).
   The sheet never mentions SRRV Smile existed or was killed — it simply never lists it, which
   produces a correct end-state table by omission rather than by explaining the change. For a page
-  aimed at readers who may have seen older SRRV marketing quoting "$10,000," this is a recency gap
+  aimed at readers who may have seen older SRRV marketing quoting "USD 10,000," this is a recency gap
   worth closing. **Upgrade:** `pra.gov.ph/SRRVisa`, fetched live 2026-08-24 (the page renders the
   Philippine clock at capture time), states plainly "Principal/s: 40 years old and above" as a
   blanket qualification and lists **exactly three** options — SRRV Classic, SRRV Courtesy (Foreign
@@ -150,7 +150,7 @@ Largely current, with one gap the sheet itself does not flag clearly enough:
   Smile's retirement — so "no longer on the authoritative tier page today" is as far as this
   session can honestly go; see §2 for why the stronger claim stays out.
 - **Thailand LTR**: launched September 2022, no material restructure since — the sheet's "Active"
-  framing is fine. 🟡
+  framing is fine. 🔴 **UNVERIFIED**
 - **Indonesia E33**: not re-graded per mandate (SSOT already governs it) — but for context, the
   sheet's age-55-vs-60 ambiguity note matches `e33-fact-registry.json`'s
   `age_55_59_ambiguity_e33e` entry exactly, so this column is at least internally consistent with
@@ -158,11 +158,10 @@ Largely current, with one gap the sheet itself does not flag clearly enough:
 
 ### Axis 3 — The custody field
 
-This is the sheet's strongest section, and it does not evade the question. Every one of the five
-programme families gets an explicit "Custody & Liquidity of Funds" paragraph, and the summary
-table has a dedicated "Capital Custody" row and a separate "Capital Locked?" row — this is exactly
-the load-bearing comparison the feature is built to answer, and the sheet does not go vague on it
-anywhere.
+This is the underlying generator sheet's strongest section, and it does not evade the question.
+Every one of the five programme families gets an explicit "Custody & Liquidity of Funds"
+paragraph, and its summary table has a dedicated "Capital Custody" row and a separate "Capital
+Locked?" row — this is exactly the load-bearing comparison the feature is built to answer.
 
 Content check: it claims **every** competitor deposit/investment sits in the applicant's own name
 (Malaysia FD, Sarawak FD, Thailand's Thai-registered investments, Portugal's fund units, Philippines'
@@ -196,7 +195,8 @@ safe to lead with on the public page.
 
 ### Axis 4 — Fairness ("Where the Alternatives Beat Indonesia")
 
-The section exists, is five numbered points, and is substantive — not a token paragraph. It
+The underlying generator sheet's section exists, is five numbered points, and is substantive —
+not a token paragraph. It
 names specific programmes for specific advantages (Portugal for citizenship/mobility, Portugal+
 Thailand for zero lockup, Philippines/Thailand/Malaysia for lifetime permanence vs. Indonesia's
 hard cap, Portugal/Thailand/Philippines for work rights, Philippines for lower entry capital) and
@@ -205,7 +205,7 @@ is a real attempt at "a sceptical reader should not be able to catch this flatte
 
 The one defect found under scrutiny is factual, not structural: point 4's "17% personal income tax
 caps" claim for Thailand LTR is wrong as applied to the Wealthy Pensioner category — see Axis 1
-and Axis 5 claim #4. I have corrected this in §3 below rather than dropping the point, because the
+and Axis 5 claim #5. I have corrected this in §3 below rather than dropping the point, because the
 underlying point (Thailand LTR gives real domestic work/tax benefits Indonesia does not) is true;
 only the specific mechanism named was wrong.
 
@@ -216,11 +216,12 @@ claim found during the sweep (Thailand's 17% tax figure).
 
 1. **Thailand LTR, Wealthy Pensioner passive-income floor.** Sheet claims USD 80,000/year (or
    USD 40,000–80,000/year + USD 250,000 Thai investment). Fetched `https://ltr.boi.go.th/`
-   directly: confirms **USD 80,000/year**, and the USD 40k–80k + USD 250,000-investment
+   directly: confirms **USD 80,000/year**, and the USD 40,000–80,000/year + USD 250,000-investment
    alternative, verbatim. Also confirms the "10 years total (5+5 renewable)" validity structure
-   and the health-insurance-or-bank-deposit alternative (USD 50,000 insurance / USD 100,000
-   deposit — sheet says "USD 100,000 in escrow," source just says bank account; immaterial
-   wording difference). **✅ PRIMARY-CONFIRMED, accurate.**
+   and the health-insurance-or-bank-deposit alternative (USD 50,000 minimum insurance coverage /
+   USD 100,000 bank-account alternative). The sheet says "USD 100,000 in escrow," while the source
+   described here says only bank account; escrow or lockup is therefore not confirmed. **✅
+   PRIMARY-CONFIRMED for the thresholds; custody condition not confirmed.**
 
 2. **Malaysia MM2H tier deposits (Silver USD 150,000 / Gold USD 500,000 / Platinum USD 1,000,000,
    with RM 600k / RM 1,000k / RM 2,000k mandatory property).** Both government URLs the sheet
@@ -236,12 +237,12 @@ claim found during the sweep (Thailand's 17% tax figure).
    for 10 years. Source: `mm2h.gov.my`, Ministry of Tourism, Arts and Culture, captured 2026-08-24.
 
 3. **Portugal Golden Visa — real-estate route eliminated 7 October 2023 (Lei 56/2023), remaining
-   routes capped at €500,000 (funds/research) and €250,000/€200,000 (cultural heritage).**
+   routes capped at €500,000 (funds/research) and €250,000 (cultural heritage).**
    Multiple independent legal/relocation sources (Bright!Tax, Bitizenship, Connaught Law, Belzuz —
    the last three specifically wrote "law 56/2023 real estate eliminated 2026" pieces) agree on
    the date, the mechanism (Mais Habitação), and the surviving routes and thresholds, matching the
    sheet's figures exactly. AIMA's own page could not be fetched (TLS error) — and, per the Axis 1
-   upgrade, AIMA does not publish this content under any path. **Upgrade: ✅ PRIMARY-CONFIRMED**
+   upgrade, this review found no AIMA page through the search and paths tested. **Upgrade: ✅ PRIMARY-CONFIRMED**
    against the actual primary source, the gazette itself: `diariodarepublica.pt`'s consolidated
    text of Lei n.º 23/2007, Art. 3.º(1)(d), browser-fetched live 2026-08-24. Three of the original
    five real-estate-linked subalíneas — i), iii), iv) — are marked "(Revogada.)" in the consolidated
@@ -286,18 +287,19 @@ claim found during the sweep (Thailand's 17% tax figure).
    Professional category only**, taxing employment income in BOI-targeted industries. The
    **Wealthy Pensioner** and **Wealthy Global Citizen** categories — the ones this entire sheet
    uses for the HNW/retiree comparison — instead get a **full exemption from Thai tax on
-   foreign-sourced income**, a different and, for a retiree living on foreign pension/investment
-   income, generally more valuable benefit than a 17% rate on Thai employment income they likely
-   don't have. The sheet's sentence conflates two different LTR sub-categories and states the
+   foreign-sourced income**, a different tax treatment from the 17% rate on Thai employment
+   income. The sheet's sentence conflates two different LTR sub-categories and states the
    wrong mechanism as if it applied to the category under comparison. **❌ CORRECTED** in §3.
 
-6. **Philippines SRRV age-40 standardisation, and the FULL deposit-tier table (40–49 AND 50+;
-   pension-income floor).** ACCRALAW and Chambers and Partners (regional law-firm/legal-publisher
-   sources, materially higher quality than a relocation blog) confirmed age standardised to 40 for
+6. **Philippines SRRV age-40 standardisation and the SRRV Classic deposit-tier table (40–49 AND
+   50+; pension-income floor), plus a Courtesy-table capture.** ACCRALAW and Chambers and Partners
+   (regional law-firm/legal-publisher sources, materially higher quality than a relocation blog)
+   confirmed age standardised to 40 for
    all applicants effective 1 September 2025, and the 40–49 deposit figures. **Upgrade: ✅
-   PRIMARY-CONFIRMED, and extended to the 50+ tier and the income floor the first pass could not
-   reach.** `pra.gov.ph/SRRVisa`, browser-fetched live 2026-08-24 (the page renders "Monday August
-   24, 2026" via a live Philippine clock at capture time, unlike the homepage the first pass
+   PRIMARY-CONFIRMED for SRRV Classic, including the 50+ tier and the income floor the first pass
+   could not reach; not confirmed for the Courtesy table.** `pra.gov.ph/SRRVisa`, browser-fetched
+   live 2026-08-24 (the page renders "Monday August 24, 2026" via a live Philippine clock at
+   capture time, unlike the homepage the first pass
    loaded): **SRRV Classic** — Pensioner USD 15,000 (age 50+) / USD 25,000 (age 40–49); Non-Pensioner
    USD 30,000 (50+) / USD 50,000 (40–49); pensioner applicants additionally require proof of a
    lifetime pension of ≥USD 800/month (single) or ≥USD 1,000/month (with dependents). **SRRV
@@ -317,16 +319,17 @@ claim found during the sweep (Thailand's 17% tax figure).
 government/gazette pages `WebFetch` could not, and the picture below supersedes §2 as it stood
 after the first pass. Four rows that were previously gated on a working primary-source fetch —
 Malaysia's full tier table, Portugal's Golden Visa legal basis, Portugal's D7 threshold mechanism,
-and the Philippines' 50+ SRRV tier — are now primary-confirmed. Two things stay gated, and stay
-gated for a structural reason, not a fetch failure: see "Still cannot publish" below.
+and the Philippines' 50+ SRRV Classic tier — are now primary-confirmed. Three things stay gated,
+and stay gated for a structural reason, not a fetch failure: see "Still cannot publish" below.
 
 ### Safe to publish now
 
 - **Indonesia E33's 100% capital lock, own-name custody, and hard 6/10-year cumulative cap** — SSOT
   facts, unchanged by this review, and the sharpest true differentiator against every competitor.
-- **Thailand LTR Wealthy Pensioner: USD 80,000/year passive income (or USD 40k–80k + USD 250,000
-  investment), 5+5 = 10-year validity, zero capital lockup for the passive-income route.**
-  Primary-source confirmed, `ltr.boi.go.th`.
+- **Thailand LTR Wealthy Pensioner: USD 80,000/year passive income (or USD
+  40,000–80,000/year + USD 250,000 investment), 5+5 = 10-year validity.** The income test itself
+  creates no investment requirement; the separate insurance-or-bank-account condition still
+  applies. Primary-source confirmed, `ltr.boi.go.th`.
 - **Malaysia MM2H — the full five-tier table, primary-confirmed against `mm2h.gov.my`** (each page
   footer-stamped "Last Update: 10/02/2026"): Platinum (USD 1,000,000 deposit, 20-year renewable,
   RM 2,000,000 compulsory property), Gold (USD 500,000 / 15 years / RM 1,000,000), Silver
@@ -347,14 +350,16 @@ gated for a structural reason, not a fetch failure: see "Still cannot publish" b
   `diariodarepublica.pt`, Lei n.º 23/2007 Art. 3.º(1)(d), consolidated to its last relevant
   amendment (Lei n.º 9/2025, 2025-02-13) — including the statutory ban's own wording (Art. 3.º n.º
   5: investment routes "não se podem destinar, direta ou indiretamente, ao investimento
-  imobiliário"). Cite the gazette, not AIMA — AIMA does not publish this content (see below).
+  imobiliário"). Cite the gazette; this review did not locate an AIMA page for this content (see
+  below).
 - **Portugal D7: zero capital lockup, full domestic work rights, and an income floor of ~€920/month
   for a single applicant** — but publish it as a **formula**, not a fixed figure: 100% of the RMMG
   (statutory minimum wage) for the principal, +50% per additional adult, +30% per dependent child,
   per Portaria n.º 1563/2007 Art. 2.º(2) (still in force), with the RMMG itself set annually
-  (€920.00/month for 2026, per Decreto-Lei n.º 139/2025). A page that states "€920/month" without
-  the formula will read as wrong the next time the RMMG changes; a page that states the formula
-  plus "€920/month for 2026" is accurate and durable. Primary-confirmed against the gazette.
+  (€920.00/month for 2026, confirmed by the recital of Decreto-Lei n.º 29-A/2026, which cites
+  Decreto-Lei n.º 139/2025 as the instrument setting the figure). A page that states "€920/month"
+  without the formula will read as wrong the next time the RMMG changes; a page that states the
+  formula plus "€920/month for 2026" is accurate and durable. Primary-confirmed against the gazette.
 - **The "Where the Alternatives Beat Indonesia" section, minus point 4's tax-rate sentence**, which
   must be rewritten to say Thailand LTR's Wealthy Pensioner/Wealthy Global Citizen categories get
   **exemption from tax on foreign-sourced income** (not a "17% cap") before this page goes live —
@@ -364,32 +369,31 @@ gated for a structural reason, not a fetch failure: see "Still cannot publish" b
   3,000/month senior-income requirement — publish both the "alternatives beat Indonesia" cases
   (mobility, work rights, zero/partial lockup, lower entry capital in some programmes) and the
   places Indonesia's structure is the outlier the other direction (Malaysia's compulsory property
-  purchase; the sheer entry-capital gap against Portugal D7 and Philippines Classic pensioner) —
+  purchase; the income-threshold gap against Portugal D7 and the entry-deposit gap against the
+  Philippines Classic pensioner tier) —
   see the strengthened analysis below.
-- **The core "Capital Custody" / "Capital Locked?" comparison framing** — the structural argument
-  (Indonesia locks 100% in the applicant's own name with no mandatory secondary purchase; Malaysia
-  offers partial withdrawal but requires a compulsory separate property purchase; Thailand and
-  Portugal offer no lockup at all) is sound and is the section that makes this page worth building.
-- **Philippines SRRV — the full deposit-tier table**, primary-confirmed against `pra.gov.ph/SRRVisa`
-  fetched live: SRRV Classic (Pensioner USD 15,000 age 50+ / USD 25,000 age 40–49; Non-Pensioner
-  USD 30,000 / USD 50,000; pensioner applicants also need a lifetime pension of ≥USD 800/month
-  single or ≥USD 1,000/month with dependents) and the two SRRV Courtesy variants (Foreign Nationals:
-  USD 1,500 at 50+, USD 3,000–6,000 at 40–49; Former Filipinos: USD 1,500 / USD 3,000). Age
+- **The core "Capital Locked?" comparison framing** — the structural argument (Indonesia locks
+  100% with no mandatory secondary purchase; Malaysia offers partial withdrawal but requires a
+  compulsory separate property purchase; Thailand and Portugal offer no lockup for the routes
+  described) is sound. The broader literal claim that every competitor asset is held in the
+  applicant's own name remains 🔴 **UNVERIFIED** under Axis 3 and must not be presented as verified.
+- **Philippines SRRV Classic — the full deposit-tier table**, primary-confirmed against
+  `pra.gov.ph/SRRVisa` fetched live: Pensioner USD 15,000 age 50+ / USD 25,000 age 40–49;
+  Non-Pensioner USD 30,000 / USD 50,000; pensioner applicants also need a lifetime pension of
+  ≥USD 800/month single or ≥USD 1,000/month with dependents. Age
   standardised to 40+ for all principal applicants. This is the sharpest low-end contrast against
   Indonesia in the entire comparator: Philippines' pensioner-with-pension entry point (USD 15,000 +
-  a modest monthly pension) sits at roughly **30% of Indonesia E33's USD 50,000 deposit alone**,
+  a modest monthly pension) sits at exactly **30% of Indonesia E33E's USD 50,000 deposit alone**,
   before Indonesia's separate USD 3,000/month senior-income requirement is even added.
 
-### A property of the source, not a gap in this research
+### What the checked AIMA paths showed
 
-- **AIMA (Portugal's immigration authority) publishes nothing on Golden Visa or D7.** This was
-  proven, not merely assumed: AIMA's own site search returns "0 Search results" for "golden visa"
+- **No AIMA Golden Visa or D7 page was located by the checks described here.** AIMA's own site
+  search returns "0 Search results" for "golden visa"
   (screenshotted, 2026-08-24), and direct URL probes for both a golden-visa-shaped and a
-  D7-shaped path return "Page not found." A reader of the public comparator page should be told
-  the national immigration authority does not publish these terms and that the correct primary
-  source — used above — is the official gazette, `diariodarepublica.pt`. This is a fact about the
-  Portuguese source landscape, not a hole in this research; do not soften it into "we couldn't
-  find the AIMA page."
+  D7-shaped path return "Page not found." The primary source used above is the official gazette,
+  `diariodarepublica.pt`; the finite checks made here do not prove that AIMA publishes nothing
+  anywhere on either programme.
 
 ### Still cannot publish as settled fact
 
@@ -406,12 +410,12 @@ gated for a structural reason, not a fetch failure: see "Still cannot publish" b
   sheet is unrelated to anything checked this session (visa mechanics, not citizenship policy) and
   remains unverified — do not publish it without a dedicated check.
 
-**Bottom line for the feature team:** every financial figure that matters for the comparator —
+**Bottom line for the feature team:** the principal entry thresholds cleared in this review —
 Indonesia's SSOT, Thailand's, Malaysia's full five-tier table, Portugal's Golden Visa legal basis
-and D7 formula, and the Philippines' full SRRV table — is now primary-source-confirmed and safe to
-carry a number a client will make a six-figure decision against. What remains gated is narrow and
-named: SRRV Smile's discontinuation stays inference-labelled, the Courtesy row needs a cleaner
-re-capture, and the Malaysia naturalisation claim is simply out of scope for what was checked.
+and D7 formula, and the Philippines' SRRV Classic table — are primary-source-confirmed. What
+remains gated is named: SRRV Smile's discontinuation stays inference-labelled, the Courtesy row
+needs a cleaner re-capture, and the Malaysia naturalisation claim is simply out of scope for what
+was checked.
 
 ---
 
@@ -436,13 +440,14 @@ permits domestic employment for SRRV holders who obtain a DOLE Alien Employment 
 ## 4. Notes for the country-comparator feature build
 
 - **Upgraded 2026-08-24**: most cells that were 🟡/🔴 after the first pass are now ✅
-  PRIMARY-CONFIRMED (Axis 5 items 2/3/4/6, and the Axis 3 Malaysia withdrawal clause) — the build
-  blocker list has shrunk to three named items: SRRV Smile's discontinuation (ship inference-
+  PRIMARY-CONFIRMED (Axis 5 items 2/3/4, the SRRV Classic portion of item 6, and the Axis 3
+  Malaysia withdrawal clause) — the build blocker list has shrunk to three named items: SRRV
+  Smile's discontinuation (ship inference-
   labelled, not as fact), the SRRV Courtesy deposit row (re-screenshot before quoting), and the
-  Malaysia naturalisation-pathway claim (out of scope, don't publish). Everything else in the
-  comparator can now carry a cited government/gazette URL and capture date.
-- Treat the three remaining named items as build blockers for those specific cells only — ship
-  everything else.
+  Malaysia naturalisation-pathway claim (out of scope, don't publish). This list is not exhaustive;
+  see the adversarial review for the additional open blockers.
+- Treat these three named items as existing cell-level blockers, and resolve the additional open
+  blockers in the adversarial review before publication.
 - The custody/lock comparison (Axis 3) is the page's actual differentiator; lead with it, and now
   state Malaysia's compulsory-property-purchase structure alongside it explicitly rather than
   folding it into a generic "partial liquidity" label.
@@ -453,3 +458,86 @@ permits domestic employment for SRRV holders who obtain a DOLE Alien Employment 
   overstates primary-source verification for Malaysia, Portugal, and the Philippines relative to
   what the first grading pass could reproduce, even though this upgrade pass has since closed most
   of that gap independently. Use this document's tagging instead, including its citations.
+
+## Adversarial review
+
+**Verdetto: NON PUBBLICABILE.** Revisione cross-family Codex del 2026-08-24, condotta senza web e
+senza nuove fonti. La colonna Indonesia E33 non è stata riaperta né modificata; l'attacco riguarda
+soltanto coerenza, aritmetica, qualità dell'evidenza e correttezza del confronto concorrenti.
+
+1. **Coerenza interna — non regge come documento autonomo.** Questo file è un memo di grading,
+   non il comparatore che descrive: la tabella “Capital Custody / Capital Locked?” è solo riferita
+   come parte dell'underlying generator sheet (L161–164), e lo stesso vale per la sezione completa
+   in cinque punti “Where the Alternatives Beat Indonesia” (L196–204). Non essendo presenti qui,
+   non è possibile verificare la coerenza tabella-dettaglio richiesta per la pubblicazione. Inoltre,
+   le catture su cui poggiano gli upgrade ✅ sono dichiarate in uno scratchpad di sessione
+   (L39–44), ma né quello scratchpad né `country-comparator-facts.md` risultano nel worktree: il
+   fascicolo probatorio non è riproducibile dal documento. Ho corretto le contraddizioni interne
+   risolvibili: SRRV Courtesy non è più contemporaneamente “safe” e “not publishable”; il conteggio
+   degli elementi rimasti gated è tre, non due; la custody “own name” dei concorrenti resta
+   esplicitamente 🔴 e separata dal confronto sul lock (L375–379).
+
+2. **Cifre orfane — restano rilievi aperti.** Le soglie principali MM2H, Golden Visa, D7 e SRRV
+   Classic hanno valuta, natura, fonte e data nel testo. Restano però: il vecchio SRRV Smile
+   USD 10.000–20.000 (L133–142), privo di una fonte puntuale con data di pubblicazione e descritto
+   solo come “entry tier”; il confronto storico D7 €870/mese nel 2025 (L261–264), attribuito a
+   “multiple sources” senza URL o data puntuale; il requisito LTR USD 100.000 in conto (L217–224),
+   la cui soglia e fonte sono indicate ma non la durata di mantenimento né il vincolo, quindi non è
+   classificabile come capitale libero o bloccato; il 17% fiscale e l'esenzione sul reddito estero
+   thailandese (L284–292, L430–435), senza fonte identificata e data per il claim fiscale; i numeri
+   SRRV Courtesy (L305–311), per i quali la mappatura categoria-valore è dichiaratamente illeggibile.
+
+3. **Aritmetica — regge.** Con RMMG 2026 pari a €920, la formula a L271–279 produce €920/mese per
+   il richiedente, €460/mese per ogni adulto aggiuntivo e €276/mese per ogni figlio; quindi
+   richiedente + adulto = €1.380/mese e richiedente + figlio = €1.196/mese. L'unico valore derivato
+   pubblicato, €920/mese, è corretto ed è ora dichiarato come derivato, non come soglia D7 fissata
+   in euro. Anche USD 15.000 / USD 50.000 = 30% esatto (L380–387), e 5+5 = 10 anni (L328–331).
+   Ho rimosso €200.000 dal riepilogo Golden Visa perché il passaggio primario riportato sosteneva
+   €250.000 ma non esplicitava né la formula né la condizione che avrebbe prodotto €200.000.
+
+4. **Onestà del confronto — i fatti ci sono, la sezione no.** Il testo dice chiaramente che il D7
+   richiede circa €920/mese contro USD 3.000/mese per il senior indonesiano e che SRRV Classic 50+
+   richiede USD 15.000 contro USD 50.000 per E33E (L363–369 e L380–387). Questi due svantaggi netti
+   non sono ammorbiditi e i numeri sono corretti. Sono però sepolti dentro “Safe to publish now”,
+   mentre Axis 4 commenta una sezione esterna non inclusa (L196–210). Per un documento pubblico
+   questo fallisce il requisito sostanziale: serve una vera sezione autonoma che esponga quei due
+   punti insieme agli altri vantaggi delle alternative. Posizionamento e riscrittura restano una
+   decisione editoriale aperta, quindi non li ho imposti.
+
+5. **Categorie — reggono in gran parte dopo le correzioni.** MM2H distingue deposito parzialmente
+   prelevabile, acquisto immobiliare obbligatorio e tassa una tantum; LTR distingue test di reddito,
+   investimento alternativo e requisito assicurazione/conto; il Golden Visa è trattato come
+   investimento e D7 come formula reddituale; SRRV separa deposito e pensione. Ho sostituito
+   “entry-capital gap against Portugal D7” con “income-threshold gap”, e ho chiarito che il test di
+   reddito LTR non crea di per sé un investimento ma non elimina il requisito separato
+   assicurazione/conto (L328–331). Il vantaggio fiscale thailandese è ora attribuito alla categoria
+   corretta, ma resta non pubblicabile finché manca la fonte puntuale indicata al punto 2.
+
+6. **Claim non sostenibili — confini rispettati, supporto ancora insufficiente.** Non ci sono dati
+   personali, promesse di approvazione, proiezioni di rendimento o consigli su dove investire. Ho
+   eliminato il giudizio secondo cui un regime fiscale sarebbe “più vantaggioso” per il pensionato
+   e ho ridotto le affermazioni universali su AIMA a ciò che i controlli finiti dimostrano
+   (L389–396). Restano senza fonte identificata nel documento i diritti di lavoro Portogallo/LTR/
+   Filippine e i claim fiscali del corrected excerpt (L430–436); la custody “own name” per tutti i
+   concorrenti è ammessa come 🔴 non verificata (L166–174). Questi claim non possono entrare in una
+   pagina decisionale finché non sono citati claim-per-claim.
+
+**Correzioni puntuali applicate:** aggiunto `adversarial_review: codex`; corretti i due rinvii Axis
+5 da claim #4 a #5; Thailand LTR “nessuna ristrutturazione” declassato da 🟡 a 🔴; rimossi i due
+giudizi “generally more valuable”; reso annuale il range LTR USD 40.000–80.000; distinto coverage
+assicurativo, conto bancario ed escrow; rimosso il Golden Visa €200.000 non dimostrato; ristretto
+l'upgrade SRRV a Classic, lasciando Courtesy gated; corretto “due” in “tre” blocchi; reso esplicito
+che il RMMG €920 è confermato indirettamente dal recital del Decreto-Lei 29-A/2026 che cita il
+139/2025; separato test di reddito da capitale d'ingresso; corretto E33 in E33E nel confronto
+pensionati e “roughly 30%” in “exactly 30%”; separato lock verificato da custody non verificata;
+ridotte le affermazioni assolute su AIMA; chiarito che tabella e sezione in cinque punti appartengono
+all'underlying sheet, non a questo file.
+
+**Rilievi aperti alla decisione:** incorporare la tabella effettiva e la sezione completa di
+fairness; rendere disponibili nel repo le catture probatorie; decidere se eliminare o documentare
+le cifre orfane; aggiungere fonti puntuali per tax/work/custody; aggiungere la caveat di
+grandfathering portoghese già segnalata a L128–132; mantenere esclusi SRRV Courtesy, la data di
+discontinuazione SRRV Smile e il claim sulla naturalizzazione malese finché non risolti.
+
+**Decisione di pubblicazione: no.** Il documento diventa pubblicabile solo dopo la chiusura dei
+rilievi aperti sopra; le soglie principali e l'aritmetica, da sole, hanno retto l'attacco.


### PR DESCRIPTION
## What

Grades a Gemini 3.1 Pro-generated country-comparator fact sheet (Indonesia E33 vs. Malaysia MM2H,
Thailand LTR, Portugal D7/Golden Visa, Philippines SRRV) for the upcoming Second Home Studio
country comparator feature, and lands the graded result at
`research/visa/2026-08-24-second-home-country-comparison.md`.

## Grading summary

- **Source quality**: only 1 of 5 cited government URLs (Thailand BOI) was independently
  fetchable and confirmed this session. Malaysia (mm2h.gov.my 403, motac.gov.my no content),
  Portugal (AIMA TLS error, MNE 404), and Philippines (PRA homepage has no tier table) figures are
  demoted from the sheet's claimed "primary-source verified" to secondary-consensus or
  unverified.
- **Hallucination sweep**: 5 spot-checks (exceeds the 4-claim minimum). One outright error found
  and corrected — the sheet attributed Thailand LTR's 17% flat tax rate to the Wealthy Pensioner
  category used throughout the comparison; that rate is exclusive to the Highly-Skilled
  Professional category. Pensioners get foreign-income tax exemption instead.
- **Custody field**: the sheet's strongest section — every programme gets an explicit
  custody/lock paragraph, no vagueness. Indonesia's 100% lock survives as the sharpest true
  differentiator.
- **Fairness**: the "Where the Alternatives Beat Indonesia" section is substantive (5 numbered,
  regulation-cited points), not a token paragraph — minus the tax-rate error above, corrected in
  §3 of the document.
- **Recency**: mostly current (MM2H 2024 restructure, Portugal's Mais Habitação route removal
  both correctly reflected); Philippines SRRV's September 2025 restructure (age standardised to
  40, SRRV Smile discontinued) is under-explained in the original draft.

Does NOT touch the E33 column — that's the repo's existing SSOT
(`research/secondhome/e33-fact-registry.json`).

## Deliverable for the feature build

§2 "What is safe to publish" is the actual build input: ship the custody/lock framing + Thailand
LTR + Portugal Golden Visa figures now; Malaysia's tier table and the Philippines' 50+ deposit
tier need re-grounding (working primary-source fetch) before they carry a client-facing number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)