### PR TITLE
fix(mouth): the button on every wizard step failed AA, and the one beside it had no visible edge

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -486,4 +486,33 @@ describe("StudioApp", () => {
       expect(stored).toEqual(saved);
     });
   });
+
+  describe("NavRow contrast fix (WCAG AA, 2026-08-24)", () => {
+    // jsdom resolves neither `color-mix()` nor custom properties, so a
+    // computed-color assertion here would be vacuous (verified instead on a
+    // real Chromium render — see the commit body for the measured
+    // before/after contrast numbers). These pin the RULE: the resting style
+    // must not be the bare token that measured under the WCAG floor.
+    it("primary CTA's resting background is not the bare --accent-funnel token (white-on-red measured 3.62:1, below the 4.5:1 floor for 16px/600 text)", () => {
+      render(<StudioApp />);
+
+      const continueBtn = screen.getByRole("button", { name: "Continue" });
+      const styleAttr = continueBtn.getAttribute("style") ?? "";
+      const bg = styleAttr.match(/background:\s*([^;]+)/)?.[1]?.trim();
+
+      expect(bg).toBeDefined();
+      expect(bg).not.toBe("var(--accent-funnel)");
+    });
+
+    it("Back button's resting border is not the bare --color-border-subtle token (measured ~1.2:1 against the card backdrop, below the 3.0:1 non-text UI floor)", () => {
+      render(<StudioApp />);
+
+      const backBtn = screen.getByRole("button", { name: "Back" });
+      const styleAttr = backBtn.getAttribute("style") ?? "";
+      const border = styleAttr.match(/border:\s*([^;]+)/)?.[1]?.trim();
+
+      expect(border).toBeDefined();
+      expect(border).not.toBe("1px solid var(--color-border-subtle)");
+    });
+  });
 });

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -135,21 +135,38 @@ const mastheadLabelStyle: React.CSSProperties = {
   color: "var(--text-secondary, var(--color-text-muted))",
 };
 
+/** WCAG contrast fix (2026-08-24): `--color-border-subtle` composites to
+ *  ~1.2:1 against the editorial card backdrop — invisible, and below the
+ *  3.0:1 floor for non-text UI boundaries (WCAG 1.4.11). No shipped border
+ *  token clears that floor on the editorial theme (`--border-strong` tops
+ *  out at ~1.9:1 there), so this derives an opaque-enough value from
+ *  `--text-primary` instead of inventing a bare hex — it composites to
+ *  ~3.5:1 against the editorial backdrop and stays theme-adaptive. */
 const navButtonStyle: React.CSSProperties = {
   padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
   borderRadius: 8,
-  border: "1px solid var(--color-border-subtle)",
+  border: "1px solid color-mix(in srgb, var(--text-primary) 45%, transparent)",
   background: "transparent",
   color: "var(--text-primary)",
   cursor: "pointer",
   minHeight: 44,
 };
 
+/** WCAG contrast fix (2026-08-24): white-on-`var(--accent-funnel)` measured
+ *  3.62:1 on the visa/editorial pairing (and 4.36:1 on the editorial-base
+ *  blue) — both fail the 4.5:1 floor for this 16px/600 text, which is
+ *  normal-size (large-text exemption needs >=24px, or >=18.66px at
+ *  weight>=700). This funnel sells E33E/E33F senior visas (55+), whose own
+ *  audience skews toward LOWER contrast tolerance, not higher — so the cure
+ *  is darkening the fill to clear 4.5:1, never stretching the label to
+ *  dodge the floor via the large-text carve-out. Derived via color-mix so
+ *  it holds across every `--accent-funnel` resolution (per-theme, not one
+ *  hardcoded hex) — verified >=4.5:1 on both known resolutions. */
 const primaryNavButtonStyle: React.CSSProperties = {
   ...navButtonStyle,
   marginLeft: "auto",
   border: "none",
-  background: "var(--accent-funnel)",
+  background: "color-mix(in srgb, var(--accent-funnel) 85%, black)",
   color: "var(--text-on-accent, #fff)",
   fontWeight: 600,
 };


### PR DESCRIPTION
## The defect — measured on production, then re-measured on painted pixels

The Second Home Studio's navigation row appears on all six wizard steps. Both of its controls failed WCAG.

**1. The primary CTA.** Labelled "Continue" on steps 1-5 and "See your fit-check result" on step 6 — the most-pressed control in the funnel.

```
white 16px/600 on rgb(255,51,68)   =  3.62:1     floor 4.5:1    FAIL
```

16px at weight 600 is **normal** text: the large-text exemption needs ≥24px, or ≥18.66px at weight ≥700. The default `--accent-funnel` blue (`#3a6dff`) computes 4.36:1 — also under — so this was never a visa-funnel-only problem.

**2. The Back button had no visible boundary.** `1px solid var(--color-border-subtle)` composites to roughly **1.2:1** against the card backdrop, against a 3.0:1 floor for non-text UI boundaries (WCAG 1.4.11). Only its label was visible, so the control read as bare text rather than a button.

## The cure, and why it is a darker fill rather than a bigger label

```diff
-  border: "1px solid var(--color-border-subtle)",
+  border: "1px solid color-mix(in srgb, var(--text-primary) 45%, transparent)",
...
-  background: "var(--accent-funnel)",
+  background: "color-mix(in srgb, var(--accent-funnel) 85%, black)",
```

3.62:1 could also have been "fixed" by pushing the label to 19px/700 to qualify for the 3.0:1 large-text floor. That was rejected deliberately: **this funnel sells E33E and E33F — senior visas, 55+.** The product's own audience skews toward lower contrast tolerance, not higher, so reaching for a large-text carve-out here would be exactly backwards. Fix the contrast.

Both values derive from tokens via `color-mix` rather than a hardcoded hex, so they hold across every `--accent-funnel` resolution instead of only the visa one. No shipped border token clears 3.0:1 on the editorial theme (`--border-strong` tops out near 1.9:1 there), which is why the Back edge derives from `--text-primary`.

## Verified by the grader on painted pixels, not on declared values

Rendered in Chromium so `color-mix()` is resolved by the compositor, then sampled a single pixel:

| | before | after | floor | |
|---|---|---|---|---|
| CTA fill / white label | 3.62:1 | **4.82:1** — painted `rgb(217,43,58)` | 4.5 | PASS |
| Back border vs backdrop | ~1.2:1 | **3.74:1** — painted `rgb(124,136,155)` on `rgb(26,47,80)` | 3.0 | PASS |

One correction worth recording: measuring the Back border on **step 1** gives 1.97:1 — because Back is `disabled` there and the row applies `opacity: 0.5`. Disabled controls are exempt, so that reading is the instrument, not the defect. The number above is from step 2, where Back is enabled at `opacity: 1`.

**Focus visibility was checked and deliberately left alone.** With focus genuinely on the button (`document.activeElement` confirmed), it carries the UA `outline-style: auto` ring — Chromium's adaptive two-tone indicator. Adding a hand-rolled ring on top of a working one would be churn.

## Tests

They pin the rule, not a pixel: jsdom resolves neither `color-mix()` nor custom properties, so a computed-colour assertion would be vacuous. Each was mutation-checked by reverting the production line and confirming RED:

- revert the CTA background → `1 failed | 29 passed` — × *primary CTA's resting background is not the bare `--accent-funnel` token*
- revert the Back border → `1 failed | 29 passed` — × *Back button's resting border is not the bare `--color-border-subtle` token*
- restored → `Tests 30 passed (30)`; full studio suite `13 files, 126 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D