### PR TITLE
fix(ingestion): make a legal identity collision impossible to commit silently

### DIFF
--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -302,6 +302,26 @@ class LegalIngestionService:
 
         Re-ingesting the SAME source document is not a collision and must pass:
         that is how a corpus is refreshed.
+
+        TWO RESIDUAL HOLES, stated rather than papered over:
+
+        1. A point carrying NEITHER ``source_basename`` NOR ``file_path``
+           yields no claimant, so an identity held only by such points is
+           unguarded. Every point written by this service has always carried
+           ``file_path``, so this is about foreign or hand-written payloads.
+           Measurement: scroll the collection grouped by ``document_id`` and
+           count points where neither key resolves; any identity that is 100%
+           keyless is unprotected.
+        2. The ``/upload`` route names its temp file from the
+           uploader-supplied filename, so on that path the comparator is only
+           as unique as what the uploader typed. Two different laws uploaded
+           as ``UU_6_2023.pdf`` would still collide. Curated corpus ingests,
+           which is where the incident happened, use repo-controlled
+           filenames.
+
+        Neither hole is a reason to withhold the guard: it converts the common
+        case from silent loss into a loud refusal, and a partial guard that
+        says so is worth more than none.
         """
         existing = await vector_db.scroll_strict(
             metadata_filter={"document_id": document_id},
@@ -845,15 +865,36 @@ Return ONLY valid JSON, no markdown."""
             # Use HierarchicalIndexer
             indexing_start = time.time()
             quarantined_current_ids: list[str] = []
-            # Fail BEFORE the first mutation: the quarantine below already
-            # rewrites payloads, so a collision detected after it would leave
-            # the other document's points half-modified.
+            source_basename = Path(file_path).name
+            # Fail before the first mutation OF THE VECTOR STORE: the quarantine
+            # below already rewrites payloads, so a collision detected after it
+            # would leave the other document's points half-modified. (STAGE 1.5
+            # has already archived the file to Drive by this point -- that is an
+            # outward copy, not a mutation of the corpus, and a refused ingest
+            # therefore leaves an archived PDF behind. Deliberate: the archive is
+            # idempotent and a spare copy is harmless, whereas moving the guard
+            # earlier is impossible -- the identity is not known until metadata
+            # extraction, which runs after the archive step.)
             await self._assert_identity_unclaimed(
                 request_vector_db,
                 doc_id,
-                Path(file_path).name,
+                source_basename,
             )
             if retrieval_scope == HISTORICAL_RETRIEVAL_SCOPE:
+                # The historical path does not merely WRITE to `doc_id`
+                # (`X__historical`) -- it quarantines and then DELETES every
+                # point under `current_doc_id` (`X`). Guarding only `doc_id`
+                # leaves `X` uninspected, so a historical ingest whose derived
+                # identity happens to match a DIFFERENT ministry's current-law
+                # document would pass the guard and then delete that document in
+                # full. That is strictly worse than the incident this guard was
+                # written for: the incident overwrote 50 chunks, this would
+                # remove all of them, with the guard's blessing.
+                await self._assert_identity_unclaimed(
+                    request_vector_db,
+                    current_doc_id,
+                    source_basename,
+                )
                 reconciliation_state = "QUARANTINE_IN_PROGRESS"
                 quarantined_current_ids = await self._quarantine_current_points(
                     request_vector_db,

--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -274,6 +274,65 @@ class LegalIngestionService:
         )
         return [str(point["id"]) for point in points]
 
+    @staticmethod
+    async def _assert_identity_unclaimed(
+        vector_db: QdrantClient,
+        document_id: str,
+        source_basename: str,
+    ) -> None:
+        """Refuse to write onto an identity another source document already holds.
+
+        Chunk ids are ``{document_id}_Pasal_{n}`` and Qdrant point ids are
+        ``uuid5(chunk_id)``, so two documents sharing a ``document_id`` share
+        point ids and the second ingest OVERWRITES the first. Qdrant reports
+        that as a successful upsert, because it is one — which is why the
+        failure mode is silent data loss rather than an error.
+
+        Measured on 2026-08-25: ``Permen_1_2026`` held 544 points belonging to
+        PMK 1/2026 (Ministry of Finance, Coretax) *and* Permen Imipas 1/2026
+        (Ministry of Immigration). The tax regulation had upserted 544 chunks of
+        its own; 494 survived; the immigration regulation's 50 account for the
+        difference exactly.
+
+        This guard is deliberately the LOUD half of the cure. It does not decide
+        what a good identity is — it only refuses to let one document silently
+        become another. That makes every future collision, including classes
+        nobody has enumerated yet, an error at write time instead of a hole
+        discovered months later.
+
+        Re-ingesting the SAME source document is not a collision and must pass:
+        that is how a corpus is refreshed.
+        """
+        existing = await vector_db.scroll_strict(
+            metadata_filter={"document_id": document_id},
+        )
+        if not existing:
+            return
+
+        claimants: set[str] = set()
+        for point in existing:
+            payload = point.get("payload") or {}
+            metadata = payload.get("metadata")
+            if not isinstance(metadata, dict):
+                metadata = payload
+            claimant = metadata.get("source_basename")
+            if not claimant:
+                stored_path = metadata.get("file_path")
+                claimant = Path(str(stored_path)).name if stored_path else None
+            if claimant:
+                claimants.add(str(claimant))
+
+        foreign = claimants - {source_basename}
+        if foreign:
+            raise LegalIngestIntegrityError(
+                "Legal identity collision: document_id "
+                f"{document_id!r} is already held by {sorted(foreign)!r}; "
+                f"refusing to overwrite it with {source_basename!r}. "
+                "Two documents sharing an identity share point ids, so this "
+                "write would silently destroy the other document's chunks. "
+                "Declare a distinct document_id for one of them."
+            )
+
     async def ingest_legal_document(
         self,
         file_path: str,
@@ -301,6 +360,15 @@ class LegalIngestionService:
 
         try:
             retrieval_scope = validate_legal_retrieval_scope(retrieval_scope)
+            # The caller's document_id is the DECLARED STORAGE IDENTITY when it
+            # is given. Until 2026-08-25 this parameter reached only the
+            # ingestion logger and the log `extra` fields, while the identity
+            # actually written to Qdrant was always derived from the extracted
+            # (type, number, year) triple — so a caller who passed a
+            # document_id got a correlation id and believed they had set the
+            # storage key. Capture it here, before `start_ingestion` reassigns
+            # `document_id` to its own trace id.
+            declared_storage_id = document_id
             # Generate document ID if not provided
             if not document_id:
                 document_id = f"legal_{int(start_time)}_{Path(file_path).stem}"
@@ -718,7 +786,16 @@ Return ONLY valid JSON, no markdown."""
 
             # STAGE 6: Hierarchical Indexing (Parent-Child)
             # Generate a document ID
-            current_doc_id = build_content_bound_legal_doc_id(metadata, source_sha256)
+            # A declared identity wins over the derived one. The derived triple
+            # (type, number, year) does NOT identify an Indonesian instrument:
+            # every ministry numbers its regulations from 1 each year, so PMK
+            # 1/2026 and Permen Imipas 1/2026 both reduce to `Permen_1_2026`.
+            # Declaring the identity is how a curated corpus states which
+            # instrument a file is; derivation stays the fallback for ingests
+            # that declare nothing.
+            current_doc_id = declared_storage_id or build_content_bound_legal_doc_id(
+                metadata, source_sha256
+            )
             doc_id = current_doc_id
             if retrieval_scope == HISTORICAL_RETRIEVAL_SCOPE:
                 doc_id = f"{doc_id}__historical"
@@ -732,6 +809,11 @@ Return ONLY valid JSON, no markdown."""
                 "min_level": min_level,
                 "language": "id",  # Indonesian
                 "file_path": file_path,
+                # Stable per-source comparator for the identity-collision guard.
+                # `file_path` is absolute and therefore machine-dependent (the
+                # same file ingested from a worktree and from the checkout
+                # differs), so the basename is what the guard compares.
+                "source_basename": Path(file_path).name,
                 "doc_type": "legal",
                 # Legal-specific metadata
                 "legal_type": metadata.get("type_abbrev"),
@@ -763,6 +845,14 @@ Return ONLY valid JSON, no markdown."""
             # Use HierarchicalIndexer
             indexing_start = time.time()
             quarantined_current_ids: list[str] = []
+            # Fail BEFORE the first mutation: the quarantine below already
+            # rewrites payloads, so a collision detected after it would leave
+            # the other document's points half-modified.
+            await self._assert_identity_unclaimed(
+                request_vector_db,
+                doc_id,
+                Path(file_path).name,
+            )
             if retrieval_scope == HISTORICAL_RETRIEVAL_SCOPE:
                 reconciliation_state = "QUARANTINE_IN_PROGRESS"
                 quarantined_current_ids = await self._quarantine_current_points(

--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
@@ -49,7 +49,13 @@ def _build_service() -> LegalIngestionService:
         mch.return_value = MagicMock()
         mbm.return_value = MagicMock()
         mce.return_value = MagicMock()
-        mqd.return_value = MagicMock()
+        # The identity-collision guard scrolls for points already holding the
+        # computed document_id before anything is written. The default world for
+        # these tests is "nothing there yet"; tests that need a pre-existing
+        # document override scroll_strict themselves.
+        _vector_db = MagicMock()
+        _vector_db.scroll_strict = AsyncMock(return_value=[])
+        mqd.return_value = _vector_db
         mtc.return_value = MagicMock()
         mhi.return_value = MagicMock()
 
@@ -380,6 +386,9 @@ class TestIngestSuccess:
         base_vector_db = service.vector_db
         base_indexer_qdrant = service.indexer.qdrant
         request_vector_db = MagicMock(collection_name="tax_genius")
+        # Same as the shared fixture: the identity guard scrolls the
+        # REQUEST-local client, so it needs an empty world too.
+        request_vector_db.scroll_strict = AsyncMock(return_value=[])
         service.cleaner.clean.return_value = "cleaned tax regulation"
         service.metadata_extractor.extract.return_value = {
             "type": "Peraturan Menteri Keuangan",
@@ -795,6 +804,232 @@ class TestSkipPricing:
             )
 
             assert result["success"] is True
+
+
+# --------------------------------------------------------------------------- #
+# ingest_legal_document -- identity collision guard
+# --------------------------------------------------------------------------- #
+
+
+class TestIdentityCollisionGuard:
+    """The incident of 2026-08-25, encoded.
+
+    In production, `Permen_1_2026` held 544 points belonging to TWO unrelated
+    laws: PMK 1/2026 (Ministry of Finance, Coretax) and Permen Imipas 1/2026
+    (Ministry of Immigration). Every Indonesian ministry numbers its regulations
+    from 1 each year, so the extracted (type, number, year) triple collapsed
+    them onto one identity. Chunk ids are `{document_id}_Pasal_{n}` and point
+    ids are `uuid5(chunk_id)`, so the second ingest OVERWROTE 50 chunks of the
+    first. Qdrant reported a successful upsert, because it was one.
+
+    A guard that only proves guilt is half a guard: the refresh case (the SAME
+    document re-ingested) must still pass, or the corpus can never be updated.
+    Both halves are asserted here.
+    """
+
+    @staticmethod
+    def _coretax_metadata() -> dict:
+        return {
+            "type": "Peraturan Menteri",
+            "type_abbrev": "Permen",
+            "number": "1",
+            "year": "2026",
+            "topic": "Coretax",
+            "status": None,
+            "full_title": "PMK 1/2026",
+        }
+
+    def _prime(self, service: MagicMock, existing: list) -> None:
+        service.cleaner.clean.return_value = "cleaned legal text"
+        service.metadata_extractor.extract.return_value = self._coretax_metadata()
+        service.classifier.classify_book_tier.return_value = MagicMock(value="golden")
+        service.classifier.get_min_access_level.return_value = "member"
+        service.indexer.index_legal_document = AsyncMock(
+            return_value={
+                "chunks_indexed": 4,
+                "chunks_upserted": 4,
+                "parent_documents": 1,
+                "total_bab": 0,
+                "total_pasal": 4,
+            }
+        )
+        service.vector_db.scroll_strict = AsyncMock(return_value=existing)
+        service.vector_db.set_payload_by_filter = AsyncMock()
+        service.vector_db.delete_by_filter = AsyncMock()
+        service.vector_db.ensure_keyword_payload_index = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_guilt_a_second_document_on_a_held_identity_is_refused(
+        self, service: MagicMock
+    ) -> None:
+        """The real collision: a DIFFERENT source file on an occupied identity."""
+        self._prime(
+            service,
+            existing=[
+                {
+                    "id": "coretax-point",
+                    "payload": {
+                        "document_id": "Permen_1_2026",
+                        "source_basename": "PMK_1_2026_Coretax_System.pdf",
+                    },
+                }
+            ],
+        )
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/PermenImipas_1_2026_Perubahan.pdf",
+                title="Permen Imipas 1/2026",
+                category="01_immigrazione",
+            )
+
+        assert result["success"] is False
+        assert "identity collision" in str(result.get("error", "")).lower()
+        # Nothing may be written, and nothing may be mutated: the guard runs
+        # before the quarantine, which already rewrites payloads.
+        service.indexer.index_legal_document.assert_not_awaited()
+        service.vector_db.set_payload_by_filter.assert_not_awaited()
+        service.vector_db.delete_by_filter.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_innocence_the_same_document_may_be_re_ingested(
+        self, service: MagicMock
+    ) -> None:
+        """Refreshing a document is not a collision. It is the point of a corpus."""
+        self._prime(
+            service,
+            existing=[
+                {
+                    "id": "coretax-point",
+                    "payload": {
+                        "document_id": "Permen_1_2026",
+                        "source_basename": "PMK_1_2026_Coretax_System.pdf",
+                    },
+                }
+            ],
+        )
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/somewhere/else/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+            )
+
+        assert result["success"] is True
+        service.indexer.index_legal_document.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_innocence_an_unclaimed_identity_passes(
+        self, service: MagicMock
+    ) -> None:
+        self._prime(service, existing=[])
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_alone_does_not_read_as_a_foreign_document(
+        self, service: MagicMock
+    ) -> None:
+        """Legacy points carry an absolute `file_path`, which is machine-specific.
+
+        The same file ingested from a worktree and from the checkout has two
+        different absolute paths. Comparing those would refuse every legitimate
+        re-ingest from a different machine, so the guard compares BASENAMES.
+        """
+        self._prime(
+            service,
+            existing=[
+                {
+                    "id": "legacy-point",
+                    "payload": {
+                        "document_id": "Permen_1_2026",
+                        "file_path": "/Users/someone/else/PMK_1_2026_Coretax_System.pdf",
+                    },
+                }
+            ],
+        )
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/laws/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+            )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_declared_identity_is_what_gets_stored(
+        self, service: MagicMock
+    ) -> None:
+        """`document_id` must mean the storage key, not a log correlation id.
+
+        Until 2026-08-25 the caller's `document_id` reached only the ingestion
+        logger, while the id written to Qdrant was always the derived triple —
+        so a caller who declared an identity got a trace id and believed they
+        had set the storage key. Declaring it is what lets a curated corpus say
+        which instrument a file is, when the extractor cannot tell PMK 1/2026
+        from Permen Imipas 1/2026.
+        """
+        self._prime(service, existing=[])
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id_not_the_storage_key"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+                document_id="PMK_1_2026",
+            )
+
+        assert result["success"] is True
+        stored = service.indexer.index_legal_document.await_args.kwargs["document_id"]
+        assert stored == "PMK_1_2026"
+        assert stored != "Permen_1_2026", (
+            "the derived triple is exactly the value that collided; declaring "
+            "an identity must override it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_without_a_declaration_the_derived_identity_is_unchanged(
+        self, service: MagicMock
+    ) -> None:
+        """No declaration ⇒ the pre-existing derivation, byte for byte.
+
+        This pins the blast radius: nothing already in the collection changes
+        identity, so no migration is owed and the historical-replacement key
+        keeps matching.
+        """
+        self._prime(service, existing=[])
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            await service.ingest_legal_document(
+                file_path="/tmp/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+            )
+
+        stored = service.indexer.index_legal_document.await_args.kwargs["document_id"]
+        assert stored == "Permen_1_2026"
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
@@ -975,6 +975,87 @@ class TestIdentityCollisionGuard:
         assert result["success"] is True
 
     @pytest.mark.asyncio
+    async def test_guilt_a_historical_ingest_may_not_delete_a_foreign_document(
+        self, service: MagicMock
+    ) -> None:
+        """The historical path DELETES, so it must be guarded on what it deletes.
+
+        A historical ingest writes to `X__historical` but quarantines and then
+        deletes every point under `X`. Guarding only the write target leaves `X`
+        uninspected: a historical ingest whose derived identity happens to match
+        a different ministry's current-law document would pass the guard and
+        then remove that document in full. That is strictly worse than the
+        incident the guard was written for — 50 chunks overwritten there, an
+        entire law deleted here, with the guard's blessing.
+        """
+        self._prime(service, existing=[])
+
+        # The write target `Permen_1_2026__historical` is free; the identity the
+        # delete will actually hit, `Permen_1_2026`, belongs to someone else.
+        def _scroll(metadata_filter: dict, **_kwargs: object) -> list:
+            if metadata_filter.get("document_id") == "Permen_1_2026":
+                return [
+                    {
+                        "id": "foreign-current-point",
+                        "payload": {
+                            "document_id": "Permen_1_2026",
+                            "source_basename": "PMK_1_2026_Coretax_System.pdf",
+                        },
+                    }
+                ]
+            return []
+
+        service.vector_db.scroll_strict = AsyncMock(side_effect=_scroll)
+        service.indexer._get_db_pool = AsyncMock(return_value=MagicMock())
+
+        # Historical ingestion demands a verified Drive archive BEFORE the
+        # identity is even known (STAGE 1.5 runs ahead of metadata extraction),
+        # so the archive has to succeed for this test to reach the guard at all.
+        drive = MagicMock()
+        drive.archive_file_idempotent = AsyncMock(
+            return_value=(
+                {
+                    "id": "drive_file_x",
+                    "webViewLink": "https://drive.example/x",
+                    "md5Checksum": hashlib.md5(b"unit-test-legal-source").hexdigest(),
+                },
+                "reused",
+            )
+        )
+        legal_settings = SimpleNamespace(
+            legal_drive_root_folder_id="legal_root",
+            legal_drive_impersonate_user="legal-archive@example.com",
+            google_drive_root_folder_id="generic_root",
+        )
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with (
+            p1,
+            p2 as mock_logger,
+            p3,
+            p4,
+            patch(
+                "backend.services.ingestion.legal_ingestion_service.ServiceAccountDriveService",
+                return_value=drive,
+            ),
+            patch("backend.app.core.config.settings", legal_settings),
+        ):
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/SomeOtherMinistry_1_2026.pdf",
+                title="Some other ministry 1/2026",
+                category="01_immigrazione",
+                retrieval_scope="historical_only",
+            )
+
+        assert result["success"] is False
+        assert "identity collision" in str(result.get("error", "")).lower()
+        # The foreign document must be neither quarantined nor deleted.
+        service.vector_db.set_payload_by_filter.assert_not_awaited()
+        service.vector_db.delete_by_filter.assert_not_awaited()
+        service.indexer.index_legal_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_a_declared_identity_is_what_gets_stored(
         self, service: MagicMock
     ) -> None:

--- a/apps/backend-rag/scripts/ingest_2026_laws.py
+++ b/apps/backend-rag/scripts/ingest_2026_laws.py
@@ -53,6 +53,23 @@ logger = logging.getLogger("ingest_2026_laws")
 # Target documents with marketing metadata
 LAWS_2026 = [
     {
+        # DECLARED IDENTITY -- read this before touching either entry below.
+        #
+        # Both PMK 1/2026 and Permen Imipas 1/2026 derive the SAME document_id
+        # from the extracted (type, number, year) triple: `Permen_1_2026`. Every
+        # Indonesian ministry numbers its regulations from 1 each year, so that
+        # triple does not identify an instrument.
+        #
+        # Chunk ids are `{document_id}_Pasal_{n}` and Qdrant point ids are
+        # `uuid5(chunk_id)`. On 2026-08-25 the collision destroyed 50 chunks of
+        # this Coretax regulation when the immigration one was ingested over it,
+        # with no error at all -- an overwrite IS a successful upsert.
+        #
+        # Declaring `document_id` here is how the corpus states which instrument
+        # a file is, in the one place that actually knows. The service honours a
+        # declared id as the storage key and refuses to write onto an identity
+        # another source file already holds.
+        "document_id": "PMK_1_2026",
         "filename": "PMK_1_2026_Coretax_System.pdf",
         "title": "PMK 1/2026 - Perubahan Keempat atas PMK 81/2024 tentang Ketentuan Perpajakan dalam rangka Pelaksanaan Sistem Inti Administrasi Perpajakan (Coretax)",
         "category": "perpajakan_2026",
@@ -244,6 +261,9 @@ LAWS_2026 = [
         "marketing_title_en": "Permen Imipas 14/2025 - Zero-Rupiah Tariff for Immigration Services",
     },
     {
+        # Declared for the same reason as PMK_1_2026 above: without it this
+        # regulation and the Coretax one share the identity `Permen_1_2026`.
+        "document_id": "PermenImipas_1_2026",
         "filename": "PermenImipas_1_2026_Perubahan_Pencegahan_dan_Penangkalan.pdf",
         "title": "Permen Imipas 1/2026 - Perubahan atas Peraturan Menteri Imigrasi dan Pemasyarakatan Nomor 13 Tahun 2025 tentang Pelaksanaan Pencegahan dan Penangkalan",
         "category": "keimigrasian",
@@ -294,6 +314,17 @@ async def run_ingestion(dry_run: bool = False, file_filter: str | None = None):
         # Pin the literals used in LAWS_2026 against the real constants. If the
         # service ever renames a scope, this fails loudly here instead of
         # silently passing an unrecognised string into ingestion.
+        # A declared identity that repeats inside this very list would
+        # re-create by hand the exact collision the declaration exists to
+        # prevent. Fail here, before the first byte is written, rather than
+        # discovering it as missing chunks weeks later.
+        declared_ids = [law["document_id"] for law in LAWS_2026 if law.get("document_id")]
+        duplicate_ids = {i for i in declared_ids if declared_ids.count(i) > 1}
+        if duplicate_ids:
+            raise ValueError(
+                f"LAWS_2026 declares the same document_id more than once: {sorted(duplicate_ids)}"
+            )
+
         declared_scopes = {law.get("retrieval_scope") for law in LAWS_2026} - {None}
         known_scopes = {CURRENT_RETRIEVAL_SCOPE, HISTORICAL_RETRIEVAL_SCOPE}
         unknown_scopes = declared_scopes - known_scopes
@@ -378,6 +409,10 @@ async def run_ingestion(dry_run: bool = False, file_filter: str | None = None):
                 title=law["title"],
                 category=law["category"],
                 retrieval_scope=law.get("retrieval_scope", CURRENT_RETRIEVAL_SCOPE),
+                # Entries that declare one get that identity as the storage key;
+                # the rest keep the derived triple, so nothing already indexed
+                # changes identity and no migration is owed.
+                document_id=law.get("document_id"),
             )
 
             if result["success"]:


### PR DESCRIPTION
Cures the incident recorded in `research/operations/2026-08-25-legal-document-identity-collision-spec.md`, in the order that spec recommends: **the loud half first**.

## The incident, measured

`Permen_1_2026` in production held **544 points from two unrelated laws** — 494 from PMK 1/2026 (Ministry of **Finance**, Coretax) and 50 from Permen Imipas 1/2026 (Ministry of **Immigration**). Coretax had upserted 544 chunks of its own; 494 survive. **50 were destroyed**, silently: every Indonesian ministry numbers from 1 each year, chunk ids are `{document_id}_Pasal_{n}`, point ids are `uuid5(chunk_id)` — and an overwrite *is* a successful upsert. A scan of all 83,969 points across 28 document ids found exactly this one collision.

This is the **second** attempt. [#4864](https://github.com/Bali-Zero/Teman2/pull/4864) made the source-hash suffix unconditional; that was refuted, confirmed wrong, and reverted — it broke historical replacement and institutionalised duplication on re-download.

## What lands

1. **`_assert_identity_unclaimed`** — refuses to write onto an identity another source document already holds, before the vector store is touched. Compares **basenames**, not the stored absolute `file_path` (machine-specific: comparing it would refuse every legitimate re-ingest from another checkout). Points now carry `source_basename`; legacy points fall back to `basename(file_path)`.
2. **A declared `document_id` governs storage.** It previously reached only the ingestion logger while the stored identity was always the derived triple — a caller who declared an identity got a trace id and believed they had set the storage key.
3. **`LAWS_2026` declares `PMK_1_2026` and `PermenImipas_1_2026`** for the two colliding entries, plus a runtime pin that fails if the list ever declares one identity twice.

Every other document keeps its derived id, so **nothing already indexed changes identity** and the historical-replacement key keeps matching. Pinned by `test_without_a_declaration_the_derived_identity_is_unchanged`.

## Adversarial review

A cross-family refuter (Kimi K3) attacked the first commit on six axes. Findings, each re-verified by me in the code before acting:

| # | Finding | Verdict | Action |
|---|---|---|---|
| 3 | **P0 — the guard was blind to the identity the historical path DELETES.** It ran on `doc_id` (`X__historical`), while quarantine and `delete_by_filter` operate on `current_doc_id` (`X`). A historical ingest matching another ministry's current document would pass the guard and then delete it in full — worse than the incident: 50 chunks overwritten there, an entire law removed here. | **CONFIRMED in my own diff** | Fixed in `f7384e8ac`; `test_guilt_a_historical_ingest_may_not_delete_a_foreign_document` pins it |
| 4 | **P1 — "no migration owed" is wrong for the two colliding entries.** Re-ingesting under declared ids leaves the polluted `Permen_1_2026` live and retrievable. | **CONFIRMED** | Commit message corrected; the repair now explicitly includes deleting that identity |
| 7d | The comment "fail BEFORE the first mutation" was **false** — STAGE 1.5 archives to Drive first. | **CONFIRMED** | Comment corrected to name the vector store, and to say why the guard cannot move earlier (identity is unknown until metadata extraction) |
| 1 | Residual: a point with neither `source_basename` nor `file_path` yields no claimant and passes. | Real, narrow | Documented in the guard with the scroll-and-count measurement that would find any |
| 5 | Residual: `/upload` names its temp file from the uploader-supplied filename. | Real | Documented; curated ingests (where the incident happened) use repo-controlled filenames |
| 2 | `scroll_strict` is paginated and **raises** past 10,000 points rather than truncating — no wrong-pass. | Survives | Noted; a >10k-point document would become un-re-ingestable, latent at a 1,223-chunk max |

Neither hole is a reason to withhold the guard: it turns the common case from silent loss into a loud refusal, and a partial guard that says so is worth more than none.

## Evidence

Full file, colour disabled, judged by **process exit code** rather than by grepping for a word:

```
WITH the fix        -> exit=0  FAILED lines=0     (36 tests)
WITHOUT the historical guard -> exit=1  FAILED lines=1
```

The guilt tests fail without the change and pass with it; the four innocence tests pass either way, which is what innocence means.

**Measurement discipline, recorded because it is the reusable part.** My own probes lied twice in this session: `grep -c '^FAILED'` counts zero because ANSI colour codes precede the word, and a `-k` filtered run reports green while the rest of the file is red — precisely how #4864's regression got past me. Every count above comes from the exit code.

## Still owed (PENDING-ARMS)

Delete the polluted `Permen_1_2026` points and re-ingest both documents under their declared identities — that restores the **50 destroyed Coretax chunks**. Separately, the metadata extractor still assigns the wrong legal type and number to **6 of 19** documents in this corpus (a Kepmen indexed as `UU 28/2025`); that is a citation defect with its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW