### PR TITLE
feat(mouth): the route comparison stops being a spreadsheet

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.test.tsx
@@ -1,31 +1,150 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render, within } from "@testing-library/react";
 import { RouteComparator } from "./RouteComparator";
 
+function relativeLuminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/../g)
+    ?.map((channel) => Number.parseInt(channel, 16) / 255);
+
+  if (!channels || channels.length !== 3) {
+    throw new Error(`Invalid hex colour: ${hex}`);
+  }
+
+  const [red, green, blue] = channels.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const luminances = [
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  ].sort((a, b) => b - a);
+
+  return (luminances[0] + 0.05) / (luminances[1] + 0.05);
+}
+
 describe("RouteComparator", () => {
-  it("renders the three column headings with their text labels", () => {
-    render(<RouteComparator />);
-
-    expect(screen.getByText("Deposit route")).toBeInTheDocument();
-    expect(screen.getByText("Property route")).toBeInTheDocument();
-    expect(screen.getByText("Senior route (55+)")).toBeInTheDocument();
-  });
-
-  it("renders an aria-hidden icon next to each column heading", () => {
+  it("keeps the wide comparison as a semantic table with three named routes", () => {
     const { container } = render(<RouteComparator />);
-
-    const headings = container.querySelectorAll(
-      "th > span > svg[aria-hidden='true']",
+    const tableView = container.querySelector<HTMLElement>(
+      '[data-comparison-view="table"]',
     );
-    expect(headings.length).toBe(3);
+
+    expect(tableView).not.toBeNull();
+    const table = within(tableView as HTMLElement);
+    expect(
+      table.getByRole("table", { name: "Second Home route comparison" }),
+    ).toBeInTheDocument();
+    expect(table.getByText("Deposit route")).toBeInTheDocument();
+    expect(table.getByText("Property route")).toBeInTheDocument();
+    expect(table.getByText("Senior route (55+)")).toBeInTheDocument();
+    expect(table.getAllByRole("columnheader")).toHaveLength(4);
+    expect(table.getAllByRole("rowheader")).toHaveLength(4);
   });
 
-  it("does not remove the accessible column text when icons are present", () => {
-    render(<RouteComparator highlight />);
+  it("gives each route a different hidden icon and preserves highlight", () => {
+    const { container } = render(<RouteComparator highlight />);
+    const icons = container.querySelectorAll(
+      '[data-comparison-view="table"] .bz-shs-route-icon > svg[aria-hidden="true"]',
+    );
 
-    const depositHeading = screen.getByText("Deposit route").closest("th");
-    expect(depositHeading).toBeInTheDocument();
-    const icon = depositHeading?.querySelector("svg");
-    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icons).toHaveLength(3);
+    expect(
+      new Set(Array.from(icons, (icon) => icon.getAttribute("class"))).size,
+    ).toBe(3);
+    expect(container.querySelector("section")).toHaveAttribute(
+      "data-highlighted",
+      "true",
+    );
+    expect(container.querySelector("section")?.getAttribute("style")).toContain(
+      "border: 2px solid var(--accent-funnel)",
+    );
+  });
+
+  it("keeps every route fact and explicit mobile label/value pair", () => {
+    const { container } = render(<RouteComparator />);
+    const cards = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-route-card]"),
+    );
+
+    expect(cards).toHaveLength(3);
+    for (const card of cards) {
+      expect(card.querySelectorAll("dt")).toHaveLength(4);
+      expect(card.querySelectorAll("dd")).toHaveLength(4);
+    }
+
+    expect(cards[0]).toHaveTextContent(
+      "USD 130,000 held on deposit, in your own name",
+    );
+    expect(cards[0]).toHaveTextContent(
+      "A deposit at a state-owned (BUMN) Indonesian bank",
+    );
+    expect(cards[1]).toHaveTextContent(
+      "USD 1,000,000 completed strata-title property",
+    );
+    expect(cards[1]).toHaveTextContent(
+      "Only a completed strata-title unit — villas, land, leasehold, and off-plan do not qualify",
+    );
+    expect(cards[1]).toHaveTextContent(
+      "Pending our property validation standard",
+    );
+    expect(cards[2]).toHaveTextContent(
+      "USD 50,000 deposit plus USD 3,000/month income, or USD 3,000/month income only",
+    );
+    expect(cards[2]).toHaveTextContent(
+      "Age 55 or older, with a matching funding pattern",
+    );
+  });
+
+  it("has no horizontal scroll container and switches to cards at the mobile breakpoint", () => {
+    const { container } = render(<RouteComparator />);
+    const css = container.querySelector("style")?.textContent ?? "";
+    const sectionStyle =
+      container.querySelector("section")?.getAttribute("style") ?? "";
+
+    expect(css).not.toMatch(/overflow(?:-x)?\s*:\s*(?:auto|scroll)/i);
+    expect(sectionStyle).toContain("min-width: 0px");
+    expect(sectionStyle).toContain("width: 100%");
+    expect(sectionStyle).toContain("max-width: 100%");
+    expect(sectionStyle).toContain("box-sizing: border-box");
+    expect(css).toMatch(/@media \(max-width: 760px\)/);
+    expect(css).toMatch(/\.bz-shs-route-table-view\s*{\s*display:\s*none;/);
+    expect(css).toMatch(/\.bz-shs-route-cards\s*{\s*display:\s*grid;/);
+    expect(css).toMatch(
+      /grid-template-columns:\s*minmax\(0, 1fr\);[\s\S]*?\.bz-shs-route-card\s*{[\s\S]*?min-width:\s*0;/,
+    );
+  });
+
+  it("keeps text AA and identity marks perceivable on every route tint", () => {
+    const { container } = render(<RouteComparator />);
+    const css = container.querySelector("style")?.textContent ?? "";
+    const copy = css.match(/--route-copy:\s*(#[0-9a-f]{6})/i)?.[1];
+    const label = css.match(/--route-label:\s*(#[0-9a-f]{6})/i)?.[1];
+    const tints = Array.from(
+      css.matchAll(/--route-tint:\s*(#[0-9a-f]{6})/gi),
+      (match) => match[1],
+    );
+    const accents = Array.from(
+      css.matchAll(/--route-accent:\s*(#[0-9a-f]{6})/gi),
+      (match) => match[1],
+    );
+
+    if (!copy || !label) {
+      throw new Error("Route text colours are missing");
+    }
+    expect(tints).toHaveLength(3);
+    expect(accents).toHaveLength(3);
+    for (const tint of tints) {
+      expect(contrastRatio(copy, tint)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(label, tint)).toBeGreaterThanOrEqual(4.5);
+    }
+    for (const [index, accent] of accents.entries()) {
+      expect(contrastRatio(accent, tints[index])).toBeGreaterThanOrEqual(3);
+    }
+    expect(contrastRatio("#704116", "#fff7e8")).toBeGreaterThanOrEqual(4.5);
   });
 });

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
@@ -1,21 +1,25 @@
 "use client";
 
-import { Home, Landmark, Scale } from "lucide-react";
+import { CircleDashed, Home, Landmark, Scale } from "lucide-react";
+import type { ReactNode } from "react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 
-const COLUMNS = ["deposit", "property", "senior"] as const;
+const ROUTES = ["deposit", "property", "senior"] as const;
+type Route = (typeof ROUTES)[number];
 
-const COLUMN_ICONS = {
+const ROUTE_ICONS = {
   deposit: Landmark,
   property: Home,
   senior: Scale,
 } as const;
+
 const ROWS = [
   "capital",
   "liquidity",
   "whatQualifies",
   "currentStatus",
 ] as const;
+type Row = (typeof ROWS)[number];
 
 export interface RouteComparatorProps {
   /** Shown prominently when the plan's route is "unsure" (spec §3 row 8) —
@@ -23,15 +27,53 @@ export interface RouteComparatorProps {
   highlight?: boolean;
 }
 
-/** Static, honest deposit vs property vs senior comparison table (spec §5).
- *  Wrapped in an overflow-x container so a narrow viewport scrolls the
- *  table, never the page. */
+function RouteHeading({ route }: { route: Route }): ReactNode {
+  const RouteIcon = ROUTE_ICONS[route];
+
+  return (
+    <span className="bz-shs-route-heading">
+      <span className="bz-shs-route-icon" aria-hidden="true">
+        <RouteIcon size={24} strokeWidth={1.7} />
+      </span>
+      <span>{getCopy(`routeComparator.columns.${route}.title`)}</span>
+    </span>
+  );
+}
+
+function RouteValue({ route, row }: { route: Route; row: Row }): ReactNode {
+  const value = getCopy(`routeComparator.rows.${row}.${route}`);
+
+  if (route === "property" && row === "currentStatus") {
+    return (
+      <span className="bz-shs-route-status">
+        <CircleDashed size={17} strokeWidth={2} aria-hidden="true" />
+        <span>{value}</span>
+      </span>
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Static, honest deposit vs property vs senior comparison.
+ *
+ * The native table is shown on wide screens. At 760px and below it is removed
+ * from layout and the same data is presented as explicit label/value cards;
+ * the inactive representation is `display: none`, including for assistive tech.
+ */
 export function RouteComparator({ highlight = false }: RouteComparatorProps) {
   return (
     <section
+      className="bz-shs-route-comparator"
+      data-highlighted={highlight ? "true" : "false"}
       style={{
         display: "grid",
         gap: "var(--space-3, 1rem)",
+        minWidth: 0,
+        width: "100%",
+        maxWidth: "100%",
+        boxSizing: "border-box",
         background: "var(--surface-raised)",
         border: highlight
           ? "2px solid var(--accent-funnel)"
@@ -50,75 +92,38 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
       >
         Compare the routes
       </h2>
-      <div style={{ overflowX: "auto" }}>
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+
+      <div className="bz-shs-route-table-view" data-comparison-view="table">
+        <table aria-label="Second Home route comparison">
+          <colgroup>
+            <col className="bz-shs-route-criteria-column" />
+            {ROUTES.map((route) => (
+              <col key={route} />
+            ))}
+          </colgroup>
           <thead>
             <tr>
-              <th scope="col" style={{ padding: "var(--space-2, 0.5rem)" }} />
-              {COLUMNS.map((c) => {
-                const ColumnIcon = COLUMN_ICONS[c];
-                return (
-                  <th
-                    key={c}
-                    scope="col"
-                    style={{
-                      textAlign: "left",
-                      padding: "var(--space-2, 0.5rem)",
-                      color: "var(--text-primary)",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    <span
-                      style={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: "var(--space-2, 0.5rem)",
-                      }}
-                    >
-                      <ColumnIcon
-                        size={18}
-                        strokeWidth={1.5}
-                        aria-hidden
-                        style={{
-                          flexShrink: 0,
-                          color: "var(--color-text-muted)",
-                        }}
-                      />
-                      {getCopy(`routeComparator.columns.${c}.title`)}
-                    </span>
-                  </th>
-                );
-              })}
+              <th scope="col">
+                <span className="bz-shs-route-visually-hidden">
+                  Comparison criterion
+                </span>
+              </th>
+              {ROUTES.map((route) => (
+                <th key={route} scope="col" data-route={route}>
+                  <RouteHeading route={route} />
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
-            {ROWS.map((r) => (
-              <tr
-                key={r}
-                style={{ borderTop: "1px solid var(--color-border-subtle)" }}
-              >
-                <th
-                  scope="row"
-                  style={{
-                    textAlign: "left",
-                    padding: "var(--space-2, 0.5rem)",
-                    color: "var(--color-text-muted)",
-                    fontWeight: 600,
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {getCopy(`routeComparator.rows.${r}.label`)}
+            {ROWS.map((row) => (
+              <tr key={row}>
+                <th scope="row">
+                  {getCopy(`routeComparator.rows.${row}.label`)}
                 </th>
-                {COLUMNS.map((c) => (
-                  <td
-                    key={c}
-                    style={{
-                      padding: "var(--space-2, 0.5rem)",
-                      color: "var(--text-primary)",
-                      fontSize: "var(--text-sm, 0.9rem)",
-                    }}
-                  >
-                    {getCopy(`routeComparator.rows.${r}.${c}`)}
+                {ROUTES.map((route) => (
+                  <td key={route} data-route={route}>
+                    <RouteValue route={route} row={row} />
                   </td>
                 ))}
               </tr>
@@ -126,6 +131,293 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
           </tbody>
         </table>
       </div>
+
+      <div
+        className="bz-shs-route-cards"
+        data-comparison-view="cards"
+        role="group"
+        aria-label="Second Home route comparison"
+      >
+        {ROUTES.map((route) => (
+          <article
+            className="bz-shs-route-card"
+            data-route={route}
+            data-route-card={route}
+            key={route}
+            aria-labelledby={`bz-shs-route-${route}-title`}
+          >
+            <h3 id={`bz-shs-route-${route}-title`}>
+              <RouteHeading route={route} />
+            </h3>
+            <dl>
+              {ROWS.map((row) => (
+                <div className="bz-shs-route-pair" key={row}>
+                  <dt>{getCopy(`routeComparator.rows.${row}.label`)}</dt>
+                  <dd>
+                    <RouteValue route={route} row={row} />
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </article>
+        ))}
+      </div>
+
+      <style>{`
+        .bz-shs-route-comparator {
+          --route-copy: #172033;
+          --route-label: #475569;
+        }
+
+        .bz-shs-route-table-view {
+          min-width: 0;
+        }
+
+        .bz-shs-route-table-view table {
+          width: 100%;
+          table-layout: fixed;
+          border-spacing: 0;
+          border: 1px solid var(--color-border-subtle);
+          border-radius: 10px;
+        }
+
+        .bz-shs-route-criteria-column {
+          width: 18%;
+        }
+
+        .bz-shs-route-table-view th,
+        .bz-shs-route-table-view td {
+          min-width: 0;
+          padding: var(--space-3, 0.75rem);
+          text-align: left;
+          overflow-wrap: break-word;
+        }
+
+        .bz-shs-route-table-view thead th {
+          position: relative;
+          height: 5.75rem;
+          vertical-align: middle;
+          color: var(--text-primary);
+          background: var(--surface-raised);
+        }
+
+        .bz-shs-route-table-view thead th[data-route] {
+          color: var(--route-copy);
+          background: var(--route-tint);
+        }
+
+        .bz-shs-route-table-view thead th[data-route]::before,
+        .bz-shs-route-card::before {
+          position: absolute;
+          inset: 0 0 auto;
+          height: 4px;
+          content: "";
+        }
+
+        .bz-shs-route-table-view thead th[data-route="deposit"]::before,
+        .bz-shs-route-card[data-route="deposit"]::before {
+          background: var(--route-accent);
+        }
+
+        .bz-shs-route-table-view thead th[data-route="property"]::before,
+        .bz-shs-route-card[data-route="property"]::before {
+          height: 6px;
+          background: linear-gradient(
+            to bottom,
+            var(--route-accent) 0 2px,
+            transparent 2px 4px,
+            var(--route-accent) 4px 6px
+          );
+        }
+
+        .bz-shs-route-table-view thead th[data-route="senior"]::before,
+        .bz-shs-route-card[data-route="senior"]::before {
+          background: repeating-linear-gradient(
+            to right,
+            var(--route-accent) 0 8px,
+            transparent 8px 13px
+          );
+        }
+
+        .bz-shs-route-table-view tbody th,
+        .bz-shs-route-table-view tbody td {
+          border-top: 1px solid var(--color-border-subtle);
+          vertical-align: top;
+        }
+
+        .bz-shs-route-table-view tbody th {
+          color: var(--color-text-muted);
+          font-size: 0.76rem;
+          font-weight: 700;
+          line-height: 1.4;
+          letter-spacing: 0.035em;
+          text-transform: uppercase;
+          background: var(--surface-raised);
+        }
+
+        .bz-shs-route-table-view tbody td {
+          color: var(--route-copy);
+          font-size: var(--text-sm, 0.9rem);
+          line-height: 1.55;
+          background: var(--route-tint);
+        }
+
+        .bz-shs-route-table-view [data-route="deposit"],
+        .bz-shs-route-card[data-route="deposit"] {
+          --route-accent: #315f73;
+          --route-tint: #eef5f7;
+        }
+
+        .bz-shs-route-table-view [data-route="property"],
+        .bz-shs-route-card[data-route="property"] {
+          --route-accent: #79502f;
+          --route-tint: #f8f2eb;
+        }
+
+        .bz-shs-route-table-view [data-route="senior"],
+        .bz-shs-route-card[data-route="senior"] {
+          --route-accent: #66517a;
+          --route-tint: #f4f0f7;
+        }
+
+        .bz-shs-route-heading {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--space-2, 0.5rem);
+          min-width: 0;
+          font-family: var(--font-serif, Georgia, serif);
+          font-size: 1rem;
+          font-weight: 700;
+          line-height: 1.25;
+        }
+
+        .bz-shs-route-icon {
+          display: inline-grid;
+          flex: 0 0 42px;
+          width: 42px;
+          height: 42px;
+          place-items: center;
+          color: var(--route-accent);
+          border: 2px solid currentColor;
+        }
+
+        [data-route="deposit"] .bz-shs-route-icon {
+          border-radius: 50%;
+          box-shadow: inset 0 0 0 3px var(--route-tint);
+        }
+
+        [data-route="property"] .bz-shs-route-icon {
+          border-radius: 4px;
+          border-bottom-width: 5px;
+        }
+
+        [data-route="senior"] .bz-shs-route-icon {
+          width: 34px;
+          height: 34px;
+          margin: 4px;
+          border-radius: 4px;
+          transform: rotate(45deg);
+        }
+
+        [data-route="senior"] .bz-shs-route-icon svg {
+          transform: rotate(-45deg);
+        }
+
+        .bz-shs-route-status {
+          display: inline-flex;
+          align-items: flex-start;
+          gap: var(--space-2, 0.5rem);
+          padding: 0.4rem 0.55rem;
+          color: #704116;
+          font-weight: 700;
+          line-height: 1.4;
+          background: #fff7e8;
+          border: 1px dashed #9b6327;
+          border-radius: 6px;
+        }
+
+        .bz-shs-route-status svg {
+          flex: 0 0 auto;
+          margin-top: 0.08rem;
+        }
+
+        .bz-shs-route-cards {
+          display: none;
+        }
+
+        .bz-shs-route-visually-hidden {
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
+        }
+
+        @media (max-width: 760px) {
+          .bz-shs-route-comparator {
+            padding: var(--space-3, 1rem) !important;
+          }
+
+          .bz-shs-route-table-view {
+            display: none;
+          }
+
+          .bz-shs-route-cards {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr);
+            gap: var(--space-3, 1rem);
+            min-width: 0;
+          }
+
+          .bz-shs-route-card {
+            position: relative;
+            min-width: 0;
+            padding: var(--space-4, 1.5rem);
+            color: var(--route-copy);
+            background: var(--route-tint);
+            border: 1px solid var(--color-border-subtle);
+            border-radius: 10px;
+          }
+
+          .bz-shs-route-card h3 {
+            margin: 0;
+            overflow-wrap: break-word;
+          }
+
+          .bz-shs-route-card dl {
+            display: grid;
+            gap: 0;
+            margin: var(--space-3, 1rem) 0 0;
+          }
+
+          .bz-shs-route-pair {
+            min-width: 0;
+            padding: var(--space-3, 0.75rem) 0;
+            border-top: 1px solid var(--color-border-subtle);
+          }
+
+          .bz-shs-route-pair dt {
+            color: var(--route-label);
+            font-size: 0.76rem;
+            font-weight: 700;
+            line-height: 1.4;
+            letter-spacing: 0.035em;
+            text-transform: uppercase;
+          }
+
+          .bz-shs-route-pair dd {
+            min-width: 0;
+            margin: 0.35rem 0 0;
+            color: var(--route-copy);
+            font-size: var(--text-sm, 0.9rem);
+            line-height: 1.55;
+            overflow-wrap: break-word;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -182,7 +182,7 @@ export const COPY = {
     },
     reasons: {
       propertyPendingStandard:
-        "Property-route cases go through our property validation standard (addendum 007) before we can confirm fit — that keeps the review honest on both sides.",
+        "Property-route cases go through our property validation standard before we can confirm fit — that keeps the review honest on both sides.",
       propertyDoesNotQualify:
         "Only a completed strata-title unit valued at USD 1,000,000 or more qualifies. Villas, land, leasehold, and off-plan purchases do not qualify for the property route.",
       unsureRoute:
@@ -329,7 +329,7 @@ export const COPY = {
       propertyEvidence: {
         title: "Provide your property evidence",
         range:
-          "Timing depends on our pending property validation standard (addendum 007), once published — typical, not a promise.",
+          "Timing depends on our pending property validation standard, once published — typical, not a promise.",
       },
       incomeEvidence: {
         title: "Prepare your income evidence",


### PR DESCRIPTION
> **Draft on purpose.** This is the highest-stakes square inch on the funnel. It gets looked at in a browser before it merges — a green suite is not a look.

## The defect, measured on production at 390px

"Compare the routes" is the moment the page asks a visitor to choose between three fundamentally different financial commitments — a **USD 130,000 deposit**, a **USD 1,000,000 property**, or the **USD 50,000 + income senior path**. It presented that choice as a plain data table.

On a phone the table was wider than the viewport and scrolled **inside its own container with no affordance** — no gradient, no shadow, no indicator. The audit screenshot shows "Deposit Route" clipped mid-word at the right edge, with the Property and Senior columns entirely invisible. **On a phone, two of the three routes did not exist for the reader.** The proximate cause was `white-space: nowrap` on the column headers, which stopped the table ever narrowing.

An independent audit named this "the least-designed square inch on the whole funnel, sitting at the highest-stakes decision point."

## What changed

- **Narrow viewports get three stacked route units, not a table.** No information is reachable only by scrolling sideways.
- **Wide viewports keep the side-by-side comparison** — comparing attributes across options is exactly what a table is good at. The table was never the defect; its unresponsiveness and its anonymity were.
- **Each route gets its own visual identity** through weight and icon treatment — never colour alone, so it survives a colour-blind reader.
- **Only one representation exists at a time.** The inactive one is `display: none`, which removes it from the accessibility tree too, so a screen-reader user is not read the same three routes twice.

## What it deliberately does not do

No ranking, no score, no "recommended" badge. The three routes are not ordered. The verdict bands remain the only judgement this page makes.

The property route stays honestly flagged as subject to our pending validation standard — that disclosure is one of the more honest things on the page.

## Also in this PR (declared, not smuggled)

An internal document number had leaked into customer-facing copy: **"our property validation standard (addendum 007)"**, twice in `copy.ts`. Removed. The honesty is untouched — the standard is still declared as pending — only our internal case number goes. Two lines, same surface, declared here rather than deferred.

## Verification

`vitest run src/app/visa/second-home src/lib/secondhome-studio` — **19 files, 330 tests passing**, re-run independently by the conductor on this branch rather than taken from the build seat's report. A new test fails if the comparison container returns to scrolling horizontally without affordance.

Built on the Codex seat at `xhigh`; graded, tested and published by the conductor — generator is not grader. An independent adversarial pass is running against this diff.