### PR TITLE
feat(garuda): build the truth-freshness authority (G-FRESHNESS-FAIL-CLOSED)

### DIFF
--- a/apps/admin-dashboard-local/lib/garuda-preview-adapter.ts
+++ b/apps/admin-dashboard-local/lib/garuda-preview-adapter.ts
@@ -32,6 +32,7 @@ const DECLINE_CODES = new Set([
   "ARRIVAL_TOO_FAR",
   "ARRIVAL_DATE_UNCONFIRMED",
   "EXTENSION_EXCEEDS_MAX_STAY",
+  "TRUTH_SHEET_STALE",
 ]);
 const BASE_WARNINGS = [
   "Internal preliminary pre-screen only; it is not an immigration decision or an approval guarantee.",

--- a/apps/backend-rag/backend/app/routers/garuda_voa_public.py
+++ b/apps/backend-rag/backend/app/routers/garuda_voa_public.py
@@ -229,14 +229,25 @@ def _set_result_session_cookie(response: Response, secret: str) -> None:
     )
 
 
-# TODO(ground, orchestrator-scoped — deliberately not this lane's to fix):
-# `x-truth-freshness-max-age-days` (nationality_eligibility / rule_constants /
-# price_catalogue) has no dated-source tracking anywhere in `garuda_flow`, so
-# nothing can currently emit TRUTH_SHEET_STALE or TRUTH_AUTHORITY_UNAVAILABLE.
-# The numbers are binding in the contract and the reader does not exist yet —
-# G-FRESHNESS-FAIL-CLOSED is declared and absent, and it stays with the
-# orchestrator on purpose: a freshness check implemented per-lane is how one
-# surface declines while another sells the same stale price.
+# UPDATE (orchestrator, `freshness.py`, G-FRESHNESS-FAIL-CLOSED): the reader
+# now exists. `intake.build_verdict` checks nationality_eligibility and
+# rule_constants freshness unconditionally and DECLINEs with the new
+# `DeclineCode.TRUTH_SHEET_STALE` when either is past its window — the SAME
+# shape as the calendar precedent immediately below (a 201 DECLINE via the
+# closed vocabulary, never a bare error), which is why the outcome reaches
+# this router exactly like any other DECLINE and needs no new branch here.
+# `pricing.price_for_case` checks price_catalogue freshness and returns its
+# EXISTING `(None, None)` fail-closed shape when stale, which this router
+# already turns into 503 PRICE_UNRESOLVABLE via `PriceUnresolvable` below —
+# also no new branch needed.
+#
+# Net effect: neither `TRUTH_SHEET_STALE` nor `TRUTH_AUTHORITY_UNAVAILABLE`
+# in `contracts/openapi.yaml`'s `x-error-codes` (503 shape) is ever emitted
+# by this design — they are now the SAME dead-declared-code situation the
+# paragraph below already resolved once for CALENDAR_COVERAGE_EXCEEDED.
+# Orchestrator-scoped, not this lane's to fix: whether to remove those two
+# codes from the frozen contract (contracts/** is orchestrator-only) is a
+# call for whoever owns that freeze, not a router change.
 #
 # The calendar half of this note is CLOSED. It used to name
 # CALENDAR_COVERAGE_EXCEEDED, a 503 the contract declared; the lane was right

--- a/apps/backend-rag/backend/services/garuda_flow/constants.py
+++ b/apps/backend-rag/backend/services/garuda_flow/constants.py
@@ -31,6 +31,24 @@ Every number here is traceable to a governance document, NOT invented:
 - ``INTERNAL_ESCALATION_DAYS`` (D-3) / ``FINAL_CHECK_DAYS`` (D-1): internal
   Bali Zero checkpoints only (SOP §6) — never quoted to clients.
 - ``MIN_PASSPORT_VALIDITY_DAYS`` (≥6 months from entry): SOP §1 + §4 checklist.
+- ``RULES_VERIFIED_ON``: the single machine-read stamp `freshness.py` reads for
+  the "rule constants" truth source (DECISIONS.md Q9 / GROUND.md §2 — D-7,
+  D-14, the eVOA usability window, and the max-total-stay convention). This
+  bundle has THREE different dates already in this docstring above —
+  2026-07-14 (eVOA usability window, ``## GARUDA B1 — fatti chiave`` line 41),
+  2026-07-24 (D-7/D-10, verified verbatim on ngurahrai.imigrasi.go.id), and
+  2026-08-23 (the max-total-stay day-counting CONVENTION, a code-correctness
+  verification, not a re-read of a regulation page). The stamp takes the
+  OLDEST of the two genuine source-verification dates — 2026-07-14 — never
+  the newest: a single stamp covering several facts is only honest if it
+  reports how long the WEAKEST-verified fact in the bundle has gone
+  unchecked, and taking the newest date would let one freshly-touched fact
+  (or, worse, an unrelated code fix like the 2026-08-23 entry) hide that the
+  others have not been looked at in longer. On a future re-verification pass,
+  bump this the same way ``nationality_eligibility.RETRIEVED_ON`` already
+  mandates in prose: re-source, re-check every constant this bundle covers,
+  and only then move the date — never hand-edit one constant and carry the
+  old stamp forward.
 - ``b1_max_total_stay_exceeded()``: B1 stay is counted with the arrival day AS
   DAY 1 — imigrasi.go.id's own B1 page states the initial stay is "maksimal 30
   hari, dihitung sejak tanggal kedatangan" (max 30 days, counted FROM the
@@ -66,6 +84,12 @@ MIN_PASSPORT_VALIDITY_DAYS: int = 180  # >= 6 months from entry (SOP §1/§4)
 # possible issuance date; the gate is therefore conservative.
 EVOA_USABILITY_WINDOW_DAYS: int = 90
 
+# G-FRESHNESS-FAIL-CLOSED (DECISIONS.md Q9) — see the module docstring entry
+# above for why this is 2026-07-14, the OLDEST of the bundle's dates, not the
+# newest. Read by `freshness.rule_constants_freshness`; never compared to
+# `today` anywhere else.
+RULES_VERIFIED_ON: str = "2026-07-14"
+
 
 def b1_max_total_stay_exceeded(day_difference: int, max_total_stay_days: int) -> bool:
     """Whether a B1 printed-expiry day-difference exceeds the legal max stay.
@@ -88,5 +112,6 @@ __all__ = [
     "MIN_PASSPORT_VALIDITY_DAYS",
     "PILOT_INTAKE_THRESHOLD_DAYS",
     "PUBLISHED_FILING_DEADLINE_DAYS",
+    "RULES_VERIFIED_ON",
     "b1_max_total_stay_exceeded",
 ]

--- a/apps/backend-rag/backend/services/garuda_flow/eligibility.py
+++ b/apps/backend-rag/backend/services/garuda_flow/eligibility.py
@@ -103,6 +103,19 @@ class DeclineCode(str, Enum):
     # boundary bug on the client-facing surface — here it is a DECLINE with
     # this neutral code, never a bare error.
     EXTENSION_EXCEEDS_MAX_STAY = "EXTENSION_EXCEEDS_MAX_STAY"
+    # Not emitted by `screen()` either — layered on by `intake.build_verdict`
+    # for G-FRESHNESS-FAIL-CLOSED (`freshness.py`, DECISIONS.md Q9): the
+    # decree-sourced nationality list or the D-7/D-14/eVOA-window/passport-
+    # validity rule bundle has gone unverified past its own re-verification
+    # window. This is the SAME pattern as `ARRIVAL_DATE_UNCONFIRMED` — the
+    # calendar's existing fail-closed path the freshness guard was designed
+    # to copy (GROUND.md §2): a normal DECLINE via this closed vocabulary,
+    # never a bare error and never a guessed answer built on data nobody has
+    # looked at recently. Reuses the exact token
+    # `contracts/openapi.yaml`'s `x-error-codes` already names for the
+    # (currently unwired) 503 shape of the same guardrail — same vocabulary,
+    # different layer, deliberately not two invented words for one concept.
+    TRUTH_SHEET_STALE = "TRUTH_SHEET_STALE"
 
 
 @dataclass(frozen=True)

--- a/apps/backend-rag/backend/services/garuda_flow/freshness.py
+++ b/apps/backend-rag/backend/services/garuda_flow/freshness.py
@@ -1,0 +1,236 @@
+"""GARUDA VOA — the truth-freshness authority (pure; the registry wraps I/O).
+
+`products/garuda-voa/product.yaml` declares a guardrail, ``G-FRESHNESS-FAIL-
+CLOSED``, that has never had a reader. `DECISIONS.md` Q9 decided the windows
+in prose; the contract freeze put them into `contracts/openapi.yaml` as
+``x-truth-freshness-max-age-days``; and `GROUND.md` §2 confirmed that nothing
+in `garuda_flow` compares ``today`` against any of the three dated sources
+that exist (``nationality_eligibility.RETRIEVED_ON`` was read by nothing;
+the rule constants had no single stamp at all; the price catalogue's
+``metadata.last_updated`` was read by a different service entirely). This
+module is that reader — the ONE place age-vs-window is computed, so a
+freshness check implemented per-lane cannot let one surface decline while
+another sells the same stale price.
+
+This module is orchestrator-owned, cross-cutting, and deliberately narrow:
+it does not decide what a caller does with a stale verdict (that is
+`intake.build_verdict` for the nationality/rule-constants sources, and
+`pricing.price_for_case` for the price catalogue — see those modules).
+
+Design decisions, made explicit because each has a defensible alternative
+that was NOT chosen, and an untested alternative left in a guardrail is
+exactly the defect this module exists to close:
+
+- **The boundary.** Staleness is ``today - stamp > max_age_days`` — strict
+  greater-than. A source re-verified on day 0 stays FRESH through the whole
+  of day ``max_age_days`` and only goes STALE the day after. The window
+  itself IS the safety margin `DECISIONS.md` Q9 chose ("the longest we could
+  defend having not looked"); reading it as an inclusive ``<=`` cutoff would
+  quietly shave a day off a number the owner already picked deliberately.
+- **Fail-closed on absence and on garbage.** A missing stamp, a stamp that
+  is not a string, a string that is not a parseable ISO date, or a stamp
+  accessor that raises are ALL treated as STALE — never as fresh. "I could
+  not tell" must never read as "fine"; that is the entire point of a
+  freshness guard, and a guard that treats an unreadable signal as a green
+  light is worse than no guard (it actively hides the failure it exists to
+  catch).
+- **A stamp dated after `today` is not special-cased.** In real production
+  traffic this cannot happen — `today` is always
+  `civil_clock.garuda_today()`, a wall clock that only advances, and a
+  ``RETRIEVED_ON``/``RULES_VERIFIED_ON`` stamp is always in the past at the
+  moment it is committed. It DOES happen routinely in this engine's own test
+  suite, where fixed historical ``today`` values predate a truth source that
+  was verified (or re-verified) later in this repository's real history.
+  Rather than invent a third state for an impossible-in-production but
+  common-in-fixtures shape, the plain arithmetic comparison is used as-is:
+  a negative age is never ``> max_age_days``, so it reads as FRESH. This is
+  a considered choice, not an oversight — see
+  ``test_a_future_stamp_reads_as_fresh_not_as_an_error`` in
+  ``test_freshness.py``.
+- **The windows live here, in Python, as the single source of truth**
+  (``MAX_AGE_DAYS``). Runtime code never parses the frozen OpenAPI contract;
+  instead ``test_freshness_windows_match_the_frozen_contract`` (in
+  ``test_freshness.py``) reads `contracts/openapi.yaml`'s
+  ``x-truth-freshness-max-age-days`` block and asserts the two agree, so the
+  contract and the code can never drift silently in either direction.
+- **The operating calendar is deliberately NOT a member of this registry.**
+  It already enforces its own bound (`operating_calendar.COVERAGE_START` /
+  `COVERAGE_END`) and is the pattern the other three sources copy (Q9);
+  adding it here would just be a second, redundant clock on the same fact.
+
+PURE in the narrow sense the rest of this engine uses the word: no network
+call, and every comparison takes ``today`` as an explicit parameter (never
+reads a clock itself — see `civil_clock.py`). It is NOT free of I/O in the
+broader sense: the two convenience readers below import
+`nationality_eligibility` / `constants` to read their string constants, and
+a stamp accessor a caller supplies (e.g. `pricing.py`'s catalogue reader) may
+do real file I/O. ``check_freshness`` treats any such access uniformly and
+never assumes it is cheap or side-effect-free.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+
+__all__ = [
+    "MAX_AGE_DAYS",
+    "FreshnessReport",
+    "FreshnessVerdict",
+    "check_freshness",
+    "nationality_eligibility_freshness",
+    "render_report",
+    "rule_constants_freshness",
+]
+
+
+class FreshnessVerdict(str, Enum):
+    FRESH = "FRESH"
+    STALE = "STALE"
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessReport:
+    """The outcome for ONE truth source, plus enough to explain it to staff.
+
+    ``detail`` is a human-readable diagnostic for the reporter script and
+    logs — never serialized to a visitor (this engine's house rule: only a
+    closed, neutral machine vocabulary crosses the wire, same as
+    `eligibility.DeclineCode`).
+    """
+
+    source: str
+    verdict: FreshnessVerdict
+    stamp: str | None
+    age_days: int | None  # None only when the stamp could not be parsed at all
+    max_age_days: int
+    detail: str
+
+    @property
+    def stale(self) -> bool:
+        return self.verdict is FreshnessVerdict.STALE
+
+
+# DECISIONS.md Q9 / contracts/openapi.yaml `x-truth-freshness-max-age-days`.
+# SINGLE SOURCE OF TRUTH for the three numbers — the contract mirrors this,
+# not the other way around. `test_freshness_windows_match_the_frozen_contract`
+# pins the two together so they cannot silently drift.
+MAX_AGE_DAYS: dict[str, int] = {
+    "nationality_eligibility": 90,
+    "rule_constants": 180,
+    "price_catalogue": 90,
+}
+
+
+def _parse_iso_date(raw: object) -> date | None:
+    if not isinstance(raw, str):
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def check_freshness(
+    *,
+    source: str,
+    stamp_accessor: Callable[[], object],
+    max_age_days: int,
+    today: date,
+) -> FreshnessReport:
+    """Evaluate ONE truth source against ``today``. Never raises.
+
+    ``stamp_accessor`` is called exactly once. Any exception it raises is
+    itself treated as STALE (fail-closed on "I could not tell" — see the
+    module docstring) rather than propagated: a truth-freshness check must
+    never be the reason an unrelated request 500s.
+    """
+    try:
+        raw_stamp = stamp_accessor()
+    except Exception as exc:  # deliberate broad catch: any failure => STALE, never propagated
+        return FreshnessReport(
+            source=source,
+            verdict=FreshnessVerdict.STALE,
+            stamp=None,
+            age_days=None,
+            max_age_days=max_age_days,
+            detail=f"stamp accessor raised {exc.__class__.__name__}: {exc}",
+        )
+
+    stamp_str = raw_stamp if isinstance(raw_stamp, str) else None
+    parsed = _parse_iso_date(raw_stamp)
+    if parsed is None:
+        detail = (
+            "stamp is missing"
+            if raw_stamp is None
+            else f"stamp {raw_stamp!r} is not a parseable ISO date (YYYY-MM-DD)"
+        )
+        return FreshnessReport(
+            source=source,
+            verdict=FreshnessVerdict.STALE,
+            stamp=stamp_str,
+            age_days=None,
+            max_age_days=max_age_days,
+            detail=detail,
+        )
+
+    age_days = (today - parsed).days
+    verdict = FreshnessVerdict.STALE if age_days > max_age_days else FreshnessVerdict.FRESH
+    return FreshnessReport(
+        source=source,
+        verdict=verdict,
+        stamp=stamp_str,
+        age_days=age_days,
+        max_age_days=max_age_days,
+        detail=f"age {age_days}d vs max {max_age_days}d -> {verdict.value}",
+    )
+
+
+def _nationality_eligibility_stamp() -> object:
+    from backend.services.garuda_flow.nationality_eligibility import RETRIEVED_ON
+
+    return RETRIEVED_ON
+
+
+def nationality_eligibility_freshness(*, today: date) -> FreshnessReport:
+    """Freshness of the decree-sourced VOA-eligible-nationality list."""
+    return check_freshness(
+        source="nationality_eligibility",
+        stamp_accessor=_nationality_eligibility_stamp,
+        max_age_days=MAX_AGE_DAYS["nationality_eligibility"],
+        today=today,
+    )
+
+
+def _rule_constants_stamp() -> object:
+    from backend.services.garuda_flow.constants import RULES_VERIFIED_ON
+
+    return RULES_VERIFIED_ON
+
+
+def rule_constants_freshness(*, today: date) -> FreshnessReport:
+    """Freshness of the D-7/D-14/eVOA-window/passport-validity rule bundle."""
+    return check_freshness(
+        source="rule_constants",
+        stamp_accessor=_rule_constants_stamp,
+        max_age_days=MAX_AGE_DAYS["rule_constants"],
+        today=today,
+    )
+
+
+def render_report(reports: list[FreshnessReport]) -> str:
+    """One human-readable line per source — the shape the diagnostic script
+    and any future ops dashboard print. Never used to drive a decision;
+    ``FreshnessReport.stale`` is the only thing callers should branch on.
+    """
+    lines = []
+    for report in reports:
+        stamp = report.stamp if report.stamp is not None else "(missing)"
+        age = f"{report.age_days}d" if report.age_days is not None else "n/a"
+        lines.append(
+            f"{report.source:<24} stamp={stamp:<12} age={age:<6} "
+            f"max={report.max_age_days}d -> {report.verdict.value}  ({report.detail})"
+        )
+    return "\n".join(lines)

--- a/apps/backend-rag/backend/services/garuda_flow/freshness_report.py
+++ b/apps/backend-rag/backend/services/garuda_flow/freshness_report.py
@@ -1,0 +1,53 @@
+"""GARUDA VOA — read-only truth-freshness diagnostic.
+
+This is NOT a test. A test that asserted the real catalogue's current
+freshness state would pass today and go red the day someone re-stamps the
+file — a time bomb that trains people to edit tests instead of data. This
+script exists precisely so a human can ask "what is the real state right
+now?" without that trap: it prints each of the three truth sources
+`freshness.py` tracks, its stamp, its age, and its verdict, using the real
+engine clock (`civil_clock.garuda_today()`) and the real, loaded price
+catalogue. It is allowed to print STALE.
+
+Run from ``apps/backend-rag``::
+
+    .venv/bin/python -m backend.services.garuda_flow.freshness_report
+"""
+
+from __future__ import annotations
+
+import sys
+
+from backend.services.garuda_flow import freshness
+from backend.services.garuda_flow.civil_clock import garuda_today
+from backend.services.garuda_flow.pricing import price_catalogue_freshness
+
+
+def collect_real_reports() -> list[freshness.FreshnessReport]:
+    """The real, current freshness state of all three tracked truth sources."""
+    today = garuda_today()
+    return [
+        freshness.nationality_eligibility_freshness(today=today),
+        freshness.rule_constants_freshness(today=today),
+        price_catalogue_freshness(today=today),
+    ]
+
+
+def main() -> int:
+    reports = collect_real_reports()
+    today = garuda_today()
+    print(f"GARUDA VOA truth-freshness — as of {today.isoformat()} (Asia/Makassar)\n")
+    print(freshness.render_report(reports))
+    stale = [r for r in reports if r.stale]
+    if stale:
+        print(
+            f"\n{len(stale)} of {len(reports)} truth source(s) STALE — "
+            "build_verdict/price_for_case will decline to sell/quote on these."
+        )
+        return 1
+    print(f"\nAll {len(reports)} truth sources FRESH.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/backend-rag/backend/services/garuda_flow/intake.py
+++ b/apps/backend-rag/backend/services/garuda_flow/intake.py
@@ -70,7 +70,7 @@ from dataclasses import dataclass, field
 from datetime import date, timedelta
 from enum import Enum
 
-from backend.services.garuda_flow import operating_calendar
+from backend.services.garuda_flow import freshness, operating_calendar
 from backend.services.garuda_flow.constants import (
     EVOA_USABILITY_WINDOW_DAYS,
     MIN_PASSPORT_VALIDITY_DAYS,
@@ -213,6 +213,13 @@ _MAX_STAY_EXCEEDED_REASON_TEMPLATE = (
     "hand off to the ordinary channel"
 )
 
+_TRUTH_SHEET_STALE_REASON_TEMPLATE = (
+    "truth source '{source}' has not been re-verified within its "
+    "{max_age_days}-day window (last stamp: {stamp}, age: {age_days}d) — "
+    "declining to sell on data nobody has looked at recently, hand off to "
+    "the ordinary channel"
+)
+
 
 def _issuance_submission_verdict(
     *, entry_date: date, today: date
@@ -319,6 +326,33 @@ def build_verdict(request: VoaIntakeRequest, *, today: date) -> VoaVerdict:
     decision = result.decision
     reasons = list(result.decline_reasons)
     codes = list(result.decline_codes)
+
+    # G-FRESHNESS-FAIL-CLOSED (DECISIONS.md Q9, `freshness.py`): the two
+    # truth sources every case shape depends on regardless of
+    # issuance/extension — the decree-sourced nationality list and the D-7/
+    # D-14/eVOA-window/passport-validity rule bundle — must have been
+    # re-verified inside their own window, or this DECLINEs exactly like the
+    # operating calendar's existing fail-closed path (GROUND.md §2). This is
+    # unconditional and checked first, but it does NOT short-circuit the
+    # collection below (house style, per `eligibility.screen`'s own
+    # docstring: never short-circuit, collect every failing reason) — a
+    # decline built on stale data should still show what ELSE was wrong, not
+    # hide it behind the staleness.
+    for report in (
+        freshness.nationality_eligibility_freshness(today=today),
+        freshness.rule_constants_freshness(today=today),
+    ):
+        if report.stale:
+            decision = Decision.DECLINE
+            reasons.append(
+                _TRUTH_SHEET_STALE_REASON_TEMPLATE.format(
+                    source=report.source,
+                    max_age_days=report.max_age_days,
+                    stamp=report.stamp,
+                    age_days=report.age_days,
+                )
+            )
+            codes.append(DeclineCode.TRUTH_SHEET_STALE.value)
 
     # Computed up front (moved ahead of the layered checks below, 2026-08-23)
     # so the max-total-stay guard can reuse `max_total_days` — the same

--- a/apps/backend-rag/backend/services/garuda_flow/internal_preview_cli.py
+++ b/apps/backend-rag/backend/services/garuda_flow/internal_preview_cli.py
@@ -163,7 +163,7 @@ def build_internal_preview(
         extension_already_used=request.extension_already_used,
     )
     verdict = build_verdict(intake, today=today)
-    price_idr, price_source = price_for_case(request.case_type)
+    price_idr, price_source = price_for_case(request.case_type, today=today)
     price_status: Literal["confirmed", "unavailable"] = (
         "confirmed"
         if price_idr is not None and price_source is not None

--- a/apps/backend-rag/backend/services/garuda_flow/pricing.py
+++ b/apps/backend-rag/backend/services/garuda_flow/pricing.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import date
 
+from backend.services.garuda_flow import freshness
 from backend.services.garuda_flow.intake import CaseType
 from backend.services.pricing.pricing_service import PricingService
 
@@ -17,6 +19,44 @@ logger = logging.getLogger(__name__)
 _ISSUANCE_PRICE_KEY = "B1 Visa on Arrival (VOA)"
 _EXTENSION_PRICE_KEY = "B1 Visa on Arrival Extension"
 _pricing = PricingService()
+
+
+def catalogue_last_updated_stamp(service: PricingService | object) -> object:
+    """Raw ``metadata.last_updated`` from the loaded catalogue, unvalidated.
+
+    Deliberately does no validation of its own — ``freshness.check_freshness``
+    owns "is this a good stamp"; this only reaches into whatever object it is
+    handed (the real `PricingService`, or a test double that may not even
+    carry a ``prices`` attribute — ``getattr`` with a dict default keeps that
+    case a clean "no stamp" rather than an `AttributeError`).
+    """
+    prices = getattr(service, "prices", None)
+    if not isinstance(prices, dict):
+        return None
+    metadata = prices.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    return metadata.get("last_updated")
+
+
+def price_catalogue_freshness(
+    *, today: date, service: PricingService | None = None
+) -> freshness.FreshnessReport:
+    """Freshness of the ``service`` catalogue's ``metadata.last_updated``.
+
+    A named function (rather than an inline `freshness.check_freshness` call
+    inside `price_for_case`) so it can be monkeypatched independently, the
+    same way `freshness.nationality_eligibility_freshness` /
+    `rule_constants_freshness` are — see
+    `tests/services/garuda_flow/conftest.py`.
+    """
+    resolved = service or _pricing
+    return freshness.check_freshness(
+        source="price_catalogue",
+        stamp_accessor=lambda: catalogue_last_updated_stamp(resolved),
+        max_age_days=freshness.MAX_AGE_DAYS["price_catalogue"],
+        today=today,
+    )
 
 
 def _positive_idr_amount(value: object) -> int | None:
@@ -33,15 +73,30 @@ def price_for_case(
     case_type: CaseType,
     *,
     pricing: PricingService | None = None,
+    today: date,
 ) -> tuple[int | None, str | None]:
     """Return the official ``(amount_idr, catalogue_key)`` for a B1 case.
 
     ``None`` values are deliberate fail-safe output: callers must ask staff to
-    confirm rather than invent a price when the official catalogue is absent
-    or cannot be matched.
+    confirm rather than invent a price when the official catalogue is absent,
+    cannot be matched, OR has not been re-verified within its freshness
+    window (G-FRESHNESS-FAIL-CLOSED, DECISIONS.md Q9, `freshness.py`) —
+    exactly the existing "no price" shape, never a new one. ``today`` is
+    caller-supplied (never a clock read here), matching every other
+    date-taking function in this engine.
     """
 
     service = pricing or _pricing
+
+    freshness_report = price_catalogue_freshness(today=today, service=service)
+    if freshness_report.stale:
+        logger.warning(
+            "garuda_flow: price catalogue stale for case_type=%s (%s) — declining to quote",
+            case_type.value,
+            freshness_report.detail,
+        )
+        return None, None
+
     key = _EXTENSION_PRICE_KEY if case_type is CaseType.EXTENSION else _ISSUANCE_PRICE_KEY
     try:
         row = service.get_service_by_key(key)
@@ -58,4 +113,4 @@ def price_for_case(
     return amount, key
 
 
-__all__ = ["price_for_case"]
+__all__ = ["catalogue_last_updated_stamp", "price_catalogue_freshness", "price_for_case"]

--- a/apps/backend-rag/backend/services/garuda_flow/public_api.py
+++ b/apps/backend-rag/backend/services/garuda_flow/public_api.py
@@ -147,7 +147,7 @@ def evaluate_public_check(
     if not verdict.accepted:
         return EligibilityCheckOutcome(accepted=False, reason_codes=reason_codes)
 
-    amount, source = price_for_case(case_type)
+    amount, source = price_for_case(case_type, today=today)
     if amount is None:
         raise PriceUnresolvable(f"no catalogue price for case_type={case_type.value}")
 

--- a/apps/backend-rag/backend/tests/services/garuda_flow/conftest.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/conftest.py
@@ -1,0 +1,72 @@
+"""Shared fixtures for the `garuda_flow` test package.
+
+`freshness.py` (G-FRESHNESS-FAIL-CLOSED, DECISIONS.md Q9) makes
+`intake.build_verdict` DECLINE, and `pricing.price_for_case` decline to
+quote, whenever a real stamp — `nationality_eligibility.RETRIEVED_ON`,
+`constants.RULES_VERIFIED_ON`, or the real price catalogue's
+``metadata.last_updated`` — is older than its window relative to the
+``today`` a test passes in. Most tests in this package fix a historical
+``today`` (or, for pricing, use the real wall clock at `civil_clock.
+garuda_today()` at time of writing) to exercise engine behaviour that has
+nothing to do with freshness — calendar cutoffs, passport validity,
+extension limits, real-catalogue price-key wiring. Several of those dates
+already fall outside one or more real windows (December 2026 is >90 days
+past the nationality list's 2026-08-23 retrieval; the real price catalogue's
+2026-05-06 stamp is well past its own 90-day window as of this writing), and
+every one of them will eventually fall outside the rest as this repository's
+calendar advances. Left unpinned, that would flip an unrelated ACCEPT to
+DECLINE (or a confirmed price to "unavailable") out from under a test that
+was never about freshness in the first place.
+
+This autouse fixture pins all three checks to FRESH for every test in this
+package by default, so freshness is tested ONLY where it is the point of the
+test:
+
+- `test_freshness.py` for the `check_freshness`/registry mechanism,
+- `TestTruthFreshnessGate` in `test_intake.py` for the `build_verdict`
+  integration (nationality/rule-constants),
+- `TestPriceCatalogueFreshnessGate` in `test_pricing.py` for the
+  `price_for_case` integration (price catalogue).
+
+A test that needs the STALE path, or the REAL unpatched function, calls
+`monkeypatch.setattr` (or `monkeypatch.undo()`) again on top of this fixture
+within its own body — the same `monkeypatch` fixture instance restores the
+TRUE original at teardown regardless of how many times it was re-patched
+inside one test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.garuda_flow import freshness, pricing
+
+
+def _fresh_report(source: str) -> freshness.FreshnessReport:
+    return freshness.FreshnessReport(
+        source=source,
+        verdict=freshness.FreshnessVerdict.FRESH,
+        stamp="2026-01-01",
+        age_days=0,
+        max_age_days=freshness.MAX_AGE_DAYS[source],
+        detail="conftest fixture: forced fresh for a test unrelated to freshness",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _assume_truth_sheets_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        freshness,
+        "nationality_eligibility_freshness",
+        lambda *, today: _fresh_report("nationality_eligibility"),
+    )
+    monkeypatch.setattr(
+        freshness,
+        "rule_constants_freshness",
+        lambda *, today: _fresh_report("rule_constants"),
+    )
+    monkeypatch.setattr(
+        pricing,
+        "price_catalogue_freshness",
+        lambda *, today, service=None: _fresh_report("price_catalogue"),
+    )

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_freshness.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_freshness.py
@@ -1,0 +1,213 @@
+"""Tests for the truth-freshness authority (G-FRESHNESS-FAIL-CLOSED, `freshness.py`).
+
+Every guard here is proven to bite: each mechanism test below exercises BOTH
+sides of the boundary it names (the literal red a broken guard would produce
+IS the STALE-when-it-should-be-FRESH / FRESH-when-it-should-be-STALE case;
+the literal green is the correct verdict on each side).
+
+This file deliberately does NOT assert the real catalogue's, the real
+nationality list's, or the real rule bundle's CURRENT freshness state
+relative to the real wall clock — such an assertion passes today and goes
+red the day someone re-stamps the file, training people to edit the test
+instead of the data. `freshness_report.py` is the read-only diagnostic for
+"what is the real state right now"; this file tests the MECHANISM with
+injected/synthetic stamps and dates only.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from backend.services.garuda_flow import freshness
+from backend.services.garuda_flow.constants import RULES_VERIFIED_ON
+from backend.services.garuda_flow.nationality_eligibility import RETRIEVED_ON
+
+_SOURCE = "test_source"
+_MAX_AGE = 90
+_STAMP_DATE = date(2026, 1, 1)
+_STAMP_STR = _STAMP_DATE.isoformat()
+
+
+def _check(*, stamp: object, today: date, max_age_days: int = _MAX_AGE) -> freshness.FreshnessReport:
+    return freshness.check_freshness(
+        source=_SOURCE,
+        stamp_accessor=lambda: stamp,
+        max_age_days=max_age_days,
+        today=today,
+    )
+
+
+class TestBoundary:
+    """`today - stamp > max_age_days` — strict greater-than.
+
+    A source re-verified on day 0 stays FRESH through the entire window and
+    only goes STALE the day after — never on the boundary day itself.
+    """
+
+    def test_age_exactly_at_the_window_is_fresh(self) -> None:
+        today = date(2026, 4, 1)  # exactly 90 days after 2026-01-01
+        assert (today - _STAMP_DATE).days == _MAX_AGE
+        report = _check(stamp=_STAMP_STR, today=today)
+        assert report.verdict is freshness.FreshnessVerdict.FRESH
+        assert not report.stale
+        assert report.age_days == _MAX_AGE
+
+    def test_one_day_past_the_window_is_stale(self) -> None:
+        today = date(2026, 4, 2)  # 91 days after 2026-01-01
+        assert (today - _STAMP_DATE).days == _MAX_AGE + 1
+        report = _check(stamp=_STAMP_STR, today=today)
+        assert report.verdict is freshness.FreshnessVerdict.STALE
+        assert report.stale
+        assert report.age_days == _MAX_AGE + 1
+
+    def test_one_day_before_the_window_boundary_is_fresh(self) -> None:
+        today = date(2026, 3, 31)  # 89 days after 2026-01-01
+        report = _check(stamp=_STAMP_STR, today=today)
+        assert not report.stale
+
+    def test_verified_today_is_fresh(self) -> None:
+        report = _check(stamp=_STAMP_STR, today=_STAMP_DATE)
+        assert not report.stale
+        assert report.age_days == 0
+
+
+class TestFailClosedOnAbsenceAndGarbage:
+    """Missing, malformed, or exception-raising stamps must ALL read STALE —
+    "I could not tell" must never read as "fine"."""
+
+    def test_missing_stamp_is_stale(self) -> None:
+        report = _check(stamp=None, today=date(2026, 1, 2))
+        assert report.stale
+        assert report.age_days is None
+        assert "missing" in report.detail
+
+    def test_non_string_stamp_is_stale(self) -> None:
+        report = _check(stamp=20260101, today=date(2026, 1, 2))
+        assert report.stale
+        assert report.age_days is None
+
+    def test_malformed_iso_string_is_stale(self) -> None:
+        report = _check(stamp="not-a-date", today=date(2026, 1, 2))
+        assert report.stale
+        assert report.age_days is None
+
+    def test_wrong_format_date_string_is_stale(self) -> None:
+        report = _check(stamp="01/01/2026", today=date(2026, 1, 2))
+        assert report.stale
+
+    def test_accessor_that_raises_is_stale_not_propagated(self) -> None:
+        def _boom() -> object:
+            raise RuntimeError("catalogue unreadable")
+
+        report = freshness.check_freshness(
+            source=_SOURCE,
+            stamp_accessor=_boom,
+            max_age_days=_MAX_AGE,
+            today=date(2026, 1, 2),
+        )
+        assert report.stale
+        assert report.stamp is None
+        assert "RuntimeError" in report.detail
+
+    def test_a_future_stamp_reads_as_fresh_not_as_an_error(self) -> None:
+        """Design decision (see freshness.py module docstring): a stamp
+        dated after ``today`` cannot happen in real production traffic
+        (`civil_clock.garuda_today()` only advances), but does happen
+        routinely in this engine's own test fixtures that fix a historical
+        ``today``. The plain arithmetic comparison is used as-is rather than
+        inventing a third state for it."""
+        today = date(2025, 6, 1)
+        report = _check(stamp=_STAMP_STR, today=today)
+        assert (today - _STAMP_DATE).days < 0
+        assert not report.stale
+
+
+class TestRegistryWiring:
+    """The two convenience readers wire to the REAL module constants — but
+    the ``today`` used here is synthetic and chosen relative to those fixed
+    constants, never the real wall clock, so this never asserts "the real
+    current state".
+
+    ``conftest.py``'s autouse fixture pins both readers to a canned FRESH
+    report for every other file's engine tests (so a real stamp aging past
+    its window can't flip an unrelated ACCEPT/DECLINE assertion elsewhere
+    out from under it) — that fixture also applies here since this file
+    lives in the same package, so every test below starts with
+    ``monkeypatch.undo()`` to reach the REAL functions this class exists to
+    test.
+    """
+
+    def test_nationality_eligibility_freshness_reads_the_real_stamp(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        stamp_date = date.fromisoformat(RETRIEVED_ON)
+        fresh = freshness.nationality_eligibility_freshness(today=stamp_date)
+        assert fresh.stamp == RETRIEVED_ON
+        assert fresh.max_age_days == freshness.MAX_AGE_DAYS["nationality_eligibility"]
+        assert not fresh.stale
+
+    def test_nationality_eligibility_freshness_goes_stale_past_its_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        from datetime import timedelta
+
+        stamp_date = date.fromisoformat(RETRIEVED_ON)
+        window = freshness.MAX_AGE_DAYS["nationality_eligibility"]
+        stale = freshness.nationality_eligibility_freshness(
+            today=stamp_date + timedelta(days=window + 1)
+        )
+        assert stale.stale
+
+    def test_rule_constants_freshness_reads_the_real_stamp(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        stamp_date = date.fromisoformat(RULES_VERIFIED_ON)
+        fresh = freshness.rule_constants_freshness(today=stamp_date)
+        assert fresh.stamp == RULES_VERIFIED_ON
+        assert fresh.max_age_days == freshness.MAX_AGE_DAYS["rule_constants"]
+        assert not fresh.stale
+
+    def test_rule_constants_freshness_goes_stale_past_its_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        from datetime import timedelta
+
+        stamp_date = date.fromisoformat(RULES_VERIFIED_ON)
+        window = freshness.MAX_AGE_DAYS["rule_constants"]
+        stale = freshness.rule_constants_freshness(today=stamp_date + timedelta(days=window + 1))
+        assert stale.stale
+
+
+def _repo_root() -> Path:
+    """Find the worktree root without depending on pytest's current directory
+    (same pattern as `test_preview_adapter_parity.py::_repo_root`)."""
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / ".git").exists():
+            return candidate
+    raise AssertionError("repository root: no parent containing .git")
+
+
+def test_freshness_windows_match_the_frozen_contract() -> None:
+    """`freshness.MAX_AGE_DAYS` is the single source of truth in Python;
+    `contracts/openapi.yaml`'s `x-truth-freshness-max-age-days` mirrors it.
+    This pins the two together so they cannot silently drift in either
+    direction — the contract is read here, never touched."""
+    yaml = pytest.importorskip("yaml")
+    contract_path = _repo_root() / "products/garuda-voa/contracts/openapi.yaml"
+    assert contract_path.is_file(), f"contract missing: {contract_path}"
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    contract_windows = contract["x-truth-freshness-max-age-days"]
+
+    assert contract_windows == freshness.MAX_AGE_DAYS, (
+        "freshness.MAX_AGE_DAYS has drifted from "
+        "contracts/openapi.yaml's x-truth-freshness-max-age-days — the contract is "
+        "frozen (orchestrator-only); fix the Python side to match it, never the "
+        "other way around from this lane."
+    )

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_intake.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_intake.py
@@ -12,6 +12,7 @@ from datetime import date, timedelta
 
 import pytest
 
+from backend.services.garuda_flow import freshness
 from backend.services.garuda_flow.constants import (
     EVOA_USABILITY_WINDOW_DAYS,
     MIN_PASSPORT_VALIDITY_DAYS,
@@ -525,3 +526,105 @@ class TestPurity:
         assert v1.decision == v2.decision
         assert v1.decline_reasons == v2.decline_reasons
         assert v1.stay_window == v2.stay_window
+
+
+class TestTruthFreshnessGate:
+    """G-FRESHNESS-FAIL-CLOSED (DECISIONS.md Q9, `freshness.py`) at the
+    `build_verdict` integration point. `conftest.py`'s autouse fixture pins
+    both checks to FRESH for every OTHER test in this file — these tests
+    override that pin, on top of it, to exercise the STALE path
+    specifically. Proven to bite both ways: an otherwise-ACCEPT request
+    DECLINEs the moment either dependency goes stale, and reverts to its
+    original verdict the moment freshness is restored.
+    """
+
+    def _stale(self, source: str) -> freshness.FreshnessReport:
+        return freshness.FreshnessReport(
+            source=source,
+            verdict=freshness.FreshnessVerdict.STALE,
+            stamp="2020-01-01",
+            age_days=9999,
+            max_age_days=freshness.MAX_AGE_DAYS[source],
+            detail="test: forced stale",
+        )
+
+    def test_stale_nationality_eligibility_declines_an_otherwise_accepted_case(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        baseline = build_verdict(_issuance(), today=_TODAY)
+        assert baseline.accepted is True  # sanity: this request is a real ACCEPT
+
+        monkeypatch.setattr(
+            freshness,
+            "nationality_eligibility_freshness",
+            lambda *, today: self._stale("nationality_eligibility"),
+        )
+        verdict = build_verdict(_issuance(), today=_TODAY)
+        assert verdict.decision is Decision.DECLINE
+        assert "TRUTH_SHEET_STALE" in verdict.decline_codes
+
+    def test_stale_rule_constants_declines_an_otherwise_accepted_case(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        baseline = build_verdict(_issuance(), today=_TODAY)
+        assert baseline.accepted is True
+
+        monkeypatch.setattr(
+            freshness,
+            "rule_constants_freshness",
+            lambda *, today: self._stale("rule_constants"),
+        )
+        verdict = build_verdict(_issuance(), today=_TODAY)
+        assert verdict.decision is Decision.DECLINE
+        assert "TRUTH_SHEET_STALE" in verdict.decline_codes
+
+    def test_restoring_freshness_restores_the_original_verdict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The other direction of the same guard: once patched back to FRESH
+        # (conftest's own default, reapplied here explicitly for clarity),
+        # the request accepts again exactly as it did before the gate ever
+        # ran — the guard adds a decline path, it does not change the
+        # underlying eligibility computation.
+        monkeypatch.setattr(
+            freshness,
+            "nationality_eligibility_freshness",
+            lambda *, today: self._stale("nationality_eligibility"),
+        )
+        assert build_verdict(_issuance(), today=_TODAY).decision is Decision.DECLINE
+
+        monkeypatch.undo()
+        assert build_verdict(_issuance(), today=_TODAY).accepted is True
+
+    def test_stale_source_does_not_suppress_other_decline_reasons(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # House style: never short-circuit, collect every failing reason.
+        # A request that is ALSO ineligible on nationality must show BOTH
+        # codes when the truth sheet is stale, not just one.
+        monkeypatch.setattr(
+            freshness,
+            "nationality_eligibility_freshness",
+            lambda *, today: self._stale("nationality_eligibility"),
+        )
+        verdict = build_verdict(_issuance(nationality="PRK"), today=_TODAY)
+        assert verdict.decision is Decision.DECLINE
+        assert "TRUTH_SHEET_STALE" in verdict.decline_codes
+        assert "NATIONALITY_NOT_ELIGIBLE" in verdict.decline_codes
+
+    def test_extension_path_is_also_covered_by_the_gate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Unconditional per DECISIONS.md Q9 — both case shapes depend on
+        # the rule bundle, not issuance alone.
+        baseline = build_verdict(_extension(), today=_TODAY)
+        assert baseline.accepted is True
+
+        monkeypatch.setattr(
+            freshness,
+            "rule_constants_freshness",
+            lambda *, today: self._stale("rule_constants"),
+        )
+        verdict = build_verdict(_extension(), today=_TODAY)
+        assert verdict.decision is Decision.DECLINE
+        assert "TRUTH_SHEET_STALE" in verdict.decline_codes

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_internal_preview_cli.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_internal_preview_cli.py
@@ -66,7 +66,7 @@ def test_unavailable_price_is_explicit_and_requires_staff_confirmation(
 ) -> None:
     monkeypatch.setattr(
         "backend.services.garuda_flow.internal_preview_cli.price_for_case",
-        lambda _case_type: (None, None),
+        lambda _case_type, **_kwargs: (None, None),
     )
 
     response = build_internal_preview(_request(), today=_TODAY, generated_at=_NOW)

--- a/apps/backend-rag/backend/tests/services/garuda_flow/test_pricing.py
+++ b/apps/backend-rag/backend/tests/services/garuda_flow/test_pricing.py
@@ -2,18 +2,29 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
 
 import pytest
 
 from backend.services.garuda_flow.intake import CaseType
-from backend.services.garuda_flow.pricing import price_for_case
+from backend.services.garuda_flow.pricing import catalogue_last_updated_stamp, price_for_case
+
+# A fixed, fresh-relative pair used by every test below that isn't
+# specifically exercising the freshness gate itself (that's
+# `TestPriceCatalogueFreshnessGate`) — chosen well inside the 90-day
+# `price_catalogue` window so those tests stay about key-matching, not dates.
+_FRESH_LAST_UPDATED = "2026-01-01"
+_TODAY_WITHIN_WINDOW = date(2026, 1, 15)
 
 
 class _PricingStub:
-    def __init__(self, row: object) -> None:
+    def __init__(self, row: object, *, last_updated: str | None = _FRESH_LAST_UPDATED) -> None:
         self.row = row
         self.keys: list[str] = []
+        self.prices: dict[str, Any] = (
+            {"metadata": {"last_updated": last_updated}} if last_updated is not None else {}
+        )
 
     def get_service_by_key(self, key: str) -> Any:
         self.keys.append(key)
@@ -43,7 +54,10 @@ def test_price_for_case_uses_only_the_exact_official_key(
 ) -> None:
     pricing = _PricingStub({"key": key, "price": price})
 
-    assert price_for_case(case_type, pricing=pricing) == (expected, key)  # type: ignore[arg-type]
+    assert price_for_case(case_type, pricing=pricing, today=_TODAY_WITHIN_WINDOW) == (  # type: ignore[arg-type]
+        expected,
+        key,
+    )
     assert pricing.keys == [key]
 
 
@@ -69,4 +83,88 @@ def test_price_for_case_fails_closed_on_missing_drifted_or_malformed_rows(
 ) -> None:
     pricing = _PricingStub(row)
 
-    assert price_for_case(CaseType.ISSUANCE, pricing=pricing) == (None, None)  # type: ignore[arg-type]
+    assert price_for_case(CaseType.ISSUANCE, pricing=pricing, today=_TODAY_WITHIN_WINDOW) == (  # type: ignore[arg-type]
+        None,
+        None,
+    )
+
+
+class TestCatalogueLastUpdatedStamp:
+    def test_reads_the_metadata_last_updated_field(self) -> None:
+        pricing = _PricingStub({"key": "x"}, last_updated="2026-05-06")
+        assert catalogue_last_updated_stamp(pricing) == "2026-05-06"  # type: ignore[arg-type]
+
+    def test_missing_prices_attribute_reads_as_no_stamp(self) -> None:
+        class _NoPricesAttr:
+            pass
+
+        assert catalogue_last_updated_stamp(_NoPricesAttr()) is None  # type: ignore[arg-type]
+
+    def test_prices_without_metadata_reads_as_no_stamp(self) -> None:
+        class _NoMetadata:
+            prices: dict[str, Any] = {"services": {}}
+
+        assert catalogue_last_updated_stamp(_NoMetadata()) is None  # type: ignore[arg-type]
+
+    def test_metadata_without_last_updated_reads_as_no_stamp(self) -> None:
+        pricing = _PricingStub({"key": "x"}, last_updated=None)
+        assert catalogue_last_updated_stamp(pricing) is None  # type: ignore[arg-type]
+
+
+class TestPriceCatalogueFreshnessGate:
+    """Proven to bite both ways: a fresh catalogue prices the case, a stale
+    one declines to quote via the EXISTING `(None, None)` shape — never a
+    new one — exactly like a missing/malformed row already does.
+
+    `conftest.py`'s autouse fixture pins `pricing.price_catalogue_freshness`
+    to a canned FRESH report for every OTHER test in this package (so real
+    dates/the real catalogue can't flip an unrelated assertion) — these
+    tests exist specifically to test THAT function, so each starts with
+    `monkeypatch.undo()` to reach the real, unpatched wiring.
+    """
+
+    _KEY = "B1 Visa on Arrival (VOA)"
+    _ROW = {"key": _KEY, "price": "790.000 IDR"}
+
+    def test_catalogue_exactly_at_the_90_day_window_still_prices(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        pricing = _PricingStub(self._ROW, last_updated="2026-01-01")
+        today = date(2026, 4, 1)  # exactly 90 days after 2026-01-01
+        assert price_for_case(CaseType.ISSUANCE, pricing=pricing, today=today) == (  # type: ignore[arg-type]
+            790_000,
+            self._KEY,
+        )
+
+    def test_catalogue_one_day_past_the_window_declines_to_quote(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        pricing = _PricingStub(self._ROW, last_updated="2026-01-01")
+        today = date(2026, 4, 2)  # 91 days after 2026-01-01
+        assert price_for_case(CaseType.ISSUANCE, pricing=pricing, today=today) == (  # type: ignore[arg-type]
+            None,
+            None,
+        )
+        # the row is never even looked up once the catalogue is stale —
+        # staleness is checked before key-matching.
+        assert pricing.keys == []
+
+    def test_catalogue_with_no_stamp_at_all_declines_to_quote(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        pricing = _PricingStub(self._ROW, last_updated=None)
+        assert price_for_case(  # type: ignore[arg-type]
+            CaseType.ISSUANCE, pricing=pricing, today=_TODAY_WITHIN_WINDOW
+        ) == (None, None)
+
+    def test_catalogue_with_a_malformed_stamp_declines_to_quote(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.undo()
+        pricing = _PricingStub(self._ROW, last_updated="not-a-date")
+        assert price_for_case(  # type: ignore[arg-type]
+            CaseType.ISSUANCE, pricing=pricing, today=_TODAY_WITHIN_WINDOW
+        ) == (None, None)

--- a/apps/backend-rag/pyproject.toml
+++ b/apps/backend-rag/pyproject.toml
@@ -399,6 +399,7 @@ exclude = [
 "backend/scripts/*.py" = ["ARG001", "E402", "SIM", "G", "LOG"]  # Utility scripts; f-string OK in CLI one-shots
 "backend/scripts/drop_kbli_phantoms.py" = ["T20"]  # manual DB-maintenance one-shot; the before/after/status prints ARE the script's output — no logger setup in this file, unlike its siblings
 "backend/scripts/visa_engine/*.py" = ["T20"]  # compile_pack.py/sign_pack.py: offline authoring/signing CLI one-shots — print() IS the operator-facing report (CompilationReport / signing ceremony summary), never app logging
+"backend/services/garuda_flow/freshness_report.py" = ["T20"]  # read-only truth-freshness diagnostic CLI one-shot — print() IS the human-facing report, never app logging (same rationale as the visa_engine authoring CLIs above)
 "backend/verify_soul_persona.py" = ["E402"]  # Verification script with late imports
 "add_docstrings.py" = ["ARG001"]  # Root level script
 "extract_company_data.py" = ["T20"]  # CLI entry point: prints a missing-env-var message before exit(1)


### PR DESCRIPTION
## Summary

Builds the orchestrator-owned truth-freshness authority `garuda_flow/freshness.py` that DECISIONS.md Q9 decided, `contracts/openapi.yaml` froze as `x-truth-freshness-max-age-days`, and GROUND.md §2 confirmed nothing read.

- `freshness.py` — one `FreshnessReport` primitive: fail-closed on missing/malformed stamps and on a raising accessor, boundary at strict `age > max_age_days`, a future-dated stamp reads as fresh (design decision, documented — real production `today` only advances; this shape only occurs in this engine's own historical-`today` test fixtures). Windows pinned as the Python single source of truth, tested for equality against the frozen contract.
- `intake.build_verdict` — declines unconditionally (both case shapes) via a new `DeclineCode.TRUTH_SHEET_STALE` when `nationality_eligibility` or `rule_constants` is stale — the same 201-DECLINE shape as the existing `ARRIVAL_DATE_UNCONFIRMED` calendar precedent, never a bare error. Mirrored into the admin-dashboard TS parity set (`test_decline_codes_match_engine_enum`).
- `pricing.price_for_case` — declines to quote via its EXISTING `(None, None)` fail-closed shape when the price catalogue is stale. No new return shape.
- `constants.RULES_VERIFIED_ON` — new stamp, dated to the OLDEST of the three dates already in that file's docstring (2026-07-14), not the newest, so it reports the weakest-verified fact's age (documented in-line why).
- `freshness_report.py` — read-only diagnostic (explicitly not a test) for "what is the real state right now": today it reports `price_catalogue` STALE (110d vs 90d window), matching `owner_decisions` id 7 already logged on this branch.

## Design decisions

- **Boundary**: `today - stamp > max_age_days` is STALE; equal to the window is still FRESH — the window itself is the safety margin Q9 chose.
- **Fail-closed**: missing stamp, wrong type, unparseable ISO string, or a raising accessor are ALL STALE — never treated as fresh.
- **No new vocabulary duplication**: `TRUTH_SHEET_STALE` reuses the exact token `contracts/openapi.yaml`'s `x-error-codes` already names for the (previously unwired) 503 shape — same word, now actually wired as a 201 DECLINE code instead, matching the calendar precedent. Net effect documented inline in `garuda_voa_public.py`: neither `TRUTH_SHEET_STALE` nor `TRUTH_AUTHORITY_UNAVAILABLE` is ever emitted as a 503 under this design — that's now the same dead-declared-code situation the file already resolved once for `CALENDAR_COVERAGE_EXCEEDED`. Flagged for whoever owns the contract freeze; not resolved here.

## Verified (every guard proven to bite both ways)

- `test_freshness.py` — mechanism: boundary (exact/one-day-over/one-day-under), fail-closed on absence/type/malformed-ISO/raising-accessor, the future-stamp design decision, registry wiring to the real constants (with synthetic `today`s, never the real wall clock), and the contract-window parity test.
- `TestTruthFreshnessGate` (`test_intake.py`) — stale nationality/rule-constants flips a real ACCEPT to DECLINE with `TRUTH_SHEET_STALE`, restoring freshness restores the original verdict, staleness never suppresses other decline reasons, extension path is covered too.
- `TestPriceCatalogueFreshnessGate` (`test_pricing.py`) — fresh-at-boundary still prices, one-day-over declines to quote (row never even looked up), missing/malformed stamp declines to quote.
- `tests/services/garuda_flow/` full suite: green. `test_garuda_voa.py` (archive route, read-only) and `test_garuda_voa_no_internal_leak.py`: green, unaffected.

## Known, NOT fixed here (by design)

`tests/app/routers/test_garuda_voa_public.py` (L2's public-router suite) goes red on 4 tests: `test_default_store_is_unconfigured_and_fails_closed`, `test_idempotency_conflict_maps_to_409`, `test_accept_create_then_get_then_delete_round_trip`, `test_privacy_headers_present_on_successful_create`. All four fail because they exercise the REAL price catalogue against the REAL wall-clock `today`, and the real catalogue genuinely is 110 days old against a 90-day window — exactly the "the funnel declines to sell, and that is correct" case the mandate anticipated. This is `owner_decisions` id 7 (already logged on this branch by an earlier commit) — re-stamp the catalogue or rule the window — not something this PR should paper over by injecting a fake-fresh catalogue into L2's suite.

## Guardrails respected

- `products/garuda-voa/contracts/**` untouched.
- `garuda_flow/retention*.py` and `migrations_v2/` untouched (L1's lane).
- Two one-line additions to `public_api.py` / `internal_preview_cli.py` (pass `today=` through to `price_for_case`, otherwise both would TypeError on this branch) — flagged here since `public_api.py` is L2's file.

Targets `feature/garuda-voa`, not `main`. Not merging — the orchestrator merges the integration branch.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>