### PR TITLE
fix(tests): update stale reachability-report NOT_ASKED expectation to five

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_reachability_report.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_reachability_report.py
@@ -158,7 +158,7 @@ def test_required_facts_ast_invariant_holds_on_the_real_pack(seq7_report) -> Non
     assert seq7_report.required_facts_ast_mismatches == ()
 
 
-def test_not_asked_facts_are_exactly_the_six_hardcoded_in_the_mapper() -> None:
+def test_not_asked_facts_are_exactly_the_five_hardcoded_in_the_mapper() -> None:
     assert DEFAULT_FACT_MAPPER_PATH.exists(), (
         "the default fact-mapper path is stale — the live interview moved "
         "and this script's default needs updating"
@@ -167,16 +167,17 @@ def test_not_asked_facts_are_exactly_the_six_hardcoded_in_the_mapper() -> None:
     # Independent extraction: a plain unconditional-assignment regex, not the
     # module's own compiled pattern.
     found = sorted(set(re.findall(r'"([a-z_]+\.[a-z_]+)":\s*unknownFact\(NOT_ASKED\),', text)))
-    # Was five; 2026-08-24 F4 (D12 active-stay-permit exclusion) adds the
-    # sixth, `immigration.renewal_paid` — the fact-mapper placeholder that
-    # emits it as NOT_ASKED until the interview question (Item 1, its own
-    # PR) collects it. Same "vocabulary before the question exists" shape
-    # as the other five.
+    # `immigration.renewal_paid` used to be a sixth entry here, but 2026-08-24
+    # F4 (D12 active-stay-permit exclusion) shipped the real interview
+    # question for it (tree.ts, gated in flow.ts's
+    # `computeNextNode`/`shouldAskRenewalPaid`), so fact-mapper.ts:591 now
+    # maps it through `booleanFact(facts.renewal_paid)` — a real answered
+    # fact, not an unconditional NOT_ASKED placeholder. It correctly drops
+    # out of this list; this file just hadn't caught up.
     assert found == [
         "commercial.service_fee_budget_idr",
         "commercial.wants_quote",
         "immigration.last_entry_date",
-        "immigration.renewal_paid",
         "intent.desired_entry_date",
         "intent.requested_product_code",
     ]


### PR DESCRIPTION
## Summary

`test_not_asked_facts_are_exactly_the_six_hardcoded_in_the_mapper` was red on
every open PR because the fact-mapper moved forward and the test didn't. F4
(2026-08-24, D12 active-stay-permit exclusion) promoted
`immigration.renewal_paid` from an unconditional `unknownFact(NOT_ASKED)`
placeholder to a real `booleanFact(facts.renewal_paid)` mapping at
`fact-mapper.ts:591`, because the interview question that collects it now
ships (`tree.ts`, gated in `flow.ts`'s `computeNextNode`/`shouldAskRenewalPaid`).
The test's independent regex extraction still expected `renewal_paid` among
the hardcoded NOT_ASKED entries, so it kept failing against correct
production code. Fixed the test to expect five entries (renamed accordingly)
and rewrote the stale comment to point at where the promotion happened.

Checked the neighbouring `unused_fact_paths == 13` assertion in the same
file for the same kind of staleness — it is independently correct and
green, so it was left untouched.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/scripts/visa_engine/test_reachability_report.py -q` — 30/30 green
- [x] Bite-proof: temporarily reverted `fact-mapper.ts:591` to `unknownFact(NOT_ASKED)`, re-ran — test went RED (assertion mismatch at index 3), confirming it still catches the regression it's meant to catch
- [x] Restored `fact-mapper.ts`, re-ran — green again; `git diff origin/main -- fact-mapper.ts` is empty (0 lines) — only the test file is touched in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)