### PR TITLE
docs(research-os): fix P04-D4 __init__.py pointer to real exclusion rationale

### DIFF
--- a/apps/backend-rag/backend/services/research_os/__init__.py
+++ b/apps/backend-rag/backend/services/research_os/__init__.py
@@ -11,8 +11,14 @@ in as plain mappings by whatever caller eventually wires up a real read path
 
 This first slice covers the Magazine `ops_intents`/`ops_receipts` action
 chain only (`ActionItem`, `ActionIntent`, `OperationalReceipt`). It
-deliberately excludes `ExecutionAttempt` and `ApprovalReceipt` -- see
-`action_intent_adapter.py`'s module docstring for why.
+deliberately excludes `ExecutionAttempt` and `ApprovalReceipt` -- see the
+"ExecutionAttempt stays EXCLUDED from D3's three-adapter scope" ledger row
+in `.claude/skills/modus/PENDING-ARMS.md` for the ruling and its two open
+blockers, grounded in `compatibility-matrix-001.md` §1.3/§1.4/§2.0
+(`research/operations/execution/research-os-v1.0.0/evidence/p04/`).
+`operational_receipt_adapter.py`'s module docstring covers the adjacent,
+narrower blocker on `ExecutionAttempt` refs specifically inside
+`OperationalReceipt` construction.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

`apps/backend-rag/backend/services/research_os/__init__.py`'s package docstring claimed the
`ExecutionAttempt`/`ApprovalReceipt` exclusion from D3's three-adapter scope was explained in
`action_intent_adapter.py`'s module docstring. It is not.

## Verified defect (re-verified against `origin/main` before touching anything)

- `action_intent_adapter.py`'s module docstring (top ~19 lines) has **zero** occurrences of
  `ExecutionAttempt` or `ApprovalReceipt`.
- The whole 546-line file has **zero** occurrences of `ApprovalReceipt` and only **4** of
  `ExecutionAttempt` (lines 383/396/402/469) -- all inline loss-report reason strings deep in the
  adapter body (e.g. `"belongs to ExecutionAttempt.attempt_number, a kind this slice excludes"`),
  not a docstring, and not an explanation of *why* the package excludes these kinds.
- The pointer sent a reader to a real file that opens without error and just doesn't contain the
  promised rationale -- worse than a dead link, because it looks like the reader mis-searched.

## Where the real motivation lives

The authoritative ruling is the **"ExecutionAttempt stays EXCLUDED from D3's three-adapter scope"**
ledger row in `.claude/skills/modus/PENDING-ARMS.md` (P04-D3 lane, scope ruling on a 4th adapter
kind). It gives two structural blockers, neither adapter-resolvable, and explicitly covers
`ApprovalReceipt` too: *"ApprovalReceipt is itself a confirmed true-negative for this legacy source
(matrix §1.3/§2.0)."*

That row is itself grounded in `compatibility-matrix-001.md`
(`research/operations/execution/research-os-v1.0.0/evidence/p04/`):
- §1.3 -- `ApprovalReceipt`: ⬛ no legacy source found.
- §1.4 -- `ExecutionAttempt`: full field table, 4 of 9 canonical fields ⬛/🔴.
- §2.0 -- confirms and closes §1.3's provisional flag (true-negative outside `research_os`'s own tests).

I also named `operational_receipt_adapter.py`'s module docstring in the new text -- it's real and
relevant (it covers *why* `OperationalReceipt` construction can't carry a synthesized
`execution_attempt_ref`), but it's a narrower, adjacent blocker specific to that one adapter's
receipt-closure semantics, not a general explanation of why the package excludes the two kinds --
so it's named as related context, not as the primary pointer.

## Scope

Docstring-only, one file (`__init__.py`), no behavior change, no new imports. Did not touch the
adapters, `contract-pass-001.md`, `handoff-index-001.md`, `SESSION-BOARD.md`, or `PENDING-ARMS.md`
itself (other lanes are active there today).

## Verification

- `ruff check` / `ruff format --check` on the file: both rc=0. Config resolved:
  `apps/backend-rag/pyproject.toml` (confirmed via `ruff check --show-settings`) -- this file lives
  under `apps/backend-rag/`, not `packages/research-os-core/`, so the missing `[tool.ruff]` table
  there does not apply here.
- Pre-commit + pre-push hooks: all green, including the scoped pytest run over the 4
  `research_os` test modules impacted by this diff (`test_action_intent_adapter.py`,
  `test_action_item_adapter.py`, `test_adapter_extensions_invariant.py`,
  `test_operational_receipt_adapter.py`).

base: `227227334d4b1e03861b69f68214772183c62538`

🤖 Generated with [Claude Code](https://claude.com/claude-code)