### PR TITLE
chore(mouth): stop every worktree going dirty on the block next dev writes itself

### DIFF
--- a/apps/mouth/CLAUDE.md
+++ b/apps/mouth/CLAUDE.md
@@ -46,3 +46,13 @@ Log only: message count, first/last item summary. Never `console.log(fullArray)`
 - KBLI Navigator at `/kbli-navigator` → 301 → `/kbli` (rewrite in `next.config.ts`)
 - SSO: `nz_access_token` httpOnly cookie on `.balizero.com` domain
 - All subdomains share auth via cookie domain
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
## Why

`next dev` appends a marker-delimited block to `apps/mouth/CLAUDE.md` on every run. It was never committed, so **every worktree that starts a dev server shows a dirty `apps/mouth/CLAUDE.md`**.

That cost real time twice today: two separate lanes finished unrelated work — a contrast fix and a WhatsApp-ink fix — and left this file modified, and in both cases it nearly rode along into a PR about something else entirely. Reverting does not help; the next `next dev` re-creates it. The block says so itself:

> Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.

Committing it once ends the noise for every lane on every machine.

## The check that decides whether this fixes or merely postpones

A pre-commit Prettier hook runs on this file. If Prettier reformatted the generated block into a shape Next.js disagrees with, the very next `next dev` would rewrite it and we would be exactly where we started.

Tested directly, after the commit:

```
pre-run  dirty=0
npx next dev --webpack -p 3782   →  /visa/second-home 200
POST-RUN dirty=0
```

Clean. Prettier and the generator agree on this block, so the fix holds.

## One inaccuracy left in place deliberately

The block tells the reader to verify at `node_modules/next/dist/server/lib/generate-agent-files.js`, "resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root."

For this repo that parenthetical is **backwards**. `apps/mouth/node_modules/next` does not exist — `next` is hoisted, and the generator lives at the repo root:

```
/Users/nuzantara/nuzantara/node_modules/next/dist/server/lib/generate-agent-files.js   ✓ exists
/Users/nuzantara/nuzantara/apps/mouth/node_modules/next                                ✗ absent
```

The generator is real and does write the marker — confirmed by grepping `BEGIN:nextjs-agent-rules` inside it — so the substance of the claim holds; only the "resolved from this file's directory" hint is inverted for our layout.

It is **not** corrected here, on purpose: this text is generated, and hand-editing it guarantees divergence from what the tool writes next, which recreates the dirty-file problem this PR closes. Recorded here instead so the next reader is not sent to a path that does not exist.

One file, +10 lines, committed verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbbCLEkwgcnHY6aJ1DLp3D