### PR TITLE
fix(mouth): one red carried three meanings, so the Studio's price stopped meaning anything

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
@@ -33,11 +33,44 @@ describe("ScenarioToggle", () => {
     });
   });
 
-  it("renders the control label when closed", () => {
+  it("keeps the closed trigger neutral at rest and exposes accent only on interaction", () => {
+    const { container } = render(
+      <ScenarioToggle plan={basePlan({ route: "deposit" })} />,
+    );
+    const trigger = screen.getByRole("button", { name: /other route/i });
+    const inlineStyle = trigger.getAttribute("style") ?? "";
+    const css = container.querySelector("style")?.textContent ?? "";
+    const restingRule = css.match(
+      /\.bz-shs-scenario-toggle-trigger\s*\{([^}]*)\}/,
+    )?.[1];
+
+    expect(inlineStyle).not.toContain("--accent-funnel");
+    expect(inlineStyle).not.toMatch(
+      /(?:^|;)\s*(?:border|background|color)\s*:/,
+    );
+    expect(restingRule).toContain(
+      "border: 1px solid var(--color-border-subtle)",
+    );
+    expect(restingRule).toContain("color: var(--text-secondary)");
+    expect(restingRule).not.toContain("--accent-funnel");
+    expect(css).toMatch(
+      /\.bz-shs-scenario-toggle-trigger:is\(:hover, :focus-visible\)\s*\{[^}]*border-color:\s*var\(--accent-funnel\)[^}]*color:\s*color-mix\(in srgb, var\(--accent-funnel\) 70%, white\)[^}]*text-decoration-line:\s*underline/s,
+    );
+    expect(css).toMatch(
+      /\.bz-shs-scenario-toggle-trigger:focus-visible\s*\{[^}]*outline:\s*3px solid var\(--accent-funnel\)[^}]*outline-offset:\s*3px/s,
+    );
+  });
+
+  it("keeps its accessible name, decorative icon, and 44px touch target", () => {
     render(<ScenarioToggle plan={basePlan({ route: "deposit" })} />);
-    expect(
-      screen.getByRole("button", { name: /other route/i }),
-    ).toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: /other route/i });
+    const icon = trigger.querySelector("svg");
+
+    expect(trigger).toBeInTheDocument();
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(Number.parseFloat(trigger.style.minHeight)).toBeGreaterThanOrEqual(
+      44,
+    );
   });
 
   it("opens the preview when the control is clicked and closes it with the back button", () => {

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
@@ -24,6 +24,64 @@ import type {
 import { TimelineView } from "./TimelineView";
 import { VerdictPanel } from "./VerdictPanel";
 
+type RestingScenarioTriggerStyle = {
+  borderColor: "var(--color-border-subtle)";
+  color: "var(--text-secondary)";
+};
+
+// Compile-time guard: the exploratory control stays neutral until the user
+// points to it or focuses it, preserving the funnel accent for the price box.
+// These values belong to the class rule only; putting them on the element's
+// inline style would prevent the interaction selectors below from winning.
+const restingScenarioTriggerStyle = {
+  borderColor: "var(--color-border-subtle)",
+  color: "var(--text-secondary)",
+} satisfies RestingScenarioTriggerStyle;
+
+const SCENARIO_TRIGGER_STYLES = `
+  .bz-shs-scenario-toggle-trigger {
+    border: 1px solid ${restingScenarioTriggerStyle.borderColor};
+    background: transparent;
+    color: ${restingScenarioTriggerStyle.color};
+    transition:
+      border-color var(--motion-duration-fast, 150ms) ease,
+      color var(--motion-duration-fast, 150ms) ease,
+      background-color var(--motion-duration-fast, 150ms) ease,
+      box-shadow var(--motion-duration-fast, 150ms) ease;
+  }
+
+  .bz-shs-scenario-toggle-trigger:is(:hover, :focus-visible) {
+    border-color: var(--accent-funnel);
+    background: color-mix(
+      in srgb,
+      var(--accent-funnel) 8%,
+      transparent
+    );
+    box-shadow: inset 0 0 0 1px currentColor;
+    /* This button's label is 16px/600 — WCAG "normal text" (large-text
+       exemption needs >=24px, or >=18.66px bold), so the floor is 4.5:1.
+       The full accent measures 4.13:1 on this backdrop and fails. 70%
+       accent mixed with white measures 5.59:1 and still reads as the
+       accent hue rather than washing out to pink. Do not tidy this back
+       to var(--accent-funnel). */
+    color: color-mix(in srgb, var(--accent-funnel) 70%, white);
+    text-decoration-line: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.2em;
+  }
+
+  .bz-shs-scenario-toggle-trigger:focus-visible {
+    outline: 3px solid var(--accent-funnel);
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bz-shs-scenario-toggle-trigger {
+      transition: none;
+    }
+  }
+`;
+
 export function otherRoute(route: RouteIntent): RouteIntent {
   return route === "property" ? "deposit" : "property";
 }
@@ -114,27 +172,27 @@ export function ScenarioToggle({ plan }: ScenarioToggleProps) {
 
   if (!isOpen) {
     return (
-      <button
-        type="button"
-        onClick={() => setIsOpen(true)}
-        className="bz-shs-scenario-toggle-trigger"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "var(--space-2, 0.5rem)",
-          padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
-          borderRadius: 8,
-          border: "1px solid var(--accent-funnel)",
-          background: "transparent",
-          color: "var(--accent-funnel)",
-          cursor: "pointer",
-          fontWeight: 600,
-          minHeight: 44,
-        }}
-      >
-        <GitCompare size={18} strokeWidth={1.5} aria-hidden />
-        {getCopy("scenarioToggle.controlLabel")}
-      </button>
+      <>
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          className="bz-shs-scenario-toggle-trigger"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "var(--space-2, 0.5rem)",
+            padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
+            borderRadius: 8,
+            cursor: "pointer",
+            fontWeight: 600,
+            minHeight: 44,
+          }}
+        >
+          <GitCompare size={18} strokeWidth={1.5} aria-hidden />
+          {getCopy("scenarioToggle.controlLabel")}
+        </button>
+        <style>{SCENARIO_TRIGGER_STYLES}</style>
+      </>
     );
   }
 

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.test.tsx
@@ -99,6 +99,15 @@ describe("StudioAtmosphere", () => {
     expect(style).not.toContain(".bz-shs-atmosphere::before");
   });
 
+  it("does not override the scenario trigger's neutral resting colors", () => {
+    const { container } = render(<StudioAtmosphere />);
+    const style = container.querySelector("style")?.textContent ?? "";
+
+    expect(style).not.toMatch(
+      /\.bz-shs-scenario-toggle-trigger\s*\{[^}]*(?:--accent-funnel|--accent-funnel-text)/s,
+    );
+  });
+
   it("removes its scroll-linked movement under reduced motion", () => {
     const { container } = render(<StudioAtmosphere />);
     const style = container.querySelector("style")?.textContent ?? "";

--- a/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/StudioAtmosphere.tsx
@@ -302,10 +302,6 @@ export function StudioAtmosphere() {
           ) !important;
         }
 
-        .bz-shs-scenario-toggle-trigger {
-          color: var(--accent-funnel-text) !important;
-        }
-
         .bz-shs-verdict-stack section[data-verdict-band] > p:first-child,
         .bz-shs-memo [data-known="false"] dd {
           opacity: 1 !important;


### PR DESCRIPTION
## What I measured

I enumerated every element on the **live** verdict screen whose computed colour is the funnel red `#ff3344`, at viewport 1440. Four hits — four different things being said with one signal:

| y | element | what it means |
|---|---|---|
| 954 | comparator "pending" status icon | a caveat |
| 1683 | `<button>` "What if I took the other route?" | neutral exploring |
| 3092 | `<section>` "Your all-inclusive figure / 35.000.000 IDR" | **the price** |
| 3575 | "Clear saved plan" (`#ef4444`) | destructive |

This product's pricing doctrine is that the client sees **one** all-inclusive figure, never decomposed. That box is the page's single commercial payoff. When an exploratory "what if?" affordance wears the identical token 1400px above it, the colour stops meaning *this is the number* and starts meaning *this is clickable* — and the price becomes just another red thing on a page of red things.

`y=3575` was already cured in #4795. **This PR is the toggle.**

## The defect at source

`ScenarioToggle.tsx:127,129` styled the closed trigger with `border: 1px solid var(--accent-funnel)` and `color: var(--accent-funnel)` — not a similar red, *the same variable* the price box uses.

## The cure

Neutral at rest; the accent is earned on `:hover`/`:focus-visible`. This follows the idiom **#4795** established rather than inventing a second one:

- colours live in a **CSS class**, never the inline style — an inline `style` out-ranks `:hover` no matter how the selector is written, and that exact bug was written and caught by measurement in #4795;
- the inline style keeps **layout only**;
- non-colour signals carry the state: inset ring, underline, and a 3px focus outline with offset;
- a `satisfies` guard fails the typecheck if the resting values are ever set back to an accent token.

### The blocker this uncovered

`StudioAtmosphere.tsx` carried an unconditional `.bz-shs-scenario-toggle-trigger { color: var(--accent-funnel-text) !important; }`. Left in place, the resting colour would have stayed forced and the hover rule could **never** have won. Removed, with a test that keeps it gone.

## Measured live in Chromium, not judged by eye

| state | colour | border | non-colour signals |
|---|---|---|---|
| rest | `rgba(255,255,255,0.68)` | `rgba(255,255,255,0.06)` | none — **not the accent** |
| hover | `rgb(255,112,124)` | `rgb(255,51,68)` | 8% tint, inset ring, underline |
| focus | as hover | as hover | + `outline: solid 3px`, offset 3px |

`minHeight: 44px` preserved; the inline style carries no colour, border or background.

### Why the hover text is a mix, not the flat accent

The label is **16px at weight 600** — WCAG "normal" text (the large-text exemption needs ≥24px, or ≥18.66px when bold), so its floor is **4.5:1**.

| candidate | colour | contrast on `rgb(29,39,59)` | |
|---|---|---|---|
| flat accent | `rgb(255,51,68)` | **4.13:1** | ❌ fails |
| `color-mix(… 70%, white)` | `rgb(255,112,124)` | **5.6:1** | ✅ shipped |

Border and outline stay at the full accent **deliberately**: as non-text they need 3.0:1 and measure 4.13:1.

## Verification

- `vitest` — **346 passed** (20 files)
- `tsc --noEmit` — exit **0**, 0 lines

## Left alone on purpose

The comparator's "pending" icon (`y=954`). Its red may be carrying the *"Pending our property validation standard"* caveat by design — the Property column's cream tint appears to encode the same state — and that is a content decision, not a styling slip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D