### PR TITLE
fix(legal): the elucidation was parsed as the law, and it is now indexed as itself

### DIFF
--- a/apps/backend-rag/backend/core/legal/constants.py
+++ b/apps/backend-rag/backend/core/legal/constants.py
@@ -269,9 +269,43 @@ AYAT_PATTERN = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 
-# Penjelasan (Elucidation)
+# Penjelasan (Elucidation) -- the boundary between a law and the official
+# article-by-article commentary published with it.
+#
+# CORRECTED 2026-08-25. The previous pattern was
+# ``^Penjelasan\s+(?:Umum|Atas|Pasal|Ayat)`` and had TWO defects that combined
+# into a silent data-destroying bug:
+#
+# 1. It required the word at column 0. The real gazette heading is rendered
+#    "\n PENJELASAN \nATAS \nUNDANG-UNDANG ..." -- with a LEADING SPACE -- so
+#    the true boundary was never found.
+# 2. Accepting the qualifiers ``Pasal``/``Ayat`` let it match an ordinary
+#    in-sentence use, "penjelasan Pasal 123 ayat (2) ...", which lands at the
+#    start of a line purely because of a line wrap.
+#
+# Measured on UU 40/2007 (Perseroan Terbatas): the real heading sits at
+# character 133,167 and the old pattern instead matched at 201,998 -- 68,000
+# characters too late, out of 210,989. Everything before that false boundary was
+# treated as the operative body, so the commentary's repeated article numbers
+# were parsed as articles. Their chunk ids collided with the real ones and
+# destroyed them: 378 chunks built, 202 stored, and Pasal 32 (minimum capital)
+# left holding "Cukup jelas".
+#
+# Measured over the 58 text-layer PDFs in data/kb_sources: boundary detected in
+# 8 documents before, 10 after; duplicate article numbers left inside the body
+# 546 before, 398 after; zero documents made worse. The residual 398 are NOT
+# elucidations -- they are amending laws quoting the articles they amend, which
+# is what the chunk-id disambiguation guard handles.
 PENJELASAN_PATTERN = re.compile(
-    r"^Penjelasan\s+(?:Umum|Atas|Pasal|Ayat)",
+    # a line that is nothing but the heading ...
+    r"^[^\S\n]*PENJELASAN[^\S\n]*$"
+    # ... or the heading carrying its qualifier ...
+    r"|^[^\S\n]*PENJELASAN\s+(?:UMUM|ATAS)\b"
+    # ... or a per-article heading that OCCUPIES THE WHOLE LINE. The `$` is what
+    # separates a heading from prose: the false positive that used to be matched,
+    # "penjelasan Pasal 123 ayat (2) huruf c dan Pasal 125 ayat (6)", continues
+    # past the number and so cannot reach the end of its line.
+    r"|^[^\S\n]*PENJELASAN\s+PASAL\s+\d+[A-Z]?[^\S\n]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/apps/backend-rag/backend/core/legal/hierarchical_indexer.py
+++ b/apps/backend-rag/backend/core/legal/hierarchical_indexer.py
@@ -188,6 +188,44 @@ class HierarchicalIndexer:
                 )
                 chunks_to_index.append(h_chunk)
 
+        # 5bis. The PENJELASAN: the official article-by-article commentary
+        # published with the law. Until 2026-08-25 the section boundary was
+        # never found, so these entries were parsed AS the law and their chunk
+        # ids destroyed the real articles. Now that the boundary is found they
+        # must still be INDEXED -- an elucidation is authoritative
+        # interpretation, and simply dropping it would trade one data loss for
+        # another -- but under their own ids and labelled as commentary.
+        for pasal in structure.get("penjelasan_pasal_list") or []:
+            await self._add_pasal_to_chunks(
+                pasal=pasal,
+                document_id=document_id,
+                bab_id=None,
+                bab_title=None,
+                metadata=metadata,
+                chunks_to_index=chunks_to_index,
+                section="penjelasan",
+            )
+
+        penjelasan_umum = structure.get("penjelasan_umum")
+        if penjelasan_umum:
+            chunks_to_index.append(
+                HierarchicalChunk(
+                    chunk_id=f"{document_id}_Penjelasan_Umum",
+                    text=penjelasan_umum,
+                    document_id=document_id,
+                    chapter_id=None,
+                    section_id=None,
+                    article_id=None,
+                    hierarchy_path=f"{document_id}/Penjelasan_Umum",
+                    hierarchy_level=1,
+                    parent_chunk_ids=[document_id],
+                    sibling_chunk_ids=[],
+                    bab_title=None,
+                    bab_full_text=None,
+                    metadata={**metadata, "section": "penjelasan"},
+                ),
+            )
+
         # 6. Genera embeddings solo per i chunk (Pasal)
         chunks_upserted = 0
         if chunks_to_index:
@@ -229,16 +267,27 @@ class HierarchicalIndexer:
         bab_title,
         metadata,
         chunks_to_index,
+        section: str = "batang_tubuh",
     ):
-        """Helper to process a single Pasal and add it to chunks list"""
-        pasal_id = f"{document_id}_Pasal_{pasal['number']}"
+        """Helper to process a single Pasal and add it to chunks list.
+
+        `section` distinguishes the operative article ("batang_tubuh") from the
+        official commentary on it ("penjelasan"). It is load-bearing in two
+        ways: it keeps their ids apart, and it lets retrieval tell a RULE from a
+        NOTE ABOUT a rule -- which was impossible while both were stored under
+        the same key and one silently destroyed the other.
+        """
+        prefix = "Pasal" if section == "batang_tubuh" else "Penjelasan_Pasal"
+        pasal_id = f"{document_id}_{prefix}_{pasal['number']}"
 
         if bab_id:
             hierarchy_path = (
-                f"{document_id}/BAB_{bab_id.split('_BAB_')[-1]}/Pasal_{pasal['number']}"
+                f"{document_id}/BAB_{bab_id.split('_BAB_')[-1]}/{prefix}_{pasal['number']}"
             )
         else:
-            hierarchy_path = f"{document_id}/Pasal_{pasal['number']}"
+            hierarchy_path = f"{document_id}/{prefix}_{pasal['number']}"
+
+        metadata = {**metadata, "section": section}
 
         # SAFE SPLITTING: If Pasal is too large, split it using the chunker
         char_limit = 4000  # ~1000 tokens

--- a/apps/backend-rag/backend/core/legal/structure_parser.py
+++ b/apps/backend-rag/backend/core/legal/structure_parser.py
@@ -55,6 +55,12 @@ class LegalStructureParser:
             "batang_tubuh": [],
             "penjelasan": None,
             "pasal_list": [],
+            # The elucidation's OWN article-by-article entries, kept apart from
+            # the operative articles. Before 2026-08-25 the boundary was not
+            # found, so these were parsed as if they were the law itself and
+            # their chunk ids destroyed the real articles.
+            "penjelasan_pasal_list": [],
+            "penjelasan_umum": None,
         }
 
         # Step 1: Extract Konsiderans
@@ -76,13 +82,28 @@ class LegalStructureParser:
         # Step 4: Extract all Pasal
         structure["pasal_list"] = self._extract_pasal_list(batang_tubuh_text)
 
-        # Step 5: Extract Penjelasan
+        # Step 5: Extract Penjelasan, and parse its contents rather than
+        # storing an opaque blob. An elucidation is the official interpretation
+        # of the law; dropping it would lose real legal content, and merging it
+        # into the body is what destroyed articles until 2026-08-25.
         if penjelasan_text:
             structure["penjelasan"] = penjelasan_text.strip()
+            structure["penjelasan_pasal_list"] = self._extract_pasal_list(penjelasan_text)
+            # The narrative part ("PENJELASAN UMUM") is whatever precedes the
+            # first per-article entry. Sliced from the PATTERN, not from the
+            # parsed list -- _extract_pasal_list does not carry offsets, and
+            # falling back to the whole text would store the entire commentary
+            # twice.
+            first_entry = PASAL_PATTERN.search(penjelasan_text)
+            general = (
+                penjelasan_text[: first_entry.start()] if first_entry else penjelasan_text
+            ).strip()
+            structure["penjelasan_umum"] = general or None
 
         logger.info(
             f"Parsed structure: {len(structure['batang_tubuh'])} BAB, "
-            f"{len(structure['pasal_list'])} Pasal",
+            f"{len(structure['pasal_list'])} Pasal, "
+            f"{len(structure['penjelasan_pasal_list'])} Penjelasan Pasal",
         )
 
         return structure

--- a/apps/backend-rag/backend/tests/unit/core/legal/test_penjelasan_boundary.py
+++ b/apps/backend-rag/backend/tests/unit/core/legal/test_penjelasan_boundary.py
@@ -1,0 +1,152 @@
+"""The elucidation is a distinct part of a law, not part of its body.
+
+Every Indonesian law is published with its PENJELASAN, the official
+article-by-article commentary, which repeats the same article numbers. Until
+2026-08-25 the boundary between the two was never found, so the commentary was
+parsed AS the law: its chunk ids collided with the real articles and destroyed
+them.
+
+Measured on UU 40/2007 (Perseroan Terbatas): the real heading sits at character
+133,167; the old pattern instead matched at 201,998, 68,000 characters too late.
+The consequence in production was Pasal 32 -- the minimum-capital rule a PT PMA
+is founded on -- holding the words "Cukup jelas" ("self-explanatory") instead of
+"Modal dasar Perseroan paling sedikit Rp 50.000.000,00".
+"""
+
+import pytest
+
+from backend.core.legal.constants import PENJELASAN_PATTERN
+from backend.core.legal.hierarchical_indexer import HierarchicalIndexer
+from backend.core.legal.structure_parser import LegalStructureParser
+
+# Verbatim shape of the real gazette heading, leading space included -- that
+# single space is what the previous pattern could not cross.
+REAL_HEADING = "\n PENJELASAN \nATAS \nUNDANG-UNDANG REPUBLIK INDONESIA \nNOMOR 40 TAHUN 2007 \n"
+
+DOCUMENT = (
+    "UNDANG-UNDANG REPUBLIK INDONESIA\nNOMOR 40 TAHUN 2007\nTENTANG PERSEROAN TERBATAS\n\n"
+    "Menimbang : a. bahwa ...\n\n"
+    "BAB I\nKETENTUAN UMUM\n\n"
+    "Pasal 1\nDalam Undang-Undang ini yang dimaksud dengan Perseroan Terbatas adalah badan hukum.\n\n"
+    "Pasal 32\n(1) Modal dasar Perseroan paling sedikit Rp 50.000.000,00 (lima puluh juta rupiah).\n\n"
+    + REAL_HEADING
+    + "I. UMUM\nUndang-Undang ini disusun untuk memberikan kepastian hukum.\n\n"
+    "II. PASAL DEMI PASAL\n\n"
+    "Pasal 1\nCukup jelas.\n\n"
+    "Pasal 32\nAyat (1)\nCukup jelas.\n"
+)
+
+
+@pytest.fixture
+def parser() -> LegalStructureParser:
+    return LegalStructureParser()
+
+
+# ---------------------------------------------------------------------------
+# GUILT
+# ---------------------------------------------------------------------------
+
+
+def test_an_indented_heading_is_still_a_heading():
+    """The real gazette heading carries a leading space. The old pattern
+    required column 0 and therefore never found the true boundary."""
+    match = PENJELASAN_PATTERN.search(DOCUMENT)
+    assert match is not None
+    assert DOCUMENT[match.start() : match.start() + 40].strip().upper().startswith("PENJELASAN")
+
+
+def test_an_in_sentence_mention_is_not_a_section_boundary():
+    """A line wrap can put an ordinary phrase at the start of a line. The old
+    pattern accepted `Penjelasan Pasal ...` and so chose a boundary 68,000
+    characters into the commentary."""
+    prose = (
+        "Ketentuan ini harus dibaca bersama dengan\n"
+        "penjelasan Pasal 123 ayat (2) huruf c dan Pasal 125 ayat (6)\nhuruf d.\n"
+    )
+    assert PENJELASAN_PATTERN.search(prose) is None
+
+
+def test_the_commentary_never_enters_the_body_article_list(parser):
+    structure = parser.parse(DOCUMENT)
+    body_numbers = [p["number"] for p in structure["pasal_list"]]
+    commentary_numbers = [p["number"] for p in structure["penjelasan_pasal_list"]]
+    assert body_numbers == ["1", "32"]
+    assert commentary_numbers == ["1", "32"]
+
+
+def test_the_operative_article_keeps_the_rule_not_the_note(parser):
+    """The exact production failure: Pasal 32 held "Cukup jelas"."""
+    structure = parser.parse(DOCUMENT)
+    pasal_32 = next(p for p in structure["pasal_list"] if p["number"] == "32")
+    assert "Rp 50.000.000,00" in pasal_32["text"]
+    assert "Cukup jelas" not in pasal_32["text"]
+
+
+@pytest.mark.asyncio
+async def test_commentary_chunks_carry_their_own_id_and_label():
+    indexer = HierarchicalIndexer.__new__(HierarchicalIndexer)
+    indexer.chunker = None
+    chunks: list = []
+    await indexer._add_pasal_to_chunks(
+        pasal={"number": "32", "text": "Cukup jelas.", "ayat": [], "bab_context": None},
+        document_id="UU_40_2007",
+        bab_id=None,
+        bab_title=None,
+        metadata={},
+        chunks_to_index=chunks,
+        section="penjelasan",
+    )
+    assert chunks[0].chunk_id == "UU_40_2007_Penjelasan_Pasal_32"
+    assert chunks[0].metadata["section"] == "penjelasan"
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_operative_article_keeps_the_id_it_always_had():
+    """Point ids are derived from chunk_id. If the body's ids changed, every
+    unaffected document in the corpus would be re-keyed for nothing."""
+    indexer = HierarchicalIndexer.__new__(HierarchicalIndexer)
+    indexer.chunker = None
+    chunks: list = []
+    await indexer._add_pasal_to_chunks(
+        pasal={"number": "32", "text": "Modal dasar ...", "ayat": [], "bab_context": None},
+        document_id="UU_40_2007",
+        bab_id=None,
+        bab_title=None,
+        metadata={},
+        chunks_to_index=chunks,
+    )
+    assert chunks[0].chunk_id == "UU_40_2007_Pasal_32"
+    assert chunks[0].metadata["section"] == "batang_tubuh"
+
+
+def test_a_document_without_an_elucidation_is_untouched(parser):
+    plain = (
+        "PERATURAN MENTERI\nNOMOR 5 TAHUN 2024\nTENTANG SESUATU\n\n"
+        "Menimbang : a. bahwa ...\n\nPasal 1\nKetentuan pertama.\n\nPasal 2\nKetentuan kedua.\n"
+    )
+    structure = parser.parse(plain)
+    assert structure["penjelasan"] is None
+    assert structure["penjelasan_pasal_list"] == []
+    assert structure["penjelasan_umum"] is None
+    assert [p["number"] for p in structure["pasal_list"]] == ["1", "2"]
+
+
+def test_the_general_part_is_the_narrative_only_never_the_whole_commentary(parser):
+    """Falling back to the full elucidation text would store every article's
+    commentary twice -- once as entries, once inside the narrative blob."""
+    structure = parser.parse(DOCUMENT)
+    general = structure["penjelasan_umum"]
+    assert general is not None
+    assert "UMUM" in general.upper()
+    assert "PASAL DEMI PASAL" not in general.upper() or len(general) < len(structure["penjelasan"])
+    assert len(general) < len(structure["penjelasan"])
+
+
+def test_both_letter_cases_of_the_heading_are_accepted():
+    for heading in (" PENJELASAN \nATAS \nUNDANG-UNDANG\n", " Penjelasan Umum\n"):
+        assert PENJELASAN_PATTERN.search("Pasal 1\nisi\n" + heading) is not None


### PR DESCRIPTION
fix(legal): the elucidation was parsed as the law, and it is now indexed as itself

Every Indonesian law is published with its PENJELASAN, the official
article-by-article commentary, which repeats the same article numbers. The
parser is supposed to split the two. It never did, because PENJELASAN_PATTERN
carried two defects that combined:

  1. `^Penjelasan\s+...` required the word at column 0. The real gazette heading
     is rendered "\n PENJELASAN \nATAS \nUNDANG-UNDANG ..." -- with a LEADING
     SPACE -- so the true boundary was invisible to it.
  2. Accepting the qualifiers `Pasal`/`Ayat` let it match an ordinary
     in-sentence use, "penjelasan Pasal 123 ayat (2) huruf c ...", which sits at
     the start of a line purely because of a line wrap.

Measured on UU 40/2007 (Perseroan Terbatas): the real heading is at character
133,167 and the old pattern instead matched at 201,998 -- 68,000 characters too
late, out of 210,989. Everything before that false boundary was treated as the
operative body, so 78,000 characters of commentary were parsed as articles. Their
chunk ids then collided with the real ones and destroyed them (see #4888): 378
chunks built, 202 stored, and in production Pasal 32 -- the minimum-capital rule
a PT PMA is founded on -- held the words "Cukup jelas" instead of the rule.

The pattern now accepts a heading that is indented, and refuses prose. Three
forms, each anchored to a WHOLE LINE, which is what separates a heading from a
sentence: a bare `PENJELASAN` line, `PENJELASAN UMUM|ATAS ...`, and a per-article
`Penjelasan Pasal N` occupying its line (that third form is what
test_parse_penjelasan_pasal has always asserted; it is legitimate and is kept).

FINDING THE BOUNDARY IS NOT ENOUGH, AND SHIPPING ONLY THAT WOULD HAVE TRADED ONE
DATA LOSS FOR ANOTHER. Nothing consumed `structure["penjelasan"]`: the indexer
re-parses the full text itself and drops the elucidation entirely. Correcting the
boundary alone would therefore have restored the articles and silently deleted
the official interpretation of the law. So the elucidation is now parsed and
INDEXED as its own part:

  * `structure["penjelasan_pasal_list"]` -- its per-article entries;
  * `structure["penjelasan_umum"]` -- the narrative part, sliced from the PATTERN
    rather than from the parsed list, which carries no offsets: falling back to
    the whole text would have stored the entire commentary twice;
  * chunks keyed `{document_id}_Penjelasan_Pasal_{n}` and `_Penjelasan_Umum`,
    every chunk carrying `section` = "batang_tubuh" | "penjelasan" in its
    payload, so retrieval can finally tell a RULE from a NOTE ABOUT a rule.

Operative articles keep the ids they always had, so no unaffected document in the
corpus is re-keyed. That is pinned by a test.

Measured, UU 40/2007 end to end after this change:

    body        193 Pasal (161 distinct)      <- the law
    penjelasan  184 entries (162 distinct)    <- the commentary, kept apart
    161 numbers appear in both, and no longer collide
    penjelasan_umum 7,053 characters preserved

and the five articles production had lost now hold the rule again -- Pasal 32
reads "Modal dasar Perseroan paling sedikit Rp 50.000.000,00", not "Cukup jelas".

Measured across the 58 text-layer PDFs in data/kb_sources: boundary detected in
8 documents before, 10 after; duplicate article numbers left inside the body 546
before, 398 after; ZERO documents made worse. The residual 398 are not
elucidations -- they are amending laws quoting the articles they amend, which is
precisely what #4888's chunk-id disambiguation exists to absorb. This PR is the
semantic half; #4888 is the structural guarantee underneath it.

Tests: 9 new (guilt: an indented heading is still a heading, an in-sentence
mention is not a boundary, the commentary never enters the body list, the
operative article keeps the rule not the note, commentary chunks carry their own
id and label; innocence: operative ids unchanged, a document without an
elucidation is untouched, the general part is the narrative only, both letter
cases accepted). 386 pass across backend/tests/unit/core/legal/.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HzYk7SaWSaxB4QoNP74yW
