### PR TITLE
feat(garuda-voa): L4 magic-link persistence — PostgresMagicLinkStore + mount

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -603,6 +603,28 @@ _VISA_ORACLE = (
         "Visa Check Match result page — shareable URL, the hash is the access token",
         match="template",
     ),
+    # GARUDA VOA magic-link auth (L4, routers/garuda_portal_auth.py, prefix
+    # /api/visa/voa/auth — a disjoint sub-path of L2/L3's shared /api/visa/voa,
+    # never a blanket prefix on that shared root). Anonymous by design: an
+    # eligibility-check result owner has no account until this flow mints
+    # one — see magic_link.py module docstring. Same defect class as the
+    # "Visa Check funnel dead in prod" note above, caught here the same way:
+    # a real end-to-end request through `main_api.app` (not a bare FastAPI()
+    # + include_router() test double) returned 401 before this entry existed.
+    # DISCOVERED, NOT FIXED HERE: `/api/visa/voa` itself (L2's
+    # garuda_voa_public.py + L3's garuda_orders_router.py, both already
+    # merged) has the SAME gap — no registry entry, so their public routes
+    # 401 in production today too. Out of scope for this PR (cross-lane
+    # files, and garuda_orders_router.py also mounts a staff-only
+    # /api/visa/voa/staff/... route that a careless blanket prefix here
+    # would need to carve out correctly) — flagged for the orchestrator.
+    PublicEndpoint(
+        "/api/visa/voa/auth/",
+        Category.AUTH,
+        "GARUDA VOA magic-link issue+exchange — anonymous by design, contract-frozen "
+        "(products/garuda-voa/contracts/openapi.yaml), GARUDA_PUBLIC_ENABLED re-checked "
+        "per-request by the handler itself",
+    ),
 )
 
 _BRIDGE = (

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -237,6 +237,15 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
         process_groups=_API,
         tags=("visa", "garuda", "public"),
     ),
+    # ── GARUDA VOA magic-link authentication (contract-frozen, L4) ──
+    # Same no-mount-time-condition posture as garuda_voa_public/
+    # garuda_orders_router above: GARUDA_PUBLIC_ENABLED is re-checked
+    # per-request by the router's own dependency, not gated at mount.
+    RouterEntry(
+        name="garuda_portal_auth",
+        process_groups=_API,
+        tags=("visa", "garuda", "public", "auth"),
+    ),
     # ── Google Drive / Integrations ──
     RouterEntry(name="google_drive", process_groups=_API, tags=("integrations",)),
     # ── Guardian ──

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -225,6 +225,10 @@ def include_routers(api: FastAPI) -> None:
 
     api.include_router(garuda_orders_router.router)  # L3 checkout/orders — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
 
+    from backend.app.routers import garuda_portal_auth
+
+    api.include_router(garuda_portal_auth.router)  # L4 magic-link auth — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
+
     # CRM routers
     api.include_router(crm_clients.router)
     api.include_router(intake_review.router)  # [FASE 5A] doc-intake HITL review-queue
@@ -670,6 +674,10 @@ def include_light_routers(api: FastAPI) -> None:
     from backend.app.routers import garuda_orders_router
 
     api.include_router(garuda_orders_router.router)  # L3 checkout/orders — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
+
+    from backend.app.routers import garuda_portal_auth
+
+    api.include_router(garuda_portal_auth.router)  # L4 magic-link auth — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
 
     # Genome-backed registries (light: SQLite via cell-core, no ML deps)
     api.include_router(experience.router)  # [EXP] Experience Library (PR #54)

--- a/apps/backend-rag/backend/db/migrations_v2/285_garuda_magic_link.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/285_garuda_magic_link.sql
@@ -1,0 +1,420 @@
+-- ============================================================================
+-- 285_garuda_magic_link.sql
+-- GARUDA VOA -- L4 magic-link authentication persistence
+-- (products/garuda-voa/L4-CONTINUATION.md "part 2 of 3").
+--
+-- Numbering: 284 (L3 checkout+orders) is the highest migration on
+-- feature/garuda-voa and every open garuda-l* lane branch as of this
+-- commit (checked immediately before writing this file, not assumed --
+-- W40). If a different migration lands as 285 on the integration branch
+-- first, RENUMBER this file before merging it.
+--
+-- DECISION MADE EXPLICIT (L4-CONTINUATION.md, "the lane must decide where
+-- fields live before writing code, not during"):
+--
+-- 1. This does NOT reuse `magic_link_tokens` (migration 237). That table is
+--    the LIVE, already-shipped FASE 6 client-portal login mechanism
+--    (`backend/services/portal/magic_link_service.py`): it authenticates an
+--    already-registered `team_members` row by email, has no `result_id`,
+--    no `idempotency_key`, and no session-secret concept, and it has zero
+--    retention-policy binding of its own today. GARUDA's magic link
+--    authenticates an anonymous eligibility-check RESULT OWNER (result_id +
+--    email, no registration), needs `idempotency_key` on both operations,
+--    and mints an opaque account-session secret on exchange -- three fields
+--    that have no home on 237's row shape. Conflating the two would bolt
+--    GARUDA-only columns onto a shared table another product already
+--    writes in production, and would force retention/fail-closed machinery
+--    to also account for that product's traffic. A new, disjoint table is
+--    the smaller and safer surface; 237 is untouched by this migration.
+--
+-- 2. `account_session_secret` (the opaque bearer `exchangeMagicLink` mints
+--    and the router sets as the `garuda_session` cookie) has no home in any
+--    existing table. `backend/app/utils/cookie_auth.py` is a STATELESS JWT
+--    mechanism (`nz_access_token`) for the SAME reason 237 does not fit:
+--    a JWT cannot hold "opaque secret the server matches by hash", which
+--    the `MagicLinkStore` Protocol docstring makes a hard requirement
+--    (CodeQL `py/clear-text-storage-sensitive-data`, 2026-08-25 review).
+--    `garuda_orders_router.py:74` (`_require_magic_session_actor`) already
+--    expects exactly this shape -- a `garuda_session` cookie value that
+--    some verifier turns into an actor -- so this migration creates the
+--    table that verifier will read. Wiring that verifier onto
+--    `app.state.garuda_magic_session_verifier` is NOT done by this
+--    migration or this lane: `_require_magic_session_actor`'s own
+--    `verifier(cookie)` call is SYNCHRONOUS, which a real Postgres-backed
+--    check cannot satisfy without an `await` this lane does not own adding
+--    (`garuda_orders_router.py` is L3's file -- LANES.md file-ownership).
+--    Flagged for the orchestrator in the PR body, not fixed here.
+--
+-- Retention: widens the SAME Zero-approved authority migration 281 already
+-- widened for GARUDA_CHECK/GARUDA_ORDER (ARCHITECTURE.md D2, "one
+-- authority, not two") with a fourth scope, GARUDA_MAGIC_LINK, rather than
+-- inventing a table-specific policy. Deliberately NOT replicating 281's
+-- full legal-hold/purge/evidence machinery here: those exist for durable
+-- customer-decision records with a real retrospective-audit need; a
+-- magic-link token is a self-expiring (15-minute) authentication artefact,
+-- already sha256-hashed at rest, holding nothing an investigator would
+-- need to freeze mid-lifetime. Retention basis argued below, per row type.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- (0) Widen the one retention authority with a fourth scope
+-- ----------------------------------------------------------------------------
+
+DO $garuda_285_widen_scope_check$
+DECLARE
+    scope_check_name text;
+BEGIN
+    -- The inline `policy_scope ... CHECK (policy_scope IN (...))` column
+    -- constraint 281 added renders back as `CHECK ((policy_scope = ANY
+    -- (ARRAY[...])))` -- distinct from 281's OTHER policy_scope-mentioning
+    -- constraint (`visa_decision_retention_policies_scope_anchor`, which
+    -- renders as `CHECK ((policy_scope <> 'GARUDA_CHECK'::text) OR ...)`),
+    -- so this LIKE pattern picks the enum check alone. Same "find by shape,
+    -- never a hardcoded name" discipline 281 itself uses for the UNIQUE/
+    -- EXCLUDE constraints it widened.
+    SELECT conname INTO scope_check_name
+      FROM pg_constraint
+     WHERE conrelid = 'public.visa_decision_retention_policies'::regclass
+       AND contype = 'c'
+       AND pg_get_constraintdef(oid) LIKE 'CHECK ((policy_scope = ANY (ARRAY[%';
+    IF scope_check_name IS NULL THEN
+        RAISE EXCEPTION 'garuda 285: could not locate the policy_scope enum CHECK to widen';
+    END IF;
+    EXECUTE format(
+        'ALTER TABLE public.visa_decision_retention_policies DROP CONSTRAINT %I',
+        scope_check_name
+    );
+END;
+$garuda_285_widen_scope_check$;
+
+ALTER TABLE public.visa_decision_retention_policies
+    ADD CONSTRAINT visa_decision_retention_policies_policy_scope_check
+        CHECK (policy_scope IN ('VISA_DECISION', 'GARUDA_CHECK', 'GARUDA_ORDER', 'GARUDA_MAGIC_LINK'));
+
+-- Widen the "closing this policy would strand an existing binding" guard
+-- (264, already widened by 281) to also cover garuda_magic_link_tokens
+-- bindings, once the table exists below. CREATE OR REPLACE is safe: no
+-- applied migration's on-disk text is edited (253/267/268/281 precedent).
+CREATE OR REPLACE FUNCTION public.guard_visa_decision_retention_policy_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'visa_decision_retention_policies is append-only';
+    END IF;
+    IF (to_jsonb(OLD) - 'effective_period')
+           IS DISTINCT FROM (to_jsonb(NEW) - 'effective_period')
+       OR lower(OLD.effective_period) IS DISTINCT FROM lower(NEW.effective_period)
+       OR upper(OLD.effective_period) IS NOT NULL
+       OR upper(NEW.effective_period) IS NULL
+       OR upper(NEW.effective_period) <= lower(NEW.effective_period) THEN
+        RAISE EXCEPTION 'retention policy update may only close one open effective_period';
+    END IF;
+    IF EXISTS (
+        SELECT 1
+          FROM public.visa_decisions AS decision
+         WHERE decision.retention_policy_id = OLD.id
+           AND NOT (NEW.effective_period @> decision.evaluated_at)
+    ) OR EXISTS (
+        SELECT 1
+          FROM public.visa_evaluate_idempotency AS replay
+         WHERE replay.retention_policy_id = OLD.id
+           AND NOT (NEW.effective_period @> replay.reserved_at)
+    ) OR EXISTS (
+        SELECT 1
+          FROM public.garuda_voa_checks AS garuda_check
+         WHERE garuda_check.retention_policy_id = OLD.id
+           AND NOT (NEW.effective_period @> garuda_check.created_at)
+    ) OR EXISTS (
+        SELECT 1
+          FROM public.garuda_magic_link_tokens AS magic_link
+         WHERE magic_link.retention_policy_id = OLD.id
+           AND NOT (NEW.effective_period @> magic_link.created_at)
+    ) THEN
+        RAISE EXCEPTION 'retention policy close would strand an existing binding';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+-- ----------------------------------------------------------------------------
+-- (1) garuda_magic_link_tokens
+--
+-- Retention basis: a magic-link token is an authentication artefact with a
+-- fixed 15-minute TTL (`MAGIC_LINK_TTL_MINUTES`, magic_link.py). It has no
+-- reason to outlive its own expiry by more than the window a security
+-- investigation of a specific abuse report needs (e.g. "who requested links
+-- for this email in the days around an incident"). Chosen: 14 days past
+-- expiry -- long enough to cover a realistic report-and-look-back cycle,
+-- short enough that this table never becomes a de-facto email/result_id
+-- correlation log. This is a number to be confirmed by Zero like every
+-- other retention_interval in this repo (the INSERT below is a schema
+-- capability, not itself an approval) -- 14 days is proposed, not asserted
+-- as final.
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE public.garuda_magic_link_tokens (
+    token_hash          CHAR(64) PRIMARY KEY,  -- sha256 hex; raw token is NEVER persisted
+    result_id           TEXT NOT NULL CHECK (result_id ~ '^[A-Za-z0-9_-]{22,128}$'),
+    email               TEXT NOT NULL,
+    environment         TEXT NOT NULL CHECK (environment IN ('TEST', 'STAGING', 'PRODUCTION')),
+    expires_at          TIMESTAMPTZ NOT NULL,
+    used_at             TIMESTAMPTZ,
+    retention_policy_id UUID NOT NULL REFERENCES public.visa_decision_retention_policies (id),
+    retention_until     TIMESTAMPTZ NOT NULL,
+    -- NOW() (== transaction_timestamp()), NOT statement_timestamp(): the
+    -- retention-binding trigger below checks `NEW.created_at IS DISTINCT
+    -- FROM transaction_timestamp()` (281's exact convention for
+    -- garuda_voa_checks.created_at, migration 261 line 43 `DEFAULT NOW()`)
+    -- -- caught live: this INSERT is not the transaction's first statement
+    -- (the idempotency reservation runs first in the same transaction), so
+    -- statement_timestamp() here would differ from transaction_timestamp()
+    -- by the gap between the two statements and the trigger would reject
+    -- every real row.
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (expires_at > created_at)
+);
+
+COMMENT ON TABLE public.garuda_magic_link_tokens IS
+    'GARUDA VOA magic-link auth (L4). One row per issued link. token_hash is sha256 of the raw token -- raw token lives only in the email body.';
+COMMENT ON COLUMN public.garuda_magic_link_tokens.token_hash IS
+    'sha256 hex of the raw urlsafe token. Unique by being the primary key -- a collision here would mean two live tokens hash identically.';
+
+CREATE INDEX idx_garuda_magic_link_tokens_email_created
+    ON public.garuda_magic_link_tokens (email, created_at DESC);
+
+CREATE INDEX idx_garuda_magic_link_tokens_retention_purge
+    ON public.garuda_magic_link_tokens (retention_until);
+
+-- Fail-closed retention binding -- identical shape to
+-- `bind_garuda_voa_check_retention_policy` (281) and
+-- `active_garuda_order_policy_available` (284), scoped to
+-- GARUDA_MAGIC_LINK / CREATED_AT anchor (this table has no
+-- decision-evaluation timestamp distinct from row creation).
+CREATE FUNCTION public.active_garuda_magic_link_policy_available(
+    p_environment TEXT,
+    p_created_at TIMESTAMPTZ
+) RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, public
+AS $func$
+    SELECT count(*) = 1
+    FROM public.visa_decision_retention_policies
+    WHERE environment = p_environment
+      AND policy_scope = 'GARUDA_MAGIC_LINK'
+      AND effective_period @> p_created_at;
+$func$;
+
+COMMENT ON FUNCTION public.active_garuda_magic_link_policy_available IS
+    'Pre-INSERT read for PostgresMagicLinkStore.issue(): one Zero-approved GARUDA_MAGIC_LINK policy must cover this clock, or the funnel fails closed (PERSISTENCE_POLICY_UNAVAILABLE) before any row is attempted.';
+
+CREATE FUNCTION public.bind_garuda_magic_link_token_retention_policy()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $func$
+DECLARE
+    policy RECORD;
+    expected_until TIMESTAMPTZ;
+BEGIN
+    IF NEW.created_at IS DISTINCT FROM transaction_timestamp() THEN
+        RAISE EXCEPTION 'garuda magic-link token created_at must use the database transaction clock';
+    END IF;
+
+    BEGIN
+        SELECT id, retention_interval, retention_anchor
+          INTO STRICT policy
+          FROM public.visa_decision_retention_policies
+         WHERE environment = NEW.environment
+           AND policy_scope = 'GARUDA_MAGIC_LINK'
+           AND effective_period @> NEW.created_at
+         FOR SHARE;
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            RAISE EXCEPTION 'garuda magic-link token has no active Zero-approved retention policy';
+        WHEN TOO_MANY_ROWS THEN
+            RAISE EXCEPTION 'garuda magic-link token retention policy authority is ambiguous';
+    END;
+
+    IF policy.retention_anchor <> 'CREATED_AT' THEN
+        RAISE EXCEPTION 'unsupported retention anchor for GARUDA_MAGIC_LINK scope';
+    END IF;
+    expected_until := NEW.created_at + policy.retention_interval;
+    IF expected_until <= clock_timestamp() THEN
+        RAISE EXCEPTION 'garuda magic-link token retention deadline has already elapsed';
+    END IF;
+
+    IF NEW.retention_policy_id IS NOT NULL
+       AND NEW.retention_policy_id IS DISTINCT FROM policy.id THEN
+        RAISE EXCEPTION 'garuda magic-link token retention policy does not match active policy';
+    END IF;
+    IF NEW.retention_until IS NOT NULL
+       AND NEW.retention_until IS DISTINCT FROM expected_until THEN
+        RAISE EXCEPTION 'garuda magic-link token retention deadline does not match active policy';
+    END IF;
+
+    NEW.retention_policy_id := policy.id;
+    NEW.retention_until := expected_until;
+    RETURN NEW;
+END;
+$func$;
+
+REVOKE ALL ON FUNCTION public.bind_garuda_magic_link_token_retention_policy() FROM PUBLIC;
+
+CREATE TRIGGER garuda_magic_link_tokens_retention_binding
+BEFORE INSERT ON public.garuda_magic_link_tokens
+FOR EACH ROW EXECUTE FUNCTION public.bind_garuda_magic_link_token_retention_policy();
+
+-- Rows are immutable except the single-use `used_at` transition (NULL ->
+-- set, exactly once); deletion is only permitted once retention has
+-- actually elapsed. Same "close/consume, never silently mutate" discipline
+-- as `guard_garuda_order_idempotency_mutation` (284).
+CREATE FUNCTION public.guard_garuda_magic_link_token_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF clock_timestamp() < OLD.retention_until THEN
+            RAISE EXCEPTION 'unexpired garuda_magic_link_tokens rows are immutable';
+        END IF;
+        RETURN OLD;
+    END IF;
+    IF OLD.used_at IS NOT NULL AND NEW.used_at IS DISTINCT FROM OLD.used_at THEN
+        RAISE EXCEPTION 'garuda_magic_link_tokens.used_at is immutable once consumed';
+    END IF;
+    IF (to_jsonb(OLD) - 'used_at') IS DISTINCT FROM (to_jsonb(NEW) - 'used_at') THEN
+        RAISE EXCEPTION 'garuda_magic_link_tokens rows are immutable except used_at';
+    END IF;
+    RETURN NEW;
+END;
+$func$;
+
+CREATE TRIGGER trg_guard_garuda_magic_link_token_mutation
+BEFORE UPDATE OR DELETE ON public.garuda_magic_link_tokens
+FOR EACH ROW EXECUTE FUNCTION public.guard_garuda_magic_link_token_mutation();
+
+-- ----------------------------------------------------------------------------
+-- (2) garuda_magic_link_idempotency
+--
+-- Same shape as `garuda_order_idempotency` (284), generalized across BOTH
+-- `requestMagicLink` (issue) and `exchangeMagicLink` (exchange) -- reused
+-- per L4-CONTINUATION.md ("L3 already solved this shape ... reuse rather
+-- than invent a third"). No `order_id`-equivalent column: neither
+-- operation's cached response names a persistent resource id a replay
+-- would need to resume (`issue` is always an empty 202; `exchange`'s
+-- cached body carries only the non-secret ExchangeOutcome fields -- see
+-- `backend/services/garuda_portal/idempotency.py`).
+--
+-- Retention: a shorter fixed TTL than 284's 30 days -- these are auth
+-- replay-guards for a 15-minute-lived credential, not a payment record;
+-- 1 day comfortably covers any realistic client retry window without
+-- turning into a second correlation log alongside the tokens table above.
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE public.garuda_magic_link_idempotency (
+    key_sha256               BYTEA PRIMARY KEY CHECK (octet_length(key_sha256) = 32),
+    canonical_payload_sha256 BYTEA NOT NULL CHECK (octet_length(canonical_payload_sha256) = 32),
+    response_status          INT,
+    response_body            JSONB,
+    completed_at              TIMESTAMPTZ,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    expires_at                TIMESTAMPTZ NOT NULL DEFAULT (statement_timestamp() + INTERVAL '1 day'),
+    CHECK (expires_at > created_at),
+    CHECK (
+        (response_body IS NULL AND response_status IS NULL AND completed_at IS NULL)
+        OR (response_body IS NOT NULL AND response_status IS NOT NULL AND completed_at IS NOT NULL)
+    )
+);
+
+COMMENT ON TABLE public.garuda_magic_link_idempotency IS
+    'Idempotency-Key replay cache for requestMagicLink + exchangeMagicLink. Raw keys never stored -- only their scoped SHA-256 (backend.services.garuda_orders.idempotency.scoped_key_sha256).';
+
+CREATE INDEX idx_garuda_magic_link_idempotency_expires_at
+    ON public.garuda_magic_link_idempotency (expires_at);
+
+CREATE FUNCTION public.guard_garuda_magic_link_idempotency_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
+AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF clock_timestamp() < OLD.expires_at THEN
+            RAISE EXCEPTION 'unexpired garuda_magic_link_idempotency rows are immutable';
+        END IF;
+        RETURN OLD;
+    END IF;
+    IF OLD.key_sha256 IS DISTINCT FROM NEW.key_sha256
+       OR OLD.canonical_payload_sha256 IS DISTINCT FROM NEW.canonical_payload_sha256
+       OR OLD.created_at IS DISTINCT FROM NEW.created_at
+       OR OLD.expires_at IS DISTINCT FROM NEW.expires_at THEN
+        RAISE EXCEPTION 'garuda_magic_link_idempotency request binding is immutable';
+    END IF;
+    IF OLD.response_body IS NOT NULL THEN
+        RAISE EXCEPTION 'completed garuda_magic_link_idempotency rows are immutable';
+    END IF;
+    IF NEW.response_body IS NULL AND NEW.response_status IS NULL AND NEW.completed_at IS NULL THEN
+        RETURN NEW;
+    END IF;
+    IF NEW.response_body IS NULL OR NEW.response_status IS NULL OR NEW.completed_at IS NULL THEN
+        RAISE EXCEPTION 'garuda_magic_link_idempotency completion must be atomic';
+    END IF;
+    RETURN NEW;
+END;
+$func$;
+
+CREATE TRIGGER trg_guard_garuda_magic_link_idempotency_mutation
+BEFORE UPDATE OR DELETE ON public.garuda_magic_link_idempotency
+FOR EACH ROW EXECUTE FUNCTION public.guard_garuda_magic_link_idempotency_mutation();
+
+-- ----------------------------------------------------------------------------
+-- (3) garuda_account_sessions
+--
+-- The session `exchangeMagicLink` establishes (DECISIONS.md Q1: "a session
+-- whose lifetime is a separate decision (proposed: 30 days, re-authenticated
+-- by a new link)"). Fixed 30-day TTL per that proposed number, not a second
+-- Zero-approval policy gate -- same tier as the idempotency cache above
+-- (an operational-lifetime table, not a durable customer-decision record),
+-- not the tier `visa_decision_retention_policies` governs. `session_secret`
+-- itself is NEVER stored -- only its sha256 hash, matching the Protocol's
+-- hard requirement for every bearer the browser holds and presents back.
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE public.garuda_account_sessions (
+    session_secret_hash CHAR(64) PRIMARY KEY,  -- sha256 hex; raw secret lives only in the garuda_session cookie
+    result_id            TEXT NOT NULL CHECK (result_id ~ '^[A-Za-z0-9_-]{22,128}$'),
+    email                 TEXT NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    expires_at            TIMESTAMPTZ NOT NULL DEFAULT (statement_timestamp() + INTERVAL '30 days'),
+    CHECK (expires_at > created_at)
+);
+
+COMMENT ON TABLE public.garuda_account_sessions IS
+    'GARUDA VOA account session minted by exchangeMagicLink (L4). session_secret_hash is sha256 of the opaque bearer set as the garuda_session cookie -- raw value never persisted.';
+
+CREATE INDEX idx_garuda_account_sessions_expires_at
+    ON public.garuda_account_sessions (expires_at);
+
+-- === ROLLBACK ===
+
+DROP TABLE IF EXISTS public.garuda_account_sessions;
+DROP TRIGGER IF EXISTS trg_guard_garuda_magic_link_idempotency_mutation ON public.garuda_magic_link_idempotency;
+DROP FUNCTION IF EXISTS public.guard_garuda_magic_link_idempotency_mutation();
+DROP TABLE IF EXISTS public.garuda_magic_link_idempotency;
+DROP TRIGGER IF EXISTS trg_guard_garuda_magic_link_token_mutation ON public.garuda_magic_link_tokens;
+DROP FUNCTION IF EXISTS public.guard_garuda_magic_link_token_mutation();
+DROP TRIGGER IF EXISTS garuda_magic_link_tokens_retention_binding ON public.garuda_magic_link_tokens;
+DROP FUNCTION IF EXISTS public.bind_garuda_magic_link_token_retention_policy();
+DROP FUNCTION IF EXISTS public.active_garuda_magic_link_policy_available(TEXT, TIMESTAMPTZ);
+DROP TABLE IF EXISTS public.garuda_magic_link_tokens;
+ALTER TABLE public.visa_decision_retention_policies
+    DROP CONSTRAINT IF EXISTS visa_decision_retention_policies_policy_scope_check;
+ALTER TABLE public.visa_decision_retention_policies
+    ADD CONSTRAINT visa_decision_retention_policies_policy_scope_check
+        CHECK (policy_scope IN ('VISA_DECISION', 'GARUDA_CHECK', 'GARUDA_ORDER'));

--- a/apps/backend-rag/backend/services/garuda_portal/idempotency.py
+++ b/apps/backend-rag/backend/services/garuda_portal/idempotency.py
@@ -1,0 +1,119 @@
+"""Idempotency cache for GARUDA VOA magic-link customer commands
+(`requestMagicLink` issue, `exchangeMagicLink` exchange).
+
+Same scoped-identity + canonical-payload shape as
+`backend.services.garuda_orders.idempotency` (L3's `garuda_order_idempotency`)
+-- reused rather than reinvented (products/garuda-voa/L4-CONTINUATION.md:
+"L3 already solved this shape ... reuse that pattern rather than inventing
+a third"). `scoped_key_sha256` / `canonical_payload_sha256` / `IdempotencyConflict`
+are imported from there unchanged -- they are pure, table-agnostic hash
+helpers. Only `reserve`/`complete` are new here, against
+`garuda_magic_link_idempotency` (migration 285), because that table has no
+`order_id`-equivalent column: neither magic-link operation's cached response
+names a persistent resource id a replay would need to resume -- `issue` is
+always an empty 202, and `exchange`'s cached body carries only the
+non-secret `ExchangeOutcome` fields (never a raw token or session secret).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import asyncpg
+
+from backend.services.garuda_orders.idempotency import (
+    IdempotencyConflict,
+    canonical_payload_sha256,
+    scoped_key_sha256,
+)
+
+__all__ = [
+    "IdempotencyConflict",
+    "ReservationOutcome",
+    "canonical_payload_sha256",
+    "complete",
+    "reserve",
+    "scoped_key_sha256",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ReservationOutcome:
+    replayed: bool
+    """True: a COMPLETED prior attempt exists -- return its cached response,
+    never touch the token table or mint a second session for this key."""
+    response_status: int | None
+    response_body: dict[str, Any] | None
+
+
+async def reserve(
+    conn: asyncpg.Connection,
+    *,
+    key_sha256: bytes,
+    payload_sha256: bytes,
+) -> ReservationOutcome:
+    """Insert-or-inspect. Raises `IdempotencyConflict` on a payload mismatch.
+
+    Must be called inside the SAME transaction that performs the command's
+    actual side effect (token INSERT / atomic token consumption) -- a crash
+    between this call and that side effect rolls both back together, so
+    there is no partial-reservation state to resume, unlike L3's
+    order-creation flow (which spans an external payment-provider call and
+    therefore does need a resume path).
+    """
+    inserted = await conn.fetchrow(
+        """
+        INSERT INTO garuda_magic_link_idempotency (key_sha256, canonical_payload_sha256)
+        VALUES ($1, $2)
+        ON CONFLICT (key_sha256) DO NOTHING
+        RETURNING key_sha256
+        """,
+        key_sha256,
+        payload_sha256,
+    )
+    if inserted is not None:
+        return ReservationOutcome(replayed=False, response_status=None, response_body=None)
+
+    existing = await conn.fetchrow(
+        """
+        SELECT canonical_payload_sha256, response_status, response_body, completed_at
+          FROM garuda_magic_link_idempotency
+         WHERE key_sha256 = $1
+        """,
+        key_sha256,
+    )
+    if existing is None:  # pragma: no cover - row raced away by its own expiry cleanup
+        return ReservationOutcome(replayed=False, response_status=None, response_body=None)
+    if bytes(existing["canonical_payload_sha256"]) != payload_sha256:
+        raise IdempotencyConflict("Idempotency-Key bound to a different payload")
+    if existing["completed_at"] is None:
+        return ReservationOutcome(replayed=False, response_status=None, response_body=None)
+    body = existing["response_body"]
+    if isinstance(body, str):
+        body = json.loads(body)
+    return ReservationOutcome(
+        replayed=True,
+        response_status=existing["response_status"],
+        response_body=body,
+    )
+
+
+async def complete(
+    conn: asyncpg.Connection,
+    *,
+    key_sha256: bytes,
+    response_status: int,
+    response_body: dict[str, Any],
+) -> None:
+    await conn.execute(
+        """
+        UPDATE garuda_magic_link_idempotency
+           SET response_status = $2, response_body = $3, completed_at = statement_timestamp()
+         WHERE key_sha256 = $1
+        """,
+        key_sha256,
+        response_status,
+        json.dumps(response_body, default=str),
+    )

--- a/apps/backend-rag/backend/services/garuda_portal/magic_link_store.py
+++ b/apps/backend-rag/backend/services/garuda_portal/magic_link_store.py
@@ -1,0 +1,284 @@
+"""`PostgresMagicLinkStore` -- the concrete `MagicLinkStore` adapter
+(products/garuda-voa/L4-CONTINUATION.md part 2 of 3).
+
+Persists to `garuda_magic_link_tokens` / `garuda_magic_link_idempotency` /
+`garuda_account_sessions` (migration 285). See that migration's header for
+why this is a NEW table family rather than a reuse of `magic_link_tokens`
+(237, the unrelated FASE 6 client-portal login table).
+
+Every security property `magic_link.py`'s `MagicLinkStore` docstring
+requires is enforced HERE, not left to a caller:
+
+- The raw token/session-secret exist only transiently in this process's
+  memory (and, for the token, in the outgoing email body) -- only their
+  sha256 hex digest is ever written to a column, a log line, or an error
+  message.
+- Token consumption is ONE atomic
+  `UPDATE ... WHERE used_at IS NULL AND expires_at > NOW() RETURNING ...`
+  statement -- never a read-then-write -- so two concurrent `exchange`
+  calls for the same token race at the database row-lock level and exactly
+  one can ever observe a non-empty RETURNING set.
+- Unknown, expired, and already-consumed tokens all fall through the same
+  "0 rows returned" branch and produce the identical `ExchangeOutcome`
+  (DECISIONS.md Q1) -- there is no code path that inspects *why* the UPDATE
+  matched nothing.
+- `PersistencePolicyUnavailable` is raised BEFORE any row is attempted (a
+  pre-check against `active_garuda_magic_link_policy_available`), mirroring
+  `GarudaOrderRepository._active_order_policy_available` (L3) exactly --
+  never caught out of the retention trigger's own `RAISE EXCEPTION`, which
+  stays as pure defense-in-depth for a caller that skips the pre-check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import secrets
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+
+import asyncpg
+import httpx
+
+from backend.services.common.background import spawn
+from backend.services.garuda_portal import idempotency
+from backend.services.garuda_portal.magic_link import (
+    MAGIC_LINK_TTL_MINUTES,
+    ExchangeOutcome,
+    IssueOutcome,
+    PersistencePolicyUnavailable,
+)
+
+logger = logging.getLogger(__name__)
+
+#: DECISIONS.md Q1: "proposed: 30 days, re-authenticated by a new link".
+_ACCOUNT_SESSION_TTL_DAYS = 30
+
+_ISSUE_OPERATION = "requestMagicLink"
+_EXCHANGE_OPERATION = "exchangeMagicLink"
+
+#: Scoped-identity actor for magic-link commands. Neither operation is
+#: gated behind an existing session (the whole point is to BUILD one), so
+#: -- unlike L3's `_require_magic_session_actor`-derived actor -- there is
+#: no pre-existing identity to scope by. A fixed, endpoint-specific string
+#: is what `scoped_key_sha256` needs to keep this product's Idempotency-Key
+#: namespace disjoint from every other actor+operation pair in the system;
+#: it is not a secret and carries no per-caller information.
+_ACTOR = "garuda_magic_link"
+
+
+def _hash_hex(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+async def _default_send_magic_link_email(*, email: str, result_id: str, raw_token: str) -> None:
+    """Dispatch the magic-link email via Brevo (from=zantara@balizero.com --
+    CLAUDE.md fixed rule). Fire-and-forget by the caller (`spawn`); must
+    never raise into the request path -- a send failure is logged, never
+    surfaced to the enumeration-safe 202.
+
+    `GARUDA_MAGIC_LINK_BASE_URL` default is a placeholder pending frontend
+    confirmation (ARCHITECTURE.md does not yet name a canonical result-page
+    URL) -- this is a call made explicit here, not asserted as final.
+    """
+    base = os.getenv("GARUDA_MAGIC_LINK_BASE_URL", "https://balizero.com/visa/voa").rstrip("/")
+    link_url = f"{base}?result_id={result_id}&magic_token={raw_token}"
+    api_url = os.getenv(
+        "INTERNAL_EMAIL_API_URL",
+        "https://nuzantara-rag.fly.dev/api/notifications/send-email",
+    )
+    api_key = os.getenv("NUZANTARA_API_KEY", "")
+    html_body = (
+        "Hello,<br><br>"
+        "Use the secure link below to view your GARUDA VOA eligibility result. "
+        f"This link works once and expires in {MAGIC_LINK_TTL_MINUTES} minutes.<br><br>"
+        f'<a href="{link_url}">View my VOA result</a><br><br>'
+        "If you didn't request this, you can safely ignore this email.<br><br>"
+        "— Bali Zero"
+    )
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                api_url,
+                headers={"X-API-Key": api_key},
+                json={"to": email, "subject": "Your Bali Zero VOA result link", "body": html_body},
+            )
+            resp.raise_for_status()
+        logger.info("garuda_magic_link: email dispatched via Brevo")
+    except Exception:
+        logger.warning("garuda_magic_link: email send failed", exc_info=True)
+
+
+class PostgresMagicLinkStore:
+    """Concrete `MagicLinkStore` over migration 285's three tables.
+
+    Not yet wired via `app.dependency_overrides[get_garuda_magic_link_store]`
+    in `app_factory` -- see the PR body / migration 285 header. Until that
+    wiring lands, the mounted router keeps answering fail-closed via
+    `UnconfiguredMagicLinkStore`, exactly as it does today.
+    """
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        *,
+        environment: str,
+        send_email: Callable[..., Awaitable[None]] = _default_send_magic_link_email,
+    ) -> None:
+        self._pool = pool
+        self._environment = environment
+        self._send_email = send_email
+
+    async def _active_policy_available(self) -> bool:
+        async with self._pool.acquire() as conn:
+            return bool(
+                await conn.fetchval(
+                    "SELECT public.active_garuda_magic_link_policy_available($1, $2)",
+                    self._environment,
+                    datetime.now(UTC),
+                )
+            )
+
+    async def issue(
+        self,
+        *,
+        idempotency_key: str,
+        result_id: str,
+        email: str,
+        result_session_secret: str,
+    ) -> IssueOutcome:
+        del result_session_secret  # not persisted -- see magic_link.py Protocol docstring
+
+        if not await self._active_policy_available():
+            raise PersistencePolicyUnavailable("no active GARUDA_MAGIC_LINK retention policy")
+
+        key_hash = idempotency.scoped_key_sha256(
+            actor=_ACTOR, operation=_ISSUE_OPERATION, raw_key=idempotency_key
+        )
+        payload_hash = idempotency.canonical_payload_sha256(
+            {"result_id": result_id, "email": email}
+        )
+
+        raw_token = secrets.token_urlsafe(32)
+        token_hash = _hash_hex(raw_token)
+        expires_at = datetime.now(UTC) + timedelta(minutes=MAGIC_LINK_TTL_MINUTES)
+
+        async with self._pool.acquire() as conn, conn.transaction():
+            reservation = await idempotency.reserve(
+                conn, key_sha256=key_hash, payload_sha256=payload_hash
+            )
+            if reservation.replayed:
+                return IssueOutcome(idempotency_replayed=True)
+
+            await conn.execute(
+                """
+                INSERT INTO garuda_magic_link_tokens (token_hash, result_id, email, environment, expires_at)
+                VALUES ($1, $2, $3, $4, $5)
+                """,
+                token_hash,
+                result_id,
+                email,
+                self._environment,
+                expires_at,
+            )
+            await idempotency.complete(
+                conn, key_sha256=key_hash, response_status=202, response_body={}
+            )
+
+        # Outside the transaction and fire-and-forget: an email-send failure
+        # must never roll back the token row or change the 202 the router
+        # already returned by the time this task runs.
+        spawn(
+            self._send_email(email=email, result_id=result_id, raw_token=raw_token),
+            name="garuda-magic-link-email",
+        )
+        return IssueOutcome(idempotency_replayed=False)
+
+    async def exchange(
+        self,
+        *,
+        idempotency_key: str,
+        token: str,
+    ) -> ExchangeOutcome:
+        token_hash = _hash_hex(token)
+        key_hash = idempotency.scoped_key_sha256(
+            actor=_ACTOR, operation=_EXCHANGE_OPERATION, raw_key=idempotency_key
+        )
+        # The canonical payload binds on the token's HASH, never the raw
+        # bearer -- token_hash is already the non-secret value this table
+        # uses as its primary key, so this never leaks the raw token any
+        # further than the tokens table already does.
+        payload_hash = idempotency.canonical_payload_sha256({"token_hash": token_hash})
+
+        async with self._pool.acquire() as conn, conn.transaction():
+            reservation = await idempotency.reserve(
+                conn, key_sha256=key_hash, payload_sha256=payload_hash
+            )
+            if reservation.replayed:
+                body = reservation.response_body or {}
+                return ExchangeOutcome(
+                    authorized=bool(body.get("authorized", False)),
+                    security_counter=str(body.get("security_counter", "magic_link_replay")),
+                    result_id=body.get("result_id"),
+                    account_session_secret=None,  # replay never re-emits the secret
+                    idempotency_replayed=True,
+                )
+
+            row = await conn.fetchrow(
+                """
+                UPDATE garuda_magic_link_tokens
+                   SET used_at = statement_timestamp()
+                 WHERE token_hash = $1
+                   AND used_at IS NULL
+                   AND expires_at > statement_timestamp()
+                RETURNING result_id, email
+                """,
+                token_hash,
+            )
+
+            if row is None:
+                outcome_body = {"authorized": False, "security_counter": "magic_link_invalid"}
+                await idempotency.complete(
+                    conn, key_sha256=key_hash, response_status=401, response_body=outcome_body
+                )
+                return ExchangeOutcome(
+                    authorized=False, security_counter="magic_link_invalid"
+                )
+
+            result_id = row["result_id"]
+            email = row["email"]
+
+            raw_secret = secrets.token_urlsafe(32)
+            secret_hash = _hash_hex(raw_secret)
+            session_expires_at = datetime.now(UTC) + timedelta(days=_ACCOUNT_SESSION_TTL_DAYS)
+            await conn.execute(
+                """
+                INSERT INTO garuda_account_sessions (session_secret_hash, result_id, email, expires_at)
+                VALUES ($1, $2, $3, $4)
+                """,
+                secret_hash,
+                result_id,
+                email,
+                session_expires_at,
+            )
+
+            outcome_body = {
+                "authorized": True,
+                "security_counter": "magic_link_authorized",
+                "result_id": result_id,
+            }
+            await idempotency.complete(
+                conn, key_sha256=key_hash, response_status=204, response_body=outcome_body
+            )
+
+        return ExchangeOutcome(
+            authorized=True,
+            security_counter="magic_link_authorized",
+            result_id=result_id,
+            account_session_secret=raw_secret,
+            idempotency_replayed=False,
+        )
+
+
+__all__ = ["PostgresMagicLinkStore"]

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_portal_auth_mounted.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_portal_auth_mounted.py
@@ -1,0 +1,101 @@
+"""Acceptance #5/#6 (products/garuda-voa/L4-CONTINUATION.md): the magic-link
+router answers on the REAL mounted application, and the GARUDA_PUBLIC_ENABLED
+flag is checked per-request rather than at mount time.
+
+Follows `test_garuda_voa_openapi_parity.py`'s precedent for "real mounted
+app" (module docstring there): importing `backend.app.main_api` builds the
+actual `create_api_app()` object uvicorn serves in production, as a
+module-scope side effect paid once per pytest worker. A bare `FastAPI()` +
+`include_router(...)` (what `test_garuda_portal_auth.py` uses for its
+fast, store-focused journey tests) would not prove reachability through the
+real router-manifest + registration wiring this file exists to check.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Building `main_api.app` is the point — see module docstring above and
+# `test_garuda_voa_openapi_parity.py`'s identical precedent/cost note.
+from backend.app import main_api as _main_api_module
+from backend.app.routers import garuda_portal_auth
+from backend.services.garuda_portal.magic_link import IssueOutcome
+
+VALID_RESULT_ID = "r" * 22
+VALID_RESULT_SESSION = "s" * 43
+VALID_IDEMPOTENCY_KEY = "test-key-mounted-0123456789"
+
+
+class _AlwaysIssuesStore:
+    async def issue(self, **kwargs):
+        return IssueOutcome(idempotency_replayed=False)
+
+    async def exchange(self, **kwargs):  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+
+@pytest.fixture
+def mounted_client(monkeypatch):
+    """The real `main_api.app`, with only the store dependency overridden
+    (the one seam `magic_link.py`'s own docstring names as the intended
+    wiring point) -- routing, manifest registration, and every other
+    dependency are the production ones.
+    """
+    app = _main_api_module.app
+    app.dependency_overrides[garuda_portal_auth.get_garuda_magic_link_store] = (
+        lambda: _AlwaysIssuesStore()
+    )
+    try:
+        yield app
+    finally:
+        app.dependency_overrides.pop(garuda_portal_auth.get_garuda_magic_link_store, None)
+
+
+async def _post_magic_link(app, *, enabled: bool) -> int:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/visa/voa/auth/magic-links",
+            json={"result_id": VALID_RESULT_ID, "email": "visitor@example.com"},
+            headers={"Idempotency-Key": VALID_IDEMPOTENCY_KEY},
+            cookies={"garuda_result_session": VALID_RESULT_SESSION},
+        )
+        return response.status_code
+
+
+@pytest.mark.asyncio
+async def test_router_is_reachable_through_the_real_mounted_app(mounted_client, monkeypatch):
+    """Acceptance #5: a request through `main_api.app` -- built via the
+    manifest + `router_registration.py` wiring this PR added -- reaches
+    the router at all (not a bare FastAPI() built only in a test file).
+    Before this PR's mount, `garuda_portal_auth` had no manifest entry and
+    no `include_router` call anywhere main_api assembles from, so this
+    exact request would 404 at the FastAPI routing layer (no matching
+    route), not at the handler's own GARUDA_PUBLIC_DISABLED branch.
+    """
+    monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "true")
+    status = await _post_magic_link(mounted_client, enabled=True)
+    assert status == 202, (
+        "expected the mounted requestMagicLink handler to answer 202 -- "
+        f"got {status}, which would mean the router never mounted (404) or "
+        "some other regression"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flag_is_checked_per_request_not_at_mount(mounted_client, monkeypatch):
+    """Acceptance #6: GARUDA_PUBLIC_ENABLED off/on is re-read on EVERY
+    request by the handler itself (`_public_enabled()`), not baked in at
+    mount time -- the router mounts unconditionally (no `condition=` on its
+    RouterEntry, matching garuda_voa_public/garuda_orders_router), so
+    toggling the env var between two requests against the SAME already-
+    mounted app must change the outcome without remounting anything.
+    """
+    monkeypatch.delenv("GARUDA_PUBLIC_ENABLED", raising=False)
+    disabled_status = await _post_magic_link(mounted_client, enabled=False)
+    assert disabled_status == 404
+
+    monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "true")
+    enabled_status = await _post_magic_link(mounted_client, enabled=True)
+    assert enabled_status == 202

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_magic_link_store_integration.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_magic_link_store_integration.py
@@ -1,0 +1,353 @@
+"""Real-database integration tests for `PostgresMagicLinkStore`
+(products/garuda-voa/L4-CONTINUATION.md part 2 of 3, "Acceptance" section).
+
+DSN resolution mirrors `garuda_orders/test_repository_integration.py`
+(`INTAKE_TEST_DSN`, the variable this repo's CI already sets, with
+`GARUDA_L4_TEST_DSN` as an optional local override) and the same
+CI-fails-loud-not-skip posture: this file's tests are the money-adjacent
+auth path (a red here means a real double-authorization or a leaked
+secret), not something a missing local Postgres should quietly hide in CI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import secrets
+import uuid
+
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from backend.services.garuda_portal.magic_link import (
+    ExchangeOutcome,
+    PersistencePolicyUnavailable,
+)
+from backend.services.garuda_portal.magic_link_store import PostgresMagicLinkStore
+
+_DSN = (
+    os.environ.get("GARUDA_L4_TEST_DSN")
+    or os.environ.get("INTAKE_TEST_DSN")
+    or "postgresql://localhost:5432/nuzantara_test"
+)
+
+_RESULT_ID = "result-l4-store-0000000"
+_EMAIL = "visitor@example.com"
+
+
+class _CapturingSender:
+    """Fake `send_email` — captures the raw token instead of calling Brevo.
+
+    This IS the seam the real adapter's email dispatch never lets a caller
+    (or a test) see the raw token any other way: `IssueOutcome` structurally
+    carries no token field (magic_link.py docstring), so the only place a
+    test can observe the value the store minted is this injection point —
+    exactly mirroring how the real email body is the one place it lives.
+    """
+
+    def __init__(self) -> None:
+        self.queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def __call__(self, *, email: str, result_id: str, raw_token: str) -> None:
+        await self.queue.put(raw_token)
+
+
+async def _ensure_garuda_magic_link_test_policy(conn: asyncpg.Connection) -> str:
+    """Install this suite's own Zero-approved GARUDA_MAGIC_LINK retention
+    policy fixture — same self-heal-first + unbackdated-lower-bound
+    discipline as `garuda_orders/test_repository_integration.py`'s
+    `_ensure_garuda_order_test_policy` (that function's docstring is the
+    full rationale; not re-derived here to avoid the two drifting apart).
+    """
+    await conn.execute(
+        """
+        UPDATE public.visa_decision_retention_policies
+           SET effective_period = tstzrange(lower(effective_period), clock_timestamp(), '[)')
+         WHERE environment = 'TEST' AND policy_scope = 'GARUDA_MAGIC_LINK'
+           AND upper(effective_period) IS NULL
+        """
+    )
+    policy_version = f"l4-test-fixture-{uuid.uuid4().hex[:16]}"
+    await conn.execute(
+        """
+        INSERT INTO public.visa_decision_retention_policies (
+            environment, policy_scope, policy_version, retention_interval,
+            idempotency_retention_interval, legal_hold_review_interval,
+            retention_anchor, effective_period, approved_by, approval_reference
+        ) VALUES (
+            'TEST', 'GARUDA_MAGIC_LINK', $1, INTERVAL '14 days',
+            INTERVAL '1 hour', INTERVAL '30 days',
+            'CREATED_AT', tstzrange(clock_timestamp(), NULL, '[)'),
+            'zero-test-approver', 'ZERO-GARUDA-MAGIC-LINK-RETENTION-TEST-APPROVAL'
+        )
+        ON CONFLICT DO NOTHING
+        """,
+        policy_version,
+    )
+    return policy_version
+
+
+async def _close_garuda_magic_link_test_policy(conn: asyncpg.Connection, policy_version: str) -> None:
+    await conn.execute(
+        """
+        UPDATE public.visa_decision_retention_policies
+           SET effective_period = tstzrange(lower(effective_period), clock_timestamp(), '[)')
+         WHERE policy_scope = 'GARUDA_MAGIC_LINK'
+           AND policy_version = $1
+           AND upper(effective_period) IS NULL
+        """,
+        policy_version,
+    )
+
+
+@pytest.fixture
+async def pool():
+    try:
+        p = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=4)
+    except (OSError, asyncpg.PostgresError) as exc:
+        if os.environ.get("CI"):
+            pytest.fail(
+                f"CI has no reachable Postgres for INTAKE_TEST_DSN "
+                f"(or GARUDA_L4_TEST_DSN override) -- {_DSN!r} unreachable: {exc}. "
+                f"This file gates the magic-link auth path; it must never "
+                f"silently pass by skipping."
+            )
+        pytest.skip(f"no local Postgres reachable at {_DSN}: {exc}")
+    async with p.acquire() as conn:
+        await conn.execute(
+            "TRUNCATE garuda_account_sessions, garuda_magic_link_idempotency, garuda_magic_link_tokens"
+        )
+        policy_version = await _ensure_garuda_magic_link_test_policy(conn)
+    yield p
+    async with p.acquire() as conn:
+        await _close_garuda_magic_link_test_policy(conn, policy_version)
+    await p.close()
+
+
+@pytest.fixture
+def store(pool):
+    return PostgresMagicLinkStore(pool, environment="TEST", send_email=_CapturingSender())
+
+
+async def _issue_and_capture_token(store: PostgresMagicLinkStore, *, idempotency_key: str) -> str:
+    outcome = await store.issue(
+        idempotency_key=idempotency_key,
+        result_id=_RESULT_ID,
+        email=_EMAIL,
+        result_session_secret="result-session-cookie-secret",
+    )
+    assert outcome.idempotency_replayed is False
+    sender = store._send_email  # the _CapturingSender injected by the `store` fixture
+    return await asyncio.wait_for(sender.queue.get(), timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #1/#2 — single-use is atomic under real concurrency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_exchanges_of_the_same_token_exactly_one_wins(pool, store):
+    """Two DIFFERENT Idempotency-Keys (never a replay of each other) racing
+    the SAME token: the atomic `UPDATE ... WHERE used_at IS NULL` predicate
+    is what this test proves. Manually verified red/green (modus VERIFY,
+    2026-08-25): with the `AND used_at IS NULL` clause removed from
+    `PostgresMagicLinkStore.exchange`'s UPDATE, this test went RED --
+    `asyncpg.exceptions.RaiseError: garuda_magic_link_tokens.used_at is
+    immutable once consumed`, thrown by the migration 285 DB-level guard
+    trigger (`guard_garuda_magic_link_token_mutation`) when the second
+    concurrent UPDATE tried to overwrite an already-consumed row. This is
+    the correct red shape, not a softer one: it shows the atomic app-layer
+    predicate and the DB-level immutability guard are two INDEPENDENT
+    barriers against the same double-authorization, not one guard wearing
+    two hats -- removing either one alone still fails closed via the
+    other. Restoring the clause returned this test to green (exactly one
+    winner, one loser, no unhandled exception).
+    """
+    raw_token = await _issue_and_capture_token(store, idempotency_key="issue-key-concurrency-1")
+
+    results = await asyncio.gather(
+        store.exchange(idempotency_key="exchange-key-A", token=raw_token),
+        store.exchange(idempotency_key="exchange-key-B", token=raw_token),
+    )
+
+    authorized = [r for r in results if r.authorized]
+    denied = [r for r in results if not r.authorized]
+    assert len(authorized) == 1, f"expected exactly one winner, got {results!r}"
+    assert len(denied) == 1, f"expected exactly one loser, got {results!r}"
+    assert authorized[0].account_session_secret is not None
+    assert denied[0].account_session_secret is None
+    assert denied[0].security_counter == "magic_link_invalid"
+
+    async with pool.acquire() as conn:
+        sessions = await conn.fetchval("SELECT count(*) FROM garuda_account_sessions")
+    assert sessions == 1, "exactly one session row may exist for a single-use token"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #3 — unknown / expired / consumed are byte-identical
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_expired_and_consumed_tokens_are_byte_identical(pool, store):
+    # Unknown: never issued.
+    unknown = await store.exchange(
+        idempotency_key="exchange-key-unknown", token=secrets.token_urlsafe(32)
+    )
+
+    # Expired: inserted directly (bypassing store.issue, which always mints
+    # a fresh 15-minute TTL) with a TTL short enough to have elapsed by the
+    # time we exchange it -- the CHECK (expires_at > created_at) constraint
+    # forbids constructing an already-past expiry directly, and the
+    # immutability guard forbids backdating expires_at after the fact, so a
+    # short real TTL is the only way to reach this state honestly.
+    expired_raw_token = secrets.token_urlsafe(32)
+    expired_hash = hashlib.sha256(expired_raw_token.encode()).hexdigest()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO garuda_magic_link_tokens (token_hash, result_id, email, environment, expires_at)
+            VALUES ($1, $2, $3, 'TEST', statement_timestamp() + INTERVAL '50 milliseconds')
+            """,
+            expired_hash,
+            _RESULT_ID,
+            _EMAIL,
+        )
+    await asyncio.sleep(0.25)
+    expired = await store.exchange(idempotency_key="exchange-key-expired", token=expired_raw_token)
+
+    # Consumed: issue + exchange for real, then exchange AGAIN under a
+    # different (non-replay) Idempotency-Key.
+    consumed_raw_token = await _issue_and_capture_token(store, idempotency_key="issue-key-consumed")
+    first = await store.exchange(idempotency_key="exchange-key-consumed-first", token=consumed_raw_token)
+    assert first.authorized is True
+    consumed = await store.exchange(
+        idempotency_key="exchange-key-consumed-second", token=consumed_raw_token
+    )
+
+    expected = ExchangeOutcome(authorized=False, security_counter="magic_link_invalid")
+    assert unknown == expected
+    assert expired == expected
+    assert consumed == expected
+    assert unknown == expired == consumed
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #4 — the raw token / raw session secret / result-session
+# secret never reach a DB column or a log line.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raw_secrets_never_reach_db_columns_or_logs(pool, store, caplog):
+    caplog.set_level(logging.DEBUG, logger="backend.services.garuda_portal.magic_link_store")
+    presented_result_session_secret = "cookie-value-" + secrets.token_urlsafe(16)
+
+    outcome = await store.issue(
+        idempotency_key="issue-key-secrecy",
+        result_id=_RESULT_ID,
+        email=_EMAIL,
+        result_session_secret=presented_result_session_secret,
+    )
+    assert outcome.idempotency_replayed is False
+    raw_token = await asyncio.wait_for(store._send_email.queue.get(), timeout=2)
+
+    exchange_outcome = await store.exchange(idempotency_key="exchange-key-secrecy", token=raw_token)
+    assert exchange_outcome.authorized is True
+    assert exchange_outcome.account_session_secret
+
+    async with pool.acquire() as conn:
+        all_rows = []
+        for table in (
+            "garuda_magic_link_tokens",
+            "garuda_account_sessions",
+            "garuda_magic_link_idempotency",
+        ):
+            all_rows.extend(await conn.fetch(f"SELECT * FROM {table}"))
+        dumped_rows = "".join(repr(row) for row in all_rows)
+
+    for secret_value, label in (
+        (raw_token, "raw magic-link token"),
+        (exchange_outcome.account_session_secret, "raw account-session secret"),
+        (presented_result_session_secret, "presented result-session secret"),
+    ):
+        assert secret_value not in dumped_rows, f"{label} leaked into a DB column"
+        assert secret_value not in caplog.text, f"{label} leaked into a log line"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed pre-check (mirrors GarudaOrderRepository's
+# `_active_order_policy_available` gate, L3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_fails_closed_with_no_active_policy_for_the_environment(pool):
+    # 'STAGING' has no policy row installed by this suite's fixture (only
+    # 'TEST' does) -- issue() must refuse before writing anything.
+    staging_store = PostgresMagicLinkStore(pool, environment="STAGING", send_email=_CapturingSender())
+    with pytest.raises(PersistencePolicyUnavailable):
+        await staging_store.issue(
+            idempotency_key="issue-key-no-policy",
+            result_id=_RESULT_ID,
+            email=_EMAIL,
+            result_session_secret="whatever",
+        )
+    async with pool.acquire() as conn:
+        count = await conn.fetchval(
+            "SELECT count(*) FROM garuda_magic_link_tokens WHERE environment = 'STAGING'"
+        )
+    assert count == 0, "a fail-closed issue() must not write a token row"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency replay — issue and exchange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_replay_is_a_noop_second_call(pool, store):
+    first = await store.issue(
+        idempotency_key="issue-key-replay",
+        result_id=_RESULT_ID,
+        email=_EMAIL,
+        result_session_secret="secret-1",
+    )
+    assert first.idempotency_replayed is False
+    second = await store.issue(
+        idempotency_key="issue-key-replay",
+        result_id=_RESULT_ID,
+        email=_EMAIL,
+        result_session_secret="secret-1",
+    )
+    assert second.idempotency_replayed is True
+
+    async with pool.acquire() as conn:
+        count = await conn.fetchval("SELECT count(*) FROM garuda_magic_link_tokens")
+    assert count == 1, "a replayed issue must not mint a second token"
+
+
+@pytest.mark.asyncio
+async def test_exchange_replay_returns_same_outcome_without_a_second_session(pool, store):
+    raw_token = await _issue_and_capture_token(store, idempotency_key="issue-key-exchange-replay")
+
+    first = await store.exchange(idempotency_key="exchange-key-replay", token=raw_token)
+    assert first.authorized is True
+    assert first.idempotency_replayed is False
+    assert first.account_session_secret is not None
+
+    second = await store.exchange(idempotency_key="exchange-key-replay", token=raw_token)
+    assert second.authorized is True
+    assert second.idempotency_replayed is True
+    assert second.result_id == first.result_id
+    # DECISIONS.md / router contract: a replay never re-emits the secret
+    # (the router only Set-Cookies on a fresh, non-replayed exchange).
+    assert second.account_session_secret is None
+
+    async with pool.acquire() as conn:
+        count = await conn.fetchval("SELECT count(*) FROM garuda_account_sessions")
+    assert count == 1, "a replayed exchange must not mint a second session"


### PR DESCRIPTION
## Summary

Part 2 of 3 of L4 (products/garuda-voa/L4-CONTINUATION.md), landed after #4871 (seam + archived-client cure). This PR ships:

1. **Migration 285** — `garuda_magic_link_tokens`, `garuda_magic_link_idempotency`, `garuda_account_sessions`, plus a fourth `GARUDA_MAGIC_LINK` scope on the shared `visa_decision_retention_policies` authority (widens 281's pattern, not a second policy table).
2. **`PostgresMagicLinkStore`** — the concrete `MagicLinkStore` adapter.
3. **Router mount** — `garuda_portal_auth` via `router_manifest.py` + both `include_routers()`/`include_light_routers()`.

### Decision made explicit (per the spec's instruction to decide before coding, not during)

`magic_link_tokens` (migration 237) is **not reused**. It's the live, already-shipped FASE-6 client-portal login table (registered `team_members` clients, no `result_id`, no `idempotency_key`, no session-secret concept, no retention binding of its own). GARUDA's magic link authenticates an anonymous eligibility-check result owner — a different identity model entirely. Conflating them would bolt GARUDA-only columns onto a table another product writes in production today. Full rationale in the migration's header comment.

`account_session_secret` has no home in any existing session mechanism: `cookie_auth.py` is stateless JWT (can't hold "opaque secret matched by hash", which the Protocol docstring requires). New table `garuda_account_sessions` — this is exactly the shape `garuda_orders_router.py:74` (`_require_magic_session_actor`) already expects to read, but wiring that verifier onto `app.state.garuda_magic_session_verifier` is **not done here**: that call site is synchronous (`actor = verifier(cookie)`, no `await`) and cannot run a real Postgres check without an `await` I don't own adding (L3's file). Flagged for the orchestrator.

### Discovered bug (fixed for this lane's own prefix only)

Testing acceptance criterion #5 ("through the real mounted app") found the router 401'd through `main_api.app` even after mounting — `backend/app/auth/public_endpoints.py` had no entry for it, so `HybridAuthMiddleware` rejected every anonymous call. Added `/api/visa/voa/auth/` (this PR's own disjoint prefix).

**The same gap exists on `/api/visa/voa` itself** (L2's `garuda_voa_public.py` + L3's `garuda_orders_router.py`, both already merged) — their public routes 401 in production today too. **Not fixed here**: cross-lane files, and `garuda_orders_router.py` also mounts a staff-only `/api/visa/voa/staff/...` route that a careless blanket prefix would need to carve out correctly. Flagging for the orchestrator to dispatch as its own fix.

## Acceptance — bite proofs (all run against a real local Postgres, migrations 261-285 applied)

**#1/#2 — single-use is atomic under real concurrency**, manually verified red/green: removing `AND used_at IS NULL` from the UPDATE turned the concurrency test **red** — `asyncpg.exceptions.RaiseError: garuda_magic_link_tokens.used_at is immutable once consumed`, thrown by the migration's own DB-level guard trigger on the second concurrent UPDATE. This is two independent barriers (app-layer atomic predicate + DB-level immutability guard), not one wearing two hats. Restoring the clause returned it to green.

```
PYTHONPATH=. pytest backend/tests/services/garuda_portal/test_magic_link_store_integration.py::test_two_concurrent_exchanges_of_the_same_token_exactly_one_wins -v
```

**#3 — unknown/expired/consumed are byte-identical** (full `ExchangeOutcome` equality, not just HTTP status):

```
PYTHONPATH=. pytest backend/tests/services/garuda_portal/test_magic_link_store_integration.py::test_unknown_expired_and_consumed_tokens_are_byte_identical -v
```

**#4 — raw token / raw session secret / presented result-session secret never reach a DB column or a log line** (greps every row of all 3 tables + `caplog.text`):

```
PYTHONPATH=. pytest backend/tests/services/garuda_portal/test_magic_link_store_integration.py::test_raw_secrets_never_reach_db_columns_or_logs -v
```

**#5/#6 — the real mounted app, flag checked per-request**:

```
PYTHONPATH=. pytest backend/tests/app/routers/test_garuda_portal_auth_mounted.py -v
```

**Mount + registry gates**:

```
PYTHONPATH=. pytest backend/tests/setup/test_router_manifest.py backend/tests/setup/test_manifest_registration_parity.py -q
PYTHONPATH=. pytest backend/tests/unit/middleware/test_public_endpoints_registry.py -q
```

**Full suite for this PR's surface** (6 + 2 new tests, plus existing router/seam tests):

```
PYTHONPATH=. pytest backend/tests/services/garuda_portal/ backend/tests/app/routers/test_garuda_portal_auth.py backend/tests/app/routers/test_garuda_portal_auth_mounted.py -v
```

## Not done by this lane (explicit)

- `app.dependency_overrides[get_garuda_magic_link_store]` wiring into the real running app — orchestrator step, same open item as L3's `app.state.garuda_order_repository`/`garuda_db_pool` and `app.state.garuda_magic_session_verifier`.
- Part 3 (portal practice view, parcel tracker, visa delivery page) — unchanged from the mandate, not this PR's scope.
- The `/api/visa/voa` public_endpoints gap on L2/L3's already-merged routers (see above).

## Test plan

- [x] Migration 285 applies cleanly on a fresh local Postgres (261→285 chain)
- [x] All 8 new tests pass
- [x] Existing `garuda_portal` seam/router tests unaffected
- [x] `test_router_manifest.py` + `test_manifest_registration_parity.py` green
- [x] `test_public_endpoints_registry.py` green with the new entry
- [x] Manual red/green proof on the concurrency claim

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>