### PR TITLE
fix(legal): a document's identity was assembled from three different laws

### DIFF
--- a/apps/backend-rag/backend/core/legal/constants.py
+++ b/apps/backend-rag/backend/core/legal/constants.py
@@ -88,21 +88,64 @@ NOISE_PATTERNS = [
 # LEGAL DOCUMENT TYPE PATTERNS
 # ============================================================================
 
-LEGAL_TYPE_PATTERN = re.compile(
-    r"(UNDANG-UNDANG|PERATURAN PEMERINTAH|PERATURAN PRESIDEN|KEPUTUSAN PRESIDEN|PERATURAN MENTERI|QANUN|PERATURAN DAERAH|PERATURAN KEPALA)",
-    re.IGNORECASE,
+# Ordered LONGEST-FIRST wherever one name is a prefix of another. Python
+# alternation is first-match-wins at a given position, so "UNDANG-UNDANG" listed
+# before "UNDANG-UNDANG DASAR" would silently file the constitution as an
+# ordinary law, and "PERATURAN PEMERINTAH" before its PENGGANTI form would file
+# an emergency regulation (Perppu) as a government regulation (PP). Both are
+# identity collisions waiting to happen, since document_id is built from the
+# abbreviation.
+LEGAL_TYPE_NAMES = (
+    "PERATURAN PEMERINTAH PENGGANTI UNDANG-UNDANG",
+    "UNDANG-UNDANG DASAR",
+    "UNDANG-UNDANG",
+    "PERATURAN PEMERINTAH",
+    "PERATURAN PRESIDEN",
+    "KEPUTUSAN PRESIDEN",
+    "INSTRUKSI PRESIDEN",
+    "PERATURAN MENTERI",
+    "KEPUTUSAN MENTERI",
+    "INSTRUKSI MENTERI",
+    "PERATURAN GUBERNUR",
+    "KEPUTUSAN GUBERNUR",
+    "PERATURAN BUPATI",
+    "PERATURAN WALIKOTA",
+    "PERATURAN WALI KOTA",
+    "PERATURAN DAERAH",
+    "PERATURAN BADAN",
+    "PERATURAN KEPALA",
+    "SURAT EDARAN",
+    "QANUN",
 )
 
-# Abbreviations mapping
+_LEGAL_TYPE_ALTERNATION = "|".join(re.escape(name) for name in LEGAL_TYPE_NAMES)
+
+LEGAL_TYPE_PATTERN = re.compile(rf"({_LEGAL_TYPE_ALTERNATION})", re.IGNORECASE)
+
+# Abbreviations mapping. Every name in LEGAL_TYPE_NAMES must appear here --
+# a missing entry does not raise, it falls through to the full Indonesian name
+# and quietly changes the shape of document_id (see the tripwire test).
 LEGAL_TYPE_ABBREV = {
+    "PERATURAN PEMERINTAH PENGGANTI UNDANG-UNDANG": "Perppu",
+    "UNDANG-UNDANG DASAR": "UUD",
     "UNDANG-UNDANG": "UU",
     "PERATURAN PEMERINTAH": "PP",
     "PERATURAN PRESIDEN": "Perpres",
     "KEPUTUSAN PRESIDEN": "Keppres",
+    "INSTRUKSI PRESIDEN": "Inpres",
     "PERATURAN MENTERI": "Permen",
-    "QANUN": "Qanun",
+    "KEPUTUSAN MENTERI": "Kepmen",
+    "INSTRUKSI MENTERI": "Inmen",
+    "PERATURAN GUBERNUR": "Pergub",
+    "KEPUTUSAN GUBERNUR": "Kepgub",
+    "PERATURAN BUPATI": "Perbup",
+    "PERATURAN WALIKOTA": "Perwali",
+    "PERATURAN WALI KOTA": "Perwali",
     "PERATURAN DAERAH": "Perda",
+    "PERATURAN BADAN": "Perban",
     "PERATURAN KEPALA": "Perkep",
+    "SURAT EDARAN": "SE",
+    "QANUN": "Qanun",
 }
 
 # ============================================================================
@@ -114,6 +157,53 @@ NUMBER_PATTERN = re.compile(r"NOMOR\s+(\d+[A-Z]?)(?:[/-]\d+)?", re.IGNORECASE)
 
 # Year
 YEAR_PATTERN = re.compile(r"TAHUN\s+(\d{4})", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# TITLE-BLOCK IDENTITY PATTERN
+# ---------------------------------------------------------------------------
+# Why this exists. The three patterns above are searched INDEPENDENTLY over the
+# whole document, each taking its first hit. Every Indonesian regulation cites
+# other regulations, so that lets the type come from one instrument, the number
+# from a second and the year from a third -- an identity assembled from three
+# different laws. It is not hypothetical: PP 31/2013 (Immigration) was stored as
+# number 5409, and a ministerial decree measured on 2026-08-25 came out as
+# "UU 28/2025" with every field scavenged from its own citation list.
+#
+# This pattern requires type, number and year to be CO-LOCATED, in title order,
+# inside a bounded window, so all three can only come from one instrument.
+# Measured over the 188 real PDFs in kb_sources (27 with a filename that states
+# the expected answer): 20/27 correct before, 26/27 after. The single remaining
+# miss is a PDF whose title page does not survive parsing at all -- no pattern
+# can reach it.
+#
+# The gaps are bounded and lazy ({0,120} and {0,40}) and no quantifier nests
+# over an overlapping character class. Measured against 200k-character
+# pathological inputs: 0.011s and 0.006s. This file already carries a ReDoS
+# scar (see the page-pattern comment above) -- the bounds are load-bearing,
+# not decorative.
+
+# A document number is NOT always an integer. Ministerial decrees are numbered
+# alphanumerically (e.g. "M.IP-19.GR.01.01"), so the token is captured broadly
+# here and interpreted in normalize_document_number().
+_NUMBER_TOKEN = r"[A-Za-z0-9][A-Za-z0-9./-]{0,40}"
+
+LEGAL_TITLE_PATTERN = re.compile(
+    rf"(?P<type>{_LEGAL_TYPE_ALTERNATION})"
+    rf"[\s\S]{{0,120}}?"
+    rf"NOMOR\s*(?P<number>{_NUMBER_TOKEN})"
+    rf"[\s\S]{{0,40}}?"
+    rf"TAHUN\s*(?P<year>(?:19|20)\d{{2}})",
+    re.IGNORECASE,
+)
+
+# The citation list opens with "Menimbang"/"Mengingat"; the title block is what
+# precedes it. The search deliberately starts at CITATION_SEARCH_OFFSET rather
+# than 0: on some scans the cleaner hoists those two words to the very front of
+# the text, and a guard that merely required `start > 200` then fell through to
+# the whole document (measured on Perpres 157/2024).
+CITATION_START_PATTERN = re.compile(r"\bMENIMBANG\b|\bMENGINGAT\b", re.IGNORECASE)
+CITATION_SEARCH_OFFSET = 200
+TITLE_BLOCK_FALLBACK_CHARS = 6000
 
 # Topic (text after "TENTANG" until "DENGAN RAHMAT" or end)
 TOPIC_PATTERN = re.compile(

--- a/apps/backend-rag/backend/core/legal/metadata_extractor.py
+++ b/apps/backend-rag/backend/core/legal/metadata_extractor.py
@@ -8,15 +8,90 @@ import re
 from typing import Any
 
 from backend.core.legal.constants import (
+    CITATION_SEARCH_OFFSET,
+    CITATION_START_PATTERN,
+    LEGAL_TITLE_PATTERN,
     LEGAL_TYPE_ABBREV,
     LEGAL_TYPE_PATTERN,
     NUMBER_PATTERN,
     STATUS_PATTERNS,
+    TITLE_BLOCK_FALLBACK_CHARS,
     TOPIC_PATTERN,
     YEAR_PATTERN,
 )
 
 logger = logging.getLogger(__name__)
+
+# `1` is read as `I` or `l` and `0` as `O` on scanned title pages. Perpres
+# 157/2024 reaches the extractor as "NOMOR I57 TAHUN 2024".
+_OCR_DIGIT_MAP = str.maketrans({"I": "1", "l": "1", "O": "0"})
+
+# "40/2007" fuses number and year; only the leading part is the number.
+_NUMBER_FUSED_WITH_YEAR = re.compile(r"^(\d{1,4}[A-Za-z]?)[/-]\d{2,4}$")
+
+# A token made only of digits and their OCR look-alikes, optionally suffixed by
+# a single letter ("12A"). Anything else -- notably a ministerial number like
+# "M.IP-19.GR.01.01" -- must be left alone.
+_NUMBER_OCR_CONFUSABLE = re.compile(r"^[0-9IlO]{1,4}[A-Za-z]?$")
+
+
+def normalize_document_number(raw: str) -> str | None:
+    """Interpret a captured `NOMOR ...` token, or return None if it is not one.
+
+    Three shapes occur in the real corpus and each needs different handling:
+
+    * ``40``, ``12A``        plain, optionally with a letter suffix;
+    * ``40/2007``            number and year fused -- only ``40`` is the number;
+    * ``M.IP-19.GR.01.01``   ministerial decrees are numbered alphanumerically,
+      and must be kept VERBATIM: applying the OCR correction here would turn
+      ``M.IP`` into ``M.1P``.
+
+    Returns None when the token carries no digit at all, so the caller falls
+    back rather than minting an identity out of a stray word.
+    """
+    token = raw.strip().rstrip("./-")
+    if not token:
+        return None
+
+    fused = _NUMBER_FUSED_WITH_YEAR.match(token)
+    if fused:
+        token = fused.group(1)
+
+    if _NUMBER_OCR_CONFUSABLE.match(token):
+        token = token.translate(_OCR_DIGIT_MAP)
+
+    if not any(character.isdigit() for character in token):
+        return None
+    return token.upper()
+
+
+def _title_block(text: str) -> str:
+    """The text that precedes the citation list, i.e. the document's own title."""
+    match = CITATION_START_PATTERN.search(text, CITATION_SEARCH_OFFSET)
+    if match:
+        return text[: match.start()]
+    return text[:TITLE_BLOCK_FALLBACK_CHARS]
+
+
+def extract_title_identity(text: str) -> dict[str, str] | None:
+    """Return type/number/year taken from ONE co-located title match, or None.
+
+    The title block is preferred; the whole document is a second pass, because a
+    co-located match anywhere still beats three independent first-hits.
+    """
+    for scope in (_title_block(text), text):
+        for match in LEGAL_TITLE_PATTERN.finditer(scope):
+            number = normalize_document_number(match.group("number"))
+            if number is None:
+                continue
+            doc_type = match.group("type").upper()
+            return {
+                "type": doc_type,
+                "type_abbrev": LEGAL_TYPE_ABBREV.get(doc_type, doc_type),
+                "number": number,
+                "year": match.group("year"),
+            }
+    return None
 
 
 class LegalMetadataExtractor:
@@ -52,37 +127,54 @@ class LegalMetadataExtractor:
             logger.warning("Empty text provided to metadata extractor")
             return {}
 
-        metadata = {}
+        metadata: dict[str, Any] = {}
 
-        # Extract document type
-        type_match = LEGAL_TYPE_PATTERN.search(text)
-        if type_match:
-            doc_type = type_match.group(1).upper()
-            metadata["type"] = doc_type
-            metadata["type_abbrev"] = LEGAL_TYPE_ABBREV.get(doc_type, doc_type)
-            logger.debug(f"Extracted type: {doc_type} ({metadata['type_abbrev']})")
-        else:
-            logger.warning("Could not extract document type")
-            metadata["type"] = "UNKNOWN"
-            metadata["type_abbrev"] = "UNKNOWN"
+        # PREFERRED: all three fields from ONE co-located title match, so they
+        # cannot be assembled out of three different laws the document cites.
+        identity = extract_title_identity(text)
+        if identity:
+            metadata.update(identity)
+            logger.debug(
+                "Extracted co-located identity: %s %s/%s",
+                identity["type_abbrev"],
+                identity["number"],
+                identity["year"],
+            )
 
-        # Extract document number
-        number_match = NUMBER_PATTERN.search(text)
-        if number_match:
-            metadata["number"] = number_match.group(1)
-            logger.debug(f"Extracted number: {metadata['number']}")
-        else:
-            logger.warning("Could not extract document number")
-            metadata["number"] = "UNKNOWN"
+        # FALLBACK: the independent whole-document searches, per field, only for
+        # what the title match could not supply. These are what mint a wrong
+        # identity when a document's own title block did not survive parsing --
+        # kept because a scavenged field still beats UNKNOWN for retrieval, but
+        # deliberately demoted to second place.
+        if "type" not in metadata:
+            type_match = LEGAL_TYPE_PATTERN.search(text)
+            if type_match:
+                doc_type = type_match.group(1).upper()
+                metadata["type"] = doc_type
+                metadata["type_abbrev"] = LEGAL_TYPE_ABBREV.get(doc_type, doc_type)
+                logger.debug(f"Extracted type: {doc_type} ({metadata['type_abbrev']})")
+            else:
+                logger.warning("Could not extract document type")
+                metadata["type"] = "UNKNOWN"
+                metadata["type_abbrev"] = "UNKNOWN"
 
-        # Extract year
-        year_match = YEAR_PATTERN.search(text)
-        if year_match:
-            metadata["year"] = year_match.group(1)
-            logger.debug(f"Extracted year: {metadata['year']}")
-        else:
-            logger.warning("Could not extract year")
-            metadata["year"] = "UNKNOWN"
+        if "number" not in metadata:
+            number_match = NUMBER_PATTERN.search(text)
+            if number_match:
+                metadata["number"] = number_match.group(1)
+                logger.debug(f"Extracted number: {metadata['number']}")
+            else:
+                logger.warning("Could not extract document number")
+                metadata["number"] = "UNKNOWN"
+
+        if "year" not in metadata:
+            year_match = YEAR_PATTERN.search(text)
+            if year_match:
+                metadata["year"] = year_match.group(1)
+                logger.debug(f"Extracted year: {metadata['year']}")
+            else:
+                logger.warning("Could not extract year")
+                metadata["year"] = "UNKNOWN"
 
         # Extract topic (text after "TENTANG")
         topic_match = TOPIC_PATTERN.search(text)

--- a/apps/backend-rag/backend/tests/unit/core/legal/test_legal_title_identity.py
+++ b/apps/backend-rag/backend/tests/unit/core/legal/test_legal_title_identity.py
@@ -1,0 +1,233 @@
+"""Identity is taken from the document's own title, not from the laws it cites.
+
+Every Indonesian regulation opens with a citation list. Until 2026-08-25 the
+extractor searched for type, number and year INDEPENDENTLY over the whole
+document and took each one's first hit, so a single identity could be assembled
+out of three different instruments. Measured consequences, both real:
+
+* PP 31/2013 (Immigration) was stored under number 5409 -- 441 points.
+* A ministerial decree measured on 2026-08-25 came out as "UU 28/2025", with
+  every field scavenged from its own citation list.
+
+Since ``document_id`` is built from type_abbrev/number/year, a wrong identity is
+not a cosmetic error: it is how two unrelated documents come to share a point id
+and silently overwrite each other.
+"""
+
+import re
+import time
+
+import pytest
+
+from backend.core.legal.constants import (
+    LEGAL_TITLE_PATTERN,
+    LEGAL_TYPE_ABBREV,
+    LEGAL_TYPE_NAMES,
+)
+from backend.core.legal.metadata_extractor import (
+    LegalMetadataExtractor,
+    extract_title_identity,
+    normalize_document_number,
+)
+
+
+@pytest.fixture
+def extractor() -> LegalMetadataExtractor:
+    return LegalMetadataExtractor()
+
+
+# ---------------------------------------------------------------------------
+# GUILT -- each of these fails against the pre-2026-08-25 extractor
+# ---------------------------------------------------------------------------
+
+
+def test_identity_is_not_assembled_from_three_different_cited_laws(extractor):
+    """The PP 31/2013 shape, which production stored under number 5409.
+
+    The foreign number deliberately PRECEDES the title. That placement is what
+    makes this test discriminate: the old extractor scans linearly and takes the
+    first ``NOMOR <digits>`` anywhere, so a noise number that comes after the
+    title is harmless and a test built that way passes before and after the fix,
+    proving nothing. Gazette headers really do carry such a number, and 441
+    points of PP 31/2013 were stored under it.
+    """
+    text = (
+        "SALINAN\n"
+        "TAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA NOMOR 5409\n\n"
+        "PERATURAN PEMERINTAH REPUBLIK INDONESIA\n"
+        "NOMOR 31 TAHUN 2013\n"
+        "TENTANG PERATURAN PELAKSANAAN UNDANG-UNDANG KEIMIGRASIAN\n\n"
+        "Menimbang : a. bahwa untuk melaksanakan ketentuan ...\n"
+        "Mengingat : 1. Undang-Undang Nomor 6 Tahun 2011 tentang Keimigrasian;\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["type_abbrev"] == "PP"
+    assert metadata["number"] == "31"
+    assert metadata["year"] == "2013"
+
+
+def test_a_ministerial_decree_keeps_its_alphanumeric_number(extractor):
+    """Real specimen, OCR'd from the scan on 2026-08-25.
+
+    Ministries do not number decrees with integers. The old pattern required
+    ``\\d+``, found nothing in the title, and took ``Nomor 6 Tahun 2011`` out of
+    the citation list -- the Immigration Law's own identity.
+    """
+    text = (
+        "MENTERI IMIGRASI DAN PEMASYARAKATAN\nREPUBLIK INDONESIA\n\n"
+        "KEPUTUSAN MENTERI IMIGRASI DAN PEMASYARAKATAN\nREPUBLIK INDONESIA\n\n"
+        "NOMOR M.IP-19.GR.01.01 TAHUN 2025\n\nTENTANG\n\n"
+        "SISTEM KERJA PADA TEMPAT PEMERIKSAAN IMIGRASI\n\n"
+        "Menimbang : a. bahwa peningkatan lalu lintas orang ...\n"
+        "Mengingat : 4. Undang-Undang Nomor 6 Tahun 2011 tentang Keimigrasian;\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["type_abbrev"] == "Kepmen"
+    assert metadata["number"] == "M.IP-19.GR.01.01"
+    assert metadata["year"] == "2025"
+
+
+def test_ocr_confusion_of_one_as_capital_i_is_corrected(extractor):
+    """Perpres 157/2024 reaches the extractor as "NOMOR I57"."""
+    text = (
+        "PERATURAN PRESIDEN REPUBLIK INDONESIA\n"
+        "NOMOR I57 TAHUN 2024\n"
+        "TENTANG KEMENTERIAN IMIGRASI DAN PEMASYARAKATAN\n\n"
+        "Mengingat : Undang-Undang Nomor 39 Tahun 2008 tentang Kementerian Negara;\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["type_abbrev"] == "Perpres"
+    assert metadata["number"] == "157"
+    assert metadata["year"] == "2024"
+
+
+def test_citation_words_at_the_very_start_do_not_blind_the_title_search(extractor):
+    """The cleaner sometimes hoists "Menimbang Mengingat" to character 0.
+
+    A title-block guard of the form ``start > 200`` then declines to cut and
+    hands the whole document -- citation list included -- to the search.
+    """
+    text = (
+        "Menimbang Mengingat Menetapkan SALINAN\nPRESIDEN\nREPUBLIK INDONESIA\n"
+        "TAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA NOMOR 6634\n"
+        "PERATURAN PRESIDEN REPUBLIK INDONESIA\n"
+        "NOMOR 157 TAHUN 2024\n"
+        "TENTANG KEMENTERIAN IMIGRASI DAN PEMASYARAKATAN\n\n"
+        "Mengingat : Undang-Undang Nomor 39 Tahun 2008 tentang Kementerian Negara;\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["number"] == "157"
+    assert metadata["year"] == "2024"
+
+
+def test_an_emergency_regulation_is_not_filed_as_a_government_regulation(extractor):
+    """Perppu vs PP: alternation order decides, and both mint a document_id."""
+    text = (
+        "PERATURAN PEMERINTAH PENGGANTI UNDANG-UNDANG REPUBLIK INDONESIA\n"
+        "NOMOR 2 TAHUN 2022\nTENTANG CIPTA KERJA\n\nMenimbang : a. bahwa ...\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["type_abbrev"] == "Perppu"
+    assert metadata["number"] == "2"
+
+
+def test_the_constitution_is_not_filed_as_an_ordinary_law(extractor):
+    text = (
+        "UNDANG-UNDANG DASAR NEGARA REPUBLIK INDONESIA\n"
+        "NOMOR 1 TAHUN 1945\nTENTANG PEMBUKAAN\n\nMenimbang : ...\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["type_abbrev"] == "UUD"
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE -- behaviour that must not change
+# ---------------------------------------------------------------------------
+
+
+def test_a_plain_law_is_extracted_exactly_as_before(extractor):
+    """UU 40/2007 (Perseroan Terbatas), verbatim opening of the real PDF."""
+    text = (
+        "UNDANG-UNDANG REPUBLIK INDONESIA \nNOMOR 40 TAHUN 2007 \nTENTANG \n"
+        "PERSEROAN TERBATAS \n\nDENGAN RAHMAT TUHAN YANG MAHA ESA \n\n"
+        "PRESIDEN REPUBLIK INDONESIA, \n\nMenimbang : a. bahwa perekonomian nasional ...\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["type_abbrev"] == "UU"
+    assert metadata["number"] == "40"
+    assert metadata["year"] == "2007"
+
+
+def test_a_letter_suffixed_number_keeps_its_letter(extractor):
+    text = (
+        "PERATURAN MENTERI KEUANGAN REPUBLIK INDONESIA\n"
+        "NOMOR 12A TAHUN 2020\nTENTANG SESUATU\n\nMenimbang : ...\n"
+    )
+    metadata = extractor.extract(text)
+    assert metadata["number"] == "12A"
+
+
+def test_a_number_fused_with_its_year_yields_only_the_number():
+    assert normalize_document_number("40/2007") == "40"
+    assert normalize_document_number("12A-2007") == "12A"
+
+
+def test_a_token_without_any_digit_is_refused():
+    """Otherwise a stray word becomes a document number, and then an identity."""
+    assert normalize_document_number("TENTANG") is None
+    assert normalize_document_number("") is None
+    assert normalize_document_number("...") is None
+
+
+def test_the_ocr_correction_never_touches_a_ministerial_number():
+    """Mapping I->1 on "M.IP-19.GR.01.01" would produce "M.1P-19.GR.01.01"."""
+    assert normalize_document_number("M.IP-19.GR.01.01") == "M.IP-19.GR.01.01"
+
+
+def test_no_title_match_still_falls_back_to_the_old_behaviour(extractor):
+    """A document whose title block did not survive parsing must still yield."""
+    text = "3. Undang-Undang tentang sesuatu\na. bahwa Presiden selaku Kepala Pemerintahan\n"
+    metadata = extractor.extract(text)
+    assert extract_title_identity(text) is None
+    assert metadata["type_abbrev"] == "UU"
+    assert metadata["number"] == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# STRUCTURAL TRIPWIRES
+# ---------------------------------------------------------------------------
+
+
+def test_every_declared_type_name_has_an_abbreviation():
+    """A missing entry does not raise -- it silently changes document_id shape."""
+    missing = [name for name in LEGAL_TYPE_NAMES if name not in LEGAL_TYPE_ABBREV]
+    assert missing == [], f"types without an abbreviation: {missing}"
+
+
+def test_type_names_are_ordered_longest_first_where_one_prefixes_another():
+    """First-match-wins alternation: a prefix listed first shadows the longer name."""
+    for shorter_index, shorter in enumerate(LEGAL_TYPE_NAMES):
+        for longer_index, longer in enumerate(LEGAL_TYPE_NAMES):
+            if longer != shorter and longer.startswith(shorter):
+                assert longer_index < shorter_index, (
+                    f"{longer!r} is shadowed by {shorter!r}: list it first"
+                )
+
+
+def test_the_title_pattern_does_not_backtrack_catastrophically():
+    """This file carries a ReDoS scar; the gap bounds are load-bearing."""
+    for payload in (
+        "PERATURAN PEMERINTAH " + "A" * 200_000,
+        "PERATURAN PEMERINTAH NOMOR " + "1" * 100_000,
+    ):
+        started = time.perf_counter()
+        LEGAL_TITLE_PATTERN.search(payload)
+        assert time.perf_counter() - started < 1.0
+
+
+def test_the_number_token_cannot_swallow_the_year_keyword():
+    """The token class excludes whitespace, so "NOMOR 40 TAHUN" cannot fuse."""
+    match = LEGAL_TITLE_PATTERN.search("UNDANG-UNDANG NOMOR 40 TAHUN 2007")
+    assert match is not None
+    assert match.group("number") == "40"
+    assert not re.search(r"\s", match.group("number"))


### PR DESCRIPTION
fix(legal): a document's identity was assembled from three different laws

`LegalMetadataExtractor.extract` searched for type, number and year with three
INDEPENDENT `.search()` calls over the whole document, each taking its first hit.
Every Indonesian regulation opens with a citation list, so the type could come
from one instrument, the number from a second and the year from a third. Since
`build_content_bound_legal_doc_id` is built from those three fields, this is not
cosmetic: it is how two unrelated documents come to share a `document_id`, hence
a point id, and silently overwrite each other in Qdrant.

Measured, not hypothesised. Against the 188 real PDFs in kb_sources (27 whose
filename states the expected answer): 20/27 correct before, 26/27 after. The one
remaining miss is a PDF whose title page does not survive parsing at all -- no
pattern can reach it. Concrete repairs:

  PP_31_2013_Imigrasi          number 5409 -> 31   (441 points)
  PP_18_2021_HakPakai_HGB      number 6630 -> 18
  PP_103_2015_Properti_Asing   number 5793 -> 103
  PP_103_2015_Penjelasan       number  325 -> 103
  Perpres_157_2024             number   39 -> 157

Three defects, one surface:

1. NO CO-LOCATION. `LEGAL_TITLE_PATTERN` now requires type, number and year to
   appear together, in title order, inside a bounded window, so all three can
   only come from one instrument. The title block (everything before the
   citation list) is searched first; the whole document is a second pass.

2. THE NUMBER WAS ASSUMED TO BE AN INTEGER. `NOMOR\s+(\d+[A-Z]?)` cannot express
   a ministerial number. Measured 2026-08-25 on a real scanned decree --
   Keputusan Menteri Imigrasi dan Pemasyarakatan No. M.IP-19.GR.01.01 Tahun 2025
   -- the old extractor produced `UU_28_2025`, every field scavenged from the
   document's own citation list. `normalize_document_number` now handles the
   three shapes that actually occur: plain (`40`, `12A`), fused with the year
   (`40/2007` -> `40`), and alphanumeric ministerial (`M.IP-19.GR.01.01`, kept
   VERBATIM -- the OCR correction would otherwise turn `M.IP` into `M.1P`).
   It also corrects the OCR confusion of `1` as `I`/`l` and `0` as `O`, which is
   how Perpres 157/2024 arrives as `NOMOR I57`, and returns None on a token with
   no digit so a stray word cannot become an identity.

3. MISSING AND SHADOWED TYPE NAMES. The alternation had no entry for Keputusan
   Menteri, Instruksi Presiden, Peraturan Gubernur/Bupati/Walikota/Badan or
   Surat Edaran, and listed `UNDANG-UNDANG` before its longer forms -- so a
   Perppu was filed as a PP and the constitution as an ordinary law, both by
   prefix shadowing. Names are now ordered longest-first, with a tripwire test
   that fails if a future edit reintroduces the shadowing, and a second that
   fails if a name is added without an abbreviation (a missing entry does not
   raise -- it silently changes the shape of `document_id`).

The three independent searches are KEPT as a per-field fallback for documents
whose title block did not survive parsing: a scavenged field still beats UNKNOWN
for retrieval, but it is now demoted to second place rather than being the only
path.

ReDoS: this file carries a scar and the gap bounds are load-bearing. The pattern
uses lazy, bounded gaps with no quantifier nesting over overlapping classes;
measured 0.011s and 0.006s against 200k-character pathological inputs, and it is
swept automatically by the existing `vars(constants)` enumeration in
test_redos_anchor_patterns.py.

Tests: 16 new. An independent verification pass found that two of the six guilt
tests did NOT actually fail on origin/main -- with their original inputs the
correct number happened to precede the citation, so the old linear scan got it
right by position and the tests would have passed before and after, proving
nothing. Both inputs now place the foreign number BEFORE the title, as gazette
headers really do; origin/main's own `NUMBER_PATTERN` returns 5409 and 6634 on
them, measured directly. 377 pass across backend/tests/unit/core/legal/.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW
