### PR TITLE
fix(mouth): make the SHS studio clear-plan button actually turn red on hover/focus

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Trash2 } from "lucide-react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 import {
   encodePlanFragment,
@@ -113,6 +114,80 @@ const PRINT_STYLES = `
   }
 `;
 
+type RestingClearButtonStyle = {
+  borderColor: "var(--text-secondary)";
+  color: "var(--text-secondary)";
+};
+
+// Compile-time regression guard: the rare destructive action stays neutral
+// until the user points to it or focuses it. Changing either value back to an
+// error token fails the mouth typecheck instead of silently restoring the red
+// clash with the all-inclusive price.
+//
+// These values are consumed ONLY by CLEAR_BUTTON_STYLES below — never spread
+// into the button's own `style` prop. An inline `color`/`border-color` on the
+// element itself would permanently out-rank the `:hover`/`:focus-visible`
+// class rule below, no matter how that selector is written: an inline style
+// attribute beats every stylesheet selector, pseudo-classes included. That
+// was the shape of a real bug here — measured live in Chromium, hover left
+// color/border-color/background completely unchanged, only the CSS
+// properties the inline style didn't also touch (text-decoration, the
+// currentColor-driven box-shadow ring's hue aside, outline) moved at all.
+const restingClearButtonStyle = {
+  borderColor: "var(--text-secondary)",
+  color: "var(--text-secondary)",
+} satisfies RestingClearButtonStyle;
+
+const CLEAR_BUTTON_STYLES = `
+  .bz-shs-clear-plan {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid ${restingClearButtonStyle.borderColor};
+    background: transparent;
+    color: ${restingClearButtonStyle.color};
+    transition:
+      border-color var(--motion-duration-fast, 150ms) ease,
+      color var(--motion-duration-fast, 150ms) ease,
+      background-color var(--motion-duration-fast, 150ms) ease,
+      box-shadow var(--motion-duration-fast, 150ms) ease;
+  }
+
+  .bz-shs-clear-plan:is(:hover, :focus-visible) {
+    /* The editorial gradient is darkest at the bottom and lightest at the
+       top. This mix keeps danger text at >= 4.81:1 even on the lightest
+       raised surface plus the active tint, while remaining visibly separate
+       from the price red. */
+    --bz-shs-clear-active: color-mix(
+      in srgb,
+      var(--color-error, #c0392b) 40%,
+      white
+    );
+    border-color: var(--bz-shs-clear-active);
+    background: color-mix(
+      in srgb,
+      var(--color-error, #c0392b) 16%,
+      transparent
+    );
+    box-shadow: inset 0 0 0 1px currentColor;
+    color: var(--bz-shs-clear-active);
+    text-decoration-line: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.2em;
+  }
+
+  .bz-shs-clear-plan:focus-visible {
+    outline: 3px solid var(--bz-shs-clear-active);
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bz-shs-clear-plan {
+      transition: none;
+    }
+  }
+`;
+
 export interface SavePlanBarProps {
   plan: PlanState;
   /** Clears localStorage (plan-codec's clearPlan) and resets the wizard to
@@ -131,6 +206,20 @@ const buttonStyle: React.CSSProperties = {
   minHeight: 44,
   fontSize: "0.9rem",
   fontFamily: "inherit",
+};
+
+// Layout-only for the clear button: deliberately excludes border/background/
+// color (those come from buttonStyle for the other three buttons) so
+// CLEAR_BUTTON_STYLES above is the sole owner of this button's border,
+// background and text color — see the comment on restingClearButtonStyle for
+// why that ownership can't be shared with an inline `style` prop.
+const clearButtonLayoutStyle: React.CSSProperties = {
+  padding: buttonStyle.padding,
+  borderRadius: buttonStyle.borderRadius,
+  cursor: buttonStyle.cursor,
+  minHeight: buttonStyle.minHeight,
+  fontSize: buttonStyle.fontSize,
+  fontFamily: buttonStyle.fontFamily,
 };
 
 /** "Your plan stays on this device" bar (spec §5). Answers auto-save on
@@ -217,12 +306,10 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
         <button
           type="button"
           onClick={onClear}
-          style={{
-            ...buttonStyle,
-            borderColor: "var(--color-error, #c0392b)",
-            color: "var(--color-error, #c0392b)",
-          }}
+          className="bz-shs-clear-plan"
+          style={clearButtonLayoutStyle}
         >
+          <Trash2 size={16} strokeWidth={1.75} aria-hidden />
           {getCopy("savePlanBar.clearButton")}
         </button>
       </div>
@@ -260,6 +347,7 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
         {getCopy("savePlanBar.linkWarning")}
       </p>
       <style>{PRINT_STYLES}</style>
+      <style>{CLEAR_BUTTON_STYLES}</style>
     </section>
   );
 }

--- a/apps/mouth/tsconfig.json
+++ b/apps/mouth/tsconfig.json
@@ -33,5 +33,10 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "vitest.config.ts", "e2e/**"]
+  "exclude": [
+    "node_modules",
+    "node_modules.symlink-bak",
+    "vitest.config.ts",
+    "e2e/**"
+  ]
 }


### PR DESCRIPTION
## The defect

On the Second Home Studio verdict screen, two elements ~321px apart carried nearly the same red: the all-inclusive price box border (`--accent-funnel` → `#ff3344`) and the "Clear saved plan" destructive button's border/text (`--color-error` → `#ef4444`, 16/17/0 RGB apart). The price read as an alarm; the destructive action read as decoration.

## The intended cure (pre-existing diff, verified here)

Make the clear button neutral at rest (`--text-secondary`) and red only on `:hover`/`:focus-visible`, backed by non-color signals (background tint, inset ring, underline, focus outline, a `Trash2` icon), plus a `satisfies` compile-time guard so the resting values can't silently regress to an error token.

## What was actually broken, found during browser verification

The hover/focus CSS rule could never win: the resting `color`/`border-color` were spread into the button's own inline `style` attribute, and an inline style permanently outranks *any* stylesheet selector — `:hover`/`:focus-visible` included — regardless of specificity. Measured live in Chromium: hovering left `color`/`border-color`/`background` completely unchanged; only the properties the inline style didn't also set (`text-decoration`, an inset ring tinted by the still-stale `currentColor`) moved at all. The `≥4.81:1` contrast comment was describing a color that never actually rendered.

**Fix**: moved `color`/`border`/`background` for this button entirely out of the inline `style` prop and into the `.bz-shs-clear-plan` CSS class (base + `:hover`/`:focus-visible` rules), so the cascade can apply normally. The button's inline style is now layout-only. The `satisfies` compile-time guard is preserved — its values now feed the CSS class via template literal instead of the inline style attribute.

Also included, as a separate atomic commit: a one-line `tsconfig.json` `exclude` addition for `node_modules.symlink-bak`, an artifact of this worktree's node_modules setup that was making `tsc --noEmit` fail on vendored library source unrelated to any app code — no-op in any normal checkout.

## Measured (real dev server, not synthetic)

Reached the verdict stage via the plan-fragment URL fast-path. Turbopack panics on this worktree's non-symlinked `node_modules` layout with an unrelated FS-root error, so verification ran on `next dev --webpack` (same flag the `build` script already uses) — same app code, same CSS, real render.

| State | color/border | effective background (composited) | contrast (text vs bg) | RGB distance from `#ff3344` |
|---|---|---|---|---|
| Resting | `rgba(255,255,255,0.68)` (`--text-secondary`) | — | 12.7:1 | 276.7 |
| Hover | `rgb(249,180,180)` (color-mix result) | `rgb(73,54,70)` | **6.43:1** | 170.9 |
| Focus-visible | same as hover, plus a 3px solid red-tinted outline (3px offset) | `rgb(73,54,70)` | **6.43:1** | 170.9 |

- Price box confirmed unchanged: border `rgb(255,51,68)` = `#ff3344`.
- The `≥4.81:1` comment holds, with headroom, at this scroll position on the editorial gradient — not exhaustively checked at every position (the comment itself says the gradient varies).
- Grayscale screenshots: hover/focus stay distinguishable from resting without color (underline carries it).

## Judgment call (asked for explicitly)

At rest, the button is styled identically to its three neutral siblings (Save/Copy/Print) — distinguished only by the trash icon and label text — and `handleClear()` fires immediately, no confirmation step. Defensible for a low-frequency, re-creatable action, but worth flagging: on mobile there's no hover state at all, so a tap gets zero advance-warning styling before the action fires. Out of scope for this fix.

## Verification

- `vitest run src/app/visa/second-home src/lib/secondhome-studio` — 331/331 passing.
- `npm run typecheck -w apps/mouth` — clean (0 errors) on the real committed config.
- `satisfies` guard bites: reverting `borderColor` to `var(--color-error, #c0392b)` produces `TS2322`; reverted back, clean again.
- `git diff --stat -- package.json package-lock.json` — empty (no new dependency; `lucide-react` was already used elsewhere in this tree).
- `@media print` block untouched — no bare element selectors, the `a[href^="https://wa.me"]::after` phone-number-on-paper rule intact.

Auto-merge intentionally **not** armed — grading by the requester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)