### PR TITLE
fix(mouth): the money-path headings wrapped to five lines on a laptop

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.test.tsx
@@ -99,6 +99,46 @@ describe("CustodyMap", () => {
     );
   });
 
+  // 2026-08-24 screen-breakpoint fix: the print half of this section's
+  // cramped-heading disease was cured above (2026-08-24 print-layout fix);
+  // the screen half — the same headings wrapping to 4-5 lines between
+  // ~760-1180px viewport width — was never measured and stayed broken.
+  // Fixed by (1) making the aside sit below the step flow instead of
+  // beside it (so the flow always gets the section's full width) and
+  // (2) raising the flow's own 3-column -> 1-column stacking breakpoint
+  // from 760px to 1024px, since even the full section width isn't enough
+  // for a 3-up card between ~760-1024px.
+  //
+  // Same jsdom limitation as the print test above: no layout engine, no
+  // viewport, so this can only regex-match the emitted CSS source text —
+  // it proves the rules exist and target the right selectors, not that a
+  // browser actually renders <=2 lines per heading at every width. The
+  // real proof for that is a Playwright measurement done by hand across
+  // 360-1920px (line-count table + before/after screenshots), not this
+  // test.
+  it("keeps the aside below the step flow and raises the 3-column breakpoint (source-text only, see comment)", () => {
+    const { container } = render(<CustodyMap />);
+    const css = Array.from(container.querySelectorAll("style"))
+      .map((style) => style.textContent ?? "")
+      .join("\n");
+
+    // Default (no media query): single-column layout, not the old
+    // side-by-side (flow | aside) two-track grid.
+    expect(css).toMatch(
+      /\.custody-layout\s*{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
+    );
+    expect(css).not.toMatch(
+      /grid-template-columns: minmax\(0, 1fr\) minmax\(12rem/,
+    );
+
+    expect(css).toMatch(
+      /@media \(max-width: 1024px\)\s*{[\s\S]*?\.custody-flow\s*{[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
+    );
+    expect(css).toMatch(
+      /@media \(max-width: 480px\)\s*{[\s\S]*?\.custody-icon\s*{[\s\S]*?display: none;/,
+    );
+  });
+
   it("renders only user-visible strings sourced from copy.ts", () => {
     const { container } = render(<CustodyMap />);
     const assertRenderedTextComesFromCopy = () => {

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
@@ -143,11 +143,32 @@ export function CustodyMap() {
           line-height: 1.2;
         }
 
+        /* Screen breakpoint fix (2026-08-24): #4823 cured the print half of
+         * this section's cramped-heading disease (@media print below); the
+         * screen half was never measured and stayed broken. The old
+         * side-by-side layout (3-column step flow | aside note) gave the
+         * aside's own minmax(12rem, 0.3fr) track first claim on the row,
+         * leaving the flow — and therefore each step card — squeezed at
+         * every width up to this section's 1120px content cap, not just
+         * near mobile. Measured on production: from 1024px to 1180px
+         * viewport width, each heading's actual text box was 82-113px
+         * wide (narrower than the word "application") and wrapped to 4-5
+         * lines. Fix, two parts: (1) the aside now always sits BELOW the
+         * step flow instead of beside it, so the flow keeps the full
+         * section width at every viewport; (2) the step flow's own
+         * 3-column -> 1-column stacking breakpoint moves from 760px to
+         * 1024px (below), because even with the full section width a
+         * 3-up card is still too narrow for the longest heading between
+         * ~760-1024px — measured 4 lines at 860px on this fix's own first
+         * draft. Both breakpoints now share the same 1024px threshold on
+         * purpose: below it the flow is a single vertical column (full
+         * width, roomy), at or above it there is enough per-card width
+         * for 3 columns to stay <=2 lines up to the 1120px content cap
+         * (measured 2 lines flat from 1180px to 1920px). */
         .custody-layout {
           display: grid;
-          grid-template-columns: minmax(0, 1fr) minmax(12rem, 0.3fr);
-          align-items: center;
-          gap: clamp(2rem, 4vw, 3.5rem);
+          grid-template-columns: minmax(0, 1fr);
+          gap: clamp(1.75rem, 4vw, 2.5rem);
           min-width: 0;
         }
 
@@ -250,20 +271,16 @@ export function CustodyMap() {
           stroke-width: 1.5;
         }
 
+        /* No side connector by default: the aside sits BELOW the (still
+         * horizontal, >1024px) step flow now, not beside it, so a
+         * pointing-left dashed line has nothing on its left to point at.
+         * The <=1024px breakpoint below restores a connector shaped for
+         * that width's fully-stacked, single-column step list. */
         .custody-outside {
           position: relative;
           padding: 1rem;
           border: 1px dashed var(--color-border-subtle);
           border-radius: 10px;
-        }
-
-        .custody-outside::before {
-          position: absolute;
-          top: 50%;
-          right: 100%;
-          width: clamp(2rem, 4vw, 3.5rem);
-          border-top: 1px dashed var(--color-border-subtle);
-          content: "";
         }
 
         .custody-outside p,
@@ -292,8 +309,10 @@ export function CustodyMap() {
            * per line), and the unbroken word "application" in step 2's
            * heading overflowed past this section's overflow:hidden and
            * was clipped mid-word ("applicatio|n"). Stack to one step per
-           * row, full page width — same shape as the <=760px screen
-           * breakpoint below, but scoped to @media print so it fires
+           * row, full page width — same shape as the <=1024px screen
+           * breakpoint below (760px when this comment was written; raised
+           * 2026-08-24, see the .custody-layout comment above), but scoped
+           * to @media print so it fires
            * regardless of what width the print engine's internal layout
            * pass actually computes (measured to differ from both the live
            * viewport and the @page content box — screen-narrow media
@@ -318,8 +337,11 @@ export function CustodyMap() {
           }
         }
 
-        @media (max-width: 760px) {
-          .custody-layout,
+        /* Was <=760px; raised to <=1024px (2026-08-24, see the .custody-layout
+         * comment above) — the 3-column flow needs more per-card width
+         * than 760-1024px viewports have to give without re-squeezing the
+         * headings this whole fix exists to un-squeeze. */
+        @media (max-width: 1024px) {
           .custody-flow {
             grid-template-columns: minmax(0, 1fr);
           }
@@ -338,20 +360,54 @@ export function CustodyMap() {
             transform: translateX(-50%) rotate(90deg);
           }
 
+          /* Only at this width is the flow itself a single vertical
+           * column (see .custody-flow override above), so a connector
+           * pointing left from the aside to that column reads correctly.
+           * Defined here (not as a default with per-width overrides)
+           * because >1024px has no such column for it to point at. */
           .custody-outside::before {
+            position: absolute;
             top: 1.5rem;
             right: 100%;
-            bottom: auto;
-            left: auto;
             width: 2rem;
-            height: 0;
             border-top: 1px dashed var(--color-border-subtle);
-            border-left: 0;
+            content: "";
           }
 
           .custody-outside {
             width: calc(100% - 2rem);
             margin-left: 2rem;
+          }
+        }
+
+        /* Narrow-phone tightening (2026-08-24): even full-width at this
+         * point (single-column flow, see above), a small-phone viewport
+         * still isn't wide enough for the longest heading ("Use the bank
+         * evidence for your application") to clear 2 lines once the
+         * button's own decorative chrome (icon + its gap + padding) is
+         * subtracted — measured 3 lines at 360-390px on this fix's first
+         * draft. The icon is aria-hidden decoration, so it is dropped
+         * here rather than shrunk: that returns its full width (icon +
+         * one gap) to the heading instead of only a few px. */
+        @media (max-width: 480px) {
+          .custody-icon {
+            display: none;
+          }
+
+          /* Explicit 2-column track (text, chevron) now that the icon
+           * column is gone — left as the original 3-column template's
+           * implicit auto-placement, the heading would land in an "auto"
+           * track sized by its own content instead of the flexible track,
+           * which is the wrong track for something meant to wrap. */
+          button {
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 0.5rem;
+            padding: 0.85rem 0.65rem;
+          }
+
+          .custody-chevron {
+            width: 14px;
+            height: 14px;
           }
         }
 


### PR DESCRIPTION
## Problem

The "Your money stays yours" custody-map section on the E33 verdict page kept the three step headings unreadable on screen between roughly 760px and 1400px viewport width. #4823 cured the printed-PDF half of this disease; the screen half was never measured and stayed broken (its commit message tested one width, 390px, and generalized incorrectly).

Measured live on production before this fix:

| viewport | heading width | lines (step1/step2/step3) |
|---|---|---|
| 1180px | 113px | 4/4/3 |
| 1024px | 82px | 5/5/4 |
| 600px | 392px | 1/1/1 ✅ |

## Cause

Read directly from `CustodyMap.tsx`'s grid definitions: the old side-by-side layout (3-column step flow \| aside note) gave the aside's own `minmax(12rem, 0.3fr)` track first claim on the row, squeezing the flow — and therefore each step card — at every width up to the section's 1120px content cap, not just near mobile.

## Fix

1. The aside now always sits **below** the step flow instead of beside it, so the flow keeps the full section width at every viewport (the same shape the old `<=760px` breakpoint already used for mobile, made universal).
2. The step flow's own 3-column → 1-column stacking breakpoint moves from **760px → 1024px**, because even with the full section width a 3-up card is still too narrow for the longest heading between ~760-1024px.
3. A narrow-phone tier (`<=480px`) drops the decorative step icon (already `aria-hidden`) to return its width to the heading — even a full-width single column isn't enough room at 360-390px otherwise.

## Verification

**Screen, measured across the full required range** (Playwright, driving the wizard to the E33 strong-fit verdict — under_55 + deposit + ready_130k):

| viewport | lines (step1/step2/step3) | card width | columns |
|---|---|---|---|
| 360px  | 2/2/2 | 254px | 1 |
| 390px  | 2/2/2 | 284px | 1 |
| 600px  | 1/1/1 | 494px | 1 |
| 760px  | 1/1/1 | 632px | 1 |
| 860px  | 1/1/1 | 726px | 1 |
| 1024px | 1/1/1 | 865px | 1 |
| 1180px | 2/2/2 | 303px | 3 |
| 1280px | 2/2/2 | 303px | 3 |
| 1440px | 2/2/2 | 303px | 3 |
| 1920px | 2/2/2 | 303px | 3 |

No heading wraps past 2 lines at any sampled width. The `<=760px` (now `<=1024px`) single-column layout keeps working. The "not a payment to Bali Zero" aside and the Imigrasi disclaimer stay present and visible at every width.

**Print regression check** (Playwright, `printBackground:false`, A4, same verdict page): re-rendered PDF still shows 6 pages; page 2 (the money-path section) is byte-for-byte-equivalent in size to before this change (582205 bytes) and visually identical — three full-width readable step cards, complete headings including the word "application" that #4823 fixed from clipping mid-word, arrows and connector hidden as #4823 intended. I also rendered #4823's own merged baseline (the real pre-existing code, not assumed) and diffed the print output against it directly — identical, confirming this change does not regress the print fix.

## Tests

One new source-text regression guard in `CustodyMap.test.tsx`, same limitation as #4823's own print-block guards — jsdom has no layout engine and cannot evaluate `@media`, so it can only regex-match that the new rules exist and target the right selectors. It does not and cannot prove a browser renders ≤2 lines per heading at any width; that proof is the Playwright measurement above, done by hand, not by this test. Full `vitest run` banner (proving the root was the worktree, not the main checkout):

```
RUN  v4.1.10 /Users/nuzantara/nuzantara/.worktrees/mouth-shs-custody-breakpoint/apps/mouth
Test Files  12 passed (12)
     Tests  113 passed (113)
```

## Scope

Touches only `CustodyMap.tsx` and its test file, per the one-concern rule. Does not touch `SavePlanBar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
