### PR TITLE
docs(research-os): P04-D4 contract pass — close §9 condition 7 (TRUNCATE gap)

### DIFF
--- a/research/operations/execution/research-os-v1.0.0/evidence/p04/contract-pass-001.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p04/contract-pass-001.md
@@ -636,10 +636,34 @@ unconditional; each has an owner and a closure test.
    against `postgres:15` in CI. Declared, not hidden: neither the manual proof nor this future
    automated test composes against production's existing 278 migrations — both apply to an empty
    schema, which is what "isolated database" means, not a staging-parity claim.
-7. **The `TRUNCATE` gap on `research_os_objects` (§3, M1).** Owner: next P04 builder. Closes when:
-   a `BEFORE TRUNCATE ... FOR EACH STATEMENT` trigger exists and a `TRUNCATE` attempt against the
-   table in a throwaway database is proven rejected — tracked in `PENDING-ARMS.md` alongside this
-   commit.
+7. **The `TRUNCATE` gap on `research_os_objects` (§3, M1). CLOSED — post-merge correction,
+   2026-08-24.** Owner: next P04 builder. Closes when: a `BEFORE TRUNCATE ... FOR EACH STATEMENT`
+   trigger exists and a `TRUNCATE` attempt against the table in a throwaway database is proven
+   rejected — tracked in `PENDING-ARMS.md` alongside this commit. **Both closure tests are now met.**
+   Migration `280_research_os_objects_truncate_guard.sql` (PR #4780, `45a298eb4`, merged 2026-08-24)
+   adds `CREATE TRIGGER research_os_objects_no_wipe BEFORE TRUNCATE ON public.research_os_objects
+   FOR EACH STATEMENT EXECUTE FUNCTION public.reject_research_os_objects_mutation()`.
+   `apps/backend-rag/backend/tests/db/test_migration_280_research_os_objects_truncate_guard.py`
+   (8 test functions total — 6 static `def test_*` plus 2 live-DB `async def test_*`; a bare
+   `grep -cE '^def test_'` undercounts to 6 by missing the `async` ones — the two that decide this
+   condition) proves it both directions against a real connection:
+   `test_truncate_guard_blocks_truncate_but_not_insert` (guilt — `TRUNCATE` raises `append-only`,
+   `INSERT` still succeeds) and `test_truncate_guard_rollback_restores_truncate_then_reapply_reblocks`
+   (innocence — with the new trigger's own rollback applied, `TRUNCATE` succeeds again; re-applying
+   the forward SQL re-blocks it).
+   **Condition 6, immediately above, is a separate question and stays open — this closure does not
+   touch it.** `_apply_clean()` in that same test file applies migration 279's forward SQL only as
+   fixture setup, asserting nothing about the shape 279 itself produces, and 279's rollback is
+   exercised nowhere in this file or anywhere else in the repository; the permanent, automated PG15
+   apply/rollback test for migration 279 that condition 6 asks for still does not exist.
+   **Also unmoved by this closure: the migration is applied in NO environment.** Both live-DB tests
+   run inside the `db_tx` fixture's transaction (`apps/backend-rag/backend/tests/db/conftest.py:38-47`),
+   which is rolled back at teardown (`:46`) — nothing persists. That the guard runs and passes in CI
+   is itself real: `tests.yml` runs a `postgres:15` service with `TEST_DATABASE_URL` set, neither
+   `pyproject.toml`'s `addopts` nor the pytest invocation excludes the `integration` marker, and
+   `db_tx` calls `asyncpg.connect` directly with no skip-if-absent guard (a missing DB fails the test,
+   it does not skip it) — but "proven executed by a test" and "lives in a database" are different
+   questions, and this closure answers only the former.
 8. **D7 — freeze-change ratification, `CONTRACTS.md` §2 vs §3's UTC-spelling inconsistency.**
    Owner: **S9-C0**. **Post-merge correction, 2026-08-24: the second half of this condition is now
    DONE.** This condition originally required BOTH the freeze-change ratified AND PR #4615's fold

--- a/research/operations/execution/research-os-v1.0.0/evidence/p04/contract-pass-001.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p04/contract-pass-001.md
@@ -718,7 +718,17 @@ survived would hide from the reader how much scrutiny the surviving ones actuall
   the wider one R1 originally addressed (does any proof exist at all).
 - **R2 — "conditional pass" was asserted with no stated conditions.** Applied: new §9 lists seven
   numbered conditions, each with an owner and a closure test, plus an explicit list of what would move
-  this document to REFUSE.
+  this document to REFUSE. **Revised, after §9 itself moved, same class as R1 above**: this file's own
+  creation commit (`8089125ec`, squashed) shows the sub-commit that first wrote this Adversarial-review
+  section — the one counting "seven" — landing before a later sub-commit titled "reverse D7 to NOT
+  DELIVERED", whose message states verbatim "Adds §9 condition 8 (freeze-change ratification, owner
+  S9-C0)". So §9 gained an eighth condition after this bullet was written and the count here was never
+  refreshed. Arithmetic recount today (`grep -cE '^[0-9]+\. \*\*'` over §9's body): **eight**, not
+  seven. Deliberately not restated here as a number: how many of the eight remain open — read each
+  condition's own text for an inline `CLOSED`/`DONE` marker (condition 7 carries one as of this pass;
+  condition 8 carries one on its own second half only) rather than trust a count printed here, which
+  would go stale again the moment any other condition closes — exactly the failure this correction
+  exists to fix.
 - **R3 — as formulated, false; the underlying principle correct, and the finer check it demanded gives
   stronger evidence than the original.** Kimi hypothesized `primitives.py` lives inside `models/` and
   inflates the 25-file model count. It does not — `research_os/primitives.py`, one level above


### PR DESCRIPTION
lane: docs
task-id: p04-cond7-freshen
base: f7a3f2daf9b301f328008dc744fcc7ee4c779151

## What

`research/operations/execution/research-os-v1.0.0/evidence/p04/contract-pass-001.md` §9
condition 7 tracked the `TRUNCATE` gap on `research_os_objects` (279's row-level append-only
trigger never fires on `TRUNCATE`). That gap closed 2026-08-24 via migration
`280_research_os_objects_truncate_guard.sql` (PR #4780, `45a298eb4`) and its test file, but the
contract-pass document never mentioned the migration number, the PR, or the commit — re-measured
this session: `grep -c 280` = 0, `grep -c 4780` = 0 in the prior text (`279` = 13).

This PR refreshes **only §9 condition 7**, marking it CLOSED with the evidence:

- The trigger: `CREATE TRIGGER research_os_objects_no_wipe BEFORE TRUNCATE ON
  public.research_os_objects FOR EACH STATEMENT EXECUTE FUNCTION
  public.reject_research_os_objects_mutation()`.
- `test_migration_280_research_os_objects_truncate_guard.py` has **8** test functions (6 static
  `def test_*` + 2 live-DB `async def test_*` — re-measured both ways: a bare
  `grep -cE '^def test_'` undercounts to 6 by missing the `async` ones, which are the two that
  decide this condition).
- Guilt: `test_truncate_guard_blocks_truncate_but_not_insert` (`TRUNCATE` raises `append-only`,
  `INSERT` still succeeds).
- Innocence: `test_truncate_guard_rollback_restores_truncate_then_reapply_reblocks` (with the
  guard's own rollback applied, `TRUNCATE` succeeds again; re-applying the forward SQL re-blocks
  it).

Two honesty caveats kept explicit (verified by reading `_apply_clean()` in that same test file):

- **Condition 6 stays open.** 279's forward SQL is applied only as this test's fixture setup,
  with no assertion on the shape 279 itself produces, and 279's rollback is exercised nowhere in
  the repo. The permanent, automated PG15 apply/rollback test for migration 279 that condition 6
  asks for still does not exist.
- **The migration is applied in NO environment.** Both live-DB tests run inside the `db_tx`
  fixture's transaction (`conftest.py:38-47`), rolled back at teardown (`:46`) — nothing persists.
  CI does execute the tests for real (`tests.yml`'s `postgres:15` service, `TEST_DATABASE_URL`
  set, no `-m "not integration"` filter anywhere in `pyproject.toml`'s `addopts` or the pytest
  invocation, `db_tx` calling `asyncpg.connect` directly with no skip-if-absent guard) — but
  "proven executed by a test" and "lives in a database" are different questions, and this closure
  answers only the former.

## Scope

Single concern, single file. The other seven conditions, the verdict (`PASS_WITH_LIMITS`), and §7
("What Cohort B may and may not start on") are unchanged. Does **not** touch `SESSION-BOARD.md`
or `handoff-index-001.md` (two other lanes have open PRs on those).

## Verification

- R1 adversarial-review gate: `python3 scripts/check_adversarial_review.py --files
  research/.../contract-pass-001.md` → `PASS`, rc=0. Frontmatter (`adversarial_review: kimi-k3`)
  and the `## Adversarial review` heading are untouched.
- Headings re-enumerated post-edit (`grep -nE '^#+ '`) — identical structure, no section added or
  removed.
- Searched for stale summary counts post-edit (`grep -niE 'eight|8 (conditions|numbered)'`): none
  reference §9's condition count as a fixed "8" that my edit would make stale.

## Found, not fixed (reported here per single-concern discipline)

An **unrelated, pre-existing** stale count survives in the `## Adversarial review` section: *"new
§9 lists seven numbered conditions"* — but §9 has **8** numbered items today (item 8, the D7
freeze-change condition, was evidently added after that R2 note was written). This predates this
PR and is not caused by this edit; out of scope for a single-concern PR touching only condition 7.
Flagging for the Conductor/next builder.

## Not armed

Per mandate — arming is the team lead's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
