### PR TITLE
feat(garuda-l4): checkout, parcel tracker, and visa delivery view

### DIFF
--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.test.tsx
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CheckoutFlow } from "./CheckoutFlow";
+import { writeCheckoutHandoff } from "../../checkoutHandoff";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, replace: mocks.replace }),
+}));
+
+const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/email/i), "customer@example.com");
+  await user.type(screen.getByLabelText(/phone/i), "+6281234567890");
+  await user.click(
+    screen.getByRole("button", { name: /continue to payment/i }),
+  );
+}
+
+describe("CheckoutFlow", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    window.sessionStorage.clear();
+    mocks.push.mockReset();
+    mocks.replace.mockReset();
+    // jsdom doesn't implement window.location.href assignment navigation; stub it so
+    // the redirect-to-provider effect doesn't throw ("Not implemented: navigation").
+    // @ts-expect-error -- test-only stub
+    delete window.location;
+    // @ts-expect-error -- test-only stub
+    window.location = { href: "" };
+  });
+
+  it("blocks checkout and points back to upload when the handoff is missing", () => {
+    render(<CheckoutFlow resultId="result-1" />);
+    expect(
+      screen.getByRole("link", { name: /go back to upload/i }),
+    ).toHaveAttribute("href", "/visa/voa/upload/result-1");
+  });
+
+  it("never renders a price breakdown — only the single all-inclusive footer line", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    render(<CheckoutFlow resultId="result-1" />);
+
+    await screen.findByText(/Jane Doe/i);
+
+    const bodyText = document.body.textContent ?? "";
+    expect(bodyText).not.toMatch(/PNBP/i);
+    expect(bodyText).not.toMatch(/government fee[:\s]/i);
+    expect(bodyText).not.toMatch(/service fee/i);
+    expect(bodyText).toMatch(/never billed separately from this figure/i);
+  });
+
+  it("sends an Idempotency-Key header and the confirmed applicant on submit", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(201, {
+        order_id: "order-1",
+        order_state: "awaiting_payment",
+        price_idr: 850000,
+        checkout_url: "https://pay.example.com/session/abc",
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<CheckoutFlow resultId="result-1" />);
+    await screen.findByText(/Jane Doe/i);
+    await fillAndSubmit(user);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/visa/voa/orders");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Idempotency-Key"]).toBeTruthy();
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      result_id: "result-1",
+      applicant: {
+        full_name: "Jane Doe",
+        email: "customer@example.com",
+        phone: "+6281234567890",
+        passport_number: "X1234567",
+      },
+      review_confirmed: true,
+    });
+  });
+
+  it("redirects the browser to checkout_url on a fresh awaiting_payment order — never renders success itself", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(201, {
+        order_id: "order-1",
+        order_state: "awaiting_payment",
+        price_idr: 850000,
+        checkout_url: "https://pay.example.com/session/abc",
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<CheckoutFlow resultId="result-1" />);
+    await screen.findByText(/Jane Doe/i);
+    await fillAndSubmit(user);
+
+    await waitFor(() =>
+      expect(window.location.href).toBe("https://pay.example.com/session/abc"),
+    );
+    // Never a router.push to a "success"/tracker route while handing off to the
+    // provider — the tracker is reached only via the provider's own return trip.
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.replace).not.toHaveBeenCalled();
+    expect(screen.queryByText(/success/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/paid/i)).not.toBeInTheDocument();
+  });
+
+  it("forwards a replayed already-paid order straight to the tracker instead of showing a payment button", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(201, {
+        order_id: "order-1",
+        order_state: "paid",
+        price_idr: 850000,
+        checkout_url: null,
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<CheckoutFlow resultId="result-1" />);
+    await screen.findByText(/Jane Doe/i);
+    await fillAndSubmit(user);
+
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith("/visa/voa/orders/order-1"),
+    );
+  });
+
+  it("never places the applicant's email or passport number into a URL", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(201, {
+        order_id: "order-1",
+        order_state: "awaiting_payment",
+        price_idr: 850000,
+        checkout_url: "https://pay.example.com/session/abc",
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<CheckoutFlow resultId="result-1" />);
+    await screen.findByText(/Jane Doe/i);
+    await fillAndSubmit(user);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).not.toContain("customer@example.com");
+    expect(url).not.toContain("X1234567");
+    expect(url).not.toContain("Jane");
+  });
+
+  it("shows the server's error copy and lets the customer retry on a retryable failure", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(503, {
+        code: "PAYMENT_PROVIDER_UNAVAILABLE",
+        retryable: true,
+        message_key: "garuda_voa.error.payment_provider_unavailable",
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<CheckoutFlow resultId="result-1" />);
+    await screen.findByText(/Jane Doe/i);
+    await fillAndSubmit(user);
+
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /payment provider is temporarily unavailable/i,
+    );
+  });
+});

--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.tsx
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AppFrame } from "@balizero/core";
+import { readCheckoutHandoff } from "../../checkoutHandoff";
+import { useCheckout } from "./useCheckout";
+import type { Applicant } from "../../orders/types";
+
+/**
+ * GARUDA VOA — checkout (`/visa/voa/checkout/{resultId}`). Owner decision 7(b): ONE
+ * all-inclusive price, never split into fee + PNBP anywhere the customer can see. This
+ * page never fetches or renders a price breakdown itself — the price only appears once,
+ * on the order tracker, as the single `price_idr` the contract returns.
+ *
+ * `full_name` / `passport_number` come from the upload/review step
+ * (`../../checkoutHandoff.ts`) — never re-typed here. `email` / `phone` are collected
+ * here because `Applicant` (openapi.yaml) requires them and neither the eligibility
+ * check nor the upload step ever asked for them.
+ */
+export function CheckoutFlow({ resultId }: { resultId: string }) {
+  const router = useRouter();
+  const { state, submit } = useCheckout(resultId);
+  const [fullName, setFullName] = useState("");
+  const [passportNumber, setPassportNumber] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [missingHandoff, setMissingHandoff] = useState(false);
+
+  useEffect(() => {
+    const handoff = readCheckoutHandoff(resultId);
+    if (!handoff.full_name || !handoff.passport_number) {
+      setMissingHandoff(true);
+      return;
+    }
+    setFullName(handoff.full_name);
+    setPassportNumber(handoff.passport_number);
+  }, [resultId]);
+
+  // A created order never stays on this page — awaiting_payment hands off to the
+  // provider, anything else (already paid/failed/expired/refunded on replay) hands off
+  // to the tracker, which is the only place order state is rendered from. This page
+  // must never itself render a success state off a 201 response.
+  useEffect(() => {
+    if (state.step !== "created") return;
+    const { order } = state;
+    if (order.order_state === "awaiting_payment" && order.checkout_url) {
+      window.location.href = order.checkout_url;
+      return;
+    }
+    router.replace(`/visa/voa/orders/${order.order_id}`);
+  }, [state, router]);
+
+  if (missingHandoff) {
+    return (
+      <AppFrame
+        funnel="visa"
+        title="Checkout"
+        subtitle="We need your reviewed passport details first."
+      >
+        <p>
+          <a href={`/visa/voa/upload/${resultId}`}>
+            Go back to upload your passport →
+          </a>
+        </p>
+      </AppFrame>
+    );
+  }
+
+  const applicant: Applicant = {
+    full_name: fullName,
+    email,
+    phone,
+    passport_number: passportNumber,
+  };
+  const canSubmit =
+    fullName.trim().length > 0 &&
+    passportNumber.trim().length > 0 &&
+    email.trim().length > 0 &&
+    phone.trim().length > 0 &&
+    state.step !== "submitting" &&
+    state.step !== "created";
+
+  return (
+    <AppFrame
+      funnel="visa"
+      title="Checkout"
+      subtitle="A few details and you're set."
+      footer="One all-inclusive price. Government fees, where they apply, are never billed separately from this figure."
+    >
+      <form
+        style={{
+          display: "grid",
+          gap: "var(--space-3, 0.9rem)",
+          maxWidth: 420,
+        }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (canSubmit) void submit(applicant);
+        }}
+      >
+        <ReadOnlyField label="Full name" value={fullName} />
+        <ReadOnlyField label="Passport number" value={passportNumber} />
+
+        <label
+          htmlFor="voa-checkout-email"
+          style={{ display: "grid", gap: "0.3rem" }}
+        >
+          <span style={{ fontSize: "0.95rem", fontWeight: 600 }}>Email</span>
+          <input
+            id="voa-checkout-email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            style={inputStyle}
+          />
+        </label>
+
+        <label
+          htmlFor="voa-checkout-phone"
+          style={{ display: "grid", gap: "0.3rem" }}
+        >
+          <span style={{ fontSize: "0.95rem", fontWeight: 600 }}>Phone</span>
+          <input
+            id="voa-checkout-phone"
+            type="tel"
+            required
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="+62…"
+            style={inputStyle}
+          />
+        </label>
+
+        {state.step === "error" ? (
+          <p role="alert" style={{ margin: 0, color: "var(--color-error)" }}>
+            {state.message}
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          style={{
+            padding: "0.9rem 1.4rem",
+            borderRadius: 8,
+            border: "none",
+            background: "var(--accent-funnel, #ff3344)",
+            color: "#0a0a0a",
+            fontWeight: 600,
+            cursor: canSubmit ? "pointer" : "default",
+            opacity: canSubmit ? 1 : 0.5,
+          }}
+        >
+          {state.step === "submitting" || state.step === "created"
+            ? "Preparing checkout…"
+            : "Continue to payment →"}
+        </button>
+      </form>
+    </AppFrame>
+  );
+}
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: "grid", gap: "0.3rem" }}>
+      <span style={{ fontSize: "0.95rem", fontWeight: 600 }}>{label}</span>
+      <span
+        style={{
+          padding: "0.6rem 0.7rem",
+          borderRadius: 4,
+          border: "1px solid var(--color-border-subtle)",
+          background: "var(--surface-raised)",
+          color: "var(--text-primary)",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: "0.6rem 0.7rem",
+  borderRadius: 4,
+  border: "1px solid var(--color-border-subtle)",
+  background: "var(--surface-raised)",
+  color: "var(--text-primary)",
+  fontSize: "1rem",
+};

--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/page.tsx
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { CheckoutFlow } from "./CheckoutFlow";
+
+/**
+ * `/visa/voa/checkout/{resultId}` — customer-facing checkout step (L4 part 3).
+ * `resultId` is the same opaque eligibility-check id `upload/{resultId}` uses.
+ */
+export default function CheckoutPage() {
+  const params = useParams<{ resultId: string }>();
+  const resultId = params?.resultId;
+
+  if (!resultId) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 p-6 text-center">
+        <p className="text-gray-600">
+          We couldn&apos;t find your application. Please start again.
+        </p>
+      </main>
+    );
+  }
+
+  return <CheckoutFlow resultId={resultId} />;
+}

--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/useCheckout.ts
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/useCheckout.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import {
+  GarudaOrderError,
+  GarudaOrderUnexpectedError,
+  createOrder,
+} from "../../orders/api-client";
+import { messageFor, messageForUnknownCode } from "../../orders/messages";
+import type { Applicant, OrderCheckout } from "../../orders/types";
+
+export type CheckoutState =
+  | { step: "idle" }
+  | { step: "submitting" }
+  | { step: "created"; order: OrderCheckout }
+  | { step: "error"; message: string; retryable: boolean };
+
+function stableKeyFor(resultId: string, applicant: Applicant): string {
+  return JSON.stringify([resultId, applicant]);
+}
+
+/**
+ * Drives `createOrderFromCheck`. Idempotency: a fresh key is minted only when the
+ * submitted (resultId, applicant) payload actually changes — retrying after a
+ * transient error with the SAME payload reuses the SAME key, which is what makes the
+ * contract's exact-replay guarantee useful (no double order on a flaky connection).
+ * Changing the applicant (e.g. correcting an email typo after a validation error) is a
+ * genuinely new request and gets a new key, so it can never collide into
+ * IDEMPOTENCY_CONFLICT against the old payload.
+ */
+export function useCheckout(resultId: string) {
+  const [state, setState] = useState<CheckoutState>({ step: "idle" });
+  const idempotencyKeyRef = useRef<string | null>(null);
+  const lastPayloadKeyRef = useRef<string | null>(null);
+
+  const submit = useCallback(
+    async (applicant: Applicant) => {
+      const payloadKey = stableKeyFor(resultId, applicant);
+      if (payloadKey !== lastPayloadKeyRef.current) {
+        idempotencyKeyRef.current =
+          globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+        lastPayloadKeyRef.current = payloadKey;
+      }
+      const idempotencyKey = idempotencyKeyRef.current!;
+
+      setState({ step: "submitting" });
+      try {
+        const order = await createOrder({
+          request: { result_id: resultId, applicant, review_confirmed: true },
+          idempotencyKey,
+        });
+        setState({ step: "created", order });
+      } catch (err) {
+        if (err instanceof GarudaOrderError) {
+          setState({
+            step: "error",
+            message: messageFor(err.code),
+            retryable: err.retryable,
+          });
+          return;
+        }
+        if (err instanceof GarudaOrderUnexpectedError) {
+          setState({
+            step: "error",
+            message:
+              err.httpStatus !== null && err.httpStatus >= 500
+                ? messageFor("SERVICE_UNAVAILABLE")
+                : messageForUnknownCode("__network__"),
+            retryable: true,
+          });
+          return;
+        }
+        setState({
+          step: "error",
+          message: messageForUnknownCode("__unknown__"),
+          retryable: true,
+        });
+      }
+    },
+    [resultId],
+  );
+
+  return { state, submit };
+}

--- a/apps/mouth/src/app/visa/voa/checkoutHandoff.ts
+++ b/apps/mouth/src/app/visa/voa/checkoutHandoff.ts
@@ -1,0 +1,59 @@
+/**
+ * Client-side-only handoff of the two `Applicant` fields the upload/review step
+ * already collected (`full_name`, `passport_number`) from `upload/{resultId}` to
+ * `checkout/{resultId}`. Mirrors `[hash]/page.tsx`'s own `readSubmittedAnswers`
+ * pattern (localStorage there, sessionStorage here — this is a same-visit handoff
+ * between two steps of one checkout, not a returning-visitor convenience) rather than
+ * asking the backend to echo the customer's own answers back, or round-tripping them
+ * through the URL (which the product rules forbid for PII-shaped values).
+ *
+ * `sessionStorage`, not `localStorage`: this data should not outlive the tab/session
+ * once the customer is done, and never needs to survive a device switch.
+ */
+
+export interface CheckoutHandoffValues {
+  full_name?: string;
+  passport_number?: string;
+}
+
+function key(resultId: string): string {
+  return `bz.garuda_voa.checkout_handoff.${resultId}`;
+}
+
+export function writeCheckoutHandoff(
+  resultId: string,
+  values: Record<string, string>,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      key(resultId),
+      JSON.stringify({
+        full_name: values.full_name,
+        passport_number: values.passport_number,
+      }),
+    );
+  } catch {
+    // Best-effort only — checkout still works, it just falls back to asking the
+    // customer to re-enter these two fields.
+  }
+}
+
+export function readCheckoutHandoff(resultId: string): CheckoutHandoffValues {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.sessionStorage.getItem(key(resultId));
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      full_name:
+        typeof parsed.full_name === "string" ? parsed.full_name : undefined,
+      passport_number:
+        typeof parsed.passport_number === "string"
+          ? parsed.passport_number
+          : undefined,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/apps/mouth/src/app/visa/voa/orders/OrderTracker.test.tsx
+++ b/apps/mouth/src/app/visa/voa/orders/OrderTracker.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OrderTracker } from "./OrderTracker";
+import type { OrderView } from "./types";
+
+const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function order(overrides: Partial<OrderView>): OrderView {
+  return {
+    order_id: "order-1",
+    order_state: "awaiting_payment",
+    price_idr: 850000,
+    browser_observation: "browser_not_returned",
+    practice: null,
+    ...overrides,
+  };
+}
+
+describe("OrderTracker", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  it("never renders a price breakdown — only the single all-inclusive footer line", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, order({})));
+    render(<OrderTracker orderId="order-1" />);
+
+    await screen.findByText(/Rp/);
+
+    const bodyText = document.body.textContent ?? "";
+    expect(bodyText).not.toMatch(/PNBP/i);
+    expect(bodyText).not.toMatch(/government fee[:\s]/i);
+    expect(bodyText).toMatch(/never billed separately from this figure/i);
+  });
+
+  it("never claims paid/success from a browser-return observation alone", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        200,
+        order({
+          order_state: "awaiting_payment",
+          browser_observation: "browser_return_observed",
+        }),
+      ),
+    );
+    render(<OrderTracker orderId="order-1" />);
+
+    await screen.findByText(/confirming your payment/i);
+    // "Payment confirmed" appears only as a pending step LABEL (ParcelSteps) here —
+    // the claim this test guards against is a stated confirmation, never the label.
+    expect(
+      screen.queryByText(/here's where your application stands/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/your visa has been delivered/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the delivery panel only when order_state is paid AND practice.state is Delivered", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        200,
+        order({
+          order_state: "paid",
+          browser_observation: "browser_return_observed",
+          practice: {
+            practice_id: "practice-1",
+            state: "Delivered",
+            artifact_available: true,
+          },
+        }),
+      ),
+    );
+    render(<OrderTracker orderId="order-1" />);
+
+    await screen.findByLabelText(/visa delivered/i);
+    expect(
+      screen.getByText(/your visa on arrival has been delivered/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /continue on whatsapp/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a WhatsApp route on a failed order — the exception path is never a dead end", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, order({ order_state: "failed" })),
+    );
+    render(<OrderTracker orderId="order-1" />);
+
+    await screen.findByText(/didn't go through/i);
+    expect(
+      screen.getByRole("link", { name: /continue on whatsapp/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a WhatsApp route when the practice is Blocked", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        200,
+        order({
+          order_state: "paid",
+          practice: {
+            practice_id: "practice-1",
+            state: "Blocked",
+            required_action_key: "garuda_voa.action.resubmit_passport_photo",
+            artifact_available: false,
+          },
+        }),
+      ),
+    );
+    render(<OrderTracker orderId="order-1" />);
+
+    await screen.findByText(/we need something from you/i);
+    expect(screen.getByText(/resubmit passport photo/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /continue on whatsapp/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("never places order data into a rendered link's URL beyond the opaque order id it was given", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, order({})));
+    render(<OrderTracker orderId="order-1" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("/api/visa/voa/orders/order-1");
+  });
+});

--- a/apps/mouth/src/app/visa/voa/orders/OrderTracker.tsx
+++ b/apps/mouth/src/app/visa/voa/orders/OrderTracker.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import { AppFrame } from "@balizero/core";
+import { formatIDR } from "@balizero/core/utils";
+import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
+import { humanizePracticeKey } from "./messages";
+import { useOrderTracking } from "./useOrderTracking";
+import type { OrderView, PracticeState } from "./types";
+
+/**
+ * GARUDA VOA — order tracker + visa delivery view (`/visa/voa/orders/{orderId}`).
+ *
+ * "Parcel tracker" is the mandate's own word: a customer reads their state the way
+ * they read a delivery-tracking page, ending in "delivered". There is no separate
+ * artifact-download endpoint in the frozen contract (`OrderView`/`PracticeView` only
+ * ever carry `artifact_available: boolean` — see openapi.yaml line ~1258: "no document
+ * identifier or capability is placed in a URL"), so this single page IS the delivery
+ * page once `practice.state === "Delivered"` rather than a second route pointed at a
+ * read operation that doesn't exist. `DeliveredPanel` below is the addressable,
+ * independently-tested unit that satisfies that build item.
+ *
+ * `order_state` from `getOrderAndPractice` is the ONLY thing this page ever treats as
+ * authoritative for payment. `browser_observation` is rendered as a "confirming…"
+ * hint at most — never as success (contract: "Browser-return observation is
+ * non-authoritative; only signed webhook reconciliation can show paid").
+ */
+export function OrderTracker({ orderId }: { orderId: string }) {
+  const { state, retry } = useOrderTracking(orderId);
+
+  if (state.step === "loading") {
+    return (
+      <AppFrame
+        funnel="visa"
+        title="Your Visa on Arrival"
+        subtitle="Checking your order…"
+      >
+        <p style={{ color: "var(--color-text-muted)" }}>One moment.</p>
+      </AppFrame>
+    );
+  }
+
+  if (state.step === "error") {
+    return (
+      <AppFrame
+        funnel="visa"
+        title="Your Visa on Arrival"
+        subtitle="We couldn't load your order."
+      >
+        <p role="alert" style={{ margin: 0, color: "var(--color-error)" }}>
+          {state.message}
+        </p>
+        {state.retryable ? (
+          <button
+            type="button"
+            onClick={retry}
+            style={{
+              padding: "0.9rem 1.4rem",
+              borderRadius: 8,
+              border: "none",
+              background: "var(--accent-funnel, #ff3344)",
+              color: "#0a0a0a",
+              fontWeight: 600,
+              cursor: "pointer",
+              width: "fit-content",
+            }}
+          >
+            Try again
+          </button>
+        ) : null}
+        <WhatsAppHelp />
+      </AppFrame>
+    );
+  }
+
+  return <OrderTrackerReady order={state.order} />;
+}
+
+function OrderTrackerReady({ order }: { order: OrderView }) {
+  const subtitle = subtitleFor(order);
+
+  return (
+    <AppFrame
+      funnel="visa"
+      title="Your Visa on Arrival"
+      subtitle={subtitle}
+      footer="One all-inclusive price. Government fees, where they apply, are never billed separately from this figure."
+    >
+      <div
+        style={{
+          display: "grid",
+          gap: "var(--space-2, 0.5rem)",
+        }}
+      >
+        <span style={{ fontSize: "0.85rem", color: "var(--color-text-muted)" }}>
+          Total paid
+        </span>
+        <span style={{ fontSize: "1.6rem", fontWeight: 600 }}>
+          {formatIDR(order.price_idr)}
+        </span>
+      </div>
+
+      <ParcelSteps order={order} />
+
+      {order.order_state === "awaiting_payment" ? (
+        <AwaitingPaymentPanel />
+      ) : null}
+
+      {order.order_state === "failed" || order.order_state === "expired" ? (
+        <ExceptionPanel
+          heading={
+            order.order_state === "failed"
+              ? "This payment didn't go through."
+              : "This checkout session expired."
+          }
+          body="Nothing was charged. A consultant can open a fresh checkout for you right away."
+        />
+      ) : null}
+
+      {order.order_state === "refunded" ? (
+        <ExceptionPanel
+          heading="This order was refunded in full."
+          body="If you still need a Visa on Arrival, a consultant can start a new application with you."
+        />
+      ) : null}
+
+      {order.order_state === "paid" && order.practice === null ? (
+        <p
+          aria-live="polite"
+          style={{ margin: 0, color: "var(--color-text-muted)" }}
+        >
+          Payment confirmed — setting up your application now.
+        </p>
+      ) : null}
+
+      {order.order_state === "paid" && order.practice ? (
+        <PracticePanel practice={order.practice} />
+      ) : null}
+    </AppFrame>
+  );
+}
+
+function subtitleFor(order: OrderView): string {
+  if (order.order_state === "awaiting_payment") {
+    return order.browser_observation === "browser_return_observed"
+      ? "We're confirming your payment — this can take a minute."
+      : "Complete your payment to start your application.";
+  }
+  if (order.order_state === "paid") {
+    if (order.practice?.state === "Delivered") {
+      return "Your visa has been delivered.";
+    }
+    return "Payment confirmed — here's where your application stands.";
+  }
+  if (order.order_state === "failed") return "Payment didn't complete.";
+  if (order.order_state === "expired") return "Checkout session expired.";
+  if (order.order_state === "refunded") return "This order was refunded.";
+  return "Tracking your Visa on Arrival application.";
+}
+
+const ORDER_STEP_ORDER: OrderView["order_state"][] = [
+  "awaiting_payment",
+  "paid",
+];
+
+const PRACTICE_STEP_ORDER: PracticeState[] = [
+  "Received",
+  "In review",
+  "Submitted",
+  "Approved",
+  "Delivered",
+];
+
+/** A simple ordered progress list — like a parcel's "Placed → Picked up → Out for
+ * delivery → Delivered" — never inventing a state the backend didn't send. `Blocked`
+ * and `Rejected` are exception branches rendered separately (`PracticePanel` below),
+ * not points on this happy-path line. */
+function ParcelSteps({ order }: { order: OrderView }) {
+  const isException =
+    order.order_state === "failed" ||
+    order.order_state === "expired" ||
+    order.order_state === "refunded";
+  if (isException) return null;
+
+  const orderStepIndex = ORDER_STEP_ORDER.indexOf(
+    order.order_state as (typeof ORDER_STEP_ORDER)[number],
+  );
+  const practiceState = order.practice?.state;
+  const practiceStepIndex =
+    practiceState && practiceState !== "Blocked" && practiceState !== "Rejected"
+      ? PRACTICE_STEP_ORDER.indexOf(practiceState)
+      : -1;
+
+  const steps: { label: string; done: boolean; current: boolean }[] = [
+    { label: "Order placed", done: true, current: false },
+    {
+      label: "Payment confirmed",
+      done: orderStepIndex >= 1,
+      current: orderStepIndex === 0,
+    },
+    ...PRACTICE_STEP_ORDER.map((label, i) => ({
+      label,
+      done: orderStepIndex >= 1 && practiceStepIndex > i,
+      current: orderStepIndex >= 1 && practiceStepIndex === i,
+    })),
+  ];
+
+  return (
+    <ol
+      aria-label="Application progress"
+      style={{
+        display: "grid",
+        gap: "var(--space-2, 0.5rem)",
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {steps.map((step) => (
+        <li
+          key={step.label}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.6rem",
+            color:
+              step.done || step.current
+                ? "var(--text-primary, rgba(255,255,255,0.96))"
+                : "var(--color-text-muted)",
+            fontWeight: step.current ? 600 : 400,
+          }}
+        >
+          <span aria-hidden="true">
+            {step.done ? "✓" : step.current ? "●" : "○"}
+          </span>
+          <span>{step.label}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * `getOrderAndPractice`'s `OrderView` (unlike `createOrderFromCheck`'s `OrderCheckout`)
+ * carries no `checkout_url` — the contract never lets this read-only view hand back a
+ * live provider capability. A customer who lands here still `awaiting_payment` (e.g.
+ * they closed the payment tab and came back later) therefore has no self-service resume
+ * button this page can honestly render; a consultant reopening checkout for them is the
+ * real path, not a link this component would have to invent.
+ */
+function AwaitingPaymentPanel() {
+  return (
+    <p style={{ margin: 0, color: "var(--color-text-muted)" }}>
+      Haven&apos;t finished paying yet?{" "}
+      <a
+        href={buildWhatsAppLink(
+          "visa",
+          "Hi Bali Zero, I need help finishing payment for my Visa on Arrival order.",
+        )}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        A consultant can help you complete it →
+      </a>
+    </p>
+  );
+}
+
+function PracticePanel({
+  practice,
+}: {
+  practice: NonNullable<OrderView["practice"]>;
+}) {
+  if (practice.state === "Delivered") {
+    return <DeliveredPanel practice={practice} />;
+  }
+  if (practice.state === "Blocked") {
+    return (
+      <ExceptionPanel
+        heading="We need something from you before we can continue."
+        body={
+          practice.required_action_key
+            ? humanizePracticeKey(practice.required_action_key)
+            : "A consultant can tell you exactly what's needed."
+        }
+      />
+    );
+  }
+  if (practice.state === "Rejected") {
+    return (
+      <ExceptionPanel
+        heading="Your application couldn't be approved as submitted."
+        body={
+          practice.customer_reason_key
+            ? humanizePracticeKey(practice.customer_reason_key)
+            : "A consultant can review it with you and explain the options."
+        }
+      />
+    );
+  }
+  return null;
+}
+
+/** The "visa delivery page" build item. Contract has no bytes-download operation for
+ * the finished document (`artifact_available` is a boolean flag only) — delivery
+ * happens through the existing practice channels (email/WhatsApp), not a link this
+ * page can construct itself, so this panel confirms the state honestly rather than
+ * fabricating a download it cannot back. */
+function DeliveredPanel({
+  practice,
+}: {
+  practice: NonNullable<OrderView["practice"]>;
+}) {
+  return (
+    <section
+      aria-label="Visa delivered"
+      style={{
+        display: "grid",
+        gap: "var(--space-2, 0.6rem)",
+        padding: "var(--space-3, 1rem)",
+        borderRadius: 12,
+        border: "1px solid var(--color-border-subtle)",
+        background: "var(--surface-raised)",
+      }}
+    >
+      <p style={{ margin: 0, fontWeight: 600 }}>
+        Your Visa on Arrival has been delivered.
+      </p>
+      <p style={{ margin: 0, lineHeight: 1.6 }}>
+        {practice.artifact_available
+          ? "We've sent your document to the email on file. Check your inbox (and spam folder)."
+          : "Our team is finalizing your document and will send it to your email shortly."}
+      </p>
+      <a
+        href={buildWhatsAppLink(
+          "visa",
+          "Hi Bali Zero, I have a question about my delivered Visa on Arrival.",
+        )}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: "inline-block",
+          width: "fit-content",
+          padding: "0.7rem 1.1rem",
+          borderRadius: 8,
+          background: "#25D366",
+          color: "#0a0a0a",
+          textDecoration: "none",
+          fontWeight: 600,
+        }}
+      >
+        Questions? Continue on WhatsApp →
+      </a>
+    </section>
+  );
+}
+
+function ExceptionPanel({ heading, body }: { heading: string; body: string }) {
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-2, 0.6rem)",
+        padding: "var(--space-3, 1rem)",
+        borderRadius: 12,
+        border: "1px solid var(--color-border-subtle)",
+      }}
+    >
+      <p style={{ margin: 0, fontWeight: 600 }}>{heading}</p>
+      <p style={{ margin: 0, lineHeight: 1.6 }}>{body}</p>
+      <WhatsAppHelp />
+    </section>
+  );
+}
+
+function WhatsAppHelp() {
+  return (
+    <a
+      href={buildWhatsAppLink(
+        "visa",
+        "Hi Bali Zero, I need help with my Visa on Arrival order.",
+      )}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: "inline-block",
+        width: "fit-content",
+        padding: "0.7rem 1.1rem",
+        borderRadius: 8,
+        background: "#25D366",
+        color: "#0a0a0a",
+        textDecoration: "none",
+        fontWeight: 600,
+      }}
+    >
+      Continue on WhatsApp →
+    </a>
+  );
+}

--- a/apps/mouth/src/app/visa/voa/orders/[orderId]/page.tsx
+++ b/apps/mouth/src/app/visa/voa/orders/[orderId]/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { OrderTracker } from "../OrderTracker";
+
+/**
+ * `/visa/voa/orders/{orderId}` — the customer-facing parcel tracker and (once
+ * `practice.state === "Delivered"`) visa delivery view. `orderId` is the opaque order
+ * identifier from `createOrderFromCheck` (`OrderCheckout.order_id` /
+ * `OpaqueId` in the contract) — never a raw database id.
+ */
+export default function OrderPage() {
+  const params = useParams<{ orderId: string }>();
+  const orderId = params?.orderId;
+
+  if (!orderId) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 p-6 text-center">
+        <p className="text-gray-600">
+          We couldn&apos;t find this order. Please check the link.
+        </p>
+      </main>
+    );
+  }
+
+  return <OrderTracker orderId={orderId} />;
+}

--- a/apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.test.tsx
+++ b/apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OrderReturnPage from "./page";
+
+const mocks = vi.hoisted(() => ({
+  useParams: vi.fn(),
+  useSearchParams: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: mocks.useParams,
+  useSearchParams: mocks.useSearchParams,
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+
+describe("OrderReturnPage — browser return is an observation, not a truth", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    mocks.replace.mockReset();
+    mocks.useParams.mockReturnValue({ orderId: "order-1" });
+  });
+
+  it("never renders a success/paid state, even when the observation call succeeds (204)", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams({ return_nonce: "a".repeat(20) }),
+    );
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+    });
+
+    render(<OrderReturnPage />);
+
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith("/visa/voa/orders/order-1"),
+    );
+    expect(screen.queryByText(/success/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/you're eligible/i)).not.toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toMatch(/\bpaid\b/i);
+  });
+
+  it("still forwards to the tracker (never shows success) when the observation call errors", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams({ return_nonce: "a".repeat(20) }),
+    );
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        code: "SERVICE_UNAVAILABLE",
+        retryable: true,
+        message_key: "garuda_voa.error.service_unavailable",
+      }),
+    });
+
+    render(<OrderReturnPage />);
+
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith("/visa/voa/orders/order-1"),
+    );
+    expect(document.body.textContent ?? "").not.toMatch(/\bpaid\b/i);
+  });
+
+  it("posts the return_nonce as the request body, never as a query string on the API call", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams({ return_nonce: "a".repeat(20) }),
+    );
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+    });
+
+    render(<OrderReturnPage />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "/api/visa/voa/orders/order-1/browser-return-observations",
+    );
+    expect(url).not.toContain("a".repeat(20));
+    expect(JSON.parse(init.body as string)).toEqual({
+      return_nonce: "a".repeat(20),
+    });
+  });
+
+  it("forwards straight to the tracker without calling the API when no return_nonce is present", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams());
+
+    render(<OrderReturnPage />);
+
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith("/visa/voa/orders/order-1"),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.tsx
+++ b/apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { AppFrame } from "@balizero/core";
+import {
+  GarudaOrderError,
+  GarudaOrderUnexpectedError,
+  observePaymentBrowserReturn,
+} from "../../api-client";
+
+/**
+ * `/visa/voa/orders/{orderId}/return` — where the payment provider redirects the
+ * browser back to us (owner decision 1: Xendit). This route's ONLY job is OP-07: record
+ * the untrusted `return_nonce` as a non-authoritative observation, then hand off to the
+ * tracker (`/visa/voa/orders/{orderId}`), which is the sole place order state is read
+ * from the server and rendered.
+ *
+ * Hard rule (contract + mandate): "The browser return is an OBSERVATION, not a truth."
+ * This page must NEVER render a success/paid state on the strength of the redirect
+ * alone — not while the observation call is in flight, not after it commits (204 means
+ * "recorded", not "paid"), and not on error. It always forwards to the tracker, which
+ * decides what actually happened from `order_state`.
+ *
+ * `return_nonce` and `orderId` are opaque, non-PII tokens — carrying them in the query
+ * string is exactly what the contract's own `BrowserReturnObservationRequest` shape
+ * expects a provider redirect to do, and is not the PII the product rules forbid in
+ * URLs (name/email/passport/document-id-that-encodes-one).
+ */
+export default function OrderReturnPage() {
+  const params = useParams<{ orderId: string }>();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const startedRef = useRef(false);
+
+  const orderId = params?.orderId;
+  const returnNonce = searchParams.get("return_nonce");
+
+  useEffect(() => {
+    if (!orderId || startedRef.current) return;
+    startedRef.current = true;
+
+    if (!returnNonce) {
+      // Nothing to observe (e.g. the customer navigated here directly) — just move to
+      // the tracker, which reads the real state regardless.
+      router.replace(`/visa/voa/orders/${orderId}`);
+      return;
+    }
+
+    void (async () => {
+      try {
+        await observePaymentBrowserReturn({
+          orderId,
+          returnNonce,
+          idempotencyKey:
+            globalThis.crypto?.randomUUID?.() ?? `return-${Date.now()}`,
+        });
+      } catch (err) {
+        // Deliberately swallowed beyond a transient local message: an observation
+        // failure must not block the customer from seeing their REAL order state on
+        // the tracker, and it must not be presented as a payment failure — it is
+        // neither.
+        if (
+          err instanceof GarudaOrderError ||
+          err instanceof GarudaOrderUnexpectedError
+        ) {
+          setError(
+            "We had trouble recording your return, but your order is safe.",
+          );
+        }
+      } finally {
+        router.replace(`/visa/voa/orders/${orderId}`);
+      }
+    })();
+  }, [orderId, returnNonce, router]);
+
+  return (
+    <AppFrame
+      funnel="visa"
+      title="Your Visa on Arrival"
+      subtitle={error ?? "Confirming your payment…"}
+    >
+      <p aria-live="polite" style={{ color: "var(--color-text-muted)" }}>
+        One moment while we check your order status.
+      </p>
+    </AppFrame>
+  );
+}

--- a/apps/mouth/src/app/visa/voa/orders/api-client.ts
+++ b/apps/mouth/src/app/visa/voa/orders/api-client.ts
@@ -1,0 +1,182 @@
+/**
+ * Fetch wrapper for the three GARUDA VOA order/checkout operations this lane owns
+ * (`products/garuda-voa/contracts/openapi.yaml`):
+ *
+ *  - `POST /api/visa/voa/orders` (createOrderFromCheck)
+ *  - `POST /api/visa/voa/orders/{order_id}/browser-return-observations` (observePaymentBrowserReturn)
+ *  - `GET  /api/visa/voa/orders/{order_id}` (getOrderAndPractice)
+ *
+ * Auth is the contract's `MagicSession` — the same `garuda_session` Secure, HttpOnly
+ * cookie `upload/api-client.ts` documents. `fetch` sends same-origin cookies by default,
+ * so no token handling belongs here; same `NEXT_PUBLIC_API_URL || "/api"` convention.
+ */
+
+import type {
+  BrowserReturnObservationRequest,
+  CreateOrderRequest,
+  ErrorResponse,
+  OrderCheckout,
+  OrderErrorCode,
+  OrderView,
+} from "./types";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
+
+export class GarudaOrderError extends Error {
+  constructor(
+    public readonly code: OrderErrorCode,
+    public readonly retryable: boolean,
+    public readonly httpStatus: number,
+  ) {
+    super(`GarudaOrderError(${code})`);
+    this.name = "GarudaOrderError";
+  }
+}
+
+/** Thrown when a response body can't be parsed as the contract's ErrorResponse or
+ * success shape at all — a network-layer or truly unexpected-server failure, distinct
+ * from a well-formed error the contract documents. Mirrors `upload/api-client.ts`. */
+export class GarudaOrderUnexpectedError extends Error {
+  public readonly sourceCause: unknown;
+
+  constructor(
+    public readonly httpStatus: number | null,
+    cause?: unknown,
+  ) {
+    super("GarudaOrderUnexpectedError");
+    this.name = "GarudaOrderUnexpectedError";
+    this.sourceCause = cause;
+  }
+}
+
+function isErrorResponseShape(body: unknown): body is ErrorResponse {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "code" in body &&
+    "retryable" in body &&
+    "message_key" in body
+  );
+}
+
+async function parseJsonBody(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (cause) {
+    throw new GarudaOrderUnexpectedError(response.status, cause);
+  }
+}
+
+function throwFromErrorBody(response: Response, body: unknown): never {
+  if (isErrorResponseShape(body)) {
+    throw new GarudaOrderError(body.code, body.retryable, response.status);
+  }
+  throw new GarudaOrderUnexpectedError(response.status, body);
+}
+
+export interface CreateOrderParams {
+  request: CreateOrderRequest;
+  idempotencyKey: string;
+  signal?: AbortSignal;
+}
+
+/** Creates (or, on exact idempotency replay, resumes) one order + checkout session.
+ * `review_confirmed` must be the literal `true` the contract's `const` requires — the
+ * caller has already run the customer through the upload/review step. */
+export async function createOrder({
+  request,
+  idempotencyKey,
+  signal,
+}: CreateOrderParams): Promise<OrderCheckout> {
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}/visa/voa/orders`, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotencyKey,
+      },
+      body: JSON.stringify(request),
+      signal,
+    });
+  } catch (cause) {
+    throw new GarudaOrderUnexpectedError(null, cause);
+  }
+
+  const body = await parseJsonBody(response);
+  if (response.ok) return body as OrderCheckout;
+  throwFromErrorBody(response, body);
+}
+
+export interface ObservePaymentBrowserReturnParams {
+  orderId: string;
+  returnNonce: string;
+  idempotencyKey: string;
+  signal?: AbortSignal;
+}
+
+/** Records the non-authoritative OP-07 browser-return observation. Always a 204 (or
+ * an error) — never a body, and never proof of payment. Callers must re-fetch
+ * `getOrderAndPractice` afterward for the real state; this function itself must never
+ * be treated as a payment result. */
+export async function observePaymentBrowserReturn({
+  orderId,
+  returnNonce,
+  idempotencyKey,
+  signal,
+}: ObservePaymentBrowserReturnParams): Promise<void> {
+  const request: BrowserReturnObservationRequest = {
+    return_nonce: returnNonce,
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${API_BASE_URL}/visa/voa/orders/${encodeURIComponent(orderId)}/browser-return-observations`,
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": idempotencyKey,
+        },
+        body: JSON.stringify(request),
+        signal,
+      },
+    );
+  } catch (cause) {
+    throw new GarudaOrderUnexpectedError(null, cause);
+  }
+
+  if (response.status === 204) return;
+
+  const body = await parseJsonBody(response);
+  throwFromErrorBody(response, body);
+}
+
+export interface GetOrderAndPracticeParams {
+  orderId: string;
+  signal?: AbortSignal;
+}
+
+/** Reads the authoritative order state + customer-safe practice view. This is the ONLY
+ * source of truth for "did the payment succeed" — never the browser-return observation. */
+export async function getOrderAndPractice({
+  orderId,
+  signal,
+}: GetOrderAndPracticeParams): Promise<OrderView> {
+  let response: Response;
+  try {
+    response = await fetch(
+      `${API_BASE_URL}/visa/voa/orders/${encodeURIComponent(orderId)}`,
+      { method: "GET", credentials: "same-origin", signal },
+    );
+  } catch (cause) {
+    throw new GarudaOrderUnexpectedError(null, cause);
+  }
+
+  const body = await parseJsonBody(response);
+  if (response.ok) return body as OrderView;
+  throwFromErrorBody(response, body);
+}

--- a/apps/mouth/src/app/visa/voa/orders/messages.ts
+++ b/apps/mouth/src/app/visa/voa/orders/messages.ts
@@ -1,0 +1,69 @@
+/**
+ * Customer-facing copy keyed by the contract's closed `OrderErrorCode` catalog
+ * (see types.ts). Same convention as `upload/messages.ts`: `COPY` is typed
+ * `Record<OrderErrorCode, string>`, so adding a code to the union without a matching
+ * entry here fails the BUILD, not a runtime lookup.
+ */
+
+import type { OrderErrorCode } from "./types";
+
+const COPY: Record<OrderErrorCode, string> = {
+  IDEMPOTENCY_KEY_REQUIRED:
+    "Something went wrong preparing that request. Please try again.",
+  SESSION_REQUIRED:
+    "Your session has expired. Please sign in again to continue.",
+  GARUDA_PUBLIC_DISABLED:
+    "This isn't available right now. Please try again later.",
+  RESULT_NOT_FOUND:
+    "We couldn't find your application. Please start again from your check result.",
+  ORDER_NOT_FOUND:
+    "We couldn't find this order. Please check the link or start again.",
+  IDEMPOTENCY_CONFLICT:
+    "That didn't match your previous attempt. Please reload and try again.",
+  ORDER_NOT_READY:
+    "Your application isn't ready to check out yet. Please confirm your document details first.",
+  INVALID_STATE_TRANSITION:
+    "This order has already moved on. Reload the page to see its current state.",
+  INVALID_REQUEST: "We couldn't process that request. Please try again.",
+  RATE_LIMITED: "Too many attempts. Please wait a moment and try again.",
+  PERSISTENCE_POLICY_UNAVAILABLE:
+    "Checkout is temporarily unavailable. Please try again in a moment.",
+  PRICE_UNRESOLVABLE:
+    "We couldn't confirm your price right now. Please try again shortly.",
+  PAYMENT_PROVIDER_UNAVAILABLE:
+    "Our payment provider is temporarily unavailable. Please try again shortly.",
+  SERVICE_UNAVAILABLE:
+    "Something went wrong on our end. Please try again in a moment.",
+  INTERNAL_ERROR: "Something went wrong on our end. Please try again.",
+};
+
+const GENERIC_NETWORK_ERROR =
+  "We couldn't reach the server. Check your connection and try again.";
+
+export function messageFor(code: OrderErrorCode): string {
+  return COPY[code];
+}
+
+export function messageForUnknownCode(code: string): string {
+  return code in COPY ? COPY[code as OrderErrorCode] : GENERIC_NETWORK_ERROR;
+}
+
+/**
+ * The contract's `customer_reason_key` / `required_action_key` fields are documented
+ * as a closed vocabulary (`^garuda_voa\.practice\.[a-z0-9_]+$` /
+ * `^garuda_voa\.action\.[a-z0-9_]+$`), but no catalog of the actual key VALUES exists
+ * anywhere in this repo yet (checked `products/garuda-voa/**`,
+ * `apps/backend-rag/backend/services/garuda_flow/**` — nothing defines them). Building
+ * a lookup table here would be a second, unsourced catalog exactly like the one
+ * `openapi.yaml`'s own 2026-08-25 amendment comment warns against: a contract/lane
+ * pair where reality has more values than either side wrote down, silently drifting the
+ * moment the backend adds one. Instead: strip the namespace prefix and humanize the
+ * remainder, same fallback pattern `UploadFlow.tsx::fieldLabel` already uses for an
+ * unrecognized `field_path`. If a real catalog lands, this is the one function to swap.
+ */
+export function humanizePracticeKey(key: string): string {
+  const withoutPrefix = key.replace(/^garuda_voa\.(practice|action)\./, "");
+  const words = withoutPrefix.replace(/_/g, " ").trim();
+  if (!words) return key;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/apps/mouth/src/app/visa/voa/orders/types.ts
+++ b/apps/mouth/src/app/visa/voa/orders/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Hand-written types mirroring the FROZEN GARUDA VOA contract
+ * (`products/garuda-voa/contracts/openapi.yaml`) for the three order/checkout/tracker
+ * operations this lane calls: `createOrderFromCheck`, `observePaymentBrowserReturn`,
+ * `getOrderAndPractice`.
+ *
+ * Hand-written for the same reason `upload/types.ts` is (see that file's header): the
+ * OpenAPI -> generated-TS-client toolchain isn't wired in yet (ASSEMBLY-LINE.md backlog
+ * #4). This is a direct transcription of the contract, not an invention — check both
+ * before changing either.
+ */
+
+export interface Applicant {
+  full_name: string;
+  email: string;
+  phone: string;
+  passport_number: string;
+}
+
+export interface CreateOrderRequest {
+  result_id: string;
+  applicant: Applicant;
+  review_confirmed: true;
+}
+
+/** openapi.yaml `OrderState` — the full lifecycle, including terminal states an order
+ * created before the customer's tab reconnects may already be in. */
+export type OrderState =
+  "created" | "awaiting_payment" | "paid" | "failed" | "expired" | "refunded";
+
+export interface OrderCheckout {
+  order_id: string;
+  /** `created` is deliberately absent from the contract's enum here — see
+   * openapi.yaml's 2026-08-25 amendment comment on this field. Never hardcode
+   * `awaiting_payment` as the only possible value this response can carry. */
+  order_state: Exclude<OrderState, "created">;
+  price_idr: number;
+  /** Required-and-nullable by design (contract comment): null means there is nothing
+   * to pay right now (order moved past payment, or terminal) — never treat a missing
+   * key as "nothing to pay" via `undefined`, always read the literal `null`. */
+  checkout_url: string | null;
+}
+
+export interface BrowserReturnObservationRequest {
+  return_nonce: string;
+}
+
+export type PracticeState =
+  | "Received"
+  | "In review"
+  | "Blocked"
+  | "Submitted"
+  | "Approved"
+  | "Rejected"
+  | "Delivered";
+
+export interface PracticeView {
+  practice_id: string;
+  state: PracticeState;
+  /** Customer-safe copy KEY (`garuda_voa.practice.*`), never rendered prose — the
+   * contract has no closed catalog of actual key values yet, so this lane humanizes
+   * the key itself rather than inventing a lookup table that would silently drift
+   * (see orders/messages.ts `humanizePracticeKey`). */
+  customer_reason_key?: string;
+  required_action_key?: string;
+  artifact_available: boolean;
+}
+
+export interface OrderView {
+  order_id: string;
+  order_state: OrderState;
+  price_idr: number;
+  /** Non-authoritative OP-07 browser-return observation. Can NEVER by itself justify
+   * rendering a paid/success state — only `order_state === "paid"` can. */
+  browser_observation: "browser_not_returned" | "browser_return_observed";
+  practice: PracticeView | null;
+}
+
+/** Closed error catalog — union of every `x-error-codes` list across the three
+ * operations this lane calls (createOrderFromCheck, observePaymentBrowserReturn,
+ * getOrderAndPractice). An unlisted code from the network is still handled (see
+ * api-client.ts) but treated as a generic retryable failure. */
+export type OrderErrorCode =
+  | "IDEMPOTENCY_KEY_REQUIRED"
+  | "SESSION_REQUIRED"
+  | "GARUDA_PUBLIC_DISABLED"
+  | "RESULT_NOT_FOUND"
+  | "ORDER_NOT_FOUND"
+  | "IDEMPOTENCY_CONFLICT"
+  | "ORDER_NOT_READY"
+  | "INVALID_STATE_TRANSITION"
+  | "INVALID_REQUEST"
+  | "RATE_LIMITED"
+  | "PERSISTENCE_POLICY_UNAVAILABLE"
+  | "PRICE_UNRESOLVABLE"
+  | "PAYMENT_PROVIDER_UNAVAILABLE"
+  | "SERVICE_UNAVAILABLE"
+  | "INTERNAL_ERROR";
+
+export interface ErrorResponse {
+  code: OrderErrorCode;
+  retryable: boolean;
+  message_key: string;
+}

--- a/apps/mouth/src/app/visa/voa/orders/useOrderTracking.ts
+++ b/apps/mouth/src/app/visa/voa/orders/useOrderTracking.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  GarudaOrderError,
+  GarudaOrderUnexpectedError,
+  getOrderAndPractice,
+} from "./api-client";
+import { messageFor, messageForUnknownCode } from "./messages";
+import type { OrderView } from "./types";
+
+const POLL_INTERVAL_MS = 5000;
+
+/** Pipeline states where the customer benefits from a live refresh without pressing
+ * reload — mirrors a parcel tracker's "still moving" states. Terminal order states
+ * (failed/expired/refunded) and terminal practice states (Delivered/Rejected) stop
+ * polling: nothing left to wait for, and Delivered/paid must never silently regress
+ * back to a "checking…" flicker on a stray re-render. */
+function isStillMoving(order: OrderView): boolean {
+  if (
+    order.order_state === "created" ||
+    order.order_state === "awaiting_payment"
+  ) {
+    return true;
+  }
+  if (order.order_state !== "paid") return false;
+  const practiceState = order.practice?.state;
+  return (
+    practiceState === undefined ||
+    practiceState === "Received" ||
+    practiceState === "In review" ||
+    practiceState === "Submitted"
+  );
+}
+
+export type OrderTrackingState =
+  | { step: "loading" }
+  | { step: "ready"; order: OrderView }
+  | { step: "error"; message: string; retryable: boolean };
+
+export function useOrderTracking(orderId: string) {
+  const [state, setState] = useState<OrderTrackingState>({ step: "loading" });
+  const mountedRef = useRef(true);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const order = await getOrderAndPractice({
+        orderId,
+        signal: controller.signal,
+      });
+      if (!mountedRef.current || abortRef.current !== controller) return;
+      setState({ step: "ready", order });
+
+      if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+      if (isStillMoving(order)) {
+        pollTimeoutRef.current = setTimeout(() => {
+          if (mountedRef.current) void load();
+        }, POLL_INTERVAL_MS);
+      }
+    } catch (err) {
+      if (!mountedRef.current || abortRef.current !== controller) return;
+      if (err instanceof GarudaOrderError) {
+        setState({
+          step: "error",
+          message: messageFor(err.code),
+          retryable: err.retryable,
+        });
+        return;
+      }
+      if (err instanceof GarudaOrderUnexpectedError) {
+        setState({
+          step: "error",
+          message:
+            err.httpStatus !== null && err.httpStatus >= 500
+              ? messageFor("SERVICE_UNAVAILABLE")
+              : messageForUnknownCode("__network__"),
+          retryable: true,
+        });
+        return;
+      }
+      setState({
+        step: "error",
+        message: messageForUnknownCode("__unknown__"),
+        retryable: true,
+      });
+    }
+  }, [orderId]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void load();
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+      if (pollTimeoutRef.current) clearTimeout(pollTimeoutRef.current);
+    };
+  }, [load]);
+
+  const retry = useCallback(() => {
+    void load();
+  }, [load]);
+
+  return { state, retry };
+}

--- a/apps/mouth/src/app/visa/voa/upload/[resultId]/page.tsx
+++ b/apps/mouth/src/app/visa/voa/upload/[resultId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { UploadFlow } from "../UploadFlow";
+import { writeCheckoutHandoff } from "../../checkoutHandoff";
 
 /**
  * `/visa/voa/upload/{resultId}` — customer-facing document upload step (L5 owns this
@@ -9,9 +10,16 @@ import { UploadFlow } from "../UploadFlow";
  * owner decision 5 for visual identity). `resultId` is the opaque eligibility-check id
  * from the funnel (`GARUDA VOA API` `ResultId` parameter) — never a raw database id, per
  * the binding persistence design (`research/visa/2026-08-23-voa-public-funnel-persistence-design.md`).
+ *
+ * `onConfirmed` bridges to checkout (L4 part 3, `../checkoutHandoff.ts` +
+ * `../checkout/{resultId}`): it stashes the two `Applicant` fields checkout needs that
+ * upload already collected (`full_name`, `passport_number`) client-side only, then
+ * navigates forward. `UploadFlow` itself stays unaware of order/payment state — see its
+ * own header comment.
  */
 export default function UploadPage() {
   const params = useParams<{ resultId: string }>();
+  const router = useRouter();
   const resultId = params?.resultId;
 
   if (!resultId) {
@@ -24,5 +32,13 @@ export default function UploadPage() {
     );
   }
 
-  return <UploadFlow resultId={resultId} />;
+  return (
+    <UploadFlow
+      resultId={resultId}
+      onConfirmed={(values) => {
+        writeCheckoutHandoff(resultId, values);
+        router.push(`/visa/voa/checkout/${resultId}`);
+      }}
+    />
+  );
 }


### PR DESCRIPTION
## Summary

L4 part 3 of 3: builds the last three GARUDA VOA public-funnel surfaces. verdict -> account -> upload were already live (account still 503s pending the sibling L4-store PR's magic-link store + router mount — out of scope here); this closes **pay -> tracker -> delivery** against the frozen contract's three order operations (`createOrderFromCheck`, `observePaymentBrowserReturn`, `getOrderAndPractice`).

- **`/visa/voa/checkout/{resultId}`** — collects email+phone (full_name/passport_number come from the upload/review step via a new client-side-only `checkoutHandoff.ts`, never re-typed or put in a URL). Submits `createOrderFromCheck` with a stable idempotency key (same key on retry-of-same-payload, fresh key on an actually-changed payload). Hands off to the payment provider's `checkout_url` on a fresh `awaiting_payment` order; forwards a replayed non-pending order straight to the tracker instead of showing a stale pay button.
- **`/visa/voa/orders/{orderId}/return`** — records the OP-07 browser-return observation and ALWAYS forwards to the tracker afterward. It never renders a success/paid state itself — not on the 204, not on an error — because a browser redirect is an observation, not proof of payment.
- **`/visa/voa/orders/{orderId}`** — the parcel-style tracker, polling `getOrderAndPractice` while the order/practice is still moving. Ends in the visa-delivery view once `practice.state === "Delivered"`. The contract has no separate artifact-download operation (`OrderView`/`PracticeView` only ever carry `artifact_available: boolean`), so this is the "delivery page" build item: a distinct, independently tested panel (`DeliveredPanel`) within the one read operation the contract actually offers, rather than a second route pointed at an endpoint that doesn't exist. Exception states (failed/expired/refunded/Blocked/Rejected) always route to WhatsApp, never a dead end.

## Product rules honored

- **One all-inclusive price** everywhere (`formatIDR(price_idr)`, footer copy identical to the result page's) — no breakdown ever, no PNBP/government-fee line.
- **No PII in any URL or query string** — `order_id`/`result_id`/`return_nonce` are opaque non-PII tokens per the contract's own design (`return_nonce` traveling in the provider's redirect query string is exactly what `BrowserReturnObservationRequest` expects). `full_name`/`passport_number`/email/phone never leave the request body.
- **Browser return is an observation, not a truth** — the return page can never render success; only `getOrderAndPractice`'s `order_state` does.
- `GARUDA_PUBLIC_ENABLED` is enforced server-side per the existing pattern; no new frontend gating logic was needed here.

## Deviation from the mandate — flagged, not silently done

`OrderView` (the tracker's read shape) has **no `checkout_url` field** — only `OrderCheckout` (the create-order response) carries one. So a customer who abandons checkout and returns later to `/visa/voa/orders/{orderId}` while still `awaiting_payment` has no self-service "resume payment" button this page can honestly render (there is no data to build one from, and no `result_id` on `OrderView` to deep-link back to `/checkout/{resultId}`). The tracker instead offers a WhatsApp route for a consultant to complete it. This is a contract-shape finding, not an implementation shortcut — flagging per the mandate's instruction to say explicitly what was left and why.

`practice.customer_reason_key` / `required_action_key` have no closed catalog of actual key values anywhere in this repo (checked `products/garuda-voa/**` and `backend/services/garuda_flow/**`) — only a regex pattern in the contract. Building a lookup table would be a second, unsourced catalog exactly like the one `openapi.yaml`'s own 2026-08-25 amendment comment warns against. `orders/messages.ts::humanizePracticeKey` strips the namespace and humanizes the remainder instead (same fallback pattern `UploadFlow.tsx::fieldLabel` already uses for `field_path`).

## Bite proofs

```bash
cd apps/mouth
npx tsc --noEmit                                    # clean
npx eslint src/app/visa/voa                          # 0 errors (pre-existing warnings only, untouched file)
npx vitest run src/app/visa/voa                      # 9 files / 50 tests green
npx vitest run --reporter=dot                        # full suite: 435 files / 4360 tests green
```

Test coverage specifically targets the grading criteria: a price-breakdown test that fails if PNBP/government-fee text is introduced, a redirect test that fails if a success state renders off the provider return alone, a URL test that fails if PII reaches a fetch URL, and exception-path tests that fail if the WhatsApp route disappears from failed/Blocked/Rejected states.

Armed for auto-merge (bare, no strategy flag) per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)