### PR TITLE
fix(mouth): the public E33 teaser dropped the two conditions that make it true

### DIFF
--- a/apps/mouth/src/app/visa/page.tsx
+++ b/apps/mouth/src/app/visa/page.tsx
@@ -122,7 +122,8 @@ export default function VisaEntryPage() {
             margin: 0,
           }}
         >
-          Buying property or keeping USD 130,000+ in savings?{" "}
+          Have a USD 130,000 deposit in your own name at a state-owned (BUMN)
+          Indonesian bank, or a USD 1,000,000 completed strata unit?{" "}
           <Link
             href="/visa/second-home"
             style={{ color: "var(--accent-funnel)" }}

--- a/apps/mouth/src/content/articles/digital-nomad/bali-digital-nomad-complete-guide.mdx
+++ b/apps/mouth/src/content/articles/digital-nomad/bali-digital-nomad-complete-guide.mdx
@@ -183,7 +183,7 @@ Let's address the elephant in the room first.
     },
     {
       id: "employee-assets",
-      question: "Do you have $130,000+ in savings/investments?",
+      question: "Do you have a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata unit?",
       options: [
         { label: "Yes", nextNodeId: "result-second-home" },
         { label: "No", nextNodeId: "result-rotation-strategy" },
@@ -214,7 +214,7 @@ Let's address the elephant in the room first.
     },
     {
       id: "freelance-assets",
-      question: "Do you have $130,000+ in savings/investments?",
+      question: "Do you have a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata unit?",
       options: [
         { label: "Yes", nextNodeId: "result-second-home-freelance" },
         {
@@ -285,7 +285,7 @@ Let's address the elephant in the room first.
       title: "Second Home Visa",
       description: "5-year legitimate stay, renewable to 10 years cumulative",
       recommendation:
-        "If you have $130k+ in bank/investments, the Second Home Visa offers a 5-year first-grant legitimate residency, renewable up to 10 years cumulative. No work permit but allows you to manage overseas affairs.",
+        "If you have a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata unit, the Second Home Visa offers a 5-year first-grant legitimate residency, renewable up to 10 years cumulative. No work permit but allows you to manage overseas affairs.",
       nextSteps: [
         "Verify asset requirements",
         "Apply through Immigration",


### PR DESCRIPTION
## What changed

Four instances of the public E33 Second Home teaser were corrected — two files, both touched by commit `003aa1b8f`:

1. `apps/mouth/src/app/visa/page.tsx` — the `/visa` index page's below-the-fold teaser link into `/visa/second-home`.
2. `apps/mouth/src/content/articles/digital-nomad/bali-digital-nomad-complete-guide.mdx` — three instances: two quiz-node questions (`employee-assets`, `freelance-assets`) and the `result-second-home` recommendation text.

All four now read:

> "a USD 130,000 deposit in your own name at a state-owned (BUMN) Indonesian bank, or a USD 1,000,000 completed strata unit"

replacing wording that had dropped the two conditions that make the claim true (own-name + state-owned-bank on the deposit route; no figure at all on the property route, inviting readers to think a 130k purchase qualified).

## Authority

`research/secondhome/e33-fact-registry.json`:
- `e33_base_deposit_amount` — **confirmed**, JELAS: "USD 130,000 deposit in the applicant's own name at a state-owned (BUMN) Indonesian bank."
- `e33_base_property_alternative` — **confirmed**, BERSYARAT: "USD 1,000,000 qualifying property — completed strata unit (rumah susun / apartment) only; off-plan/leasehold do NOT qualify."

## Adversarial review (this PR, independent of the author)

I did not write this copy — a different seat did. I read both registry entries directly and attacked the new wording on four axes before shipping:

1. **Does it assert anything the registry does not confirm?** No. Three related facts are `unknown`/`pending` in the registry — whether the deposit must be blocked vs. merely evidenced, whether it may be split across banks, and which legal title type qualifies for the property route — and the new wording touches none of them in either direction. "Deposit... at a state-owned bank" is the registry's own phrasing, not an embellishment toward "frozen" or toward "just sitting there."
2. **Does it read as an OR of two independent routes?** Yes, in all four instances — no reading implies both are required or that the property route also needs $130k.
3. **Does "completed strata unit" mislead?** No — "completed" excludes off-plan and "strata unit" excludes villas/land by the term itself, without adding qualifying clauses that would re-inflate the teaser back toward the length the original fix was curing.
4. **Does anything now state or imply a price?** No — these are eligibility thresholds (what a reader must already hold to qualify), not the Bali Zero service fee, which does not appear on either surface.

Also ran the four new strings through `apps/backend-rag/backend/services/visa_check/e33_claim_guard.py::check_e33_claims` — zero matches against all ten forbidden patterns (any-bank, split-deposit, BSI-equivalence, automatic-KITAP, 5-10-years, etc.).

**Verdict: no defects found. No changes made beyond the inherited commit** — this PR ships the copy as written.

## Verification

- `npx tsc --noEmit` from `apps/mouth` — clean, exit 0.
- No test asserts on the old strings (`Buying property or keeping USD 130,000+ in savings?`, `$130,000+ in savings/investments?`, `$130k+ in bank/investments`) — searched `apps/mouth/src`, `e2e`, and `tests`; zero hits. `apps/mouth/src/app/visa/page.tsx` and the digital-nomad MDX have no dedicated test file, and `article-body-integrity.test.ts` (the one test that references this MDX) only floor-checks body length / tool-output leaks, not this copy. Nothing to update.

## Out of scope (carried forward from `003aa1b8f`)

Not in scope, and deliberately left: an independent sweep found the same loose shape across roughly eight more articles plus their id/ru translations ("proof of funds ... in an Indonesian bank account", "$130K proof of funds", an Rp 5 billion property threshold, and the E33A/E33B codes). Three of the four sampled are NOT noindexed, so they are live — but rewriting the article corpus is the tracked F7 editorial task, a different concern with different risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
