### PR TITLE
docs(kb): audit legal_status corpus-wide, propose narrow dry-run repair (decision 5)

### DIFF
--- a/kb/inventory/immigration.yaml
+++ b/kb/inventory/immigration.yaml
@@ -178,18 +178,89 @@ instruments:
 # ── Findings measured this session that lane A does NOT chase (§8, rule 8) ─────
 open_findings:
   - id: LANE-A-1
-    title: "`legal_status` metadata is wrong on at least one live, in-force instrument"
-    owner: "unassigned — likely a corpus-wide ingestion/parsing defect, not a lane-A ingest edit"
+    title: "`legal_status` is derivation-broken corpus-wide, not just mis-populated on two documents — decision 5's audit, closed"
+    owner: "Lane P (parser capability) — root cause is in the ingestion parser, not a lane-A data edit"
     detail: >-
-      Permen_22_2023 (current, in-force Visa dan Izin Tinggal regulation) carries
-      `legal_status: dicabut` ("revoked") on every one of its 402 points, sampled
-      directly. Permen_29_2021 (genuinely superseded) carries the SAME value. Any
-      retrieval-time filter that trusts this field to exclude revoked content (e.g.
-      `SearchService.search(..., apply_filters=True)`'s documented exclude_repealed
-      behaviour) would either do nothing here (both flagged identically) or exclude
-      the WRONG document. This is the field that would have been the clean fix for
-      journey 4's defect (below) and it cannot be trusted as-is. Scope of the defect
-      beyond these two documents is UNDETERMINED — not measured this session.
+      SECOND PASS (2026-08-25, same day, per MANDATE.md §7 decision 5 — the owner
+      chose MARK over REMOVE and required an audit before any filter is written).
+      Whole-scroll, not sampled: `scripts/kb/audit_legal_status.py` against all
+      84,283 points of legal_unified_hybrid_hybrid. Vocabulary is closed at exactly
+      two named values plus absence — `dicabut` (42,420 pts / 202 document_ids),
+      `berlaku` (26,107 pts / 168 document_ids), missing entirely (15,756 pts / 33
+      document_ids). Field location: 74.4% under `metadata.legal_status` (legacy
+      shape), 6.9% top-level (modern shape) — both read every scroll, per the
+      MANDATE §4.1 lesson. 14 document_ids hold BOTH values across their own
+      points (e.g. Permen_1_2026: 931 dicabut / 575 berlaku) — a single document
+      cannot honestly be both, which by itself proves the signal is per-chunk
+      noise, not a document-level fact.
+
+      ROOT CAUSE FOUND, read from the source, not inferred: `STATUS_PATTERNS` in
+      `apps/backend-rag/backend/core/legal/constants.py` is a bare regex —
+      `dicabut: DICABUT|TIDAK BERLAKU|DIGANTI`, `berlaku: BERLAKU|MASIH BERLAKU` —
+      searched against chunk text in `metadata_extractor.py` with dict-order
+      first-match-wins (dicabut checked before berlaku) and ZERO disambiguation of
+      WHAT or WHOM the match refers to. Sampled directly against production text
+      (not inferred): the DIGANTI pattern fires on the generic verb "digantikan" (a
+      guarantor being substituted — Permen_22_2023); TIDAK BERLAKU fires on "Izin
+      Tinggal yang tidak berlaku lagi" (an individual's STAY PERMIT expiring —
+      UU_6_2011) and on a provision not applying to a class of person ("tidak
+      berlaku terhadap warga negara Indonesia" — UU_6_2011 penjelasan); and, the
+      specific mechanism behind journey 4's defect, a law's own standard closing
+      clause revoking ITS PREDECESSORS ("Keputusan Presiden Nomor 31 Tahun 1998 ...
+      dicabut dan dinyatakan tidak berlaku" — PP_31_2013) gets read as the CURRENT,
+      still-valid document being revoked. This is family #3 (guard-over-match):
+      deciding legal status by bare substring, not by entity/intent.
+
+      SCALE, on ground truth verified this session (source_url fetch/search per
+      kb/topics/immigration.yaml): of lane A's 7 present, real-status-known
+      instruments, 4 of 5 `dicabut`-marked ones are WRONGLY marked — UU_6_2011
+      (413 pts), Permen_22_2023 (402 pts), Permen_11_2024 (345 pts), PP_31_2013
+      (324 pts) are all amended-but-valid or in-force, not revoked. Only
+      Permen_29_2021 (340 pts, genuinely superseded) is correctly `dicabut`, most
+      likely by the same coincidental mechanism rather than a correct
+      determination. UU_63_2024 (38 pts) is correctly `berlaku`. Outside lane A's
+      scope (bounding per the mandate: immigration's own instruments + the
+      highest-point documents corpus-wide), the two largest `dicabut`-marked
+      documents in the ENTIRE collection are also independently confirmed
+      (peraturan.go.id / JDIH Kemenkeu, web search 2026-08-25) to be currently
+      "Berlaku": UU_40_2007 (Company Law, 379 pts, 100% dicabut) and UU_6_2023
+      (Cipta Kerja ratification, 4,685 pts — the single largest dicabut-marked
+      document by point count in the whole corpus, 100% dicabut). Not chased
+      further (Lane B/C territory, MANDATE.md rule "a defect outside immigration:
+      inventory row, do not chase it") — recorded because it answers the
+      mandate's own scale question: this is not an immigration-lane quirk.
+
+      DRY-RUN REPAIR PROPOSED, NOT APPLIED: `scripts/kb/propose_legal_status_repair.py`
+      would flip exactly 4 document_ids / 1,484 points (`dicabut`→`berlaku`:
+      UU_6_2011 413, Permen_22_2023 402, Permen_11_2024 345, PP_31_2013 324) — the
+      only instruments this session can name a source for. Permen_27_2021
+      (dicabut, 6 pts) is deliberately EXCLUDED: its real status is recorded
+      `unknown` in kb/topics/immigration.yaml (source_verified: false) — proposing
+      a value would be guessing. No write was performed; this script has no
+      --apply flag by design.
+
+      MARKING PROBE BUILT AND RUN, makes decision 5 testable rather than declared:
+      `scripts/kb/probe_legal_status_marking.py` re-asks journey 4's exact question
+      through the real production path (`SearchService`, same as
+      kb/ops/probe_retrieval.py) and checks the retrieved chunks' own
+      `legal_status`. MEASURED 2026-08-25: Permen_22_2023 ranks 1st and is marked
+      `dicabut` (WRONG — should read as current) — OUTSTANDING; Permen_29_2021
+      ranks 3rd (matching journey 4's recorded rank) and is marked `dicabut`
+      (correct) — AT TARGET. Re-running this script after any repair is how a lane
+      proves the mark is correct in production, not just corrected in a report.
+
+      RECOMMENDATION (owner gesture — MANDATE §7 asked for one): the field is NOT
+      repairable by patching mismarked rows at large — the derivation mechanism
+      has no relationship to the fact it names, so a broader row-patch would make
+      hundreds of other document_ids' values look equally trustworthy with no
+      basis for that claim. Two separate actions: (1) apply the narrow, fully-
+      sourced 4-document /1,484-point correction above as a stopgap for THIS
+      lane's live defect — it is small enough to name every source and every
+      point; (2) declare `legal_status` corpus-wide UNTRUSTWORTHY for any
+      filter/exclude logic (the exact concern journey 4 already raised) until it
+      is re-derived from a document-level authoritative source, the way
+      kb/topics/*.yaml is built lane-by-lane, or the parser-level STATUS_PATTERNS
+      mechanism itself is retired/gated — a Lane P task, not a lane-A data edit.
     severity: high
 
   - id: LANE-A-2

--- a/scripts/kb/audit_legal_status.py
+++ b/scripts/kb/audit_legal_status.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""audit_legal_status — whole-scroll audit of `legal_status` across legal_unified_hybrid_hybrid.
+
+Decision 5 (Zero, 2026-08-25, KB current-live campaign) chose MARK over REMOVE for
+Golden-Visa-canary journey 4's live defect: Permen_22_2023 (in force) and
+Permen_29_2021 (superseded) BOTH carry `legal_status: dicabut` in their own payload.
+A filter excluding `dicabut` would drop the correct regulation and keep the wrong
+one — so the field is not trustworthy enough to filter on until an audit says how
+far the damage goes. This script is that audit. READ-ONLY: it never writes to Qdrant.
+
+It answers, whole-scroll (not sampled) over the collection named by --collection:
+
+  1. What vocabulary does `legal_status` actually use? (never assume two values)
+  2. How many points / documents carry it, and where does it live in the payload
+     (top-level vs metadata.legal_status vs both vs neither)?
+  3. For each distinct document_id: what value(s) does it carry? A document is
+     INCONSISTENT if its own points disagree — that is itself evidence the field
+     is not a per-document constant the way ingestion assumes.
+
+It does NOT independently verify legal reality (in-force vs superseded) — that is
+an external-verification step layered on top for a bounded instrument list (see
+--topics), because verifying a document's real-world status requires a web/registry
+fetch per instrument, not a Qdrant scroll.
+
+Run: apps/backend-rag/.venv/bin/python scripts/kb/audit_legal_status.py \
+        --collection legal_unified_hybrid_hybrid --topics kb/topics/immigration.yaml
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import sys
+from pathlib import Path
+
+_MISSING = "<missing:no legal_status field anywhere>"
+
+
+def repo_root(start: Path | None = None) -> Path:
+    here = (start or Path(__file__)).resolve()
+    for candidate in (here, *here.parents):
+        if (candidate / ".git").exists() and (candidate / "apps").is_dir():
+            return candidate
+    raise SystemExit("audit_legal_status: repo root not found")
+
+
+def load_env(root: Path) -> None:
+    env = root / "apps" / "backend-rag" / ".env"
+    if not env.is_file():
+        print(f"BROKEN — {env} not found, no credentials to reach Qdrant with. "
+              "Nothing was measured.", file=sys.stderr)
+        raise SystemExit(3)
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def extract_legal_status(payload: dict) -> tuple[str, str]:
+    """Returns (effective_value, where) — where in {'top', 'metadata', 'both', 'none'}.
+
+    Both locations are read every time (mandate §4.1 lesson: a probe reading only
+    one payload shape reports damage as zero on the shape it never looked at).
+    When both are present and DISAGREE, the raw pair is returned as the value so
+    that disagreement is visible rather than silently resolved by a preference
+    order.
+    """
+    meta = payload.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    top = payload.get("legal_status")
+    nested = meta.get("legal_status")
+    top_present = "legal_status" in payload and top is not None
+    nested_present = "legal_status" in meta and nested is not None
+    if top_present and nested_present:
+        if top == nested:
+            return (str(top), "both")
+        return (f"CONFLICT[top={top!r} vs metadata={nested!r}]", "both")
+    if top_present:
+        return (str(top), "top")
+    if nested_present:
+        return (str(nested), "metadata")
+    return (_MISSING, "none")
+
+
+def extract_document_id(payload: dict) -> str:
+    meta = payload.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    return payload.get("document_id") or meta.get("document_id") or "<none>"
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                      formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--collection", default="legal_unified_hybrid_hybrid")
+    parser.add_argument("--json-out", type=Path, default=None,
+                         help="write the full per-document census as JSON here")
+    parser.add_argument("--top-n", type=int, default=40,
+                         help="how many highest-point documents to print in detail")
+    args = parser.parse_args(argv)
+
+    root = repo_root()
+    load_env(root)
+    from qdrant_client import QdrantClient
+
+    client = QdrantClient(
+        url=os.environ["QDRANT_URL"], api_key=os.environ["QDRANT_API_KEY"], timeout=300
+    )
+    live = {c.name for c in client.get_collections().collections}
+    if args.collection not in live:
+        print(f"ABSENT — {args.collection!r} is not a live Qdrant collection. "
+              f"Live collections: {sorted(live)}", file=sys.stderr)
+        return 3
+
+    total_points = 0
+    where_counts: collections.Counter = collections.Counter()
+    value_counts: collections.Counter = collections.Counter()
+    # doc_id -> Counter(value -> count)
+    per_doc: dict[str, collections.Counter] = collections.defaultdict(collections.Counter)
+    doc_points: collections.Counter = collections.Counter()
+
+    offset = None
+    batches = 0
+    while True:
+        batch, offset = client.scroll(
+            args.collection, limit=2000, offset=offset, with_payload=True, with_vectors=False
+        )
+        if not batch:
+            break
+        batches += 1
+        for point in batch:
+            total_points += 1
+            payload = point.payload or {}
+            doc_id = extract_document_id(payload)
+            doc_points[doc_id] += 1
+            value, where = extract_legal_status(payload)
+            where_counts[where] += 1
+            value_counts[value] += 1
+            per_doc[doc_id][value] += 1
+        if offset is None:
+            break
+
+    print(f"=== audit_legal_status — {args.collection} ===")
+    print(f"scroll batches: {batches}, total points: {total_points}, "
+          f"distinct document_id values: {len(per_doc)}")
+    print()
+    print("--- Q1: where does legal_status live in the payload? ---")
+    for where, count in where_counts.most_common():
+        pct = 100.0 * count / total_points if total_points else 0.0
+        print(f"  {where:10s} {count:7d} points ({pct:5.1f}%)")
+    print()
+    print("--- Q2: what is the FULL vocabulary of legal_status? (never assume 2 values) ---")
+    for value, count in value_counts.most_common():
+        pct = 100.0 * count / total_points if total_points else 0.0
+        docs_with_value = sum(1 for c in per_doc.values() if value in c)
+        print(f"  {value!r:60s} {count:7d} points ({pct:5.1f}%)  across {docs_with_value:4d} document_ids")
+    print()
+
+    # Q3: internal consistency — does every point of a document agree on the value?
+    inconsistent = {doc: counter for doc, counter in per_doc.items() if len(counter) > 1}
+    print(f"--- Q3: documents whose OWN points disagree on legal_status: {len(inconsistent)} ---")
+    for doc, counter in sorted(inconsistent.items(), key=lambda kv: -sum(kv[1].values())):
+        breakdown = ", ".join(f"{v!r}={c}" for v, c in counter.most_common())
+        print(f"  {doc:40s} ({doc_points[doc]:5d} pts total): {breakdown}")
+    print()
+
+    print(f"--- top {args.top_n} documents by point count, with their legal_status ---")
+    header = "%-40s %8s  %s" % ("document_id", "points", "legal_status(es)")
+    print(header)
+    print("-" * len(header))
+    for doc, npts in doc_points.most_common(args.top_n):
+        counter = per_doc[doc]
+        breakdown = ", ".join(f"{v!r}={c}" for v, c in counter.most_common())
+        print("%-40s %8d  %s" % (doc, npts, breakdown))
+
+    if args.json_out:
+        out = {
+            "collection": args.collection,
+            "total_points": total_points,
+            "distinct_document_ids": len(per_doc),
+            "where_counts": dict(where_counts),
+            "value_counts": dict(value_counts),
+            "per_document": {
+                doc: dict(counter) for doc, counter in per_doc.items()
+            },
+        }
+        args.json_out.write_text(json.dumps(out, indent=2, ensure_ascii=False))
+        print(f"\nfull per-document census written to {args.json_out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kb/probe_legal_status_marking.py
+++ b/scripts/kb/probe_legal_status_marking.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""probe_legal_status_marking — makes Decision 5 (MARK over REMOVE) testable.
+
+Zero's reasoning for MARK over REMOVE (docs/plans/2026-08-25-kb-current-live/
+MANDATE.md §7 decision 5, and the orchestrator's brief for this task): a filter
+that excludes anything `legal_status: dicabut` would have dropped Permen_22_2023
+(the CURRENT, in-force visa regulation — journey 3/4's live defect) while keeping
+Permen_29_2021 (the genuinely superseded predecessor) — REMOVE makes the corpus
+worse, not better. MARK survives only if a mark is actually retrievable and
+correct at query time. This script measures exactly that, read-only, against the
+SAME production retrieval path `kb/ops/probe_retrieval.py` uses (imports its
+`repo_root`/`load_env`/`retrieve` rather than reimplementing them — a probe that
+reimplements retrieval logic can go green while production goes red, per that
+file's own docstring).
+
+It does NOT replace probe_retrieval.py's phrase-based journeys, and it
+deliberately does not touch that 622-line shared tool (used by property/tax lanes
+too) or its guilt/innocence test contract — this is a narrow, additive companion
+scoped to the ONE pair MANDATE.md names directly (journeys 3 & 4 of
+kb/journeys/immigration.yaml): the current instrument (Permen_22_2023) vs. the
+superseded one it replaced (Permen_29_2021), asked with journey 4's real
+ITAS-duration question.
+
+WHAT IT ASSERTS
+For the SAME question journey 4 already probes, among the retrieved chunks:
+  - is Permen_29_2021 (superseded) present, and is it MARKED as such
+    (legal_status == 'dicabut')?
+  - is Permen_22_2023 (current) present, and is it MARKED as CURRENT
+    (legal_status == 'berlaku', i.e. NOT 'dicabut')?
+Today (2026-08-25, before any repair), the audit (audit_legal_status.py) measured
+BOTH documents carrying legal_status='dicabut' — so this script is expected to
+report the superseded side AT TARGET and the current side OUTSTANDING, which is
+the live defect this campaign exists to fix. After the narrow repair proposed in
+propose_legal_status_repair.py is (if ever) applied, re-running this script is
+how a lane proves the mark, not just the presence, is now correct — a green here
+is decision 5 becoming true in production, not just declared.
+
+Run: apps/backend-rag/.venv/bin/python scripts/kb/probe_legal_status_marking.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "kb" / "ops"))
+from probe_retrieval import load_env, repo_root, retrieve  # noqa: E402
+
+QUESTION = (
+    "Berapa lama masa berlaku Izin Tinggal Terbatas (ITAS) bagi WNA yang masuk "
+    "dengan visa tinggal terbatas?"
+)
+COLLECTION = "legal_unified"
+CURRENT_DOC = "Permen_22_2023"
+SUPERSEDED_DOC = "Permen_29_2021"
+EXPECT_CURRENT_STATUS = "berlaku"
+EXPECT_SUPERSEDED_STATUS = "dicabut"
+
+
+def doc_id_of(chunk: dict) -> str:
+    meta = chunk.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    return chunk.get("document_id") or meta.get("document_id") or "<none>"
+
+
+def legal_status_of(chunk: dict) -> str:
+    meta = chunk.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    val = chunk.get("legal_status")
+    if val is None:
+        val = meta.get("legal_status")
+    return str(val) if val is not None else "<missing>"
+
+
+async def main() -> int:
+    root = repo_root()
+    load_env(root)
+    sys.path.insert(0, str(root / "apps" / "backend-rag"))
+    from backend.services.search.search_service import SearchService
+
+    service = SearchService()
+    chunks = await retrieve(service, QUESTION, COLLECTION, limit=10)
+
+    print("=== probe_legal_status_marking — Decision 5, journey 3/4 pair ===")
+    print("question: %r" % QUESTION)
+    print("collection: %s\n" % COLLECTION)
+
+    findings = []
+    for label, doc_id, expect in (
+        ("CURRENT (should read as in-force)", CURRENT_DOC, EXPECT_CURRENT_STATUS),
+        ("SUPERSEDED (should read as revoked)", SUPERSEDED_DOC, EXPECT_SUPERSEDED_STATUS),
+    ):
+        rank = None
+        status = None
+        for i, chunk in enumerate(chunks, start=1):
+            if doc_id_of(chunk) == doc_id:
+                rank = i
+                status = legal_status_of(chunk)
+                break
+        print(f"--- {doc_id} — {label} ---")
+        if rank is None:
+            print(f"  NOT in top {len(chunks)} results for this question.")
+            findings.append((doc_id, "absent_from_results"))
+            print()
+            continue
+        marked_correctly = status == expect
+        print(f"  rank: {rank}")
+        print(f"  legal_status on the retrieved chunk: {status!r}")
+        print(f"  expected for a correct mark: {expect!r}")
+        print(f"  verdict: {'AT TARGET' if marked_correctly else 'OUTSTANDING — wrong mark'}")
+        findings.append((doc_id, "at_target" if marked_correctly else "outstanding"))
+        print()
+
+    outstanding = [d for d, v in findings if v != "at_target"]
+    if outstanding:
+        print(f"OUTSTANDING — {len(outstanding)} of {len(findings)} instrument(s) not "
+              f"correctly marked: {', '.join(outstanding)}")
+        print("Decision 5 (MARK) is not yet true in production for this pair.")
+        return 2
+    print("AT TARGET — both instruments carry the correct mark in production.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/kb/propose_legal_status_repair.py
+++ b/scripts/kb/propose_legal_status_repair.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""propose_legal_status_repair — dry-run diff ONLY. Never writes to Qdrant.
+
+Companion to audit_legal_status.py. That audit found `legal_status` is not a
+document-level legal fact: it is derived per-chunk by a bare regex
+(`apps/backend-rag/backend/core/legal/constants.py::STATUS_PATTERNS`) matching the
+literal substrings DICABUT|TIDAK BERLAKU|DIGANTI vs BERLAKU|MASIH BERLAKU anywhere
+in the chunk text, dict-order-first-match, with zero grammatical disambiguation of
+what the match refers to. Sampled directly against production text (not inferred):
+the DIGANTI pattern fires on the generic verb "digantikan" (a guarantor being
+substituted, nothing to do with the regulation's status); TIDAK BERLAKU fires on
+"Izin Tinggal yang tidak berlaku lagi" (an individual's STAY PERMIT expiring) and on
+"ketentuan ... tidak berlaku terhadap warga negara Indonesia" (a provision not
+applying to a class of person); and — the specific defect Decision 5 exists to
+answer — a law's own standard closing clause revoking ITS PREDECESSORS
+("Keputusan Presiden Nomor 31 Tahun 1998 ... dicabut dan dinyatakan tidak
+berlaku") gets read as the CURRENT, still-valid document being revoked.
+
+Given that mechanism, a corpus-wide row-patch is NOT proposed here — it would make
+590+ other document_ids' values look equally trustworthy when the audit gives no
+basis for that. This script proposes ONLY the narrow set of document_ids lane A
+externally verified against peraturan.go.id / peraturan.bpk.go.id this session
+(kb/topics/immigration.yaml), where a specific correct value can be named with a
+source. Print-only: no --apply flag exists. Applying is the orchestrator's decision
+once the audit has been reviewed.
+
+Run: apps/backend-rag/.venv/bin/python scripts/kb/propose_legal_status_repair.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# document_id -> (current census value, proposed value, source)
+# Restricted to instruments lane A verified this session with a live source_url
+# fetch/search (kb/topics/immigration.yaml) AND that are actually present in
+# legal_unified_hybrid_hybrid. Permen_27_2021 is deliberately EXCLUDED: its real
+# status is recorded as `unknown` in kb/topics/immigration.yaml (source_verified:
+# false) — proposing a value for it here would be exactly the guessing the mandate
+# forbids ("If external verification of a given instrument is not possible, say
+# UNDETERMINED for that one — do not guess").
+PROPOSED_CORRECTIONS = {
+    "UU_6_2011": (
+        "dicabut", "berlaku",
+        "peraturan.go.id: base articles still valid (amended by UU 63/2024, not "
+        "repealed). kb/topics/immigration.yaml status=amended.",
+    ),
+    "Permen_22_2023": (
+        "dicabut", "berlaku",
+        "peraturan.go.id direct fetch 2026-08-25: current Visa dan Izin Tinggal "
+        "regulation, amended by Permen_11_2024, not revoked. This is the exact "
+        "instrument journey 3/4 (kb/journeys/immigration.yaml) named as the live "
+        "defect.",
+    ),
+    "Permen_11_2024": (
+        "dicabut", "berlaku",
+        "peraturan.bpk.go.id + Permen_22_2023's own page: the 2024 amendment "
+        "currently in force, not revoked.",
+    ),
+    "PP_31_2013": (
+        "dicabut", "berlaku",
+        "web search: standing implementing regulation for UU 6/2011, amended "
+        "(most recently by PP 40/2023), not repealed. NOTE: lane A left OPEN "
+        "whether the corpus TEXT reflects the article content as amended through "
+        "PP 40/2023 or only the 2013 original — this correction addresses only "
+        "the legal_status field, not that separate open question.",
+    ),
+}
+# Verified correct, listed for completeness so this file is a full account of
+# lane A's 7 present, real-status-known instruments — NOT proposed as changes:
+#   Permen_29_2021: dicabut (340 pts) — genuinely superseded by Permen_22_2023.
+#   UU_63_2024:     berlaku (38 pts)  — genuinely in force.
+# Excluded (real status not established with a source):
+#   Permen_27_2021: dicabut (6 pts) — kb/topics/immigration.yaml records
+#                   status=unknown, source_verified=false. UNDETERMINED, not
+#                   proposed.
+
+
+def repo_root(start: Path | None = None) -> Path:
+    here = (start or Path(__file__)).resolve()
+    for candidate in (here, *here.parents):
+        if (candidate / ".git").exists() and (candidate / "apps").is_dir():
+            return candidate
+    raise SystemExit("propose_legal_status_repair: repo root not found")
+
+
+def load_env(root: Path) -> None:
+    env = root / "apps" / "backend-rag" / ".env"
+    if not env.is_file():
+        print(f"BROKEN — {env} not found, no credentials to reach Qdrant with.",
+              file=sys.stderr)
+        raise SystemExit(3)
+    for line in env.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+def extract_legal_status_location(payload: dict) -> str:
+    """Returns 'top', 'metadata', 'both', or 'none' — where the point's own
+    legal_status field actually lives, so the diff line shows exactly which key
+    a real repair script would need to touch on THIS point."""
+    meta = payload.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    top_present = "legal_status" in payload and payload.get("legal_status") is not None
+    nested_present = "legal_status" in meta and meta.get("legal_status") is not None
+    if top_present and nested_present:
+        return "both"
+    if top_present:
+        return "top"
+    if nested_present:
+        return "metadata"
+    return "none"
+
+
+def main() -> int:
+    root = repo_root()
+    load_env(root)
+    from qdrant_client import QdrantClient
+
+    client = QdrantClient(
+        url=os.environ["QDRANT_URL"], api_key=os.environ["QDRANT_API_KEY"], timeout=300
+    )
+    collection = "legal_unified_hybrid_hybrid"
+
+    print("=== propose_legal_status_repair — DRY RUN, NOTHING IS WRITTEN ===")
+    print(f"collection: {collection}\n")
+    print("Scope: lane-A externally-verified immigration instruments ONLY. This is")
+    print("NOT a corpus-wide repair proposal — see the audit for why one row-patch")
+    print("pass cannot make the field trustworthy at large.\n")
+
+    total_points_changed = 0
+    for doc_id, (expect_from, to_value, source) in PROPOSED_CORRECTIONS.items():
+        from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+        flt = Filter(should=[
+            FieldCondition(key="document_id", match=MatchValue(value=doc_id)),
+            FieldCondition(key="metadata.document_id", match=MatchValue(value=doc_id)),
+        ])
+        offset = None
+        n_points = 0
+        n_matching_expected = 0
+        locations = {"top": 0, "metadata": 0, "both": 0, "none": 0}
+        while True:
+            batch, offset = client.scroll(
+                collection, scroll_filter=flt, limit=1000, offset=offset,
+                with_payload=True, with_vectors=False,
+            )
+            if not batch:
+                break
+            for point in batch:
+                payload = point.payload or {}
+                meta = payload.get("metadata")
+                meta = meta if isinstance(meta, dict) else {}
+                current = payload.get("legal_status") or meta.get("legal_status")
+                n_points += 1
+                if str(current) == expect_from:
+                    n_matching_expected += 1
+                locations[extract_legal_status_location(payload)] += 1
+            if offset is None:
+                break
+
+        print(f"--- {doc_id} ---")
+        print(f"  proposed: {expect_from!r} -> {to_value!r}")
+        print(f"  source:   {source}")
+        print(f"  live points matching document_id: {n_points}")
+        print(f"  of those, currently == {expect_from!r}: {n_matching_expected}")
+        print(f"  field location across these points: {locations}")
+        if n_points != n_matching_expected:
+            print(f"  ⚠ {n_points - n_matching_expected} point(s) do NOT currently "
+                  f"hold {expect_from!r} — census may have moved since the audit ran, "
+                  f"or a point already has a different value. A real repair script "
+                  f"must re-check per-point, not assume uniformity.")
+        print(f"  WOULD WRITE {n_matching_expected} point(s): legal_status "
+              f"{expect_from!r} -> {to_value!r} (in whichever of top-level/"
+              f"metadata key each point actually holds it)")
+        print(f"  NOTHING WRITTEN (dry-run only, no --apply flag exists in this script)")
+        print()
+        total_points_changed += n_matching_expected
+
+    print(f"=== TOTAL: {total_points_changed} points across "
+          f"{len(PROPOSED_CORRECTIONS)} document_ids WOULD change if applied ===")
+    print("No write performed. This script has no code path that calls .set_payload/")
+    print(".overwrite_payload — the apply step, if authorized, is separate work.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Whole-scroll audit (`scripts/kb/audit_legal_status.py`) of `legal_status` across all 84,283 points of `legal_unified_hybrid_hybrid` — decision 5 (Zero, MARK over REMOVE) required this before any filter is written on the field.
- Root cause found and confirmed against live text: `STATUS_PATTERNS` in `apps/backend-rag/backend/core/legal/constants.py` is a bare per-chunk regex (`DICABUT|TIDAK BERLAKU|DIGANTI` vs `BERLAKU|MASIH BERLAKU`) with no disambiguation of what the match refers to — it fires on unrelated verb forms, on individual permits/provisions, and (the mechanism behind journey 4's live defect) on a law's own clause revoking its predecessors, which reads the CURRENT law as revoked.
- Of lane A's 7 present, real-status-verified immigration instruments, 4/5 `dicabut`-marked ones are wrongly marked (UU_6_2011, Permen_22_2023, Permen_11_2024, PP_31_2013). Outside lane A, the two largest `dicabut`-marked documents corpus-wide (UU_40_2007, UU_6_2023) are also independently confirmed still in force — the defect is corpus-wide, not immigration-specific.
- `scripts/kb/propose_legal_status_repair.py`: read-only dry-run (no `--apply` exists) naming exactly 1,484 points / 4 document_ids this session can source a correction for. Permen_27_2021 deliberately excluded (real status recorded `unknown`).
- `scripts/kb/probe_legal_status_marking.py`: makes decision 5 testable — re-runs journey 4's exact question through the real `SearchService` path and checks the retrieved chunks' own `legal_status`. Measured: Permen_22_2023 ranks 1st marked `dicabut` (OUTSTANDING), Permen_29_2021 ranks 3rd marked `dicabut` (AT TARGET).
- `kb/inventory/immigration.yaml` LANE-A-1 updated with the full audit, scale evidence, and recommendation: apply the narrow 4-document correction as a stopgap; declare `legal_status` corpus-wide untrustworthy for any filter/exclude logic until re-derived document-level or the parser mechanism is retired/gated (Lane P, not a lane-A data edit).

**Nothing was written to Qdrant. No document text/identity touched. No filter added.**

## Test plan
- [x] `cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/kb/ -q --color=no` — exit 1, single pre-existing failure `test_real_journey_files_obey_the_contract[tax]` (lane C is replacing that file, not in scope here). No new failures.
- [x] `./apps/backend-rag/.venv/bin/python kb/ops/probe_retrieval.py kb/journeys/immigration.yaml` — exit 2 OUTSTANDING, every RECORDED value matches MEASURED (no drift).
- [x] `apps/backend-rag/.venv/bin/python scripts/kb/audit_legal_status.py` — whole-scroll audit, output captured in PR description above.
- [x] `apps/backend-rag/.venv/bin/python scripts/kb/propose_legal_status_repair.py` — dry-run, confirms 1,484 points / 4 document_ids, zero writes.
- [x] `apps/backend-rag/.venv/bin/python scripts/kb/probe_legal_status_marking.py` — confirms the live asymmetric defect against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)