### PR TITLE
fix(ingestion): the identity guard's own query was rejected, so it failed every ingest

### DIFF
--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -422,6 +422,28 @@ class LegalIngestionService:
                 else self.vector_db
             )
 
+            # Payload indexes the fail-closed filters below REQUIRE. A missing
+            # index does not degrade a Qdrant filter, it makes the query an
+            # ERROR: "Index required but not found for <key>". Both
+            # representations are named because on a flat-payload collection
+            # `_convert_filter_to_qdrant_format` ADDS the bare key to the
+            # nested one (`should: [metadata.X, X]`) rather than replacing it,
+            # and a `should` member is an indexed key like any other.
+            #
+            # `document_id` is unconditional because three fail-closed filters
+            # depend on it and the first of them runs on EVERY ingest: the
+            # identity guard, the current-scope quarantine, and the historical
+            # delete. Measured 2026-08-25 against `legal_unified`, which indexes
+            # the flat `document_id` and not `metadata.document_id`: every
+            # `scroll_strict` answered HTTP 400 for every document_id, colliding
+            # or not. The guard shipped in #4865 therefore failed 100% of legal
+            # ingests rather than only the colliding ones, and the historical
+            # quarantine/delete pair had the same latent defect before it --
+            # unnoticed only because the Drive fail-closed archive check aborts
+            # that path earlier.
+            await request_vector_db.ensure_keyword_payload_index("document_id")
+            await request_vector_db.ensure_keyword_payload_index("metadata.document_id")
+
             # Historical instruments must only enter a collection once the
             # executable retrieval guard's payload indexes exist.
             if retrieval_scope == HISTORICAL_RETRIEVAL_SCOPE:

--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
@@ -55,6 +55,12 @@ def _build_service() -> LegalIngestionService:
         # document override scroll_strict themselves.
         _vector_db = MagicMock()
         _vector_db.scroll_strict = AsyncMock(return_value=[])
+        # Awaited on EVERY ingest now (the identity guard's filter keys
+        # must be indexed before it scrolls), so the bare MagicMock this
+        # attribute would otherwise be is not awaitable.
+        _vector_db.ensure_keyword_payload_index = AsyncMock(
+            return_value={"success": True}
+        )
         mqd.return_value = _vector_db
         mtc.return_value = MagicMock()
         mhi.return_value = MagicMock()
@@ -389,6 +395,9 @@ class TestIngestSuccess:
         # Same as the shared fixture: the identity guard scrolls the
         # REQUEST-local client, so it needs an empty world too.
         request_vector_db.scroll_strict = AsyncMock(return_value=[])
+        request_vector_db.ensure_keyword_payload_index = AsyncMock(
+            return_value={"success": True}
+        )
         service.cleaner.clean.return_value = "cleaned tax regulation"
         service.metadata_extractor.extract.return_value = {
             "type": "Peraturan Menteri Keuangan",
@@ -1116,6 +1125,124 @@ class TestIdentityCollisionGuard:
 # --------------------------------------------------------------------------- #
 # ingest_legal_document -- metadata fallback
 # --------------------------------------------------------------------------- #
+
+
+    @staticmethod
+    def _keys_named_by(qdrant_filter: object) -> set[str]:
+        """Every payload key a Qdrant filter names, at any nesting depth."""
+        found: set[str] = set()
+        if isinstance(qdrant_filter, dict):
+            key = qdrant_filter.get("key")
+            if isinstance(key, str):
+                found.add(key)
+            for value in qdrant_filter.values():
+                found |= TestIdentityCollisionGuard._keys_named_by(value)
+        elif isinstance(qdrant_filter, list):
+            for item in qdrant_filter:
+                found |= TestIdentityCollisionGuard._keys_named_by(item)
+        return found
+
+    @staticmethod
+    def _ensured_fields(mock: AsyncMock) -> set[str]:
+        return {
+            (c.args[0] if c.args else c.kwargs["field_name"])
+            for c in mock.call_args_list
+        }
+
+    @pytest.mark.asyncio
+    async def test_every_key_the_identity_filter_names_has_an_index(
+        self, service: MagicMock
+    ) -> None:
+        """The guard's query must be ANSWERABLE, not merely well-formed.
+
+        This is the defect the seven tests above could not see, because every
+        one of them mocks `scroll_strict` -- the exact call that failed. Qdrant
+        does not treat a filter on an unindexed key as "matches nothing"; it
+        REJECTS it with HTTP 400 "Index required but not found". So the guard
+        shipped in #4865 did not silently pass, it made every legal ingest fail
+        -- colliding or not -- and no unit test could tell, because the mock
+        answered where production errored.
+
+        The expectation here is DERIVED from the production filter builder
+        rather than typed as a literal, so it tracks the builder: whatever keys
+        `_convert_filter_to_qdrant_format` decides to name, the service must
+        have ensured an index for each of them.
+        """
+        from backend.core.qdrant_db import QdrantClient as RealQdrantClient
+
+        real = RealQdrantClient(collection_name="legal_unified")
+        # Premise: legal_unified is a flat-payload collection, so the builder
+        # ADDS the bare key beside the nested one instead of replacing it. If
+        # that ever becomes a replacement, this pin fails and whoever changed
+        # it is sent back to re-read the guard.
+        assert real._include_flat_payload_filters() is True
+        required = self._keys_named_by(
+            real._convert_filter_to_qdrant_format(
+                {"document_id": "PMK_1_2026"},
+                include_flat_payload=True,
+            )
+        )
+        assert required == {"document_id", "metadata.document_id"}
+
+        self._prime(service, existing=[])
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+            )
+
+        assert result["success"] is True
+        ensured = self._ensured_fields(service.vector_db.ensure_keyword_payload_index)
+        assert required <= ensured, (
+            f"the identity filter names {sorted(required)} but the service only "
+            f"ensured indexes for {sorted(ensured)}; the unindexed keys make the "
+            "guard's scroll an HTTP 400 instead of an answer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_index_is_ensured_before_the_guard_scrolls(
+        self, service: MagicMock
+    ) -> None:
+        """Ordering is the whole point: an index created after the query that
+        needs it cures nothing. Asserting only that both calls happened would
+        pass on the broken ordering, so the sequence itself is asserted."""
+        self._prime(service, existing=[])
+        order: list[str] = []
+
+        async def _record_index(field_name: str) -> dict:
+            order.append(f"index:{field_name}")
+            return {"success": True, "field_name": field_name}
+
+        async def _record_scroll(**_: object) -> list:
+            order.append("scroll")
+            return []
+
+        service.vector_db.ensure_keyword_payload_index = AsyncMock(
+            side_effect=_record_index
+        )
+        service.vector_db.scroll_strict = AsyncMock(side_effect=_record_scroll)
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "trace_id"
+            result = await service.ingest_legal_document(
+                file_path="/tmp/PMK_1_2026_Coretax_System.pdf",
+                title="PMK 1/2026",
+                category="04_fiscale",
+            )
+
+        assert result["success"] is True
+        assert "scroll" in order, "the guard did not run at all"
+        for field in ("document_id", "metadata.document_id"):
+            marker = f"index:{field}"
+            assert marker in order, f"{field} was never indexed"
+            assert order.index(marker) < order.index("scroll"), (
+                f"{field} was indexed AFTER the guard's scroll, which is the "
+                "same outage in a different order"
+            )
 
 
 class TestMetadataFallback:


### PR DESCRIPTION
## What is broken right now on `main`

PR #4865 shipped `_assert_identity_unclaimed`, a guard that refuses to write onto a `document_id` another source document already holds. Measured against the live collection today, **that guard has never once answered its own question**:

```
HTTP 400 Bad request: Index required but not found for
"metadata.document_id" of one of the following types: [keyword]
```

…for **every** `document_id` — colliding, absent, or otherwise. Qdrant does not treat a filter on an unindexed key as "matches nothing"; it refuses the query. The exception propagates out of the guard (there is no `try/except`), out of the call site, into `ingest_legal_document`'s outer handler, which returns `success: False`.

So the guard did not merely fail to protect. **It turned 100% of legal-document ingestion into an outage** — and all seven of its unit tests stayed green, because every one of them mocks `scroll_strict`, the exact call that errors in production. The mock answered where the world refused.

## The fix was already in the file, twenty lines above the break

The historical branch ensures **both** `retrieval_scope` and `metadata.retrieval_scope`. On a flat-payload collection, `_convert_filter_to_qdrant_format` **adds** the bare key beside the nested one (`should: [metadata.X, X]`) rather than replacing it, and a `should` member needs an index like any other key. `legal_unified` indexes the flat `document_id` only.

`document_id` now gets the same dual-index treatment, **unconditionally** — three fail-closed filters depend on it (identity guard, current-scope quarantine, historical delete) and the first runs on every ingest.

## Proven live, not by mock

| probe | before | after the two idempotent index PUTs |
|---|---|---|
| `Permen_1_2026` | HTTP 400 | **1506 points** |
| `PMK_1_2026` | HTTP 400 | 0 |
| nonexistent id | HTTP 400 | 0 |

The index now exists on production `legal_unified_hybrid_hybrid`; the code call keeps it true for a fresh collection or any other environment.

## A consequence worth naming rather than discovering later

While the filter errored, the historical path's quarantine and delete were **inert by accident**. They now *work* — meaning `delete_by_filter({"document_id": X})` will really delete every point matching X, across both payload shapes. On `Permen_1_2026` that is 1506 points belonging to **eight different ministries**.

What makes this safe is **ordering, not luck**: the identity guard runs before the quarantine, sees the foreign claimants, and refuses. That ordering is now asserted, not assumed.

## Tests — both red on the parent commit, for the right reason

- **`test_every_key_the_identity_filter_names_has_an_index`** derives its expectation from the *production* filter builder instead of a literal: it asks the real `_convert_filter_to_qdrant_format` which keys the guard's filter will name, then requires an ensured index for each. On the parent commit it fails with *"the identity filter names ['document_id', 'metadata.document_id'] but the service only ensured indexes for []"*.
- **`test_the_index_is_ensured_before_the_guard_scrolls`** pins the sequence. A test asserting only that both calls happened would pass on the broken ordering, which cures nothing.

The shared fixture now defaults `ensure_keyword_payload_index` to an `AsyncMock` — it is awaited on every ingest now, and a bare `MagicMock` is not awaitable. **Baseline was verified green on the parent commit first**, so no pre-existing red is attributed here. Full file: 0 failures, exit 0.

## Separately discovered, NOT fixed here

The 1506 points under `Permen_1_2026` belong to at least eight regulations — Permenperin (698), PMK Coretax (494), Permenkes (142), Permenko Ekon (73), Permen Imipas (50), Permenko Pangan (31), Permenpora (14), Permensos (4). The earlier scan that reported "one collision, two documents" was blind to 78,747 nested-payload points; it could only see the 5,222 flat ones. The true blast radius of the identity defect is being measured now and will land as its own PR with its own repair — this PR is the outage cure and nothing else.