### PR TITLE
fix(mouth): the two buttons this vertical exists to produce were unreadable

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -676,8 +676,15 @@ export function SecondHomeLanding() {
             gap: 8,
             padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
             borderRadius: 8,
+            // WCAG AA fix (measured 2026-08-24): `--text-on-accent` resolves
+            // to #fff here, which on the WhatsApp green computes to ~1.98:1,
+            // failing the 4.5:1 normal-text floor. Ratified cure
+            // (app/(visa-oracle)/visa-oracle/oracle.css:23-30, 2026-07-17
+            // adversarial review): #0d3a1f on #25D366 ~6.45:1. Only this
+            // call site's ink changes — the shared token and the brand
+            // green stay untouched.
             background: "var(--accent-whatsapp, #25D366)",
-            color: "var(--text-on-accent)",
+            color: "#0d3a1f",
             fontWeight: 600,
             textDecoration: "none",
             minHeight: 44,

--- a/apps/mouth/src/app/visa/second-home/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.test.tsx
@@ -131,6 +131,27 @@ describe("SecondHomeLanding", () => {
     expect(screen.queryByRole("button", { name: /apply/i })).toBeNull();
   });
 
+  // WCAG AA contrast guard (measured 2026-08-24): white text on the
+  // WhatsApp brand green (`#25D366`) computes to ~1.98:1, badly failing the
+  // 4.5:1 normal-text floor. Ratified cure
+  // (app/(visa-oracle)/visa-oracle/oracle.css:23-30, 2026-07-17 adversarial
+  // review): `#0d3a1f` on `#25D366` ~6.45:1. jsdom resolves neither
+  // `color-mix()` nor custom properties, so this asserts on the literal
+  // inline style value rather than a computed color (confirmed live via
+  // Playwright render — see the shipping commit for the measured
+  // rgb()/contrast numbers).
+  it("keeps the WhatsApp CTA's ink dark enough on the brand green (WCAG AA)", () => {
+    renderLanding();
+
+    const cta = screen.getByRole("link", { name: /free fit memo/i });
+    // Brand green stays byte-identical — only the ink moves. (jsdom's CSSOM
+    // normalizes the literal hex it parses to rgb() form; the var()
+    // fallback expression is left as-is since it isn't a plain color.)
+    expect(cta.style.background).toBe("var(--accent-whatsapp, #25D366)");
+    expect(cta.style.color).toBe("rgb(13, 58, 31)"); // #0d3a1f
+    expect(cta.style.color).not.toBe("var(--text-on-accent)");
+  });
+
   it("never states a forbidden claim", () => {
     const { container } = renderLanding();
     const text = container.textContent ?? "";

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { emptyPlan } from "@/lib/secondhome-studio/plan-codec";
+import type { Verdict } from "@/lib/secondhome-studio/types";
+import { WhatsAppHandoff } from "./WhatsAppHandoff";
+
+/**
+ * WCAG AA contrast guard (measured 2026-08-24): white text on the WhatsApp
+ * brand green (`#25D366`) computes to ~1.98:1, badly failing the 4.5:1
+ * normal-text floor. Ratified cure (app/(visa-oracle)/visa-oracle/oracle.css
+ * :23-30, 2026-07-17 adversarial review): `#0d3a1f` on `#25D366` ~6.45:1.
+ *
+ * jsdom resolves neither `color-mix()` nor custom properties, so this
+ * asserts on the literal inline style value the component sets rather than
+ * a computed color (jsdom's CSSOM normalizes a literal hex it parses to
+ * `rgb()` form, hence the expected values below — confirmed live via
+ * Playwright render, see the shipping commit for the measured
+ * rgb()/contrast numbers).
+ */
+describe("WhatsAppHandoff", () => {
+  const verdict: Verdict = {
+    band: "strong_fit",
+    product: "E33",
+    reasons: [],
+    humanReviewNote: null,
+  };
+
+  it("keeps the WhatsApp button's ink dark enough on the brand green (WCAG AA)", () => {
+    render(<WhatsAppHandoff plan={emptyPlan()} verdict={verdict} />);
+
+    const cta = screen.getByRole("link", { name: /ask us to review my plan/i });
+
+    // Brand green stays byte-identical — only the ink moves.
+    expect(cta.style.background).toBe("rgb(37, 211, 102)"); // #25D366
+    expect(cta.style.color).toBe("rgb(13, 58, 31)"); // #0d3a1f
+    expect(cta.style.color).not.toBe("rgb(255, 255, 255)"); // was #fff
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
@@ -69,8 +69,13 @@ export function WhatsAppHandoff({ plan, verdict }: WhatsAppHandoffProps) {
           gap: 8,
           padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
           borderRadius: 8,
+          // WCAG AA fix (measured 2026-08-24): white on the WhatsApp brand
+          // green computes to ~1.98:1, failing the 4.5:1 normal-text floor.
+          // Ratified cure (app/(visa-oracle)/visa-oracle/oracle.css:23-30,
+          // 2026-07-17 adversarial review): #0d3a1f on #25D366 ~6.45:1. The
+          // brand green stays untouched — only the ink moves.
           background: "#25D366",
-          color: "#fff",
+          color: "#0d3a1f",
           fontWeight: 600,
           textDecoration: "none",
           minHeight: 44,


### PR DESCRIPTION
## The defect

Both conversion CTAs of the Second Home vertical were white text on the WhatsApp brand green. Measured on production:

```
balizero.com/visa/second-home         "Get my free Fit Memo →"     16px/600  #fff on rgb(37,211,102)  = 1.98:1
balizero.com/visa/second-home/studio  "Ask us to review my plan"   16px/600  #fff on rgb(37,211,102)  = 1.98:1
                                                                             WCAG AA floor            = 4.5:1
```

1.98:1 is close to the 1:1 of no contrast at all. 16px at weight 600 is normal text — the large-text exemption needs ≥24px, or ≥18.66px at weight ≥700.

These are the only two conversion points in the vertical: the landing's sole CTA and the studio's handoff at the end of a six-step wizard.

## This repo already solved this, and wrote the answer down

`app/(visa-oracle)/visa-oracle/oracle.css:23-30`, from an adversarial review on 2026-07-17:

> the previous `color: #ffffff` on `.oracle-whatsapp-cta` computed to **~1.98:1**, badly failing WCAG AA (needs 4.5:1 for normal text). **#0d3a1f on #25d366 computes to ~6.45:1.**

The same value, to two decimals, as what I measured on Second Home today. `NavWhatsAppCTA.tsx` reached the same shape independently and recorded 7.5:1 in its own comment. The Second Home vertical shipped after both and got neither.

So this PR does not design a cure — it applies the ratified one.

## What changed: the ink, and only the ink

```diff
- color: "#fff",                     // studio
+ color: "#0d3a1f",
- color: "var(--text-on-accent)",    // landing
+ color: "#0d3a1f",
```

The WhatsApp green is a third-party brand identity colour and is what signals "this opens WhatsApp" — darkening it would pass contrast and destroy the signal. Flipping the ink is why the ratified fix works.

`--text-on-accent` resolves to `#fff` globally and was **deliberately not touched**: it is chrome used well outside this vertical, and repointing it would silently repaint surfaces nobody measured. The shared `WhatsAppLeadButton` component is likewise untouched — both call sites pass their own inline `style`, so other verticals that render it are unaffected.

## Verified by the grader on a live render

| | before | after | floor | |
|---|---|---|---|---|
| landing CTA | 1.98:1 | **6.45:1** | 4.5 | PASS |
| studio CTA | 1.98:1 | **6.45:1** | 4.5 | PASS |
| `<Phone>` icon (non-text) | — | **6.45:1**, stroke `rgb(13,58,31)` | 3.0 | PASS |

Background measured `rgb(37,211,102)` on both after the change — the brand green is byte-identical. The icon follows via `currentColor`, confirmed on the render rather than assumed.

## Tests

One per call site, asserting the literal inline style value — jsdom resolves neither `color-mix()` nor custom properties, so a computed-colour assertion would be vacuous. Each mutation-checked:

- revert the landing ink → `1 failed | 7 passed` — × *keeps the WhatsApp CTA's ink dark enough on the brand green*
- revert the studio ink → `1 failed (1)` — × *keeps the WhatsApp button's ink dark enough on the brand green*
- restored → both green; full second-home suite `14 files, 126 passed`

## Out of scope, reported separately

The same shape is live elsewhere and is **not** touched here: `balizero.com/book` measures 1.98:1 and `balizero.com/services` 2.28:1 on a different green (`rgb(34,197,94)`). Those cross other verticals and belong in their own change — along with the real structural fix, which is a shared "ink on the WhatsApp accent" token plus a lint rule, so the cure travels instead of being re-derived per surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D