### PR TITLE
fix(mouth): GARUDA VOA hero jargon, above-fold first step, dead Back button

### DIFF
--- a/apps/mouth/src/app/visa/voa/page.test.tsx
+++ b/apps/mouth/src/app/visa/voa/page.test.tsx
@@ -125,3 +125,36 @@ describe("VoaEligibilityPage — wire contract", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("VoaEligibilityPage — customer-facing surface", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    fetchMock.mockReset();
+  });
+
+  it("never leaks an internal service/class name (PricingTool etc.) into rendered copy", () => {
+    render(<VoaEligibilityPage />);
+    const rendered = document.body.textContent ?? "";
+    // Guards the class of bug, not just the one string: any
+    // TitleCase-word-immediately-followed-by-"Tool" token (PricingTool,
+    // EligibilityTool, ...) is an internal identifier, never customer copy.
+    expect(rendered).not.toMatch(/[A-Z][a-zA-Z]*Tool\b/);
+  });
+
+  it("has no Back control on step 1 (there is nowhere to go back to)", () => {
+    render(<VoaEligibilityPage />);
+    expect(
+      screen.queryByRole("button", { name: "Back" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Back control from step 2 onward", () => {
+    render(<VoaEligibilityPage />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Get a new Visa on Arrival/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/visa/voa/page.tsx
+++ b/apps/mouth/src/app/visa/voa/page.tsx
@@ -483,7 +483,7 @@ export default function VoaEligibilityPage() {
           items={[
             { value: "4", label: "quick questions" },
             { value: "1", label: "all-inclusive price" },
-            { value: "0", label: "prices invented (all from PricingTool)" },
+            { value: "0", label: "extra to pay the government after" },
           ]}
         />
       }

--- a/packages/core/components/apps/AppFrame.tsx
+++ b/packages/core/components/apps/AppFrame.tsx
@@ -39,6 +39,15 @@ export const AppFrame: FC<AppFrameProps> = ({
         padding: "var(--space-5, 2rem) var(--space-4, 1.5rem)",
         display: "grid",
         gap: "var(--space-5, 2rem)",
+        // Without this, the 3 implicit rows (header / trust strip / main)
+        // stretch to fill the leftover space that `minHeight: 100vh` creates
+        // once content is shorter than the viewport — CSS Grid's default
+        // `align-content: normal` behaves as `stretch` for auto row tracks.
+        // That silently pushed every funnel's first interactive step below
+        // the fold (measured on GARUDA VOA: ~260px of dead stretch at
+        // 1280x900). `start` makes rows size to content; minHeight still
+        // guarantees a full-height page.
+        alignContent: "start",
         minHeight: "100vh",
         background: "var(--surface-base)",
         color: "var(--text-primary, rgba(255, 255, 255, 0.96))",

--- a/packages/core/components/apps/AppFrame.tsx
+++ b/packages/core/components/apps/AppFrame.tsx
@@ -38,16 +38,29 @@ export const AppFrame: FC<AppFrameProps> = ({
         margin: "0 auto",
         padding: "var(--space-5, 2rem) var(--space-4, 1.5rem)",
         display: "grid",
+        // Explicit row sizing, not implicit `auto` for every row. Without
+        // this, CSS Grid's default `align-content: normal` behaves as
+        // `stretch` for auto row tracks: once real content is shorter than
+        // the `minHeight: 100vh` below, ALL rows (header / trust strip /
+        // main / footer) stretch equally to eat the leftover space. That
+        // silently pushed every funnel's first interactive step below the
+        // fold (measured on GARUDA VOA: ~260px of dead stretch at
+        // 1280x900). Marking the main-content row `1fr` fixes it two ways
+        // at once: header/trust-strip/footer size to content (no more dead
+        // space above the fold), AND the main row itself absorbs the
+        // leftover space instead of the browser spreading it around — so a
+        // `footer` (disclaimers, CTA bar) still sits near the bottom of a
+        // short page exactly as it did before, instead of floating right
+        // under a now-compact header.
+        gridTemplateRows: [
+          "auto",
+          trustStrip ? "auto" : null,
+          "1fr",
+          footer ? "auto" : null,
+        ]
+          .filter(Boolean)
+          .join(" "),
         gap: "var(--space-5, 2rem)",
-        // Without this, the 3 implicit rows (header / trust strip / main)
-        // stretch to fill the leftover space that `minHeight: 100vh` creates
-        // once content is shorter than the viewport — CSS Grid's default
-        // `align-content: normal` behaves as `stretch` for auto row tracks.
-        // That silently pushed every funnel's first interactive step below
-        // the fold (measured on GARUDA VOA: ~260px of dead stretch at
-        // 1280x900). `start` makes rows size to content; minHeight still
-        // guarantees a full-height page.
-        alignContent: "start",
         minHeight: "100vh",
         background: "var(--surface-base)",
         color: "var(--text-primary, rgba(255, 255, 255, 0.96))",
@@ -85,6 +98,18 @@ export const AppFrame: FC<AppFrameProps> = ({
           display: "grid",
           gap: "var(--space-5, 2rem)",
           gridTemplateColumns: sidebar ? "minmax(0, 1fr) 320px" : "1fr",
+          // This wrapper sits in the outer grid's `1fr` row, which absorbs
+          // whatever height minHeight:100vh leaves over. Grid items stretch
+          // to fill their row by default (align-items: stretch) — without
+          // overriding it here, that leftover height would inflate this
+          // wrapper's own box, and since it (and <main>, and AppWizard's own
+          // internal grid below it) all default to `stretch` too, the extra
+          // space cascades all the way down and reopens the same dead-space
+          // bug one level deeper (visible as a large gap inside the wizard
+          // body). `start` keeps this wrapper sized to its own content; the
+          // outer row still grows to push a `footer` (if any) toward the
+          // bottom of a short page.
+          alignSelf: "start",
         }}
       >
         <main style={{ display: "grid", gap: "var(--space-4, 1.5rem)" }}>

--- a/packages/core/components/apps/AppWizard.tsx
+++ b/packages/core/components/apps/AppWizard.tsx
@@ -114,7 +114,8 @@ export const AppWizard: FC<AppWizardProps> = ({
   const nextStep = idx + 1 < steps.length ? steps[idx + 1] : null;
 
   const prevSummary = prevStep
-    ? (prevStep.summary?.(values[prevStep.id]) ?? defaultSummary(prevStep, values[prevStep.id]))
+    ? (prevStep.summary?.(values[prevStep.id]) ??
+      defaultSummary(prevStep, values[prevStep.id]))
     : null;
 
   const next = () => {
@@ -146,7 +147,13 @@ export const AppWizard: FC<AppWizardProps> = ({
   const progress = ((idx + 1) / steps.length) * 100;
 
   return (
-    <div style={{ display: "grid", gap: "var(--space-4, 1.5rem)", position: "relative" }}>
+    <div
+      style={{
+        display: "grid",
+        gap: "var(--space-4, 1.5rem)",
+        position: "relative",
+      }}
+    >
       {/* Hairline 2px progress bar, top */}
       <div
         role="progressbar"
@@ -173,28 +180,34 @@ export const AppWizard: FC<AppWizardProps> = ({
       </div>
 
       {/* Step label */}
-      <div style={{
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "baseline",
-        fontSize: "var(--text-xs, 0.72rem)",
-        letterSpacing: "0.1em",
-        textTransform: "uppercase",
-        color: "var(--color-text-muted)",
-      }}>
-        <span>Step {idx + 1} of {steps.length}</span>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          fontSize: "var(--text-xs, 0.72rem)",
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        <span>
+          Step {idx + 1} of {steps.length}
+        </span>
         <span>{step.title}</span>
       </div>
 
       {/* Previous step stacked summary */}
       {prevSummary ? (
-        <div style={{
-          opacity: 0.25,
-          fontSize: "var(--text-sm, 0.88rem)",
-          fontStyle: "italic",
-          paddingBottom: "var(--space-2, 0.5rem)",
-          borderBottom: "1px dashed var(--color-border-subtle)",
-        }}>
+        <div
+          style={{
+            opacity: 0.25,
+            fontSize: "var(--text-sm, 0.88rem)",
+            fontStyle: "italic",
+            paddingBottom: "var(--space-2, 0.5rem)",
+            borderBottom: "1px dashed var(--color-border-subtle)",
+          }}
+        >
           — {prevSummary}
         </div>
       ) : null}
@@ -232,42 +245,52 @@ export const AppWizard: FC<AppWizardProps> = ({
 
       {/* Next step peek */}
       {nextStep ? (
-        <div style={{
-          opacity: 0.2,
-          fontSize: "var(--text-sm, 0.88rem)",
-          fontStyle: "italic",
-          paddingTop: "var(--space-2, 0.5rem)",
-          borderTop: "1px dashed var(--color-border-subtle)",
-        }}>
+        <div
+          style={{
+            opacity: 0.2,
+            fontSize: "var(--text-sm, 0.88rem)",
+            fontStyle: "italic",
+            paddingTop: "var(--space-2, 0.5rem)",
+            borderTop: "1px dashed var(--color-border-subtle)",
+          }}
+        >
           — {nextStep.title} ↓
         </div>
       ) : null}
 
       {/* Error */}
       {error ? (
-        <p role="alert" style={{ margin: 0, color: "var(--color-error)", fontSize: "var(--text-sm, 0.88rem)" }}>
+        <p
+          role="alert"
+          style={{
+            margin: 0,
+            color: "var(--color-error)",
+            fontSize: "var(--text-sm, 0.88rem)",
+          }}
+        >
           {error}
         </p>
       ) : null}
 
       {/* Nav buttons */}
       <div style={{ display: "flex", gap: "var(--space-3, 1rem)" }}>
-        <button
-          type="button"
-          onClick={back}
-          disabled={idx === 0}
-          style={{
-            padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
-            borderRadius: "4px",
-            border: "1px solid var(--color-border-subtle)",
-            background: "transparent",
-            cursor: idx === 0 ? "not-allowed" : "pointer",
-            color: "var(--text-primary)",
-            minHeight: "44px",
-          }}
-        >
-          Back
-        </button>
+        {idx > 0 ? (
+          <button
+            type="button"
+            onClick={back}
+            style={{
+              padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
+              borderRadius: "4px",
+              border: "1px solid var(--color-border-subtle)",
+              background: "transparent",
+              cursor: "pointer",
+              color: "var(--text-primary)",
+              minHeight: "44px",
+            }}
+          >
+            Back
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={next}


### PR DESCRIPTION
## Summary

Three real-browser defects found by rendering the GARUDA VOA public funnel in an actual browser for the first time (previously only jsdom-tested).

**This PR also changes `/visa/match`, not just VOA/`apps/mouth`** — both fixes below landed in the two shared components (`AppFrame`, `AppWizard`) `/visa/match` also renders through. Both were originally VOA-scoped fixes that I widened after the reviewer measured the real blast radius (`AppWizard`: 2 pages; `AppFrame`: 12 pages across `/visa`, `/visa/clock(+[hash])`, `/visa/match(+[hash])`, `/visa/second-home`, and 5 VOA surfaces) and ruled to keep the fix in the shared component rather than fork it behind a prop — hiding a Back button with nowhere to go, and not stretching short content to fill the viewport, are correct for every wizard/funnel, not VOA-specific.

1. **Internal jargon in the hero.** The third trust-strip stat read "0 — prices invented (all from PricingTool)" — `PricingTool` is our internal service class. Replaced with a true, verified customer fact: "0 — extra to pay the government after" (products/garuda-voa/GROUND.md F18/F19: the catalogue price is all-inclusive, PNBP already folded in). VOA-only change.

2. **First question below the fold.** At 1280x900, `AppFrame`'s outer `display:grid` section has `minHeight:100vh` with no explicit row sizing — CSS Grid's default `align-content:normal` behaves as `stretch` for auto row tracks, so the 3-4 rows (header/trust-strip/main/footer) stretched equally to fill leftover viewport space instead of sizing to content, pushing the first step ~260px below the fold. Fixed with explicit `gridTemplateRows` (header/trust-strip/footer `auto`, main-content row `1fr`) plus `alignSelf:"start"` on the wrapper around `<main>` (needed to stop the leftover height cascading down into `<main>` and then into `AppWizard`'s own internal grid — caught and fixed during review, see commit 2). This is the more careful fix than a blanket `align-content:start`: it preserves footer bottom-anchoring on short pages that pass the `footer` prop (verified against the real component, not simulated — see Verification). Affects all 12 `AppFrame` consumers.

3. **Dead "Back" button on step 1.** `AppWizard` rendered a disabled-but-visible Back button on the first step, where there's nowhere to go back to. Now omitted below step 1 (shown from step 2 onward). Affects `visa/voa` and `visa/match` (both use the shared `AppWizard`).

Left as-is: the "— Purpose ↓" line under the answer cards — it's `AppWizard`'s deliberate "next step peek" (Stacked Context pattern, `docs/superpowers/specs/2026-04-20-visa-check-ui-design.md` §3), not a leaked label.

## Verification

- New test in `page.test.tsx`: asserts no `[A-Z][a-z]+Tool`-shaped identifier in rendered copy — verified it reddens by temporarily putting `PricingTool` back.
- New tests: Back button absent on step 1, present on step 2.
- `AppFrame.test.tsx` / `AppWizard.test.tsx` (existing suites): 9/9 passing.
- `apps/mouth/src/app/visa/match/page.test.tsx`: 4/4 passing (checked per reviewer request before push).
- Layout fix verified with real Playwright bounding boxes against a live `next dev --webpack` render (jsdom cannot lay out CSS Grid): VOA first card ends at y=399 inside a 900px viewport, no internal wizard-body gap.
- Next-button horizontal position confirmed unchanged between step 1 (no Back) and step 2 (Back present) on both `/visa/voa` and `/visa/match` — `marginLeft:auto` pins it regardless.
- Footer bottom-anchor check (per reviewer request): rendered a throwaway page using `AppFrame` with the `footer` prop + one line of main content (deleted before commit, not part of this diff) — footer box lands at y=886-924 in a 900px viewport, i.e. still anchored near the bottom, matching pre-fix behavior.
- Rendered `/visa`, `/visa/clock`, `/visa/match`, `/visa/second-home` — no visible layout regression; `/visa`'s bottom bar is `position:fixed` (independent of the grid change) and unaffected either way.
- `tsc --noEmit` exits 0.
- Full `src/app/visa/**` suite: 197/197 passing.

## Test plan

- [x] `npx vitest run src/app/visa` — 197 passed
- [x] `npx vitest run src/app/visa/match/page.test.tsx` — 4 passed
- [x] `npx tsc --noEmit` — exit 0
- [x] Manual Playwright bounding-box verification at 1280x900 (VOA layout, Next-button position across steps, footer anchor on a synthetic AppFrame page)
- [ ] CI green (not armed — per lane instructions, opening for review/merge by the operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)