### PR TITLE
fix(wa): recovery net re-routed meta-inbox messages through the retired ChannelRouter pipeline — the systematic second reply

### DIFF
--- a/apps/backend-rag/backend/app/routers/whatsapp_chat.py
+++ b/apps/backend-rag/backend/app/routers/whatsapp_chat.py
@@ -1247,7 +1247,12 @@ async def _ingest_meta_inbox_media(raw_payload: dict[str, Any], request: Request
         logger.error("meta-inbox media handoff failed: %s", exc, exc_info=True)
 
 
-async def process_meta_inbox_payload(raw_payload: dict[str, Any], request: Request) -> None:
+async def process_meta_inbox_payload(
+    raw_payload: dict[str, Any],
+    request: Request | None,
+    *,
+    db_pool: Any | None = None,
+) -> None:
     """Background task: drive the meta-inbox ledger for the target number only.
 
     Runs AFTER the webhook has persisted to inbound_webhooks and ACKed 200, so
@@ -1255,9 +1260,24 @@ async def process_meta_inbox_payload(raw_payload: dict[str, Any], request: Reque
     META_INBOX_PHONE_NUMBER_IDS (every phone_number_id known to route to this
     number, not just the canonical one); any other number is ignored here (it
     stays on the existing inline triage flow).
+
+    ``db_pool`` lets a caller that has no ``Request`` (the WebhookProcessor
+    recovery net, see ``route_whatsapp_recovery``) inject the pool directly
+    instead of going through ``_get_db_pool(request)``. The normal webhook
+    call site still passes ``request`` and leaves ``db_pool`` unset.
+
+    On success — the message was handled (real work, an idempotent duplicate
+    no-op, or a lost cross-path claim) — marks the ``inbound_webhooks`` row
+    processed (2026-08-25 double-reply scar prong 1), mirroring the legacy
+    path's ``process_whatsapp_message_and_mark_processed``. Without this the
+    row stayed ``processed_at IS NULL`` forever, so the WebhookProcessor's
+    30s recovery net re-dispatched it through the retired ChannelRouter
+    pipeline, which crafted and sent its own, different reply — the
+    systematic second reply this fix closes. On handler FAILURE the row is
+    deliberately left unmarked so the recovery net still retries it.
     """
-    db_pool = _get_db_pool(request)
-    if db_pool is None:
+    pool = db_pool if db_pool is not None else _get_db_pool(request)
+    if pool is None:
         return
 
     try:
@@ -1267,7 +1287,9 @@ async def process_meta_inbox_payload(raw_payload: dict[str, Any], request: Reque
         return
 
     try:
-        async with db_pool.acquire() as conn:
+        from backend.services.channels import inbound_webhook_repo
+
+        async with pool.acquire() as conn:
             for entry in webhook.entry:
                 for change in entry.changes:
                     if change.field != "messages":
@@ -1291,8 +1313,64 @@ async def process_meta_inbox_payload(raw_payload: dict[str, Any], request: Reque
                         wamid = msg.get("id")
                         webhook_id = await _resolve_webhook_id(conn, wamid) if wamid else None
                         await _handle_meta_inbox_message(conn, msg, sender_name, webhook_id)
+
+                        if not wamid:
+                            continue
+                        try:
+                            await inbound_webhook_repo.mark_processed(
+                                pool,
+                                channel="whatsapp",
+                                dedup_key=wamid,
+                            )
+                        except Exception:
+                            logger.warning(
+                                "meta-inbox: failed to mark inbound row processed "
+                                "(wamid=%s)",
+                                wamid,
+                                exc_info=True,
+                            )
     except Exception as exc:
         logger.error("meta-inbox: processing failed: %s", exc, exc_info=True)
+
+
+async def route_whatsapp_recovery(
+    payload: dict[str, Any],
+    *,
+    db_pool: Any,
+    legacy_route: Any,
+) -> None:
+    """WebhookProcessor recovery-net dispatch for the ``whatsapp`` channel.
+
+    Keeps meta-inbox-targeted payloads out of the retired ChannelRouter
+    pipeline (2026-08-25 double-reply scar prong 2). ``ChannelRouter`` always
+    classifies intent itself and sends its own reply — it never passes
+    through ``wa_reply_claims`` — so routing a meta-inbox payload there on
+    recovery produced a second, different reply. Non-meta-inbox payloads are
+    unaffected: they still go through ``legacy_route`` exactly as before.
+
+    ``legacy_route`` is an ``Awaitable``-returning callable taking the raw
+    payload — the caller supplies its own bound ``_route_via_channel_router``
+    so this function never has to know about ``ChannelRouter``'s shape.
+    """
+    try:
+        webhook = WhatsAppWebhook(**payload)
+        is_meta_inbox = any(
+            change.field == "messages" and _change_belongs_to_meta_inbox(change)
+            for entry in webhook.entry
+            for change in entry.changes
+        )
+    except Exception:
+        logger.warning(
+            "whatsapp recovery: payload parse failed, defaulting to legacy route",
+            exc_info=True,
+        )
+        is_meta_inbox = False
+
+    if is_meta_inbox:
+        await process_meta_inbox_payload(raw_payload=payload, request=None, db_pool=db_pool)
+        return
+
+    await legacy_route(payload)
 
 
 @router.get("")

--- a/apps/backend-rag/backend/app/routers/whatsapp_chat.py
+++ b/apps/backend-rag/backend/app/routers/whatsapp_chat.py
@@ -1252,7 +1252,8 @@ async def process_meta_inbox_payload(
     request: Request | None,
     *,
     db_pool: Any | None = None,
-) -> None:
+    mark_row: bool = True,
+) -> bool:
     """Background task: drive the meta-inbox ledger for the target number only.
 
     Runs AFTER the webhook has persisted to inbound_webhooks and ACKed 200, so
@@ -1266,25 +1267,42 @@ async def process_meta_inbox_payload(
     instead of going through ``_get_db_pool(request)``. The normal webhook
     call site still passes ``request`` and leaves ``db_pool`` unset.
 
-    On success — the message was handled (real work, an idempotent duplicate
-    no-op, or a lost cross-path claim) — marks the ``inbound_webhooks`` row
-    processed (2026-08-25 double-reply scar prong 1), mirroring the legacy
-    path's ``process_whatsapp_message_and_mark_processed``. Without this the
-    row stayed ``processed_at IS NULL`` forever, so the WebhookProcessor's
-    30s recovery net re-dispatched it through the retired ChannelRouter
-    pipeline, which crafted and sent its own, different reply — the
-    systematic second reply this fix closes. On handler FAILURE the row is
-    deliberately left unmarked so the recovery net still retries it.
+    ``mark_row`` (default True, the webhook/BackgroundTasks call site) marks
+    the ``inbound_webhooks`` row processed itself after a message is handled
+    without raising (2026-08-25 double-reply scar prong 1) — mirroring the
+    legacy path's ``process_whatsapp_message_and_mark_processed``. The
+    recovery net (``route_whatsapp_recovery``) passes ``mark_row=False``: its
+    caller, ``WebhookProcessor._process_one``, already holds that SAME row
+    ``FOR UPDATE SKIP LOCKED`` in an open transaction and marks it itself on
+    handler success — a second ``mark_processed`` from THIS function, on a
+    different pool connection, would block against that open transaction
+    until ``statement_timeout``, stalling the shared drain loop for every
+    channel (round-2 adversarial-gate finding, proven at SQL level on
+    PG 17.10).
+
+    Returns True iff every meta-inbox message in the payload was handled
+    without ``_handle_meta_inbox_message`` raising (a parse failure or a
+    missing db pool are non-retryable — no payload to retry against — and
+    also return True). Returns False on a per-message handler failure, so
+    that a ``mark_row=False`` caller can re-raise and let the
+    WebhookProcessor's own retry ladder (backoff, MAX_ATTEMPTS, eventual
+    "GIVING UP") apply to meta-inbox rows exactly as it does to every other
+    channel — this function itself never raises (round-2 finding: silently
+    swallowing every exception made those retry semantics dead for
+    meta-inbox rows; a handler crash during recovery was permanent, silent
+    message loss). The webhook/BackgroundTasks call site (``mark_row=True``)
+    ignores the return value and must never see an exception either way —
+    unaffected by this change.
     """
     pool = db_pool if db_pool is not None else _get_db_pool(request)
     if pool is None:
-        return
+        return True
 
     try:
         webhook = WhatsAppWebhook(**raw_payload)
     except Exception as exc:
         logger.warning("meta-inbox: payload parse failed: %s", exc)
-        return
+        return True
 
     try:
         from backend.services.channels import inbound_webhook_repo
@@ -1314,7 +1332,7 @@ async def process_meta_inbox_payload(
                         webhook_id = await _resolve_webhook_id(conn, wamid) if wamid else None
                         await _handle_meta_inbox_message(conn, msg, sender_name, webhook_id)
 
-                        if not wamid:
+                        if not mark_row or not wamid:
                             continue
                         try:
                             await inbound_webhook_repo.mark_processed(
@@ -1331,6 +1349,9 @@ async def process_meta_inbox_payload(
                             )
     except Exception as exc:
         logger.error("meta-inbox: processing failed: %s", exc, exc_info=True)
+        return False
+
+    return True
 
 
 async def route_whatsapp_recovery(
@@ -1351,6 +1372,19 @@ async def route_whatsapp_recovery(
     ``legacy_route`` is an ``Awaitable``-returning callable taking the raw
     payload — the caller supplies its own bound ``_route_via_channel_router``
     so this function never has to know about ``ChannelRouter``'s shape.
+
+    Calls ``process_meta_inbox_payload`` with ``mark_row=False`` — this
+    function's caller, ``WebhookProcessor._process_one``, already holds the
+    row ``FOR UPDATE SKIP LOCKED`` in an open transaction and marks it itself
+    on success; a second ``mark_processed`` from a different connection would
+    block against that open transaction until ``statement_timeout`` (round-2
+    adversarial-gate finding). On a handler failure (``process_meta_inbox_payload``
+    returns False) this function RE-RAISES, so ``_process_one``'s own retry
+    ladder (backoff, MAX_ATTEMPTS, eventual "GIVING UP") applies to
+    meta-inbox rows exactly as it does to every other channel — without this,
+    ``process_meta_inbox_payload``'s internal catch-all silently discarded
+    those retry semantics and a handler crash during recovery was permanent,
+    silent message loss (round-2 finding).
     """
     try:
         webhook = WhatsAppWebhook(**payload)
@@ -1367,7 +1401,15 @@ async def route_whatsapp_recovery(
         is_meta_inbox = False
 
     if is_meta_inbox:
-        await process_meta_inbox_payload(raw_payload=payload, request=None, db_pool=db_pool)
+        success = await process_meta_inbox_payload(
+            raw_payload=payload, request=None, db_pool=db_pool, mark_row=False
+        )
+        if not success:
+            raise RuntimeError(
+                "meta-inbox recovery: process_meta_inbox_payload reported a "
+                "handler failure — re-raising so the WebhookProcessor's own "
+                "retry ladder applies"
+            )
         return
 
     await legacy_route(payload)

--- a/apps/backend-rag/backend/app/setup/app_factory.py
+++ b/apps/backend-rag/backend/app/setup/app_factory.py
@@ -292,10 +292,26 @@ async def lifespan(app: FastAPI):
                         )
                     await cr.route_message(channel_name, payload)
 
+                # WhatsApp recovery is scope-aware (2026-08-25 double-reply
+                # scar prong 2): a meta-inbox-targeted payload must recover
+                # through process_meta_inbox_payload (idempotent, passes the
+                # wa_reply_claims gate), never through the retired
+                # ChannelRouter pipeline used for every other channel.
+                async def _route_whatsapp(payload: dict) -> None:
+                    from backend.app.routers.whatsapp_chat import (
+                        route_whatsapp_recovery,
+                    )
+
+                    await route_whatsapp_recovery(
+                        payload,
+                        db_pool=app.state.db_pool,
+                        legacy_route=lambda p: _route_via_channel_router("whatsapp", p),
+                    )
+
                 webhook_processor = WebhookProcessor(
                     db_pool=app.state.db_pool,
                     handlers={
-                        "whatsapp": lambda p: _route_via_channel_router("whatsapp", p),
+                        "whatsapp": _route_whatsapp,
                         "telegram": lambda p: _route_via_channel_router("telegram", p),
                         "instagram": lambda p: _route_via_channel_router("instagram", p),
                         "twitter": lambda p: _route_via_channel_router("twitter", p),

--- a/apps/backend-rag/backend/tests/unit/routers/test_wa_double_reply_defenses.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_wa_double_reply_defenses.py
@@ -442,6 +442,20 @@ async def test_claim_same_path_retry_reaffirms_its_own_win() -> None:
 # marks the row on success and NOT on handler failure, and (B) the
 # WebhookProcessor's recovery dispatch keeps meta-inbox payloads off
 # ChannelRouter entirely, as a second, independent line of defense.
+#
+# Round 2 (adversarial gate on PR #4894) found two defects in the recovery
+# path itself, fixed and tested here too:
+#   - process_meta_inbox_payload(mark_row=True) marking the SAME row that
+#     WebhookProcessor._process_one already holds FOR UPDATE SKIP LOCKED in
+#     an open transaction self-blocks against that transaction until
+#     statement_timeout. route_whatsapp_recovery now passes mark_row=False.
+#   - process_meta_inbox_payload previously swallowed every handler
+#     exception unconditionally, so the WebhookProcessor's retry ladder
+#     (backoff/MAX_ATTEMPTS/GIVING UP) never fired for meta-inbox rows — a
+#     handler crash during recovery was silent, permanent message loss.
+#     process_meta_inbox_payload now returns False on failure and
+#     route_whatsapp_recovery re-raises so the processor's own retry
+#     semantics apply.
 # ---------------------------------------------------------------------------
 
 
@@ -492,7 +506,7 @@ async def test_meta_inbox_payload_marks_row_processed_on_success(
         mark_processed_mock,
     )
 
-    await whatsapp_chat.process_meta_inbox_payload(
+    result = await whatsapp_chat.process_meta_inbox_payload(
         _webhook_payload(CANONICAL_ID, wamid="wamid.MARKED"),
         request=None,
         db_pool=pool,
@@ -502,6 +516,7 @@ async def test_meta_inbox_payload_marks_row_processed_on_success(
     mark_processed_mock.assert_awaited_once_with(
         pool, channel="whatsapp", dedup_key="wamid.MARKED"
     )
+    assert result is True
 
 
 @pytest.mark.asyncio
@@ -526,14 +541,17 @@ async def test_meta_inbox_payload_does_not_mark_row_on_handler_failure(
     )
 
     # process_meta_inbox_payload swallows the handler exception internally
-    # (existing "processing failed" catch-all) — must not raise here either.
-    await whatsapp_chat.process_meta_inbox_payload(
+    # (existing "processing failed" catch-all) — must not raise here itself,
+    # but must SIGNAL the failure via its return value (round-2 fix) so a
+    # mark_row=False caller (route_whatsapp_recovery) can re-raise.
+    result = await whatsapp_chat.process_meta_inbox_payload(
         _webhook_payload(CANONICAL_ID, wamid="wamid.UNMARKED"),
         request=None,
         db_pool=pool,
     )
 
     mark_processed_mock.assert_not_awaited()
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -542,7 +560,7 @@ async def test_recovery_net_routes_meta_inbox_payload_away_from_channel_router(
 ) -> None:
     """Prong 2, guilt case avoided: meta-inbox payload never reaches ChannelRouter."""
     pool = MagicMock()
-    process_meta_inbox_mock = AsyncMock(return_value=None)
+    process_meta_inbox_mock = AsyncMock(return_value=True)
     monkeypatch.setattr(whatsapp_chat, "process_meta_inbox_payload", process_meta_inbox_mock)
     legacy_route_mock = AsyncMock(
         side_effect=AssertionError("ChannelRouter must not run for a meta-inbox payload")
@@ -553,8 +571,11 @@ async def test_recovery_net_routes_meta_inbox_payload_away_from_channel_router(
         payload, db_pool=pool, legacy_route=legacy_route_mock
     )
 
+    # mark_row=False is load-bearing (round-2 finding): the WebhookProcessor
+    # already holds this row FOR UPDATE SKIP LOCKED and marks it itself —
+    # a mutant that drops mark_row=False (or flips it True) must go red here.
     process_meta_inbox_mock.assert_awaited_once_with(
-        raw_payload=payload, request=None, db_pool=pool
+        raw_payload=payload, request=None, db_pool=pool, mark_row=False
     )
     legacy_route_mock.assert_not_awaited()
 
@@ -578,3 +599,81 @@ async def test_recovery_net_still_routes_non_meta_inbox_payload_through_channel_
 
     legacy_route_mock.assert_awaited_once_with(payload)
     process_meta_inbox_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_entry_point_never_calls_mark_processed_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Round-2 finding 1, guilt case avoided: recovery never self-blocks on
+
+    WebhookProcessor's own FOR UPDATE SKIP LOCKED transaction. Drives the
+    REAL process_meta_inbox_payload (not mocked) through route_whatsapp_recovery
+    end-to-end and proves inbound_webhook_repo.mark_processed is never
+    awaited from that path — a mutant that reverts mark_row=False (or drops
+    the mark_row guard inside process_meta_inbox_payload) must go red here.
+    """
+    conn = MagicMock()
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    monkeypatch.setattr(
+        whatsapp_chat, "_handle_meta_inbox_message", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(whatsapp_chat, "_resolve_webhook_id", AsyncMock(return_value=None))
+    mark_processed_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "backend.services.channels.inbound_webhook_repo.mark_processed",
+        mark_processed_mock,
+    )
+    legacy_route_mock = AsyncMock(
+        side_effect=AssertionError("ChannelRouter must not run for a meta-inbox payload")
+    )
+
+    payload = _webhook_payload(CANONICAL_ID, wamid="wamid.NO-SELF-MARK")
+    await whatsapp_chat.route_whatsapp_recovery(
+        payload, db_pool=pool, legacy_route=legacy_route_mock
+    )
+
+    mark_processed_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_reraises_on_handler_failure_so_processor_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Round-2 finding 2, guilt case avoided: a handler crash during recovery
+
+    must propagate out of route_whatsapp_recovery (not be silently
+    swallowed) so WebhookProcessor._process_one's retry ladder (backoff,
+    MAX_ATTEMPTS, GIVING UP) applies — and the row must NOT be marked
+    processed either, by the processor OR by this function.
+    """
+    conn = MagicMock()
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    monkeypatch.setattr(
+        whatsapp_chat,
+        "_handle_meta_inbox_message",
+        AsyncMock(side_effect=RuntimeError("handler exploded during recovery")),
+    )
+    monkeypatch.setattr(whatsapp_chat, "_resolve_webhook_id", AsyncMock(return_value=None))
+    mark_processed_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "backend.services.channels.inbound_webhook_repo.mark_processed",
+        mark_processed_mock,
+    )
+    legacy_route_mock = AsyncMock(
+        side_effect=AssertionError("ChannelRouter must not run for a meta-inbox payload")
+    )
+
+    payload = _webhook_payload(CANONICAL_ID, wamid="wamid.RETRY-ME")
+
+    with pytest.raises(RuntimeError, match="process_meta_inbox_payload reported a"):
+        await whatsapp_chat.route_whatsapp_recovery(
+            payload, db_pool=pool, legacy_route=legacy_route_mock
+        )
+
+    mark_processed_mock.assert_not_awaited()
+    legacy_route_mock.assert_not_awaited()

--- a/apps/backend-rag/backend/tests/unit/routers/test_wa_double_reply_defenses.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_wa_double_reply_defenses.py
@@ -432,3 +432,149 @@ async def test_claim_same_path_retry_reaffirms_its_own_win() -> None:
 
     assert first is True
     assert retry is True
+
+
+# ---------------------------------------------------------------------------
+# 3rd-pipeline scar (2026-08-25): the 30s recovery net re-routed meta-inbox
+# messages through the retired ChannelRouter pipeline because
+# process_meta_inbox_payload never marked the inbound_webhooks row
+# processed. Two prongs tested below: (A) process_meta_inbox_payload now
+# marks the row on success and NOT on handler failure, and (B) the
+# WebhookProcessor's recovery dispatch keeps meta-inbox payloads off
+# ChannelRouter entirely, as a second, independent line of defense.
+# ---------------------------------------------------------------------------
+
+
+def _webhook_payload(phone_number_id: str, wamid: str = "wamid.RECOVERY") -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "entry-1",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "metadata": {"phone_number_id": phone_number_id},
+                            "contacts": [{"profile": {"name": "Mario"}}],
+                            "messages": [
+                                {
+                                    "id": wamid,
+                                    "from": "628111",
+                                    "type": "text",
+                                    "text": {"body": "hello"},
+                                    "timestamp": "1735689600",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_meta_inbox_payload_marks_row_processed_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prong 1, innocence: a handled message closes its inbound_webhooks row."""
+    conn = MagicMock()
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    handle_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(whatsapp_chat, "_handle_meta_inbox_message", handle_mock)
+    monkeypatch.setattr(whatsapp_chat, "_resolve_webhook_id", AsyncMock(return_value=None))
+    mark_processed_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "backend.services.channels.inbound_webhook_repo.mark_processed",
+        mark_processed_mock,
+    )
+
+    await whatsapp_chat.process_meta_inbox_payload(
+        _webhook_payload(CANONICAL_ID, wamid="wamid.MARKED"),
+        request=None,
+        db_pool=pool,
+    )
+
+    handle_mock.assert_awaited_once()
+    mark_processed_mock.assert_awaited_once_with(
+        pool, channel="whatsapp", dedup_key="wamid.MARKED"
+    )
+
+
+@pytest.mark.asyncio
+async def test_meta_inbox_payload_does_not_mark_row_on_handler_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prong 1, guilt: a handler crash must leave the row open for retry."""
+    conn = MagicMock()
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=_AcquireCM(conn))
+
+    monkeypatch.setattr(
+        whatsapp_chat,
+        "_handle_meta_inbox_message",
+        AsyncMock(side_effect=RuntimeError("handler exploded")),
+    )
+    monkeypatch.setattr(whatsapp_chat, "_resolve_webhook_id", AsyncMock(return_value=None))
+    mark_processed_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "backend.services.channels.inbound_webhook_repo.mark_processed",
+        mark_processed_mock,
+    )
+
+    # process_meta_inbox_payload swallows the handler exception internally
+    # (existing "processing failed" catch-all) — must not raise here either.
+    await whatsapp_chat.process_meta_inbox_payload(
+        _webhook_payload(CANONICAL_ID, wamid="wamid.UNMARKED"),
+        request=None,
+        db_pool=pool,
+    )
+
+    mark_processed_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_net_routes_meta_inbox_payload_away_from_channel_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prong 2, guilt case avoided: meta-inbox payload never reaches ChannelRouter."""
+    pool = MagicMock()
+    process_meta_inbox_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(whatsapp_chat, "process_meta_inbox_payload", process_meta_inbox_mock)
+    legacy_route_mock = AsyncMock(
+        side_effect=AssertionError("ChannelRouter must not run for a meta-inbox payload")
+    )
+
+    payload = _webhook_payload(CANONICAL_ID, wamid="wamid.NET")
+    await whatsapp_chat.route_whatsapp_recovery(
+        payload, db_pool=pool, legacy_route=legacy_route_mock
+    )
+
+    process_meta_inbox_mock.assert_awaited_once_with(
+        raw_payload=payload, request=None, db_pool=pool
+    )
+    legacy_route_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_net_still_routes_non_meta_inbox_payload_through_channel_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prong 2, innocence (regression guard): unrelated numbers keep the old path."""
+    pool = MagicMock()
+    process_meta_inbox_mock = AsyncMock(
+        side_effect=AssertionError("non-meta-inbox payload must not use process_meta_inbox_payload")
+    )
+    monkeypatch.setattr(whatsapp_chat, "process_meta_inbox_payload", process_meta_inbox_mock)
+    legacy_route_mock = AsyncMock(return_value=None)
+
+    payload = _webhook_payload(UNRELATED_ID, wamid="wamid.LEGACY-NET")
+    await whatsapp_chat.route_whatsapp_recovery(
+        payload, db_pool=pool, legacy_route=legacy_route_mock
+    )
+
+    legacy_route_mock.assert_awaited_once_with(payload)
+    process_meta_inbox_mock.assert_not_awaited()


### PR DESCRIPTION
## Root cause (verified on prod DB 2026-08-25)

- `whatsapp_webhook()` persists EVERY inbound WA message to `inbound_webhooks` with `next_retry_at = received_at + 30s` (`WHATSAPP_FAST_PATH_RECOVERY_DELAY_SECONDS`), regardless of whether the change targets meta-inbox.
- For meta-inbox-targeted messages the fast path schedules `process_meta_inbox_payload`, which **never called `inbound_webhook_repo.mark_processed`** on that row. The only caller of `mark_processed` anywhere in the backend was the legacy wrapper `process_whatsapp_message_and_mark_processed`.
- So every meta-inbox message's row sat `processed_at IS NULL`. After 30s the P0-6 `WebhookProcessor` drained it and dispatched it via `app_factory.py`'s `_route_via_channel_router("whatsapp", payload)` → the OLD `ChannelRouter` pipeline, which classifies intent itself and sends its own reply — the systematic second reply.
- Timeline matched exactly: `processed_at = received_at + ~31s` (30s window + 5s poll).
- PR #4881's `wa_reply_claims` claim gate instruments `process_whatsapp_message` and `_handle_meta_inbox_message`; `ChannelRouter.route_message` never claims — orthogonal, not a fix for this.

## Cure, two prongs

1. **`process_meta_inbox_payload` now marks the `inbound_webhooks` row processed** after each message `_handle_meta_inbox_message` handles without raising (real work, an idempotent duplicate no-op, or a lost cross-path claim — mirrors `process_whatsapp_message_and_mark_processed`'s best-effort pattern). On handler failure the row stays unmarked so recovery still retries it.
2. **New `whatsapp_chat.route_whatsapp_recovery()`** scopes the `WebhookProcessor`'s whatsapp recovery dispatch: a meta-inbox-targeted payload recovers through `process_meta_inbox_payload` (idempotent, passes the `wa_reply_claims` gate) instead of `ChannelRouter`, even if prong 1's mark races past the 30s window. Non-meta-inbox payloads are unaffected — unchanged `ChannelRouter` path. `app_factory.py` wires this in without touching `ChannelRouter` internals.

`process_meta_inbox_payload` gained an optional `db_pool` kwarg so the recovery path (no FastAPI `Request` available) can inject the pool directly instead of `_get_db_pool(request)`.

## Round 2 (adversarial gate findings, fixed on the same branch)

The gate found two defects in the round-1 recovery path itself:

1. **Self-blocking on the drain transaction.** `WebhookProcessor.drain_pending` holds the row `FOR UPDATE SKIP LOCKED` in an open transaction while calling the handler. Round 1's recovery path then called `mark_processed` on that SAME row from a DIFFERENT pool connection, which blocks until `statement_timeout` (30s) — stalling the SHARED drain loop, for every channel, up to ~25 min for a 50-row backlog. Proven at SQL level on PG 17.10.
   **Fix:** `process_meta_inbox_payload` gained `mark_row: bool = True`; `route_whatsapp_recovery` now passes `mark_row=False` — the processor's own `_process_one` already marks the row on success from inside the transaction that holds it.
2. **Recovery lost all retry semantics.** `process_meta_inbox_payload` swallowed every exception unconditionally and never re-raised, so `_process_one` always took the success branch and set `processed_at` — `MAX_ATTEMPTS`/backoff were dead for meta-inbox rows, and a handler crash during recovery meant silent, permanent message loss.
   **Fix:** `process_meta_inbox_payload` now returns `bool` (`True` iff every message was handled without the per-message handler raising); `route_whatsapp_recovery` re-raises on `False` so the processor's own retry ladder (backoff, `MAX_ATTEMPTS`, eventual "GIVING UP") applies to meta-inbox rows exactly as it does to every other channel. The webhook/BackgroundTasks fast-path call site is unaffected — it ignores the return value and never sees an exception either way.

Both docstrings corrected to state the true contract for both call sites.

## Residual risk

- A crash between the `wa_reply_claims` claim and the `mark_processed` call means one retried recovery pass through the already-claimed meta-inbox path — safe and idempotent by construction (the claim gate and the `ON CONFLICT DO NOTHING` ledger insert both no-op on replay).
- `_ingest_meta_inbox_media` (the official-line media handoff background task, scheduled alongside `process_meta_inbox_payload` on the fast path) is **not replayed by the recovery net** — informational only, out of scope for this fix, left as-is.

## Evidence

`conversation_messages` id=901/902 (two replies, one message); `inbound_webhooks` `processed_at` = `received_at` + 31s.

## Tests

`backend/tests/unit/routers/test_wa_double_reply_defenses.py` — 6 new tests, all 21 in the file green:
- `test_meta_inbox_payload_marks_row_processed_on_success`
- `test_meta_inbox_payload_does_not_mark_row_on_handler_failure`
- `test_recovery_net_routes_meta_inbox_payload_away_from_channel_router`
- `test_recovery_net_still_routes_non_meta_inbox_payload_through_channel_router`
- `test_recovery_entry_point_never_calls_mark_processed_itself` (round 2)
- `test_recovery_reraises_on_handler_failure_so_processor_retries` (round 2)

Round-2 mutation-proofed locally: reverting `mark_row=False` turned the two `mark_row`-asserting tests red; swallowing the re-raise (reverting to "await + return") turned `test_recovery_reraises_on_handler_failure_so_processor_retries` red. Both mutations applied, confirmed red, then reverted before committing.

## Constraints honored

No migration, no ChannelRouter internals touched, no prod access, no deploy in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Residual risk (declared, gate round 2)
- Latent no-pool hole: `process_meta_inbox_payload` returns True when `db_pool` resolution fails, so a hypothetical recovery drain with `app.state.db_pool=None` would mark a row processed without handling it. Judged UNREACHABLE today (the only None assignment, main_api.py light-init failure, also skips constructing the WebhookProcessor, whose own drain SELECT needs the pool). One-word hardening if ever needed: `return mark_row` at the no-pool early-out.
