### PR TITLE
fix(garuda): surface an unavailable official price instead of dropping it silently

### DIFF
--- a/apps/admin-dashboard-local/__tests__/garuda-preview-adapter.test.ts
+++ b/apps/admin-dashboard-local/__tests__/garuda-preview-adapter.test.ts
@@ -29,6 +29,8 @@ const VALID_RESULT = {
   internal_checkpoints: [],
   price_idr: 790_000,
   price_source: "B1 Visa on Arrival (VOA)",
+  price_status: "confirmed",
+  price_warning: null,
   generated_at: "2026-08-19T08:00:00Z",
   calendar_coverage_start: "2026-07-28",
   calendar_coverage_end: "2026-12-31",
@@ -191,6 +193,31 @@ describe("GARUDA Python execFile adapter", () => {
     { price_source: "B1 Visa on Arrival Extension" },
     { case_type: "extension", calendar_status: "not_applicable" },
   ])("rejects an inconsistent official price pair: %o", async (change) => {
+    engineResult({ ...VALID_RESULT, ...change });
+
+    await expect(runGarudaPreview("{}")).rejects.toMatchObject({
+      code: "preview_unavailable",
+    });
+  });
+
+  it.each([
+    {
+      price_status: "unavailable",
+      price_warning:
+        "The official catalogue price is unavailable. No price is shown; staff must confirm the price rather than invent one.",
+    },
+    {
+      price_status: "confirmed",
+      price_warning:
+        "The official catalogue price is unavailable. No price is shown; staff must confirm the price rather than invent one.",
+    },
+    {
+      price_idr: null,
+      price_source: null,
+      price_status: "unavailable",
+      price_warning: "Official price lookup failed.",
+    },
+  ])("rejects an inconsistent official price status: %o", async (change) => {
     engineResult({ ...VALID_RESULT, ...change });
 
     await expect(runGarudaPreview("{}")).rejects.toMatchObject({

--- a/apps/admin-dashboard-local/__tests__/garuda-preview-boundary.test.ts
+++ b/apps/admin-dashboard-local/__tests__/garuda-preview-boundary.test.ts
@@ -166,6 +166,14 @@ describe("GARUDA internal preview boundaries", () => {
     expect(ui).not.toContain("Verified coverage ends");
   });
 
+  it("renders the engine price status and warning without an invented fallback", () => {
+    const ui = source("app/garuda-voa/GarudaPreviewClient.tsx");
+    expect(ui).toContain("Price status: {result.price_status}");
+    expect(ui).toContain("result.price_warning");
+    expect(ui).toContain('className="garuda-warning"');
+    expect(ui).not.toContain("No catalogue source returned");
+  });
+
   it("requires Bearer validation in every cockpit and GARUDA protected API", () => {
     for (const route of [
       "app/api/cockpit/session/route.ts",

--- a/apps/admin-dashboard-local/app/garuda-voa/GarudaPreviewClient.tsx
+++ b/apps/admin-dashboard-local/app/garuda-voa/GarudaPreviewClient.tsx
@@ -38,6 +38,8 @@ interface PreviewResult {
   internal_checkpoints: InternalCheckpoint[];
   price_idr: number | null;
   price_source: string | null;
+  price_status: "confirmed" | "unavailable";
+  price_warning: string | null;
   calendar_coverage_start: string;
   calendar_coverage_end: string;
   calendar_status: "confirmed" | "uncovered" | "not_applicable";
@@ -443,8 +445,12 @@ export function GarudaPreviewClient() {
                 <span>PricingTool result</span>
                 <strong>{formatIdr(result.price_idr)}</strong>
                 <small>
-                  {result.price_source ?? "No catalogue source returned"}
+                  Price status: {result.price_status}
+                  {result.price_source ? ` · ${result.price_source}` : null}
                 </small>
+                {result.price_warning ? (
+                  <div className="garuda-warning">{result.price_warning}</div>
+                ) : null}
               </div>
 
               <div className="garuda-calendar">

--- a/apps/admin-dashboard-local/lib/garuda-preview-adapter.ts
+++ b/apps/admin-dashboard-local/lib/garuda-preview-adapter.ts
@@ -42,6 +42,8 @@ const EXTENSION_WARNING =
   "Extension processing requires office-specific verification and an in-person photo/interview step.";
 const CALENDAR_WARNING =
   "The operating calendar does not cover this entry date. No issuance deadline is shown; staff must verify the applicable decree manually.";
+const PRICE_WARNING =
+  "The official catalogue price is unavailable. No price is shown; staff must confirm the price rather than invent one.";
 const SUCCESS_KEYS = [
   "decision",
   "reason_codes",
@@ -55,6 +57,8 @@ const SUCCESS_KEYS = [
   "internal_checkpoints",
   "price_idr",
   "price_source",
+  "price_status",
+  "price_warning",
   "generated_at",
   "calendar_coverage_start",
   "calendar_coverage_end",
@@ -103,6 +107,8 @@ export interface GarudaPreviewResult {
   internal_checkpoints: GarudaInternalCheckpoint[];
   price_idr: number | null;
   price_source: string | null;
+  price_status: "confirmed" | "unavailable";
+  price_warning: string | null;
   generated_at: string;
   calendar_coverage_start: string;
   calendar_coverage_end: string;
@@ -314,6 +320,7 @@ function parseEngineSuccess(stdout: string): GarudaPreviewResult {
     "uncovered",
     "not_applicable",
   ]);
+  const priceStatuses = new Set(["confirmed", "unavailable"]);
   if (
     containsForbiddenMarker(value) ||
     !hasExactKeys(value, SUCCESS_KEYS) ||
@@ -340,6 +347,9 @@ function parseEngineSuccess(stdout: string): GarudaPreviewResult {
       (typeof value.price_source === "string" &&
         OFFICIAL_PRICE_KEYS.has(value.price_source))
     ) ||
+    typeof value.price_status !== "string" ||
+    !priceStatuses.has(value.price_status) ||
+    !(value.price_warning === null || value.price_warning === PRICE_WARNING) ||
     !isIsoDateTime(value.generated_at) ||
     !isIsoDate(value.calendar_coverage_start) ||
     !isIsoDate(value.calendar_coverage_end) ||
@@ -368,6 +378,11 @@ function parseEngineSuccess(stdout: string): GarudaPreviewResult {
     (value.decision === "ACCEPT" && value.reason_codes.length !== 0) ||
     (value.decision === "DECLINE" && value.reason_codes.length === 0) ||
     (value.price_idr === null) !== (value.price_source === null) ||
+    (value.price_status === "unavailable") !==
+      (value.price_warning === PRICE_WARNING) ||
+    (value.price_status === "confirmed") !== (value.price_warning === null) ||
+    (value.price_status === "unavailable") !== (value.price_idr === null) ||
+    (value.price_status === "unavailable") !== (value.price_source === null) ||
     (value.price_source !== null &&
       value.price_source !==
         (value.case_type === "issuance"

--- a/apps/backend-rag/backend/services/garuda_flow/internal_preview_cli.py
+++ b/apps/backend-rag/backend/services/garuda_flow/internal_preview_cli.py
@@ -100,6 +100,8 @@ class InternalPreviewResponse(_StrictModel):
     internal_checkpoints: list[InternalCheckpoint]
     price_idr: int | None
     price_source: str | None
+    price_status: Literal["confirmed", "unavailable"]
+    price_warning: str | None
     generated_at: datetime
     calendar_coverage_start: date
     calendar_coverage_end: date
@@ -161,6 +163,19 @@ def build_internal_preview(
     )
     verdict = build_verdict(intake, today=today)
     price_idr, price_source = price_for_case(request.case_type)
+    price_status: Literal["confirmed", "unavailable"] = (
+        "confirmed"
+        if price_idr is not None and price_source is not None
+        else "unavailable"
+    )
+    price_warning: str | None = None
+    if price_status == "unavailable":
+        price_idr = None
+        price_source = None
+        price_warning = (
+            "The official catalogue price is unavailable. "
+            "No price is shown; staff must confirm the price rather than invent one."
+        )
 
     checkpoints: list[InternalCheckpoint] = []
     if request.case_type is CaseType.EXTENSION:
@@ -218,6 +233,8 @@ def build_internal_preview(
         internal_checkpoints=checkpoints,
         price_idr=price_idr,
         price_source=price_source,
+        price_status=price_status,
+        price_warning=price_warning,
         generated_at=generated_at,
         calendar_coverage_start=COVERAGE_START,
         calendar_coverage_end=COVERAGE_END,

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_internal_preview_cli.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_internal_preview_cli.py
@@ -50,6 +50,8 @@ def test_accepted_issuance_uses_real_pricing_and_no_internal_checkpoints() -> No
     assert response.internal_checkpoints == []
     assert response.price_idr is not None
     assert response.price_source == "B1 Visa on Arrival (VOA)"
+    assert response.price_status == "confirmed"
+    assert response.price_warning is None
     assert response.generated_at == _NOW
     assert response.submit_by_date is not None
     assert response.submit_by_date < response.entry_date
@@ -57,6 +59,24 @@ def test_accepted_issuance_uses_real_pricing_and_no_internal_checkpoints() -> No
     assert response.calendar_coverage_start == date(2026, 7, 28)
     assert response.computed_stay_end == response.expiry_date
     assert "last_legal_day" not in response.model_dump()
+
+
+def test_unavailable_price_is_explicit_and_requires_staff_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "backend.services.garuda_flow.internal_preview_cli.price_for_case",
+        lambda _case_type: (None, None),
+    )
+
+    response = build_internal_preview(_request(), today=_TODAY, generated_at=_NOW)
+
+    assert response.decision == "ACCEPT"
+    assert response.price_idr is None
+    assert response.price_source is None
+    assert response.price_status == "unavailable"
+    assert response.price_warning is not None
+    assert "staff must confirm the price rather than invent one" in response.price_warning
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## The defect

`pricing.py::price_for_case` documents its `(None, None)` return as deliberate
fail-safe output — *"callers must ask staff to confirm rather than invent a price
when the official catalogue is absent or cannot be matched"*. The producer is
correct and says so. **The consumer threw the signal away.**

`build_internal_preview` passed `price_idr=None` straight into the response with
no status field, no warning string, and nothing appended to `warnings`. A
catalogue failure therefore rendered as a plain `ACCEPT` with a blank price and
no indication that anything had gone wrong.

## The fix

Mirror the calendar contract that already lives twenty lines below in the same
function: a typed `price_status` alongside a `price_warning`, exactly as
`calendar_status` / `calendar_warning` express an uncovered entry date. Same
shape, same reason — the codebase already knows how to say *"this input is
degraded, do not act on it silently"*; price simply was not using it. No new
mechanism was invented.

`price_for_case` returns both-or-neither on every path, so the defensive
re-nulling is belt-and-braces rather than load-bearing.

## Verification

- **Guilt proven RED** against unmodified source: `AttributeError:
  'InternalPreviewResponse' object has no attribute 'price_status'`. The
  `price_idr is None` / `price_source is None` assertions preceding it passed
  under the old code — the red lands on the **missing signal**, not the missing
  price.
- **Innocence**: the normal path stays `confirmed` with `price_warning is None`
  and no new entry in `warnings`, so a healthy lookup adds no noise.
- **190 tests green**, RC=0: `backend/tests/services/garuda_flow/` +
  `test_garuda_voa.py` + `test_garuda_voa_no_internal_leak.py`.
- **Wire safety**: `InternalPreviewResponse` is consumed only by the CLI and its
  own tests — the public archive route serializes `VoaResponse`, a separate
  model with no price field. The two new fields cannot reach the wire, so the
  no-internal-leak suite needs no additional case.
- **Evidence floor measured on the committed diff** with an explicit SHA range
  (`83f5f61d..f9a507e0`): **floor 1, 2 changed files** — below the pack
  threshold, so `evidence/*.yml` is deliberately untouched.

## Deploy note

`apps/backend-rag/**` merging to `main` triggers `fly-deploy.yml` — this
auto-deploys to Fly on merge.
