### PR TITLE
fix(ingest): two callers reported a refused document as stored

### DIFF
--- a/apps/backend-rag/backend/cli/ingestion_cli.py
+++ b/apps/backend-rag/backend/cli/ingestion_cli.py
@@ -228,10 +228,16 @@ class IngestionCLI:
             if file_path:
                 logger.info(f"Ingesting legal document: {file_path}")
                 result = await self.legal_ingestion_service.ingest_legal_document(file_path)
+                # Was a hardcoded True. `ingest_legal_document` signals failure by
+                # RETURNING {"success": False, "error": ...} rather than raising,
+                # so this path printed "✅ Ingestion successful!" and exited 0 for
+                # a document that had just been refused.
+                ingested_ok = bool(result.get("success")) if isinstance(result, dict) else False
                 return {
-                    "success": True,
-                    "ingested": 1,
+                    "success": ingested_ok,
+                    "ingested": 1 if ingested_ok else 0,
                     "collection": "legal_intelligence",
+                    "error": None if ingested_ok else (result or {}).get("error"),
                     "details": result,
                 }
             elif directory:

--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_ingest_success_is_reported_honestly.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_ingest_success_is_reported_honestly.py
@@ -1,0 +1,152 @@
+"""An ingest that refused a document must not be reported as having stored it.
+
+`LegalIngestionService.ingest_legal_document` catches everything internally and
+signals failure by RETURNING ``{"success": False, "error": ...}``; it does not
+raise. Two callers read "no exception reached me" as success:
+
+* ``infra/eventbus/regulatory_ingest_runner.py`` printed ``{"ok": True}``
+  unconditionally, so the nightly regulatory run wrote ``in_qdrant: YES`` into
+  its tracking sheet and went on to run KG extraction over a document the
+  corpus had never received;
+* ``backend/cli/ingestion_cli.py`` returned a hardcoded ``"success": True``, so
+  an operator re-running a law by hand saw "✅ Ingestion successful!" and an
+  exit code of 0 for a document that had just been refused.
+
+Both pre-date the completeness contract of #4896 and both became sharper with
+it: before, a half-read document at least left *something* searchable behind,
+so the claim was roughly true; now a refused document stores nothing at all and
+the claim is simply false.
+
+The runner lives outside any installed package, so it is loaded by path — and
+deliberately from THIS repository tree rather than from a copy on some machine,
+per the HOME-fork scar family.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _find_runner() -> Path:
+    """Walk up to the repository that CONTAINS this test, never a fixed depth.
+
+    A hardcoded `parents[N]` breaks the moment the tree is re-nested, and an
+    absolute path would let the test read a copy in some machine's home while
+    the repository's own file rots (the HOME-fork scar family).
+    """
+    relative = Path("infra") / "eventbus" / "regulatory_ingest_runner.py"
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / relative
+        if candidate.exists():
+            return candidate
+    raise AssertionError(f"{relative} not found above {__file__}")
+
+
+RUNNER_PATH = _find_runner()
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("regulatory_ingest_runner_undertest", RUNNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# GUILT
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"success": False, "error": "Legal identity collision"},
+        {"success": None},
+        {},  # the key never arrived
+        {"result": "{'success': False}"},  # only the truncated repr, no verdict
+    ],
+)
+def test_a_refused_ingest_is_never_reported_as_stored(payload):
+    runner = _load_runner()
+    verdict = runner._verdict_from_ingest_output(payload)
+    assert verdict["ok"] is False
+    assert verdict["error"], "a failure must say something, or step 8 prints nothing to act on"
+
+
+def test_a_malformed_ingest_output_is_a_failure_not_a_success():
+    """A runner that cannot tell must not claim."""
+    runner = _load_runner()
+    for junk in ("ok", 1, None, ["success"]):
+        assert runner._verdict_from_ingest_output(junk)["ok"] is False
+
+
+def test_the_subprocess_no_longer_hardcodes_its_own_verdict():
+    """The decision used to live inside a GENERATED source string, where no test
+    could reach it. This asserts on the artifact itself, because the artifact is
+    the defect.
+
+    Scoped to the doubled-brace form, which appears only inside the f-string
+    that builds the subprocess: the other `{"ok": True}` returns in this module
+    are ordinary in-process returns after work that either succeeded or raised,
+    and they are not this bug.
+    """
+    source = RUNNER_PATH.read_text()
+    assert '{{"ok": True' not in source, "the subprocess is claiming success again"
+    assert '"success": result.get("success")' in source, "it must report the ingest's own verdict"
+
+
+@pytest.mark.asyncio
+async def test_the_cli_reports_the_ingest_verdict_not_its_own_optimism():
+    from backend.cli.ingestion_cli import IngestionCLI
+
+    cli = IngestionCLI()
+
+    class _Refusing:
+        async def ingest_legal_document(self, file_path, **kwargs):
+            return {"success": False, "error": "Incomplete vision transcription of /x.pdf"}
+
+    cli.legal_ingestion_service = _Refusing()
+    out = await cli.ingest_laws(file_path="/x.pdf")
+    assert out["success"] is False
+    assert out["ingested"] == 0
+    assert "Incomplete" in (out.get("error") or "")
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_success_is_still_a_success():
+    runner = _load_runner()
+    verdict = runner._verdict_from_ingest_output({"success": True, "result": "..."})
+    assert verdict["ok"] is True
+    assert verdict.get("error") is None
+
+
+def test_a_subprocess_from_an_older_deploy_is_still_understood():
+    """Mid-rollout the running script may still speak the old `ok` key. Reading
+    that as a failure would turn a fixed reporter into a broken one."""
+    runner = _load_runner()
+    assert runner._verdict_from_ingest_output({"ok": True})["ok"] is True
+    assert runner._verdict_from_ingest_output({"ok": False})["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_the_cli_still_reports_a_genuine_success():
+    from backend.cli.ingestion_cli import IngestionCLI
+
+    cli = IngestionCLI()
+
+    class _Storing:
+        async def ingest_legal_document(self, file_path, **kwargs):
+            return {"success": True, "chunks_created": 413}
+
+    cli.legal_ingestion_service = _Storing()
+    out = await cli.ingest_laws(file_path="/x.pdf")
+    assert out["success"] is True
+    assert out["ingested"] == 1
+    assert out["error"] is None

--- a/infra/eventbus/regulatory_ingest_runner.py
+++ b/infra/eventbus/regulatory_ingest_runner.py
@@ -377,6 +377,32 @@ def step5_nlm_push(reg_code: str, domain: str, jdih_url: str,
 # ──────────────────────────────────────────────────────────────────────────
 # Step 6 — Qdrant embed + upsert via LegalIngestionService
 # ──────────────────────────────────────────────────────────────────────────
+def _verdict_from_ingest_output(payload: dict) -> dict:
+    """Turn what the ingest SAID into this runner's ok / not-ok.
+
+    `LegalIngestionService.ingest_legal_document` catches everything internally
+    and reports failure by RETURNING ``{"success": False, "error": ...}``. It
+    does not raise. So "no exception reached me" is not a verdict, it is only
+    the absence of a crash -- and this runner used to print ``ok: True``
+    unconditionally on that basis. Step 8 then wrote ``in_qdrant: YES`` and the
+    orchestrator ran KG extraction, for a document the corpus never received.
+
+    Anything that is not an explicit success is a failure, including a missing
+    key and a malformed payload: a runner that cannot tell must not claim.
+    """
+    if not isinstance(payload, dict):
+        return {"ok": False, "error": f"ingest output was {type(payload).__name__}, not an object"}
+    # A subprocess from an older deploy still speaks "ok"; honour it rather than
+    # silently downgrading a real success to a failure.
+    verdict = payload.get("success", payload.get("ok"))
+    ok = verdict is True
+    out = dict(payload)
+    out["ok"] = ok
+    if not ok and not out.get("error"):
+        out["error"] = f"ingest reported success={verdict!r}"
+    return out
+
+
 def step6_qdrant_ingest(pdf_path: str, reg_code: str, official_title: str,
                         domain: str) -> dict:
     if not Path(pdf_path).exists():
@@ -403,9 +429,17 @@ async def main():
             title={official_title + ' (' + reg_code + ')'!r},
             category={domain!r},
         )
-        print(json.dumps({{"ok": True, "result": str(result)[:500]}}))
+        # Report what the ingest SAID, not merely that it did not crash. The
+        # verdict is turned into this runner's ok/not-ok by the parent process,
+        # where it can be tested -- see _verdict_from_ingest_output.
+        print(json.dumps({{
+            "success": result.get("success") if isinstance(result, dict) else None,
+            "error": (result.get("error") if isinstance(result, dict) else str(result))
+                     and str(result.get("error") if isinstance(result, dict) else result)[:300],
+            "result": str(result)[:500],
+        }}))
     except Exception as e:
-        print(json.dumps({{"ok": False, "error": f"{{type(e).__name__}}: {{str(e)[:300]}}"}}))
+        print(json.dumps({{"success": False, "error": f"{{type(e).__name__}}: {{str(e)[:300]}}"}}))
 
 asyncio.run(main())
 """
@@ -421,7 +455,7 @@ asyncio.run(main())
         # Parse last JSON line
         last_line = result.stdout.strip().split("\n")[-1]
         try:
-            return json.loads(last_line)
+            return _verdict_from_ingest_output(json.loads(last_line))
         except json.JSONDecodeError:
             return {"ok": False, "error": f"output not JSON: {result.stdout[-300:]}"}
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
`LegalIngestionService.ingest_legal_document` catches everything internally and
signals failure by **returning** `{"success": False, "error": ...}`. It does not
raise. Two callers read *"no exception reached me"* as success — which is not a
verdict, only the absence of a crash.

| caller | what it claimed | what it should have asked |
|---|---|---|
| `infra/eventbus/regulatory_ingest_runner.py:406` | `{"ok": True}`, unconditionally | `result["success"]` |
| `apps/backend-rag/backend/cli/ingestion_cli.py:232` | `"success": True`, hardcoded | `result["success"]` |

Downstream of the first: step 8 writes `in_qdrant: YES` into the tracking sheet,
and the orchestrator runs KG extraction — for a document the corpus never
received. The nightly regulatory watcher has therefore been reporting a clean run
regardless of what the ingest actually did. Downstream of the second: an operator
re-running a law by hand sees "✅ Ingestion successful!" and an exit code of 0 for
a document that was just refused.

Both pre-date #4896 and **both matter more because of it**: before, a half-read
document at least left *something* searchable behind, so the claim was roughly
true; after #4896 a refused document stores nothing at all, and the claim is
simply false.

Found by the independent refuter on #4896, then verified line-by-line against
`origin/main` by a second, separate reader before this fix was written.

## The runner's verdict now lives where a test can reach it

It used to sit inside a **generated source string** built for a subprocess. The
subprocess now reports what the ingest *said*; the parent decides what that means
through `_verdict_from_ingest_output`, a plain function with tests.

Anything that is not an explicit success is a failure — a missing key, a
malformed payload, a non-object: **a runner that cannot tell must not claim.** A
subprocess from an older deploy still speaking the old `ok` key is honoured
rather than silently downgraded, because a rollout window should not turn a fixed
reporter into a broken one.

**Deliberately not touched**: the other `{"ok": True}` returns in that module
(PDF fetch, Drive upload, sheet write, NotebookLM add) are ordinary in-process
returns after work that either succeeded or raised. They are not this bug, and
sweeping them in would have made the diff about something else.

## Tests

10 new, placed in `backend/tests/unit/services/ingestion/` so they run inside an
already-required check. `scripts/tests/` has **no** directory-level gate — only
per-file names wired into individual workflows — and a test nobody names is a
test nobody runs.

The runner belongs to no package, so it is loaded by walking **up** from the test
file until `infra/eventbus/…` is found: never a fixed `parents[N]`, which breaks
on re-nesting, and never an absolute path, which would let the test read a copy
in someone's home while the repository's own file rots.

Run against `origin/main` all 10 fail — and not only on the missing symbol. The
CLI test fails `assert True is False`: `origin/main` really does report success
for a document the ingest refused. The artifact test catches the literal verdict
still hardcoded inside the generated subprocess.

Green: 319 across `unit/services/ingestion` + `unit/cli` + `services/ingestion`;
`ruff` clean; anti-reward-hacking lint clean.

Follows #4896.
