### PR TITLE
fix(mouth): the WhatsApp ink cure was a comment, so three surfaces never got it

### DIFF
--- a/apps/mouth/src/app/(blog)/[category]/[slug]/ArticleClient.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/[slug]/ArticleClient.tsx
@@ -584,7 +584,7 @@ export function ArticleClient({
                     { label: "Topic", value: article.category },
                   ]}
                   utm={{ page: `/${article.category}/${article.slug}` }}
-                  className="mt-4 inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                  className="mt-4 inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-[var(--accent-whatsapp-ink)] transition-opacity hover:opacity-90"
                   style={{ backgroundColor: "#25d366" }}
                 >
                   Chat with Bali Zero on WhatsApp

--- a/apps/mouth/src/app/(blog)/services/page.tsx
+++ b/apps/mouth/src/app/(blog)/services/page.tsx
@@ -26,6 +26,7 @@ interface Service {
   tagline: string;
   description: string;
   accent: string;
+  ctaInk?: string;
   icon: typeof IdCard;
   bullets: string[];
   cta: { label: string; href: string };
@@ -87,6 +88,7 @@ const SERVICES: Service[] = [
     description:
       "Plot-level zoning, legal vehicle, tax exposure and risk score before you sign.",
     accent: "#22c55e",
+    ctaInk: "var(--accent-whatsapp-ink)",
     icon: MapPinned,
     bullets: [
       "RTRW / RDTR overlay per plot",
@@ -295,7 +297,7 @@ export default function ServicesPage() {
                       className="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-[13px] font-semibold"
                       style={{
                         background: s.accent,
-                        color: "#ffffff",
+                        color: s.ctaInk ?? "#ffffff",
                         boxShadow: `0 8px 24px color-mix(in srgb, ${s.accent} 45%, transparent)`,
                       }}
                     >

--- a/apps/mouth/src/app/(book)/book/BookPage.tsx
+++ b/apps/mouth/src/app/(book)/book/BookPage.tsx
@@ -364,7 +364,7 @@ export function BookPage({ initialChapter }: BookPageProps) {
               href={`${CONTACTS.whatsappUrl}?text=${encodeURIComponent(t.contactCta)}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-[#25D366] text-white font-[family-name:var(--font-montserrat)] font-semibold text-lg hover:bg-[#1fb855] transition-colors shadow-[0_0_24px_rgba(37,211,102,0.25)]"
+              className="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-[#25D366] text-[var(--accent-whatsapp-ink)] font-[family-name:var(--font-montserrat)] font-semibold text-lg hover:bg-[#1fb855] transition-colors shadow-[0_0_24px_rgba(37,211,102,0.25)]"
             >
               {CONTACTS.whatsapp}
             </a>

--- a/apps/mouth/src/app/v2/_components/InlineNewsCTA.tsx
+++ b/apps/mouth/src/app/v2/_components/InlineNewsCTA.tsx
@@ -60,7 +60,7 @@ export function InlineNewsCTA() {
           padding: "0.55rem 1.1rem",
           borderRadius: "0.7rem",
           background: "#25D366",
-          color: "#fff",
+          color: "var(--accent-whatsapp-ink)",
           fontSize: 13,
           fontWeight: 600,
           whiteSpace: "nowrap",

--- a/apps/mouth/src/app/whatsapp-ink.guard.test.ts
+++ b/apps/mouth/src/app/whatsapp-ink.guard.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ARTICLE = join(
+  __dirname,
+  "(blog)",
+  "[category]",
+  "[slug]",
+  "ArticleClient.tsx",
+);
+const BOOK = join(__dirname, "(book)", "book", "BookPage.tsx");
+const SERVICES = join(__dirname, "(blog)", "services", "page.tsx");
+
+// __dirname is apps/mouth/src/app — four levels up is the repo root.
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const SEMANTIC_TOKENS = join(
+  REPO_ROOT,
+  "packages",
+  "core",
+  "tokens",
+  "semantic.css",
+);
+
+const OPENING_TAG_RE = /<[A-Za-z][^>]*>/gs;
+const WHATSAPP_FILL_RE =
+  /(?:bg-\[#25d366\](?:\/\d+)?|bg-\[#22c55e\](?:\/\d+)?|background(?:Color)?\s*:\s*["']?(?:#25d366|#22c55e|var\(--accent-whatsapp\b))/i;
+const UNSAFE_INK_RE =
+  /(?:\btext-(?:white|slate-(?:50|100|200)|gray-(?:50|100|200)|zinc-(?:50|100|200)|neutral-(?:50|100|200)|stone-(?:50|100|200))(?:\/\d+)?\b|\bcolor\s*:\s*["']?(?:#(?:fff(?:fff)?|[ef][0-9a-f]{5})\b|var\(--text-on-accent\b))/i;
+
+/** Return JSX opening tags that put white/near-white ink on WhatsApp green. */
+function unsafeWhatsAppPairs(source: string): string[] {
+  return [...source.matchAll(OPENING_TAG_RE)]
+    .map(([tag]) => tag)
+    .filter((tag) => WHATSAPP_FILL_RE.test(tag) && UNSAFE_INK_RE.test(tag));
+}
+
+// ---------------------------------------------------------------------------
+// Repo sweep — the actual guard. Pinning three named files (the pre-sweep
+// version of this guard) can only ever re-verify surfaces someone already
+// fixed; it can never catch the NEXT surface that pairs the WhatsApp fill
+// with light ink. Every source file under the two roots that can plausibly
+// carry a Tailwind class or inline style is swept instead.
+// ---------------------------------------------------------------------------
+
+const SWEEP_ROOTS = [
+  join(REPO_ROOT, "apps", "mouth", "src"),
+  join(REPO_ROOT, "packages", "core"),
+];
+const SWEEP_EXCLUDED_DIRS = new Set(["node_modules", ".next", "dist", "build"]);
+const SWEEP_EXTENSION_RE = /\.(?:tsx?|jsx|css)$/;
+const TEST_FILE_RE = /\.(?:test|spec)\.[^./]+$/;
+
+/**
+ * The two deliberately-different cured sites. Both already pair WhatsApp
+ * green with dark ink at a safe contrast ratio, but through their OWN local
+ * value rather than the shared `--accent-whatsapp-ink` token:
+ *  - oracle.css defines a route-scoped `--oracle-whatsapp-fg: #0d3a1f`
+ *    (measured ~6.45:1 — this is in fact the origin the shared token cites).
+ *  - NavWhatsAppCTA.tsx pairs the fill with a literal `#06301a` (measured
+ *    ~7.5:1 per its own inline comment).
+ * Neither currently trips the pairing regex (the fill/ink values here don't
+ * match WHATSAPP_FILL_RE/UNSAFE_INK_RE in the first place), but they are
+ * listed explicitly so the sweep documents the exemption instead of passing
+ * on them by regex coincidence.
+ */
+const SWEEP_ALLOWLIST = new Set([
+  join(
+    REPO_ROOT,
+    "apps",
+    "mouth",
+    "src",
+    "app",
+    "(visa-oracle)",
+    "visa-oracle",
+    "oracle.css",
+  ),
+  join(
+    REPO_ROOT,
+    "apps",
+    "mouth",
+    "src",
+    "app",
+    "v2",
+    "_components",
+    "NavWhatsAppCTA.tsx",
+  ),
+]);
+
+function sweepFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SWEEP_EXCLUDED_DIRS.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      sweepFiles(full, acc);
+    } else if (
+      SWEEP_EXTENSION_RE.test(entry.name) &&
+      !TEST_FILE_RE.test(entry.name)
+    ) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const SWEPT_FILES = SWEEP_ROOTS.flatMap((root) => sweepFiles(root)).filter(
+  (file) => !SWEEP_ALLOWLIST.has(file),
+);
+
+describe("WhatsApp accent ink guard", () => {
+  it("GUILT: rejects literal and token WhatsApp fills with light ink", () => {
+    const guilty = [
+      '<a className="bg-[#25D366] text-white">Chat</a>',
+      '<a style={{ background: "var(--accent-whatsapp)", color: "var(--text-on-accent)" }}>Chat</a>',
+      '<a style={{ backgroundColor: "#25d366", color: "#f8fafc" }}>Chat</a>',
+    ].join("\n");
+
+    expect(unsafeWhatsAppPairs(guilty)).toHaveLength(3);
+  });
+
+  it("INNOCENCE: accepts the dark ink token and non-fill green decoration", () => {
+    const innocent = [
+      '<a className="bg-[#25D366] text-[var(--accent-whatsapp-ink)]">Chat</a>',
+      '<a style={{ background: "var(--accent-whatsapp)", color: "var(--accent-whatsapp-ink)" }}>Chat</a>',
+      '<span className="text-[#25D366] border-[#25D366]">✓</span>',
+      '<span className="text-[#22c55e] border-[#22c55e]">✓</span>',
+    ].join("\n");
+
+    expect(unsafeWhatsAppPairs(innocent)).toEqual([]);
+  });
+
+  it("the ratified semantic token retains its measured origin", () => {
+    const tokens = readFileSync(SEMANTIC_TOKENS, "utf8");
+
+    expect(tokens).toContain("--accent-whatsapp-ink: #0d3a1f;");
+    expect(tokens).toContain(
+      "~6.45:1 on #25d366; ratified at apps/mouth/src/app/(visa-oracle)/visa-oracle/oracle.css:23-30.",
+    );
+  });
+
+  it("the article and book WhatsApp CTAs use the ink token", () => {
+    for (const file of [ARTICLE, BOOK]) {
+      const source = readFileSync(file, "utf8");
+      expect(unsafeWhatsAppPairs(source), file).toEqual([]);
+      expect(source, file).toContain("text-[var(--accent-whatsapp-ink)]");
+    }
+  });
+
+  it("only the green-fill services CTA selects the dark ink", () => {
+    const source = readFileSync(SERVICES, "utf8");
+
+    expect(source).toContain('accent: "#22c55e",');
+    expect(source).toContain('ctaInk: "var(--accent-whatsapp-ink)",');
+    expect(source).toContain('color: s.ctaInk ?? "#ffffff",');
+  });
+
+  it("the sweep actually visits a realistic number of files (not a silently-empty glob)", () => {
+    // The known-good baseline is in the low thousands of .ts/.tsx/.jsx/.css
+    // files under apps/mouth/src + packages/core; a handful would mean the
+    // roots/extensions are wrong, not that the repo shrank.
+    expect(SWEPT_FILES.length).toBeGreaterThan(500);
+  });
+
+  it("no surface anywhere under apps/mouth/src or packages/core pairs a WhatsApp-green fill with light ink", () => {
+    const offenders: string[] = [];
+    for (const file of SWEPT_FILES) {
+      const source = readFileSync(file, "utf8");
+      const pairs = unsafeWhatsAppPairs(source);
+      if (pairs.length > 0) {
+        offenders.push(`${relative(REPO_ROOT, file)}: ${pairs.join(" | ")}`);
+      }
+    }
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ""
+        : `\nUNSAFE WhatsApp fill+ink pairing found (green fill + light ink in the ` +
+            `same opening tag):\n  ${offenders.join("\n  ")}\n` +
+            `  Fix: swap the ink to text-[var(--accent-whatsapp-ink)] / ` +
+            `color: "var(--accent-whatsapp-ink)".\n`,
+    ).toEqual([]);
+  });
+});

--- a/apps/mouth/src/components/book/ServicePricingCard.tsx
+++ b/apps/mouth/src/components/book/ServicePricingCard.tsx
@@ -131,7 +131,7 @@ export function ServicePricingCard({
           href={`${CONTACTS.whatsappUrl}?text=${encodeURIComponent(waMessage)}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="block w-full text-center py-3 rounded-xl bg-[#25D366]/90 hover:bg-[#25D366] text-white text-sm font-medium font-[family-name:var(--font-montserrat)] transition-colors motion-reduce:transition-none shadow-[0_0_16px_rgba(37,211,102,0.15)]"
+          className="block w-full text-center py-3 rounded-xl bg-[#25D366]/90 hover:bg-[#25D366] text-[var(--accent-whatsapp-ink)] text-sm font-medium font-[family-name:var(--font-montserrat)] transition-colors motion-reduce:transition-none shadow-[0_0_16px_rgba(37,211,102,0.15)]"
         >
           {ctaLabel}
         </a>

--- a/apps/mouth/src/components/book/TeamModal.tsx
+++ b/apps/mouth/src/components/book/TeamModal.tsx
@@ -66,7 +66,7 @@ export function TeamModal({ member, open, onClose }: TeamModalProps) {
                     href={`${CONTACTS.whatsappUrl}?text=Ciao, vorrei parlare con ${encodeURIComponent(member.name)} del team Bali Zero`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block w-full text-center py-3 bg-[#25D366] text-white rounded-xl font-[family-name:var(--font-montserrat)] font-medium hover:bg-[#1fb855] transition-colors"
+                    className="block w-full text-center py-3 bg-[#25D366] text-[var(--accent-whatsapp-ink)] rounded-xl font-[family-name:var(--font-montserrat)] font-medium hover:bg-[#1fb855] transition-colors"
                   >
                     Contatta via WhatsApp
                   </a>

--- a/apps/mouth/src/components/kbli/KBLIConsultationCTA.tsx
+++ b/apps/mouth/src/components/kbli/KBLIConsultationCTA.tsx
@@ -133,7 +133,7 @@ export function KBLIConsultationCTA({
               ]}
               utm={{ page: `/kbli/${code}` }}
               fallbackHref={`${WHATSAPP_BASE}?text=${waText}`}
-              className="inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+              className="inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-semibold text-[var(--accent-whatsapp-ink)] transition-opacity hover:opacity-90"
               style={{ backgroundColor: "#25d366" }}
             >
               <svg

--- a/apps/mouth/src/components/services/ServicePricing.tsx
+++ b/apps/mouth/src/components/services/ServicePricing.tsx
@@ -273,7 +273,7 @@ export default function ServicePricing({ service, slug }: ServicePricingProps) {
                 { label: "Package", value: selectedPackage.name },
               ]}
               utm={{ page: `/services/${slug}` }}
-              className="flex items-center justify-center gap-2 w-full px-6 py-4 rounded-xl bg-[#25D366] text-white font-medium hover:bg-[#20BD5A] transition-colors mb-3"
+              className="flex items-center justify-center gap-2 w-full px-6 py-4 rounded-xl bg-[#25D366] text-[var(--accent-whatsapp-ink)] font-medium hover:bg-[#20BD5A] transition-colors mb-3"
             >
               <Phone className="w-5 h-5" />
               Chat on WhatsApp

--- a/apps/mouth/src/components/visa/WhatsAppCTA.tsx
+++ b/apps/mouth/src/components/visa/WhatsAppCTA.tsx
@@ -52,7 +52,7 @@ export function WhatsAppCTA({ whatsappUrl, onDismiss }: WhatsAppCTAProps) {
           href={whatsappUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="w-full flex items-center justify-center gap-2 py-3 px-6 rounded-xl font-medium text-white transition-opacity hover:opacity-90"
+          className="w-full flex items-center justify-center gap-2 py-3 px-6 rounded-xl font-medium text-[var(--accent-whatsapp-ink)] transition-opacity hover:opacity-90"
           style={{ backgroundColor: "#25D366" }}
         >
           <svg

--- a/packages/core/components/apps/AppWhatsAppCTA.tsx
+++ b/packages/core/components/apps/AppWhatsAppCTA.tsx
@@ -146,7 +146,7 @@ export const AppWhatsAppCTA: FC<AppWhatsAppCTAProps> = ({
           borderRadius: "4px",
           border: "none",
           background: "#25D366",
-          color: "#fff",
+          color: "var(--accent-whatsapp-ink)",
           fontWeight: 600,
           cursor: pending ? "wait" : "pointer",
           opacity: pending ? 0.7 : 1,

--- a/packages/core/tokens/semantic.css
+++ b/packages/core/tokens/semantic.css
@@ -74,6 +74,8 @@
   --cta-secondary-fg: #1e3863;
   --cta-secondary-border: rgba(30, 56, 99, 0.28);
   --accent-whatsapp: #25d366;
+  /* ~6.45:1 on #25d366; ratified at apps/mouth/src/app/(visa-oracle)/visa-oracle/oracle.css:23-30. */
+  --accent-whatsapp-ink: #0d3a1f;
 
   /* ─── State (separate from funnels — "success green" ≠ "Property green") ── */
   --state-success: var(--color-state-success);


### PR DESCRIPTION
## What
The ratified value `#0d3a1f` (6.45:1 on `#25d366`) has existed since 2026-07-17 at `apps/mouth/src/app/(visa-oracle)/visa-oracle/oracle.css:23-30`. But `--accent-whatsapp` had no shared ink token, and `--text-on-accent` resolves to `#fff`, so the path of least resistance for anyone building a new WhatsApp CTA pointed straight at 1.98:1 — badly failing WCAG AA. Three surfaces shipped the defect (`ArticleClient.tsx`, `BookPage.tsx`, `services/page.tsx`) before this change added `--accent-whatsapp-ink: #0d3a1f` to `semantic.css`.

## The defect in the guard itself
The guard added alongside that fix pinned three named files, so it could verify a correction but could never catch the NEXT surface. It now sweeps every `.ts`/`.tsx`/`.js`/`.jsx`/`.css` file under `apps/mouth/src` and `packages/core` (minus `node_modules`/`.next`/`dist`/`build` and test/spec files) instead, and the fill pattern now also matches `#22c55e` (the exact green measured at 2.28:1 on production `/services`), not just `#25d366`/`var(--accent-whatsapp)`.

## What the sweep found
Running the sweep for the first time found the token had only reached 3 of 10 real offenders. Fixed the other 7 in this same commit, all switched to `text-[var(--accent-whatsapp-ink)]` / `color: "var(--accent-whatsapp-ink)"`: `InlineNewsCTA.tsx`, `ServicePricingCard.tsx`, `TeamModal.tsx`, `KBLIConsultationCTA.tsx`, `ServicePricing.tsx`, `visa/WhatsAppCTA.tsx` (all `apps/mouth`), and `packages/core/components/apps/AppWhatsAppCTA.tsx`.

`oracle.css` and `v2/_components/NavWhatsAppCTA.tsx` are explicitly allowlisted in the sweep: both already pair the WhatsApp fill with safe dark ink through their own local value (`--oracle-whatsapp-fg` / a literal `#06301a`) rather than the shared token, and are documented as exempt rather than passing by regex coincidence.

## Verification
- Full `apps/mouth` vitest suite green: 423 files / 4250 tests.
- Mutation-checked twice:
  - Reverted `BookPage.tsx`'s ink to `text-white` → sweep went RED naming that file → restored → GREEN.
  - Added a new throwaway file anywhere under `apps/mouth/src` pairing `bg-[#25D366]` with `text-white` → sweep went RED naming it, without it being referenced anywhere → moved to `.trash/` *outside* the swept roots (not a `.trash/` subdirectory still inside them, which stays RED by design) → GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)