### PR TITLE
fix(mouth): choosing an option nudged the list, and the arrow keys did nothing

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
@@ -1,7 +1,33 @@
+import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Landmark, Home, Scale } from "lucide-react";
 import { QuestionCard, OptionButton } from "./QuestionCard";
+
+const RADIO_LABELS = ["55–59", "60 or over", "Under 55"] as const;
+
+function RadioQuestion() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  return (
+    <QuestionCard
+      heading="First, how old are you?"
+      body="Age helps determine routes."
+      why="Regulation uses different thresholds."
+      options={RADIO_LABELS.map((label) => (
+        <OptionButton
+          key={label}
+          label={label}
+          selected={selected === label}
+          onSelect={() => setSelected(label)}
+          variant="radio"
+        />
+      ))}
+    >
+      <button type="button">Continue</button>
+    </QuestionCard>
+  );
+}
 
 describe("QuestionCard > OptionButton icon support", () => {
   it("renders an icon when the icon prop is provided", () => {
@@ -91,5 +117,111 @@ describe("QuestionCard > OptionButton icon support", () => {
     );
 
     expect(container.querySelectorAll("svg").length).toBe(1); // only the chevron in <details>
+  });
+});
+
+describe("QuestionCard > OptionButton selection control", () => {
+  it("keeps selected and unselected option borders the same thickness and gives focus a separate non-layout ring", () => {
+    const { container } = render(<RadioQuestion />);
+    const first = screen.getAllByRole("radio")[0];
+
+    fireEvent.click(first);
+
+    const css = container.querySelector("style")?.textContent ?? "";
+    const baseRule = css.match(/\.bz-shs-option\s*\{([^}]*)\}/s)?.[1] ?? "";
+    const selectedRule =
+      css.match(
+        /\.bz-shs-option\[data-selected="true"\]\s*\{([^}]*)\}/s,
+      )?.[1] ?? "";
+    expect(baseRule).toMatch(/border:\s*1px solid/);
+    expect(selectedRule).not.toMatch(/(?:^|;)\s*border\s*:/);
+    expect(selectedRule).not.toMatch(/border-width\s*:/);
+    expect(selectedRule).toMatch(/border-color:\s*var\(--accent-funnel\)/);
+    expect(css).toMatch(
+      /\.bz-shs-option\[data-selected="true"\]\s*\{[^}]*box-shadow:\s*inset 0 0 0 2px/s,
+    );
+    expect(css).toMatch(
+      /\.bz-shs-option:focus-visible\s*\{[^}]*outline:\s*3px solid[^}]*outline-offset:\s*3px/s,
+    );
+    expect(css).toMatch(
+      /@media\s*\(prefers-reduced-motion:\s*reduce\)[\s\S]*\.bz-shs-option[\s\S]*transition:\s*none/s,
+    );
+  });
+
+  it("keeps exactly one radio in the tab order and moves tabindex=0 with selection", () => {
+    render(<RadioQuestion />);
+    const radios = screen.getAllByRole("radio");
+
+    expect(radios.map((radio) => radio.getAttribute("tabindex"))).toEqual([
+      "0",
+      "-1",
+      "-1",
+    ]);
+
+    fireEvent.click(radios[1]);
+
+    expect(radios.map((radio) => radio.getAttribute("tabindex"))).toEqual([
+      "-1",
+      "0",
+      "-1",
+    ]);
+    expect(radios[1]).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("moves focus and selection with arrows, Home, and End, including wrapping", () => {
+    render(<RadioQuestion />);
+
+    const expectKeyboardMove = (key: string, expectedIndex: number) => {
+      const radios = screen.getAllByRole("radio");
+      fireEvent.keyDown(document.activeElement as HTMLElement, { key });
+      expect(document.activeElement).toBe(radios[expectedIndex]);
+      expect(radios[expectedIndex]).toHaveAttribute("aria-checked", "true");
+      expect(radios[expectedIndex]).toHaveAttribute("tabindex", "0");
+      expect(
+        radios.filter((radio) => radio.getAttribute("tabindex") === "0"),
+      ).toHaveLength(1);
+    };
+
+    screen.getAllByRole("radio")[0].focus();
+    expectKeyboardMove("ArrowDown", 1);
+    expectKeyboardMove("ArrowUp", 0);
+    expectKeyboardMove("ArrowUp", 2);
+    expectKeyboardMove("ArrowDown", 0);
+    expectKeyboardMove("End", 2);
+    expectKeyboardMove("Home", 0);
+    expectKeyboardMove("ArrowRight", 1);
+    expectKeyboardMove("ArrowLeft", 0);
+  });
+
+  it("leaves toggle buttons as independent Tab stops and does not capture arrow keys", () => {
+    const firstToggle = vi.fn();
+    const secondToggle = vi.fn();
+    render(
+      <QuestionCard
+        heading="Who would you want to include?"
+        body="Choose any family members."
+        why="Each family member has a separate route."
+      >
+        <OptionButton label="Spouse" selected={false} onSelect={firstToggle} />
+        <OptionButton
+          label="Children"
+          selected={false}
+          onSelect={secondToggle}
+        />
+      </QuestionCard>,
+    );
+
+    const toggles = screen.getAllByRole("button", {
+      name: /Spouse|Children/,
+    });
+    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(toggles.map((toggle) => toggle.tabIndex)).toEqual([0, 0]);
+
+    toggles[0].focus();
+    fireEvent.keyDown(toggles[0], { key: "ArrowDown" });
+
+    expect(document.activeElement).toBe(toggles[0]);
+    expect(firstToggle).not.toHaveBeenCalled();
+    expect(secondToggle).not.toHaveBeenCalled();
   });
 });

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useId, type ReactNode, type Ref } from "react";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useId,
+  type KeyboardEvent,
+  type ReactNode,
+  type Ref,
+} from "react";
 import type { LucideIcon } from "lucide-react";
 import { ChevronRight } from "lucide-react";
 
@@ -23,6 +31,45 @@ export interface QuestionCardProps {
   children: ReactNode;
 }
 
+function handleRadioGroupKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  const currentRadio = target.closest<HTMLButtonElement>('[role="radio"]');
+  if (!currentRadio || !event.currentTarget.contains(currentRadio)) return;
+
+  const radios = Array.from(
+    event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="radio"]'),
+  );
+  const currentIndex = radios.indexOf(currentRadio);
+  if (currentIndex < 0 || radios.length === 0) return;
+
+  let nextIndex: number;
+  switch (event.key) {
+    case "ArrowDown":
+    case "ArrowRight":
+      nextIndex = (currentIndex + 1) % radios.length;
+      break;
+    case "ArrowUp":
+    case "ArrowLeft":
+      nextIndex = (currentIndex - 1 + radios.length) % radios.length;
+      break;
+    case "Home":
+      nextIndex = 0;
+      break;
+    case "End":
+      nextIndex = radios.length - 1;
+      break;
+    default:
+      return;
+  }
+
+  event.preventDefault();
+  const nextRadio = radios[nextIndex];
+  nextRadio.focus();
+  nextRadio.click();
+}
+
 /** Chrome wrapper for one wizard screen: heading/body (from copy.ts),
  *  a collapsible "Why we ask" aside, an optional radiogroup-wrapped
  *  options slot, and a slot for anything else (option cards, a custom
@@ -36,6 +83,28 @@ export function QuestionCard({
   children,
 }: QuestionCardProps) {
   const headingId = useId();
+  const optionNodes = Children.toArray(options);
+  const radioIndexes = optionNodes.flatMap((option, index) =>
+    isValidElement<OptionButtonProps>(option) &&
+    option.type === OptionButton &&
+    option.props.variant === "radio"
+      ? [index]
+      : [],
+  );
+  const selectedRadioIndex = radioIndexes.find((index) => {
+    const option = optionNodes[index];
+    return isValidElement<OptionButtonProps>(option) && option.props.selected;
+  });
+  const tabbableRadioIndex = selectedRadioIndex ?? radioIndexes[0];
+  const radioOptions = optionNodes.map((option, index) =>
+    isValidElement<OptionButtonProps>(option) &&
+    option.type === OptionButton &&
+    option.props.variant === "radio"
+      ? cloneElement(option, {
+          tabIndex: index === tabbableRadioIndex ? 0 : -1,
+        })
+      : option,
+  );
 
   return (
     <div
@@ -102,9 +171,10 @@ export function QuestionCard({
         <div
           role="radiogroup"
           aria-labelledby={headingId}
+          onKeyDown={handleRadioGroupKeyDown}
           style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}
         >
-          {options}
+          {radioOptions}
         </div>
       ) : null}
       <div style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
@@ -112,10 +182,7 @@ export function QuestionCard({
       </div>
       {/* Single instance per render (only one question stage is ever
        *  mounted at a time) — matches the local-<style> pattern already
-       *  used by ProgressRail/MemoPreview. Transitions here are already
-       *  covered by StudioApp's `.bz-shs-layout * { transition: none }`
-       *  reduced-motion rule, since QuestionCard only ever renders inside
-       *  that container — no separate media query needed. */}
+       *  used by ProgressRail/MemoPreview. */}
       <style>{`
         .bz-shs-why-summary::-webkit-details-marker {
           display: none;
@@ -135,20 +202,33 @@ export function QuestionCard({
         .bz-shs-option {
           border: 1px solid var(--color-border-subtle);
           background: transparent;
+          box-shadow: inset 0 0 0 0 transparent;
           transition:
             border-color 150ms ease-out,
-            background-color 150ms ease-out;
+            background-color 150ms ease-out,
+            box-shadow 150ms ease-out;
         }
         .bz-shs-option:hover {
           border-color: var(--accent-funnel);
           background: color-mix(in srgb, var(--accent-funnel) 6%, transparent);
         }
         .bz-shs-option[data-selected="true"] {
-          border: 2px solid var(--accent-funnel);
+          border-color: var(--accent-funnel);
           background: color-mix(in srgb, var(--accent-funnel) 12%, transparent);
+          box-shadow: inset 0 0 0 2px var(--accent-funnel);
         }
         .bz-shs-option[data-selected="true"]:hover {
           background: color-mix(in srgb, var(--accent-funnel) 16%, transparent);
+        }
+        .bz-shs-option:focus-visible {
+          outline: 3px solid var(--text-primary);
+          outline-offset: 3px;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .bz-shs-why-chevron,
+          .bz-shs-option {
+            transition: none !important;
+          }
         }
       `}</style>
     </div>
@@ -165,13 +245,15 @@ export interface OptionButtonProps {
    *  (`aria-pressed`) used by the family multi-select step, where more
    *  than one option can be true at once.
    *
-   *  Arrow-key roving-tabindex movement between radio options is left as
-   *  a future enhancement — Tab-order navigation between options still
-   *  works today; only the announced role/state changed here. */
+   *  The enclosing QuestionCard radiogroup owns roving tabindex and radio
+   *  keyboard movement. */
   variant?: "radio" | "toggle";
   /** Optional leading icon for route-style options. Rendered `aria-hidden`
    *  because the textual label already carries the meaning. */
   icon?: LucideIcon;
+  /** Injected by QuestionCard for radio variants. Toggle buttons deliberately
+   *  omit this so each remains in the document's normal Tab order. */
+  tabIndex?: 0 | -1;
 }
 
 /** Decorative leading affordance for a radio-variant option: an empty ring
@@ -251,6 +333,7 @@ export function OptionButton({
   onSelect,
   variant = "toggle",
   icon: Icon,
+  tabIndex,
 }: OptionButtonProps) {
   const isRadio = variant === "radio";
   return (
@@ -260,6 +343,7 @@ export function OptionButton({
       role={isRadio ? "radio" : undefined}
       aria-checked={isRadio ? selected : undefined}
       aria-pressed={isRadio ? undefined : selected}
+      tabIndex={isRadio ? (tabIndex ?? 0) : undefined}
       className="bz-shs-option"
       data-selected={selected ? "true" : "false"}
       style={{


### PR DESCRIPTION
Two defects in the Second Home Studio's option control, both measured on the live page.

## The list moved when you picked something

`.bz-shs-option` carried `border: 1px` at rest and `border: 2px` when selected.
`box-sizing: border-box` does not help here — it folds the border into a *declared*
width or height, and this element's height is `auto`, with `min-height: 44` sitting
below the natural height. The thicker border simply added on.

Measured at 1440×900 on step one:

| | before the click | after the click |
|---|---|---|
| height of the chosen option | 50px | **52px** |
| top of the 2nd option | 603 | **605** |
| top of the 3rd option | 661 | **663** |

Every click shifted the rest of the list under the reader's eye.

**Cure:** the border width never changes — only its colour does — and the emphasis is
an inset ring, which takes no space in the flow. Focus gets its own outline,
deliberately separate from selection: a keyboard user can be focused on an option they
have not chosen, and both facts have to be visible at once.

## The arrow keys did nothing

The control emits `role="radio"` inside a `role="radiogroup"`, and its own comment
admitted the gap: *"Arrow-key roving-tabindex movement between radio options is left as
a future enhancement."*

Measured: `Tab` landed on "55–59"; `ArrowDown` left it exactly there. All three options
carried a null `tabindex`, so each was a separate Tab stop — the opposite of what a
radio group promises an assistive-technology user.

This product is sold to people aged 55 and over. Keyboard and screen-reader behaviour is
not a future enhancement there; it is the behaviour the control already claims to have.

**Cure:** roving tabindex — one Tab stop for the group, arrows moving focus and selection
with wrapping, `Home`/`End` to the ends.

The `toggle` variant is deliberately untouched: the family step lets more than one answer
be true at once, so it is not a radio group and must not steal the arrow keys. A test pins
that it keeps both Tab stops and ignores `ArrowDown`.

## Not colour-dependent

Measured on the current behaviour before the change: in greyscale the selected option's
top edge reads at mean luminance **66.66** against **47** for the unselected ones (peak 96
against 57). The distinction never depended on colour, and this change keeps the same
colour and the same 2px of emphasis — it only stops that emphasis from occupying space.

## Checks

342 tests green (20 files), `tsc --noEmit` clean. The new tests assert the *absence* of
`border:` and `border-width:` in the selected rule, so the layout-shift defect cannot
return without turning them red.