### PR TITLE
fix(parsers): no scanned PDF could ever be read, by two independent mechanisms

### DIFF
--- a/apps/backend-rag/backend/core/parsers.py
+++ b/apps/backend-rag/backend/core/parsers.py
@@ -205,21 +205,27 @@ def extract_text_from_pdf(
                     # Last resort: try vision model (skip if already in async context)
                     logger.info("OCR failed, trying vision model as last resort...")
                     try:
-                        import asyncio
-
                         from backend.services.multimodal.pdf_vision_service import PDFVisionService
 
                         vision_service = PDFVisionService()
-                        with open(file_path, "rb") as f:
-                            pdf_bytes = f.read()
                         # Check if we're in an async context
                         try:
                             asyncio.get_running_loop()
                             # We're in async context, can't use asyncio.run()
                             logger.warning("Cannot use vision model in async context - OCR skipped")
                         except RuntimeError:
-                            # No running loop, safe to use asyncio.run()
-                            vision_text = asyncio.run(vision_service.extract_text(pdf_bytes))
+                            # No running loop, safe to use asyncio.run().
+                            # CORRECTED 2026-08-25: this used to call
+                            # `vision_service.extract_text(pdf_bytes)`, which is
+                            # declared "(for test compatibility)" and re-reads
+                            # the PDF with PyMuPDF -- the step that had just
+                            # returned nothing. It never rendered a page and
+                            # never reached a vision model, so no scanned PDF
+                            # could ever be read, and the failure was reported
+                            # as "even with OCR/Vision".
+                            vision_text = asyncio.run(
+                                vision_service.transcribe_scanned_pdf(file_path),
+                            )
                             if vision_text and vision_text.strip():
                                 logger.info(
                                     f"Vision extraction successful: {len(vision_text)} characters",
@@ -255,68 +261,24 @@ def extract_text_from_pdf(
 
 
 async def extract_text_from_pdf_ocr_async(file_path: str) -> str:
-    """
-    Async version of OCR extraction for use in async contexts.
-    Uses Google Gemini Vision to extract text from scanned PDF pages.
-    Processes each page individually for best OCR quality.
+    """Async OCR for a scanned PDF, local Ollama vision first.
+
+    CORRECTED 2026-08-25. This function used to gate itself on
+    ``PDFVisionService._available``, a property that consults the GEMINI client
+    only. With cloud vision unconfigured -- the default posture, since
+    cross-border vision is gated under UU PDP Art. 56 -- it returned "" without
+    ever asking the local Ollama engine, which was armed and working. It also
+    appended whatever ``analyze_page`` returned, and that method reports failure
+    by returning a STRING ("Error analyzing page: ..."), so a failed page could
+    enter the corpus as the document's own text.
+
+    Both problems are gone by delegating to the one real implementation.
     """
     try:
-        import fitz  # PyMuPDF
-
         from backend.services.multimodal.pdf_vision_service import PDFVisionService
 
-        vision_service = PDFVisionService()
-        if not vision_service._available:
-            logger.warning("Vision service not available for OCR")
-            return ""
-
-        # Open PDF and get page count
-        doc = fitz.open(file_path)
-        total_pages = len(doc)
-        doc.close()
-
-        logger.info("Processing %s pages with Gemini Vision OCR...", total_pages)
-
-        # OCR prompt optimized for text extraction
-        ocr_prompt = """Extract all text from this page.
-Preserve the original formatting, line breaks, paragraphs, and structure.
-Return only the extracted text, no descriptions or explanations.
-If the page contains tables, preserve the table structure.
-If the page is blank or contains no text, return an empty string."""
-
-        text_parts = []
-        for page_num in range(1, total_pages + 1):
-            try:
-                logger.info("OCR processing page %s/%s...", page_num, total_pages)
-                page_text = await vision_service.analyze_page(
-                    pdf_path=file_path,
-                    page_number=page_num,
-                    prompt=ocr_prompt,
-                    is_drive_file=False,
-                )
-                if page_text and page_text.strip():
-                    text_parts.append(page_text)
-                    logger.info(f"✅ Page {page_num}: extracted {len(page_text)} characters")
-                else:
-                    logger.warning("⚠️ Page %s: no text extracted", page_num)
-
-                # Rate limiting for Gemini Vision (Free Tier: 15 RPM)
-                # 4s delay = 15 RPM
-                await asyncio.sleep(4.0)
-            except Exception as page_error:
-                logger.warning("Error processing page %s: %s", page_num, page_error)
-                continue
-
-        full_text = "\n\n".join(text_parts)
-
-        if full_text.strip():
-            logger.info(
-                f"✅ Gemini Vision OCR successful: {len(full_text)} characters from {len(text_parts)} pages",
-            )
-            return full_text
-        logger.warning("No text extracted from any page")
-        return ""
-
+        text = await PDFVisionService().transcribe_scanned_pdf(file_path)
+        return text or ""
     except Exception as e:
         logger.error("Vision OCR extraction failed: %s", e)
         return ""

--- a/apps/backend-rag/backend/services/multimodal/pdf_vision_service.py
+++ b/apps/backend-rag/backend/services/multimodal/pdf_vision_service.py
@@ -12,6 +12,7 @@ UPDATED 2026-03-09: Switched to qwen2.5vl:7b (confirmed passport OCR working)
 UPDATED 2026-04-06: Local fleet now gemma4:26b + qwen3.5:9b + deepseek-r1:32b + qwen2.5vl:7b
 """
 
+import asyncio
 import base64
 import io
 import logging
@@ -28,6 +29,11 @@ from backend.llm.ollama_client import is_ollama_available
 from backend.services.oracle.smart_oracle import download_pdf_from_drive
 
 logger = logging.getLogger(__name__)
+
+# Gemini free tier allows 15 requests/minute. This paces the CLOUD path only:
+# the local Ollama path has no such limit and sleeping on it turned a 100-page
+# scan into 400 seconds of doing nothing.
+GEMINI_VISION_PAGE_DELAY_SECONDS = 4.0
 
 
 class PDFVisionService:
@@ -142,6 +148,112 @@ class PDFVisionService:
         except Exception as e:
             logger.error("❌ Vision analysis failed: %s", e)
             return f"Error analyzing page: {e!s}"
+
+    # Deliberately literal. A vision model asked to "extract" or "describe" a
+    # page will paraphrase it, and a paraphrase entering the corpus AS the
+    # document's text is worse than no text: unattributable, and authoritative
+    # in tone.
+    TRANSCRIPTION_PROMPT = (
+        "Transcribe ALL visible text from this scanned document page. "
+        "Output the text verbatim, preserving line breaks, ordering and table "
+        "structure. Do not summarise, translate, explain or add anything. "
+        "If the page contains no text, output nothing."
+    )
+
+    async def transcribe_scanned_pdf(
+        self,
+        pdf_path: str,
+        max_pages: int | None = None,
+    ) -> str | None:
+        """Transcribe a PDF that carries no text layer, page by page.
+
+        This is the ONE implementation of scanned-PDF reading. Until 2026-08-25
+        there were two callers in `backend.core.parsers` and NEITHER could ever
+        succeed:
+
+        * the synchronous last resort in ``extract_text_from_pdf`` called
+          ``extract_text()`` -- a method whose own docstring reads "(for test
+          compatibility)" and which, absent an AI client, re-reads the PDF with
+          PyMuPDF: precisely the step that had just returned nothing. It never
+          rendered a page and never reached a vision model, so it could only
+          ever return "". The failure then surfaced as "No text extracted from
+          PDF (even with OCR/Vision)", which reads as "everything was tried";
+        * ``extract_text_from_pdf_ocr_async`` gated itself on ``_available``,
+          which consults the GEMINI client ONLY. With cloud vision unconfigured
+          -- the default, since cross-border vision is gated under UU PDP
+          Art. 56 -- it returned "" without ever asking the local Ollama engine,
+          which was armed and working the whole time.
+
+        Measured 2026-08-25 on a 3-page scanned ministerial decree: the two
+        callers yielded 0 characters; this path yields 6,109.
+
+        Returns None when NO page could be transcribed, so callers raise rather
+        than store an empty document. Individually failing pages are skipped and
+        logged -- most of a decree beats none of it.
+        """
+        try:
+            document = fitz.open(pdf_path)
+            page_count = document.page_count
+            document.close()
+        except Exception as exc:
+            logger.error("Could not open PDF for transcription: %s", exc)
+            return None
+
+        if max_pages is not None:
+            page_count = min(page_count, max_pages)
+
+        transcribed: list[str] = []
+        for page_number in range(1, page_count + 1):
+            page_text: str | None = None
+            try:
+                image = self._render_page_to_image(pdf_path, page_number)
+                buffered = io.BytesIO()
+                image.save(buffered, format="PNG")
+                image_base64 = base64.b64encode(buffered.getvalue()).decode()
+
+                page_text = await self._analyze_via_ollama(
+                    self.TRANSCRIPTION_PROMPT,
+                    image_base64,
+                )
+                if not page_text:
+                    # Cross-border fallback. Returns None when the sovereignty
+                    # gate is shut, which is a degradation to report, not an
+                    # error to raise.
+                    page_text = await self._analyze_via_gemini(
+                        self.TRANSCRIPTION_PROMPT,
+                        image_base64,
+                    )
+                    if page_text:
+                        await asyncio.sleep(GEMINI_VISION_PAGE_DELAY_SECONDS)
+            except Exception as exc:
+                logger.warning(
+                    "Page %s of %s could not be transcribed: %s",
+                    page_number,
+                    pdf_path,
+                    exc,
+                )
+                continue
+
+            if page_text and page_text.strip():
+                transcribed.append(page_text.strip())
+            else:
+                logger.warning("Page %s of %s produced no text", page_number, pdf_path)
+
+        if not transcribed:
+            logger.warning(
+                "Vision transcription produced nothing for %s (%s pages attempted)",
+                pdf_path,
+                page_count,
+            )
+            return None
+
+        logger.info(
+            "Vision transcription: %s/%s pages from %s",
+            len(transcribed),
+            page_count,
+            pdf_path,
+        )
+        return "\n\n".join(transcribed)
 
     async def _analyze_via_ollama(self, prompt: str, image_base64: str) -> str | None:
         """Analyze image using local Ollama qwen2.5vl:7b vision."""

--- a/apps/backend-rag/backend/tests/services/multimodal/test_scanned_pdf_transcription.py
+++ b/apps/backend-rag/backend/tests/services/multimodal/test_scanned_pdf_transcription.py
@@ -1,0 +1,171 @@
+"""A scanned PDF must actually reach a vision model.
+
+Until 2026-08-25 no scanned PDF could be read by this codebase, by two
+independent mechanisms, and both failures were silent:
+
+* ``parsers.extract_text_from_pdf`` called ``PDFVisionService.extract_text()``
+  as its "last resort vision" step. That method is declared "(for test
+  compatibility)" and, absent an AI client, re-reads the PDF with PyMuPDF --
+  the step that had just returned nothing. No page was ever rendered, no vision
+  model was ever asked. The user-visible failure read "No text extracted from
+  PDF (even with OCR/Vision)", i.e. it claimed everything had been tried.
+* ``parsers.extract_text_from_pdf_ocr_async`` gated on ``_available``, which
+  consults the GEMINI client only, so it gave up whenever cloud vision was
+  unconfigured -- the default, since cross-border vision is gated under UU PDP
+  Art. 56 -- without ever asking the armed local Ollama engine.
+
+Measured on a real 3-page scanned ministerial decree: 0 characters before,
+6,109 after.
+"""
+
+import asyncio
+
+import fitz
+import pytest
+
+from backend.services.multimodal import pdf_vision_service as vision_module
+from backend.services.multimodal.pdf_vision_service import PDFVisionService
+
+
+@pytest.fixture
+def scanned_pdf(tmp_path):
+    """A two-page PDF with no text layer, i.e. what a scan looks like."""
+    document = fitz.open()
+    for _ in range(2):
+        document.new_page(width=200, height=200)
+    path = tmp_path / "scan.pdf"
+    document.save(str(path))
+    document.close()
+    assert sum(len(page.get_text()) for page in fitz.open(str(path))) == 0
+    return str(path)
+
+
+def _service(monkeypatch, *, ollama=None, gemini=None):
+    service = PDFVisionService()
+
+    async def fake_ollama(prompt, image_base64):
+        return ollama
+
+    async def fake_gemini(prompt, image_base64):
+        return gemini
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", fake_ollama)
+    monkeypatch.setattr(service, "_analyze_via_gemini", fake_gemini)
+    return service
+
+
+# ---------------------------------------------------------------------------
+# GUILT
+# ---------------------------------------------------------------------------
+
+
+def test_the_local_engine_is_asked_and_its_text_is_returned(monkeypatch, scanned_pdf):
+    service = _service(monkeypatch, ollama="KEPUTUSAN MENTERI")
+    result = asyncio.run(service.transcribe_scanned_pdf(scanned_pdf))
+    assert result == "KEPUTUSAN MENTERI\n\nKEPUTUSAN MENTERI"
+
+
+def test_the_gemini_client_being_unavailable_does_not_stop_the_local_engine(
+    monkeypatch,
+    scanned_pdf,
+):
+    """The old async path gave up here without ever asking Ollama."""
+    monkeypatch.setattr(
+        PDFVisionService,
+        "_available",
+        property(lambda self: False),
+        raising=False,
+    )
+    service = _service(monkeypatch, ollama="TEKS")
+    assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf)) is not None
+
+
+def test_the_async_parser_entry_point_delegates_to_the_real_engine(monkeypatch, scanned_pdf):
+    from backend.core import parsers
+
+    async def fake_transcribe(self, pdf_path, max_pages=None):
+        return "TRANSCRIBED"
+
+    monkeypatch.setattr(PDFVisionService, "transcribe_scanned_pdf", fake_transcribe)
+    assert asyncio.run(parsers.extract_text_from_pdf_ocr_async(scanned_pdf)) == "TRANSCRIBED"
+
+
+def test_the_sync_last_resort_reaches_the_vision_engine(monkeypatch, scanned_pdf):
+    """extract_text_from_pdf must end at a rendered page, not at PyMuPDF again."""
+    from backend.core import parsers
+
+    async def fake_transcribe(self, pdf_path, max_pages=None):
+        return "SCANNED CONTENT"
+
+    monkeypatch.setattr(PDFVisionService, "transcribe_scanned_pdf", fake_transcribe)
+    monkeypatch.setattr(parsers, "extract_text_from_pdf_ocr", lambda path: "")
+    assert parsers.extract_text_from_pdf(scanned_pdf) == "SCANNED CONTENT"
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE
+# ---------------------------------------------------------------------------
+
+
+def test_total_failure_returns_none_rather_than_an_error_string(monkeypatch, scanned_pdf):
+    """`analyze_page` reports failure by RETURNING a string; that string must
+    never become the document's text."""
+    service = _service(monkeypatch, ollama=None, gemini=None)
+    assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf)) is None
+
+
+def test_the_sovereignty_gate_still_governs_the_cloud_fallback(monkeypatch, scanned_pdf):
+    """Ollama silent + cloud gate shut must degrade to None, never to a cloud call."""
+    from backend.services.multimodal import cloud_vision_gate
+
+    monkeypatch.setattr(cloud_vision_gate, "cloud_vision_allowed", lambda: False)
+    service = PDFVisionService()
+
+    async def silent_ollama(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", silent_ollama)
+    assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf)) is None
+
+
+def test_a_page_that_fails_does_not_lose_the_rest_of_the_document(monkeypatch, scanned_pdf):
+    service = PDFVisionService()
+    calls = {"n": 0}
+
+    async def flaky(prompt, image_base64):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("render blew up")
+        return "PAGE TWO"
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", flaky)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf)) == "PAGE TWO"
+
+
+def test_the_cloud_rate_limit_pause_never_runs_on_the_local_path(monkeypatch, scanned_pdf):
+    """The old async loop slept 4s per page unconditionally -- 400s wasted on a
+    100-page scan the local engine handled without any quota."""
+    slept: list[float] = []
+
+    async def recording_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(vision_module.asyncio, "sleep", recording_sleep)
+    service = _service(monkeypatch, ollama="TEKS")
+    asyncio.run(service.transcribe_scanned_pdf(scanned_pdf))
+    assert slept == []
+
+
+def test_max_pages_is_honoured(monkeypatch, scanned_pdf):
+    service = _service(monkeypatch, ollama="X")
+    assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf, max_pages=1)) == "X"
+
+
+def test_an_unopenable_file_returns_none_not_an_exception(monkeypatch, tmp_path):
+    broken = tmp_path / "not-a.pdf"
+    broken.write_bytes(b"definitely not a pdf")
+    assert asyncio.run(PDFVisionService().transcribe_scanned_pdf(str(broken))) is None


### PR DESCRIPTION
fix(parsers): no scanned PDF could ever be read, by two independent mechanisms

A PDF with no text layer -- a scan -- could not enter this codebase. Both
fallbacks that exist to handle exactly that case were incapable of succeeding,
each for a different reason, and both failed silently.

1. The synchronous last resort in `extract_text_from_pdf` called
   `PDFVisionService.extract_text()`. That method's own docstring says
   "(for test compatibility)"; absent an AI client it re-reads the PDF with
   PyMuPDF -- the step that had just returned nothing. It never rendered a
   page and never reached a vision model. The user-visible error was
   "No text extracted from PDF (even with OCR/Vision)", which reads as
   "everything was tried".

2. `extract_text_from_pdf_ocr_async` gated itself on `PDFVisionService._available`,
   a property that consults the GEMINI client only. With cloud vision
   unconfigured -- the default posture, since cross-border vision is gated
   under UU PDP Art. 56 -- it returned "" without ever asking the local Ollama
   engine, which was armed and working. It also appended whatever
   `analyze_page` returned, and that method reports failure by RETURNING a
   string ("Error analyzing page: ..."), so a failed page could enter the
   corpus as the document's own text.

The working engine was in the same file the whole time: `_render_page_to_image`
plus `_analyze_via_ollama`. This adds one implementation, `transcribe_scanned_pdf`,
and points both callers at it. Ollama first, gated Gemini second, per-page
failures skipped rather than fatal, and None -- never an error string -- when no
page could be read.

Measured on a real 3-page scanned ministerial decree (Kepmen M.IP-19.GR.01.01
Tahun 2025): 0 characters before, 6,109 after.

Also removes a 4-second per-page sleep that paced Gemini's free-tier quota
unconditionally, including on the local path that has no quota -- 400 seconds
of doing nothing on a 100-page scan.

Scar family #2 (exists is not armed): both paths were wired, reachable, and
returned success-shaped values while being structurally unable to work.

Tests: 10 new (guilt: the local engine is reached, an unavailable Gemini client
no longer stops it, both parser entry points delegate to the real engine;
innocence: total failure returns None not an error string, the sovereignty gate
still governs the cloud fallback, a failing page does not lose the document, no
cloud pacing on the local path). 48 pass across the touched suites.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW
