### PR TITLE
fix(mouth): six personalising questions, then the same list for everyone

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -159,16 +159,23 @@ describe("StudioApp", () => {
   });
 
   it("checklist toggle updates the readiness meter", async () => {
+    // fullPlan() is a deposit-route, no-family plan: 7 of the 10 items apply
+    // (property_documents, passive_income_evidence and family_records read
+    // "may also apply" for this route/family combination — see
+    // checklist.ts's classifyChecklistItem) — the meter's denominator
+    // reflects only the applicable group, never the full union.
     window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
     render(<StudioApp />);
 
-    expect(await screen.findByText(/0 of 10 prepared/)).toBeInTheDocument();
+    expect(await screen.findByText(/0 of 7 prepared/)).toBeInTheDocument();
 
+    // All 10 items still render as checkboxes (both groups stay visible AND
+    // tickable) — only the meter narrows, nothing is hidden or deleted.
     const checkboxes = screen.getAllByRole("checkbox");
     expect(checkboxes).toHaveLength(10);
-    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[0]); // first item in the "applies" group
 
-    expect(await screen.findByText(/1 of 10 prepared/)).toBeInTheDocument();
+    expect(await screen.findByText(/1 of 7 prepared/)).toBeInTheDocument();
   });
 
   it("a crafted valid #p= fragment lands directly on the verdict page", async () => {

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -653,7 +653,11 @@ export function StudioApp() {
               route={plan.route}
               product={verdict.product}
             />
-            <ReadinessChecklist plan={plan} onToggle={toggleChecklistItem} />
+            <ReadinessChecklist
+              plan={plan}
+              verdict={verdict}
+              onToggle={toggleChecklistItem}
+            />
             {price ? (
               <section
                 style={{

--- a/apps/mouth/src/app/visa/second-home/studio/components/ReadinessChecklist.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ReadinessChecklist.tsx
@@ -1,71 +1,66 @@
 "use client";
 
-import { CHECKLIST_ITEMS, readiness } from "@/lib/secondhome-studio/checklist";
+import {
+  CHECKLIST_ITEMS,
+  classifyChecklistItem,
+  readiness,
+  type ChecklistItem,
+} from "@/lib/secondhome-studio/checklist";
 import { getCopy } from "@/lib/secondhome-studio/copy";
-import type { PlanState } from "@/lib/secondhome-studio/types";
+import type { PlanState, Verdict } from "@/lib/secondhome-studio/types";
 
 export interface ReadinessChecklistProps {
   plan: PlanState;
+  verdict: Verdict;
   onToggle: (id: string) => void;
 }
 
-/** 10-item readiness checklist bound to plan.checklist. Checkboxes only —
- *  no uploads. The meter says "prepared", never "approval likelihood"
- *  (spec §5 hard rule; copy.ts's own readiness.caption reinforces it). */
-export function ReadinessChecklist({
+const groupHeadingStyle = {
+  margin: "0 0 var(--space-2, 0.5rem)",
+  fontSize: "var(--text-sm, 0.9rem)",
+  fontWeight: 600,
+  color: "var(--text-primary)",
+} as const;
+
+const mutedSmallStyle = {
+  margin: 0,
+  fontSize: "var(--text-sm, 0.82rem)",
+  color: "var(--color-text-muted)",
+} as const;
+
+const listStyle = {
+  margin: 0,
+  padding: 0,
+  listStyle: "none",
+  display: "grid",
+  gap: "var(--space-2, 0.5rem)",
+} as const;
+
+/** One route-classification group ("Applies to your answers" / "May also
+ *  apply") — renders nothing when empty (the applicable group is never
+ *  empty in practice; the may_apply group can be, e.g. an unresolved
+ *  route). Every item stays a real, tickable checkbox in whichever group
+ *  it lands in — nothing here is disabled or read-only. */
+function ChecklistGroup({
+  headingKey,
+  noteKey,
+  items,
   plan,
   onToggle,
-}: ReadinessChecklistProps) {
-  const { done, total } = readiness(plan);
-
+}: {
+  headingKey: string;
+  noteKey?: string;
+  items: ChecklistItem[];
+  plan: PlanState;
+  onToggle: (id: string) => void;
+}) {
+  if (items.length === 0) return null;
   return (
-    <section
-      style={{
-        display: "grid",
-        gap: "var(--space-3, 1rem)",
-        background: "var(--surface-raised)",
-        border: "1px solid var(--color-border-subtle)",
-        borderRadius: 12,
-        padding: "var(--space-4, 1.5rem)",
-      }}
-    >
-      <h2
-        style={{
-          margin: 0,
-          fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
-          color: "var(--text-primary)",
-        }}
-      >
-        {getCopy("checklist.heading")}
-      </h2>
-      <p style={{ margin: 0, color: "var(--text-primary)", lineHeight: 1.6 }}>
-        {getCopy("checklist.body")}
-      </p>
-      <div>
-        <p style={{ margin: 0, fontWeight: 600, color: "var(--text-primary)" }}>
-          {done} of {total} {getCopy("checklist.readiness.preparedLabel")}
-        </p>
-        <p
-          style={{
-            margin: 0,
-            fontSize: "var(--text-sm, 0.82rem)",
-            color: "var(--color-text-muted)",
-          }}
-        >
-          {getCopy("checklist.readiness.caption")}
-        </p>
-      </div>
-      <ul
-        style={{
-          margin: 0,
-          padding: 0,
-          listStyle: "none",
-          display: "grid",
-          gap: "var(--space-2, 0.5rem)",
-        }}
-      >
-        {CHECKLIST_ITEMS.map((item) => (
+    <div>
+      <h3 style={groupHeadingStyle}>{getCopy(headingKey)}</h3>
+      {noteKey ? <p style={mutedSmallStyle}>{getCopy(noteKey)}</p> : null}
+      <ul style={listStyle}>
+        {items.map((item) => (
           <li key={item.id}>
             <label
               style={{
@@ -101,15 +96,82 @@ export function ReadinessChecklist({
           </li>
         ))}
       </ul>
-      <p
+    </div>
+  );
+}
+
+/** 10-item readiness checklist bound to plan.checklist. Checkboxes only —
+ *  no uploads. Every item stays visible regardless of route (this is a
+ *  readiness list, not a final application checklist — copy.ts's
+ *  `checklist.body` says so), but items are grouped by whether THIS plan's
+ *  answers apply to them (`classifyChecklistItem`, fail-safe toward
+ *  "applies" whenever the route is unconfirmed). The meter counts only the
+ *  applicable group, so "X of Y prepared" is always honestly reachable —
+ *  never "approval likelihood" (spec §5 hard rule; copy.ts's own
+ *  readiness.caption reinforces it). */
+export function ReadinessChecklist({
+  plan,
+  verdict,
+  onToggle,
+}: ReadinessChecklistProps) {
+  const { done, total } = readiness(plan, verdict);
+
+  const applicableItems: ChecklistItem[] = [];
+  const mayApplyItems: ChecklistItem[] = [];
+  for (const item of CHECKLIST_ITEMS) {
+    const group =
+      classifyChecklistItem(item.id, plan, verdict) === "applies"
+        ? applicableItems
+        : mayApplyItems;
+    group.push(item);
+  }
+
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <h2
         style={{
           margin: 0,
-          fontSize: "var(--text-sm, 0.82rem)",
-          color: "var(--color-text-muted)",
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          color: "var(--text-primary)",
         }}
       >
-        {getCopy("checklist.note")}
+        {getCopy("checklist.heading")}
+      </h2>
+      <p style={{ margin: 0, color: "var(--text-primary)", lineHeight: 1.6 }}>
+        {getCopy("checklist.body")}
       </p>
+      <div>
+        <p style={{ margin: 0, fontWeight: 600, color: "var(--text-primary)" }}>
+          {done} of {total} {getCopy("checklist.readiness.preparedLabel")}
+        </p>
+        <p style={mutedSmallStyle}>{getCopy("checklist.readiness.caption")}</p>
+      </div>
+
+      <ChecklistGroup
+        headingKey="checklist.groups.applicableHeading"
+        items={applicableItems}
+        plan={plan}
+        onToggle={onToggle}
+      />
+      <ChecklistGroup
+        headingKey="checklist.groups.mayApplyHeading"
+        noteKey="checklist.groups.mayApplyNote"
+        items={mayApplyItems}
+        plan={plan}
+        onToggle={onToggle}
+      />
+
+      <p style={mutedSmallStyle}>{getCopy("checklist.note")}</p>
     </section>
   );
 }

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/checklist.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/checklist.test.ts
@@ -1,14 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { CHECKLIST_ITEMS, readiness } from "../checklist";
+import {
+  CHECKLIST_ITEMS,
+  classifyChecklistItem,
+  readiness,
+  type ChecklistApplicability,
+} from "../checklist";
 import { getCopy } from "../copy";
 import { emptyPlan } from "../plan-codec";
+import { evaluatePlan } from "../rules";
+import type { PlanState, Verdict } from "../types";
 
 /**
  * Not one of the spec's 4 named test files (rules/plan-codec/timeline/
  * forbidden-claims) — added as a value-add since checklist.ts carries real
- * logic (`readiness`). Flagged in the delivery report as an addition
- * beyond the frozen spec's minimum, not a scope change.
+ * logic (`readiness`, `classifyChecklistItem`). Flagged in the delivery
+ * report as an addition beyond the frozen spec's minimum, not a scope
+ * change.
+ *
+ * Pins the defect measured across three production walks: every route
+ * rendered the byte-identical 10-item union with an identical "0 of 10"
+ * meter, so a bank-deposit applicant was told to prepare property documents
+ * and a senior income applicant was told to prepare deposit evidence.
+ * `classifyChecklistItem`/`readiness` split the union into
+ * "applies"/"may_apply" without deleting anything — see checklist.ts's
+ * module doc for the fail-safe precedence.
  */
 
 describe("CHECKLIST_ITEMS", () => {
@@ -29,29 +45,213 @@ describe("CHECKLIST_ITEMS", () => {
   });
 });
 
-describe("readiness", () => {
-  it("reports 0 of 10 for a fresh plan", () => {
-    expect(readiness(emptyPlan())).toEqual({ done: 0, total: 10 });
+function plan(overrides: Partial<PlanState>): PlanState {
+  return { ...emptyPlan(), ...overrides };
+}
+
+/** Asserts classifyChecklistItem for every item against `overrides`; any
+ *  item NOT named defaults to "applies" — the safety rule itself ("default
+ *  to APPLICABLE, only 'may_apply' when definitively inapplicable") made
+ *  literal as the test helper's own default. This also covers the six
+ *  route-independent items (always "applies") without a separate test. */
+function expectClassification(
+  testPlan: PlanState,
+  verdict: Verdict,
+  overrides: Partial<Record<string, ChecklistApplicability>>,
+) {
+  for (const item of CHECKLIST_ITEMS) {
+    expect(classifyChecklistItem(item.id, testPlan, verdict)).toBe(
+      overrides[item.id] ?? "applies",
+    );
+  }
+}
+
+// Representative plans, grounded in the same four the conductor walked live.
+const depositRoutePlan = plan({
+  age: "under_55",
+  route: "deposit",
+  capital: "ready_130k",
+});
+const propertyRoutePlan = plan({
+  age: "under_55",
+  route: "property",
+  property: "buying_completed_strata",
+});
+const seniorDepositPlan = plan({
+  age: "60_plus",
+  route: "deposit",
+  seniorFunding: "deposit_50k_income",
+});
+const seniorIncomePlan = plan({
+  age: "60_plus",
+  route: "deposit",
+  seniorFunding: "income_only_3k",
+});
+const notSureYetPlan = plan({
+  age: "under_55",
+  route: "unsure",
+  capital: "ready_130k",
+  // family_records is governed by its OWN rule (a member present or not —
+  // see the dedicated test below), not the route fail-safe. Populated here
+  // so "all ten applicable" holds for its own correct reason too.
+  family: { spouse: true, children: 0, parents: 0 },
+});
+
+describe("classifyChecklistItem — route-aware mapping", () => {
+  it("deposit-route plan: bank deposit applies, property + income may also apply", () => {
+    const verdict = evaluatePlan(depositRoutePlan);
+    expect(verdict.product).toBe("E33"); // sanity: the strong-fit deposit case
+    expectClassification(depositRoutePlan, verdict, {
+      passive_income_evidence: "may_apply",
+      property_documents: "may_apply",
+      family_records: "may_apply", // no family on this plan
+    });
   });
 
-  it("counts only items marked true", () => {
-    const plan = {
-      ...emptyPlan(),
+  it("property-route plan is the mirror image of the deposit-route plan", () => {
+    const verdict = evaluatePlan(propertyRoutePlan);
+    expect(verdict.band).toBe("edge_case"); // property is always edge_case (pending validation standard)
+    expectClassification(propertyRoutePlan, verdict, {
+      bank_deposit_evidence: "may_apply",
+      passive_income_evidence: "may_apply",
+      family_records: "may_apply",
+    });
+  });
+
+  it("senior E33E plan (60+, deposit funding): deposit + income apply, property does not", () => {
+    const verdict = evaluatePlan(seniorDepositPlan);
+    expect(verdict.product).toBe("E33E");
+    expectClassification(seniorDepositPlan, verdict, {
+      property_documents: "may_apply",
+      family_records: "may_apply",
+    });
+  });
+
+  it("senior E33F plan (60+, income-only funding): income applies, deposit + property do not", () => {
+    const verdict = evaluatePlan(seniorIncomePlan);
+    expect(verdict.product).toBe("E33F");
+    expectClassification(seniorIncomePlan, verdict, {
+      bank_deposit_evidence: "may_apply",
+      property_documents: "may_apply",
+      family_records: "may_apply",
+    });
+  });
+
+  it("FAIL-SAFE: a 'not sure yet' route plan classifies all ten items as applicable", () => {
+    const verdict = evaluatePlan(notSureYetPlan);
+    // Sanity: this really does score as a clean deposit match under the hood
+    // (evaluatePlan treats "unsure" as deposit for verdict/price purposes) —
+    // the fail-safe must hold even though the verdict alone looks resolved.
+    expect(verdict.product).toBe("E33");
+    expectClassification(notSureYetPlan, verdict, {});
+  });
+
+  it("55-59 (BERSYARAT) classifies all ten items as applicable regardless of seniorFunding", () => {
+    const bersyaratPlan = plan({
+      age: "55_59",
+      route: "deposit",
+      seniorFunding: "deposit_50k_income",
+      family: { spouse: true, children: 0, parents: 0 },
+    });
+    const verdict = evaluatePlan(bersyaratPlan);
+    expect(verdict.band).toBe("edge_case");
+    expectClassification(bersyaratPlan, verdict, {});
+  });
+
+  it("incomplete plan (no age/route yet): route items are applicable, family_records is not (no family answered)", () => {
+    const incomplete = emptyPlan();
+    const verdict = evaluatePlan(incomplete);
+    expect(verdict.band).toBe("edge_case");
+    // The two fail-safes compose independently: route/age unresolved ->
+    // applicable, but a default member-less family is its OWN definitive
+    // "not applicable" answer, not a missing one.
+    expectClassification(incomplete, verdict, { family_records: "may_apply" });
+  });
+
+  it("family_records applies only when the plan includes a family member", () => {
+    const noFamily = {
+      ...depositRoutePlan,
+      family: { spouse: false, children: 0, parents: 0 },
+    };
+    const withFamily = {
+      ...depositRoutePlan,
+      family: { spouse: true, children: 0, parents: 0 },
+    };
+    expect(
+      classifyChecklistItem("family_records", noFamily, evaluatePlan(noFamily)),
+    ).toBe("may_apply");
+    expect(
+      classifyChecklistItem(
+        "family_records",
+        withFamily,
+        evaluatePlan(withFamily),
+      ),
+    ).toBe("applies");
+  });
+});
+
+describe("readiness", () => {
+  it("reports 0 of 9 for a fresh (incomplete) plan — everything applicable except family (no members yet)", () => {
+    const fresh = emptyPlan();
+    expect(readiness(fresh, evaluatePlan(fresh))).toEqual({
+      done: 0,
+      total: 9,
+    });
+  });
+
+  it("counts only applicable items marked true, against an applicable-only total", () => {
+    const withChecks: PlanState = {
+      ...depositRoutePlan,
       checklist: {
-        passport_validity: true,
-        passport_photo: true,
-        residential_address: false,
+        passport_validity: true, // applicable, ticked
+        bank_deposit_evidence: true, // applicable, ticked
+        property_documents: true, // NOT applicable for this plan — must not count
         unknown_id_not_in_the_list: true,
       },
     };
-    expect(readiness(plan)).toEqual({ done: 2, total: 10 });
+    // 7 of 10 items apply to a deposit-route, no-family plan (income,
+    // property and family_records are "may_apply").
+    expect(readiness(withChecks, evaluatePlan(withChecks))).toEqual({
+      done: 2,
+      total: 7,
+    });
   });
 
-  it("reports 10 of 10 when every item is checked", () => {
+  it("reports total=10 for the 'not sure yet' fail-safe plan even though it scores a clean match", () => {
+    expect(readiness(notSureYetPlan, evaluatePlan(notSureYetPlan))).toEqual({
+      done: 0,
+      total: 10,
+    });
+  });
+
+  it("done never exceeds total: ticking every item still only counts the 7 applicable ones", () => {
     const checklist = Object.fromEntries(
-      CHECKLIST_ITEMS.map((i) => [i.id, true]),
+      CHECKLIST_ITEMS.map((i) => [i.id, true]), // tick all ten, including the 3 may_apply ones
     );
-    const plan = { ...emptyPlan(), checklist };
-    expect(readiness(plan)).toEqual({ done: 10, total: 10 });
+    const fullyTicked: PlanState = { ...depositRoutePlan, checklist };
+    expect(readiness(fullyTicked, evaluatePlan(fullyTicked))).toEqual({
+      done: 7,
+      total: 7,
+    });
+  });
+
+  it("ticking a 'may_apply' item and then switching route never yields done > total", () => {
+    // property_documents is may_apply on the deposit route — still tickable
+    // (both groups stay tickable) but must not count toward the meter.
+    const ticked: PlanState = {
+      ...depositRoutePlan,
+      checklist: { property_documents: true },
+    };
+    expect(readiness(ticked, evaluatePlan(ticked)).done).toBe(0);
+
+    // Switching to the property route makes it applicable — the previously
+    // ticked value carries over (localStorage semantics) and now counts.
+    const switched: PlanState = {
+      ...propertyRoutePlan,
+      checklist: { property_documents: true },
+    };
+    const after = readiness(switched, evaluatePlan(switched));
+    expect(after.done).toBe(1);
+    expect(after.done).toBeLessThanOrEqual(after.total);
   });
 });

--- a/apps/mouth/src/lib/secondhome-studio/checklist.ts
+++ b/apps/mouth/src/lib/secondhome-studio/checklist.ts
@@ -11,9 +11,30 @@
  *
  * Checkboxes only, no uploads. Progress is a "readiness meter" — copy
  * always frames this as preparation, never approval likelihood.
+ *
+ * ROUTE-AWARE CLASSIFICATION (measured defect, three production walks): the
+ * ten items are a UNION across every E33/E33E/E33F route, kept deliberately
+ * — a user who never sees an item may not prepare something they end up
+ * needing. The defect was presenting that union as if it were the
+ * visitor's PERSONAL list, with a "0 of 10" meter every route showed
+ * identically even though 2-3 of the ten provably cannot apply to what the
+ * user just answered.
+ *
+ * `classifyChecklistItem` splits the union into "applies"/"may_apply"
+ * WITHOUT hiding or deleting anything — both groups stay rendered and
+ * tickable. `readiness` then counts only the applicable group, so its
+ * denominator is honestly reachable.
+ *
+ * Safety rule: an item is "may_apply" ONLY when the plan's answers make it
+ * DEFINITIVELY inapplicable — route=property and route=unsure/55-59
+ * ambiguity always widen, never narrow. See `resolveRouteBucket` for the
+ * exact precedence, grounded in the fact registry (/secondhome corner §2)
+ * and the wizard's branch structure (sequence.ts: property is structurally
+ * exclusive of deposit/senior; "unsure" is scored as deposit for
+ * verdict/price purposes only, never a confirmed route commitment).
  */
 
-import type { PlanState } from "./types";
+import type { PlanState, Verdict } from "./types";
 
 export interface ChecklistItem {
   id: string;
@@ -74,11 +95,111 @@ export const CHECKLIST_ITEMS: readonly ChecklistItem[] = [
   },
 ];
 
-/** N-of-10 readiness meter. Never interpreted as approval likelihood. */
-export function readiness(p: PlanState): { done: number; total: number } {
-  const total = CHECKLIST_ITEMS.length;
-  const done = CHECKLIST_ITEMS.reduce(
-    (acc, item) => acc + (p.checklist[item.id] ? 1 : 0),
+export type ChecklistApplicability = "applies" | "may_apply";
+
+type RouteBucket =
+  | "property" // base E33 property route — structurally exclusive of deposit/senior
+  | "seniorDeposit" // E33E: USD 50k deposit + USD 3k/mo income
+  | "seniorIncome" // E33F: USD 3k/mo income only, no deposit
+  | "baseDeposit" // base E33 deposit route
+  | "unresolved"; // route/age ambiguous or answers incomplete — never narrow
+
+/**
+ * Resolves which route family THIS plan's answers definitively commit to,
+ * or "unresolved" when they don't — the single place the fail-safe lives.
+ *
+ * Order matters:
+ * 1. Missing age/route -> unresolved (never narrow on an absent answer).
+ * 2. route="property" -> "property", REGARDLESS of age. Property is a
+ *    structurally separate wizard branch (sequence.ts never asks
+ *    seniorFunding/capital once route=property) and neither senior product
+ *    (E33E/E33F) has a property variant in the fact registry — so a
+ *    property answer is definitive independent of the 55-59 ambiguity below.
+ * 3. route="unsure" -> unresolved. evaluatePlan() scores "unsure" AS IF it
+ *    were the deposit route so it can still show a verdict/price, but that
+ *    is a scoring convenience, not a confirmed deposit-vs-property choice —
+ *    narrowing on it would tell a user who never picked a route that a
+ *    property document does not apply to them.
+ * 4. age="55_59" -> unresolved. BERSYARAT (fact registry §2 disputed age
+ *    band): both the base route and the senior products remain open for
+ *    this band regardless of which seniorFunding was answered.
+ * 5. Otherwise, narrow on the computed verdict.product (E33E/E33F/E33).
+ * 6. product=null with none of the above (incomplete answers, or 60+ with
+ *    seniorFunding genuinely unresolved) -> unresolved.
+ */
+function resolveRouteBucket(plan: PlanState, verdict: Verdict): RouteBucket {
+  if (plan.age == null || plan.route == null) return "unresolved";
+  if (plan.route === "property") return "property";
+  if (plan.route === "unsure") return "unresolved";
+  if (plan.age === "55_59") return "unresolved";
+
+  if (verdict.product === "E33E") return "seniorDeposit";
+  if (verdict.product === "E33F") return "seniorIncome";
+  if (verdict.product === "E33") return "baseDeposit";
+  return "unresolved";
+}
+
+function hasFamilyMembers(family: PlanState["family"]): boolean {
+  return family.spouse || family.children > 0 || family.parents > 0;
+}
+
+/**
+ * Classifies one checklist item against THIS plan's answers. Never returns
+ * anything but "applies" for the six route-independent items (passport bio
+ * page, passport validity, passport photo, residential address, personal
+ * history, existing visa/permit) — only the three route-conditioned items
+ * and `family_records` can ever read "may_apply".
+ */
+export function classifyChecklistItem(
+  itemId: string,
+  plan: PlanState,
+  verdict: Verdict,
+): ChecklistApplicability {
+  if (itemId === "family_records") {
+    return hasFamilyMembers(plan.family) ? "applies" : "may_apply";
+  }
+
+  const bucket = resolveRouteBucket(plan, verdict);
+  if (bucket === "unresolved") return "applies";
+
+  switch (itemId) {
+    case "bank_deposit_evidence":
+      // Required on base E33 deposit route + E33E. Not on property (no
+      // deposit route was taken) or E33F (income only, no deposit).
+      return bucket === "property" || bucket === "seniorIncome"
+        ? "may_apply"
+        : "applies";
+    case "passive_income_evidence":
+      // Required on E33E and E33F only — base E33 has no income test,
+      // on either route.
+      return bucket === "seniorDeposit" || bucket === "seniorIncome"
+        ? "applies"
+        : "may_apply";
+    case "property_documents":
+      // Required on the base E33 property route only.
+      return bucket === "property" ? "applies" : "may_apply";
+    default:
+      return "applies";
+  }
+}
+
+/**
+ * N-of-M readiness meter. M is the count of items classified "applies" for
+ * THIS plan — never the full 10 — so the denominator is honestly reachable;
+ * an item classified "may_apply" is still rendered and tickable, but never
+ * counted toward the meter, so `done` can never exceed `total`. Never
+ * interpreted as approval likelihood.
+ */
+export function readiness(
+  plan: PlanState,
+  verdict: Verdict,
+): { done: number; total: number } {
+  const applicable = CHECKLIST_ITEMS.filter(
+    (item) => classifyChecklistItem(item.id, plan, verdict) === "applies",
+  );
+  const total = applicable.length;
+  const done = applicable.reduce(
+    (acc, item) => acc + (plan.checklist[item.id] ? 1 : 0),
     0,
   );
   return { done, total };

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -413,6 +413,18 @@ export const COPY = {
       preparedLabel: "prepared",
       caption: "This tracks preparation, not approval odds.",
     },
+    groups: {
+      // P2-checklist-route-aware: the list stays a full union across routes
+      // (never hidden, never deleted — a "final application checklist"
+      // this deliberately is not), but it is split into what THIS plan's
+      // answers apply to and what remains open. "May also apply" reads as
+      // "not ruled out", never as "not needed" — we have not confirmed the
+      // route, not decided the document is irrelevant.
+      applicableHeading: "Applies to your answers",
+      mayApplyHeading: "May also apply",
+      mayApplyNote:
+        "We haven't ruled these out — either your route isn't fully confirmed yet, or these depend on details we haven't asked.",
+    },
   },
 
   price: {


### PR DESCRIPTION
## The defect — three production walks, byte-identical results

The Studio asks six personalising questions and then hands **every** visitor the same ten-item "Documents worth preparing early" list with the same "0 of 10 prepared" meter. Walked on `balizero.com/visa/second-home/studio`:

| walk | verdict | checklist |
|---|---|---|
| property route, under 55 | edge case | the same 10 items, same order |
| senior 60+, deposit route | strong match, E33E, 45.000.000 IDR | the same 10 items, same order |
| "not sure yet", under 55 | strong match, E33, 35.000.000 IDR | the same 10 items, same order |

So a bank-deposit applicant is told to prepare **"Completed strata-title property documents"** (property route only) and **"Passive-income evidence"** (senior routes only); a senior income applicant is told to prepare property documents. Two to three of the ten provably cannot apply to what the user just answered — and since the denominator is always 10, those users cannot honestly finish their own list.

The funnel's most actionable output was ignoring every answer that precedes it.

## What this PR does NOT do

It does not delete or hide a single item. `checklist.ts`'s own header calls the list *"route-complete"* on purpose, and the on-page copy already says *"we confirm the exact requirements after reviewing your route."* Premature narrowing is a real risk here — this is immigration evidence, and a user who never sees an item may not prepare something they end up needing.

The defect was never the union. It was presenting the union as the visitor's **personal** list.

## The cure

All ten stay rendered and tickable, split into **"Applies to your answers"** and **"May also apply"**, and the meter counts only the applicable group so its denominator is reachable. The second heading reads as *not ruled out*, never *not needed*: "We haven't ruled these out — either your route isn't fully confirmed yet, or these depend on details we haven't asked."

`readiness(plan, verdict)` now counts only applicable-and-ticked items, so `done` can never exceed `total` even if the user ticks something and then changes route.

**The safety rule is the whole design: default to APPLICABLE.** An item becomes "may also apply" only when the answers make it *definitively* inapplicable.

## Two traps the implementing lane found, grounded on disk

1. **`route = "unsure"` must not narrow.** `rules.ts:141` reads *"Row 8: route=unsure is evaluated as deposit"* — a scoring convenience so a verdict and price can still be shown. Narrowing on it would tell a user who never picked a route that property documents don't apply to them. It resolves to `unresolved` **before** the verdict product is consulted.
2. **`route = "property"` is definitive regardless of age.** `sequence.ts:38` branches to the property question and never pushes `seniorFunding` or `capital`, and neither senior product has a property variant — so property narrows safely even inside the disputed 55-59 band, which otherwise always widens (BERSYARAT, fact registry §2).

## Verified by the grader on a live render, four walks

| walk | meter | shown under "May also apply" | boxes rendered |
|---|---|---|---|
| deposit, under 55 | 0 of **8** | passive income, strata-title property | 10 |
| property, under 55 | 0 of **8** | bank deposit, passive income | 10 |
| senior 60+ (E33E) | 0 of **9** | strata-title property | 10 |
| **"not sure yet"** | 0 of **10** | *(none)* | 10 |

Ten checkboxes in every case — nothing hidden. The last row is the one that matters: the fail-safe widens rather than narrows.

## Tests, mutation-checked

- neuter the classifier so everything returns "applies" → `10 failed | 6 passed`
- delete the `route === "unsure"` fail-safe → `2 failed | 14 passed`, and the two that die are exactly *FAIL-SAFE: a 'not sure yet' route plan classifies all ten items as applicable* and *reports total=10 for the 'not sure yet' fail-safe plan even though it scores a clean match*
- restored → `16 passed (16)`; full second-home suite `21 files, 372 passed`

No new domain claim was authored: the item titles and why-text are untouched, and only the two group labels plus the note are new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D