### PR TITLE
fix(pricing): a public endpoint has been serving the wrong price for four services

### DIFF
--- a/apps/backend-rag/backend/services/pricing/pricing_service.py
+++ b/apps/backend-rag/backend/services/pricing/pricing_service.py
@@ -86,28 +86,64 @@ def _entry_display_price(entry: dict[str, Any]) -> str:
     return "Contact"
 
 
+# Namespace separator for a QUALIFIED ``get_service_by_key`` argument
+# (``"<sub_block or category>::<service_name>"``). Chosen over "/" because
+# several real catalogue display names already contain a bare "/" (e.g.
+# "Working KITAS (Altus/Onshore)") — "/" would not visibly distinguish a
+# qualifier from an ordinary display name that happens to contain one. No
+# catalogue name contains "::". Kept in sync by convention (not by import —
+# this module owns the catalogue walk, the client-bot snapshot builder does
+# not) with the identical scheme in
+# ``backend/services/client_bot/grounding.py``'s ``_KEY_QUALIFIER_SEP``.
+_KEY_QUALIFIER_SEP = "::"
+
+
+def _iter_service_entries_with_subblock(
+    services: dict[str, Any],
+) -> list[tuple[str, str | None, str, dict[str, Any]]]:
+    """Yield ``(category, sub_block, service_name, entry)`` quadruples across
+    the whole ``services`` mapping. ``sub_block`` is ``None`` for the flat
+    ``_FLAT_CATEGORIES`` and the nested sub-block name (e.g.
+    ``"monthly_tax_basic"``) for ``_NESTED_CATEGORIES`` — the one extra
+    piece of context :func:`_iter_service_entries` intentionally drops, and
+    that :meth:`PricingService.get_service_by_key` needs to tell apart two
+    entries that share the same ``service_name`` across different
+    sub-blocks of the same category."""
+    quads: list[tuple[str, str | None, str, dict[str, Any]]] = []
+    for category_name, category_payload in services.items():
+        if not isinstance(category_payload, dict):
+            continue
+        if category_name in _NESTED_CATEGORIES:
+            for sub_block_name, sub_block in category_payload.items():
+                if not isinstance(sub_block, dict):
+                    continue
+                for service_name, entry in sub_block.items():
+                    if isinstance(entry, dict):
+                        quads.append((category_name, sub_block_name, service_name, entry))
+        else:
+            for service_name, entry in category_payload.items():
+                if isinstance(entry, dict):
+                    quads.append((category_name, None, service_name, entry))
+    return quads
+
+
 def _iter_service_entries(
     services: dict[str, Any],
 ) -> list[tuple[str, str, dict[str, Any]]]:
     """Yield ``(category, service_name, entry)`` triples across the whole
     ``services`` mapping, descending one extra level for nested categories
-    such as ``tax_accounting`` so callers see a flat stream."""
-    triples: list[tuple[str, str, dict[str, Any]]] = []
-    for category_name, category_payload in services.items():
-        if not isinstance(category_payload, dict):
-            continue
-        if category_name in _NESTED_CATEGORIES:
-            for sub_block in category_payload.values():
-                if not isinstance(sub_block, dict):
-                    continue
-                for service_name, entry in sub_block.items():
-                    if isinstance(entry, dict):
-                        triples.append((category_name, service_name, entry))
-        else:
-            for service_name, entry in category_payload.items():
-                if isinstance(entry, dict):
-                    triples.append((category_name, service_name, entry))
-    return triples
+    such as ``tax_accounting`` so callers see a flat stream.
+
+    A thin projection of :func:`_iter_service_entries_with_subblock` that
+    drops the sub-block column — kept as its own function because it is the
+    load-time service-count helper's public shape and nothing outside this
+    module needs the sub-block detail."""
+    return [
+        (category, service_name, entry)
+        for category, _sub_block, service_name, entry in _iter_service_entries_with_subblock(
+            services
+        )
+    ]
 
 
 class PricingService:
@@ -201,22 +237,70 @@ class PricingService:
         Returns ``None`` when the key is unknown OR when the catalogue failed to
         load, so the caller cannot mistake "not loaded" for "no such service".
         The two are distinguished by :attr:`loaded`.
+
+        ``key`` can also be AMBIGUOUS: the live 2026 catalogue has four
+        ``service_name`` collisions — "Tier 0-50", "Tier 50-100",
+        "Tier 100-200", "Tier 200+" — each shared between
+        ``tax_accounting``'s ``monthly_tax_basic`` (a tier-range price, LKPM
+        and Annual Tax NOT included) and ``monthly_tax_bundled`` (a single
+        price, LKPM + Annual Tax included) sub-blocks, with a genuinely
+        different amount behind the identical dict key. A bare colliding key
+        now returns ``None`` rather than silently resolving to whichever
+        sub-block the catalogue walk happens to reach first — the near-miss-
+        as-real-price failure this method exists to prevent, just triggered
+        by the catalogue's own shape instead of a caller's typo. To ask for
+        ONE of the colliding rows unambiguously, qualify the key as
+        ``"<sub_block or category>::<service_name>"`` (e.g.
+        ``"monthly_tax_bundled::Tier 0-50"``) — see :data:`_KEY_QUALIFIER_SEP`.
+        Every other key (105 of the catalogue's 109) is unaffected and keeps
+        resolving on its bare, human-readable name exactly as before; the
+        returned ``"key"`` always echoes back ``key`` verbatim, qualified or
+        not, so a caller's own ``row["key"] == key`` round-trip check holds
+        either way.
         """
         if not self.loaded:
             return None
 
-        for category, service_name, entry in _iter_service_entries(self.prices.get("services", {})):
-            if service_name != key:
-                continue
-            return {
-                "key": service_name,
-                "name": entry.get("name") or service_name,
-                "price": _entry_display_price(entry),
-                "category": category,
-                "validity": entry.get("validity") or None,
-                "notes": entry.get("notes") or None,
-            }
-        return None
+        quads = _iter_service_entries_with_subblock(self.prices.get("services", {}))
+
+        if _KEY_QUALIFIER_SEP in key:
+            qualifier, _sep, bare_name = key.partition(_KEY_QUALIFIER_SEP)
+            matches = [
+                (category, sub_block, entry)
+                for category, sub_block, service_name, entry in quads
+                if service_name == bare_name and (sub_block or category) == qualifier
+            ]
+        else:
+            bare_name = key
+            matches = [
+                (category, sub_block, entry)
+                for category, sub_block, service_name, entry in quads
+                if service_name == key
+            ]
+
+        if len(matches) != 1:
+            if len(matches) > 1:
+                qualifiers = sorted((sub_block or cat) for cat, sub_block, _e in matches)
+                logger.warning(
+                    "get_service_by_key(%r): %d entries share this key — refusing "
+                    "to guess. Ask for one unambiguously via '<qualifier>::%s' "
+                    "where <qualifier> in %s.",
+                    key,
+                    len(matches),
+                    bare_name,
+                    qualifiers,
+                )
+            return None
+
+        category, _sub_block, entry = matches[0]
+        return {
+            "key": key,
+            "name": entry.get("name") or bare_name,
+            "price": _entry_display_price(entry),
+            "category": category,
+            "validity": entry.get("validity") or None,
+            "notes": entry.get("notes") or None,
+        }
 
     def get_all_prices(self) -> dict[str, Any]:
         """Get all official prices"""

--- a/apps/backend-rag/backend/tests/services/pricing/test_pricing_service_key_collision.py
+++ b/apps/backend-rag/backend/tests/services/pricing/test_pricing_service_key_collision.py
@@ -1,0 +1,323 @@
+"""``get_service_by_key`` must refuse to guess when two catalogue entries
+share a key — regression suite for the "silent first-match" defect its own
+docstring names as the failure it exists to make impossible. The live 2026
+catalogue has 4 real ``service_name`` collisions, all in ``tax_accounting``
+between the ``monthly_tax_basic`` (tier-range price, LKPM/Annual Tax NOT
+included) and ``monthly_tax_bundled`` (single price, LKPM + Annual Tax
+included) sub-blocks — a real spread of ~500k-1.5M IDR and a different
+scope of work sitting behind the identical dict key.
+
+  guilt      the 4 real collisions refuse a bare key (``None``, never a
+             guess); the qualified ``"<sub_block>::<name>"`` form resolves
+             each one to its OWN, distinct row
+  innocence  every unambiguous key in the real catalogue still resolves
+             exactly as before; each of the three live consumers keeps its
+             existing behaviour on a normal (non-colliding) key
+
+Deliberately discovers the collision set from the REAL, shipped on-disk
+catalogue at test time via an independent walk (never a hardcoded literal
+list, never a call into the collision-resolution logic under test) — a 5th
+future collision widens the parametrization and is covered the day it
+lands, rather than needing this file to be remembered and updated by hand.
+
+Reachability per consumer (verified 2026-08-25, see the lane report):
+
+  * ``GET /api/pricing/service?key=...`` (``app/routers/dynamic_pricing.py``)
+    is PUBLIC, unauthenticated, and ``key`` is an arbitrary client-supplied
+    query string with no enum constraint — the ONLY consumer that could
+    reach a colliding key from outside the system today.
+  * ``garuda_flow/pricing.py::price_for_case`` uses two hardcoded source
+    literals (``_ISSUANCE_PRICE_KEY`` / ``_EXTENSION_PRICE_KEY``), never
+    client- or data-supplied, and neither is one of the 4 real colliding
+    names — provably unreachable today by construction, not merely by
+    the current data.
+  * ``visa_engine/pricing_adapter.py::resolve_candidate_pricing`` reads
+    ``product.pricing_key`` from a SIGNED RulePack payload — curated data,
+    not a live HTTP input, and no signed pack today names a
+    ``tax_accounting`` category or one of the 4 colliding item keys — but
+    the schema does not forbid it, and the adapter's own
+    ``row.get("category") != pricing_key.category`` guard cannot
+    disambiguate the two sub-blocks (both report ``category ==
+    "tax_accounting"``), so this consumer's safety is a property of the
+    catalogue data today, not a mechanism, unlike garuda_flow's.
+"""
+
+from __future__ import annotations
+
+import collections
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from backend.services.garuda_flow.intake import CaseType
+from backend.services.garuda_flow.pricing import (
+    _EXTENSION_PRICE_KEY,
+    _ISSUANCE_PRICE_KEY,
+    price_for_case,
+)
+from backend.services.pricing.pricing_service import (
+    _KEY_QUALIFIER_SEP,
+    _NESTED_CATEGORIES,
+    PricingService,
+    _entry_display_price,
+)
+from backend.services.visa_engine.models import PricingKey
+from backend.services.visa_engine.pricing_adapter import resolve_candidate_pricing
+from backend.tests.services.visa_engine.gold_harness import loader as gold_loader
+
+REAL_COLLIDING_KEYS = ["Tier 0-50", "Tier 50-100", "Tier 100-200", "Tier 200+"]
+
+_EVALUATED_AT = datetime(2026, 8, 25, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def svc() -> PricingService:
+    """A ``PricingService`` reading the REAL, shipped 2026 catalogue — not
+    a fixture stub. The whole point of this file is that the collision is
+    a property of the live data, so the tests must run against it."""
+    instance = PricingService()
+    assert instance.loaded, "the shipped catalogue failed to load — check the data file path"
+    return instance
+
+
+def _real_catalogue_collisions(
+    services: dict[str, Any],
+) -> dict[str, list[tuple[str, str | None]]]:
+    """Independently discover every ``service_name`` that names 2+ entries
+    in the real catalogue, by walking the raw services mapping directly.
+
+    Deliberately does NOT call ``_iter_service_entries_with_subblock`` (the
+    function ``get_service_by_key`` — the subject of this file — is built
+    on): a bug in the fix under test must never also blind the oracle that
+    is supposed to catch it. ``_NESTED_CATEGORIES`` is reused because it is
+    documented SCHEMA knowledge (the module docstring names it), not part
+    of the collision-resolution logic this file holds accountable.
+    """
+    locations: dict[str, list[tuple[str, str | None]]] = collections.defaultdict(list)
+    for category_name, category_payload in services.items():
+        if not isinstance(category_payload, dict):
+            continue
+        if category_name in _NESTED_CATEGORIES:
+            for sub_block_name, sub_block in category_payload.items():
+                if not isinstance(sub_block, dict):
+                    continue
+                for service_name, entry in sub_block.items():
+                    if isinstance(entry, dict):
+                        locations[service_name].append((category_name, sub_block_name))
+        else:
+            for service_name, entry in category_payload.items():
+                if isinstance(entry, dict):
+                    locations[service_name].append((category_name, None))
+    return {name: locs for name, locs in locations.items() if len(locs) > 1}
+
+
+def _unambiguous_real_entries(
+    services: dict[str, Any],
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """``(service_name, category, entry)`` for every catalogue entry whose
+    name occurs exactly once across the whole real catalogue — same
+    independent-walk discipline as :func:`_real_catalogue_collisions`."""
+    grouped: dict[str, list[tuple[str, dict[str, Any]]]] = collections.defaultdict(list)
+    for category_name, category_payload in services.items():
+        if not isinstance(category_payload, dict):
+            continue
+        if category_name in _NESTED_CATEGORIES:
+            for sub_block in category_payload.values():
+                if not isinstance(sub_block, dict):
+                    continue
+                for service_name, entry in sub_block.items():
+                    if isinstance(entry, dict):
+                        grouped[service_name].append((category_name, entry))
+        else:
+            for service_name, entry in category_payload.items():
+                if isinstance(entry, dict):
+                    grouped[service_name].append((category_name, entry))
+    return [(name, locs[0][0], locs[0][1]) for name, locs in grouped.items() if len(locs) == 1]
+
+
+# ── ground-truth pin ──────────────────────────────────────────────────────
+
+
+def test_real_catalogue_has_exactly_the_four_known_tax_tier_collisions(
+    svc: PricingService,
+) -> None:
+    """Pins the CURRENT shape of the defect against the real, shipped data.
+    If a 5th collision ever lands, this test goes red first — the
+    parametrized guilt tests below then cover it automatically once
+    ``REAL_COLLIDING_KEYS`` is updated to match."""
+    collisions = _real_catalogue_collisions(svc.prices["services"])
+    assert set(collisions) == set(REAL_COLLIDING_KEYS)
+    for name, locs in collisions.items():
+        assert len(locs) == 2, f"{name!r} collides {len(locs)} ways, expected 2"
+        assert {cat for cat, _sub in locs} == {"tax_accounting"}
+        assert {sub for _cat, sub in locs} == {"monthly_tax_basic", "monthly_tax_bundled"}
+
+
+# ── guilt: the bare key must refuse to guess ──────────────────────────────
+
+
+@pytest.mark.parametrize("key", REAL_COLLIDING_KEYS)
+def test_bare_colliding_key_refuses_to_guess(svc: PricingService, key: str) -> None:
+    """The exact defect: a bare colliding key must return ``None``, never
+    silently the first sub-block the catalogue walk happens to reach."""
+    assert svc.get_service_by_key(key) is None
+
+
+@pytest.mark.parametrize("key", REAL_COLLIDING_KEYS)
+def test_qualified_colliding_key_resolves_to_its_own_distinct_row(
+    svc: PricingService, key: str
+) -> None:
+    """The escape hatch: a qualified key resolves to exactly ONE row, and
+    the two sub-blocks of the same bare name are never priced the same."""
+    basic_key = f"monthly_tax_basic{_KEY_QUALIFIER_SEP}{key}"
+    bundled_key = f"monthly_tax_bundled{_KEY_QUALIFIER_SEP}{key}"
+
+    basic = svc.get_service_by_key(basic_key)
+    bundled = svc.get_service_by_key(bundled_key)
+
+    assert basic is not None
+    assert bundled is not None
+    assert basic["key"] == basic_key
+    assert bundled["key"] == bundled_key
+    assert basic["category"] == "tax_accounting"
+    assert bundled["category"] == "tax_accounting"
+    assert basic["price"] != bundled["price"], (
+        "the two sub-blocks of a colliding key must carry different prices "
+        "on the live catalogue — if this ever fails, re-verify the "
+        "catalogue before touching this test"
+    )
+    assert basic["notes"] and "NOT included" in basic["notes"]
+    assert bundled["notes"] and "Includes LKPM" in bundled["notes"]
+
+
+@pytest.mark.parametrize("key", REAL_COLLIDING_KEYS)
+def test_wrong_qualifier_for_a_colliding_key_is_also_none(svc: PricingService, key: str) -> None:
+    """A qualifier that names neither real sub-block must not silently
+    fall back to a guess either."""
+    assert svc.get_service_by_key(f"annual_basic_packages{_KEY_QUALIFIER_SEP}{key}") is None
+    assert svc.get_service_by_key(f"not_a_real_sub_block{_KEY_QUALIFIER_SEP}{key}") is None
+
+
+def test_qualified_form_reaches_end_to_end_through_the_public_router() -> None:
+    """The public, unauthenticated ``/api/pricing/service`` route accepts
+    the qualified form too — closing the reachability gap for the ONE
+    consumer a real client can hit directly, not just degrading it to a
+    clean 404."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from backend.app.routers import dynamic_pricing
+
+    app = FastAPI()
+    app.include_router(dynamic_pricing.router)
+    client = TestClient(app)
+
+    bare = client.get("/api/pricing/service", params={"key": "Tier 0-50"})
+    assert bare.status_code == 404, bare.text
+
+    qualified = client.get(
+        "/api/pricing/service",
+        params={"key": f"monthly_tax_bundled{_KEY_QUALIFIER_SEP}Tier 0-50"},
+    )
+    assert qualified.status_code == 200, qualified.text
+    body = qualified.json()
+    assert body["key"] == f"monthly_tax_bundled{_KEY_QUALIFIER_SEP}Tier 0-50"
+    assert body["price"] == "2.500.000 IDR"
+
+
+# ── innocence: the fix must not move anything that was never ambiguous ───
+
+
+def test_every_unambiguous_real_key_still_resolves_unchanged(svc: PricingService) -> None:
+    """The 105 keys that were never ambiguous must resolve exactly as
+    before: same key, category, name, price, validity and notes."""
+    unambiguous = _unambiguous_real_entries(svc.prices["services"])
+    assert len(unambiguous) == 105, (
+        "the real catalogue's unambiguous-key count moved — re-verify the "
+        "4-collision assumption this whole file rests on before touching "
+        "this number"
+    )
+    for service_name, category, entry in unambiguous:
+        row = svc.get_service_by_key(service_name)
+        assert row is not None, f"{service_name!r} regressed to unresolved"
+        assert row["key"] == service_name
+        assert row["category"] == category
+        assert row["name"] == (entry.get("name") or service_name)
+        assert row["price"] == _entry_display_price(entry)
+        assert row["validity"] == (entry.get("validity") or None)
+        assert row["notes"] == (entry.get("notes") or None)
+
+
+def test_unknown_key_is_still_none(svc: PricingService) -> None:
+    """Baseline unaffected: a key nothing in the catalogue names is still
+    a plain, silent ``None`` — no new warning noise for the common
+    not-found path."""
+    assert svc.get_service_by_key("No Such Service In The Catalogue 2026") is None
+
+
+# ── innocence: the three live consumers on a normal, non-colliding key ───
+
+
+def test_garuda_flow_hardcoded_keys_are_not_among_the_known_collisions() -> None:
+    """garuda_flow's two case-type keys are compile-time source literals,
+    never client- or data-supplied, and neither is a real catalogue
+    collision — this consumer cannot reach the defect today. Pinned so a
+    future rename that DID collide would fail loudly instead of silently
+    reintroducing exposure."""
+    assert _ISSUANCE_PRICE_KEY not in REAL_COLLIDING_KEYS
+    assert _EXTENSION_PRICE_KEY not in REAL_COLLIDING_KEYS
+
+
+@pytest.mark.parametrize("case_type", [CaseType.ISSUANCE, CaseType.EXTENSION])
+def test_garuda_flow_price_for_case_unchanged_on_a_normal_key(
+    svc: PricingService, case_type: CaseType
+) -> None:
+    """The fix does not alter this consumer's existing, already
+    fail-closed behaviour on either B1 case type."""
+    amount, key = price_for_case(case_type, pricing=svc)
+    assert amount is not None
+    assert amount > 0
+    assert key in (_ISSUANCE_PRICE_KEY, _EXTENSION_PRICE_KEY)
+
+
+def test_visa_engine_adapter_unchanged_on_a_normal_key(svc: PricingService) -> None:
+    """An ordinary, non-colliding visa product still resolves to
+    ``AVAILABLE`` with an amount — the fix does not degrade the common
+    path this consumer relies on for every real signed RulePack today."""
+    product = gold_loader.load_and_compile_rule_pack().source_pack.payload.products[0]
+    product = product.model_copy(
+        update={"pricing_key": PricingKey(category="single_entry_visas", item_key="C1 Tourism")}
+    )
+    result = resolve_candidate_pricing(
+        product,
+        pricing_catalog=svc,
+        evaluated_at=_EVALUATED_AT,
+    )
+    assert result.status == "AVAILABLE"
+    assert result.amount is not None
+
+
+def test_visa_engine_adapter_fails_closed_if_a_pricing_key_ever_collided(
+    svc: PricingService,
+) -> None:
+    """Consumer-facing guilt: this adapter's OWN ``category`` guard cannot
+    disambiguate ``tax_accounting``'s two sub-blocks (both report the same
+    top-level category), so the fix at the pricing-service layer is
+    load-bearing for this consumer too — proven with a hypothetical
+    ``PricingKey`` shaped like the real collision. No signed RulePack does
+    this today (verified separately against every ``contracts/packs/*``
+    file), but the schema does not forbid it, so this is a real, not a
+    theoretical, regression guard."""
+    product = gold_loader.load_and_compile_rule_pack().source_pack.payload.products[0]
+    product = product.model_copy(
+        update={"pricing_key": PricingKey(category="tax_accounting", item_key="Tier 0-50")}
+    )
+    result = resolve_candidate_pricing(
+        product,
+        pricing_catalog=svc,
+        evaluated_at=_EVALUATED_AT,
+    )
+    assert result.status == "CONTACT_REQUIRED"
+    assert result.reason_code == "PRICING_ROW_MISSING"
+    assert result.amount is None

--- a/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/brief.yml
@@ -30,10 +30,10 @@ constraints:
     sites: only the public router is not wrapped in try/except, so raising there would convert
     a wrong price into an unhandled 500 — worse, not better. Every consumer already degrades
     safely on None, so the fix needs no call-site changes."
-  - "The qualified form uses `::` and not `/`, because real catalogue names already contain a
-    bare slash (\"Working KITAS (Altus/Onshore)\") and `/` would not visibly separate a
+  - 'The qualified form uses `::` and not `/`, because real catalogue names already contain a
+    bare slash ("Working KITAS (Altus/Onshore)") and `/` would not visibly separate a
     qualified id from an ordinary name. Same convention as the sibling fix on the client-bot
-    snapshot builder — one convention for one problem, not two."
+    snapshot builder — one convention for one problem, not two.'
 acceptance:
   - "Each of the four colliding keys is refused rather than silently resolved, asserted against
     the REAL on-disk catalogue so the test fails the day a fifth collision is added."

--- a/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/brief.yml
@@ -1,0 +1,63 @@
+task_id: pricing-key-collision-0825
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  `PricingService.get_service_by_key()` promises, in its own docstring: "A caller that renders a
+  price on a client-facing surface must get either the exact row it asked for or nothing — a
+  near-miss silently rendered as the real price is the failure mode this method exists to make
+  impossible." It loops the catalogue and returns on the FIRST name match. The guarantee exists
+  in prose and not in code.
+
+  The catalogue has four duplicated service names — Tier 0-50, Tier 50-100, Tier 100-200,
+  Tier 200+ — all in tax_accounting, split between monthly_tax_basic (LKPM and Annual Tax
+  EXCLUDED) and monthly_tax_bundled (INCLUDED), each pair a different price. monthly_tax_basic
+  sorts first, so the lookup returned the basic row every time and never the bundled one. The
+  difference is not rounding: it is whether LKPM and the annual return are in scope, 500k to
+  1.5M IDR apart.
+
+  This is reachable from outside the system: GET /api/pricing/service is registered PUBLIC
+  (auth/public_endpoints.py:304) and takes `key` raw from the query string with no enum
+  constraint. Anyone asking for one of those four keys received the cheaper, wrong-scope price.
+
+  Gear 3 by PATH: the deterministic floor computes 3 because pricing_service.py is a hot-zone
+  path. Functional diff: 2 files, +436/-29.
+constraints:
+  - "The catalogue JSON is NOT touched. Renaming a client-facing service is a commercial
+    decision, raised separately with the owner as switchboard item 10. A lane does not get to
+    change what customers see a product called."
+  - "Returns None on a colliding key rather than raising, chosen after reading all three call
+    sites: only the public router is not wrapped in try/except, so raising there would convert
+    a wrong price into an unhandled 500 — worse, not better. Every consumer already degrades
+    safely on None, so the fix needs no call-site changes."
+  - "The qualified form uses `::` and not `/`, because real catalogue names already contain a
+    bare slash (\"Working KITAS (Altus/Onshore)\") and `/` would not visibly separate a
+    qualified id from an ordinary name. Same convention as the sibling fix on the client-bot
+    snapshot builder — one convention for one problem, not two."
+acceptance:
+  - "Each of the four colliding keys is refused rather than silently resolved, asserted against
+    the REAL on-disk catalogue so the test fails the day a fifth collision is added."
+  - "All 105 unambiguous keys still resolve exactly as before."
+  - "Each of the three consumers' behaviour on a normal key is unchanged."
+consumer_map:
+  - "GET /api/pricing/service (app/routers/dynamic_pricing.py:83) — PUBLIC, unauthenticated,
+    client-supplied key. The only externally reachable consumer, and the live defect."
+  - "services/garuda_flow/pricing.py:47 — key is one of two hardcoded VOA literals, neither
+    colliding. Unreachable BY CONSTRUCTION, not merely by today's data."
+  - "services/visa_engine/pricing_adapter.py:138 — key arrives inside a signed RulePack; no
+    signed pack uses tax_accounting today, so unreachable in current data. The schema does not
+    forbid a future one, and the adapter's own category guard CANNOT disambiguate this
+    collision because both sub-blocks report the same category."
+risks:
+  - "A caller that today receives the (wrong) basic price for a colliding key will now receive
+    None and render 'price unavailable'. That is the intended trade: refusing a price is
+    recoverable, quoting the wrong one to a client is not."
+  - "Residual: the underlying data ambiguity remains for humans reading the price list. Owner
+    decision, tracked as switchboard item 10."
+grader: >-
+  Opus 5 orchestrator (this session), independent of the Sonnet 5 lane that wrote the fix:
+  re-ran the collision census on the live catalogue, re-read both colliding blocks directly,
+  and independently confirmed /api/pricing/service is in the PUBLIC registry at line 304.
+budget: >-
+  No paid API. Local pytest and grep only.
+pii: none

--- a/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/pack.yml
@@ -1,92 +1,119 @@
-brief_ref: evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/brief.yml
-plan_ref: >-
-  PR #4886 (agent/mini-pro2/backend-rag/pricing-key-collision) — get_service_by_key refuses to
-  guess on a colliding catalogue key, 2026-08-25.
+brief_ref: evidence/brief.yml
+plan_ref:
+  "PR #4886 (agent/mini-pro2/backend-rag/pricing-key-collision) — get_service_by_key refuses to
+  guess on a colliding catalogue key, 2026-08-25."
 lanes:
   - lane: pricing-key-collision
     role: build
-    seat: "sonnet-5 (Mini worktree; reachability measurement, fix, guilt+innocence corpus, mutation proof)"
+    seat: sonnet-5 (Mini worktree; reachability measurement, fix, guilt+innocence corpus, mutation proof)
   - lane: pricing-key-collision-review
     role: review
-    seat: "opus-5 orchestrator (Mini; independent census, independent public-endpoint verification, diff read)"
+    seat:
+      opus-5 orchestrator (Mini; independent census, independent public-endpoint verification, diff
+      read)
 seat_diversity: satisfied
-seat_diversity_note: >-
-  Generator and grader are different seats and different model families' roles: a Sonnet 5 lane
-  built and proved it, the Opus 5 orchestrator re-derived the collision census from the raw
-  catalogue and re-verified the public-endpoint claim before accepting the report.
+seat_diversity_note:
+  "Generator and grader are different seats and different model families' roles: a
+  Sonnet 5 lane built and proved it, the Opus 5 orchestrator re-derived the collision census from the
+  raw catalogue and re-verified the public-endpoint claim before accepting the report."
 diff:
-  net_lines: >-
-    2 files changed, 436 insertions, 29 deletions (git diff --shortstat origin/main...HEAD).
-  behaviour_change: >-
+  net_lines: 2 files changed, 436 insertions, 29 deletions (git diff --shortstat origin/main...HEAD).
+  behaviour_change:
     For the four colliding keys only, a bare lookup now returns None instead of silently
-    returning the basic (cheaper, wrong-scope) row. All 105 unambiguous keys are unaffected. A
-    new qualified form "<sub_block>::<name>" lets a caller name one colliding row exactly.
+    returning the basic (cheaper, wrong-scope) row. All 105 unambiguous keys are unaffected. A new qualified
+    form "<sub_block>::<name>" lets a caller name one colliding row exactly.
 receipts:
-  - claim: "The catalogue contains exactly four duplicate service keys, all in tax_accounting, each pair with a different price."
-    cmd: "python3 walk of bali_zero_official_prices_2026.json counting service-level keys, then filtering names appearing more than once with differing prices"
-    result: "4 collisions: Tier 0-50 (1.8-2.0M vs 2.5M), Tier 50-100 (2.5-3.0M vs 3.5M), Tier 100-200 (3.5-4.5M vs 4.5M), Tier 200+ (5.0M vs 6.5M)"
+  - claim:
+      The catalogue contains exactly four duplicate service keys, all in tax_accounting, each pair
+      with a different price.
+    cmd:
+      python3 walk of bali_zero_official_prices_2026.json counting service-level keys, then filtering
+      names appearing more than once with differing prices
+    result:
+      "4 collisions: Tier 0-50 (1.8-2.0M vs 2.5M), Tier 50-100 (2.5-3.0M vs 3.5M), Tier 100-200 (3.5-4.5M
+      vs 4.5M), Tier 200+ (5.0M vs 6.5M)"
     exit: 0
     ts: "2026-08-25T05:12:00Z"
-    seat: "opus-5 orchestrator (Mini) — independently re-derived from the lane's own census, which matched exactly"
-  - claim: "The affected endpoint is PUBLIC and unauthenticated, so the wrong price was reachable from outside the system."
-    cmd: "grep -n '\"/api/pricing/service\"' apps/backend-rag/backend/app/auth/public_endpoints.py"
-    result: "304:        \"/api/pricing/service\","
+    seat:
+      opus-5 orchestrator (Mini) — independently re-derived from the lane's own census, which matched
+      exactly
+  - claim:
+      The affected endpoint is PUBLIC and unauthenticated, so the wrong price was reachable from outside
+      the system.
+    cmd: grep -n '"/api/pricing/service"' apps/backend-rag/backend/app/auth/public_endpoints.py
+    result: '304:        "/api/pricing/service",'
     exit: 0
     ts: "2026-08-25T06:56:07Z"
-    seat: "opus-5 orchestrator (Mini)"
-  - claim: "The deterministic floor is 3 because pricing_service.py is hot-zone; the brief declares Gear 3."
-    cmd: "git diff --name-only origin/main...HEAD > /tmp/pk_changed.txt && python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/pk_changed.txt"
+    seat: opus-5 orchestrator (Mini)
+  - claim:
+      The deterministic floor is 3 because pricing_service.py is hot-zone; the brief declares Gear
+      3.
+    cmd:
+      git diff --name-only origin/main...HEAD > /tmp/pk_changed.txt && python3 scripts/evidence_pack_lint.py
+      --print-floor --changed-files-file /tmp/pk_changed.txt
     result: "3"
     exit: 0
     ts: "2026-08-25T06:56:07Z"
-    seat: "opus-5 orchestrator (Mini)"
-  - claim: "The fix is mutation-proven: reverting only the resolution logic reddens the guilt corpus and leaves the innocence corpus green."
-    cmd: "revert resolution logic (helpers kept so imports resolve); rerun the corpus with PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider"
-    result: "10 guilt tests RED, 11 innocence tests GREEN; restored and re-verified clean"
+    seat: opus-5 orchestrator (Mini)
+  - claim:
+      "The fix is mutation-proven: reverting only the resolution logic reddens the guilt corpus and
+      leaves the innocence corpus green."
+    cmd:
+      revert resolution logic (helpers kept so imports resolve); rerun the corpus with PYTHONDONTWRITEBYTECODE=1
+      -p no:cacheprovider
+    result: 10 guilt tests RED, 11 innocence tests GREEN; restored and re-verified clean
     exit: 0
     ts: "2026-08-25T06:10:00Z"
-    seat: "sonnet-5 lane (Mini worktree)"
-  - claim: "No consumer regressed."
-    cmd: "PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 -m pytest backend/tests/services/pricing backend/tests -k 'dynamic_pricing or public_pricing or pricing_adapter' -p no:randomly -p no:cacheprovider"
-    result: "no FAILED or ERROR lines (127 tests across pricing, dynamic_pricing, public lookup, garuda_flow, visa_engine adapter; 106 pre-existing + 21 new)"
+    seat: sonnet-5 lane (Mini worktree)
+  - claim: No consumer regressed.
+    cmd:
+      PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 -m pytest backend/tests/services/pricing backend/tests
+      -k 'dynamic_pricing or public_pricing or pricing_adapter' -p no:randomly -p no:cacheprovider
+    result:
+      no FAILED or ERROR lines (127 tests across pricing, dynamic_pricing, public lookup, garuda_flow,
+      visa_engine adapter; 106 pre-existing + 21 new)
     exit: 0
     ts: "2026-08-25T06:40:00Z"
-    seat: "opus-5 orchestrator (Mini)"
-  - claim: "ruff caught a real UnboundLocalError in the lane's own first draft before it shipped."
-    cmd: "ruff check on the modified pricing_service.py"
-    result: "unbound loop variable in the ambiguity warning path — reachable only by a future collision spanning a flat category; fixed and re-verified before commit"
+    seat: opus-5 orchestrator (Mini)
+  - claim: ruff caught a real UnboundLocalError in the lane's own first draft before it shipped.
+    cmd: ruff check on the modified pricing_service.py
+    result:
+      unbound loop variable in the ambiguity warning path — reachable only by a future collision spanning
+      a flat category; fixed and re-verified before commit
     exit: 0
     ts: "2026-08-25T06:05:00Z"
-    seat: "sonnet-5 lane (Mini worktree)"
+    seat: sonnet-5 lane (Mini worktree)
 pii_scan: clean
-dissent: >-
-  None recorded. The one judgement worth naming is None-versus-raise: a reviewer could argue an
-  ambiguous key deserves a loud exception. It was rejected on evidence — the public router is
-  the one call site with no try/except, so raising there turns a wrong price into an unhandled
-  500. Refusing loudly at the service layer and degrading safely at the edge is the better trade.
+dissent:
+  - seat: opus-5 orchestrator (Mini), against the None-versus-raise choice
+    objection: An ambiguous key arguably deserves a loud exception rather than a silent None.
+    resolution:
+      Rejected on evidence. The public router is the one call site with no try/except, so raising
+      there converts a wrong price into an unhandled 500 — worse, not better. Refusing loudly at the service
+      layer and degrading safely at the edge is the better trade.
+    status: PLAUSIBLE
 tests:
-  - "backend/tests/services/pricing/test_pricing_service_key_collision.py — 21 new (10 guilt, 11 innocence)"
-  - "127 tests across pricing / dynamic_pricing / public lookup / garuda_flow / visa_engine adapter — 0 failures before and after"
-  - "full garuda_flow/ (163) and full visa_engine/ suites green"
+  - backend/tests/services/pricing/test_pricing_service_key_collision.py — 21 new (10 guilt, 11 innocence)
+  - 127 tests across pricing / dynamic_pricing / public lookup / garuda_flow / visa_engine adapter — 0 failures
+    before and after
+  - full garuda_flow/ (163) and full visa_engine/ suites green
 static:
-  - "ruff check clean on the touched files"
-runtime_proof: >-
-  The qualified-key path was exercised end to end through the actual public router, not only at
-  the service layer. NOT claimed: no request was made against the deployed Fly instance — this
-  is local proof against the real on-disk catalogue.
+  - ruff check clean on the touched files
+runtime_proof:
+  "The qualified-key path was exercised end to end through the actual public router, not
+  only at the service layer. NOT claimed: no request was made against the deployed Fly instance — this
+  is local proof against the real on-disk catalogue."
 residual_risks:
-  - "The data ambiguity itself persists for any human reading the price list: two rows called
-    Tier 0-50, 700k apart, distinguished only inside a long name. Owner decision, switchboard
-    item 10."
-  - "PricingService callers that pass a colliding key and render None as an empty string rather
-    than 'unavailable' would show a blank where a wrong number used to be. All three current
-    consumers were read and degrade safely; a future one might not."
+  - "The data ambiguity itself persists for any human reading the price list: two rows called Tier 0-50,
+    700k apart, distinguished only inside a long name. Owner decision, switchboard item 10."
+  - PricingService callers that pass a colliding key and render None as an empty string rather than 'unavailable'
+    would show a blank where a wrong number used to be. All three current consumers were read and degrade
+    safely; a future one might not.
 sources:
-  - "docs/plans/2026-08-25-due-bot-live/SPEC-price-service-binding.md — the sibling defect one layer up"
-  - "docs/plans/2026-08-25-due-bot-live/OWNER-DECISION-PACKET.md item 10 — the data-side decision"
-notes: >-
-  Found because a sibling lane closing the same disease on the client-bot's snapshot builder
-  flagged this method as carrying the identical first-match-wins bug and correctly refused to
-  fix it out of scope. The reachability was then measured per consumer rather than assumed,
-  which is what separated one publicly-exploitable path from two that are unreachable by
-  construction.
+  - docs/plans/2026-08-25-due-bot-live/SPEC-price-service-binding.md — the sibling defect one layer up
+  - docs/plans/2026-08-25-due-bot-live/OWNER-DECISION-PACKET.md item 10 — the data-side decision
+notes:
+  Found because a sibling lane closing the same disease on the client-bot's snapshot builder flagged
+  this method as carrying the identical first-match-wins bug and correctly refused to fix it out of scope.
+  The reachability was then measured per consumer rather than assumed, which is what separated one publicly-exploitable
+  path from two that are unreachable by construction.

--- a/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/pack.yml
@@ -1,0 +1,92 @@
+brief_ref: evidence/2026-08/agent-mini-pro2-backend-rag-pricing-key-collisio-1d77e447/brief.yml
+plan_ref: >-
+  PR #4886 (agent/mini-pro2/backend-rag/pricing-key-collision) — get_service_by_key refuses to
+  guess on a colliding catalogue key, 2026-08-25.
+lanes:
+  - lane: pricing-key-collision
+    role: build
+    seat: "sonnet-5 (Mini worktree; reachability measurement, fix, guilt+innocence corpus, mutation proof)"
+  - lane: pricing-key-collision-review
+    role: review
+    seat: "opus-5 orchestrator (Mini; independent census, independent public-endpoint verification, diff read)"
+seat_diversity: satisfied
+seat_diversity_note: >-
+  Generator and grader are different seats and different model families' roles: a Sonnet 5 lane
+  built and proved it, the Opus 5 orchestrator re-derived the collision census from the raw
+  catalogue and re-verified the public-endpoint claim before accepting the report.
+diff:
+  net_lines: >-
+    2 files changed, 436 insertions, 29 deletions (git diff --shortstat origin/main...HEAD).
+  behaviour_change: >-
+    For the four colliding keys only, a bare lookup now returns None instead of silently
+    returning the basic (cheaper, wrong-scope) row. All 105 unambiguous keys are unaffected. A
+    new qualified form "<sub_block>::<name>" lets a caller name one colliding row exactly.
+receipts:
+  - claim: "The catalogue contains exactly four duplicate service keys, all in tax_accounting, each pair with a different price."
+    cmd: "python3 walk of bali_zero_official_prices_2026.json counting service-level keys, then filtering names appearing more than once with differing prices"
+    result: "4 collisions: Tier 0-50 (1.8-2.0M vs 2.5M), Tier 50-100 (2.5-3.0M vs 3.5M), Tier 100-200 (3.5-4.5M vs 4.5M), Tier 200+ (5.0M vs 6.5M)"
+    exit: 0
+    ts: "2026-08-25T05:12:00Z"
+    seat: "opus-5 orchestrator (Mini) — independently re-derived from the lane's own census, which matched exactly"
+  - claim: "The affected endpoint is PUBLIC and unauthenticated, so the wrong price was reachable from outside the system."
+    cmd: "grep -n '\"/api/pricing/service\"' apps/backend-rag/backend/app/auth/public_endpoints.py"
+    result: "304:        \"/api/pricing/service\","
+    exit: 0
+    ts: "2026-08-25T06:56:07Z"
+    seat: "opus-5 orchestrator (Mini)"
+  - claim: "The deterministic floor is 3 because pricing_service.py is hot-zone; the brief declares Gear 3."
+    cmd: "git diff --name-only origin/main...HEAD > /tmp/pk_changed.txt && python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/pk_changed.txt"
+    result: "3"
+    exit: 0
+    ts: "2026-08-25T06:56:07Z"
+    seat: "opus-5 orchestrator (Mini)"
+  - claim: "The fix is mutation-proven: reverting only the resolution logic reddens the guilt corpus and leaves the innocence corpus green."
+    cmd: "revert resolution logic (helpers kept so imports resolve); rerun the corpus with PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider"
+    result: "10 guilt tests RED, 11 innocence tests GREEN; restored and re-verified clean"
+    exit: 0
+    ts: "2026-08-25T06:10:00Z"
+    seat: "sonnet-5 lane (Mini worktree)"
+  - claim: "No consumer regressed."
+    cmd: "PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 -m pytest backend/tests/services/pricing backend/tests -k 'dynamic_pricing or public_pricing or pricing_adapter' -p no:randomly -p no:cacheprovider"
+    result: "no FAILED or ERROR lines (127 tests across pricing, dynamic_pricing, public lookup, garuda_flow, visa_engine adapter; 106 pre-existing + 21 new)"
+    exit: 0
+    ts: "2026-08-25T06:40:00Z"
+    seat: "opus-5 orchestrator (Mini)"
+  - claim: "ruff caught a real UnboundLocalError in the lane's own first draft before it shipped."
+    cmd: "ruff check on the modified pricing_service.py"
+    result: "unbound loop variable in the ambiguity warning path — reachable only by a future collision spanning a flat category; fixed and re-verified before commit"
+    exit: 0
+    ts: "2026-08-25T06:05:00Z"
+    seat: "sonnet-5 lane (Mini worktree)"
+pii_scan: clean
+dissent: >-
+  None recorded. The one judgement worth naming is None-versus-raise: a reviewer could argue an
+  ambiguous key deserves a loud exception. It was rejected on evidence — the public router is
+  the one call site with no try/except, so raising there turns a wrong price into an unhandled
+  500. Refusing loudly at the service layer and degrading safely at the edge is the better trade.
+tests:
+  - "backend/tests/services/pricing/test_pricing_service_key_collision.py — 21 new (10 guilt, 11 innocence)"
+  - "127 tests across pricing / dynamic_pricing / public lookup / garuda_flow / visa_engine adapter — 0 failures before and after"
+  - "full garuda_flow/ (163) and full visa_engine/ suites green"
+static:
+  - "ruff check clean on the touched files"
+runtime_proof: >-
+  The qualified-key path was exercised end to end through the actual public router, not only at
+  the service layer. NOT claimed: no request was made against the deployed Fly instance — this
+  is local proof against the real on-disk catalogue.
+residual_risks:
+  - "The data ambiguity itself persists for any human reading the price list: two rows called
+    Tier 0-50, 700k apart, distinguished only inside a long name. Owner decision, switchboard
+    item 10."
+  - "PricingService callers that pass a colliding key and render None as an empty string rather
+    than 'unavailable' would show a blank where a wrong number used to be. All three current
+    consumers were read and degrade safely; a future one might not."
+sources:
+  - "docs/plans/2026-08-25-due-bot-live/SPEC-price-service-binding.md — the sibling defect one layer up"
+  - "docs/plans/2026-08-25-due-bot-live/OWNER-DECISION-PACKET.md item 10 — the data-side decision"
+notes: >-
+  Found because a sibling lane closing the same disease on the client-bot's snapshot builder
+  flagged this method as carrying the identical first-match-wins bug and correctly refused to
+  fix it out of scope. The reachability was then measured per consumer rather than assumed,
+  which is what separated one publicly-exploitable path from two that are unreachable by
+  construction.


### PR DESCRIPTION
## What

`PricingService.get_service_by_key()` promises this, verbatim, in its own docstring:

> *"A caller that renders a price on a client-facing surface must get either the exact row it asked for or nothing — a near-miss silently rendered as the real price is the failure mode this method exists to make impossible."*

It loops the catalogue and `return`s on the **first** name match. The catalogue contains four duplicated service names, so for those four it returns whichever sub-block the walk reaches first. The method's own docstring names the exact failure it permits.

## The four, verified on the live catalogue

All in `tax_accounting`, split between `monthly_tax_basic` (LKPM & Annual Tax **excluded**) and `monthly_tax_bundled` (**included**):

| key | basic | bundled |
|---|---|---|
| `Tier 0-50` | 1.800.000 – 2.000.000 IDR | 2.500.000 IDR |
| `Tier 50-100` | 2.500.000 – 3.000.000 IDR | 3.500.000 IDR |
| `Tier 100-200` | 3.500.000 – 4.500.000 IDR | 4.500.000 IDR |
| `Tier 200+` | 5.000.000 IDR | 6.500.000 IDR |

`monthly_tax_basic` sorts first, so the lookup returned the **basic** row every time — never the bundled one. The difference is not a rounding error: it is whether LKPM and the Annual Tax report are in scope.

## Why this is not a latent trap

Reachability was measured per consumer, not assumed:

- **`GET /api/pricing/service` — PUBLIC and unauthenticated** (registered in `auth/public_endpoints.py:304`), with `key` taken raw from the query string, no enum constraint. Anyone on the internet asking for one of those four keys got the cheaper, wrong-scope price. This is the live surface.
- `garuda_flow/pricing.py` — key is one of two hardcoded VOA literals, neither colliding. Unreachable **by construction**, not merely by today's data.
- `visa_engine/pricing_adapter.py` — key arrives inside a *signed* RulePack; no signed pack in `contracts/packs/` uses `tax_accounting` today, so unreachable in current data, but the schema does not forbid a future one — and the adapter's own `category` guard **cannot** disambiguate this collision, because both sub-blocks report the same category. Proven live against a hypothetical key; degrades safely post-fix.

## The fix

Count matches instead of returning the first. A bare colliding key now returns `None` — the docstring's "or nothing".

`None` rather than an exception, chosen after reading all three call sites: only the public router is not wrapped in `try/except`, so raising there would turn a wrong price into an unhandled 500, which is worse. Every consumer already degrades safely on `None`, so the fix needs no call-site changes.

A qualified form `"<sub_block>::<service_name>"` lets a caller ask for one colliding row unambiguously. `::` deliberately, and consistently with the same convention adopted for the same collision on the client-bot's snapshot builder — one convention for one problem, not two.

**The catalogue JSON is untouched.** Renaming a client-facing service is a commercial decision and has been raised with the owner separately.

## Verification

127 tests across `pricing/`, `dynamic_pricing`, `test_public_pricing_lookup.py`, `garuda_flow/test_pricing.py`, `visa_engine/test_pricing_adapter.py` — 0 failures before and after (106 pre-existing + 21 new). Full `garuda_flow/` and `visa_engine/` suites green.

Mutation-proven: reverting only the resolution logic reddens 10 guilt tests and leaves 11 innocence tests green.

`ruff` caught a real `UnboundLocalError` in the first draft of the ambiguity warning — reachable only by a future collision spanning a flat category — fixed before commit rather than shipped.

## Noted, not fixed

Combining the `pricing/` + `garuda_flow/` + `visa_engine/` test directories in one pytest invocation intermittently produces a collection `ImportError` and occasional live-DB `asyncpg` errors. Reproduced identically on unmodified `origin/main` with none of these changes present — pre-existing test-infrastructure fragility, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nCopHghNKdDKHxeDRy9H1