### PR TITLE
fix(mouth): Second Home Studio money-path section unreadable in printed PDF

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -429,6 +429,23 @@ describe("StudioApp", () => {
     });
   });
 
+  describe("Print layout fix (2026-08-24) — verdict-stage nav control is print-hidden", () => {
+    it("the 'Back to your answers' control is wrapped in the class SavePlanBar's print stylesheet hides", async () => {
+      window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      render(<StudioApp />);
+      const backButton = await screen.findByRole("button", {
+        name: /back to your answers/i,
+      });
+
+      // Behavioural, not source-text: this proves the actual DOM node the
+      // print stylesheet's `.bz-shs-back-to-answers { display: none }`
+      // selector (see SavePlanBar's PRINT_STYLES) targets really exists
+      // and really wraps this control — not just that some string with
+      // that name appears somewhere in a CSS blob.
+      expect(backButton.closest(".bz-shs-back-to-answers")).not.toBeNull();
+    });
+  });
+
   describe("S13 verdict-crown — exactly one <h1> at every stage", () => {
     it("question stage: exactly one <h1>, and its text is the page masthead 'Check your fit'", () => {
       const { container } = render(<StudioApp />);

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -651,7 +651,7 @@ export function StudioApp() {
             className="bz-shs-verdict-stack"
             style={{ display: "grid", gap: "var(--space-4, 1.5rem)" }}
           >
-            <div>
+            <div className="bz-shs-back-to-answers">
               <button
                 type="button"
                 onClick={goBack}

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
@@ -68,6 +68,37 @@ describe("CustodyMap", () => {
     );
   });
 
+  // 2026-08-24 print-layout fix: at A4 print width the 3-column step grid
+  // squeezed each card to ~55px, wrapping headings one word per line and
+  // clipping "Use the bank evidence for your application" mid-word. Fixed
+  // by stacking to one column in `@media print`.
+  //
+  // jsdom does not evaluate `@media` at all (no layout engine, no paginator)
+  // so this — like the "prints every node body" test above it — can only
+  // regex-match the emitted CSS source text. That proves the rule exists
+  // and targets the right selectors; it does NOT prove the browser actually
+  // computes a single-column, non-clipped layout when printing. The real
+  // proof for that is the rendered-PDF check done by hand for this change
+  // (before/after screenshots) — this test exists to catch a regression
+  // that deletes or renames the rule, not to catch a regression in what it
+  // visually produces.
+  it("stacks the money-path steps to one column and hides arrows in print (source-text only, see comment)", () => {
+    const { container } = render(<CustodyMap />);
+    const css = Array.from(container.querySelectorAll("style"))
+      .map((style) => style.textContent ?? "")
+      .join("\n");
+
+    expect(css).toMatch(
+      /@media print\s*{[\s\S]*?\.custody-layout,\s*\n\s*\.custody-flow\s*{[\s\S]*?grid-template-columns: minmax\(0, 1fr\) !important;/,
+    );
+    expect(css).toMatch(
+      /@media print\s*{[\s\S]*?\.custody-arrow\s*{[\s\S]*?display: none !important;/,
+    );
+    expect(css).toMatch(
+      /@media print\s*{[\s\S]*?\.custody-outside::before\s*{[\s\S]*?display: none !important;/,
+    );
+  });
+
   it("renders only user-visible strings sourced from copy.ts", () => {
     const { container } = render(<CustodyMap />);
     const assertRenderedTextComesFromCopy = () => {

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
@@ -286,6 +286,36 @@ export function CustodyMap() {
           .custody-chevron {
             display: none !important;
           }
+
+          /* Print fix (2026-08-24): at A4 print width the 3-column grid
+           * squeezed each step into an unreadable ~55px ribbon (one word
+           * per line), and the unbroken word "application" in step 2's
+           * heading overflowed past this section's overflow:hidden and
+           * was clipped mid-word ("applicatio|n"). Stack to one step per
+           * row, full page width — same shape as the <=760px screen
+           * breakpoint below, but scoped to @media print so it fires
+           * regardless of what width the print engine's internal layout
+           * pass actually computes (measured to differ from both the live
+           * viewport and the @page content box — screen-narrow media
+           * queries can't be trusted to also cover print).
+           *
+           * Arrows are hidden rather than rotated 90° like the mobile
+           * breakpoint does: a printed page has no scroll/hover affordance,
+           * consecutive steps are already separated by spacing and their
+           * own headings, and a disconnected floating chevron between
+           * full-width rows reads as clutter rather than flow. */
+          .custody-layout,
+          .custody-flow {
+            grid-template-columns: minmax(0, 1fr) !important;
+          }
+
+          .custody-arrow {
+            display: none !important;
+          }
+
+          .custody-outside::before {
+            display: none !important;
+          }
         }
 
         @media (max-width: 760px) {

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -70,6 +70,10 @@ describe("SavePlanBar print action", () => {
     expect(css).toContain(".bz-shs-save-plan-bar,");
     expect(css).toContain(".bz-shs-option,");
     expect(css).toContain(".bz-shs-scenario-toggle-trigger,");
+    // 2026-08-24: the verdict page's "Back to your answers" nav control is
+    // dead weight in a printed/saved PDF — hidden alongside the other
+    // controls this block already suppresses.
+    expect(css).toContain(".bz-shs-back-to-answers");
     expect(css).not.toMatch(/(?:^|[,{])\s*button\s*(?=[,{])/);
     expect(css).toContain("break-inside: avoid");
     expect(css).toContain('input[type="checkbox"]');

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -56,7 +56,8 @@ const PRINT_STYLES = `
     .bz-shs-save-plan-bar,
     .bz-shs-option,
     .bz-shs-scenario-toggle-trigger,
-    .bz-shs-scenario-toggle-back {
+    .bz-shs-scenario-toggle-back,
+    .bz-shs-back-to-answers {
       display: none !important;
     }
 


### PR DESCRIPTION
## The regression

The Second Home Studio verdict page's "Your money stays yours" custody/money-path diagram (`CustodyMap.tsx`) survives printing since #4764 (which fixed it disappearing entirely), but at A4 print width its on-screen 3-column grid squeezes each step card to an unreadable ~55px ribbon: text wraps one word per line, and the unbroken word "application" in step 2's heading overflows the section's `overflow: hidden` and gets clipped mid-word ("...for your applicatio|n").

## The fix

Scoped to `@media print` only — verified the on-screen layout at 390px already stacks to one column below the existing `<=760px` breakpoint, so this was never a screen bug, and screen CSS is untouched.

Extends the exact `@media print` block #4764 added in `CustodyMap.tsx` (not a new/competing block — same file, same block, `grep -n "@media print"` on the file shows one occurrence):
- Stack the three steps to one full-width row each (`grid-template-columns: minmax(0, 1fr)`), mirroring the existing `<=760px` screen breakpoint's own override.
- Hide the horizontal step-arrows in print (`.custody-arrow`) rather than rotating them 90° like the screen breakpoint does: a printed page has no hover/scroll affordance, and stacked full-width rows are already separated by spacing + their own headings — a disconnected floating chevron reads as clutter, not flow.
- Hide the decorative dashed connector (`.custody-outside::before`) on the "not a payment" aside for the same reason.

Also extends #4764's named-selector print-hide list in `SavePlanBar.tsx` (`.bz-shs-save-plan-bar, .bz-shs-option, .bz-shs-scenario-toggle-trigger, .bz-shs-scenario-toggle-back`) with one more entry, `.bz-shs-back-to-answers`, and wires that class onto the verdict page's "← Back to your answers" nav control in `StudioApp.tsx` — dead weight in a saved/printed PDF, same mechanism already hiding the save/copy/print controls.

## Verified by rendered PDF, not by eye or by unit test

Rendered actual PDFs with Playwright (`page.emulateMedia({media:'print'})`, `page.pdf({format:'A4', printBackground:false})`) — before from production, after from a local `next dev --webpack` server:

- Both render 6 pages; only page 2 (the money-path section) changes.
- `pdftotext -layout` on page 2, before: `"Open / an / account / in / your / own / name"` one word per line, "application" split/clipped at a column boundary.
- `pdftotext -layout` on page 2, after: all three headings complete on one line each ("Use the bank evidence for your application" whole), natural paragraph wrapping, aside and Imigrasi disclaimer both intact.
- Pages 1, 3-6 unaffected (byte-diffed).
- #4764's own protected property re-verified: all three custody nodes still print (only decorative `.custody-arrow` / `.custody-outside::before` are hidden by this change — the step cards, their headings, and their bodies are untouched).

**The vitest tests below do NOT prove any of this.** jsdom does not evaluate `@media` at all — it has no layout engine and cannot paginate. The two CSS-regex tests only prove the print rule text exists and targets the right selectors; they cannot prove the browser computes the resulting single-column, non-clipped layout. That proof is the rendered-PDF check above, done by hand for this change. The one test that IS behavioural (see below) proves DOM structure, not visual layout.

## Tests

`cd apps/mouth && npx vitest run src/app/visa/second-home/studio` — 12 files, 112 tests, all passing.

- `CustodyMap.test.tsx`: 1 new test, regex-matching the emitted CSS source for the 3 new print rules (source-text only — see caveat above).
- `SavePlanBar.test.tsx`: extended the existing print-CSS test with `toContain(".bz-shs-back-to-answers")` (same source-text category; #4764's own blanket-`button`-hide regression guard in this file is untouched and still passing).
- `StudioApp.test.tsx`: 1 new **behavioural** test — reaches the verdict stage, finds the actual "Back to your answers" button by role/name, asserts `.closest(".bz-shs-back-to-answers")` is non-null. Real DOM, not string matching.

`git diff --stat origin/main...HEAD`: 6 files changed, 85 insertions(+), 2 deletions(-).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
