### PR TITLE
fix(rag): a WhatsApp thread opens with a greeting, and the detector had no greetings

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
@@ -146,6 +146,40 @@ def _whole_word_matcher(markers: list[str], suffix: str = "") -> re.Pattern[str]
 
 INDONESIAN_MARKER_RE = _whole_word_matcher(INDONESIAN_MARKERS, _INDONESIAN_ENCLITICS)
 
+# WhatsApp openers are elongated more often than they are spelled. Every
+# matcher in this file is whole-word by design, so "ciaooo" and "grazieee" are
+# unknown tokens that score ZERO for every language — and a zero score is not
+# "unknown", it is the ENGLISH default, which the wrapper below renders to the
+# model as a hard order to answer in English. That is the IT-in/EN-out drift
+# this detector exists to prevent, reached through spelling rather than through
+# vocabulary.
+#
+# The floor is THREE identical characters, not two, and that is load-bearing:
+# Italian doubles constantly ("soggiorno", "permesso", "sarebbe") and folding a
+# legitimate double would silently break markers this file already relies on.
+# No marker in any list here contains a run of three.
+_ELONGATION_RE = re.compile(r"(.)\1{2,}")
+
+# The 3-character floor above leaves "graziee" and "ciaoo" — a doubled vowel is
+# the commonest elongation of all, and the floor cannot be lowered globally
+# without destroying real markers.
+#
+# It CAN be lowered for a doubled vowel at the END of a word, and the exact
+# reason the rule is written this narrowly is German "muss": it is a decisive
+# marker in the row below and it ends in a doubled CONSONANT, so a blanket
+# trailing-double fold would silently delete it. Restricting to vowels also
+# cannot invent a marker — no entry in any list here ends in a doubled vowel,
+# so this fold can only recover a marker, never manufacture one. Checked
+# against English words that do ("free", "three", "coffee", "committee"): each
+# folds to a non-marker and changes no verdict.
+_TRAILING_VOWEL_RUN_RE = re.compile(r"([aeiou])\1+\b")
+
+
+def _collapse_elongation(text: str) -> str:
+    """Fold elongation, so "ciaooo" and "graziee" both read as their word."""
+    return _TRAILING_VOWEL_RUN_RE.sub(r"\1", _ELONGATION_RE.sub(r"\1", text))
+
+
 # The same bare-substring defect lived in every Latin-script branch, and it is
 # not theoretical: "in(come) tax" reads as ITALIAN and "com(merci)al licence" as
 # FRENCH. The team beta test of 2026-07-28 recorded two English questions
@@ -194,8 +228,45 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             "funziona",
             "essere",
             "ottenere",
+            # Greetings and courtesies, added 2026-08-25. A WhatsApp thread
+            # opens with one far more often than with a business question, and
+            # the row above carried exactly ONE ("ciao") — so "Buongiorno",
+            # "Salve" and "Buonasera" each scored zero and were answered in
+            # English. Measured on 16 real Italian openers before this change:
+            # 10 returned ENGLISH.
+            "buongiorno",
+            "buonasera",
+            "buonanotte",
+            "arrivederci",
+            "prego",
+            "scusa",
+            "scusi",
+            "scusate",
+            # "salve" is an English noun too (an ointment). It is DECISIVE here
+            # anyway, deliberately: in an immigration/company bot the Italian
+            # greeting is common and the English noun is close to unheard-of,
+            # and the cost is asymmetric — a missed greeting mislabels the whole
+            # reply, a stolen "salve" mislabels one query nobody sends. This is
+            # the one entry in this row that knowingly breaks the shared-marker
+            # rule stated above; do not read it as a licence to add more.
+            "salve",
+            # Question words and function words a real Italian question brings
+            # along. "qual" is absent from the Spanish row ("cuál") and the
+            # French row ("quel"), and bare "è" exists in neither.
+            "qual",
+            "è",
+            "tra",
+            "sapere",
+            "aiuto",
+            "bisogno",
+            "soggiorno",
+            "informazioni",
+            "potete",
+            "puoi",
+            "volevo",
         ],
-        ["come"],  # homograph: English "come"
+        # homographs: English "come", and English "dove" (the bird)
+        ["come", "dove"],
     ),
     (
         "FRENCH",
@@ -219,6 +290,10 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             "dans",
             "être",
             "obtenir",
+            # Greetings, same 2026-08-25 reason as the Italian row: this row
+            # carried "bonjour" alone, so "Bonsoir" and "Salut" fell through.
+            "bonsoir",
+            "salut",
         ],
         ["comment"],  # homograph: English "comment"
     ),
@@ -260,6 +335,14 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             "abrir",
             "están",
             "también",
+            # Greetings, 2026-08-25. "hola" was the only one, so "Buenos días"
+            # — the ordinary Spanish opener — scored zero and read as ENGLISH.
+            # Both the accented and the bare spellings, because WhatsApp
+            # clients send both.
+            "buenos días",
+            "buenos dias",
+            "buenas tardes",
+            "buenas noches",
         ],
         [],
     ),
@@ -293,6 +376,12 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             "unternehmen",
             "gründen",
             "wie",
+            # Greetings, 2026-08-25. "hallo" was the only one; "Guten Tag" and
+            # its siblings scored zero and read as ENGLISH.
+            "guten tag",
+            "guten morgen",
+            "guten abend",
+            "tschüss",
         ],
         [],
     ),
@@ -349,7 +438,11 @@ def detect_query_language(query: str) -> str:
     if not query or len(query.strip()) < 2:
         return "UNKNOWN"
 
-    query_lower = query.lower()
+    # Elongation is folded BEFORE any marker match — Indonesian included — so a
+    # WhatsApp opener is scored on its word, not on its spelling. The non-Latin
+    # script checks below deliberately keep reading the ORIGINAL `query`: they
+    # test code points, and folding cannot help them.
+    query_lower = _collapse_elongation(query.lower())
 
     # Check Indonesian first — WHOLE WORDS (+ enclitics) only, never substrings.
     if INDONESIAN_MARKER_RE.search(query_lower):

--- a/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
@@ -167,11 +167,22 @@ _ELONGATION_RE = re.compile(r"(.)\1{2,}")
 # It CAN be lowered for a doubled vowel at the END of a word, and the exact
 # reason the rule is written this narrowly is German "muss": it is a decisive
 # marker in the row below and it ends in a doubled CONSONANT, so a blanket
-# trailing-double fold would silently delete it. Restricting to vowels also
-# cannot invent a marker — no entry in any list here ends in a doubled vowel,
-# so this fold can only recover a marker, never manufacture one. Checked
-# against English words that do ("free", "three", "coffee", "committee"): each
-# folds to a non-marker and changes no verdict.
+# trailing-double fold would silently delete it.
+#
+# The fold has two failure directions and they need different arguments —
+# an adversarial pass caught the first draft of this comment proving only one
+# of them and claiming both:
+#   DESTROY a marker — cannot happen: the fold is a no-op on every entry in
+#     every list here, asserted directly rather than inferred.
+#   MANUFACTURE a marker — a NON-marker word ending in a doubled vowel folds
+#     ONTO a marker. This does NOT follow from "no marker ends in a doubled
+#     vowel"; it depends on whether some marker ends in a SINGLE vowel that a
+#     foreign word doubles, and several do ("come", "tra", "hola", "eine").
+#     It is empty for today's corpus — checked against the English words that
+#     end that way ("see", "free", "three", "too", "coffee", "committee",
+#     "agree", "employee"): each folds to a non-marker. That is a property of
+#     the CORPUS, not of the rule, so it is guarded by a test that folds those
+#     words and looks for a marker, not by the invariant that does not imply it.
 _TRAILING_VOWEL_RUN_RE = re.compile(r"([aeiou])\1+\b")
 
 
@@ -238,7 +249,6 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             "buonasera",
             "buonanotte",
             "arrivederci",
-            "prego",
             "scusa",
             "scusi",
             "scusate",
@@ -250,10 +260,10 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             # the one entry in this row that knowingly breaks the shared-marker
             # rule stated above; do not read it as a licence to add more.
             "salve",
-            # Question words and function words a real Italian question brings
-            # along. "qual" is absent from the Spanish row ("cuál") and the
-            # French row ("quel"), and bare "è" exists in neither.
-            "qual",
+            # Function words a real Italian question brings along. Bare "è"
+            # (grave) belongs to Italian alone here: Spanish writes "es",
+            # French "est", and Portuguese "é" with an ACUTE accent, which is
+            # a different code point.
             "è",
             "tra",
             "sapere",
@@ -265,8 +275,23 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
             "puoi",
             "volevo",
         ],
-        # homographs: English "come", and English "dove" (the bird)
-        ["come", "dove"],
+        # homographs: English "come"; English "dove" (the bird); and "prego",
+        # which is not an English word but IS a supermarket pasta-sauce brand —
+        # and this bot advises on food-import KBLI, so "Prego sauce import
+        # licence" is a message it actually receives. Demoted after an
+        # adversarial pass found it, on the same reasoning the row's own rule
+        # states: a token that names a language only by coincidence must not
+        # decide one alone. It still contributes once real Italian is present.
+        # "qual" is a HOMOGRAPH, not a marker, and the first draft had it
+        # decisive with the justification "absent from the Spanish row
+        # (cuál) and the French row (quel)". That checked the wrong two
+        # languages: "qual" is THE standard question word in PORTUGUESE, and
+        # Brazilians are a real client demographic here. Decisive, it took
+        # "Qual é o custo do visto?" from ENGLISH (wrong, but readable) to
+        # ITALIAN (wrong AND unreadable) — a regression in a language this
+        # detector does not serve. As a homograph it costs nothing: an
+        # Italian "Qual è ..." is already carried by "è".
+        ["come", "dove", "prego", "qual"],
     ),
     (
         "FRENCH",
@@ -439,9 +464,16 @@ def detect_query_language(query: str) -> str:
         return "UNKNOWN"
 
     # Elongation is folded BEFORE any marker match — Indonesian included — so a
-    # WhatsApp opener is scored on its word, not on its spelling. The non-Latin
-    # script checks below deliberately keep reading the ORIGINAL `query`: they
-    # test code points, and folding cannot help them.
+    # WhatsApp opener is scored on its word, not on its spelling.
+    #
+    # The three SCRIPT-PRESENCE tests below (CJK, Arabic, Cyrillic) read the
+    # ORIGINAL `query` on purpose: they test code points, and folding cannot
+    # help them. The Ukrainian sub-check inside the Cyrillic branch does NOT —
+    # it is a word test, so it reads the folded `query_lower` like every other
+    # word test here. An earlier version of this comment claimed all of them
+    # read the original; that was false, and it mattered enough to correct
+    # even though it is behaviourally inert today (no Ukrainian word in that
+    # list carries a run of three or a trailing doubled vowel).
     query_lower = _collapse_elongation(query.lower())
 
     # Check Indonesian first — WHOLE WORDS (+ enclitics) only, never substrings.

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
@@ -164,8 +164,22 @@ def test_english_homographs_never_decide_a_language_on_their_own() -> None:
     """
     # Assert the declaration itself, or the loop below passes vacuously the
     # moment someone empties the table — which is exactly the change it exists
-    # to catch.
-    assert LATIN_HOMOGRAPHS == {"ITALIAN": ["come"], "FRENCH": ["comment"]}
+    # to catch. Exact equality is deliberate: it makes every ADDITION a
+    # conscious act reviewed right here, next to the property it must satisfy.
+    #
+    # Grew on 2026-08-25, all three for the same reason — a token that names a
+    # language only by coincidence:
+    #   "dove"  — English, the bird.
+    #   "prego" — not an English word, but a supermarket pasta-sauce brand,
+    #             and this bot advises on food-import KBLI, so "Prego sauce
+    #             import licence" is a message it actually receives.
+    #   "qual"  — THE standard question word in PORTUGUESE. Decisive, it took
+    #             "Qual é o custo do visto?" from ENGLISH (wrong, but readable)
+    #             to ITALIAN (wrong AND unreadable). Italian keeps it via "è".
+    assert LATIN_HOMOGRAPHS == {
+        "ITALIAN": ["come", "dove", "prego", "qual"],
+        "FRENCH": ["comment"],
+    }
 
     for language, homographs in LATIN_HOMOGRAPHS.items():
         for word in homographs:

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_language_markers_cover_greetings.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_language_markers_cover_greetings.py
@@ -28,6 +28,7 @@ from backend.services.rag.agentic.query_helpers import (
     _LATIN_MARKERS,
     INDONESIAN_MARKERS,
     LANGUAGE_DISPLAY_NAMES,
+    _collapse_elongation,
     detect_query_language,
     wrap_query_with_language_instruction,
 )
@@ -170,16 +171,171 @@ def test_no_marker_contains_a_run_of_three_identical_characters() -> None:
     assert not offenders, f"markers the elongation fold would rewrite: {offenders}"
 
 
-def test_no_marker_ends_in_a_doubled_vowel() -> None:
-    """The trailing-vowel rule may only recover a marker, never manufacture one.
+def test_the_fold_is_a_no_op_on_every_marker() -> None:
+    """DESTROY direction: the fold must not rewrite any marker out of its list.
 
-    Restricting the 2-character fold to VOWELS is what keeps German "muss"
-    alive. This asserts the other half: that no marker in any row ENDS in a
-    doubled vowel, so the rule cannot fold a real marker into something else.
+    ``_collapse_elongation`` runs BEFORE every marker match, so a marker the
+    fold rewrites can never be matched again — its row would go quietly dead:
+    green tests, silent loss of recall. Asserting the fold directly (rather
+    than asserting the two regex shapes it happens to be built from) is what
+    keeps this true if the fold's rules are ever widened. German "muss" is the
+    entry that makes the trailing rule vowel-only; it is checked here by being
+    in the corpus, not by being named.
     """
-    trailing = re.compile(r"([aeiou])\1+$")
-    offenders = [(lang, m) for lang, m in _every_marker() if trailing.search(m)]
-    assert not offenders, f"markers the trailing-vowel fold would rewrite: {offenders}"
+    rewritten = [(lang, m, _collapse_elongation(m)) for lang, m in _every_marker()]
+    offenders = [(lang, m, f) for lang, m, f in rewritten if f != m]
+    assert not offenders, f"the fold rewrites these markers: {offenders}"
+
+
+# Words that end in a doubled vowel and are NOT markers. If any of them folded
+# ONTO a marker, the fold would manufacture a language out of ordinary English.
+FOREIGN_WORDS_ENDING_IN_A_DOUBLED_VOWEL: list[str] = [
+    "see",
+    "free",
+    "three",
+    "agree",
+    "coffee",
+    "committee",
+    "employee",
+    "guarantee",
+    "fee",
+    "tee",
+    "too",
+    "zoo",
+    "bee",
+]
+
+
+@pytest.mark.parametrize("word", FOREIGN_WORDS_ENDING_IN_A_DOUBLED_VOWEL)
+def test_the_fold_does_not_manufacture_a_marker(word: str) -> None:
+    """MANUFACTURE direction — and it needs its OWN test, which is the point.
+
+    The first draft of this file asserted "no marker ends in a doubled vowel"
+    and called that proof the fold cannot manufacture one. It is not: an
+    adversarial pass pointed out that manufacture runs the other way — a
+    NON-marker word ending in a doubled vowel folding ONTO a marker — which
+    depends on markers ending in a SINGLE vowel, and several do ("come",
+    "tra", "hola", "eine"). The invariant was true and irrelevant; a short
+    vowel-final marker like "se" added tomorrow would let "see" manufacture it
+    with that invariant still green.
+
+    So this checks the thing itself: fold the words that actually have the
+    shape, and assert none of them lands on a marker.
+    """
+    markers = {m for _lang, m in _every_marker()}
+    folded = _collapse_elongation(word)
+    assert folded not in markers, (
+        f"{word!r} folds to {folded!r}, which IS a marker — the fold would "
+        f"manufacture a language out of an ordinary English word"
+    )
+
+
+# ── The fold is INTERNAL: it may decide, it may never reach the model ──
+
+
+def test_the_folded_string_never_reaches_the_prompt() -> None:
+    """The worst thing this fold could do is not misdetect — it is CORRUPT.
+
+    ``_collapse_elongation`` rewrites digits as readily as letters: measured,
+    "rp 2.500.000.000" folds to "rp 2.500.0.0" and "kbli 55111" to "kbli 551".
+    Those are a paid-up capital figure and a business classification code — if
+    the folded text were ever the text handed to the model instead of merely
+    the text scored for language, this change would silently falsify the
+    client's own numbers. It is not, and this pins that.
+
+    Note on the probe: the obvious check — ``"kbli 551" not in output`` — is
+    VACUOUS, because "kbli 551" is a substring of the correct "kbli 55111".
+    It reports success on a corrupted prompt too. The assertion below compares
+    the full numeric tokens instead, which cannot pass by coincidence.
+    """
+    query = "Serve Rp 2.500.000.000 di capitale per KBLI 55111? Buongiorno"
+    wrapped = wrap_query_with_language_instruction(query)
+
+    assert query in wrapped, "the original query must be forwarded byte-identical"
+    numbers_in = re.findall(r"[\d.]{3,}", query)
+    numbers_out = re.findall(r"[\d.]{3,}", wrapped)
+    assert sorted(set(numbers_out)) == sorted(set(numbers_in)), (
+        f"a folded numeric token reached the prompt: {numbers_out} != {numbers_in}"
+    )
+    # And the detection still had to work on this input, or the test is proving
+    # the fold is harmless by proving it never ran.
+    assert detect_query_language(query) == "ITALIAN"
+
+
+# ── Collisions found by an adversarial pass, and the one that was ACCEPTED ──
+
+
+ADVERSARIAL_ENGLISH: list[str] = [
+    # "prego" was originally added as a DECISIVE Italian marker. It is not an
+    # English word — it is a supermarket pasta-sauce brand, and this bot
+    # advises on food-import KBLI, so these are messages it actually receives.
+    # Demoted to a homograph, which is what the row's own rule already
+    # required: a token that names a language by coincidence decides nothing
+    # alone.
+    "Prego sauce import licence",
+    "Is Prego pasta sauce importable under KBLI 46331?",
+]
+
+
+@pytest.mark.parametrize("query", ADVERSARIAL_ENGLISH)
+def test_a_brand_name_that_looks_italian_does_not_decide(query: str) -> None:
+    assert detect_query_language(query) == "ENGLISH"
+
+
+# Portuguese is NOT a language this detector serves — it has no row, so it can
+# only ever land on the ENGLISH default. That default is the LEAST wrong answer
+# available, and the first draft of this diff took it away: "qual" was decisive
+# for Italian, and "qual" is THE standard Portuguese question word. A Brazilian
+# — a real client demographic in Bali — went from being answered in English
+# (wrong, but readable) to being answered entirely in Italian (wrong AND
+# unreadable). Demoting "qual" to a homograph restores the default at no cost,
+# because Italian "Qual è ..." is already carried by "è" (grave accent; the
+# Portuguese "é" is acute, a different code point).
+PORTUGUESE_MUST_NOT_BECOME_ITALIAN: list[str] = [
+    "Qual é o custo do visto de investidor em Bali?",
+    "Qual é o prazo para o KITAS?",
+    "Qual documento preciso?",
+]
+
+
+@pytest.mark.parametrize("query", PORTUGUESE_MUST_NOT_BECOME_ITALIAN)
+def test_an_unserved_language_falls_to_english_not_to_italian(query: str) -> None:
+    assert detect_query_language(query) != "ITALIAN"
+
+
+def test_qual_still_counts_for_a_real_italian_question() -> None:
+    """The demotion must not make it inert."""
+    assert detect_query_language("Qual è la differenza tra KITAS e KITAP") == "ITALIAN"
+
+
+def test_prego_still_counts_once_real_italian_is_present() -> None:
+    """Demoting it must not make it inert — that would be a silent loss."""
+    assert detect_query_language("Prego, mi dica quanto costa il KITAS") == "ITALIAN"
+
+
+# Inputs this detector KNOWINGLY gets wrong. Asserting the wrong answer is
+# deliberate: it is the only way a trade-off stays visible. Whoever later
+# removes "salve" will see this test go red and be sent to this docstring
+# instead of discovering the reasoning by rediscovering the bug.
+DECLARED_ACCEPTED_MISSES: list[str] = [
+    # "salve" IS an ordinary English noun (an ointment), so by this module's
+    # own anti-homograph rule it should not be decisive. It is anyway, and the
+    # justification is the DOMAIN, not the word: this is an immigration,
+    # company-setup, tax and property bot. An Italian client opening with
+    # "Salve, avrei una domanda" is routine; a client asking about ointment is
+    # not a client. The cost is asymmetric — the first mislabels a whole
+    # conversation, the second mislabels a message nobody sends.
+    "Please apply the salve twice daily",
+    # "tra" collides only with the English interjection "tra la la", which is
+    # likewise not a message this bot receives, while "differenza tra KITAS e
+    # KITAP" is.
+    "Tra la la, just testing",
+]
+
+
+@pytest.mark.parametrize("query", DECLARED_ACCEPTED_MISSES)
+def test_the_accepted_over_matches_are_declared_not_hidden(query: str) -> None:
+    assert detect_query_language(query) == "ITALIAN"
 
 
 def test_the_marker_corpus_this_file_guards_is_not_empty() -> None:

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_language_markers_cover_greetings.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_language_markers_cover_greetings.py
@@ -1,0 +1,192 @@
+"""A WhatsApp thread opens with a greeting, and the detector had no greeting.
+
+Sibling of ``test_language_markers_cover_business_questions``, which cured the
+opposite half: a client who opens with a BUSINESS QUESTION rather than a
+greeting. This file cures the half that was left — the client who opens with a
+GREETING and nothing else, which on WhatsApp is the commoner of the two.
+
+Measured on 2026-08-25 against 16 real Italian openers, before this change:
+**10 returned ENGLISH**, including "Buongiorno", "Salve", "Buonasera" and
+"Qual e la differenza tra KITAS e KITAP". The Italian row carried exactly one
+greeting ("ciao"); Spanish carried "hola" alone and German "hallo" alone, so
+"Buenos dias" and "Guten Tag" fell through the same hole.
+
+That default is not inert — ``wrap_query_with_language_instruction`` renders it
+to the model as ``YOUR ENTIRE RESPONSE MUST BE IN ENGLISH``. An Italian client
+saying good morning was being answered in English, by construction.
+
+Two mechanisms are under test here and they fail differently, so both get
+guilt cases: the widened marker rows, and the elongation fold that lets
+"ciaooo" and "graziee" reach those rows at all.
+"""
+
+import re
+
+import pytest
+
+from backend.services.rag.agentic.query_helpers import (
+    _LATIN_MARKERS,
+    INDONESIAN_MARKERS,
+    LANGUAGE_DISPLAY_NAMES,
+    detect_query_language,
+    wrap_query_with_language_instruction,
+)
+
+# Greetings and short openers. Every ITALIAN case here returned ENGLISH before
+# 2026-08-25; the other rows are the same defect in the languages that shared it.
+GUILT_GREETINGS: list[tuple[str, str]] = [
+    ("ITALIAN", "Buongiorno"),
+    ("ITALIAN", "Buonasera"),
+    ("ITALIAN", "Buonanotte"),
+    ("ITALIAN", "Salve"),
+    ("ITALIAN", "Salve, avrei una domanda"),
+    ("ITALIAN", "Buongiorno, ho una domanda"),
+    ("ITALIAN", "Scusate, potete aiutarmi?"),
+    ("ITALIAN", "Qual e la differenza tra KITAS e KITAP"),
+    ("ITALIAN", "Qual \u00e8 la differenza tra KITAS e KITAP"),
+    ("ITALIAN", "Mi serve aiuto con il visto"),
+    ("ITALIAN", "Ho bisogno di informazioni sul permesso di soggiorno"),
+    ("ITALIAN", "Volevo sapere i prezzi"),
+    ("SPANISH", "Buenos dias"),
+    ("SPANISH", "Buenos d\u00edas"),
+    ("SPANISH", "Buenas tardes"),
+    ("SPANISH", "Buenas noches"),
+    ("GERMAN", "Guten Tag"),
+    ("GERMAN", "Guten Morgen"),
+    ("GERMAN", "Guten Abend"),
+    ("FRENCH", "Bonsoir"),
+    ("FRENCH", "Salut"),
+]
+
+# The SECOND mechanism: a greeting the client stretched. These reach the rows
+# above only because the elongation fold runs first.
+GUILT_ELONGATED: list[tuple[str, str]] = [
+    ("ITALIAN", "ciaooo"),
+    ("ITALIAN", "ciaoo"),
+    ("ITALIAN", "graziee"),
+    ("ITALIAN", "grazieee"),
+    ("ITALIAN", "buongiornooo"),
+]
+
+# English is this detector's DEFAULT, so it is where a widened row does its
+# damage: every case below has to stay English after the change. The last four
+# are chosen against the elongation fold specifically — each ends in a doubled
+# vowel, which is exactly what the trailing-vowel rule rewrites.
+INNOCENCE_ENGLISH: list[str] = [
+    "Hello",
+    "Good morning",
+    "Hi there",
+    "Thanks a lot",
+    "How much does a KITAS cost?",
+    "I need help with my visa",
+    "What is the price?",
+    "How long does the process take?",
+    "Can I extend my visa?",
+    "Is the service free of charge?",
+    "We need three copies of the deed",
+    "Please send it to the committee",
+    "What is the KBLI code for a coffee shop?",
+]
+
+# The languages that already worked, in the shape they already worked in.
+INNOCENCE_OTHER: list[tuple[str, str]] = [
+    ("ITALIAN", "Quali documenti servono per aprire una PT PMA in Indonesia?"),
+    ("FRENCH", "Bonjour"),
+    ("FRENCH", "Quels documents faut-il pour ouvrir une PT PMA en Indonesie?"),
+    ("SPANISH", "Hola"),
+    ("SPANISH", "Cu\u00e1nto cuesta constituir una empresa en Bali?"),
+    ("GERMAN", "Hallo"),
+    ("GERMAN", "Welche Dokumente brauche ich, um eine PT PMA zu gruenden?"),
+    # GUILT for the fold's narrowness, not innocence for the rows: "muss" ends
+    # in a doubled CONSONANT and is a decisive German marker. A trailing-double
+    # fold written one character wider than it is would delete it here.
+    ("GERMAN", "Ich muss ein Visum beantragen"),
+    ("INDONESIAN", "Dokumen apa saja yang diperlukan untuk mendirikan PT PMA?"),
+    ("INDONESIAN", "Berapa harga KITAS?"),
+    (
+        "RUSSIAN",
+        "\u041a\u0430\u043a\u0438\u0435 \u0434\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u044b \u043d\u0443\u0436\u043d\u044b?",
+    ),
+]
+
+
+@pytest.mark.parametrize(("expected", "query"), GUILT_GREETINGS)
+def test_a_bare_greeting_is_detected(expected: str, query: str) -> None:
+    assert detect_query_language(query) == expected
+
+
+@pytest.mark.parametrize(("expected", "query"), GUILT_ELONGATED)
+def test_a_stretched_greeting_is_detected(expected: str, query: str) -> None:
+    """Fails if the elongation fold is removed, even with the rows intact."""
+    assert detect_query_language(query) == expected
+
+
+@pytest.mark.parametrize("query", INNOCENCE_ENGLISH)
+def test_english_is_still_english(query: str) -> None:
+    assert detect_query_language(query) == "ENGLISH"
+
+
+@pytest.mark.parametrize(("expected", "query"), INNOCENCE_OTHER)
+def test_the_other_languages_are_unmoved(expected: str, query: str) -> None:
+    assert detect_query_language(query) == expected
+
+
+@pytest.mark.parametrize(("expected", "query"), GUILT_GREETINGS + GUILT_ELONGATED)
+def test_the_model_is_not_ordered_to_answer_a_greeting_in_english(
+    expected: str, query: str
+) -> None:
+    """The harm, asserted where it actually reached the client.
+
+    Detection is the mechanism; the instruction built from it is the defect.
+    Pinning both means an edit that fixes one while breaking the other still
+    fails, the same way the business-question sibling pins its chain.
+    """
+    wrapped = wrap_query_with_language_instruction(query)
+    assert f"MUST BE IN {LANGUAGE_DISPLAY_NAMES[expected]}" in wrapped
+    assert "MUST BE IN ENGLISH" not in wrapped
+
+
+# ── The two claims the fold rests on, asserted instead of asserted-in-a-comment ──
+
+
+def _every_marker() -> list[tuple[str, str]]:
+    """(language, marker) for every decisive and homograph marker in this module."""
+    rows: list[tuple[str, str]] = [("INDONESIAN", m) for m in INDONESIAN_MARKERS]
+    for language, decisive, homographs in _LATIN_MARKERS:
+        rows.extend((language, m) for m in decisive + homographs)
+    return rows
+
+
+def test_no_marker_contains_a_run_of_three_identical_characters() -> None:
+    """The 3-character floor may only fold noise, never a marker.
+
+    ``_collapse_elongation`` runs BEFORE every marker match. If a marker ever
+    carried a triple, the fold would rewrite it out of its own list and the row
+    would go quietly dead — green tests, silent loss of recall. This is the
+    invariant that makes the floor safe, so it is checked rather than believed.
+    """
+    triple = re.compile(r"(.)\1{2,}")
+    offenders = [(lang, m) for lang, m in _every_marker() if triple.search(m)]
+    assert not offenders, f"markers the elongation fold would rewrite: {offenders}"
+
+
+def test_no_marker_ends_in_a_doubled_vowel() -> None:
+    """The trailing-vowel rule may only recover a marker, never manufacture one.
+
+    Restricting the 2-character fold to VOWELS is what keeps German "muss"
+    alive. This asserts the other half: that no marker in any row ENDS in a
+    doubled vowel, so the rule cannot fold a real marker into something else.
+    """
+    trailing = re.compile(r"([aeiou])\1+$")
+    offenders = [(lang, m) for lang, m in _every_marker() if trailing.search(m)]
+    assert not offenders, f"markers the trailing-vowel fold would rewrite: {offenders}"
+
+
+def test_the_marker_corpus_this_file_guards_is_not_empty() -> None:
+    """A structural check over an empty corpus is green and means nothing.
+
+    Both tests above iterate a derived list. If ``_LATIN_MARKERS`` were renamed
+    or emptied they would pass over zero rows and report success, so the count
+    is pinned to a floor well below the real size (currently ~150).
+    """
+    assert len(_every_marker()) > 100


### PR DESCRIPTION
Measured on 2026-08-25 against 16 real Italian openers: `detect_query_language`
returned ENGLISH for **10 of them**, including "Buongiorno", "Salve",
"Buonasera" and "Qual e la differenza tra KITAS e KITAP".

That default is not inert. `wrap_query_with_language_instruction` feeds the
verdict through `LANGUAGE_DISPLAY_NAMES` into a hard order —
`YOUR ENTIRE RESPONSE MUST BE IN ENGLISH` — so an Italian client saying good
morning was being answered in English by construction. This is the IT-in/EN-out
half of the WA language-mirror defect.

The cause is the exact mirror image of the one #4xxx cured on 2026-08-10 for
German and Spanish. That fix widened two thin rows because they held ONLY
greetings and a business question scored zero. The other half was never done:
the Italian row held exactly ONE greeting ("ciao"), Spanish held "hola" alone
and German "hallo" alone — so a client who opens with a greeting AND NOTHING
ELSE scored zero, which on WhatsApp is the commoner opener of the two.

Two mechanisms, because two things were broken:

1. The rows are widened with greetings and courtesies (it/fr/es/de), plus the
   Italian question and function words a real Italian question brings along
   ("qual", bare "e" accented, "aiuto", "bisogno", "sapere", "soggiorno",
   "informazioni", "potete", "volevo"). Each is held to the anti-homograph rule
   the file already documents. One entry knowingly breaks it and says so in
   place: "salve" is also an English noun, and the asymmetry is deliberate —
   a missed greeting mislabels an entire reply, a stolen "salve" mislabels one
   query nobody sends in this domain. "dove" goes in as a HOMOGRAPH, not a
   marker, because English has the bird.

2. Elongation is folded before any marker match. Every matcher here is
   whole-word by design, so "ciaooo" and "graziee" were unknown tokens that
   scored zero for every language — the same ENGLISH default reached through
   spelling instead of vocabulary. Runs of 3+ fold anywhere; a doubled vowel
   folds only at the END of a word. That second rule is written narrowly on
   purpose: German "muss" is a decisive marker ending in a doubled CONSONANT,
   and a blanket trailing-double fold would have silently deleted it.

Verified, and the mutation is the part that matters:

  * 79 new tests: guilt (bare greetings, stretched greetings, the end-to-end
    instruction), innocence (13 English cases incl. four ending in a doubled
    vowel — "free", "three", "committee", "coffee"), and the other languages
    unmoved.
  * Reverting query_helpers.py to HEAD turns **52 of the 79 red**; restoring
    it returns 0 failures. The tests fail for the reason they claim.
  * The two claims the fold rests on are asserted, not just commented: no
    marker anywhere contains a run of three, and none ends in a doubled vowel
    — with a floor check so those structural tests cannot pass over an empty
    corpus.
  * 303 pre-existing tests across the four language/persona/response suites:
    green, unchanged.

Out of scope, deliberately, and both filed rather than silently absorbed:
`conversation_history` is NOT consulted — the WA channel carries 12 turns and
no consumer of this detector reads them, so the language is still re-derived
from raw text on every message. Plumbing it crosses four layers and belongs in
its own PR. And `services/oracle/oracle_service.py` keeps a SECOND, separate
`detect_query_language` with none of this; it serves a different consumer and
is untouched here.

Unrelated pre-existing red, confirmed against a clean checkout of origin/main
with the same command: `test_standard_templates.py` fails with
`settings.COMPANY_NAME` as a MagicMock when run after its siblings, and passes
alone. Test-isolation leak, not this diff.