### PR TITLE
docs(secondhome): make the E33E/E33F price-conflation trap explicit in §4

### DIFF
--- a/.agents/skills/secondhome/SKILL.md
+++ b/.agents/skills/secondhome/SKILL.md
@@ -119,7 +119,11 @@ BY DESIGN until the first real case (F4b).
   28 sources, seq 1, version `2026.7.25`, payload sha `47a97c32…`.
 - **Pricing**: `VisaType.E33` + dedicated rows: base 35M; E33E 45M 5-year
   (+ 10M extend); E33F 14M offshore / 16M onshore (+ 10M extend). Bridge
-  resolves all three.
+  resolves all three. **E33E and E33F are different products, not tiers of
+  one product**: E33E is the 5-year deposit-plus-income senior route (flat
+  45M, no location split); E33F is the 1-year income-only senior route
+  (14M offshore / 16M onshore) — only E33F splits by offshore/onshore
+  location.
 - **Guard**: `e33_claim_guard.py` hooked in `orchestrator_core.py` step 12b
   (log + safe fallback note, non-blocking). 10 forbidden patterns:
   USD 1,500, any-bank, E33S/E33R, local work, ITAP-automatic, 5-10y,


### PR DESCRIPTION
## What

Adds one clarifying sentence to `.agents/skills/secondhome/SKILL.md` §4 (the tracked
target of the `.claude/skills/secondhome/SKILL.md` symlink, PR #4395's twin pattern):
**E33E and E33F are different products, not tiers of one product** — E33E is the
5-year deposit-plus-income senior route (flat 45M, no location split), E33F is the
1-year income-only senior route (14M offshore / 16M onshore). Only E33F splits by
offshore/onshore location.

## Ground truth, independently re-verified this session

`mcp__nuzantara-knowledge__search_service_pricing` (live PricingTool), category
`kitas_permits`, queried fresh in this session — matches exactly:

| Row | Price |
|---|---|
| E33 Second Home (5 Years) | 35.000.000 IDR |
| E33E Second Home Senior (5 Years) | 45.000.000 IDR |
| E33E Second Home Senior (Extend) | 10.000.000 IDR |
| E33F Second Home Senior (1 Year, Offshore) | 14.000.000 IDR |
| E33F Second Home Senior (1 Year, Altus/Onshore) | 16.000.000 IDR |
| E33F Second Home Senior (Extend) | 10.000.000 IDR |

## Important finding: the originally-reported defect is already fixed

The mandate for this PR described two wrong figures in this file (a stale "base 39M"
in §4, and a wrong E33E figure inside the §4bis `Pricing` row). **Both are already
correct on `origin/main`** — verified via `git blame`/`git log`, not assumed:
PR #4721 (E33E repriced to 45M), PR #4742 (secondhome corner re-aligned), and PR
#4743 (§4 base-E33 price aligned) all merged before this branch was cut, and the
closure is recorded in `.claude/skills/modus/PENDING-ARMS.md:1239-1240` (closed
2026-08-24 by the S13 secondhome/Mini session). No numeric correction was needed —
this PR only adds the explicit "don't conflate" sentence, which stands on its own
merit regardless.

## Sweep

Grepped `research/secondhome/`, `.claude/skills/`, `docs/` for the same E33E/E33F
conflation. One hit: `research/secondhome/2026-08-19-e33-sticky-funnel-research.md:168`
still reads "PricingTool (39M; E33E/F rows)". Not fixed here — it's a dated, ad-hoc
research capture (CLAUDE.md §15: research stays archaeological, never
retro-corrected), not a living/governing doc in the same family as the corner file.

## Scope

Docs only, 1 file, +5/-1. No overlap with PR #4853 (open, touches the same file's
§4bis table rows + F7 line at lines 137/175/312 — this edit is at line 120,
outside all three of its hunks; confirmed via `gh pr diff 4853`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)