### PR TITLE
fix(kb): adversarial-review remediation for the Cukup-jelas FP-rate report

### DIFF
--- a/apps/backend-rag/backend/tests/unit/kb/test_cukup_jelas_damage_signal.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_cukup_jelas_damage_signal.py
@@ -126,10 +126,15 @@ GUILTY_SAMPLES = [
             "KERJA MENJADI UNDANG-UNDANG - Pasal 12]\n\nCukup jelas.\nAngka 4"
         ),
     },
-    {  # UU_17_2008 — the UNMARKED BOUNDARY document (471 "Cukup jelas", 0
-        # "PENJELASAN" headers); bare form is the overwhelming majority there
-        "document_id": "UU_17_2008",
-        "text": "Cukup jelas.",
+    {  # UU_66_2024 — Pelayaran (shipping) amendment, corpus-hygiene surface
+        # (no measurable client traffic per the 2026-08-25 WhatsApp-mirror
+        # census) but structurally identical pattern: boilerplate mixed with
+        # one substantive Ayat that IS informative
+        "document_id": "UU_66_2024",
+        "text": (
+            "Ayat (1)\nCukup jelas.\nAyat (2)\nCukup jelas.\nAyat (3)\n"
+            "Insentif dapat berupa insentif fiskal dan/atau nonfiskal.\nAngka 3"
+        ),
     },
     {  # environmental Perda with a long, genuinely substantive elucidation entry
         "document_id": "Perda_3_2013",
@@ -155,8 +160,12 @@ GUILTY_SAMPLES = [
 ]
 
 
-# ── INNOCENCE fixtures ───────────────────────────────────────────────────────
-INNOCENT_SAMPLES = [
+# ── TRUE INNOCENCE fixtures (expect=False, "must NOT be flagged") ───────────
+# Adversarial review (Codex, 2026-08-25) found the original single mixed list
+# labeled all 7 fixtures "INNOCENCE" when 2 actually assert the POSITIVE
+# direction — split here so the count in this comment matches what each
+# fixture actually tests.
+TRUE_INNOCENCE_SAMPLES = [
     {
         "id": "explicitly-tagged-penjelasan-top-level",
         # The one case the live sample under-represents: only 792/84,283 points
@@ -166,20 +175,17 @@ INNOCENT_SAMPLES = [
         # tagged elucidation re-enters the damaged count.
         "payload": {"document_id": "UU_6_2011", "section": "penjelasan",
                     "text": "Cukup jelas."},
-        "expect": False,
     },
     {
         "id": "explicitly-tagged-penjelasan-nested-metadata",
         # Same exclusion, legacy nested-metadata shape (78,486/84,283 points).
         "payload": {"metadata": {"document_id": "UU_40_2007", "section": "penjelasan",
                                   "text": "Cukup jelas."}},
-        "expect": False,
     },
     {
         "id": "no-phrase-at-all",
         "payload": {"document_id": "UU_1_1945",
                     "text": "Setiap warga negara berhak atas pekerjaan yang layak."},
-        "expect": False,
     },
     {
         "id": "word-boundary-should-not-fuse-unrelated-words",
@@ -191,21 +197,6 @@ INNOCENT_SAMPLES = [
         # words adjacent (whitespace-only between them), so this must be False.
         "payload": {"document_id": "UU_99_2099",
                     "text": "Ketercukupan anggaran dan kejelasan prosedur wajib dijamin."},
-        "expect": False,
-    },
-    {
-        "id": "case-insensitive-still-matches",
-        # Not an innocence case in the "should be excluded" sense — asserts the
-        # positive direction of the same word-boundary logic: case must not
-        # matter (guards against a future regex edit adding re.IGNORECASE
-        # removal as a silent regression in the guilty direction).
-        "payload": {"document_id": "UU_1_2019", "text": "Pasal 1 \nCUKUP JELAS."},
-        "expect": True,
-    },
-    {
-        "id": "multi-whitespace-between-words-still-matches",
-        "payload": {"document_id": "UU_1_2019", "text": "Cukup   \n  jelas."},
-        "expect": True,
     },
     {
         "id": "missing-text-key-does-not-crash-and-is-innocent",
@@ -213,7 +204,52 @@ INNOCENT_SAMPLES = [
         # metadata.text -> "". A point with none of those must not raise and
         # must not be flagged.
         "payload": {"document_id": "UU_0_0000"},
-        "expect": False,
+    },
+]
+
+
+# ── POSITIVE-CONTROL fixtures (expect=True) ─────────────────────────────────
+# NOT innocence cases — these assert the guilty direction still fires under
+# variations the guard could plausibly be "fixed" into over-restricting
+# (case, internal whitespace). If a future edit adding a stricter word
+# boundary silently narrowed the match, these would catch the recall loss
+# the guilt fixtures above might not exercise (none of GUILTY_SAMPLES has
+# mixed case or multi-line whitespace between the two words).
+POSITIVE_CONTROL_SAMPLES = [
+    {
+        "id": "case-insensitive-still-matches",
+        "payload": {"document_id": "UU_1_2019", "text": "Pasal 1 \nCUKUP JELAS."},
+    },
+    {
+        "id": "multi-whitespace-between-words-still-matches",
+        "payload": {"document_id": "UU_1_2019", "text": "Cukup   \n  jelas."},
+    },
+]
+
+
+# ── DOCUMENTED RESIDUAL RISK (expect=True, on purpose) ──────────────────────
+# Adversarial review (Codex) pointed out the innocence suite above never
+# tested "cukup jelas" used ADJACENT and IDIOMATICALLY in ordinary prose
+# (e.g. "informasi yang cukup jelas mengenai prosedur ini" -- "sufficiently
+# clear information about this procedure") rather than as the Penjelasan
+# boilerplate marker. This IS flagged True by design: the campaign's §6
+# signal (research/legal/2026-08-25-cukup-jelas-false-positive-rate.md) is a
+# deliberate bare substring test with no semantic-register awareness, and
+# this predicate faithfully implements that definition rather than silently
+# adding a filter the campaign never asked for. The 2026-08-25 measurement
+# (45 samples, stratified across all 34 damaged documents) found ZERO
+# fragments of this shape in the actual flagged population -- but 45 samples
+# cannot prove none exist in the other 1,974 unread fragments. Recorded here
+# as an explicit, named risk rather than a silent gap: if this pattern turns
+# out to be common, the predicate needs a smarter register check, and this
+# fixture is where that requirement would be re-verified.
+RESIDUAL_RISK_SAMPLES = [
+    {
+        "id": "ordinary-idiomatic-use-is-flagged-by-design-not-a-bug",
+        "payload": {"document_id": "UU_88_2088",
+                    "text": ("Berdasarkan penjelasan di atas, prosedur permohonan izin "
+                              "sudah cukup jelas diatur dalam Pasal 12 sehingga pemohon "
+                              "dapat langsung mengajukan berkas ke kantor terkait.")},
     },
 ]
 
@@ -222,23 +258,54 @@ INNOCENT_SAMPLES = [
 def test_guilt_real_elucidation_fragments_are_flagged(sample):
     """All 10 fixtures are verbatim text lane P manually verified as genuine
     elucidation (Penjelasan) content during the 2026-08-25 false-positive
-    read-through. If the predicate stops recognizing any of these, it has
-    lost RECALL on the exact shape the campaign is trying to measure."""
+    read-through, spanning 10 DISTINCT documents (an earlier draft repeated
+    UU_17_2008 twice under two different comments -- caught by adversarial
+    review, replaced with a UU_66_2024 sample so the "10 documents" claim in
+    the module docstring and the report is actually true). If the predicate
+    stops recognizing any of these, it has lost RECALL on the exact shape the
+    campaign is trying to measure."""
     signal = _signal()
     payload = {"document_id": sample["document_id"], "text": sample["text"]}
     assert signal.is_unmarked_penjelasan_fragment(payload) is True, (
         f"{sample['document_id']}: manually-verified genuine elucidation text "
         "was not flagged — the predicate has lost recall."
     )
+    assert len({s["document_id"] for s in GUILTY_SAMPLES}) == len(GUILTY_SAMPLES), (
+        "GUILTY_SAMPLES must span DISTINCT documents — a repeated document_id "
+        "silently shrinks the claimed sample-diversity coverage."
+    )
 
 
-@pytest.mark.parametrize("sample", INNOCENT_SAMPLES, ids=lambda s: s["id"])
-def test_innocence_constructed_edge_cases_are_not_flagged_or_are_correctly_flagged(sample):
+@pytest.mark.parametrize("sample", TRUE_INNOCENCE_SAMPLES, ids=lambda s: s["id"])
+def test_innocence_constructed_edge_cases_are_not_flagged(sample):
     signal = _signal()
     result = signal.is_unmarked_penjelasan_fragment(sample["payload"])
-    assert result is sample["expect"], (
-        f"{sample['id']}: expected is_unmarked_penjelasan_fragment()={sample['expect']}, "
-        f"got {result}"
+    assert result is False, (
+        f"{sample['id']}: expected is_unmarked_penjelasan_fragment()=False, got {result}"
+    )
+
+
+@pytest.mark.parametrize("sample", POSITIVE_CONTROL_SAMPLES, ids=lambda s: s["id"])
+def test_positive_control_variations_still_flag(sample):
+    signal = _signal()
+    result = signal.is_unmarked_penjelasan_fragment(sample["payload"])
+    assert result is True, (
+        f"{sample['id']}: expected is_unmarked_penjelasan_fragment()=True, got {result}"
+    )
+
+
+@pytest.mark.parametrize("sample", RESIDUAL_RISK_SAMPLES, ids=lambda s: s["id"])
+def test_documented_residual_risk_flags_true_by_design(sample):
+    """This is NOT asserting correctness of the campaign's own signal — it is
+    asserting FAITHFULNESS to its stated definition (bare substring, no
+    semantic-register filter). See the fixture's own comment for why this is
+    True on purpose and what would need to change for it to become False."""
+    signal = _signal()
+    result = signal.is_unmarked_penjelasan_fragment(sample["payload"])
+    assert result is True, (
+        f"{sample['id']}: expected True (faithful to the campaign's bare-substring "
+        f"definition), got {result} — if this was deliberately narrowed, update "
+        "the report's false-positive-rate claim too, not just this fixture."
     )
 
 

--- a/research/legal/2026-08-25-cukup-jelas-false-positive-rate.md
+++ b/research/legal/2026-08-25-cukup-jelas-false-positive-rate.md
@@ -303,23 +303,45 @@ the four legacy top-damage documents most relevant to this mandate
 (`UU_66_2024`, `UU_11_2020`, `UU_28_2007`, `UU_17_2008`) found **zero**
 occurrences of `"Penjelasan_Pasal"` in any of them, despite these documents
 demonstrably containing real elucidation content (per the sampled "Cukup
-jelas" fragments themselves). Two explanations are live and unresolved:
-either these legacy points were produced by an ingestion path that predates
-the current `Penjelasan_Pasal`/`Pasal` naming convention (so the convention
-never touched them), or the split fails on these documents for a different,
-uninvestigated reason. **This is reported as an open question, not a
-finding** — it is the honest state of a lead that looked promising on 792
-points and has not yet been confirmed anywhere in the 78,486-point legacy
-majority that includes this mandate's actual top-damage documents.
+jelas" fragments themselves).
 
-**Handoff, corrected**: whichever lane owns the UNMARKED BOUNDARY class
-should NOT start from `has_ayat` — that lead is retracted. It should instead
-first resolve whether `hierarchy_path`/`chunk_key`'s `Penjelasan_Pasal`
-naming convention was ever applied to legacy-shape points at all (a
-git-history / ingestion-provenance question this investigation did not have
-budget to answer), before deciding whether that field is usable on the
-documents that actually matter for this mandate. No document-ordering field
-was found to exist for a "pasal renumbering restart" boundary detector
+**This is now resolved, not open — the answer is "expected, not anomalous."**
+A follow-up code investigation (grep across the whole repo + `git log --all
+-S"Penjelasan_Pasal"`) found: (1) `hierarchy_path` is written by exactly ONE
+code path in the entire repo, `hierarchical_indexer.py`; (2) the
+`Penjelasan_Pasal`/`Pasal` prefix distinction is **one commit old** —
+`git log --all -S"Penjelasan_Pasal"` returns exactly one commit, `f0a0eab22`
+(2026-08-25 07:38:05 UTC, PR #4891), the SAME DAY as this investigation.
+Before that commit, the chunk-id builder produced only `Pasal_{n}`
+unconditionally — no elucidation/article distinction existed in
+`hierarchy_path` at all prior to that commit, for ANY point; (3) the real
+fork is a `flatten_payload` boolean in `qdrant_db.py`'s
+`_build_point_payload` — only `hierarchical_indexer.py` calls it with
+`flatten_payload=True` (producing the flat, top-level `document_id`/
+`hierarchy_path`/`chunk_key` shape); the default (`flatten_payload=False`,
+used by three OTHER ingestion callers —
+`services/ingestion/ingestion_service.py`,
+`services/ingestion/politics_ingestion.py`, `app/routers/oracle_ingest.py`,
+none of which import `HierarchicalIndexer`) nests everything under
+`metadata` instead — exactly the `legacy_metadata_text` shape that is
+78,486 of 84,283 points. Those three callers are **structurally incapable**
+of ever writing `hierarchy_path` in any naming convention — the field is not
+present-but-differently-named on legacy points, it is simply never
+constructed for them. Zero hits on the four legacy top-damage documents is
+therefore the expected result, not a mystery: `hierarchy_path`/`chunk_key`'s
+`Penjelasan_Pasal` naming convention is same-day, single-commit, and scoped
+to the 792-point `modern_full` bucket — it was never going to appear on
+points from a different, older ingestion pipeline.
+
+**Handoff, corrected and now conclusive**: whichever lane owns the UNMARKED
+BOUNDARY class should NOT start from `has_ayat` (retracted) NOR from
+`hierarchy_path`/`chunk_key` on legacy-shape points (structurally absent,
+not a lead worth chasing there). Any elucidation-vs-article signal for the
+78,486-point legacy majority — which is where this mandate's actual
+top-damage documents live — must be found elsewhere: raw chunk text, or
+`metadata.section` where it happens to be present, or a genuinely new
+signal this investigation did not attempt to build. No document-ordering
+field was found to exist for a "pasal renumbering restart" boundary detector
 either (`chunk_id` is a random per-point UUID, not a sequence number;
 `metadata.pasal_number` values come back scrambled when sorted by
 `chunk_id`) — that structural approach the mandate suggested remains
@@ -334,11 +356,15 @@ unvalidated and unbuilt, honestly, rather than shipped on a hope.
 - **No detector shipped for any Finding-3 structural signal.** The original
   `has_ayat` lead is retracted outright (confirmed confounded with ordinary
   paragraph structure and a 4,000-char chunk-size cutoff, not with
-  elucidation status — see Finding 3). The narrower `hierarchy_path`/
-  `chunk_key` lead is validated only on 792 of 84,283 points and shows zero
-  hits on the legacy documents that matter for this mandate; shipping either
-  now would repeat exactly the mistake this investigation was launched to
-  check for.
+  elucidation status — see Finding 3). The `hierarchy_path`/`chunk_key`
+  naming-convention lead is confirmed to be structurally scoped to the
+  792-point `modern_full` bucket only — a same-day, single-commit addition
+  (`f0a0eab22`, 2026-08-25) that three of the repo's four ingestion callers
+  never construct at all, in any form — so it is not usable on the
+  78,486-point legacy majority where this mandate's actual top-damage
+  documents live. Neither is a detector worth shipping; the legacy-shape
+  elucidation-vs-article problem remains genuinely unsolved by anything
+  found in this investigation.
 - **No deletions, no re-ingestion, no chunking change.** Embedding model
   (`text-embedding-3-small`, 1536 dims) untouched — nothing in this
   investigation required or would justify re-embedding.
@@ -468,10 +494,15 @@ and disposition:
   genuine elucidation. The "5.7x recall" framing assumed what it needed to
   prove. **Fixed** — Finding 3 was rewritten to retract this claim outright
   and replace it with the narrower, code-verified `hierarchy_path`/
-  `chunk_key` naming-convention lead, itself reported honestly as validated
-  on only 792/84,283 points and showing zero hits on the four legacy
-  top-damage documents this mandate actually cares about — an open question,
-  not a finding.
+  `chunk_key` naming-convention lead. That lead's zero-hits-on-legacy-
+  documents puzzle was initially reported as an open question, then CLOSED
+  within this same remediation pass by a follow-up code investigation:
+  `git log --all -S"Penjelasan_Pasal"` shows the naming convention is a
+  same-day, single-commit addition (`f0a0eab22`, 2026-08-25, PR #4891), and
+  the `flatten_payload` fork in `qdrant_db.py` means three of the repo's
+  four ingestion callers never construct `hierarchy_path` at all — the
+  field is structurally absent on legacy points, not present under a
+  different name. Zero hits was the expected result, not a mystery.
 - **E — overclaiming language** ("near-zero", "usable as-is", "undercounts...
   if anything", "5.7x recall") exceeded what 45 clustered observations plus
   an unvalidated structural lead support. **Fixed** — softened throughout:

--- a/research/legal/2026-08-25-cukup-jelas-false-positive-rate.md
+++ b/research/legal/2026-08-25-cukup-jelas-false-positive-rate.md
@@ -2,6 +2,7 @@
 date: 2026-08-25
 domain: legal
 client_case: none — KB current-live campaign, Lane P (parser capability)
+adversarial_review: codex
 sources:
   - live measurement against Qdrant collection `legal_unified_hybrid_hybrid`
     (registry name `legal_unified`), 84,283 points, scrolled in full
@@ -29,9 +30,14 @@ That number had never been checked for innocence. It has now: a stratified
 sample of 45 flagged fragments, spread across 34 distinct documents (every
 document that has ANY flagged fragment), was read in full.
 
-**Measured false-positive rate: 0/45 (0%).** Every sampled fragment was
-genuinely elucidation-style text. The 2,019/34 figure is not a fiction — it
-undercounts the real problem, if anything (see Finding 3 below).
+**Measured false-positive rate: 0/45 (0%), with document-level (not
+fragment-level) sampling guarantees — see the statistical caveat in Method.**
+Every sampled fragment was genuinely elucidation-style text. The 2,019/34
+figure is not a fiction. A related structural signal exists that plausibly
+catches additional elucidation content the substring match misses (Finding
+3), but its precision is unvalidated and an earlier draft of that finding
+over-claimed what the evidence supports — see Finding 3 for the corrected,
+more cautious version.
 
 ## Method
 
@@ -60,6 +66,24 @@ LLM call) and judged: **is this genuinely elucidation text sitting in an
 article slot, or a legitimate occurrence** (a citation, an unrelated preamble,
 ordinary non-idiomatic prose)?
 
+**What this sampling design does and does not license statistically**
+(corrected after adversarial review — see the Adversarial review section
+below; an earlier draft of this report claimed a 95%-CI upper bound derived
+from treating the sample as i.i.d. Bernoulli draws over the 2,019-fragment
+population, which is wrong and has been removed). Round-robin across 34
+documents means a document contributing 1 of the 2,019 fragments (most of
+them) and a document contributing 726 (`UU_6_2023`) each get roughly 1-2
+samples — the sample is closer to **stratified-by-document** than to a
+uniform random draw over fragments, and fragments within one document are
+NOT independent trials (most repeat the identical bare "Cukup jelas."
+string). The defensible claim is: **34/34 damaged documents were represented
+in the read-through, and 0 of the ~1-2 fragments read per document were
+innocent.** That is strong document-level coverage and a genuinely
+qualitative result (every document's damage pattern was internally
+consistent — repeated boilerplate, not a mix of boilerplate and unrelated
+hits), but it does NOT support a numeric confidence interval on the
+fragment-level false-positive rate, and this report no longer claims one.
+
 ## Result: 45/45 genuine elucidation, 0 innocent occurrences
 
 Patterns found across the sample, all consistent with genuine Penjelasan
@@ -86,13 +110,15 @@ Patterns found across the sample, all consistent with genuine Penjelasan
 No fragment in the sample was a citation of another law's elucidation, an
 unrelated preamble merely containing the phrase, or ordinary prose using
 "cukup jelas" non-idiomatically. **The narrow question the mandate asked —
-does this signal over-match — has a clean negative answer at this sample
-size.** With 0/45 hits and a sample spanning every damaged document, standard
-binomial reasoning puts the true FP rate's upper bound (95% CI, rule-of-three
-approximation) at roughly 3/45 ≈ 6.6% even in the worst case a larger sample
-might reveal — and every sampled document's damage pattern (bare boilerplate
-repeated hundreds of times, per the top-10 counts below) makes a hidden
-population of qualitatively different, innocent occurrences unlikely.
+does this signal over-match — has a clean negative answer at the document
+level: all 34 damaged documents were sampled, and every one showed a
+consistent, genuine elucidation pattern with no innocent occurrence mixed
+in.** (No numeric fragment-level confidence bound is claimed — see Method.)
+Every sampled document's damage pattern (bare boilerplate repeated hundreds
+of times, per the top-10 counts below) makes a hidden population of
+qualitatively different, innocent occurrences within an already-sampled
+document unlikely, though this is a qualitative read of the pattern, not a
+statistical guarantee.
 
 Top damaged documents (fragment count): `UU_6_2023` 726, `UU_17_2008` 337,
 `PP_1_2011` 137, `UU_43_2009` 84, `UU_14_2025` 83, `UU_16_2025` 64,
@@ -100,8 +126,10 @@ Top damaged documents (fragment count): `UU_6_2023` 726, `UU_17_2008` 337,
 
 ## What was built: a gated regression test, not a new detector
 
-Given the false-positive rate is near-zero, the signal is usable as-is. The
-deliverable is a formalization + regression gate, not a new detector:
+The measured 0/45 result is a document-level, not a fragment-level,
+guarantee (see Method), so "the signal is safe" is not claimed outright —
+what is shipped is a formalization + regression gate that locks in exactly
+what was verified, not a blanket endorsement:
 
 - `scripts/kb/cukup_jelas_signal.py` — the §6 predicate
   (`is_unmarked_penjelasan_fragment`), extracted so the live measurement
@@ -109,29 +137,53 @@ deliverable is a formalization + regression gate, not a new detector:
   restating it (a signal defined twice is a signal that can quietly diverge
   from what it claims to measure).
 - `apps/backend-rag/backend/tests/unit/kb/test_cukup_jelas_damage_signal.py`
-  — 19 tests:
+  — 20 tests (restructured once, after adversarial review — see that section
+  below for what the earlier 19-test version got wrong):
   - 10 GUILT fixtures: verbatim text from 10 of the 45 manually-verified
-    samples, spanning 10 documents and every pattern found (bare, per-Ayat
-    mix, explicit PASAL DEMI PASAL heading, substantive worked-example
-    prose).
-  - 7 INNOCENCE fixtures: the `section: penjelasan` exclusion (both payload
-    shapes — top-level and nested `metadata.section`, since the live sample
-    exercises this path on only 792/84,283 points and would not itself catch
-    a regression there), a no-phrase-at-all case, a word-boundary case
-    (`"Ketercukupan anggaran dan kejelasan prosedur..."` — contains "cukup"
-    and "jelas" as substrings of OTHER words, must not fire), case-
-    insensitivity and whitespace-tolerance in the positive direction, and a
-    missing-`text`-key case that must not crash.
+    samples, spanning **10 distinct documents** (a runtime assertion in the
+    test enforces this — an earlier draft repeated `UU_17_2008` and only
+    covered 9) and every pattern found (bare, per-Ayat mix, explicit PASAL
+    DEMI PASAL heading, substantive worked-example prose).
+  - 5 TRUE-INNOCENCE fixtures (hard-asserted `False`): the
+    `section: penjelasan` exclusion at both payload shapes (top-level and
+    nested `metadata.section`, since the live sample exercises this path on
+    only 792/84,283 points and would not itself catch a regression there), a
+    no-phrase-at-all case, a word-boundary case (`"Ketercukupan anggaran dan
+    kejelasan prosedur..."` — contains "cukup" and "jelas" as substrings of
+    OTHER words, must not fire), and a missing-`text`-key case that must not
+    crash.
+  - 2 POSITIVE-CONTROL fixtures (hard-asserted `True`): case-insensitivity
+    and whitespace-tolerance. An earlier draft mislabeled these as
+    "innocence" cases even though they assert the opposite outcome —
+    separated into their own list and test function.
+  - 1 RESIDUAL-RISK fixture (hard-asserted `True`, "by design"): ordinary
+    Indonesian prose using "cukup jelas" idiomatically and non-boilerplate
+    (`"...prosedur permohonan izin sudah cukup jelas diatur dalam Pasal
+    12..."`). This is flagged `True` — faithfully reproducing the campaign's
+    own bare-substring definition, not a bug in this test — and is the
+    fixture an earlier draft was missing entirely (adversarial review point
+    B3). The 2026-08-25 sample found zero such cases among the 45 read, but
+    45 samples cannot prove none exist among the remaining 1,974 unread
+    fragments; this fixture documents that residual risk rather than
+    hiding it.
   - 2 explicit mutation-proof tests, PLUS two mutations run BY HAND against
-    the real source during this investigation (not just simulated inline):
-    removing the `section != "penjelasan"` guard turned 3 tests red
-    (both `section:penjelasan` fixtures + the dedicated mutation-proof test);
+    the real source, TWICE — once before this restructuring and once after,
+    to confirm the restructuring didn't quietly weaken them (both runs
+    produced identical failure sets): removing the
+    `section != "penjelasan"` guard turned 3 tests red (both
+    `section:penjelasan` fixtures + the dedicated mutation-proof test);
     loosening the regex to two independent substring checks (dropping word
     adjacency) turned 2 tests red (the word-boundary fixture + its
-    mutation-proof test). Both mutations were reverted; the suite is green
-    (19/19) on the restored source. This satisfies the "every detector you
-    write ships WITH guilt AND innocence tests, and you must show each going
-    red under mutation" requirement literally, not just in prose.
+    mutation-proof test). Both mutations were reverted each time; the suite
+    is green (20/20) on the restored source. This satisfies the "every
+    detector you write ships WITH guilt AND innocence tests, and you must
+    show each going red under mutation" requirement literally, not just in
+    prose.
+- `research/legal/_cukup_jelas_sample.json` — the raw 45-item sample
+  (regenerated identically: 84,283 points scrolled, 2,019 damaged, 34
+  documents, same top-10 breakdown), committed for independent audit. An
+  earlier draft measured but never shipped this file (adversarial review
+  point B4).
 
 No re-ingestion, no chunking change, no embedding re-index — the embedding
 model stays FROZEN as required; this is a read-only classification of
@@ -191,76 +243,87 @@ annexed instrument is ~1.33M characters), all carrying the CARRIER's
 entire Cipta Kerja ... plus two elucidations") directly from sampled content,
 independent of the mandate's own prior measurement.
 
-## Finding 3 — a bigger, unvalidated lead: the corpus has a structural
-## elucidation-vs-article signal that catches ~5x more than "Cukup jelas" does
+## Finding 3 — a structural lead, CORRECTED after adversarial review: the
+## naive reading was wrong, and the honest version is much weaker
+
+**This section was substantially rewritten after adversarial review
+(Codex, point D) found the original framing over-claimed.** The original
+draft of this finding (preserved in git history on this branch, not
+reproduced here) claimed a `has_ayat`/`has_context` metadata key-set split
+was a "5.7x recall" elucidation-vs-article detector, ready for handoff. That
+claim does not survive reading the code that produces the field.
 
 Not asked for, but found while investigating the UNMARKED BOUNDARY class
 (`UU_17_2008`, 471 "Cukup jelas" occurrences, 0 "PENJELASAN" headers — no
 word-level rule can find where its elucidation section starts).
 
-Legacy-shape points (the 78,486/84,283 majority with no top-level
-`document_id`) carry a `metadata` dict whose KEY SET differs by which
-ingestion sub-path produced the chunk, independent of chunk text:
+**What is actually measured** (full 84,283-point scroll, whole-or-nothing,
+same discipline as the main measurement): legacy-shape points (the
+78,486/84,283 majority with no top-level `document_id`) split into two
+`metadata` key-set shapes — 12,624 points carry `has_ayat`/`ayat_count`/etc.,
+59,171 carry `has_context`/`chunk_index`/etc., 12,488 carry neither. Of
+those, 1,161 of the 12,624 `has_ayat`-shape points and 852 of the 59,171
+`has_context`-shape points contain "Cukup jelas". These counts are real and
+reproducible.
 
-- **Article ("Batang Tubuh") shape**: `has_context`, `chunk_index`,
-  `chunk_length`, `content_length`, `total_chunks`.
-- **Elucidation ("Penjelasan") shape**: `has_ayat`, `ayat_count`, `ayat_max`,
-  `ayat_numbers`, `ayat_sequence_valid`, `ayat_validation_error`.
+**What is NOT confirmed, and was wrongly asserted before**: that
+`has_ayat=True` marks elucidation content. Reading
+`apps/backend-rag/backend/core/legal/hierarchical_indexer.py` directly
+(lines ~280-356, "Standard processing for small Pasal") shows `has_ayat` is
+set by `len(extract_ayat_numbers(pasal_text)) > 0` — a pure text-regex count
+of `Ayat(N)` markers — for **any** Pasal chunk under the 4,000-character
+size threshold, unconditionally on the `section` value (`batang_tubuh` or
+`penjelasan`). An ordinary OPERATIVE article that happens to be organized
+into `Ayat (1)` / `Ayat (2)` sub-paragraphs — which is a very common,
+unremarkable shape for Indonesian statute articles, not a special one — gets
+`has_ayat=True` on exactly the same basis as a genuine elucidation entry.
+The field carries no section information; it is confounded with ordinary
+paragraph structure and the 4,000-character chunk-size cutoff, not with
+elucidation-vs-article status. The one spot-check performed during the
+original investigation (`UU_17_2023`, ambiguous prose that could be either
+an elucidation restatement or an ordinary operative Ayat) is consistent with
+this — it was never resolved, and the original draft reported it as an open
+question while still headlining a "5.7x recall" number that assumed the
+answer. **The correct statement is: `has_ayat` is not a validated
+elucidation signal, and the 11,463-point "additional recall" figure from the
+earlier draft should be treated as an artifact of chunk size, not evidence
+of a detector.** No detector, no handoff recommendation, is being built on
+`has_ayat` in light of this.
 
-Measured across the FULL 84,283-point scroll (whole-or-nothing, same
-discipline as the main measurement):
+**A more promising, narrower, still-unresolved lead**: where a `hierarchy_path`
+or `chunk_key` metadata field is present, `hierarchical_indexer.py`'s own
+`prefix = "Pasal" if section == "batang_tubuh" else "Penjelasan_Pasal"`
+logic (same file) means that field's string value DOES directly encode
+elucidation-vs-article status by construction, not by inference — this was
+verified live: on the 792 `modern_full` points (the two 2026-08-25 repairs,
+UU_6_2011/UU_40_2007), `chunk_key` containing `"Penjelasan_Pasal"` matches
+`section == "penjelasan"` 1:1 on every sampled row, with zero exceptions
+found. **But** the same live check against `hierarchy_path`/`chunk_key` on
+the four legacy top-damage documents most relevant to this mandate
+(`UU_66_2024`, `UU_11_2020`, `UU_28_2007`, `UU_17_2008`) found **zero**
+occurrences of `"Penjelasan_Pasal"` in any of them, despite these documents
+demonstrably containing real elucidation content (per the sampled "Cukup
+jelas" fragments themselves). Two explanations are live and unresolved:
+either these legacy points were produced by an ingestion path that predates
+the current `Penjelasan_Pasal`/`Pasal` naming convention (so the convention
+never touched them), or the split fails on these documents for a different,
+uninvestigated reason. **This is reported as an open question, not a
+finding** — it is the honest state of a lead that looked promising on 792
+points and has not yet been confirmed anywhere in the 78,486-point legacy
+majority that includes this mandate's actual top-damage documents.
 
-| bucket | total points | of which contain "Cukup jelas" |
-|---|---|---|
-| A = has_ayat shape | 12,624 | 1,161 (9.2%) |
-| C = has_context shape | 59,171 | 852 (1.44%) |
-| N = neither shape | 12,488 | 275 |
-
-Two things this shows:
-
-1. **The `has_ayat` shape catches 11,463 points that contain NO "Cukup
-   jelas" at all** — substantive elucidation prose without the boilerplate
-   phrase (e.g. `"Yang dimaksud dengan..."` glosses, or plain restatement
-   text). That is **5.7x the entire 2,019-fragment §6 count**, in ONE
-   structural bucket, using a field that is ALREADY in the payload (zero
-   re-ingestion cost to read it).
-2. **It is not a strict superset**: 852 of the 2,019 "Cukup jelas" fragments
-   are in the `has_context` (article) shape, not `has_ayat` — bare
-   single-line "Cukup jelas." elucidation entries with no per-Ayat breakdown
-   apparently get chunked through the same code path as ordinary articles.
-   A detector using `has_ayat` alone, without the substring signal, would
-   MISS these — the two signals are complementary, not redundant.
-
-**Why this is reported as a lead, not shipped as a detector**: precision was
-NOT fully validated. One spot-checked `has_ayat` example
-(`UU_17_2023`: `"Pemerintah Pusat dan Pemerintah Daerah bertanggung jawab
-dalam penyelenggaraan pelayanan kedokteran untuk kepentingan hukum."`) reads
-ambiguously — it could be genuine elucidation prose (a restatement without
-the "Yang dimaksud dengan" tell) or, less likely but not ruled out, an
-operative Ayat that happens to share the payload shape for an unrelated
-reason. Confirming this needs either (a) reading the surrounding chunks in
-document order, which requires a reliable chunk-ordering field this
-investigation did NOT find (`chunk_id` is a random per-point UUID, not a
-sequence number — sorting by it does not recover document order;
-`metadata.pasal_number` values come back in a scrambled, non-monotonic
-sequence when sorted by `chunk_id`, so the "does pasal numbering restart"
-structural boundary test the mandate suggested could not be validated with
-currently-available ordering metadata), or (b) a much larger, properly
-stratified precision sample across more of the 12,624 `has_ayat` points than
-this investigation's budget allowed.
-
-**Handoff**: whichever lane owns the UNMARKED BOUNDARY class should start
-from the `has_ayat`/`has_context` key-set split (cheap, already-computed,
-5.7x the recall of substring matching) rather than reinventing a text-pattern
-detector, but must run its own guilt+innocence validation before shipping —
-this investigation deliberately stopped short of that to avoid shipping an
-under-tested guard (superscar family #3 discipline: "nessuna guardia senza
-test di innocenza E colpevolezza"). No document-ordering field currently
-exists to support a "pasal renumbering restart" boundary detector; that would
-need either an ingestion-time addition (`chunk_index` is scoped to the
-article-shape sub-path only, not a document-wide sequence) or a
-re-derivation from `chunk_length`/`content_length` byte-offset reconstruction
-that this investigation did not attempt.
+**Handoff, corrected**: whichever lane owns the UNMARKED BOUNDARY class
+should NOT start from `has_ayat` — that lead is retracted. It should instead
+first resolve whether `hierarchy_path`/`chunk_key`'s `Penjelasan_Pasal`
+naming convention was ever applied to legacy-shape points at all (a
+git-history / ingestion-provenance question this investigation did not have
+budget to answer), before deciding whether that field is usable on the
+documents that actually matter for this mandate. No document-ordering field
+was found to exist for a "pasal renumbering restart" boundary detector
+either (`chunk_id` is a random per-point UUID, not a sequence number;
+`metadata.pasal_number` values come back scrambled when sorted by
+`chunk_id`) — that structural approach the mandate suggested remains
+unvalidated and unbuilt, honestly, rather than shipped on a hope.
 
 ## What was NOT done, and why
 
@@ -268,10 +331,14 @@ that this investigation did not attempt.
   live-code change with re-ingestion implications for a class of documents
   (WIZ-2) explicitly owned as a separate, larger workstream in the campaign
   mandate — out of scope for a false-positive measurement lane.
-- **No detector shipped for the `has_ayat` structural signal** (Finding 3).
-  Precision unvalidated at the scale this would need before gating anything
-  on it; shipping it now would repeat exactly the mistake this investigation
-  was launched to check for.
+- **No detector shipped for any Finding-3 structural signal.** The original
+  `has_ayat` lead is retracted outright (confirmed confounded with ordinary
+  paragraph structure and a 4,000-char chunk-size cutoff, not with
+  elucidation status — see Finding 3). The narrower `hierarchy_path`/
+  `chunk_key` lead is validated only on 792 of 84,283 points and shows zero
+  hits on the legacy documents that matter for this mandate; shipping either
+  now would repeat exactly the mistake this investigation was launched to
+  check for.
 - **No deletions, no re-ingestion, no chunking change.** Embedding model
   (`text-embedding-3-small`, 1536 dims) untouched — nothing in this
   investigation required or would justify re-embedding.
@@ -327,16 +394,93 @@ before calling the work done, because those four are where a client
 question actually lands.
 
 **Language note, since the team asked directly**: `is_unmarked_penjelasan_fragment`
-and the `has_ayat` structural lead (Finding 3) both classify STORED KB
-CONTENT — the Indonesian statute text sitting in Qdrant — never the client's
-QUERY. Every document in `legal_unified` is an official Indonesian legal
-instrument regardless of what language a client asks in (English, Indonesian,
-Italian, Spanish, per the census); "Cukup jelas" and the `has_ayat` payload
-shape are properties of that Indonesian source text, not of anything
-query-side. Neither signal reads, tokenizes, or makes any assumption about
-the client's question language, so there is no query-language surface for
-either to break on. This is a genuine non-issue for THESE two signals
-specifically — it would become a real issue only for a downstream component
-that tries to MATCH a client's non-Indonesian question against Indonesian
-statute phrasing (retrieval/embedding quality across that language gap), which
-is outside what this lane measured or built.
+and the `hierarchy_path`/`chunk_key` structural lead (Finding 3) both
+classify STORED KB CONTENT — the Indonesian statute text sitting in Qdrant —
+never the client's QUERY. Every document in `legal_unified` is an official
+Indonesian legal instrument regardless of what language a client asks in
+(English, Indonesian, Italian, Spanish, per the census); "Cukup jelas" and
+the `hierarchy_path` naming convention are properties of that Indonesian
+source text, not of anything query-side. Neither signal reads, tokenizes, or
+makes any assumption about the client's question language, so there is no
+query-language surface for either to break on. This is a genuine non-issue
+for THESE two signals specifically — it would become a real issue only for a
+downstream component that tries to MATCH a client's non-Indonesian question
+against Indonesian statute phrasing (retrieval/embedding quality across that
+language gap), which is outside what this lane measured or built.
+
+## Adversarial review
+
+Reviewed by `codex` (generator≠grader: the report/scripts/tests were handed
+to an independent seat in read-only sandbox, not graded by the same session
+that wrote them) against the shipped draft — sample, signal module, test
+file, and report — before this remediation pass. Findings, verbatim intent,
+and disposition:
+
+- **A — invalid statistical claim.** The "0/45 hits → ~6.6% upper bound at
+  95% CI, rule-of-three" language treated the round-robin document-stratified
+  sample as an i.i.d. Bernoulli draw over the 2,019-fragment population. It
+  is not: a 726-fragment document (`UU_6_2023`) and a 1-fragment document get
+  roughly the same 1-2 sample slots, so the claimed confidence interval has
+  no statistical basis. **Fixed** — the numeric bound was removed from both
+  Method and Result; the report now claims only document-level coverage
+  (34/34) with an explicit statement that no fragment-level confidence bound
+  is defensible from this sampling design.
+- **B1 — duplicate guilt fixture.** `GUILTY_SAMPLES` listed `UU_17_2008`
+  twice, so the claimed "10 documents" was actually 9 distinct ones. **Fixed**
+  — the duplicate was replaced with a new `UU_66_2024` fixture, and a runtime
+  assertion (`len(set(document_ids)) == len(GUILTY_SAMPLES)`) now prevents
+  silent recurrence.
+- **B2 — mislabeled innocence fixtures.** Two of the original 7
+  "INNOCENT_SAMPLES" actually asserted `expect=True` (case-insensitivity,
+  whitespace-tolerance) — positive controls, not innocence cases, sharing one
+  ambiguous list and field name. **Fixed** — split into
+  `TRUE_INNOCENCE_SAMPLES` (hard-asserted `False`) and
+  `POSITIVE_CONTROL_SAMPLES` (hard-asserted `True`), each with its own test
+  function and explicit assertion direction.
+- **B3 — missing critical innocence case.** No fixture tested "cukup jelas"
+  used adjacently and idiomatically in ordinary, non-boilerplate prose — the
+  one shape most likely to be a genuine false positive the 45-sample read
+  didn't happen to catch. **Fixed** — added `RESIDUAL_RISK_SAMPLES` with an
+  honest fixture, explicitly asserted `True` "by design" (faithfulness to the
+  campaign's own bare-substring definition), with commentary stating plainly
+  that 45 samples cannot rule out this shape existing among the 1,974 unread
+  fragments.
+- **B4 — the raw 45-sample JSON was measured but never shipped.** The
+  original run's output was deleted after use; only prose summarized it, so
+  independent audit of the actual sample was impossible. **Fixed** —
+  `scripts/kb/cukup_jelas_sample.py` was re-run (reproducing identical
+  totals: 84,283 scrolled, 2,019 damaged, 34 documents, same top-10) and its
+  output committed at `research/legal/_cukup_jelas_sample.json`.
+- **B5 — stale docstring path.** `cukup_jelas_signal.py`'s docstring pointed
+  at a `kb/inventory/` path that was never the real output location and had
+  since been deleted. **Fixed** — corrected to `research/legal/`.
+- **C — mutation-proof tests.** Reviewed and found genuinely non-tautological
+  (not decorative). **No change** — confirmed again in this remediation pass
+  by re-running both hand-applied mutations against the restructured test
+  file: identical failure sets both times (3 tests red on the section-guard
+  removal, 2 tests red on the regex-adjacency loosening), suite green (20/20)
+  on the restored source.
+- **D — the `has_ayat`-as-elucidation-signal claim in Finding 3 does not hold
+  up.** `has_ayat` is set by a pure text-regex count of `Ayat(N)` markers,
+  unconditional on `section`, gated only by a 4,000-character chunk-size
+  threshold (`hierarchical_indexer.py` lines ~280-356) — an ordinary
+  OPERATIVE article with paragraph sub-structure gets the identical shape as
+  genuine elucidation. The "5.7x recall" framing assumed what it needed to
+  prove. **Fixed** — Finding 3 was rewritten to retract this claim outright
+  and replace it with the narrower, code-verified `hierarchy_path`/
+  `chunk_key` naming-convention lead, itself reported honestly as validated
+  on only 792/84,283 points and showing zero hits on the four legacy
+  top-damage documents this mandate actually cares about — an open question,
+  not a finding.
+- **E — overclaiming language** ("near-zero", "usable as-is", "undercounts...
+  if anything", "5.7x recall") exceeded what 45 clustered observations plus
+  an unvalidated structural lead support. **Fixed** — softened throughout:
+  Summary, Result, and "What was built" no longer assert blanket safety or an
+  unqualified recall multiplier; claims are now scoped to what was actually
+  measured (document-level coverage, not a fragment-level guarantee; a
+  formalization of what was verified, not an endorsement of the signal as
+  "safe").
+
+No finding was dismissed without a code or fixture change; nothing in this
+list was addressed by adding words without changing the underlying claim,
+script, or test.

--- a/research/legal/_cukup_jelas_sample.json
+++ b/research/legal/_cukup_jelas_sample.json
@@ -1,0 +1,321 @@
+{
+  "total_points": 84283,
+  "damaged_fragment_count": 2019,
+  "damaged_document_count": 34,
+  "by_doc_top10": [
+    [
+      "UU_6_2023",
+      726
+    ],
+    [
+      "UU_17_2008",
+      337
+    ],
+    [
+      "PP_1_2011",
+      137
+    ],
+    [
+      "UU_43_2009",
+      84
+    ],
+    [
+      "UU_14_2025",
+      83
+    ],
+    [
+      "UU_16_2025",
+      64
+    ],
+    [
+      "UU_66_2024",
+      61
+    ],
+    [
+      "UU_11_2020",
+      53
+    ],
+    [
+      "UU_28_2007",
+      52
+    ],
+    [
+      "Perda_7_2015",
+      47
+    ]
+  ],
+  "sample_size": 45,
+  "sample_method": "stratified round-robin across distinct documents, seed=20260825, NOT the first N found",
+  "sample": [
+    {
+      "id": "d9d62b18-c414-5404-b1fe-70ecc357ac1f",
+      "document_id": "UU_9_2005",
+      "section": null,
+      "text": "Ayat (1) \n Cukup jelas \n Ayat (2) \n Cukup jelas \n Ayat (3) \n Cukup jelas \nAngka 8"
+    },
+    {
+      "id": "015f0847-c752-5759-aa74-e34caca236ab",
+      "document_id": "UU_4_1945",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 4 - TAHUN 1945 - TENTANG Perdagangan Melalui Sistem Elektronik) yang telah ditandatangani Pemerintah Republik Indonesia dan Pemerintah Negara-negara Anggota Perhimpunan Bangsa-Bangsa Asia Tenggara pada tanggal 22 Januari 2019]\n\nSalah satu upaya \nuntuk mewujudkan integrasi ekonomi digital di kawasan Asia Tenggara adalah \ndengan menyusun ASEAN Agreement on Electronic Commerce (Persetujuan \nASEAN tentang Perdagangan Melalui Sistem Elektronik) \n\nPRESIDEN \nREPUBLIK INDONESIA TAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA NOMOR 6728 \n- Pasal2 \nCukup jelas.."
+    },
+    {
+      "id": "a55288fd-350b-5807-aae3-6374c47578f7",
+      "document_id": "UU_11_2020",
+      "section": null,
+      "text": "Ayat (1)\nCukup jelas. \nAyat (2)\nCukup jelas. \nAyat (3)\nCukup jelas. \nAyat (4)\nCukup jelas. \n\nBiro Hukum Sekretariat Jenderal \nKementerian Ketenagakerjaan Ayat (5)\nBagi perusahaan yang telah \nmemberlakukan istirahat panjang tidak \nboleh mengurangi dari ketentuan yang \nsudah ada.\nAyat (6)\nCukup jelas.\nAngka 24"
+    },
+    {
+      "id": "a83ac177-5c51-58cc-8d71-6a7587e3246c",
+      "document_id": "Keppres_29_1959",
+      "section": null,
+      "text": "ayat (2) Undang -undang Dasar Sementara Republik Indonesia\n\nPRESIDEN\nREPUBLIK INDONESIA\n\nUndang -undang Darurat mempunyai derajat Undang -undang, sedang pencabutan\nitu dapat di samakan dengan penolakan, maka tidak perlu lagi ketiga Undang -undang Darurat itu ditetapkan secara formil sebagai Undang -undang.\nSedari saat pencabutan itu, berlaku ketentuan -ketentuan baru tentang Daerah -daerah yang dibubarkan menurut Undang -undang pemben tukan ini.\n4.Begitu pula dalam Undang -undang ini diberikan penegasan, bahwa semua Daerah -daerah Swapraja tidak sejati, baik yang defacto masih, maupun yang tidak\nberjalan dihapuskan berdasarkan alasan kepentingan umum berhubung dengan\ntelah sedemikian la njutnya proses demokrati sering berjalan mengenai\npemerintahan daerah, sehingga adanya Kepala -kepala Daerah yang bersandarkan\nhak asal -usul dan keturunan dianggap telah tidak wajar lagi dalam susunan\npemerintahan daerah pada dewasa ini. Akibat -akibat dari penghapusan ini akan\nditampung dengan aturan -aturan yang akan dikeluarkan oleh Menteri Dalam Negeri, sekedar belum diatur dalam Undang -undang ini.\n5.Mengenai tempat kedudukan Pemerintah Daerah Tingkat II Minahasa di Tondano\ndan Daerah Tingkat II Gorontal o di Isimu, perlu ditegaskan, bahwa tempat\nkedudukan kedua Pemerintah Daerah itu masing -masing untuk sementara masih\ntetap di Menado dan Gorontalo, dengan ketentuan, bahwa pemindahan tempat\nkedudukan akan dilakukan secara berangsur -angsur dan berencana, a pabila\nkeadaan telah mengidzinkan.\nII. PASAL DEMI PASAL.\nTidak diberikan penjelasan, karena cukup jelas.\nDiketahui:\nMenteri Kehakiman,\nG. A. MAENGKOM.\nTAMBAHAN LEMBARAN NEGARA NOMOR 1822."
+    },
+    {
+      "id": "ce7510bc-9e3f-518b-a50a-a32666776ab5",
+      "document_id": "UU_1_2019",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 4 - TAHUN 1945 - TENTANG Perdagangan Melalui Sistem Elektronik) yang telah ditandatangani Pemerintah Republik Indonesia dan Pemerintah Negara-negara Anggota Perhimpunan Bangsa-Bangsa Asia Tenggara pada tanggal 22 Januari 2019]\n\nSalah satu upaya \nuntuk mewujudkan integrasi ekonomi digital di kawasan Asia Tenggara adalah \ndengan menyusun ASEAN Agreement on Electronic Commerce (Persetujuan \nASEAN tentang Perdagangan Melalui Sistem Elektronik) -2- PRESIDEN \nREPUBLIK INDONESIA TAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA NOMOR 6728 - Pasal2 \nCukup jelas."
+    },
+    {
+      "id": "e4adcdf8-d45e-5e19-b0b5-eb6cfbb3f6cc",
+      "document_id": "UU_1_1945",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 1 - TAHUN 1945 - TENTANG Perjanjian Internasional (Lembaran Negara Republik Indonesia Tahun 2000 Nomor 185, Tambahan Lembaran Negara Republik Indonesia Nomor 4012); 3. Undang-Undang Nomor 7 Tahun 2014 tentang Perdagangan (Lem - Pasal 2]\n\nCukup jelas."
+    },
+    {
+      "id": "fc8a919d-a405-5a0e-a959-0c3e9c148821",
+      "document_id": "UU_3_2009",
+      "section": null,
+      "text": "Cukup jelas. \n\nAngka 13"
+    },
+    {
+      "id": "ccd16daf-59ab-5f5d-bcbd-bf9004b076e3",
+      "document_id": "UU_2_2021",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 1 - TAHUN 1945 - TENTANG Perjanjian Internasional (Lembaran Negara Republik Indonesia Tahun 2000 Nomor 185, Tambahan Lembaran Negara Republik Indonesia Nomor 4012); 3. Undang-Undang Nomor 7 Tahun 2014 tentang Perdagangan (Lem]\n\nPasal 1 \nCukup jelas."
+    },
+    {
+      "id": "837a7192-0eee-5dc0-9a8f-8be99cb27edd",
+      "document_id": "UU_14_2025",
+      "section": null,
+      "text": "Ayat (1)\nYang dimaksud dengan \"tata kelola dam\" adalah\npelayanan dam atau lndgu (denda atau sembelihan)\nbagi Jemaah Haji dan petugas haji dilaksanakan\ndengan mengikuti ketentuan yang ditetapkan oleh Pemerintah Kerajaan Arab Saudi.\nAyat (2)\nCukup jelas.\nSK No269225AAngka8.. .\n\nPRESIDEN\nREPUBLIK INDONESIA\n\nAngka 8"
+    },
+    {
+      "id": "7de18d34-1664-5dcc-b7c0-5bcf6993157e",
+      "document_id": "UU_66_2024",
+      "section": null,
+      "text": "Ayat (1)\nCukup jelas.\nAyat (2)\nCukup jelas.\nAyat (3)\nInsentif dapat berupa insentif fiskal dan/atau nonfiskal.\nAngka 3"
+    },
+    {
+      "id": "fcd7990a-e4fa-5c27-b4f2-84445e6a5633",
+      "document_id": "Perda_3_2013",
+      "section": null,
+      "text": "Pasal 1 \n Cukup Jelas."
+    },
+    {
+      "id": "678ea768-b5e5-50c3-b655-7b36ba0a6b8b",
+      "document_id": "UU_13_2006",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "dd099fab-7ff6-58eb-8c91-2473a54b9912",
+      "document_id": "Perda_7_2015",
+      "section": null,
+      "text": "Cukup Jelas"
+    },
+    {
+      "id": "5651baa3-b7bb-5149-9983-e291363bd40f",
+      "document_id": "UU_43_2009",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "7d3bb2c8-4a11-5747-a750-95ab74f7c9e7",
+      "document_id": "UU_2_1945",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 2 - TAHUN 1945 - TENTANG PENETAPAN PERATURAN PEM ERINTAH PENGGANTI UN DAN G-UN DAN G NOMOR 1 TAHUN 2O2O TENTANG KEBIJAKAN KEUANGAN NEGARA DAN STAE}ILITAS SISTEM KEUANGAN UNTUK PENANGANAN PANDEMT CORONA rmUS DTSEASE 2019 (COVI - Pasal 2]\n\nCukup jelas TAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA NOMOR 6516\nSK No 036094 A\n\nPRESIDEN\nREPUBLIK INDONESIA\nLAMPIRAN\nUNDANG-UNDANG REPUBLIK INDONESIA\nNOMOR 2 TAHUN 2O2O\nTENTANG\nPENETAPAN PERATURAN PEMERINTAH PENGGANTI\nUNDANG-UNDANG NOMOR 1 TAHUN 2O2O TENTANG\nKEBIJAKAN KEUANGAN NEGARA DAN STABILITAS\nSISTEM KEUANGAN UNTUK PENANGANAN PANDEMI\ncoRoNA yrRUS DISEASE 2019 (COVTD- 19)\nDAN/ATAU DALAM RANGKA MENGHADAPI\nANCAMAN YANG MEMBAHAYAKAN PEREKONOMIAN\nNASIONAL DAN/ATAU STABILITAS SISTEM\nKEUANGAN MENJADI UNDANG-UNDANG\nPERATURAN PEMERINTAH\nPENGGANTI UNDANG-UNDANG REPUBLIK INDONESIA\nNOMOR 1 TAHUN 2O2O\nTENTANG\nKEBIJAKAN KEUANGAN NEGARA DAN STABILITAS SISTEM KEUANGAN\nUNTUK PENANGANAN PANDEMI CORO/VA WRUS DISEASE 2019 (COVID-19)\nDAN/ATAU DALAM RANGKA MENGHADAPI ANCAMAN YANG\nMEMBAHAYAKAN PEREKONOMIAN NASIONAL DAN/ATAU STABILITAS\nSISTEM KEUANGAN\nDENGAN RAHMAT TUHAN YANG MAHA ESA\nPRESIDEN REPUBLIK INDONESIA,\nMenimbang a. bahwa penyebaran Corona Vints Disease 2019\n(COVID-19) yang dinyatakan oleh Organisasi Kesehatan Dunia (World Health Organization) sebagai pandemi pada\nsebagian besar negara-negara di seluruh dunia,\ntermasuk di Indonesia, menunjukkan peningkatan dari\nwaktu ke waktu dan telah menimbulkan korban jiwa,\ndan kerugian material yang semakin besar, sehingga\nberimplikasi pada aspek sosial, ekonomi, dan\nkesejahteraan masyarakat;\nb. bahwa implikasi pandemi Corona Virus Disease 2019\n(COVID-19) telah berdampak antara lain terhadap\nperlambatan pertumbuhan ekonomi nasional,\npenurunan penerimaan negara, dan peningkatan belanja\nnegara dan pembiayaan, sehingga diperlukan berbagai\nupaya Pemerintah untuk melakukan penyelamatan\nkesehatan dan perekonomian nasional, dengan fokus\npada belanja untuk kesehatan, jaring pengaman sosial\n(social safety net), serta pemulihan perekonomian\ntermasuk untuk dunia usaha dan masyarakat yang\nterdampak;\nc.bahwa...\nSK No 036095 A\n\nc PRESIDEN\nREPUBLIK INDONESIA\n\nbahwa implikasi pandemi Corona Virus Disease 2Ol9\n(COVID-19) telah berdampak pula terhadap\nmemburuknya sistem keuangan yang ditunjukkan\ndengan penurunan berbagai aktivitas ekonomi domestik\nsehingga perlu dimitigasi bersama oleh Pemerintah dan Komite Stabilitas Sistem Keuangan (KSSK) untuk\nmelakukan tindakan antisipasi (forward looking) dalam\nrangka menjaga stabilitas sektor keuangan;\nd. bahwa berdasarkan pertimbangan sebagaimana\ndimaksud dalam huruf a, huruf b, dan huruf c,\nPemerintah dan lembaga terkait perlu segera mengambil\nkebijakan dan langkah-langkah luar biasa dalam rangka\npenyelamatan perekonomian nasional dan stabilitas\nsistem keuangan melalui berbagai kebijakan relaksasi\nyang berkaitan dengan pelaksanaan Anggaran Pendapatan dan Belanja Negara (APBN) khususnya\ndengan melakukan peningkatan belanja untuk\nkesehatan, pengeluaran untuk jaring pengaman sosial\n(social safety net), dan pemulihan perekonomian, serta\nmemperkuat kewenangan berbagai lembaga dalam sektor\nkeuangan;\nbahwa kondisi sebagaimana dimaksud dalam huruf a,\nhuruf b, huruf c, dan huruf d, telah memenuhi\nparameter sebagai kegentingan memaksa yang\nmemberikan kewenangan kepada Presiden untuk\nmenetapkan Peraturan Pemerintah Pengganti Undang-\nUndang sebagaimana diatur dalam Pasal 22 ayat (1)\nUndang-Undang Dasar Negara Republik Indonesia Tahun\nt945;\nf. bahwa\ne SK No 036096 A\n\nMengingat Menetapkan PRESIDEN\nREPUBLIK INDONESIA\n\nf. bahwa berdasarkan pertimbangan sebagaimana\ndimaksud dalam huruf a, huruf b, huruf c, huruf d, dan\nhuruf e, serta guna memberikan landasan hukum yang\nkuat bagi Pemerintah dan lembaga terkait untuk\nmengambil kebijakan dan langkah-langkah tersebut\ndalam waktu yang sangat segera, perlu menetapkan Peraturan Pemerintah Pengganti Undang-Undang\ntentang Kebijakan Keuangan Negara dan Stabilitas Sistem Keuangan untuk Penanganan Pandemi Corona Virus Disease 2019 (COVID- 19) danlatau Dalam Rangka Menghadapi Ancaman yang Membahayakan Perekonomian Nasional dan/atau Stabilitas Sistem Keuangan;"
+    },
+    {
+      "id": "a19531e1-db36-5ec9-9b40-77b7e42bba4e",
+      "document_id": "UU_63_2024",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 63 - TAHUN 2024 - TENTANG PERUBAHAN KETIGA ATAS UNDANG-UNDANG NOMOR 6 TAHUN 2011 TENTANG KEIMIGRASIAN - Pasal 64]\n\nCukup jelas.\nAngka 5\nPasal72\nAyat (1)\nPermintaan keterangan mengenai data dapat dilakukan,\nbaik secara manual maupun elektronik.\nAyat (2)\nCukup jelas.\nAyat (3)\nCukup jelas.\nAngka 6"
+    },
+    {
+      "id": "8e4d7472-35e3-5449-8fae-e54980976ade",
+      "document_id": "UU_6_2023",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 6 - TAHUN 2023 - TENTANG PENETAPAN PERATURAN PEMERINTAH PENGGANTI UNDANG-UNDANG NOMOR 2 TAHUN 2022 TENTANG CIPTA KERJA MENJADI UNDANG-UNDANG - Pasal 12]\n\nCukup jelas.\nAngka 4"
+    },
+    {
+      "id": "5344e5bb-7992-51b8-8077-91ae9c92bbad",
+      "document_id": "UU_28_2007",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 28 - TAHUN 2007 - TENTANG PERUBAHAN KETIGA ATAS UNDANG-UNDANG NOMOR 6 TAHUN 1983 TENTANG KETENTUAN UMUM DAN TATA CARA PERPAJAKAN I. UMUM 1. Undang-Undang tentang Ketentuan Umum dan Tata Cara Perpajakan dilandasi falsafah Panca]\n\nPasal Ayat (1)\n Cukup jelas.\n Ayat (2)\nSurat Tagihan Pajak menurut ayat ini disamakan kekuatan\nhukumnya dengan surat ketetapan pajak sehingga dalam\nhal penagihannya dapat juga dilakukan dengan Surat Paksa.\n Ayat (3)\nAyat ini mengatur pengenaan sanksi administrasi berupa\nbunga atas Surat Tagihan Pajak yang diterbitkan karena:\na. Pajak Penghasilan dalam tahun berjalan tidak atau\nkurang dibayar; atau\nb. penelitian Surat Pemberitahuan yang menghasilkan\npajak kurang dibayar karena terdapat salah tulis\ndan/atau salah hitung.\nUntuk jelasnya diberikan contoh cara penghitungan\nsebagai berikut:\n1. Pajak Penghasilan dalam tahun berjalan tidak atau\nkurang dibayar.\nPajak Penghasilan Pasal 25 tahun 2008 setiap bulan\nsebesar Rp100.000.000,00 jatuh tempo misalnya tiap\ntanggal 15. Pajak Penghasilan Pasal 25 bulan Juni 2008\ndibayar tepat waktu sebesar Rp40.000.000,00.\n Atas kekurangan Pajak Penghasilan Pasal 25 tersebut\nditerbitkan Surat Tagihan Pajak pada tanggal 18\nSeptember 2008 dengan penghitungan sebagai berikut:\n- Kekurangan . . .\n\n- Kekurangan bayar Pajak Penghasilan"
+    },
+    {
+      "id": "da964bc5-9757-584c-95b7-a006744283e2",
+      "document_id": "UU_17_2008",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "e6d8eb34-9858-5420-83cf-39b0c593b6f7",
+      "document_id": "TASSE_14_2012",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "027d5a10-aba1-43fc-92b3-db01acb0f89e",
+      "document_id": "PP_28_2025",
+      "section": null,
+      "text": "Pasal 282 Cukup jelas Pasal SK No 194488 A a PRESIDEN REPUBLIK INOONESIA -44"
+    },
+    {
+      "id": "bd91363b-6ce8-5ed7-9f1d-13505ee35946",
+      "document_id": "UU_2_1986",
+      "section": null,
+      "text": "Cukup jelas"
+    },
+    {
+      "id": "58ad1b9a-3a49-5106-aaa6-09d8971dcaed",
+      "document_id": "UU_16_2025",
+      "section": null,
+      "text": "Cukup jelas.\nAngka 50"
+    },
+    {
+      "id": "a4c42488-e3fc-594f-bbe3-779e57b2897f",
+      "document_id": "UU_25_2007",
+      "section": null,
+      "text": "Ayat (1)\n Cukup jelas.\n Ayat (2)\n Cukup jelas.\n Ayat (3)\nYang dimaksud dengan bertanggung jawab langsung kepada Presiden adalah bahwa Badan Koordinasi Penanaman Modal\ndalam melaksanakan tugas, menjalankan fungsi, dan\nmenyampaikan tanggung jawabnya langsung kepada Presiden."
+    },
+    {
+      "id": "753c1e93-c804-55a7-b3b0-3e730c95489e",
+      "document_id": "UU_35_2004",
+      "section": null,
+      "text": "Cukup jelas \n\nTAMBAHAN LEMBARAN NEGARA RE PUBLIK INDONESIA NOMOR 4441"
+    },
+    {
+      "id": "65421344-01e8-5015-a3a8-c3e58156ea35",
+      "document_id": "UU_40_2008",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "ec097fb9-2d90-514b-9e20-ea780c669438",
+      "document_id": "Perda_20_2012",
+      "section": null,
+      "text": "Ayat (1) \nCukup jelas. \nAyat (2) \nLampiran peta cakupan wilayah yang digambarkan dengan skala \n1:250.000. \nYang dimaksud dengan persetujuan pihak -pihak terkait antara lain \ndiberikan oleh bupati/walikota yang menjadi cakupan daerah otonom \nbaru, bupati/walikota da erah yang berbatasan langsung dengan \ndaerah otonom baru, gubernur provinsi induk pada peta yang \nditerbitkan Badan Informasi Geospasial (BIG). \nAyat ( 3) \nCukup jelas."
+    },
+    {
+      "id": "1e8cd500-0fdd-54c2-b4c4-ba8b6cd3c2b0",
+      "document_id": "UU_3_2022",
+      "section": null,
+      "text": "0Dengan mengesampingkan peraturan perundang-undangan yang\nmengatur tentang pemerintahan daerah, di Ibu Kota Nusantara\ndibentuk Otorita Ibu Kota Nusantara yang diberi kewenangan untuk\nmengatur dan melaksanakan fungsi pemerintahan daerah dengan\nketentuan yang diatur dengan Undang-Undang ini, termasuk tetapitidak terbatas pada pelaksanaan persiapan, pembangunan,\npemindahan, dan pengelolaan Ibu Kota Negara.\nAyat (1)\nMekanisme pemilihan Kepala Otorita Ibu Kota Nusantara dan Wakil Kepala Otorita Ibu Kota Nusantara dilakukan berbeda\ndengan mekanisme pemilihan kepala daerah lainnya.\nAyat(2) ...\nSK No 116298 A\n\nPRESIDEN\nREPUBLIK INDONESIA\n\nAyat (2)\nCukup jelas.\nAyat (3)\nKepala Otorita Ibu Kota Nusantara dan Wakil Kepala Otorita Ibu Kota Nusantara yang pertama kali diangkat oleh Presiden setelah\ndiundangkannya Undang-Undang ini ditunjuk dan diangkat oleh Presiden tanpa melalui mekanisme konsultasi dengan DPR\nsebagaimana dimaksud dalam ketentuan Pasal 5 ayat (4)."
+    },
+    {
+      "id": "baacf9f3-e572-5e2e-8899-24ca299f21cf",
+      "document_id": "UU_39_2008",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "e31ae0e7-44bd-58e6-a53d-dc9ab1aea65c",
+      "document_id": "TASSE_7_1983",
+      "section": null,
+      "text": "[CONTEXT: TASSE - NO 7 - TAHUN 1983 - TENTANG PAJAK PENGHASILAN SEBAGAIMANA TELAH DIUBAH TERAKHIR DENGAN UNDANG ‐UNDANG REPUBLIK INDONESIA NOMOR 36 TAHUN 2008 UU PPh Direktorat Jenderal Pajak Departemen Keuangan Republik Indonesia Jakarta, 2008 \"]\n\nHuruf a \nBagi Wajib Pajak baru yang mulai menjalankan  usaha atau melakukan  kegiatan dalam \ntahun pajak berjalan perlu diatur perhitungan  besarnya angsuran,  karena Wajib Pajak \nbelum pernah memasukkan  Surat Pemberitahuan  Tahunan Pajak Penghasilan,  penentuan  \nbesarnya angsuran pajak didasarkan  atas kenyataan  usaha atau kegiatan Wajib Pajak. \n\nHuruf b \nBagi Wajib Pajak yang bergerak dalam bidang perbankan,  badan usaha milik negara dan \nbadan usaha milik daerah, serta Wajib Pajak masuk bursa dan Wajib Pajak lainnya yang \nberdasarkan  ketentuan  diharuskan  membuat  laporan keuangan  berkala perlu diatur \nperhitungan  besarnya angsuran  tersendiri  karena terdapat kewajiban  menyampaikan  \nlaporan yang berkaitan  dengan pengelolaan  keuangan  dalam suatu periode tertentu \nkepada instansi Pemerintah  yang dapat dipakai sebagai dasar penghitungan  untuk \nmenentukan  besarnya angsuran pajak dalam tahun berjalan. \n\nHuruf c \nBagi Wajib Pajak orang pribadi pengusaha  tertentu, yaitu Wajib Pajak orang pribadi yang \nmempunyai  1 (satu) atau lebih tempat usaha, besarnya angsuran  pajak paling tinggi \nsebesar 0,75% (nol koma tujuh lima persen) dari peredaran  bruto. \n\nAyat (8) \nCukup jelas. \n\n\"UU PPh\" \n ki_moel - 71\n\nAyat (8a) \nCukup jelas. \n Ayat (9) \nCukup jelas. \n26"
+    },
+    {
+      "id": "b74d920b-edeb-53dd-a9d5-51d328fad62d",
+      "document_id": "PP_1_2011",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "d9a79863-3e33-5c13-ac2e-8cdf8aa0aa84",
+      "document_id": "UU_12_2017",
+      "section": null,
+      "text": "Cukup jelas.\nTAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA 56149P 6135"
+    },
+    {
+      "id": "7eeb7e0f-4436-5c0d-933c-1659ed8bec6e",
+      "document_id": "UU_12_2008",
+      "section": null,
+      "text": "Cukup jelas. \n\n Angka 11"
+    },
+    {
+      "id": "24d6da79-a4c7-5d12-ba9c-416d2ea2b1d9",
+      "document_id": "UU_23_2002",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "2ac8d99b-3c4a-5664-b7a6-dd8c544af908",
+      "document_id": "UU_9_2005",
+      "section": null,
+      "text": "Ayat (1) \n Cukup jelas \n Ayat (2) \n Dana bagi hasil semula ditetapkan sebesar \nRp47.020.193.810.000, 00 (empat puluh tujuh triliun dua puluh \nmiliar seratus sembilan puluh tiga juta delapan ratus sepuluh ribu rupiah). \n Ayat (3) \n Dana alokasi umum semula ditetapkan sebesar \nRp88.765.600.000.000,00 (delapan puluh delapan triliun tujuh \nratus enam puluh lima miliar enam ratus juta rupiah). \n Ayat (4) \n Dana alokasi khusus semula ditetapkan sebesar \nRp4.774.440.000.000,0 0 (empat triliun tujuh ratus tujuh puluh \nempat miliar empat ratus empat puluh juta rupiah). \n Ayat (5) \n Peraturan pelaksanaan dari Undang-Undang Nomor 25 Tahun \n1999 tentang Perimbangan Keuangan antara Pemerintah Pusat \ndan Pemerintahan Daerah masih tetap berlaku sepanjang belum \ndiganti dengan peraturan pelaksanaan yang baru berdasarkan undang-undang dimaksud dalam ayat ini. \nAngka 11"
+    },
+    {
+      "id": "4d3c2d6f-90ed-5731-834c-c298d30ef448",
+      "document_id": "UU_4_1945",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 4 - TAHUN 1945 - TENTANG Perdagangan Melalui Sistem Elektronik) yang telah ditandatangani Pemerintah Republik Indonesia dan Pemerintah Negara-negara Anggota Perhimpunan Bangsa-Bangsa Asia Tenggara pada tanggal 22 Januari 2019 - Pasal 1]\n\nCukup jelas. \nII. PASAL DEMI PASAL \nASEAN Agreement on Electronic Commerce (Persetujuan ASEAN tentang \nPerdagangan Melalui Sistem Elektronik) terdiri dari 19 ( sembilan belas) Pasal \nyang mengatur antara lain mekanisme dan lingkup kerja sama, fasilitasi PMSE \nlintas batas, keamanan siber, pembayaran elektronik, logistik, transparansi, \npenyelesaian sengketa, pemberlakuan Persetujuan yang bertujuan untuk \nmemfasilitasi transaksi perdagangan antarwilayah ASEAN melalui PMSE, \nmendorong penciptaan lingkungan yang kondusif dalam penggunaan PMSE, \ndan meningkatkan kerja sama antara Negara Anggota ASEAN untuk \nmengembangkan serta mendorong pemanfaatan PMSE untuk menciptakan \npertumbuhan ekonomi yang inklusif dan mengurangi kesenjangan di ASEAN. \n\nPRESIDEN \nREPUBLIK INDONESIA"
+    },
+    {
+      "id": "b3c65444-eb33-566c-bdf4-82a5f6cd80ec",
+      "document_id": "UU_11_2020",
+      "section": null,
+      "text": "Cukup jelas.\nAngka 45"
+    },
+    {
+      "id": "b60942ae-fb1d-5a7e-83cd-b15e1b6ba6e4",
+      "document_id": "UU_1_2019",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 4 - TAHUN 1945 - TENTANG Perdagangan Melalui Sistem Elektronik) yang telah ditandatangani Pemerintah Republik Indonesia dan Pemerintah Negara-negara Anggota Perhimpunan Bangsa-Bangsa Asia Tenggara pada tanggal 22 Januari 2019]\n\nPasal 1 \nCukup jelas."
+    },
+    {
+      "id": "f13bb8ab-75dd-5641-bc53-b3762f0ded38",
+      "document_id": "UU_3_2009",
+      "section": null,
+      "text": "Cukup jelas. \n\nAngka 10 \nCukup jelas. \n\nAngka 11"
+    },
+    {
+      "id": "6eecbea2-07ad-5055-90f9-71e9caddeaca",
+      "document_id": "UU_2_2021",
+      "section": null,
+      "text": "[CONTEXT: UU - NO 1 - TAHUN 1945 - TENTANG Perjanjian Internasional (Lembaran Negara Republik Indonesia Tahun 2000 Nomor 185, Tambahan Lembaran Negara Republik Indonesia Nomor 4012); 3. Undang-Undang Nomor 7 Tahun 2014 tentang Perdagangan (Lem]\n\n-2- PRES I DEN \n- REPUBLIK INDONESIA SK No 083299 A TAMBAHAN LEMBARAN NEGARA REPUBLIK INDONESIA NOMOR 6684 Pasal 2 \nCukup jelas."
+    },
+    {
+      "id": "53e9acb4-a45d-5640-989b-27d48c64341e",
+      "document_id": "UU_14_2025",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "f7b609a5-fb1c-5c5f-8612-1bc7dda295f4",
+      "document_id": "UU_66_2024",
+      "section": null,
+      "text": "Cukup jelas.\nAngka 20"
+    },
+    {
+      "id": "4720faf5-500b-5509-964f-8a80d47bdbb4",
+      "document_id": "Perda_3_2013",
+      "section": null,
+      "text": "huruf a \n Cukup Jelas. \n\n huruf b \n Cukup Jelas. \n\n huruf c \n Cukup Jelas. \n\n Huruf d \n- jenis zat yang terkandung dalam air limbah adalah \nBOD (Biologi Oxygent Demand ), COD (Chemistri Design \nDemand), TSS (Total Suspende Solid) , TDS, pH \n(Potensial Hidrogen ), Sulfida , temperatur, warna, DO \n(Dissolved Oxygen ), turbidity, minyak -lemak, salinitas \n(Garam) , DHL (Daya Hantar Listrik) , logam total, Cd \n(Cadinium ), Zn, Ni (Nikel) , Fe (Fenium ) Besi , Cu(Cupim ) \nTembaga , Amonia , Fosfat , Klor bebas, Nitrit dan CN \n(Cyanida ); \n- jenis zat yang terkandung dalam pengukuran udara \nambie n adalah CO, SO2 (sulfur dioksida ), NOx, OxO \n(Oksidan ), TPS (total partikulat ), Pb (timah hitam ), HC \n(hidrokarbon ) dan kebisingan ; dan/atau \n- jenis zat yang terkandung dalam udara emisi untuk \ndapat dilakukan pengukuran adalah Amonia, Gas \nKlorin, Hidrogen Klo rida, Hidrogen Flourida, Nitrogen \nOksida, Opasitas, Sulfur Dioksida, Total Sulfur \nTereduksi, CO, CO2, O2, TS temperatur emisi () dan TA \n(temperatur udara ) serta parameter logam yaitu AS \n(arsen ), CD (kadmium ), timah Hitam (PB) dan Seng \n(Zn)."
+    },
+    {
+      "id": "f18d810d-682e-52b7-a177-d3e7dc25d750",
+      "document_id": "UU_13_2006",
+      "section": null,
+      "text": "Cukup jelas."
+    },
+    {
+      "id": "dddf2e1f-e15f-5fa4-8829-956471ceeacf",
+      "document_id": "Perda_7_2015",
+      "section": null,
+      "text": "Cukup Jelas."
+    }
+  ]
+}

--- a/scripts/kb/cukup_jelas_signal.py
+++ b/scripts/kb/cukup_jelas_signal.py
@@ -14,9 +14,11 @@ signal that can quietly diverge from what it claims to measure.
 
 Measured false-positive rate (lane P, 2026-08-25): 0/45 on a stratified sample
 spanning 34 distinct documents (round-robin, not "first N found", seed
-20260825) — see kb/inventory/_cukup_jelas_sample.json and
-research/legal/2026-08-25-cukup-jelas-false-positive-rate.md for the full method
-and the read-through of every sample. Every one of the 45 was genuinely
+20260825) — see research/legal/_cukup_jelas_sample.json (the raw sample, for
+independent audit) and research/legal/2026-08-25-cukup-jelas-false-positive-rate.md
+(full method, the read-through of every sample, and an adversarial review that
+found and fixed real issues with the original draft of this measurement — read
+that section before trusting the 45/0 figure at face value). Every one of the 45 was genuinely
 elucidation-style text (a bare "Cukup jelas." boilerplate note, a fuller
 Penjelasan Pasal Demi Pasal explanation, or a "Tidak diberikan penjelasan,
 karena cukup jelas" statement) — none was an innocent occurrence (a citation,


### PR DESCRIPTION
## Summary
- Follow-up PR to #4933 (already merged). An independent Codex adversarial review of the merged report/scripts/tests (generator≠grader) found six real defects and one over-claimed finding; this PR fixes all of them.
- Invalid statistic removed: the "~6.6% at 95% CI" claim treated document-stratified round-robin sampling as i.i.d. Bernoulli draws over the fragment population — it isn't. Replaced with an honest document-level coverage claim (34/34 damaged documents sampled, 0 innocent).
- Test-fixture bugs fixed: a duplicated guilt fixture (`UU_17_2008` counted twice, so "10 documents" was really 9 — now guarded by a runtime assertion), two mislabeled "innocence" fixtures that actually asserted the positive case (split into `TRUE_INNOCENCE_SAMPLES` / `POSITIVE_CONTROL_SAMPLES`), and a missing fixture for idiomatic non-boilerplate "cukup jelas" prose (added as `RESIDUAL_RISK_SAMPLES`, flagged `True` by design with an honest caveat about the 1,974 unread fragments).
- The raw 45-item sample was measured but never shipped — regenerated identically (84,283 scrolled / 2,019 damaged / 34 documents, same top-10) and committed at `research/legal/_cukup_jelas_sample.json`.
- **Finding 3 substantially rewritten**: the original `has_ayat`-as-elucidation-signal claim ("5.7x recall") is retracted — `has_ayat` is a pure `Ayat(N)`-regex count set unconditionally on `section` in `hierarchical_indexer.py`, confounded with ordinary paragraph structure and a 4,000-char chunk-size cutoff, not with elucidation status. Replaced with a narrower `hierarchy_path`/`chunk_key` naming-convention lead — investigated further and CLOSED within this PR: `git log --all -S"Penjelasan_Pasal"` shows it's a same-day, single-commit addition (`f0a0eab22`, PR #4891) scoped to the 792-point `modern_full` bucket only; three of the repo's four ingestion callers never construct `hierarchy_path` at all, so it's structurally absent — not differently-named — on the 78,486-point legacy majority where this mandate's actual top-damage documents live.
- Both hand-applied mutations (section-guard removal, regex-adjacency loosening) re-run against the restructured 20-test suite; identical failure sets to the pre-restructuring run.
- `adversarial_review: codex` frontmatter + `## Adversarial review` section added; R1 gate (`scripts/check_adversarial_review.py`) passes locally.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/unit/kb/test_cukup_jelas_damage_signal.py -q` → 20/20 green
- [x] `PYTHONPATH=. pytest backend/tests/unit/kb/ -q` → 93 passed, 4 skipped (pre-existing, unrelated)
- [x] Both mutations hand-applied and reverted, confirmed red under mutation, confirmed green restored
- [x] `python3 scripts/check_adversarial_review.py --files research/legal/2026-08-25-cukup-jelas-false-positive-rate.md` → PASS
- [ ] CI required checks on this PR

Not arming auto-merge — `feature/kb-current` has no required contexts, per lane mandate the orchestrator merges after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>