### PR TITLE
fix(measurer): a test with a frozen clock met the wall clock, and main went red on 2026-08-25

### DIFF
--- a/apps/backend-rag/backend/services/measurer/ig_token_watchdog.py
+++ b/apps/backend-rag/backend/services/measurer/ig_token_watchdog.py
@@ -612,12 +612,23 @@ def _resolve_token_from_env() -> tuple[str, str] | None:
     return None
 
 
-async def run_from_env(*, http_client: httpx.AsyncClient | None = None) -> int:
+async def run_from_env(
+    *,
+    http_client: httpx.AsyncClient | None = None,
+    now: datetime | None = None,
+) -> int:
     """CLI body: read config from env, run one pass, persist the result.
 
     A refresh that cannot be persisted is a FAILURE (exit 2), not a warning:
     the new token would be dropped and the cron would sit green while the
     live token marches toward expiry (family #2, esiste≠armato).
+
+    `now` is forwarded to `run_watchdog` and exists so a caller can pin the
+    clock. Production never passes it — the default reaches
+    `datetime.now(timezone.utc)` exactly as before, so behaviour is unchanged.
+    It is here because this wrapper was the ONE path in this module that could
+    not be given a fixed clock, and that is precisely where a test rotted: see
+    the note on `test_cli_fresh_state_exits_zero_without_network`.
     """
     resolved = _resolve_token_from_env()
     if resolved is None:
@@ -668,6 +679,7 @@ async def run_from_env(*, http_client: httpx.AsyncClient | None = None) -> int:
             threshold_days=threshold,
             state_file=state_file,
             http_client=http_client,
+            now=now,
         )
     finally:
         if http_client is None:

--- a/apps/backend-rag/backend/tests/services/measurer/test_ig_token_watchdog.py
+++ b/apps/backend-rag/backend/tests/services/measurer/test_ig_token_watchdog.py
@@ -565,12 +565,24 @@ async def test_cli_refresh_with_persist_target_succeeds(clean_env, tmp_path):
 
 @pytest.mark.asyncio
 async def test_cli_fresh_state_exits_zero_without_network(clean_env, tmp_path):
+    """INNOCENCE: 50 days left → exit 0 and no network call.
+
+    `now=NOW` is load-bearing, not decoration. `_state` writes an expiry
+    relative to the FROZEN NOW (2026-07-13), so without a pinned clock this
+    test asked production — which reads the wall clock — whether an expiry of
+    2026-09-01 was more than 7 days away. It was, for 43 days. On 2026-08-25
+    it stopped being, the CLI refreshed, found no IG_TOKEN_ENV_FILE, exited 2,
+    and this test went red on a commit nobody had touched — taking a merge
+    queue entry down with it. Every sibling in this file already pinned the
+    clock via run_watchdog(now=NOW); this one could not, because run_from_env
+    did not forward `now`. Now it does.
+    """
     state_file = _state(tmp_path, days_left=50)
     clean_env.setenv("IG_LONG_LIVED_TOKEN", FAKE_TOKEN)
     clean_env.setenv("IG_TOKEN_STATE_FILE", str(state_file))
     handler = GraphHandler()
     async with _client(handler) as client:
-        assert await run_from_env(http_client=client) == 0
+        assert await run_from_env(http_client=client, now=NOW) == 0
     assert handler.ig_refresh_calls == 0
 
 


### PR DESCRIPTION
## What is red, and since when

`backend/tests/services/measurer/test_ig_token_watchdog.py::test_cli_fresh_state_exits_zero_without_network`
fails on a **clean, zero-dirty checkout of `origin/main`** (`assert 2 == 0`), on a commit nobody touched.

It is not cosmetic: it took a merge-queue entry down. PR #4907 was enqueued at 11:57 and ejected at 12:06 —
`Backend Shard 3` → `Backend (Python)` → `Test Summary` → **`Tests & Coverage`**, which is a required
context. Every PR queued from today onward hits the same wall.

## The arithmetic

| | |
|---|---|
| the test's frozen `NOW` | `2026-07-13T12:00Z` |
| `_state(days_left=50)` writes expiry | `2026-09-01T12:00Z` |
| `DEFAULT_REFRESH_THRESHOLD_DAYS` | `7.0` |
| wall clock at the CI failure | `2026-08-25T12:02Z` → **6.998 days remaining** |

Below threshold ⇒ the CLI refreshed a token the test had declared fresh, found no `IG_TOKEN_ENV_FILE`
to persist it into, and returned `2`. **That is production behaving correctly.** The test was written
2026-07-13, stayed green 43 days, crossed on 2026-08-25, and gets worse every day after.

## Why it happened — the hole was in the seam, not the discipline

Every sibling in this file already pins the clock with `run_watchdog(..., now=NOW)`, including the
guilt/innocence pair at `days_left=3` and `days_left=45`. Those are hermetic and green. This one test
could not pin it, because it exercises the CLI wrapper `run_from_env` — the single path in the module
that accepted no `now` to forward.

## The change

`run_from_env` takes a keyword-only `now` and forwards it to `run_watchdog`. Production passes nothing;
the default still reaches `datetime.now(timezone.utc)`. **Behaviour is unchanged.** The test pins `NOW`.

## Verification

- measurer suite green.
- **Mutation — load-bearing:** deleting the `now=now` forwarding turns *exactly this one test* red.
- **Mutation — not vacuous:** widening `DEFAULT_REFRESH_THRESHOLD_DAYS` to `999` turns it red alongside
  three others, so it still detects a genuinely stale token and is not green-for-any-input.
- Census of the other two `_state(days_left=...)` call sites in the file: both already inject `now=NOW`
  and cannot rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)