### PR TITLE
fix(wa): normalise WhatsApp typing shapes in the greeting fast-path

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/prompt_builder.py
+++ b/apps/backend-rag/backend/services/rag/agentic/prompt_builder.py
@@ -439,6 +439,74 @@ def _word_anchored(*alternations: str) -> tuple[re.Pattern[str], ...]:
     return tuple(re.compile(rf"\b(?:{alt})\b") for alt in alternations)
 
 
+# ------------------------------------------------------------------
+# Greeting-matching normaliser (2026-08-25).
+#
+# `check_greetings` below only fires on an EXACT anchored match
+# (`^ciao$`, `^ciao\s*!*$`, ...). Measured against 34 realistic WhatsApp
+# openers, that exact-anchoring hit only 19/34 — 15 misses fell through to
+# full RAG retrieval and got an ABSTAIN instead of a greeting. All 15 misses
+# were one of three WhatsApp-typing shapes, never a missing greeting word:
+#   - word-final elongation: "ciaooo", "buongiornoo", "Salveee", "helloooo",
+#     "hiii", "heyyy", "haloo", "haiii", "selamat pagii", "holaa", "buonaseraa"
+#   - trailing emoticon/emoji: "Ciao :)", "ciao 😊"
+#   - repeated token: "ciao ciao"
+# This helper normalises the string used ONLY for pattern matching inside
+# check_greetings — it must never replace `query_lower` where that feeds the
+# response-language detection further down in the same function.
+_EMOJI_RANGES_RE = re.compile(
+    "["
+    "\U0001f000-\U0001f0ff"  # mahjong/dominoes/playing cards block
+    "\U0001f300-\U0001faff"  # symbols & pictographs (incl. supplemental, extended-A)
+    "\U00002600-\U000026ff"  # miscellaneous symbols
+    "\U00002700-\U000027bf"  # dingbats
+    "\U0001f1e6-\U0001f1ff"  # regional indicator symbols (flag components)
+    "\U00002b00-\U00002bff"  # miscellaneous symbols and arrows
+    "️"  # variation selector-16 (emoji presentation)
+    "‍"  # zero-width joiner (emoji sequences)
+    "]+"
+)
+
+# ASCII emoticon shapes anchored to the END of the string only — e.g. ":)"
+# ":-D" ";)" — never a bare charset strip, so real words ending in a letter
+# that also happens to be an emoticon mouth (e.g. "...help", "...KTP") are
+# never touched: the run must START with an eye char (:;=8).
+_TRAILING_EMOTICON_RE = re.compile(r"[:;=8][\-o^]?[)\]dDpP(/\\|3]+$")
+
+
+def _normalize_for_greeting_match(text: str) -> str:
+    """Normalise an already-lowercased query for greeting PATTERN MATCHING only.
+
+    Order: (1) strip trailing whitespace/punctuation/emoticons/emoji, repeated
+    until stable since they can stack ("ciao! :)", "ciao 😊!!"); (2) collapse
+    WORD-FINAL character elongation (a run of 2+ identical letters at the END
+    of a word -> one) — word-final ONLY, so "hello"/"hallo" (doubled letter in
+    the MIDDLE of the word, still followed by more letters) are untouched;
+    (3) collapse an immediately repeated whole token ("ciao ciao" -> "ciao").
+    """
+    while True:
+        stripped = text.rstrip()
+        stripped = _EMOJI_RANGES_RE.sub("", stripped).rstrip()
+        stripped = _TRAILING_EMOTICON_RE.sub("", stripped).rstrip()
+        stripped = stripped.rstrip(" \t!?.,;:~-")
+        if stripped == text:
+            break
+        text = stripped
+
+    # Word-final elongation: `\1+` is greedy so it consumes the WHOLE trailing
+    # run of the repeated letter, and `\b` anchors the collapse to a word
+    # boundary — a mid-word double (hello, hallo, buongiorno, buonasera,
+    # selamat, guten tag) is never followed by a boundary right after the
+    # repeat, so it never matches.
+    text = re.sub(r"(\w)\1+\b", r"\1", text)
+
+    # Repeated greeting token: the WHOLE normalised string is the same word
+    # two-or-more times, separated by whitespace.
+    text = re.sub(r"^(\w+)(?:\s+\1)+$", r"\1", text)
+
+    return text
+
+
 class SystemPromptBuilder:
     """
     Builds dynamic system prompts with caching for performance.
@@ -1031,8 +1099,13 @@ DO NOT USE ANY INDONESIAN WORDS OR SLANG.
             r"^(hallo|guten tag|guten morgen|guten abend)\s*!*$",
         ]
 
+        # Match against the NORMALISED text only — query_lower stays untouched
+        # below for response-language detection (see block comment above
+        # _normalize_for_greeting_match).
+        normalized_query = _normalize_for_greeting_match(query_lower)
+
         for pattern in greeting_patterns:
-            if re.match(pattern, query_lower):
+            if re.match(pattern, normalized_query):
                 # Determine response language: user preference > query language > default
                 if user_lang is None:
                     # Detect from query

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_greeting_wa_typing_normalization.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_greeting_wa_typing_normalization.py
@@ -1,0 +1,214 @@
+"""
+WA greeting fast-path — normaliser for realistic WhatsApp typing shapes.
+
+Context (measured 2026-08-25): `check_greetings` fires BEFORE RAG retrieval
+via `check_greeting_gate` (query_gates.py:103), but its patterns were
+exact-anchored (`^(ciao|hello|hi|hey|salve)\\s*!*$` and friends). Run against
+34 realistic WhatsApp openers, that matched only 19/34 — the other 15 fell
+through to full RAG retrieval and, lacking a knowledge-base match, got an
+ABSTAIN instead of a greeting. All 15 misses were one of three WhatsApp
+typing shapes, never a missing greeting word:
+
+  - word-final elongation (12): ciaooo, Ciaoooo!!, buongiornoo, Salveee,
+    helloooo, hiii, heyyy, haloo, haiii, selamat pagii, holaa, buonaseraa
+  - trailing emoji/emoticon (2): "Ciao :)", "ciao 😊"
+  - repetition (1): "ciao ciao"
+
+The fix is `_normalize_for_greeting_match` (module-level helper in
+prompt_builder.py), applied ONLY to the string used for pattern matching
+inside `check_greetings` — never to `query_lower`, which still drives the
+response-language detection further down the same function.
+
+This file has two halves:
+  - TestGuilt* — every measured miss now returns a greeting (non-None).
+  - TestInnocence* — the 19 that already worked keep working; the
+    normaliser is a no-op on non-elongated greeting words; and — the half
+    that matters most — real client questions are NOT swallowed by the
+    fast-path (it skips RAG entirely, so a false positive here means an
+    actual question never reaches retrieval).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.rag.agentic.prompt_builder import (
+    SystemPromptBuilder,
+    _normalize_for_greeting_match,
+)
+
+# ============================================================================
+# GUILT — the 15 measured misses must now return a greeting.
+# ============================================================================
+
+
+class TestGuiltElongationEmojiRepetition:
+    """Each of the 15 strings measured as a miss on the unmodified gate."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "ciaooo",
+            "Ciaoooo!!",
+            "buongiornoo",
+            "Salveee",
+            "helloooo",
+            "hiii",
+            "heyyy",
+            "haloo",
+            "haiii",
+            "selamat pagii",
+            "holaa",
+            "buonaseraa",
+        ],
+        ids=lambda q: f"elongation:{q}",
+    )
+    def test_elongated_greeting_returns_response(self, query: str) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings(query)
+        assert result is not None, f"{query!r} should hit the greeting fast-path"
+
+    @pytest.mark.parametrize(
+        "query",
+        ["Ciao :)", "ciao 😊"],
+        ids=lambda q: f"emoticon-emoji:{q}",
+    )
+    def test_trailing_emoticon_or_emoji_returns_response(self, query: str) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings(query)
+        assert result is not None, f"{query!r} should hit the greeting fast-path"
+
+    def test_repeated_token_returns_response(self) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings("ciao ciao")
+        assert result is not None, "'ciao ciao' should hit the greeting fast-path"
+
+
+# ============================================================================
+# INNOCENCE — half 1: the 19 openers that already worked must keep working.
+# ============================================================================
+
+
+class TestInnocenceExistingHitsUnaffected:
+    """The 19/34 openers that already matched on the unmodified gate."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "ciao",
+            "Ciao!",
+            "hello",
+            "Hi",
+            "hey",
+            "salve",
+            "hi there",
+            "buongiorno",
+            "buonasera",
+            "halo",
+            "hai",
+            "hei",
+            "selamat pagi",
+            "hallo",
+            "guten tag",
+            "bonjour",
+            "hola",
+            "привіт",
+            "привет",
+        ],
+        ids=lambda q: f"already-worked:{q}",
+    )
+    def test_existing_greeting_still_matches(self, query: str) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings(query)
+        assert result is not None, f"{query!r} regressed — it matched before this change"
+
+
+# ============================================================================
+# INNOCENCE — half 2: the normaliser is a no-op on non-elongated greeting
+# words (no false collapse of a legitimate mid-word double letter).
+# ============================================================================
+
+
+class TestInnocenceNormalizerNoOpOnMidWordDoubles:
+    """Direct unit tests on the helper — must be byte-identical output."""
+
+    @pytest.mark.parametrize(
+        "word",
+        ["hello", "hallo", "buongiorno", "buonasera", "selamat", "guten tag"],
+    )
+    def test_normalizer_leaves_word_unchanged(self, word: str) -> None:
+        assert _normalize_for_greeting_match(word) == word
+
+
+# ============================================================================
+# INNOCENCE — half 3, THE ONE THAT MATTERS MOST: real client questions must
+# NOT be swallowed by the fast-path. A false positive here means the client's
+# actual question gets "Ciao! Come posso aiutarti oggi?" and never reaches
+# RAG retrieval — worse than the defect being fixed.
+# ============================================================================
+
+
+class TestInnocenceRealQuestionsNotSwallowed:
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "Ciao, quanto costa aprire una PT PMA?",
+            "ciao ho bisogno di aiuto col KITAS",
+            "hello, what does a KITAS cost?",
+            "halo, saya mau tanya soal PT PMA",
+            "hi there, I need help with taxes",
+            "buongiorno, vorrei informazioni sul visto",
+            # additional mixed-language real questions
+            "hey, can you help me with my NPWP?",
+            "hai, saya butuh bantuan visa",
+            "привіт, мені потрібна допомога з візою",
+            "привет, сколько стоит виза?",
+        ],
+        ids=lambda q: f"real-question:{q}",
+    )
+    def test_real_question_is_not_treated_as_greeting(self, query: str) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings(query)
+        assert result is None, (
+            f"{query!r} was treated as a bare greeting — this would skip RAG "
+            "and answer a real question with a canned greeting"
+        )
+
+
+# ============================================================================
+# Response language must be preserved for elongated/decorated greetings —
+# the fix must not disturb the DOWNSTREAM language-detection logic, which
+# still reads the untouched `query_lower`, never the normalised text.
+# ============================================================================
+
+
+class TestLanguagePreservedAfterNormalization:
+    def test_italian_elongated_greeting_gets_italian_response(self) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings("ciaooo")
+        assert result is not None
+        assert "Ciao" in result and "aiutarti" in result
+
+    def test_indonesian_elongated_greeting_gets_indonesian_response(self) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings("haloo")
+        assert result is not None
+        assert "Halo" in result and "bantu" in result
+
+    def test_english_elongated_greeting_gets_english_response(self) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings("helloooo")
+        assert result is not None
+        assert "Hello" in result and "help" in result
+
+    def test_repeated_token_greeting_gets_italian_response(self) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings("ciao ciao")
+        assert result is not None
+        assert "Ciao" in result
+
+    def test_trailing_emoji_greeting_gets_italian_response(self) -> None:
+        builder = SystemPromptBuilder()
+        result = builder.check_greetings("ciao 😊")
+        assert result is not None
+        assert "Ciao" in result


### PR DESCRIPTION
## The defect (mandate item 3)

Non-template greetings — `ciaooo`, `hiii`, `Ciao :)` — missed the greeting
fast-path entirely, fell through to full RAG retrieval, and came back as an
**ABSTAIN**. A client saying hello got "I don't have enough evidence".

The fast-path itself was never broken and is correctly wired
(`query_gates.check_greeting_gate` → `SystemPromptBuilder.check_greetings`). The
patterns are exact-anchored (`^(ciao|hello|hi|hey|salve)\s*!*$`), so anything a
person actually types on a phone — an elongated vowel, a trailing emoji, a
repeated token — simply did not match. The cure is normalisation, **not** a
second greeting table (the localized templates stay where they are,
`prompt_builder.py:1055-1090`, unduplicated).

## What changed

One module-level helper, applied **only** to the string fed into the pattern
loop. `query_lower` is left untouched, so the language-detection substring
checks further down still see the original text.

1. Strip trailing whitespace/punctuation/emoticon/emoji, looped until stable.
   Emoji by Unicode block ranges, not an enumerated list. ASCII emoticons by an
   anchored eyes+mouth shape, so real words ending in `d`/`p`/`D`/`P` are never
   truncated.
2. Collapse word-final elongation — `(\w)\1+\b`, which only fires when the run
   is immediately followed by a word boundary, so mid-word doubles survive.
3. Collapse a repeated single token (`ciao ciao`).

## Verification — mine, run independently of the author

- Greeting gate: **19/34 → 34/34**. Zero remaining misses.
- **Zero false positives on real questions**: `"ciaooo quanto costa?"`,
  `"hi!!! i need a kitas urgently"`, `"salve ho una domanda"` → all still `None`,
  i.e. still routed to RAG.
- Normaliser is **byte-identical no-op** on `hello`/`hallo`/`buongiorno`/
  `buonasera`/`selamat pagi`/`guten tag`/`bonjour`/`good morning`.
- Language preserved: `ciaooo`→Italian, `haloo`→Indonesian, `hiii`→English.

**Mutation-tested** (a green test never seen red proves nothing):

| mutation | result |
| --- | --- |
| baseline | 55 passed, 0 failed |
| `_normalize_for_greeting_match` neutered to identity | **20 failed** |
| elongation-collapse line removed only | **15 failed**, correctly isolated — the emoji/emoticon/repeated-token cases stayed green |
| restored | 55 passed, tree clean |

The second mutation is the one that matters: it shows the suite distinguishes
*which* normalisation step is doing the work, rather than failing en masse.

## Pre-existing, not introduced

The full `services/rag/agentic/` directory run carries 43 failures
(`TypeError: ... not MagicMock`, a cross-file test-isolation leak in
`test_casual_gate_precision.py` / `test_identity_fastpath.py` / two
`test_reasoning_utils.py` cases). The identical 43-item set reproduces on the
unmodified baseline. Untouched by this diff — `check_casual_conversation` and
`detect_team_query` are not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017axwAcbXowBUodKEzED2LK