### PR TITLE
fix(bot): pg.sh cron/launchd fallback — wa-codex-seat-sentinel never once verified the gauge

### DIFF
--- a/scripts/pg.sh
+++ b/scripts/pg.sh
@@ -12,6 +12,25 @@
 #     host=127.0.0.1 port=15432 user=nuzantara_readonly dbname=nuzantara_rag sslmode=disable
 #     password: Keychain  service=nuzantara-postgres-readonly  account=nuzantara_readonly
 #
+# CRON/LAUNCHD FALLBACK (2026-08-24, wa-codex-seat-sentinel W-class): `security
+# find-generic-password` needs the caller's LOGIN KEYCHAIN unlocked in an
+# interactive GUI session. `crontab`/launchd jobs run outside any such
+# session, so the lookup returns EMPTY (not an error — `security` is wrapped
+# in `|| true` on purpose, W104: judge output, never exit code alone) and
+# every non-interactive caller got CANNOT-VERIFY forever, 68/68 runs measured
+# on wa-codex-seat-sentinel. Same pattern this repo already trusts for
+# `zantara-codex`'s own launchd daemon (`.wa-codex-broker.env`, scar family
+# #4: 0600, never echoed, never on argv): a per-user 0600 credential file is
+# the fallback, tried ONLY when the Keychain came back empty, so the
+# interactive path (Zero, Claude Code sessions with the item's ACL already
+# granted) is completely unchanged. Deliberately its OWN narrow-scope file —
+# not `~/.nuzantara-secrets.env` (that file holds six Claude OAuth tokens;
+# widening a cron job's file-read footprint to reach a Postgres RO password
+# would violate least-exposure for no reason). File is refused outright
+# unless its mode is EXACTLY 600 (owner rw, nothing else) — a loosely
+# permissioned credential file is not trusted, it is reported and skipped,
+# same posture as `security_permissions_audit.py --fix`.
+#
 # USAGE:
 #   scripts/pg.sh -c "SELECT 1;"            # run SQL, read-only
 #   scripts/pg.sh -A -F'|' -c "SELECT ..."  # any psql flags pass through
@@ -24,10 +43,32 @@ set -euo pipefail
 PSQL="${PSQL:-/opt/homebrew/bin/psql}"
 FLY="${FLY:-$(command -v fly || command -v flyctl || echo /opt/homebrew/bin/fly)}"
 TARGET="${PG_TARGET:-prod}"
+CRED_FILE="${NUZANTARA_PG_RO_CRED_FILE:-$HOME/.nuzantara-pg-readonly.env}"
+
+# _pg_ro_password KEYCHAIN_ACCOUNT FILE_VAR_NAME
+#   Keychain first (silent, unchanged, for every interactive caller); if that
+#   comes back empty, a 0600 credential file second. Never prints the value;
+#   never puts it on argv.
+_pg_ro_password() {
+  local kc_account="$1" file_var="$2" pw mode
+  pw="$(security find-generic-password -s nuzantara-postgres-readonly -a "$kc_account" -w 2>/dev/null || true)"
+  if [ -n "$pw" ]; then
+    printf '%s' "$pw"
+    return 0
+  fi
+  [ -f "$CRED_FILE" ] || return 0
+  mode="$(stat -f '%OLp' "$CRED_FILE" 2>/dev/null || echo '')"
+  if [ "$mode" != "600" ]; then
+    echo "pg.sh: refusing credential file $CRED_FILE — mode is ${mode:-unreadable}, must be exactly 600 (scar #4, not used)" >&2
+    return 0
+  fi
+  pw="$(grep -m1 "^${file_var}=" "$CRED_FILE" | cut -d= -f2-)"
+  printf '%s' "$pw"
+}
 
 if [ "$TARGET" = "local" ]; then
   # M5 local PG17 (PR #1349) — dev role/db.
-  PW="$(security find-generic-password -s nuzantara-postgres-readonly -a nuzantara_dev_readonly -w 2>/dev/null || true)"
+  PW="$(_pg_ro_password nuzantara_dev_readonly NUZANTARA_PG_RO_PASSWORD_LOCAL)"
   CONN="host=127.0.0.1 port=5432 user=nuzantara_dev_readonly dbname=nuzantara_dev sslmode=disable"
 else
   # PROD via Fly proxy on :15432.
@@ -40,14 +81,15 @@ else
       sleep 0.5
     done
   fi
-  PW="$(security find-generic-password -s nuzantara-postgres-readonly -a nuzantara_readonly -w 2>/dev/null || true)"
+  PW="$(_pg_ro_password nuzantara_readonly NUZANTARA_PG_RO_PASSWORD)"
   CONN="host=127.0.0.1 port=${PORT} user=nuzantara_readonly dbname=nuzantara_rag sslmode=disable"
 fi
 
 if [ -z "${PW:-}" ]; then
-  echo "pg.sh: no Keychain password found for target=${TARGET}." >&2
+  echo "pg.sh: no Keychain password found for target=${TARGET}, and no usable fallback." >&2
   echo "  prod  -> security find-generic-password -s nuzantara-postgres-readonly -a nuzantara_readonly -w" >&2
   echo "  local -> security find-generic-password -s nuzantara-postgres-readonly -a nuzantara_dev_readonly -w" >&2
+  echo "  cron/launchd fallback -> put NUZANTARA_PG_RO_PASSWORD(_LOCAL)=... in $CRED_FILE, chmod 600" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Problem (measured live 2026-08-23, reconfirmed today)

`wa-codex-seat-sentinel.sh` has been in `crontab` (`*/15 * * * *`) since it
shipped. 68/68 recent runs = `CANNOT-VERIFY` (rc=2):

```
wa_codex_seat_sentinel: gauge query returned no output (rc=2): pg.sh: no Keychain password found for target=prod.
  prod  -> security find-generic-password -s nuzantara-postgres-readonly -a nuzantara_readonly -w
```

Root cause: `security find-generic-password` needs the caller's **login
keychain unlocked in an interactive GUI session**. `crontab` jobs run
outside any such session, so the lookup returns empty (`security` is
deliberately wrapped in `|| true` — W104 discipline: judge output, never
exit code alone). `pg.sh` therefore has **never** had a way to reach the
`wa_broker_gauge` row from cron. The watchdog meant to catch the codex
daemon dying has never once actually verified the gauge — it only ever
fails loud on its own inability to look.

## Grounding

- `wa-codex-seat-sentinel.sh` and `pg.sh` are **repo-tracked**
  (`infra/launchagents/wrappers/`, `scripts/`) — crontab invokes the repo
  checkout path directly (`/Users/nuzantara/nuzantara/infra/launchagents/wrappers/wa-codex-seat-sentinel.sh`).
  No HOME-fork copy exists for either file (confirmed: `find` turned up only
  worktree copies; the wrapper's own header says so — "Runs in-place from the
  repo checkout ... NO declared-pairs entry"). Scar family #1 does not apply
  here.
- Every other current `pg.sh` consumer in this repo (`nuz_db_refresh.sh`,
  `fly_pg_tunnel_supervisor.sh`, `cost_ledger_export_run.sh`,
  `mata_garuda_invalidation_sweep_wrapper.sh`, ...) is **not** in crontab
  today, so this sentinel is the first cron-invoked caller to actually hit
  the bug.

## Fix

`pg.sh` now tries the Keychain first (**unchanged** — every interactive
caller, Zero and Claude Code sessions with the item's ACL already granted,
sees no behavior change), and only when that comes back empty falls back to
a per-user `0600` credential file (`~/.nuzantara-pg-readonly.env`, path
overridable via `NUZANTARA_PG_RO_CRED_FILE`).

This reuses the **exact pattern this repo already trusts** for
`zantara-codex`'s own launchd daemon (`.wa-codex-broker.env`: `0600`, never
echoed, never on argv, sourced only after an existence check) — no new
secret store invented. Scar #4 discipline enforced in code, not just by
convention: the file is refused outright unless its mode is **exactly 600**
— a loosely permissioned credential file is reported and skipped, never
trusted.

Deliberately its **own narrow-scope file**, not `~/.nuzantara-secrets.env`
(which holds six Claude OAuth tokens) — no reason to widen a cron job's
file-read footprint past what it actually needs.

## Proof (this turn, against the live gauge)

With a `security` stub simulating cron's keychain-denied lookup (empty
stdout, non-zero exit) and everything else on `PATH` untouched:

```
$ PATH="$STUBDIR:$PATH" bash infra/launchagents/wrappers/wa-codex-seat-sentinel.sh
wa-codex-seat-sentinel [Nuzantara]: all conditions healthy
wa-codex-seat-sentinel rc=0
```

— instead of `CANNOT-VERIFY` / rc=2. Also verified:
- Wrong file permissions (644) are correctly **refused** with the same rc=2
  path (not silently trusted).
- The normal Keychain path was re-run afterward, unchanged (`rc=0`, real
  data returned).
- `scripts/lint_pg_dsn_credentials.py` — clean, no literal secret in the
  diff.
- Existing python test suite (30 tests,
  `test_wa_codex_seat_sentinel.py` + `test_wa_codex_seat_probe.py`) —
  green, untouched (those mock `subprocess.run` at the python layer and
  never exercise `pg.sh`).
- `shellcheck` — no new warnings (one pre-existing SC2034 on an untouched
  line).

## Credential file — explicit, per scar #4

The `0600` credential file (`~/.nuzantara-pg-readonly.env`) is **host-local
material, not repo-tracked** (same class as `.wa-codex-broker.env`) — it is
NOT part of this diff. It was created on **Pro** (the machine that owns
this crontab entry) as part of shipping this fix: `owner=nuzantara:staff`,
`mode=0600`, containing the **same** Postgres RO password already present in
the Keychain — nothing new was minted, it was relocated to a place cron can
read.

**Residual, not done here**: if Mini also runs this cron entry (mirrored
crontab per the "prolunga naturale" setup), the same `0600` file needs to be
created there too before its ticks will verify — I did not check Mini's
crontab and make no claim about it either way.

## Not armed

Per instruction — not arming auto-merge; team-lead gates this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)