### PR TITLE
fix(secondhome): give the hero a call-to-action

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -119,6 +119,28 @@ const ctaSectionStyle: React.CSSProperties = {
 };
 
 /**
+ * Fit-check CTA treatment — shared by the hero entry point (2026-08-25, this
+ * PR) and the pre-existing "Two ways to qualify"/studio footer instance. Same
+ * outline vocabulary as the rest of the page: transparent fill, funnel-red
+ * border + ink. Kept the SAME strength in both places (not stronger in the
+ * hero) so this early entry point reads as an additional, low-commitment
+ * option — never a re-ranking of the WhatsApp CTA, which stays the sole
+ * solid-fill/higher-visual-weight action per Legge 5.
+ */
+const fitCheckCtaStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
+  borderRadius: 8,
+  border: "1px solid var(--accent-funnel)",
+  color: "var(--accent-funnel-text, var(--accent-funnel))",
+  fontWeight: 600,
+  textDecoration: "none",
+  minHeight: 44,
+};
+
+/**
  * Real routes for the localized second-home variants (2026-08-20) — the only
  * locales this landing has a dedicated SSG page for today. An OFFERED_LOCALES
  * entry with no route here (there are none right now: en/id/it all route)
@@ -242,6 +264,18 @@ export function SecondHomeLanding() {
         >
           {t("secondHome.hero.subtitle")}
         </p>
+        {/* Hero CTA (2026-08-25): the page's first click target used to be
+            87%/90% down the scroll (studio) — a reader had to pass six
+            sections before any action existed. Same destination + treatment
+            as the pre-existing studio CTA further down; this is an earlier
+            entry point, not a replacement for it or for the WhatsApp CTA. */}
+        <Link
+          href="/visa/second-home/studio"
+          data-testid="hero-fit-check-cta"
+          style={{ ...fitCheckCtaStyle, justifySelf: "start" }}
+        >
+          Start the fit-check
+        </Link>
         {price ? (
           <div
             style={{
@@ -613,18 +647,8 @@ export function SecondHomeLanding() {
         </p>
         <Link
           href="/visa/second-home/studio"
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 8,
-            padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
-            borderRadius: 8,
-            border: "1px solid var(--accent-funnel)",
-            color: "var(--accent-funnel-text, var(--accent-funnel))",
-            fontWeight: 600,
-            textDecoration: "none",
-            minHeight: 44,
-          }}
+          data-testid="footer-fit-check-cta"
+          style={fitCheckCtaStyle}
         >
           Start the fit-check
         </Link>

--- a/apps/mouth/src/app/visa/second-home/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.test.tsx
@@ -121,6 +121,34 @@ describe("SecondHomeLanding", () => {
     ).toBeInTheDocument();
   });
 
+  // Hero CTA (2026-08-25): the page's first click target used to sit at
+  // 87-90% scroll depth (the studio CTA further down). Pins that a fit-check
+  // entry point now exists inside the hero <section> itself, pointing at the
+  // same destination as the pre-existing footer instance, and that both
+  // pre-existing CTAs (studio footer link + WhatsApp handoff) are untouched.
+  it("gives the hero its own fit-check entry point, in addition to the existing ones", () => {
+    renderLanding();
+
+    const hero = screen.getByRole("heading", { level: 1 }).closest("section");
+    expect(hero).not.toBeNull();
+
+    const heroCta = within(hero as HTMLElement).getByTestId(
+      "hero-fit-check-cta",
+    );
+    expect(heroCta).toHaveAttribute("href", "/visa/second-home/studio");
+    expect(heroCta).toHaveTextContent("Start the fit-check");
+
+    // The pre-existing footer instance still exists, same destination.
+    const footerCta = screen.getByTestId("footer-fit-check-cta");
+    expect(footerCta).toHaveAttribute("href", "/visa/second-home/studio");
+
+    // The WhatsApp handoff is still the only "free fit memo" CTA — the hero
+    // addition is a second entry point to the studio, not a re-ranking.
+    expect(
+      screen.getByRole("link", { name: /free fit memo/i }),
+    ).toBeInTheDocument();
+  });
+
   it("the only CTA is the free fit memo WhatsApp handoff", () => {
     renderLanding();
 


### PR DESCRIPTION
## Concern
The E33 Second Home landing page's first interactive element sat at **87%** (desktop) / **90%** (mobile) scroll depth — a reader had to pass the hero, "Two ways to qualify", "Who it's for", "What Bali Zero does" + price, the 90-day duty, and the FAQ before any action existed.

## What changed
Added the existing "Start the fit-check" studio link (`/visa/second-home/studio`, already live at the bottom of the page) into the hero, placed right after the subtitle and before the three stat cards. Same destination, same label, same outline treatment as the pre-existing footer instance — both now share one `fitCheckCtaStyle` constant so they stay visually identical by construction.

**Untouched, on purpose:**
- The WhatsApp CTA (`Get my free Fit Memo →`) — unmoved, unrestyled, still the sole solid-fill primary action.
- Both existing closing sections — same position, same styling.
- No new destinations — the only href introduced is the pre-existing studio route.
- No price/figure/regulatory sentence touched.
- No sticky/floating bar — plain in-flow hero element.
- `studio/` — not touched (sibling lane `shs-hierarchy` owns it right now).

**Strength decision:** kept the hero instance the *same* visual weight as the footer one (outline, not solid-fill), not stronger. Reasoning: which action is primary is Zero's call under Legge 5 — this PR adds an earlier low-commitment entry point, not a re-ranking. The WhatsApp CTA remains the only solid-fill/higher-weight action on the page.

## Acceptance — measured (Playwright, dev server in this worktree, `next dev --webpack`)

1. **First-CTA scroll depth**: desktop 87.26% → **11.94%**, mobile 90.11% → **9.03%** (both under the 15% target; baseline cross-checked and matches the original 87%/90% measurement).
2. **Within first viewport**: hero CTA bottom edge y = **482** (desktop, target <1000) / y = **485** (mobile, target <844).
3. **Both original CTAs unchanged**: studio-footer `background-color` = `rgba(0, 0, 0, 0)` (transparent, unchanged), href `/visa/second-home/studio` (unchanged); WhatsApp `background-color` = `rgb(37, 211, 102)` (unchanged, byte-identical to the pre-existing measurement).
4. **Contrast on the new CTA** (painted pixels, not declared CSS — screenshot-clip + pngjs, WCAG relative-luminance formula): text **5.88:1** (desktop) / **5.83:1** (mobile) against its own painted background pixel — floor is 4.5:1 since it resolves to 16px/600 (not large text, confirmed via computed `font-size`/`font-weight`, not assumed). Border **4.03:1** (desktop) / **4.09:1** (mobile) against the surface behind it — floor 3.0:1.
5. **No horizontal overflow** at 360 / 390 / 768 / 1024 / 1280 / 1440 / 1920 (`scrollWidth <= clientWidth` at every width).
6. **Stat cards stay in-fold**: bottom y before → after: desktop 548 → 614, mobile 652 → 718 (both comfortably under their 1000/844 viewports — the CTA's height+gap pushes them down but never off-screen).
7. **Tests**: full `apps/mouth` vitest suite green — 423 files / 4255 tests, ran from this worktree (banner: `RUN v4.1.10 /Users/nuzantara/nuzantara/.worktrees/mouth-shs-hero-cta/apps/mouth`). Added one test (`gives the hero its own fit-check entry point, in addition to the existing ones`) pinning the new CTA's presence + href, plus that both pre-existing CTAs remain.

Also ran: `tsc --noEmit` clean, `eslint` clean (0 errors), pre-commit + pre-push hooks green.

## Net lines
64 insertions / 12 deletions across 2 files (well under the 400-line target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)