### PR TITLE
test(mouth): pin the three disarm paths that no test could lose

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { emptyPlan } from "@/lib/secondhome-studio/plan-codec";
@@ -86,6 +86,7 @@ describe("SavePlanBar print action", () => {
 describe("SavePlanBar clear-plan two-step confirm", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("does not clear on a single activation", () => {
@@ -154,6 +155,59 @@ describe("SavePlanBar clear-plan two-step confirm", () => {
     // class and never applies at rest.
     expect(css).toMatch(
       /\.bz-shs-clear-plan\.bz-shs-clear-armed\s*\{[^}]*border-color:\s*var\(--accent-funnel\)[^}]*color:\s*var\(--bz-shs-clear-armed-active\)/s,
+    );
+  });
+
+  it("disarms on blur — a subsequent single activation does not clear", () => {
+    const onClear = vi.fn();
+    render(<SavePlanBar plan={emptyPlan()} onClear={onClear} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear saved plan" }));
+    fireEvent.blur(
+      screen.getByRole("button", { name: "Press again to clear your plan" }),
+    );
+
+    // Disarmed: the label reverted, so this click only re-arms it.
+    fireEvent.click(screen.getByRole("button", { name: "Clear saved plan" }));
+
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it("disarms after the 5s arm timeout — a subsequent single activation does not clear", () => {
+    vi.useFakeTimers();
+    const onClear = vi.fn();
+    render(<SavePlanBar plan={emptyPlan()} onClear={onClear} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear saved plan" }));
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // Disarmed: the label reverted, so this click only re-arms it.
+    fireEvent.click(screen.getByRole("button", { name: "Clear saved plan" }));
+
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  // Not a console.error/"state update on an unmounted component" assertion:
+  // proven empirically vacuous first (mutation-tested — see PR discussion).
+  // React 18+ no longer warns on a hook-based setState after unmount, so
+  // that signal would pass identically whether or not the cleanup exists.
+  // This asserts the actual mechanism instead: the useEffect cleanup must
+  // call clearTimeout on the pending arm timer when the component unmounts.
+  it("clears the pending arm timer on unmount", () => {
+    const onClear = vi.fn();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const { unmount } = render(
+      <SavePlanBar plan={emptyPlan()} onClear={onClear} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear saved plan" }));
+    const callsBeforeUnmount = clearTimeoutSpy.mock.calls.length;
+    unmount();
+
+    expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(
+      callsBeforeUnmount,
     );
   });
 });


### PR DESCRIPTION
## Why

An adversarial cross-family reviewer (Codex `gpt-5.6-sol`, xhigh) graded #4811 on five surfaces. Four survived. One did not:

> Delete the production line `onBlur={disarmClear}` and every shown test remains green.

The same held for the 5s arm timeout and the unmount cleanup. The behaviour was real — I measured all three on a live render before asking for these tests — but nothing pinned it, and a behaviour no test can lose is a behaviour the next refactor deletes for free.

## What the live measurement showed (this is what the tests now encode)

- arm, then click elsewhere → label reverts to "Clear saved plan", armed class gone, plan intact (localStorage still 249 bytes); a subsequent single click only **re-arms**, it does not clear
- arm, wait 6s → label reverts on its own, plan intact
- two activations in a row → plan cleared (localStorage 0 bytes, wizard back to step 1)

Confirmed again on production after #4811 landed, at `balizero.com/visa/second-home/studio`.

## One deliberate departure from the brief

I asked for the unmount test to assert that React logged no "state update on an unmounted component" warning. That assertion is **vacuous** — React 18+ no longer emits it, so it would pass identically with the cleanup deleted. The lane proved that first and replaced it with an assertion on the actual mechanism: `clearTimeout` must be called during unmount while a timer is pending. That is the better test, and finding it was the right call.

## Mutation-verified — by the grader, not the author

Each mutation was applied to the production file, the suite re-run, and the file restored (`git checkout --`). Run from inside the worktree, not via `npm --prefix` — the latter leaves vitest's root on the main checkout and silently tests the wrong tree.

| mutation | result |
|---|---|
| baseline | `Tests 11 passed (11)` |
| delete `onBlur={disarmClear}` | `1 failed \| 10 passed` — × *disarms on blur* |
| neuter the arm `setTimeout` | `2 failed \| 9 passed` — × *disarms after the 5s arm timeout*, × *clears the pending arm timer on unmount* |
| delete the unmount cleanup | `1 failed \| 10 passed` — × *clears the pending arm timer on unmount* |
| restored | `Tests 11 passed (11)`, 0 dirty |

The second mutation killing two tests is correct, not a leak: with no timer scheduled there is no timer to clear on unmount.

Tests only — one file, +55/-1, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D