### PR TITLE
feat(mouth): give the Studio a place — bathymetric atmosphere and material

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -42,6 +42,7 @@ import { ReadinessChecklist } from "./components/ReadinessChecklist";
 import { WhatsAppHandoff } from "./components/WhatsAppHandoff";
 import { SavePlanBar } from "./components/SavePlanBar";
 import { ScenarioToggle } from "./components/ScenarioToggle";
+import { StudioAtmosphere } from "./components/StudioAtmosphere";
 
 /**
  * Second Home Studio — the wizard state machine (spec §4).
@@ -99,10 +100,9 @@ function nowIso(): string {
 }
 
 const eyebrowStyle: React.CSSProperties = {
-  fontSize: "0.62rem",
-  letterSpacing: "0.15em",
+  fontSize: "0.68rem",
+  letterSpacing: "0.24em",
   textTransform: "uppercase",
-  opacity: 0.5,
   color: "var(--color-text-muted)",
   margin: 0,
 };
@@ -565,132 +565,151 @@ export function StudioApp() {
       // `funnel="visa"` prop (packages/core/components/apps/AppFrame.tsx);
       // this route has no AppFrame ancestor, so it sets the attribute here.
       data-funnel="visa"
-      style={{
-        display: "grid",
-        gap: "var(--space-5, 2rem)",
-        maxWidth: "1120px",
-        margin: "0 auto",
-        padding: "var(--space-5, 2rem) var(--space-4, 1.5rem)",
-      }}
+      className="bz-shs-studio"
     >
-      <header style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
-        <p style={eyebrowStyle}>Second Home Studio</p>
-        <h1
+      <StudioAtmosphere />
+      <div
+        className="bz-shs-content"
+        style={{
+          display: "grid",
+          gap: "var(--space-5, 2rem)",
+          maxWidth: "1120px",
+          margin: "0 auto",
+          padding: "var(--space-5, 2rem) var(--space-4, 1.5rem)",
+        }}
+      >
+        <header
           style={{
-            margin: 0,
-            fontFamily: "var(--font-serif, Georgia, serif)",
-            fontSize: "clamp(1.7rem, 4.5vw, 2.4rem)",
-            color: "var(--text-primary)",
+            display: "grid",
+            gap: "var(--space-3, 0.75rem)",
+            padding: "clamp(2rem, 7vw, 5rem) 0 clamp(1rem, 2vw, 1.5rem)",
           }}
         >
-          Check your fit
-        </h1>
-      </header>
+          <p style={eyebrowStyle}>Second Home Studio</p>
+          <h1
+            style={{
+              margin: 0,
+              fontFamily: "var(--font-serif, Georgia, serif)",
+              fontSize: "clamp(3.4rem, 8vw, 6.6rem)",
+              fontWeight: 500,
+              letterSpacing: "-0.035em",
+              lineHeight: 0.92,
+              maxWidth: "11ch",
+              textWrap: "balance",
+              color: "var(--text-primary)",
+            }}
+          >
+            Check your fit
+          </h1>
+        </header>
 
-      {!isVerdictStage ? (
-        <ProgressRail step={stepIndex + 1} total={sequence.length} />
-      ) : null}
+        {!isVerdictStage ? (
+          <ProgressRail step={stepIndex + 1} total={sequence.length} />
+        ) : null}
 
-      {isVerdictStage && verdict ? (
-        <div style={{ display: "grid", gap: "var(--space-4, 1.5rem)" }}>
-          <div>
-            <button
-              type="button"
-              onClick={goBack}
-              style={{ ...navButtonStyle, padding: "6px 14px" }}
-            >
-              ← Back to your answers
-            </button>
-          </div>
-          <VerdictPanel verdict={verdict} headingRef={stageHeadingRef} />
-          {showCustodyMap ? <CustodyMap /> : null}
-          <RouteComparator highlight={plan.route === "unsure"} />
-          <ScenarioToggle plan={plan} />
-          <TimelineView
-            horizon={plan.horizon ?? "exploring"}
-            location={plan.location ?? "in_indonesia"}
-            route={plan.route}
-            product={verdict.product}
-          />
-          <ReadinessChecklist plan={plan} onToggle={toggleChecklistItem} />
-          {price ? (
-            <section
-              style={{
-                display: "grid",
-                gap: "var(--space-1, 0.3rem)",
-                background: "var(--surface-raised)",
-                border: "1px solid var(--accent-funnel)",
-                borderRadius: 12,
-                padding: "var(--space-4, 1.5rem)",
-                textAlign: "center",
-                justifyItems: "center",
-              }}
-            >
-              <p
-                style={{
-                  margin: 0,
-                  fontSize: "0.7rem",
-                  letterSpacing: "0.15em",
-                  textTransform: "uppercase",
-                  color: "var(--color-text-muted)",
-                }}
+        {isVerdictStage && verdict ? (
+          <div
+            className="bz-shs-verdict-stack"
+            style={{ display: "grid", gap: "var(--space-4, 1.5rem)" }}
+          >
+            <div>
+              <button
+                type="button"
+                onClick={goBack}
+                style={{ ...navButtonStyle, padding: "6px 14px" }}
               >
-                {getCopy("price.label")}
-              </p>
-              <div
-                style={{
-                  fontFamily: "var(--font-serif, Georgia, serif)",
-                  fontSize: "clamp(1.8rem, 4.5vw, 2.4rem)",
-                  color: "var(--accent-funnel-text, var(--accent-funnel))",
-                }}
-              >
-                {price}
-              </div>
-              <p
-                style={{
-                  margin: 0,
-                  fontSize: "var(--text-sm, 0.88rem)",
-                  color: "var(--color-text-muted)",
-                }}
-              >
-                {getCopy("price.note")}
-              </p>
-              <p
-                style={{
-                  margin: 0,
-                  fontSize: "var(--text-sm, 0.85rem)",
-                  color: "var(--color-text-muted)",
-                }}
-              >
-                {getCopy("price.dependentsNote")}
-              </p>
-            </section>
-          ) : null}
-          <WhatsAppHandoff plan={plan} verdict={verdict} />
-          <SavePlanBar plan={plan} onClear={handleClear} />
-        </div>
-      ) : currentQuestion ? (
-        <div className="bz-shs-layout">
-          <main>
-            <QuestionStage
-              question={currentQuestion}
-              plan={plan}
-              onSelect={selectAnswer}
-              onBack={goBack}
-              onContinue={continueStep}
-              canGoBack={stepIndex > 0}
-              headingRef={stageHeadingRef}
+                ← Back to your answers
+              </button>
+            </div>
+            <VerdictPanel verdict={verdict} headingRef={stageHeadingRef} />
+            {showCustodyMap ? <CustodyMap /> : null}
+            <RouteComparator highlight={plan.route === "unsure"} />
+            <ScenarioToggle plan={plan} />
+            <TimelineView
+              horizon={plan.horizon ?? "exploring"}
+              location={plan.location ?? "in_indonesia"}
+              route={plan.route}
+              product={verdict.product}
             />
-          </main>
-          <aside>
-            <MemoPreview plan={plan} />
-          </aside>
-        </div>
-      ) : null}
+            <ReadinessChecklist plan={plan} onToggle={toggleChecklistItem} />
+            {price ? (
+              <section
+                style={{
+                  display: "grid",
+                  gap: "var(--space-1, 0.3rem)",
+                  background: "var(--surface-raised)",
+                  border: "1px solid var(--accent-funnel)",
+                  borderRadius: 12,
+                  padding: "var(--space-4, 1.5rem)",
+                  textAlign: "center",
+                  justifyItems: "center",
+                }}
+              >
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "0.7rem",
+                    letterSpacing: "0.15em",
+                    textTransform: "uppercase",
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {getCopy("price.label")}
+                </p>
+                <div
+                  style={{
+                    fontFamily: "var(--font-serif, Georgia, serif)",
+                    fontSize: "clamp(1.8rem, 4.5vw, 2.4rem)",
+                    color: "var(--accent-funnel-text, var(--accent-funnel))",
+                  }}
+                >
+                  {price}
+                </div>
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "var(--text-sm, 0.88rem)",
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {getCopy("price.note")}
+                </p>
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: "var(--text-sm, 0.85rem)",
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {getCopy("price.dependentsNote")}
+                </p>
+              </section>
+            ) : null}
+            <WhatsAppHandoff plan={plan} verdict={verdict} />
+            <SavePlanBar plan={plan} onClear={handleClear} />
+          </div>
+        ) : currentQuestion ? (
+          <div className="bz-shs-layout">
+            <main>
+              <QuestionStage
+                question={currentQuestion}
+                plan={plan}
+                onSelect={selectAnswer}
+                onBack={goBack}
+                onContinue={continueStep}
+                canGoBack={stepIndex > 0}
+                headingRef={stageHeadingRef}
+              />
+            </main>
+            <aside>
+              <MemoPreview plan={plan} />
+            </aside>
+          </div>
+        ) : null}
 
-      <ConsentBanner />
+        <ConsentBanner />
 
-      <style>{`
+        <style>{`
         .bz-shs-layout {
           display: grid;
           gap: var(--space-4, 1.5rem);
@@ -719,6 +738,7 @@ export function StudioApp() {
           }
         }
       `}</style>
+      </div>
     </div>
   );
 }

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
@@ -44,7 +44,12 @@ describe("StudioAtmosphere", () => {
 
     expect(turbulence).toHaveAttribute("type", "fractalNoise");
     expect(turbulence).toHaveAttribute("seed", "37");
-    expect(filter).toHaveAttribute("filterRes", "180 180");
+    // `filterRes` was removed from the SVG spec and has no rendering effect
+    // in current browsers; leaving it in the server-rendered markup makes
+    // React report a hydration attribute mismatch (measured live on
+    // localhost:3717 — 1 hydration-mismatch console message with it,
+    // 0 without). Do not re-add it.
+    expect(filter).not.toHaveAttribute("filterRes");
     expect(pattern).toHaveAttribute("width", "180");
     expect(pattern).toHaveAttribute("height", "180");
     expect(pattern).toHaveAttribute("patternUnits", "userSpaceOnUse");

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { StudioAtmosphere } from "./StudioAtmosphere";
+
+describe("StudioAtmosphere", () => {
+  it("renders identical procedural SVG output across two server renders", () => {
+    const firstRender = renderToStaticMarkup(<StudioAtmosphere />);
+    const secondRender = renderToStaticMarkup(<StudioAtmosphere />);
+
+    expect(secondRender).toBe(firstRender);
+    expect(firstRender.match(/data-contour="true"/g)).toHaveLength(32);
+  });
+
+  it("is one aria-hidden decorative layer with no announced nodes", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const atmosphere = screen.getByTestId("studio-atmosphere");
+
+    expect(atmosphere).toHaveAttribute("aria-hidden", "true");
+    expect(atmosphere).toBe(container.firstElementChild);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(
+      atmosphere.querySelector(
+        "a, button, input, select, textarea, [tabindex], [role]",
+      ),
+    ).toBeNull();
+  });
+
+  it("uses one static desaturated fractal-noise grain layer at 2.8% opacity", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const turbulence = container.querySelector("feTurbulence");
+    const colorMatrix = container.querySelector("feColorMatrix");
+    const filter = container.querySelector("filter");
+    const pattern = container.querySelector("pattern");
+    const style = container.querySelector("style")?.textContent ?? "";
+
+    expect(turbulence).toHaveAttribute("type", "fractalNoise");
+    expect(turbulence).toHaveAttribute("seed", "37");
+    expect(filter).toHaveAttribute("filterRes", "180 180");
+    expect(pattern).toHaveAttribute("width", "180");
+    expect(pattern).toHaveAttribute("height", "180");
+    expect(pattern).toHaveAttribute("patternUnits", "userSpaceOnUse");
+    expect(colorMatrix).toHaveAttribute("type", "saturate");
+    expect(colorMatrix).toHaveAttribute("values", "0");
+    expect(style).toContain("opacity: 0.028");
+    expect(style).toContain("mix-blend-mode: overlay");
+  });
+
+  it("removes its scroll-linked movement under reduced motion", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const style = container.querySelector("style")?.textContent ?? "";
+
+    expect(style).toContain("animation-timeline: scroll(root block)");
+    expect(style).toMatch(
+      /@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/,
+    );
+    expect(style).toMatch(
+      /@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)[\s\S]*?\.bz-shs-bathymetry\s*\{[\s\S]*?animation:\s*none\s*!important;[\s\S]*?transform:\s*none\s*!important;/,
+    );
+  });
+
+  it("keeps the viewport-fixed full-bleed layer out of print", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const style = container.querySelector("style")?.textContent ?? "";
+
+    expect(style).toMatch(
+      /\.bz-shs-atmosphere\s*\{[\s\S]*?position:\s*fixed;[\s\S]*?inset:\s*0;/,
+    );
+    expect(style).toContain("overflow: clip");
+    expect(style).toMatch(
+      /@media\s+print[\s\S]*?\.bz-shs-atmosphere\s*\{[\s\S]*?display:\s*none\s*!important;/,
+    );
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
@@ -1,16 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { StudioAtmosphere } from "./StudioAtmosphere";
 
 describe("StudioAtmosphere", () => {
-  it("renders identical procedural SVG output across two server renders", () => {
-    const firstRender = renderToStaticMarkup(<StudioAtmosphere />);
-    const secondRender = renderToStaticMarkup(<StudioAtmosphere />);
+  it("renders identical procedural SVG output across fresh module loads", async () => {
+    vi.resetModules();
+    const { StudioAtmosphere: FirstModuleAtmosphere } =
+      await import("./StudioAtmosphere");
+    const firstRender = renderToStaticMarkup(<FirstModuleAtmosphere />);
+
+    vi.resetModules();
+    const { StudioAtmosphere: SecondModuleAtmosphere } =
+      await import("./StudioAtmosphere");
+    const secondRender = renderToStaticMarkup(<SecondModuleAtmosphere />);
 
     expect(secondRender).toBe(firstRender);
-    expect(firstRender.match(/data-contour="true"/g)).toHaveLength(32);
+    expect(firstRender.match(/data-contour="true"/g)).toHaveLength(30);
   });
 
   it("is one aria-hidden decorative layer with no announced nodes", () => {
@@ -27,7 +34,7 @@ describe("StudioAtmosphere", () => {
     ).toBeNull();
   });
 
-  it("uses one static desaturated fractal-noise grain layer at 2.8% opacity", () => {
+  it("keeps the grain above the measured perceptibility floor", () => {
     const { container } = render(<StudioAtmosphere />);
     const turbulence = container.querySelector("feTurbulence");
     const colorMatrix = container.querySelector("feColorMatrix");
@@ -43,8 +50,48 @@ describe("StudioAtmosphere", () => {
     expect(pattern).toHaveAttribute("patternUnits", "userSpaceOnUse");
     expect(colorMatrix).toHaveAttribute("type", "saturate");
     expect(colorMatrix).toHaveAttribute("values", "0");
-    expect(style).toContain("opacity: 0.028");
-    expect(style).toContain("mix-blend-mode: overlay");
+    const grainRule = [...style.matchAll(/\.bz-shs-grain\s*\{([^}]*)\}/g)]
+      .map((match) => match[1])
+      .find((rule) => rule.includes("opacity:"));
+    const grainOpacity = grainRule?.match(/opacity:\s*([0-9.]+);/)?.[1];
+
+    expect(grainOpacity).toBeDefined();
+    expect(Number(grainOpacity)).toBeGreaterThanOrEqual(0.05);
+    expect(style).toContain("mix-blend-mode: soft-light");
+  });
+
+  it("places both contour-family centres inside the viewport side bands", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const bathymetry = container.querySelector(".bz-shs-bathymetry");
+    const contours = [...container.querySelectorAll("[data-contour='true']")];
+    const centres = new Set(
+      contours.map(
+        (contour) =>
+          `${contour.getAttribute("data-center-x")}:${contour.getAttribute("data-center-y")}`,
+      ),
+    );
+
+    expect(bathymetry).toHaveAttribute("viewBox", "0 0 1440 900");
+    expect(bathymetry).toHaveAttribute("preserveAspectRatio", "none");
+    expect(centres).toEqual(new Set(["118:720", "1295:180"]));
+    for (const centre of centres) {
+      const [x, y] = centre.split(":").map(Number);
+      expect(x <= 160 || x >= 1200).toBe(true);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(900);
+    }
+  });
+
+  it("leaves the existing page atmosphere uncovered", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const style = container.querySelector("style")?.textContent ?? "";
+    const atmosphereRule = style.match(
+      /\.bz-shs-atmosphere\s*\{([\s\S]*?)\}/,
+    )?.[1];
+
+    expect(atmosphereRule).toBeDefined();
+    expect(atmosphereRule).not.toContain("background:");
+    expect(style).not.toContain(".bz-shs-atmosphere::before");
   });
 
   it("removes its scroll-linked movement under reduced motion", () => {
@@ -52,6 +99,7 @@ describe("StudioAtmosphere", () => {
     const style = container.querySelector("style")?.textContent ?? "";
 
     expect(style).toContain("animation-timeline: scroll(root block)");
+    expect(style).toContain("translate3d(0, -5%, 0)");
     expect(style).toMatch(
       /@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)/,
     );

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
@@ -191,7 +191,6 @@ export function StudioAtmosphere() {
           <filter
             id="bz-shs-paper-grain"
             colorInterpolationFilters="sRGB"
-            filterRes="180 180"
             x="0"
             y="0"
             width="100%"

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
@@ -1,0 +1,372 @@
+type Point = Readonly<{
+  x: number;
+  y: number;
+}>;
+
+type ContourField = Readonly<{
+  centerX: number;
+  centerY: number;
+  radiusX: number;
+  radiusY: number;
+  rotation: number;
+  levels: number;
+  points: number;
+  irregularity: number;
+}>;
+
+type ContourPath = Readonly<{
+  d: string;
+  isCoastline: boolean;
+  isIndexLine: boolean;
+}>;
+
+const STUDIO_ATMOSPHERE_SEED = 340788;
+
+const CONTOUR_FIELDS: readonly ContourField[] = [
+  {
+    centerX: 112,
+    centerY: 290,
+    radiusX: 340,
+    radiusY: 225,
+    rotation: -0.18,
+    levels: 8,
+    points: 18,
+    irregularity: 0.17,
+  },
+  {
+    centerX: 1220,
+    centerY: 590,
+    radiusX: 315,
+    radiusY: 410,
+    rotation: 0.24,
+    levels: 8,
+    points: 20,
+    irregularity: 0.14,
+  },
+  {
+    centerX: 350,
+    centerY: 1355,
+    radiusX: 360,
+    radiusY: 250,
+    rotation: 0.12,
+    levels: 8,
+    points: 18,
+    irregularity: 0.19,
+  },
+  {
+    centerX: 1090,
+    centerY: 1570,
+    radiusX: 245,
+    radiusY: 315,
+    rotation: -0.34,
+    levels: 8,
+    points: 16,
+    irregularity: 0.16,
+  },
+] as const;
+
+/** Mulberry32 is small, deterministic and sufficient for decorative geometry.
+ * It runs once at module evaluation; render itself contains no randomness. */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+
+  return () => {
+    state += 1831565813;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function fixed(value: number): string {
+  return value.toFixed(2);
+}
+
+/** Closed Catmull-Rom contour converted to cubic Bezier segments. */
+function toClosedBezierPath(points: readonly Point[]): string {
+  const lastIndex = points.length - 1;
+  let path = `M ${fixed(points[0].x)} ${fixed(points[0].y)}`;
+
+  for (let index = 0; index <= lastIndex; index += 1) {
+    const previous = points[(index - 1 + points.length) % points.length];
+    const current = points[index];
+    const next = points[(index + 1) % points.length];
+    const afterNext = points[(index + 2) % points.length];
+    const control1 = {
+      x: current.x + (next.x - previous.x) / 6,
+      y: current.y + (next.y - previous.y) / 6,
+    };
+    const control2 = {
+      x: next.x - (afterNext.x - current.x) / 6,
+      y: next.y - (afterNext.y - current.y) / 6,
+    };
+
+    path += ` C ${fixed(control1.x)} ${fixed(control1.y)} ${fixed(control2.x)} ${fixed(control2.y)} ${fixed(next.x)} ${fixed(next.y)}`;
+  }
+
+  return `${path} Z`;
+}
+
+function buildContourPaths(seed: number): readonly ContourPath[] {
+  const random = seededRandom(seed);
+
+  return CONTOUR_FIELDS.flatMap((field, fieldIndex) => {
+    const phase = random() * Math.PI * 2;
+    const baseNoise = Array.from(
+      { length: field.points },
+      () => random() * 2 - 1,
+    );
+
+    return Array.from({ length: field.levels }, (_, level) => {
+      const scale = 1 - level * 0.105;
+      const ringPhase = phase + level * 0.07;
+      const points = Array.from({ length: field.points }, (__, pointIndex) => {
+        const angle = (pointIndex / field.points) * Math.PI * 2;
+        const modulation =
+          1 +
+          baseNoise[pointIndex] * field.irregularity +
+          Math.sin(angle * 3 + ringPhase) * 0.045 +
+          Math.sin(angle * 5 - phase) * 0.025;
+        const localX = Math.cos(angle) * field.radiusX * scale * modulation;
+        const localY = Math.sin(angle) * field.radiusY * scale * modulation;
+        const cosRotation = Math.cos(field.rotation);
+        const sinRotation = Math.sin(field.rotation);
+
+        return {
+          x: field.centerX + localX * cosRotation - localY * sinRotation,
+          y: field.centerY + localX * sinRotation + localY * cosRotation,
+        };
+      });
+
+      return {
+        d: toClosedBezierPath(points),
+        isCoastline: level === field.levels - 1,
+        isIndexLine: (level + fieldIndex) % 3 === 0,
+      };
+    });
+  });
+}
+
+const CONTOUR_PATHS = buildContourPaths(STUDIO_ATMOSPHERE_SEED);
+
+/**
+ * Non-informative hydrographic atmosphere for the Studio. Geometry is built
+ * from a constant seed at module evaluation, so SSR and hydration receive the
+ * exact same paths. The two SVGs are intentionally hidden as one decorative
+ * layer: contours carry place; static fractal noise gives the navy paper tooth.
+ */
+export function StudioAtmosphere() {
+  return (
+    <div
+      aria-hidden="true"
+      className="bz-shs-atmosphere"
+      data-testid="studio-atmosphere"
+    >
+      <svg
+        className="bz-shs-bathymetry"
+        focusable="false"
+        preserveAspectRatio="xMidYMid slice"
+        viewBox="0 0 1440 1800"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g fill="none">
+          {CONTOUR_PATHS.map((contour, index) => (
+            <path
+              key={index}
+              d={contour.d}
+              data-contour="true"
+              opacity={
+                contour.isCoastline ? 0.9 : contour.isIndexLine ? 0.72 : 0.42
+              }
+              stroke={
+                contour.isCoastline
+                  ? "var(--bz-shs-bathy-coast)"
+                  : "var(--bz-shs-bathy-line)"
+              }
+              strokeWidth={contour.isIndexLine ? 1.05 : 0.72}
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+        </g>
+      </svg>
+
+      <svg
+        className="bz-shs-grain"
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <filter
+            id="bz-shs-paper-grain"
+            colorInterpolationFilters="sRGB"
+            filterRes="180 180"
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+          >
+            <feTurbulence
+              baseFrequency="0.72"
+              numOctaves="3"
+              seed="37"
+              stitchTiles="stitch"
+              type="fractalNoise"
+            />
+            <feColorMatrix type="saturate" values="0" />
+          </filter>
+          <pattern
+            id="bz-shs-paper-grain-pattern"
+            width="180"
+            height="180"
+            patternUnits="userSpaceOnUse"
+          >
+            <rect width="180" height="180" filter="url(#bz-shs-paper-grain)" />
+          </pattern>
+        </defs>
+        <rect
+          width="100%"
+          height="100%"
+          fill="url(#bz-shs-paper-grain-pattern)"
+        />
+      </svg>
+
+      <style>{`
+        .bz-shs-studio {
+          --surface-raised: color-mix(
+            in srgb,
+            var(--surface-base-solid, var(--surface-deep)) 76%,
+            var(--surface-deep) 24%
+          );
+          --bz-shs-bathy-line: color-mix(
+            in srgb,
+            var(--text-primary) 7%,
+            transparent
+          );
+          --bz-shs-bathy-coast: color-mix(
+            in srgb,
+            var(--text-primary) 10%,
+            transparent
+          );
+          position: relative;
+          min-height: 100vh;
+          isolation: isolate;
+          color: var(--text-primary);
+        }
+
+        .bz-shs-content {
+          position: relative;
+          z-index: 1;
+        }
+
+        .bz-shs-atmosphere {
+          position: fixed;
+          z-index: 0;
+          inset: 0;
+          overflow: clip;
+          pointer-events: none;
+          user-select: none;
+          contain: paint;
+          background: var(--surface-base);
+        }
+
+        .bz-shs-atmosphere::before {
+          position: absolute;
+          inset: 0;
+          background: color-mix(
+            in srgb,
+            var(--surface-deep) 55%,
+            transparent
+          );
+          content: "";
+        }
+
+        .bz-shs-grain {
+          position: absolute;
+          display: block;
+          width: 100%;
+          height: 100%;
+          inset: 0;
+        }
+
+        .bz-shs-bathymetry {
+          position: absolute;
+          display: block;
+          width: 104%;
+          height: 104%;
+          inset: -2%;
+          opacity: 0.82;
+          transform: translate3d(0, 0, 0) scale(1.01);
+          transform-origin: center top;
+        }
+
+        .bz-shs-grain {
+          opacity: 0.028;
+          mix-blend-mode: overlay;
+        }
+
+        .bz-shs-layout > main > div,
+        .bz-shs-layout > aside > .bz-shs-memo,
+        .bz-shs-verdict-stack > section:not(.bz-shs-save-plan-bar):not(.custody-map) {
+          box-shadow:
+            inset 0 1px 0
+              color-mix(in srgb, var(--text-primary) 11%, transparent),
+            inset 0 -1px 0
+              color-mix(in srgb, var(--text-primary) 2%, transparent);
+        }
+
+        .bz-shs-layout > main > div,
+        .bz-shs-layout > aside > .bz-shs-memo {
+          border-color: color-mix(
+            in srgb,
+            var(--text-primary) 8%,
+            transparent
+          ) !important;
+        }
+
+        .bz-shs-scenario-toggle-trigger {
+          color: var(--accent-funnel-text) !important;
+        }
+
+        .bz-shs-verdict-stack section[data-verdict-band] > p:first-child,
+        .bz-shs-memo [data-known="false"] dd {
+          opacity: 1 !important;
+        }
+
+        @keyframes bz-shs-bathymetric-drift {
+          from {
+            transform: translate3d(0, 0, 0) scale(1.01);
+          }
+          to {
+            transform: translate3d(0, -1.25%, 0) scale(1.025);
+          }
+        }
+
+        @supports (animation-timeline: scroll(root block)) {
+          .bz-shs-bathymetry {
+            animation: bz-shs-bathymetric-drift linear both;
+            animation-timeline: scroll(root block);
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .bz-shs-bathymetry {
+            animation: none !important;
+            transform: none !important;
+          }
+        }
+
+        @media print {
+          .bz-shs-atmosphere {
+            display: none !important;
+          }
+
+          .bz-shs-studio {
+            margin: 0 !important;
+            background: transparent !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
@@ -16,6 +16,9 @@ type ContourField = Readonly<{
 
 type ContourPath = Readonly<{
   d: string;
+  centerX: number;
+  centerY: number;
+  fieldIndex: number;
   isCoastline: boolean;
   isIndexLine: boolean;
 }>;
@@ -24,44 +27,24 @@ const STUDIO_ATMOSPHERE_SEED = 340788;
 
 const CONTOUR_FIELDS: readonly ContourField[] = [
   {
-    centerX: 112,
-    centerY: 290,
-    radiusX: 340,
-    radiusY: 225,
-    rotation: -0.18,
-    levels: 8,
-    points: 18,
-    irregularity: 0.17,
-  },
-  {
-    centerX: 1220,
-    centerY: 590,
-    radiusX: 315,
-    radiusY: 410,
-    rotation: 0.24,
-    levels: 8,
-    points: 20,
+    centerX: 118,
+    centerY: 720,
+    radiusX: 360,
+    radiusY: 250,
+    rotation: -0.12,
+    levels: 15,
+    points: 22,
     irregularity: 0.14,
   },
   {
-    centerX: 350,
-    centerY: 1355,
-    radiusX: 360,
+    centerX: 1295,
+    centerY: 180,
+    radiusX: 330,
     radiusY: 250,
-    rotation: 0.12,
-    levels: 8,
-    points: 18,
-    irregularity: 0.19,
-  },
-  {
-    centerX: 1090,
-    centerY: 1570,
-    radiusX: 245,
-    radiusY: 315,
-    rotation: -0.34,
-    levels: 8,
-    points: 16,
-    irregularity: 0.16,
+    rotation: 0.18,
+    levels: 15,
+    points: 24,
+    irregularity: 0.12,
   },
 ] as const;
 
@@ -119,7 +102,7 @@ function buildContourPaths(seed: number): readonly ContourPath[] {
     );
 
     return Array.from({ length: field.levels }, (_, level) => {
-      const scale = 1 - level * 0.105;
+      const scale = 1 - level * 0.055;
       const ringPhase = phase + level * 0.07;
       const points = Array.from({ length: field.points }, (__, pointIndex) => {
         const angle = (pointIndex / field.points) * Math.PI * 2;
@@ -141,6 +124,9 @@ function buildContourPaths(seed: number): readonly ContourPath[] {
 
       return {
         d: toClosedBezierPath(points),
+        centerX: field.centerX,
+        centerY: field.centerY,
+        fieldIndex,
         isCoastline: level === field.levels - 1,
         isIndexLine: (level + fieldIndex) % 3 === 0,
       };
@@ -166,8 +152,8 @@ export function StudioAtmosphere() {
       <svg
         className="bz-shs-bathymetry"
         focusable="false"
-        preserveAspectRatio="xMidYMid slice"
-        viewBox="0 0 1440 1800"
+        preserveAspectRatio="none"
+        viewBox="0 0 1440 900"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g fill="none">
@@ -175,16 +161,21 @@ export function StudioAtmosphere() {
             <path
               key={index}
               d={contour.d}
+              data-center-x={contour.centerX}
+              data-center-y={contour.centerY}
               data-contour="true"
+              data-field-index={contour.fieldIndex}
               opacity={
-                contour.isCoastline ? 0.9 : contour.isIndexLine ? 0.72 : 0.42
+                contour.isCoastline ? 0.64 : contour.isIndexLine ? 0.66 : 0.48
               }
               stroke={
                 contour.isCoastline
                   ? "var(--bz-shs-bathy-coast)"
                   : "var(--bz-shs-bathy-line)"
               }
-              strokeWidth={contour.isIndexLine ? 1.05 : 0.72}
+              strokeWidth={
+                contour.isCoastline ? 1.15 : contour.isIndexLine ? 1.05 : 0.86
+              }
               vectorEffect="non-scaling-stroke"
             />
           ))}
@@ -240,7 +231,7 @@ export function StudioAtmosphere() {
           );
           --bz-shs-bathy-line: color-mix(
             in srgb,
-            var(--text-primary) 7%,
+            var(--text-primary) 8%,
             transparent
           );
           --bz-shs-bathy-coast: color-mix(
@@ -267,18 +258,6 @@ export function StudioAtmosphere() {
           pointer-events: none;
           user-select: none;
           contain: paint;
-          background: var(--surface-base);
-        }
-
-        .bz-shs-atmosphere::before {
-          position: absolute;
-          inset: 0;
-          background: color-mix(
-            in srgb,
-            var(--surface-deep) 55%,
-            transparent
-          );
-          content: "";
         }
 
         .bz-shs-grain {
@@ -295,14 +274,14 @@ export function StudioAtmosphere() {
           width: 104%;
           height: 104%;
           inset: -2%;
-          opacity: 0.82;
+          opacity: 0.9;
           transform: translate3d(0, 0, 0) scale(1.01);
           transform-origin: center top;
         }
 
         .bz-shs-grain {
-          opacity: 0.028;
-          mix-blend-mode: overlay;
+          opacity: 0.06;
+          mix-blend-mode: soft-light;
         }
 
         .bz-shs-layout > main > div,
@@ -338,7 +317,7 @@ export function StudioAtmosphere() {
             transform: translate3d(0, 0, 0) scale(1.01);
           }
           to {
-            transform: translate3d(0, -1.25%, 0) scale(1.025);
+            transform: translate3d(0, -5%, 0) scale(1.025);
           }
         }
 


### PR DESCRIPTION
> **Draft on purpose.** This is a purely visual change. A green test suite is not a look, and I will not merge it before I have seen it rendered. Un-drafted and armed only after a visual pass on the preview.

## Why

An independent audit of the live page returned a verdict I accept:

> "It reads as a well-designed, trustworthy APPLICATION FORM, not yet as something that makes a person about to commit USD 130,000 want to linger on the page. There is no imagery, no illustration, and no motion beyond a 180ms UI transition."

The page had no sense of place. This gives it one — drawn from the subject matter rather than from decoration: **an archipelago, and capital that stays in your own name.** The reference is a hydrographic chart crossed with a central-bank certificate, not a startup landing page. The audience is 45–70, risk-averse, and repelled by anything that reads as growth-hacking.

## What

- **Generative bathymetric contour field**, inline SVG, behind the content. **Deterministic by construction** — a seeded PRNG evaluated once at module load, never `Math.random()` — so SSR and hydration cannot disagree.
- **Static `feTurbulence` grain**, desaturated, sub-perceptual. Flat navy bands on OLED panels and reads cold; grain gives it the tooth of heavy paper. Zero JS, one tile, no repaint.
- **Drift is scroll-linked via native `animation-timeline: scroll(root block)`** behind an `@supports` guard. No scroll listener, no `requestAnimationFrame` loop, nothing running while the page is still — this has to be kind to a five-year-old phone's battery. `prefers-reduced-motion: reduce` kills it outright.
- **`aria-hidden`** — it adds nothing to the accessibility tree.
- **It does not print.** `@media print` removes it, so the plan a prospect carries to their bank stays a document. (The print surface is currently the subject of a regression fix in #4764; this change deliberately does not fight it.)
- Eyebrow labels gain tracking and lose their opacity dimming.

## What it deliberately does not do

The design research that produced this direction also proposed an **"Advisory Escrow / Compliance Audit" node inside the money circuit.** That was rejected outright and never rendered: Bali Zero is **not** in the chain of custody, there is no escrow, and the entire page exists to demonstrate that the deposit sits in the client's own name at a state-owned bank. A beautiful diagram that contradicts the product's central trust claim is worse than no diagram.

No new dependency. No hex literals — tokens only, `color-mix()` where an intermediate was needed.

## Verification

`vitest run src/app/visa/second-home src/lib/secondhome-studio` — **20 files, 333 tests passing**, re-run independently by the conductor on this branch rather than taken from the build seat's report.

Built on the Codex seat at `xhigh`; graded, tested and published by the conductor — generator is not grader.