### PR TITLE
fix(mouth): the loudest thing on the Studio's answer screen said nothing about the answer

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -429,6 +429,36 @@ describe("StudioApp", () => {
     });
   });
 
+  describe("S13 verdict-crown — exactly one <h1> at every stage", () => {
+    it("question stage: exactly one <h1>, and its text is the page masthead 'Check your fit'", () => {
+      const { container } = render(<StudioApp />);
+      const h1s = container.querySelectorAll("h1");
+      expect(h1s).toHaveLength(1);
+      expect(h1s[0]).toHaveTextContent("Check your fit");
+    });
+
+    it("verdict stage: exactly one <h1>, and its text is the verdict heading — not 'Check your fit'", async () => {
+      window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      const { container } = render(<StudioApp />);
+      await screen.findByRole("heading", { name: /strong match/i });
+
+      const h1s = container.querySelectorAll("h1");
+      expect(h1s).toHaveLength(1);
+      expect(h1s[0]).toHaveTextContent(/strong match/i);
+      expect(h1s[0]).not.toHaveTextContent("Check your fit");
+    });
+
+    it("verdict stage: 'Check your fit' is still present (demoted, not deleted) but is not a heading element", async () => {
+      window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /strong match/i });
+
+      const masthead = screen.getByText("Check your fit");
+      expect(masthead).toBeInTheDocument();
+      expect(masthead.closest("h1,h2,h3,h4,h5,h6")).toBeNull();
+    });
+  });
+
   describe("ScenarioToggle — saved-plan immutability", () => {
     it("opening the route preview does not mutate the saved plan in localStorage", async () => {
       const saved = fullPlan({

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -107,6 +107,34 @@ const eyebrowStyle: React.CSSProperties = {
   margin: 0,
 };
 
+const mastheadHeadingStyle: React.CSSProperties = {
+  margin: 0,
+  fontFamily: "var(--font-serif, Georgia, serif)",
+  fontSize: "clamp(3.4rem, 8vw, 6.6rem)",
+  fontWeight: 500,
+  letterSpacing: "-0.035em",
+  lineHeight: 0.92,
+  maxWidth: "11ch",
+  textWrap: "balance",
+  color: "var(--text-primary)",
+};
+
+/** S13 verdict-crown: on the verdict stage the masthead recedes to a quiet,
+ *  PRESENTATIONAL label (paired with the "Second Home Studio" eyebrow as one
+ *  identifier block) so it stops competing with VerdictPanel's <h1>, which
+ *  becomes the page's sole <h1> at that point (INVARIANT — exactly one <h1>
+ *  at every stage). Words unchanged ("Check your fit") — demoted, never
+ *  deleted or reworded; not a heading tag, so heading-rank navigation never
+ *  sees it here. */
+const mastheadLabelStyle: React.CSSProperties = {
+  margin: 0,
+  fontFamily: "var(--font-serif, Georgia, serif)",
+  fontSize: "1.05rem",
+  fontWeight: 500,
+  letterSpacing: "-0.01em",
+  color: "var(--text-secondary, var(--color-text-muted))",
+};
+
 const navButtonStyle: React.CSSProperties = {
   padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
   borderRadius: 8,
@@ -581,26 +609,20 @@ export function StudioApp() {
         <header
           style={{
             display: "grid",
-            gap: "var(--space-3, 0.75rem)",
-            padding: "clamp(2rem, 7vw, 5rem) 0 clamp(1rem, 2vw, 1.5rem)",
+            gap: isVerdictStage
+              ? "var(--space-1, 0.3rem)"
+              : "var(--space-3, 0.75rem)",
+            padding: isVerdictStage
+              ? "clamp(1rem, 3vw, 1.75rem) 0 clamp(0.5rem, 1vw, 0.75rem)"
+              : "clamp(2rem, 7vw, 5rem) 0 clamp(1rem, 2vw, 1.5rem)",
           }}
         >
           <p style={eyebrowStyle}>Second Home Studio</p>
-          <h1
-            style={{
-              margin: 0,
-              fontFamily: "var(--font-serif, Georgia, serif)",
-              fontSize: "clamp(3.4rem, 8vw, 6.6rem)",
-              fontWeight: 500,
-              letterSpacing: "-0.035em",
-              lineHeight: 0.92,
-              maxWidth: "11ch",
-              textWrap: "balance",
-              color: "var(--text-primary)",
-            }}
-          >
-            Check your fit
-          </h1>
+          {isVerdictStage ? (
+            <p style={mastheadLabelStyle}>Check your fit</p>
+          ) : (
+            <h1 style={mastheadHeadingStyle}>Check your fit</h1>
+          )}
         </header>
 
         {!isVerdictStage ? (

--- a/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -92,7 +93,22 @@ describe("VerdictPanel", () => {
   it("renders the verdict title larger than secondary card titles would be", () => {
     render(<VerdictPanel verdict={baseVerdict("strong_fit")} />);
     const heading = screen.getByRole("heading", { name: /strong match/i });
-    expect(heading.style.fontSize).toBe("clamp(2.2rem, 6vw, 3.5rem)");
+    // S13 verdict-crown: raised from clamp(2.2rem,6vw,3.5rem)/56px so this
+    // heading reads as the page's crown now that it is the verdict stage's
+    // sole <h1> — capped at 3.75rem/60px (46-64px band, see VerdictPanel.tsx).
+    expect(heading.style.fontSize).toBe("clamp(2.4rem, 6.5vw, 3.75rem)");
+  });
+
+  describe("S13 verdict-crown — P2-3 focus contract must not regress", () => {
+    it("forwards headingRef to the <h1> and keeps tabIndex={-1}", () => {
+      const ref = createRef<HTMLHeadingElement>();
+      render(
+        <VerdictPanel verdict={baseVerdict("strong_fit")} headingRef={ref} />,
+      );
+      const heading = screen.getByRole("heading", { name: /strong match/i });
+      expect(ref.current).toBe(heading);
+      expect(heading).toHaveAttribute("tabIndex", "-1");
+    });
   });
 
   it("never renders a numeric score or probability", () => {

--- a/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
@@ -174,7 +174,13 @@ export function VerdictPanel({ verdict, headingRef }: VerdictPanelProps) {
         style={{
           margin: 0,
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(2.2rem, 6vw, 3.5rem)",
+          // S13 verdict-crown: this is now the page's SOLE <h1> on the
+          // verdict stage (StudioApp's masthead recedes to a presentational
+          // label there) — raised from clamp(2.2rem,6vw,3.5rem)/56px so it
+          // reads as the page's crown. Capped at 3.75rem/60px, inside the
+          // 46-64px "whispered authority" band (never the masthead's 105px)
+          // per spec.
+          fontSize: "clamp(2.4rem, 6.5vw, 3.75rem)",
           lineHeight: 1.1,
           color: "var(--text-primary)",
         }}


### PR DESCRIPTION
## What I measured

Live on production, verdict stage, viewport 1440 — **two `<h1>` rendered at the same time**:

| `<h1>` | size | text |
|---|---|---|
| 1st | **105.6px** | "Check your fit" — the page masthead |
| 2nd | 56.0px | "Your answers show a strong match" — **the actual verdict** |

## Two defects, one root

`StudioApp` renders its `<header>` — eyebrow plus that `<h1>` at `clamp(3.4rem, 8vw, 6.6rem)` — **unconditionally**, outside the `isVerdictStage` branch that governs everything else on that screen.

**Semantics.** A screen-reader user navigating by heading rank heard two top-level titles; the document claimed two roots. The comment at `StudioApp.tsx:479` says *"only one is ever mounted at a time"* — true of QuestionCard's `<h2>` versus VerdictPanel's `<h1>`, and silent about the masthead, which is always there.

**Hierarchy.** The generic label — identical on every stage, saying nothing about this client — was twice the size of the personal answer they completed a six-step wizard to receive, and sat above a "Back to your answers" button. The answer was neither first nor largest.

## The change

On the **question** stages the page's subject is a question being asked; the masthead is correctly the hero and the only heading of rank — **unchanged**.

On the **verdict** stage the subject becomes an answer being given. The masthead recedes to a presentational label paired with its eyebrow as one quiet identifier block, and VerdictPanel's `<h1>` becomes the page's crown. Its cap rises `3.5rem → 3.75rem` (56px → 60px), deliberately inside a 46–64px band: this design language is *whispered authority*, and a display size near the masthead's 105px would be shouting, not crowning.

The words "Check your fit" are **demoted, never deleted or reworded**.

### The invariant, now pinned by tests

**Exactly one `<h1>` in the DOM at every stage.** Question stage → the masthead. Verdict stage → the verdict. The `h2`/`h3` tree beneath the verdict is untouched — it was already correctly nested one level below it.

## Measured on a live render, all three states

| state | h1 count | h1 | "Check your fit" |
|---|---|---|---|
| verdict 1440 | **1** | the verdict, 60px | `<P>` 16.8px, not a heading |
| verdict 390 | **1** | the verdict, 38.4px | `<P>` 16.8px, not a heading |
| question 1440 | **1** | "Check your fit", 105.6px | it *is* the h1 — unchanged |

- verdict 1440 heading order: `H1>H2>H2>H3>H3>H3>H2>H2>H2` — one root
- the largest text on the verdict page **is** the verdict
- verdict 390: `scrollWidth == clientWidth`, no horizontal scroll

VerdictPanel's heading keeps its forwarded ref and `tabIndex={-1}`, so the P2-3 focus-on-stage-transition contract is untouched.

## Verification

- `vitest` — **346 passed** (20 files)
- `tsc --noEmit` — exit **0**, 0 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D