### PR TITLE
test(codex): a guard that reddens at random teaches people to ignore it

### DIFF
--- a/apps/backend-rag/backend/tests/llm/test_codex_exec_client.py
+++ b/apps/backend-rag/backend/tests/llm/test_codex_exec_client.py
@@ -1297,8 +1297,25 @@ class TestProcessGroupKill:
         This pins BOTH halves of the cure: without `start_new_session=True`
         the guard in `_kill_and_reap` skips the group-kill (shared pgid),
         and without the `os.killpg` the group is never signalled — either
-        mutation leaves the grandchild alive and turns this test red."""
-        client = _make_available_client(tmp_path, timeout_s=1.0)
+        mutation leaves the grandchild alive and turns this test red.
+
+        W-KILLTEST-FLAKE harness fix: `timeout_s` used to be `1.0`, racing
+        `generate()`'s wall-clock deadline against the REAL `/bin/sh` fork
+        + exec + inner `sleep 300 &` fork needed before the fake binary
+        writes `pid_file`. Measured directly (700 trials, idle AND under
+        2x-oversubscribed CPU load, `/tmp/probe_pid_timing.py`-shape
+        harness): that write lands at a median ~410ms after subprocess
+        creation with a fat right tail — max observed 1.83s, several
+        samples past 1.0s. At `timeout_s=1.0` the SUT's own kill could (and
+        reproducibly did — 1 failure in 40 serial re-runs on an otherwise
+        idle machine, zero external load, and 15/15 forced failures at an
+        artificially tight `timeout_s=0.05` confirming the mechanism) fire
+        BEFORE the grandchild was ever forked, so `pid_file` never gets
+        written and this test asserts on a harness precondition, not the
+        group-kill property. `8.0` leaves >4x headroom over the worst
+        latency this probe ever measured — 0 failures in 80 re-runs after
+        the bump (60 serial + 20 under concurrent `-n auto` suite load)."""
+        client = _make_available_client(tmp_path, timeout_s=8.0)
         pid_file = tmp_path / "grandchild.pid"
         binary = tmp_path / "codex"
         binary.write_text(
@@ -1312,8 +1329,22 @@ class TestProcessGroupKill:
         with pytest.raises(CodexExecTimeoutError):
             await client.generate("hello")
 
-        assert pid_file.exists(), "fake binary never ran — harness broken, not a verdict"
-        grandchild_pid = int(pid_file.read_text().strip())
+        # Defense in depth, not the primary fix: by the time generate() has
+        # raised, the SUT's own 8.0s timeout has already elapsed, which is
+        # comfortably past the write above — so this loop should resolve on
+        # its first iteration. It exists only to absorb any residual
+        # filesystem-visibility jitter, never as a substitute for the
+        # timeout_s headroom that actually closes the race.
+        setup_deadline = time.monotonic() + 2.0
+        pid_text = ""
+        while time.monotonic() < setup_deadline:
+            if pid_file.exists():
+                pid_text = pid_file.read_text().strip()
+                if pid_text:
+                    break
+            await asyncio.sleep(0.05)
+        assert pid_text, "fake binary never ran — harness broken, not a verdict"
+        grandchild_pid = int(pid_text)
         assert grandchild_pid > 1
 
         deadline = time.monotonic() + 5.0


### PR DESCRIPTION
## What

`TestProcessGroupKill::test_guilt_timeout_kills_grandchildren_via_process_group` is load-dependent flaky. It guards a property worth guarding — when a `codex exec` call times out, the whole process **group** must die so a grandchild `sh` does not survive as an orphan — and it reddens at random, which is the worst of both worlds: the repo's PR contract forbids rerunning a red without knowing why, and a guard that lies trains people to break that rule.

## The race, measured rather than reasoned

`timeout_s` was `1.0`. That clock starts the moment `create_subprocess_exec` returns — **before** the fake `/bin/sh` has necessarily been scheduled to run its own two lines (fork the background `sleep`, write its pid file).

A standalone probe measured the wall-clock latency between subprocess creation and that pid file appearing, over **700 trials** (idle, and under 2× CPU oversubscription):

- median ≈ **410 ms**
- p99 ≈ 650–940 ms
- **max observed 1.83 s**, with several samples past 1.0 s

So at `timeout_s=1.0` the margin was effectively zero, and on an unlucky scheduling tail the client killed the group before the grandchild was ever forked. The test then failed on **its own setup precondition** — `AssertionError: fake binary never ran — harness broken, not a verdict` — not on anything the code under test did wrong.

Reproduced directly: **1 failure in 40 serial re-runs on an otherwise idle machine**, zero synthetic load. Causality confirmed by forcing `timeout_s=0.05` → 15/15 failures with the identical assertion.

## The fix

- `timeout_s` 1.0 → **8.0** (>4× the worst latency ever observed across those 700 trials).
- The instant `assert pid_file.exists()` becomes a bounded 2 s poll for the file existing **and** being non-empty — defence in depth against pure filesystem-visibility jitter.

A generous deadline costs a slow test. A short sleep costs a lying one.

## What was NOT done, deliberately

- **No `@pytest.mark.flaky`, no rerun plugin, no `xfail`, no skip-under-load.** Zero such markers in the diff.
- **The property is untouched.** The grandchild-death check (`os.kill(pid, 0)` polled up to 5 s) is byte-identical. Nothing about what this test proves has changed — only whether it can state it reliably.
- `backend/llm/codex_exec_client.py` is not modified. This is a harness lane; the process-group logic was never in question.

## Evidence, same denominator on both sides

- 60 serial re-runs **before** the fix vs 60 **after** → 0 failures after.
- 20 further runs of the fixed test with a concurrent `pytest -n auto` suite saturating 8+ cores → 0 failures.
- Full file and full `backend/tests/llm/` (242 tests) green.
- Independently re-verified by the orchestrator: a further 30 serial runs of the whole `TestProcessGroupKill` class → 0 failures.

## Siblings checked

`test_innocence_kill_and_reap_never_kills_our_own_group` awaits a real `/bin/sleep` directly — no fake-binary startup, no competing deadline, structurally immune. `test_guilt_reap_is_bounded_when_orphans_hold_the_pipes` uses the same fake-binary shape but imposes no SUT deadline before the pid write — also immune. Both 25/25 clean. A race cured in one test of a pair and left in its sibling is a race that gets re-discovered.

## Caveat stated plainly

The literal 26,745-test CI suite could not be run here (it needs Postgres/Redis service containers). The reproduction used a faithful proxy — real `pytest-xdist -n auto` contention, the same mechanism CI uses (`-n auto --dist loadfile`). The measured latency distribution, not the proxy, is what the 8 s threshold is sized against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nCopHghNKdDKHxeDRy9H1