### PR TITLE
fix(vision): a half-read law was stored as if it were whole

### DIFF
--- a/apps/backend-rag/backend/core/parsers.py
+++ b/apps/backend-rag/backend/core/parsers.py
@@ -205,7 +205,10 @@ def extract_text_from_pdf(
                     # Last resort: try vision model (skip if already in async context)
                     logger.info("OCR failed, trying vision model as last resort...")
                     try:
-                        from backend.services.multimodal.pdf_vision_service import PDFVisionService
+                        from backend.services.multimodal.pdf_vision_service import (
+                            IncompleteTranscriptionError,
+                            PDFVisionService,
+                        )
 
                         vision_service = PDFVisionService()
                         # Check if we're in an async context
@@ -233,6 +236,13 @@ def extract_text_from_pdf(
                                 if return_page_markers:
                                     return vision_text, []
                                 return vision_text
+                    except IncompleteTranscriptionError as vision_err:
+                        # A partially transcribed document must not fall through
+                        # to the generic "No text extracted" below: that message
+                        # would report the opposite of what happened and hide
+                        # which pages are missing.
+                        logger.error("%s", vision_err)
+                        raise DocumentParseError(str(vision_err)) from vision_err
                     except Exception as vision_err:
                         logger.warning("Vision extraction failed: %s", vision_err)
 
@@ -274,11 +284,22 @@ async def extract_text_from_pdf_ocr_async(file_path: str) -> str:
 
     Both problems are gone by delegating to the one real implementation.
     """
-    try:
-        from backend.services.multimodal.pdf_vision_service import PDFVisionService
+    from backend.services.multimodal.pdf_vision_service import (
+        IncompleteTranscriptionError,
+        PDFVisionService,
+    )
 
+    try:
         text = await PDFVisionService().transcribe_scanned_pdf(file_path)
         return text or ""
+    except IncompleteTranscriptionError as e:
+        # ADDED 2026-08-25. Everything else here degrades to "" on purpose, and
+        # that is right for a page we could not read at all. It is WRONG for a
+        # document we read in part: returning "" would report "nothing found"
+        # while returning the survivors would store an amputated law as if it
+        # were whole. Only a typed refusal carries the truth upward.
+        logger.error("%s", e)
+        raise DocumentParseError(str(e)) from e
     except Exception as e:
         logger.error("Vision OCR extraction failed: %s", e)
         return ""

--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -36,6 +36,27 @@ from backend.utils.tier_classifier import TierClassifier
 
 logger = logging.getLogger(__name__)
 
+
+def _failure_stage(error: Exception) -> IngestionStage:
+    """Which stage does this failure belong to?
+
+    Was `PARSING if "parse" in str(error).lower() else COMPLETION`, which read
+    the stage off a word that happens to appear in some messages. "Incomplete
+    vision transcription of ..." contains no "parse" and was filed under
+    COMPLETION -- a document that never got past reading, recorded as having
+    reached the end. Parse failures are now recognised by TYPE.
+    """
+    from backend.core.parsers import DocumentParseError
+
+    if isinstance(error, DocumentParseError) or isinstance(
+        error.__cause__, DocumentParseError,
+    ):
+        return IngestionStage.PARSING
+    if "parse" in str(error).lower():
+        return IngestionStage.PARSING
+    return IngestionStage.COMPLETION
+
+
 LEGAL_CANONICAL_COLLECTION = "legal_unified"
 LEGAL_ENV_OVERRIDE_FLAG = "LEGAL_INGEST_ALLOW_QDRANT_ENV_OVERRIDE"
 CURRENT_RETRIEVAL_SCOPE = "current"
@@ -483,6 +504,20 @@ class LegalIngestionService:
             try:
                 raw_text = auto_detect_and_parse(file_path, use_ocr=False)
             except DocumentParseError as e:
+                from backend.services.multimodal.pdf_vision_service import (
+                    IncompleteTranscriptionError,
+                )
+
+                if isinstance(e.__cause__, IncompleteTranscriptionError):
+                    # A document read only in PART must not fall into the branch
+                    # below: that branch exists to give a scan a second, fuller
+                    # pass, and here the fuller pass has already happened and
+                    # came back short. Retrying runs the same engine over the
+                    # same pages to reach the same verdict, and -- worse -- the
+                    # decision is read off e.__cause__ rather than off a
+                    # substring of the message, so rewording the error can never
+                    # silently move a half-read law into the retry path.
+                    raise
                 if "No text extracted" in str(e):
                     # Try OCR for scanned PDFs (async version)
                     logger.info(
@@ -1182,9 +1217,7 @@ Return ONLY valid JSON, no markdown."""
                 document_id=document_id or f"failed_{int(start_time)}",
                 file_path=file_path,
                 error=e,
-                stage=IngestionStage.PARSING
-                if "parse" in str(e).lower()
-                else IngestionStage.COMPLETION,
+                stage=_failure_stage(e),
                 duration_ms=total_duration * 1000,
                 source=source,
                 trace_id=trace_id,

--- a/apps/backend-rag/backend/services/multimodal/pdf_vision_service.py
+++ b/apps/backend-rag/backend/services/multimodal/pdf_vision_service.py
@@ -35,6 +35,62 @@ logger = logging.getLogger(__name__)
 # scan into 400 seconds of doing nothing.
 GEMINI_VISION_PAGE_DELAY_SECONDS = 4.0
 
+# A page whose rendered image carries essentially no ink is legitimately blank
+# -- the empty verso of a two-sided scan -- and its silence is not a failure to
+# transcribe. Anything above this ratio that came back empty IS a failure.
+#
+# The threshold is measured, not guessed (2026-08-25, this renderer at 2x zoom,
+# luminance < 200 counted as ink):
+#
+#   real scanned decree pages ....... 4.7% - 8.4%
+#   ONE short line on A4 ............ 0.049%   <- must NOT be called blank
+#   a page bearing only its number .. 0.003%
+#   a truly empty page .............. 0.000%
+#
+# 0.01% sits ~5x below the shortest line that carries law and ~3x above a bare
+# page number. The bias is deliberate: misjudging a written page as blank hides
+# a hole in a law, while misjudging a blank page as missing merely refuses the
+# document out loud, which is recoverable.
+BLANK_PAGE_INK_RATIO = 0.0001
+BLANK_PAGE_LUMINANCE_THRESHOLD = 200
+
+
+class IncompleteTranscriptionError(Exception):
+    """Raised when only SOME pages of a scanned PDF could be transcribed.
+
+    Deliberately NOT a ``RuntimeError``: `backend.core.parsers` uses
+    ``except RuntimeError`` to mean "there is no running event loop", and a
+    partially transcribed decree caught by that handler would be silently
+    mistaken for an asyncio condition.
+
+    Measured 2026-08-25: a three-page ministerial decree returned 1,204 of its
+    6,109 characters because pages 2 and 3 timed out against a cold vision
+    model, and the only trace was a warning in a log nobody reads. The document
+    was stored looking whole. For a legal corpus that is the worst of the three
+    outcomes -- worse than an error, and worse than nothing -- because every
+    downstream reader, human or machine, treats an amputated decree as the
+    decree. A partial transcription must therefore be a refusal, not a value.
+    """
+
+    def __init__(
+        self,
+        pdf_path: str,
+        missing_pages: list[int],
+        page_count: int,
+        transcribed_chars: int,
+    ) -> None:
+        self.pdf_path = pdf_path
+        self.missing_pages = list(missing_pages)
+        self.page_count = page_count
+        self.transcribed_chars = transcribed_chars
+        super().__init__(
+            f"Incomplete vision transcription of {pdf_path}: "
+            f"{len(self.missing_pages)} of {page_count} pages produced no text "
+            f"(pages {self.missing_pages}). "
+            f"{transcribed_chars} characters were discarded rather than stored "
+            "as if they were the whole document.",
+        )
+
 
 class PDFVisionService:
     """
@@ -164,6 +220,9 @@ class PDFVisionService:
         self,
         pdf_path: str,
         max_pages: int | None = None,
+        *,
+        page_attempts: int = 2,
+        allow_partial: bool = False,
     ) -> str | None:
         """Transcribe a PDF that carries no text layer, page by page.
 
@@ -187,9 +246,22 @@ class PDFVisionService:
         Measured 2026-08-25 on a 3-page scanned ministerial decree: the two
         callers yielded 0 characters; this path yields 6,109.
 
+        The completeness contract, added the same day after this method's OWN
+        first live run returned 1,204 of those 6,109 characters with nothing
+        but a warning to say so:
+
+        * every page gets ``page_attempts`` tries -- the first attempt against a
+          cold vision model is the one that pays to load it, which is exactly
+          how pages 2 and 3 were lost while page 1 warmed ``qwen2.5vl:7b`` up;
+        * a page that stays silent is measured, not assumed: a page with no ink
+          on it is legitimately blank, any other silent page is MISSING;
+        * a document with missing pages RAISES ``IncompleteTranscriptionError``
+          instead of returning what survived. Callers that genuinely want a
+          best-effort excerpt must say so with ``allow_partial=True``, and then
+          the partiality is theirs to carry.
+
         Returns None when NO page could be transcribed, so callers raise rather
-        than store an empty document. Individually failing pages are skipped and
-        logged -- most of a decree beats none of it.
+        than store an empty document.
         """
         try:
             document = fitz.open(pdf_path)
@@ -203,7 +275,69 @@ class PDFVisionService:
             page_count = min(page_count, max_pages)
 
         transcribed: list[str] = []
+        missing: list[int] = []
         for page_number in range(1, page_count + 1):
+            page_text = await self._transcribe_page(pdf_path, page_number, page_attempts)
+            if page_text:
+                transcribed.append(page_text)
+            elif self._page_is_blank(pdf_path, page_number):
+                logger.info(
+                    "Page %s of %s carries no ink and is treated as blank",
+                    page_number,
+                    pdf_path,
+                )
+            else:
+                missing.append(page_number)
+
+        if not transcribed:
+            logger.warning(
+                "Vision transcription produced nothing for %s (%s pages attempted)",
+                pdf_path,
+                page_count,
+            )
+            return None
+
+        text = "\n\n".join(transcribed)
+
+        if missing:
+            if not allow_partial:
+                raise IncompleteTranscriptionError(
+                    pdf_path,
+                    missing,
+                    page_count,
+                    len(text),
+                )
+            logger.warning(
+                "PARTIAL vision transcription of %s: pages %s are missing and the "
+                "caller asked for best-effort; %s characters returned",
+                pdf_path,
+                missing,
+                len(text),
+            )
+
+        logger.info(
+            "Vision transcription: %s/%s pages from %s",
+            len(transcribed),
+            page_count,
+            pdf_path,
+        )
+        return text
+
+    async def _transcribe_page(
+        self,
+        pdf_path: str,
+        page_number: int,
+        attempts: int,
+    ) -> str | None:
+        """Transcribe ONE page, retrying an attempt that failed or said nothing.
+
+        The retry is not defensive decoration: on 2026-08-25 pages 2 and 3 of a
+        three-page decree both hit the 120s client timeout while page 1 was
+        still loading ``qwen2.5vl:7b`` into memory, and re-running the very same
+        call by hand -- against the now-warm model -- returned both pages in
+        full. That manual gesture is what this loop performs.
+        """
+        for attempt in range(1, max(1, attempts) + 1):
             page_text: str | None = None
             try:
                 image = self._render_page_to_image(pdf_path, page_number)
@@ -227,33 +361,63 @@ class PDFVisionService:
                         await asyncio.sleep(GEMINI_VISION_PAGE_DELAY_SECONDS)
             except Exception as exc:
                 logger.warning(
-                    "Page %s of %s could not be transcribed: %s",
+                    "Page %s of %s could not be transcribed (attempt %s/%s): %s",
                     page_number,
                     pdf_path,
+                    attempt,
+                    attempts,
                     exc,
                 )
                 continue
 
             if page_text and page_text.strip():
-                transcribed.append(page_text.strip())
-            else:
-                logger.warning("Page %s of %s produced no text", page_number, pdf_path)
+                return page_text.strip()
 
-        if not transcribed:
             logger.warning(
-                "Vision transcription produced nothing for %s (%s pages attempted)",
+                "Page %s of %s produced no text (attempt %s/%s)",
+                page_number,
                 pdf_path,
-                page_count,
+                attempt,
+                attempts,
             )
-            return None
+        return None
 
-        logger.info(
-            "Vision transcription: %s/%s pages from %s",
-            len(transcribed),
-            page_count,
+    def _page_is_blank(self, pdf_path: str, page_number: int) -> bool:
+        """Is this page silent because it is EMPTY, or because we failed it?
+
+        A page we cannot even render is not declared blank: an unmeasurable
+        page counts as missing, so the doubt costs a loud failure rather than a
+        quiet hole in a law.
+        """
+        try:
+            image = self._render_page_to_image(pdf_path, page_number)
+        except Exception as exc:
+            logger.warning(
+                "Could not render page %s of %s to judge whether it is blank: %s",
+                page_number,
+                pdf_path,
+                exc,
+            )
+            return False
+
+        ink_ratio = self._page_ink_ratio(image)
+        logger.debug(
+            "Page %s of %s ink ratio %.5f",
+            page_number,
             pdf_path,
+            ink_ratio,
         )
-        return "\n\n".join(transcribed)
+        return ink_ratio < BLANK_PAGE_INK_RATIO
+
+    @staticmethod
+    def _page_ink_ratio(image: Image.Image) -> float:
+        """Fraction of pixels dark enough to be ink rather than paper."""
+        histogram = image.convert("L").histogram()
+        total = sum(histogram)
+        if not total:
+            return 0.0
+        dark = sum(histogram[:BLANK_PAGE_LUMINANCE_THRESHOLD])
+        return dark / total
 
     async def _analyze_via_ollama(self, prompt: str, image_base64: str) -> str | None:
         """Analyze image using local Ollama qwen2.5vl:7b vision."""

--- a/apps/backend-rag/backend/services/multimodal/pdf_vision_service.py
+++ b/apps/backend-rag/backend/services/multimodal/pdf_vision_service.py
@@ -54,6 +54,21 @@ GEMINI_VISION_PAGE_DELAY_SECONDS = 4.0
 BLANK_PAGE_INK_RATIO = 0.0001
 BLANK_PAGE_LUMINANCE_THRESHOLD = 200
 
+# Ink is not text. A signature page, a seal, a stamped lampiran, a map or an
+# org-chart carries plenty of ink and NO transcribable text, and on Indonesian
+# legal instruments that page is routine, not exotic. Pixels cannot tell that
+# page apart from one the model simply failed on -- both are inked and silent --
+# so the question is put to the only thing that can answer it: the model is
+# asked to SAY that the page has no text. Silence keeps its old meaning, which
+# is failure, so the discrimination is fail-closed: a model that ignores the
+# instruction costs a loud refusal, never a silent hole.
+NO_TEXT_SENTINEL = "NO_TEXT_ON_THIS_PAGE"
+
+# Returned by the per-page helper to mean "the page answered, and its answer is
+# that it holds no text" -- which is neither text nor silence, and must not be
+# confusable with either.
+NO_TEXT_DECLARED = object()
+
 
 class IncompleteTranscriptionError(Exception):
     """Raised when only SOME pages of a scanned PDF could be transcribed.
@@ -213,7 +228,9 @@ class PDFVisionService:
         "Transcribe ALL visible text from this scanned document page. "
         "Output the text verbatim, preserving line breaks, ordering and table "
         "structure. Do not summarise, translate, explain or add anything. "
-        "If the page contains no text, output nothing."
+        "If the page carries no transcribable text at all -- it holds only a "
+        "seal, a signature, a photograph, a diagram or a map, or it is empty -- "
+        f"output exactly {NO_TEXT_SENTINEL} and nothing else."
     )
 
     async def transcribe_scanned_pdf(
@@ -253,8 +270,11 @@ class PDFVisionService:
         * every page gets ``page_attempts`` tries -- the first attempt against a
           cold vision model is the one that pays to load it, which is exactly
           how pages 2 and 3 were lost while page 1 warmed ``qwen2.5vl:7b`` up;
-        * a page that stays silent is measured, not assumed: a page with no ink
-          on it is legitimately blank, any other silent page is MISSING;
+        * a page that produces nothing is measured, not assumed. Three states,
+          not two: a page with no INK is blank and is never even sent to the
+          model; a page that SAYS it has no text (a seal, a signature, a
+          photograph, a map -- routine in a legal instrument, and full of ink)
+          is honoured; a page that is inked and merely SILENT is MISSING;
         * a document with missing pages RAISES ``IncompleteTranscriptionError``
           instead of returning what survived. Callers that genuinely want a
           best-effort excerpt must say so with ``allow_partial=True``, and then
@@ -277,15 +297,44 @@ class PDFVisionService:
         transcribed: list[str] = []
         missing: list[int] = []
         for page_number in range(1, page_count + 1):
-            page_text = await self._transcribe_page(pdf_path, page_number, page_attempts)
-            if page_text:
-                transcribed.append(page_text)
-            elif self._page_is_blank(pdf_path, page_number):
-                logger.info(
-                    "Page %s of %s carries no ink and is treated as blank",
+            try:
+                image = self._render_page_to_image(pdf_path, page_number)
+            except Exception as exc:
+                # An unmeasurable page is never given the benefit of the doubt.
+                logger.warning(
+                    "Page %s of %s could not be rendered: %s",
                     page_number,
                     pdf_path,
+                    exc,
                 )
+                missing.append(page_number)
+                continue
+
+            ink_ratio = self._page_ink_ratio(image)
+            if ink_ratio < BLANK_PAGE_INK_RATIO:
+                # Asked before spending anything: a page with no ink has nothing
+                # for a vision model to read, and paying two ~30s attempts per
+                # blank verso is how a double-sided scan turns into minutes of
+                # waiting for an answer that is known in advance.
+                logger.info(
+                    "Page %s of %s carries no ink (%.5f) and is treated as blank",
+                    page_number,
+                    pdf_path,
+                    ink_ratio,
+                )
+                continue
+
+            page_text = await self._transcribe_page(image, pdf_path, page_number, page_attempts)
+            if page_text is NO_TEXT_DECLARED:
+                logger.info(
+                    "Page %s of %s declared to carry no transcribable text "
+                    "(ink %.5f -- seal, signature, photograph or diagram)",
+                    page_number,
+                    pdf_path,
+                    ink_ratio,
+                )
+            elif page_text:
+                transcribed.append(page_text)
             else:
                 missing.append(page_number)
 
@@ -325,10 +374,11 @@ class PDFVisionService:
 
     async def _transcribe_page(
         self,
+        image: Image.Image,
         pdf_path: str,
         page_number: int,
         attempts: int,
-    ) -> str | None:
+    ) -> str | object | None:
         """Transcribe ONE page, retrying an attempt that failed or said nothing.
 
         The retry is not defensive decoration: on 2026-08-25 pages 2 and 3 of a
@@ -337,14 +387,13 @@ class PDFVisionService:
         call by hand -- against the now-warm model -- returned both pages in
         full. That manual gesture is what this loop performs.
         """
+        buffered = io.BytesIO()
+        image.save(buffered, format="PNG")
+        image_base64 = base64.b64encode(buffered.getvalue()).decode()
+
         for attempt in range(1, max(1, attempts) + 1):
             page_text: str | None = None
             try:
-                image = self._render_page_to_image(pdf_path, page_number)
-                buffered = io.BytesIO()
-                image.save(buffered, format="PNG")
-                image_base64 = base64.b64encode(buffered.getvalue()).decode()
-
                 page_text = await self._analyze_via_ollama(
                     self.TRANSCRIPTION_PROMPT,
                     image_base64,
@@ -371,6 +420,8 @@ class PDFVisionService:
                 continue
 
             if page_text and page_text.strip():
+                if self._declares_no_text(page_text):
+                    return NO_TEXT_DECLARED
                 return page_text.strip()
 
             logger.warning(
@@ -382,32 +433,16 @@ class PDFVisionService:
             )
         return None
 
-    def _page_is_blank(self, pdf_path: str, page_number: int) -> bool:
-        """Is this page silent because it is EMPTY, or because we failed it?
+    @staticmethod
+    def _declares_no_text(page_text: str) -> bool:
+        """Did the model SAY the page has no text, or did it just say something?
 
-        A page we cannot even render is not declared blank: an unmeasurable
-        page counts as missing, so the doubt costs a loud failure rather than a
-        quiet hole in a law.
+        Deliberately strict -- exact match on the sentinel, bar trailing
+        punctuation. A page whose real text happens to quote the sentinel inside
+        a sentence must not be silently discarded, which is the over-matching
+        failure this repository has been bitten by repeatedly.
         """
-        try:
-            image = self._render_page_to_image(pdf_path, page_number)
-        except Exception as exc:
-            logger.warning(
-                "Could not render page %s of %s to judge whether it is blank: %s",
-                page_number,
-                pdf_path,
-                exc,
-            )
-            return False
-
-        ink_ratio = self._page_ink_ratio(image)
-        logger.debug(
-            "Page %s of %s ink ratio %.5f",
-            page_number,
-            pdf_path,
-            ink_ratio,
-        )
-        return ink_ratio < BLANK_PAGE_INK_RATIO
+        return page_text.strip().rstrip(".!").strip().upper() == NO_TEXT_SENTINEL
 
     @staticmethod
     def _page_ink_ratio(image: Image.Image) -> float:

--- a/apps/backend-rag/backend/tests/services/multimodal/test_scanned_pdf_transcription.py
+++ b/apps/backend-rag/backend/tests/services/multimodal/test_scanned_pdf_transcription.py
@@ -32,7 +32,11 @@ def scanned_pdf(tmp_path):
     """A two-page PDF with no text layer, i.e. what a scan looks like."""
     document = fitz.open()
     for _ in range(2):
-        document.new_page(width=200, height=200)
+        page = document.new_page(width=200, height=200)
+        # A real scan has ink on it. An all-white fixture would sail past the
+        # ink gate as "blank" and these tests would assert on a model that was
+        # never asked anything.
+        page.draw_rect(fitz.Rect(20, 20, 180, 180), color=(0, 0, 0), fill=(0, 0, 0))
     path = tmp_path / "scan.pdf"
     document.save(str(path))
     document.close()
@@ -351,6 +355,112 @@ def test_a_whole_document_costs_exactly_one_attempt_per_page(monkeypatch, inked_
     assert calls["n"] == 3
 
 
+def test_a_seal_only_page_does_not_refuse_the_document(monkeypatch, tmp_path):
+    """A signature/seal/map page is INKED and carries no text. Pixels cannot
+    tell it apart from a page the model failed on, so the model is asked to say
+    so -- and its answer is honoured.
+
+    Found by an independent refuter on 2026-08-25: without this, the first
+    Indonesian decree with a stamped signature page -- which is most of them --
+    would have been refused whole.
+    """
+    path = _inked_scan(tmp_path, [True, True], name="seal.pdf")
+    service = PDFVisionService()
+    answers = iter(["ISI HALAMAN", vision_module.NO_TEXT_SENTINEL])
+
+    async def page_two_is_a_seal(prompt, image_base64):
+        return next(answers, None)
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", page_two_is_a_seal)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    assert asyncio.run(service.transcribe_scanned_pdf(path)) == "ISI HALAMAN"
+
+
+def test_the_declaration_must_be_the_whole_answer_not_a_phrase_inside_it(
+    monkeypatch,
+    tmp_path,
+):
+    """Innocence twin of the test above: a page whose real text merely QUOTES
+    the sentinel is transcribed, not discarded."""
+    path = _inked_scan(tmp_path, [True], name="quoting.pdf")
+    service = PDFVisionService()
+    body = f"Pasal 1: sistem menuliskan {vision_module.NO_TEXT_SENTINEL} pada halaman kosong."
+
+    async def quotes_the_sentinel(prompt, image_base64):
+        return body
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", quotes_the_sentinel)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    assert asyncio.run(service.transcribe_scanned_pdf(path)) == body
+
+
+def test_an_inked_page_that_stays_silent_is_still_missing(monkeypatch, tmp_path):
+    """The sentinel must not become a way for silence to pass. A model that
+    ignores the instruction costs a loud refusal, never a quiet hole."""
+    path = _inked_scan(tmp_path, [True, True], name="silent-inked.pdf")
+    service = PDFVisionService()
+    answers = iter(["ISI"])
+
+    async def page_two_says_nothing_at_all(prompt, image_base64):
+        return next(answers, None)
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", page_two_says_nothing_at_all)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    with pytest.raises(vision_module.IncompleteTranscriptionError):
+        asyncio.run(service.transcribe_scanned_pdf(path))
+
+
+def test_a_page_with_no_ink_is_never_sent_to_the_vision_model(monkeypatch, tmp_path):
+    """Two ~30s attempts per blank verso is a double-sided scan spending minutes
+    to learn what one millisecond of pixel counting already knows."""
+    path = _inked_scan(tmp_path, [True, False, False], name="versos.pdf")
+    service = PDFVisionService()
+    calls = {"n": 0}
+
+    async def count(prompt, image_base64):
+        calls["n"] += 1
+        return "ISI"
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", count)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    assert asyncio.run(service.transcribe_scanned_pdf(path)) == "ISI"
+    assert calls["n"] == 1  # the two blank versos cost nothing
+
+
+def test_the_prompt_actually_asks_for_the_sentinel(monkeypatch, tmp_path):
+    """A contract that reads the sentinel while the model is never told to emit
+    it would be a rule with no counterpart -- green in tests, silent in life."""
+    assert vision_module.NO_TEXT_SENTINEL in PDFVisionService.TRANSCRIPTION_PROMPT
+
+    seen: list[str] = []
+    path = _inked_scan(tmp_path, [True], name="prompt.pdf")
+    service = PDFVisionService()
+
+    async def record(prompt, image_base64):
+        seen.append(prompt)
+        return "ISI"
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", record)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    asyncio.run(service.transcribe_scanned_pdf(path))
+    assert seen and vision_module.NO_TEXT_SENTINEL in seen[0]
+
+
 def test_the_ink_measurement_separates_a_written_line_from_an_empty_page(tmp_path):
     """Measured 2026-08-25: one short line on A4 = 0.049% ink, a bare page
     number = 0.003%, an empty page = 0.000%, a real scanned decree 4.7-8.4%."""
@@ -393,3 +503,42 @@ def test_an_unopenable_file_returns_none_not_an_exception(monkeypatch, tmp_path)
     broken = tmp_path / "not-a.pdf"
     broken.write_bytes(b"definitely not a pdf")
     assert asyncio.run(PDFVisionService().transcribe_scanned_pdf(str(broken))) is None
+
+
+# ---------------------------------------------------------------------------
+# The refusal must keep its meaning all the way up the ingestion stack
+# ---------------------------------------------------------------------------
+
+
+def test_a_half_read_document_is_not_sent_round_the_ocr_retry_again():
+    """`legal_ingestion_service` decides whether to give a scan a second, fuller
+    pass by looking for "No text extracted" IN THE MESSAGE. A half-read document
+    must not reach that branch -- the fuller pass already ran and came back
+    short -- and the decision must not depend on the wording of an error."""
+    from backend.core.parsers import DocumentParseError
+    from backend.services.ingestion import legal_ingestion_service as mod
+
+    cause = vision_module.IncompleteTranscriptionError("/x.pdf", [2], 3, 1204)
+    wrapped = DocumentParseError(str(cause))
+    wrapped.__cause__ = cause
+
+    assert "No text extracted" not in str(wrapped)  # the substring test misses it
+    assert isinstance(wrapped.__cause__, vision_module.IncompleteTranscriptionError)
+    assert mod._failure_stage(wrapped) is mod.IngestionStage.PARSING
+
+
+def test_a_reading_failure_is_not_filed_as_a_completed_ingestion():
+    """The stage used to be read off the word "parse" appearing in the message:
+    "Incomplete vision transcription of ..." contains no such word and was
+    recorded as COMPLETION -- a document that never got past reading, filed as
+    having reached the end."""
+    from backend.core.parsers import DocumentParseError
+    from backend.services.ingestion import legal_ingestion_service as mod
+
+    assert mod._failure_stage(DocumentParseError("Incomplete vision transcription of /x.pdf")) is (
+        mod.IngestionStage.PARSING
+    )
+    # innocence: a genuine late-stage failure is still COMPLETION
+    assert mod._failure_stage(RuntimeError("qdrant upsert rejected the batch")) is (
+        mod.IngestionStage.COMPLETION
+    )

--- a/apps/backend-rag/backend/tests/services/multimodal/test_scanned_pdf_transcription.py
+++ b/apps/backend-rag/backend/tests/services/multimodal/test_scanned_pdf_transcription.py
@@ -40,6 +40,31 @@ def scanned_pdf(tmp_path):
     return str(path)
 
 
+def _inked_scan(tmp_path, pages, name="inked.pdf"):
+    """A scan whose pages carry INK but no text layer.
+
+    The blank-page rule is measured on pixels, so a fixture of empty pages
+    cannot exercise it: an empty page is legitimately blank and is skipped by
+    design. Pages that must count as MISSING have to look written.
+    """
+    document = fitz.open()
+    for inked in pages:
+        page = document.new_page(width=200, height=200)
+        if inked:
+            page.draw_rect(fitz.Rect(20, 20, 180, 180), color=(0, 0, 0), fill=(0, 0, 0))
+    path = tmp_path / name
+    document.save(str(path))
+    document.close()
+    assert sum(len(page.get_text()) for page in fitz.open(str(path))) == 0
+    return str(path)
+
+
+@pytest.fixture
+def inked_scan(tmp_path):
+    """Three pages that all look written."""
+    return _inked_scan(tmp_path, [True, True, True])
+
+
 def _service(monkeypatch, *, ollama=None, gemini=None):
     service = PDFVisionService()
 
@@ -128,22 +153,221 @@ def test_the_sovereignty_gate_still_governs_the_cloud_fallback(monkeypatch, scan
     assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf)) is None
 
 
-def test_a_page_that_fails_does_not_lose_the_rest_of_the_document(monkeypatch, scanned_pdf):
+def test_a_transient_page_failure_is_retried_and_the_document_survives_whole(
+    monkeypatch,
+    inked_scan,
+):
+    """REVERSED 2026-08-25.
+
+    This test used to assert that a failed page simply drops out and the rest
+    of the document is returned -- "most of a decree beats none of it". Its
+    first live run disproved it: a real three-page decree came back as 1,204 of
+    6,109 characters because pages 2 and 3 timed out against a cold vision
+    model, and it was stored looking whole. The cure is not to salvage the
+    survivors, it is to RETRY the page (which is what recovered it by hand) and
+    to refuse the document if the page is still missing.
+    """
     service = PDFVisionService()
     calls = {"n": 0}
 
-    async def flaky(prompt, image_base64):
+    async def cold_then_warm(prompt, image_base64):
         calls["n"] += 1
         if calls["n"] == 1:
-            raise RuntimeError("render blew up")
-        return "PAGE TWO"
+            raise TimeoutError("vision model still loading")
+        return "HALAMAN"
 
     async def no_gemini(prompt, image_base64):
         return None
 
-    monkeypatch.setattr(service, "_analyze_via_ollama", flaky)
+    monkeypatch.setattr(service, "_analyze_via_ollama", cold_then_warm)
     monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
-    assert asyncio.run(service.transcribe_scanned_pdf(scanned_pdf)) == "PAGE TWO"
+    result = asyncio.run(service.transcribe_scanned_pdf(inked_scan))
+    assert result == "HALAMAN\n\nHALAMAN\n\nHALAMAN"
+    assert calls["n"] == 4  # one page cost two attempts, the other two cost one
+
+
+# ---------------------------------------------------------------------------
+# GUILT -- the completeness contract (added 2026-08-25)
+# ---------------------------------------------------------------------------
+
+
+def test_a_page_that_never_transcribes_refuses_the_whole_document(monkeypatch, inked_scan):
+    """The defect this cures: 1,204 of 6,109 characters, stored as a decree."""
+    service = PDFVisionService()
+    seen: list[int] = []
+
+    async def silent_on_the_second_page(prompt, image_base64):
+        seen.append(1)
+        # call 1 = page 1; calls 2 and 3 = page 2's two attempts, both silent;
+        # call 4 = page 3.
+        return None if len(seen) in (2, 3) else "ISI HALAMAN"
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", silent_on_the_second_page)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+
+    with pytest.raises(vision_module.IncompleteTranscriptionError) as excinfo:
+        asyncio.run(service.transcribe_scanned_pdf(inked_scan))
+
+    error = excinfo.value
+    assert error.missing_pages == [2]
+    assert error.page_count == 3
+    assert error.transcribed_chars > 0
+    assert "2" in str(error)
+
+
+def test_the_refusal_reaches_the_async_parser_as_a_parse_error(monkeypatch, inked_scan):
+    """`extract_text_from_pdf_ocr_async` degrades to "" on every other failure.
+    On THIS one it must not: "" would report nothing found while a partial
+    document had in fact been read."""
+    from backend.core import parsers
+    from backend.core.parsers import DocumentParseError
+
+    async def refuse(self, pdf_path, max_pages=None, **kwargs):
+        raise vision_module.IncompleteTranscriptionError(pdf_path, [2], 3, 1204)
+
+    monkeypatch.setattr(PDFVisionService, "transcribe_scanned_pdf", refuse)
+    with pytest.raises(DocumentParseError) as excinfo:
+        asyncio.run(parsers.extract_text_from_pdf_ocr_async(inked_scan))
+    assert "Incomplete" in str(excinfo.value)
+    assert "[2]" in str(excinfo.value)
+
+
+def test_the_sync_last_resort_names_the_missing_pages_not_no_text(monkeypatch, inked_scan):
+    from backend.core import parsers
+    from backend.core.parsers import DocumentParseError
+
+    async def refuse(self, pdf_path, max_pages=None, **kwargs):
+        raise vision_module.IncompleteTranscriptionError(pdf_path, [2, 3], 3, 1204)
+
+    monkeypatch.setattr(PDFVisionService, "transcribe_scanned_pdf", refuse)
+    monkeypatch.setattr(parsers, "extract_text_from_pdf_ocr", lambda path: "")
+    with pytest.raises(DocumentParseError) as excinfo:
+        parsers.extract_text_from_pdf(inked_scan)
+    message = str(excinfo.value)
+    assert "Incomplete" in message
+    assert "No text extracted" not in message
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE -- the contract must not refuse honest documents
+# ---------------------------------------------------------------------------
+
+
+def test_a_genuinely_blank_page_does_not_refuse_the_document(monkeypatch, tmp_path):
+    """The empty verso of a two-sided scan is silent because it is empty."""
+    path = _inked_scan(tmp_path, [True, False], name="one-blank.pdf")
+    service = PDFVisionService()
+    answers = iter(["ISI"])
+
+    async def only_the_inked_page_answers(prompt, image_base64):
+        return next(answers, None)
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", only_the_inked_page_answers)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    assert asyncio.run(service.transcribe_scanned_pdf(path)) == "ISI"
+
+
+def test_a_page_bearing_ink_that_stays_silent_is_never_called_blank(monkeypatch, tmp_path):
+    """The guilty twin of the test above: same shape, inked second page."""
+    path = _inked_scan(tmp_path, [True, True], name="both-inked.pdf")
+    service = PDFVisionService()
+    answers = iter(["ISI"])
+
+    async def only_the_first_page_answers(prompt, image_base64):
+        return next(answers, None)
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", only_the_first_page_answers)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    with pytest.raises(vision_module.IncompleteTranscriptionError):
+        asyncio.run(service.transcribe_scanned_pdf(path))
+
+
+def test_allow_partial_returns_the_survivors_for_a_caller_that_asked(monkeypatch, tmp_path):
+    path = _inked_scan(tmp_path, [True, True], name="partial-ok.pdf")
+    service = PDFVisionService()
+    answers = iter(["ISI"])
+
+    async def only_the_first_page_answers(prompt, image_base64):
+        return next(answers, None)
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", only_the_first_page_answers)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    result = asyncio.run(service.transcribe_scanned_pdf(path, allow_partial=True))
+    assert result == "ISI"
+
+
+def test_a_page_that_cannot_even_be_rendered_counts_as_missing(monkeypatch, tmp_path):
+    """An unmeasurable page must not be given the benefit of the doubt."""
+    path = _inked_scan(tmp_path, [True, True], name="unrenderable.pdf")
+    service = PDFVisionService()
+    real_render = service._render_page_to_image
+
+    def render_page_two_blows_up(pdf_path, page_number):
+        if page_number == 2:
+            raise OSError("pixmap allocation failed")
+        return real_render(pdf_path, page_number)
+
+    async def answer(prompt, image_base64):
+        return "ISI"
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_render_page_to_image", render_page_two_blows_up)
+    monkeypatch.setattr(service, "_analyze_via_ollama", answer)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    with pytest.raises(vision_module.IncompleteTranscriptionError) as excinfo:
+        asyncio.run(service.transcribe_scanned_pdf(path))
+    assert excinfo.value.missing_pages == [2]
+
+
+def test_a_whole_document_costs_exactly_one_attempt_per_page(monkeypatch, inked_scan):
+    """The retry must not double every call on the happy path."""
+    service = PDFVisionService()
+    calls = {"n": 0}
+
+    async def always_answers(prompt, image_base64):
+        calls["n"] += 1
+        return "ISI"
+
+    async def no_gemini(prompt, image_base64):
+        return None
+
+    monkeypatch.setattr(service, "_analyze_via_ollama", always_answers)
+    monkeypatch.setattr(service, "_analyze_via_gemini", no_gemini)
+    assert asyncio.run(service.transcribe_scanned_pdf(inked_scan)) is not None
+    assert calls["n"] == 3
+
+
+def test_the_ink_measurement_separates_a_written_line_from_an_empty_page(tmp_path):
+    """Measured 2026-08-25: one short line on A4 = 0.049% ink, a bare page
+    number = 0.003%, an empty page = 0.000%, a real scanned decree 4.7-8.4%."""
+    document = fitz.open()
+    document.new_page(width=595, height=842)  # page 1: empty
+    written = document.new_page(width=595, height=842)
+    written.insert_text((72, 400), "Pasal 5 dihapus.", fontsize=11)
+    path = tmp_path / "ink.pdf"
+    document.save(str(path))
+    document.close()
+
+    service = PDFVisionService()
+    empty_ratio = service._page_ink_ratio(service._render_page_to_image(str(path), 1))
+    written_ratio = service._page_ink_ratio(service._render_page_to_image(str(path), 2))
+
+    assert empty_ratio < vision_module.BLANK_PAGE_INK_RATIO
+    assert written_ratio > vision_module.BLANK_PAGE_INK_RATIO
 
 
 def test_the_cloud_rate_limit_pause_never_runs_on_the_local_path(monkeypatch, scanned_pdf):


### PR DESCRIPTION
Yesterday's cure made scanned PDFs readable for the first time (#4882). Its first
live run, on a three-page ministerial decree, returned 1,204 of the document's
6,109 characters: pages 2 and 3 both hit the 120s client timeout while page 1 was
still loading `qwen2.5vl:7b` into memory. The function returned the survivor,
logged one warning, and the decree entered the corpus looking complete. Re-running
the identical call by hand — against the now-warm model — returned both pages in
full.

That is the worst of the three possible outcomes. An error is visible. Nothing
stored is visible. An amputated law is invisible: every downstream reader, human
or machine, treats it as the law. And the belief that produced it was written into
the code as a virtue — *"most of a decree beats none of it"* — with a test
asserting it. That test is **reversed** here, not deleted; its new body records why.

## The contract

Three states, not two — and the third one is what the first attempt at this fix
got wrong:

| page | verdict |
|---|---|
| no **ink** | blank; skipped, and never sent to the model at all |
| says `NO_TEXT_ON_THIS_PAGE` | honoured; a seal, a signature, a photograph, a diagram |
| inked and **silent** | **MISSING** — the document is refused |

Plus a **retry**: each page gets two attempts. The first attempt against a cold
vision model is the one that pays to load it, which is exactly how pages 2 and 3
were lost while page 1 warmed the model up. The retry is the manual gesture that
recovered them, automated.

When a page is still missing, `transcribe_scanned_pdf` raises
`IncompleteTranscriptionError` naming the missing pages and the number of
characters it is discarding, rather than returning them. A caller that genuinely
wants an excerpt must say so with `allow_partial=True`, and then the partiality is
its own to carry. Nothing transcribed at all still returns `None`, unchanged.

## Ink is not text — found by an independent refuter, with a reproduction

The first commit on this branch had only two buckets: no ink → blank, ink →
missing. A page carrying **ink and no transcribable text** — a signature page, a
stamp, a map, an org-chart — was therefore indistinguishable from a page the model
had failed on, and the refuter's probe refused a two-page document whose second
page was a solid stamp, with the vision model behaving exactly as instructed. On
Indonesian legal instruments that page is routine, not exotic; shipping the first
commit alone would have traded a silent hole for a loud wall in front of most
decrees.

Pixels cannot answer a semantic question, so it is put to the thing that can: the
prompt now instructs the model to output `NO_TEXT_ON_THIS_PAGE` for such a page,
and the declaration is honoured. The discrimination is **fail-closed by
construction** — silence keeps its old meaning, so a model that ignores the
instruction costs a loud refusal, never a quiet hole. That is the property which
makes it safe to add at all. The declaration is matched **strictly** (exact
sentinel, bar trailing punctuation), so a page whose real text quotes the sentinel
inside a sentence is transcribed, not discarded.

## The blank threshold is measured, not guessed

This renderer at 2× zoom, luminance < 200 counted as ink:

```
real scanned decree pages ....... 4.7% – 8.4%
ONE short line on A4 ............ 0.049%   <- must NOT be called blank
a page bearing only its number .. 0.003%
a truly empty page .............. 0.000%
```

`BLANK_PAGE_INK_RATIO = 0.0001` sits ~5× below the shortest line that can carry
law and ~3× above a bare page number. The bias is deliberate: calling a written
page blank hides a hole in a law, while calling a blank page missing merely
refuses the document out loud, which is recoverable. A page that cannot even be
**rendered** is never given the benefit of the doubt — an unmeasurable page counts
as missing. (Every number above was independently re-measured by the refuter on
the real file and matched.)

## Two propagation defects, same contract seen further up

* `legal_ingestion_service` decided whether to give a scan a second, fuller pass by
  testing `"No text extracted" in str(e)`. The new message does not contain that
  phrase, so a half-read document silently stopped taking a branch it used to take.
  Retrying is in fact the *wrong* thing here — the fuller pass already ran and came
  back short — so the case is now handled explicitly and read off `e.__cause__`
  rather than off a substring: rewording an error can no longer move a half-read
  law into the retry path.
* The same file filed a failure as `PARSING` or `COMPLETION` depending on whether
  the word "parse" appeared in the message. `"Incomplete vision transcription of
  …"` contains no such word, so a document that never got past **reading** was
  recorded as having reached the **end**. Stage is now decided by type.

`IncompleteTranscriptionError` derives from `Exception`, **not** `RuntimeError`, on
purpose: `parsers.py` uses `except RuntimeError` to mean "there is no running event
loop", and a partially transcribed decree caught by that handler would be silently
mistaken for an asyncio condition.

## Cost

The ink check used to run only *after* a page had spent its full retry budget, so
every blank verso of a double-sided scan paid two ~30s vision attempts to learn
what one millisecond of pixel counting already knew. The ink gate now runs first,
and the page is rendered once instead of once per attempt. The happy path is
unchanged: one attempt per page, asserted by test.

## Tests

26 in the file — 15 new, 1 reversed. The pre-existing `scanned_pdf` fixture was
all-white; under the ink gate an all-white fixture sails past as "blank" and those
tests would have asserted on a model that was never asked anything, so it now
carries ink, like a real scan.

Run against `origin/main`, the first commit's new set fails **8** — and not merely
on missing symbols: the retry test gets 2 pages where it demands 3 (the defect
itself), the async-parser test `DID NOT RAISE`, and the sync-parser test receives
the misleading `"No text extracted"` message verbatim. The two that pass on
`origin/main` are innocence tests, which is what innocence tests are for.

Green: 1300 across `backend/tests/services/multimodal` + `services/ingestion` +
`unit/core` + `unit/services/ingestion`; `ruff` clean; anti-reward-hacking lint
clean.

## Deliberately not in this PR

Two findings from the same review, verified independently against `origin/main`,
are a separate concern and follow immediately in their own PR:
`infra/eventbus/regulatory_ingest_runner.py:406` prints `ok: True` without ever
inspecting the ingest's `success` field, and `backend/cli/ingestion_cli.py:232`
returns a hardcoded `"success": True`. Both pre-date this work. Both matter more
now, because `ingest_legal_document` signals failure by *returning*
`{"success": False}` rather than raising — so a caller that only checks "did an
exception reach me" reports every refusal as a success.
