### PR TITLE
fix(legal): a law's own commentary silently destroyed its articles

### DIFF
--- a/apps/backend-rag/backend/core/legal/hierarchical_indexer.py
+++ b/apps/backend-rag/backend/core/legal/hierarchical_indexer.py
@@ -20,6 +20,10 @@ from backend.core.legal.quality_validators import (
 logger = logging.getLogger(__name__)
 
 
+class LegalIndexIntegrityError(RuntimeError):
+    """Raised when two chunks of one document would occupy the same point id."""
+
+
 @dataclass
 class HierarchicalChunk:
     """Chunk con riferimenti gerarchici"""
@@ -302,6 +306,53 @@ class HierarchicalIndexer:
         )
         chunks_to_index.append(chunk)
 
+    @staticmethod
+    def _disambiguate_chunk_ids(chunks: list[HierarchicalChunk]) -> int:
+        """Make every chunk_id unique WITHIN this document. Returns how many were renamed.
+
+        Why this exists, measured on 2026-08-25. A chunk's point id is
+        ``uuid5(NAMESPACE_LEGAL, chunk_id)`` and a chunk_id is
+        ``f"{document_id}_Pasal_{number}"``. An Indonesian law is published
+        together with its PENJELASAN, the official article-by-article
+        commentary, which repeats the SAME article numbers. Both therefore
+        produced the same chunk_id, the same point id, and the second write --
+        the commentary, since it comes later in the PDF -- silently replaced the
+        first: the article itself.
+
+        Ingesting UU 40/2007 (Perseroan Terbatas) reported 378 chunks created
+        and left 202 points in Qdrant. 176 articles were destroyed by their own
+        commentary. What remained under Pasal 1, 7, 32, 33 and 109 -- including
+        the minimum-capital and paid-up-capital rules a PT PMA is founded on --
+        was the commentary text, in several cases the literal words
+        "Cukup jelas" ("self-explanatory"). An overwrite is a SUCCESSFUL upsert:
+        nothing failed, nothing was logged, and the count in the ingest result
+        was the number of chunks BUILT, never the number that survived.
+
+        Occurrences after the first get a ``#dupN`` suffix, deterministic in
+        document order, so re-ingesting the same PDF reproduces the same ids.
+        ``#`` cannot occur in a generated id, so the suffix cannot collide with
+        a real one -- and the function still asserts that afterwards rather than
+        trusting the argument.
+        """
+        seen: dict[str, int] = {}
+        renamed = 0
+        for chunk in chunks:
+            base = chunk.chunk_id
+            occurrence = seen.get(base, 0) + 1
+            seen[base] = occurrence
+            if occurrence > 1:
+                chunk.chunk_id = f"{base}#dup{occurrence}"
+                renamed += 1
+
+        identifiers = [chunk.chunk_id for chunk in chunks]
+        if len(set(identifiers)) != len(identifiers):
+            duplicates = sorted({i for i in identifiers if identifiers.count(i) > 1})
+            raise LegalIndexIntegrityError(
+                "Chunk ids remain ambiguous after disambiguation; refusing to "
+                f"upsert because a write would destroy a sibling: {duplicates[:5]}",
+            )
+        return renamed
+
     async def _upsert_hierarchical_chunks(
         self,
         chunks: list[HierarchicalChunk],
@@ -313,6 +364,16 @@ class HierarchicalIndexer:
         import uuid
 
         qdrant = qdrant_client or self.qdrant
+
+        # No chunk may silently destroy a sibling. See _disambiguate_chunk_ids.
+        renamed = self._disambiguate_chunk_ids(chunks)
+        if renamed:
+            logger.warning(
+                "Disambiguated %s of %s chunk ids that would have overwritten a sibling "
+                "(a law published with its Penjelasan repeats its article numbers)",
+                renamed,
+                len(chunks),
+            )
 
         # Namespace UUID per generare ID deterministici (stesso chunk_id → stesso UUID)
         NAMESPACE_LEGAL = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
@@ -331,6 +392,10 @@ class HierarchicalIndexer:
                 "hierarchy_level": chunk.hierarchy_level,
                 "parent_chunk_ids": chunk.parent_chunk_ids,
                 "bab_title": chunk.bab_title,
+                # The readable key the point id is derived from. `chunk_id` below
+                # is overwritten with the uuid5, which is unreadable and made this
+                # class of collision undiagnosable from the stored payload alone.
+                "chunk_key": chunk.chunk_id,
             }
 
             chunk_texts.append(chunk.text)

--- a/apps/backend-rag/backend/tests/unit/core/legal/test_chunk_identity_collisions.py
+++ b/apps/backend-rag/backend/tests/unit/core/legal/test_chunk_identity_collisions.py
@@ -1,0 +1,165 @@
+"""No chunk of a document may silently destroy another chunk of the same document.
+
+A chunk's point id is `uuid5(NAMESPACE_LEGAL, chunk_id)` and a chunk_id is
+`f"{document_id}_Pasal_{number}"`. An Indonesian law is published together with
+its PENJELASAN -- the official article-by-article commentary -- which repeats the
+same article numbers. Both therefore produced the same point id, and the second
+write silently replaced the first.
+
+Measured on 2026-08-25 by ingesting UU 40/2007 (Perseroan Terbatas): 378 chunks
+built, 202 points in Qdrant, 176 articles destroyed by their own commentary. The
+text left under Pasal 1, 7, 32, 33 and 109 -- among them the minimum-capital and
+paid-up-capital rules a PT PMA is founded on -- was the commentary, in several
+cases the literal words "Cukup jelas" ("self-explanatory").
+
+An overwrite is a SUCCESSFUL upsert. Nothing failed and nothing was logged.
+"""
+
+import uuid
+
+import pytest
+
+from backend.core.legal.hierarchical_indexer import (
+    HierarchicalChunk,
+    HierarchicalIndexer,
+    LegalIndexIntegrityError,
+)
+
+NAMESPACE_LEGAL = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+
+def _chunk(chunk_id: str, text: str = "x") -> HierarchicalChunk:
+    return HierarchicalChunk(
+        chunk_id=chunk_id,
+        text=text,
+        document_id="UU_40_2007",
+        chapter_id=None,
+        section_id=None,
+        article_id=None,
+        hierarchy_path=chunk_id,
+        hierarchy_level=3,
+        parent_chunk_ids=["UU_40_2007"],
+        sibling_chunk_ids=[],
+        bab_title=None,
+        bab_full_text=None,
+        metadata={},
+    )
+
+
+def _point_id(chunk_id: str) -> str:
+    return str(uuid.uuid5(NAMESPACE_LEGAL, chunk_id))
+
+
+class _FakeQdrant:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def upsert_documents(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"success": True, "documents_added": len(kwargs["ids"])}
+
+
+# ---------------------------------------------------------------------------
+# GUILT
+# ---------------------------------------------------------------------------
+
+
+def test_an_article_and_its_commentary_do_not_share_a_point_id():
+    body = _chunk("UU_40_2007_Pasal_32", "Modal dasar Perseroan ...")
+    penjelasan = _chunk("UU_40_2007_Pasal_32", "Ayat (1) Cukup jelas.")
+    renamed = HierarchicalIndexer._disambiguate_chunk_ids([body, penjelasan])
+    assert renamed == 1
+    assert body.chunk_id != penjelasan.chunk_id
+    assert _point_id(body.chunk_id) != _point_id(penjelasan.chunk_id)
+
+
+def test_the_article_keeps_the_canonical_id_and_the_commentary_moves():
+    """Document order decides: the operative article comes first in the PDF, so
+    it is the one that keeps `<doc>_Pasal_<n>`. Re-ingesting a corpus that was
+    poisoned by this bug therefore CORRECTS the existing point in place rather
+    than leaving the commentary sitting on it."""
+    body = _chunk("UU_40_2007_Pasal_32", "Modal dasar ...")
+    penjelasan = _chunk("UU_40_2007_Pasal_32", "Cukup jelas.")
+    HierarchicalIndexer._disambiguate_chunk_ids([body, penjelasan])
+    assert body.chunk_id == "UU_40_2007_Pasal_32"
+    assert penjelasan.chunk_id == "UU_40_2007_Pasal_32#dup2"
+
+
+@pytest.mark.asyncio
+async def test_the_upsert_path_sends_one_point_per_chunk():
+    """The pre-existing completeness guard compared `documents_added` with
+    `len(ids)` -- both counted what was SENT, so duplicate ids passed it."""
+    indexer = HierarchicalIndexer.__new__(HierarchicalIndexer)
+    indexer.qdrant = _FakeQdrant()
+    chunks = [_chunk("UU_40_2007_Pasal_32"), _chunk("UU_40_2007_Pasal_32")]
+    added = await indexer._upsert_hierarchical_chunks(
+        chunks=chunks,
+        embeddings=[[0.0], [0.0]],
+        sparse_vectors=None,
+        qdrant_client=indexer.qdrant,
+    )
+    sent_ids = indexer.qdrant.calls[0]["ids"]
+    assert added == 2
+    assert len(set(sent_ids)) == 2, "two chunks collapsed onto one point"
+
+
+def test_a_third_occurrence_gets_its_own_id():
+    chunks = [_chunk("UU_1_2023_Pasal_5") for _ in range(3)]
+    assert HierarchicalIndexer._disambiguate_chunk_ids(chunks) == 2
+    assert len({c.chunk_id for c in chunks}) == 3
+
+
+def test_it_refuses_rather_than_overwrites_when_ambiguity_survives():
+    """A document that already contains the disambiguation suffix must not be
+    quietly re-collided. Fail closed: an overwrite is unrecoverable."""
+    chunks = [
+        _chunk("UU_1_2023_Pasal_5"),
+        _chunk("UU_1_2023_Pasal_5"),
+        _chunk("UU_1_2023_Pasal_5#dup2"),
+    ]
+    with pytest.raises(LegalIndexIntegrityError):
+        HierarchicalIndexer._disambiguate_chunk_ids(chunks)
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE
+# ---------------------------------------------------------------------------
+
+
+def test_unique_chunk_ids_are_left_byte_identical():
+    """Re-ingesting an unaffected document must produce the SAME point ids as
+    before this change, or the fix would churn the whole corpus."""
+    originals = ["UU_40_2007_Pasal_1", "UU_40_2007_Pasal_2", "UU_40_2007_BAB_I"]
+    chunks = [_chunk(i) for i in originals]
+    assert HierarchicalIndexer._disambiguate_chunk_ids(chunks) == 0
+    assert [c.chunk_id for c in chunks] == originals
+
+
+def test_disambiguation_is_deterministic_across_runs():
+    ids = ["A", "A", "B", "A", "B"]
+    run_one = [_chunk(i) for i in ids]
+    HierarchicalIndexer._disambiguate_chunk_ids(run_one)
+    run_two = [_chunk(i) for i in ids]
+    HierarchicalIndexer._disambiguate_chunk_ids(run_two)
+    assert [c.chunk_id for c in run_one] == [c.chunk_id for c in run_two]
+
+
+@pytest.mark.asyncio
+async def test_the_readable_key_reaches_the_payload():
+    """`chunk_id` in the payload is overwritten with the uuid5, which made this
+    class of collision undiagnosable from stored data alone."""
+    indexer = HierarchicalIndexer.__new__(HierarchicalIndexer)
+    indexer.qdrant = _FakeQdrant()
+    chunks = [_chunk("UU_40_2007_Pasal_32"), _chunk("UU_40_2007_Pasal_32")]
+    await indexer._upsert_hierarchical_chunks(
+        chunks=chunks,
+        embeddings=[[0.0], [0.0]],
+        sparse_vectors=None,
+        qdrant_client=indexer.qdrant,
+    )
+    keys = [m["chunk_key"] for m in indexer.qdrant.calls[0]["metadatas"]]
+    assert keys == ["UU_40_2007_Pasal_32", "UU_40_2007_Pasal_32#dup2"]
+
+
+def test_an_empty_batch_is_not_an_error():
+    assert HierarchicalIndexer._disambiguate_chunk_ids([]) == 0


### PR DESCRIPTION
fix(legal): a law's own commentary silently destroyed its articles

A chunk's Qdrant point id is `uuid5(NAMESPACE_LEGAL, chunk_id)`, and a chunk_id
is `f"{document_id}_Pasal_{number}"`. Every Indonesian law is published together
with its PENJELASAN, the official article-by-article commentary, which repeats
the same article numbers. Article and commentary therefore produced the SAME
point id, and the second write -- the commentary, since it comes later in the
PDF -- replaced the first.

Measured on production, 2026-08-25, ingesting UU 40/2007 (Perseroan Terbatas):

    chunks reported created : 378
    points actually stored  : 202
    articles destroyed      : 176

and the text left behind under the articles a PT PMA is founded on:

    Pasal 1   (definitions)              -> "Cukup jelas."   ["self-explanatory"]
    Pasal 7   (who may found a PT)       -> the commentary
    Pasal 32  (minimum capital)          -> the commentary
    Pasal 33  (paid-up capital, proof)   -> the commentary
    Pasal 109 (bankruptcy)               -> "Cukup jelas."

One chunk each: the operative text was not stored alongside its commentary, it
was gone. This is the same disease as the document_id collision cured in #4869,
one level down -- and it is silent for the same reason: AN OVERWRITE IS A
SUCCESSFUL UPSERT. Nothing raised, nothing was logged, and `chunks_created` in
the ingest result counts what was BUILT, never what survived.

The pre-existing completeness guard did not catch it because it compares
`documents_added` with `len(ids)` -- both count what was SENT. Duplicate ids
collapse inside Qdrant, after that comparison.

The cure is one chokepoint, `_upsert_hierarchical_chunks`, which every producer
(BAB, Pasal, sub-chunk, flat fallback) already funnels through:

  * `_disambiguate_chunk_ids` makes ids unique within the document. Occurrences
    after the first get a `#dupN` suffix, deterministic in document order, so
    re-ingesting the same PDF reproduces the same ids. Document order means the
    OPERATIVE ARTICLE keeps `<doc>_Pasal_<n>`, so re-ingesting a poisoned
    document CORRECTS the existing point in place instead of leaving the
    commentary sitting on it, and adds the commentary as a new point.
  * It then ASSERTS uniqueness and raises `LegalIndexIntegrityError` rather than
    proceeding, because an overwrite is unrecoverable. `#` cannot occur in a
    generated id, so the suffix cannot collide -- and the function verifies that
    instead of trusting it.
  * The payload gains `chunk_key`, the readable id the point id is derived from.
    `chunk_id` in the payload is overwritten with the uuid5, which is what made
    this class of collision undiagnosable from stored data alone.

Documents with no repeated article number are byte-identical: zero renames, same
point ids as before, no corpus churn. That is pinned by a test, because a fix
that silently re-keyed the whole corpus would be worse than the bug.

Tests: 9 new (guilt: article and commentary no longer share a point id, the
article keeps the canonical id, the upsert path sends one point per chunk, a
third occurrence gets its own id, ambiguity that survives raises instead of
overwriting; innocence: unique ids untouched, determinism across runs, the
readable key reaches the payload, empty batch fine). 386 pass across
backend/tests/unit/core/legal/.

A tenth test was written and deleted: it asserted the uuid5 collision mechanism
as `assert _point_id(k) == _point_id(k)`, which the repo's anti-reward-hacking
lint correctly rejected as RH002, a self-equal tautology. It could not have
failed, so it proved nothing the inequality assertions above do not already.

NOT included, deliberately: distinguishing article from commentary in the
payload so retrieval can tell a rule from a note about it. That is a second
concern and a second PR; this one only stops the destruction.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW
