### PR TITLE
chore(mouth): drop a tsconfig exclusion for a directory that never existed here

### DIFF
--- a/apps/mouth/tsconfig.json
+++ b/apps/mouth/tsconfig.json
@@ -33,10 +33,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "node_modules.symlink-bak",
-    "vitest.config.ts",
-    "e2e/**"
-  ]
+  "exclude": ["node_modules", "vitest.config.ts", "e2e/**"]
 }


### PR DESCRIPTION
`apps/mouth/tsconfig.json` excludes `node_modules.symlink-bak`. That is not a project directory and never was — it was a scratch backup **I** made by hand in two agent worktrees earlier today while working around a bundler problem. It exists in no clean checkout, in no CI run, and on no developer's machine: `find` over the repo returns nothing by that name.

It reached the shared config because a lane's pre-commit typecheck was failing on my leftover directory, and excluding it was the smallest way past that. The workaround outlived the mess it was working around, and rode into `main` on #4795 as a separate commit.

## Why not just leave it

It is inert, but it is not harmless:

- it tells every future reader this project has some concept called `node_modules.symlink-bak`, which it does not;
- it quietly makes hand-made copies of `node_modules` look sanctioned — when a hand-made copy is exactly what emptied the main checkout's 1099 packages today. A worktree's `node_modules` is a **symlink** to the main checkout *by design*; the rule is to use it and never install against it, not to clone it.

## Note on the formatting

The array collapses to one line because, with the fossil gone, the remaining three entries fit the print width. That is Prettier's own output, enforced by the pre-commit hook — not a formatting choice.

## Verification

From `apps/mouth`, after removal: `tsc --noEmit -p tsconfig.json` exits **0** with **0** lines of output. Nothing needed the exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D