### PR TITLE
fix(garuda-voa): allowlist L2/L3 public routes, carve out staff-only path

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -611,13 +611,86 @@ _VISA_ORACLE = (
     # "Visa Check funnel dead in prod" note above, caught here the same way:
     # a real end-to-end request through `main_api.app` (not a bare FastAPI()
     # + include_router() test double) returned 401 before this entry existed.
-    # DISCOVERED, NOT FIXED HERE: `/api/visa/voa` itself (L2's
-    # garuda_voa_public.py + L3's garuda_orders_router.py, both already
-    # merged) has the SAME gap — no registry entry, so their public routes
-    # 401 in production today too. Out of scope for this PR (cross-lane
-    # files, and garuda_orders_router.py also mounts a staff-only
-    # /api/visa/voa/staff/... route that a careless blanket prefix here
-    # would need to carve out correctly) — flagged for the orchestrator.
+    # CLOSED (orchestrator, 2026-08-25): `/api/visa/voa` itself (L2's
+    # garuda_voa_public.py + L3's garuda_orders_router.py) had the SAME gap
+    # the paragraph above used to flag — no registry entry, so every public
+    # route under this root 401'd in production even with
+    # GARUDA_PUBLIC_ENABLED=true (confirmed live: eligibility/check/orders
+    # all returned 401 against nuzantara-rag.fly.dev on 2026-08-25).
+    #
+    # `garuda_orders_router.py` ALSO mounts a STAFF-ONLY route on the same
+    # root — `/api/visa/voa/staff/orders/{order_id}/late-resolution`
+    # (`_require_staff_actor`, Authorization-header session) — so a blanket
+    # `/api/visa/voa/` prefix entry was rejected: it would make that internal
+    # surface public too, which is strictly worse than the bug being fixed.
+    # Every entry below is EXACT or TEMPLATE, never PREFIX, specifically so
+    # this file's `PublicEndpoint.matches()` cannot leak the staff path:
+    #   - `match="exact"` requires byte-for-byte path equality — the staff
+    #     path is a different literal string entirely.
+    #   - `match="template"` requires the SAME NUMBER of `/`-separated
+    #     segments as the entry (see `matches()` above) — the staff path has
+    #     7 segments (`api/visa/voa/staff/orders/{order_id}/late-resolution`);
+    #     the deepest entry below (`.../orders/{order_id}/browser-return-
+    #     observations`) has 6, `.../eligibility-checks/{result_id}` and
+    #     `.../orders/{order_id}` have 5. No entry here can ever reach 7
+    #     segments, so none can structurally match the staff route — this is
+    #     a property of segment COUNT, not of vigilance, and a future entry
+    #     added the same way (exact/template, never a bare directory prefix)
+    #     inherits the same guarantee for free.
+    # `test_garuda_voa_public_root_allowlist.py` pins both halves: every
+    # public route below answers anonymously through the REAL mounted app
+    # (`main_api.app`, not a bare `FastAPI()+include_router()` double — the
+    # note above was only caught that way), and the staff route still 401s
+    # with the middleware's OWN "Authentication required" body (never the
+    # handler's SESSION_REQUIRED) — the second assertion is what stays red
+    # if a future edit ever widens one of these entries into a prefix.
+    PublicEndpoint(
+        "/api/visa/voa/eligibility-checks",
+        Category.VISA_ORACLE,
+        "GARUDA VOA createEligibilityCheck (L2, garuda_voa_public.py) — anonymous "
+        "eligibility funnel entry point, contract-frozen, GARUDA_PUBLIC_ENABLED "
+        "re-checked per-request by the handler itself",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/visa/voa/eligibility-checks/{result_id}",
+        Category.VISA_ORACLE,
+        "GARUDA VOA getEligibilityResult/deleteEligibilityResult (L2, garuda_voa_"
+        "public.py) — anonymous, gated by the garuda_result_session cookie the "
+        "handler itself verifies, not by team auth",
+        match="template",
+    ),
+    PublicEndpoint(
+        "/api/visa/voa/orders",
+        Category.VISA_ORACLE,
+        "GARUDA VOA createOrderFromCheck (L3, garuda_orders_router.py) — the "
+        "customer checkout step; gated by the garuda_session magic-link cookie "
+        "(_require_magic_session_actor), not by team auth",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/visa/voa/orders/{order_id}",
+        Category.VISA_ORACLE,
+        "GARUDA VOA getOrderAndPractice (L3/L4) — same magic-link session gate "
+        "as createOrderFromCheck above, scoped to the caller's own order "
+        "(result_id_ref ownership predicate, #4910)",
+        match="template",
+    ),
+    PublicEndpoint(
+        "/api/visa/voa/orders/{order_id}/browser-return-observations",
+        Category.VISA_ORACLE,
+        "GARUDA VOA observePaymentBrowserReturn (L3) — same magic-link session "
+        "gate as the two entries above",
+        match="template",
+    ),
+    PublicEndpoint(
+        "/api/visa/voa/webhooks/payment",
+        Category.WEBHOOK,
+        "GARUDA VOA receivePaymentWebhook (L3, garuda_orders_router.py) — inbound "
+        "Xendit callback, authenticated by the provider's own signature header "
+        "(provider.verify_signature), never by team auth or Idempotency-Key",
+        match="exact",
+    ),
     PublicEndpoint(
         "/api/visa/voa/auth/",
         Category.AUTH,

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_public_root_allowlist.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_public_root_allowlist.py
@@ -1,0 +1,116 @@
+"""GARUDA VOA public-root allowlist (orchestrator PR, 2026-08-25).
+
+GUILT half: every public route registered in `public_endpoints.py` under the
+shared `/api/visa/voa` root (createEligibilityCheck / getEligibilityResult /
+deleteEligibilityResult -- L2, garuda_voa_public.py -- and
+createOrderFromCheck / getOrderAndPractice / observePaymentBrowserReturn /
+receivePaymentWebhook -- L3, garuda_orders_router.py) answers WITHOUT any
+API key or JWT, through the REAL mounted application (`main_api.app` --
+`test_garuda_voa_public.py`'s bare `FastAPI()` double would stay green even
+though production returned 401 for every one of these paths; confirmed live
+against nuzantara-rag.fly.dev on 2026-08-25 before this PR's registry
+entries existed). `garuda_portal_auth.py`'s magic-link pair already has an
+equivalent mounted test (`test_garuda_portal_auth_mounted.py`) from the PR
+that discovered this gap for the shared `/api/visa/voa` root -- this file is
+the same proof for the two lanes that PR flagged as out of scope.
+
+INNOCENCE half: the staff-only sibling on the SAME root
+(`/api/visa/voa/staff/orders/{order_id}/late-resolution`,
+`garuda_orders_router.py::_require_staff_actor`) must still be rejected by
+`HybridAuthMiddleware` ITSELF -- not merely end up 401 for an unrelated
+in-handler reason. A future edit that widens one of the entries above into
+a blanket `/api/visa/voa/` prefix would make the middleware treat the staff
+path as public too; the handler's OWN `_require_staff_actor` would still
+401 an unauthenticated caller in that world, so a bare `status_code == 401`
+assertion would stay green straight through that regression. Asserting the
+middleware's OWN failure body (`{"detail": "Authentication required"}`,
+never the handler's `{"code": "SESSION_REQUIRED", ...}` shape) is what
+turns this test red instead -- see `public_endpoints.py`'s comment block
+for why every entry above is EXACT or TEMPLATE (segment-count-matched),
+never a PREFIX, so this can only happen via a deliberate, reviewable change
+to the registry's matching mode.
+
+Discriminator: `X-Auth-Type: public`, set by
+`HybridAuthMiddleware.dispatch` on every response that takes its
+public-endpoint branch (`backend/middleware/hybrid_auth.py`). This is
+decoupled from whatever status code the router's own business logic
+returns -- the persistence store / payment provider / db pool are all
+unwired in this test process by design (same posture as
+`test_garuda_portal_auth_mounted.py`); the only thing under test here is
+whether the auth *gate* was bypassed, never whether the funnel's downstream
+services answer.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Building `main_api.app` is the point -- see
+# `test_garuda_portal_auth_mounted.py`'s identical precedent/cost note.
+from backend.app import main_api as _main_api_module
+
+_APP = _main_api_module.app
+
+# (case id, method, path, kwargs passed straight to httpx.AsyncClient.request)
+PUBLIC_REQUESTS: list[tuple[str, str, str, dict]] = [
+    ("create_eligibility_check", "POST", "/api/visa/voa/eligibility-checks", {"json": {}}),
+    ("get_eligibility_result", "GET", "/api/visa/voa/eligibility-checks/abc123", {}),
+    ("delete_eligibility_result", "DELETE", "/api/visa/voa/eligibility-checks/abc123", {}),
+    ("create_order_from_check", "POST", "/api/visa/voa/orders", {"json": {}}),
+    ("get_order_and_practice", "GET", "/api/visa/voa/orders/ord_abc123", {}),
+    (
+        "observe_payment_browser_return",
+        "POST",
+        "/api/visa/voa/orders/ord_abc123/browser-return-observations",
+        {"json": {}},
+    ),
+    ("receive_payment_webhook", "POST", "/api/visa/voa/webhooks/payment", {"content": b"{}"}),
+]
+
+
+@pytest.fixture(autouse=True)
+def _garuda_public_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "true")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case_id,method,path,kwargs",
+    PUBLIC_REQUESTS,
+    ids=[case[0] for case in PUBLIC_REQUESTS],
+)
+async def test_public_voa_route_bypasses_the_api_key_gate(case_id, method, path, kwargs):
+    transport = ASGITransport(app=_APP)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.request(method, path, **kwargs)
+    assert response.headers.get("X-Auth-Type") == "public", (
+        f"{case_id} ({method} {path}) did not take HybridAuthMiddleware's "
+        f"public-endpoint branch -- got status {response.status_code}, "
+        f"headers {dict(response.headers)}. This is exactly the defect this "
+        f"PR fixes: without a public_endpoints.py entry this path 401s in "
+        f"production before ever reaching the handler."
+    )
+
+
+@pytest.mark.asyncio
+async def test_staff_late_resolution_route_is_never_public():
+    """The one route on this shared root that must stay behind the
+    API-key/JWT gate. See module docstring for why the assertion checks the
+    FAILURE BODY, not just the status code."""
+    transport = ASGITransport(app=_APP)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/visa/voa/staff/orders/ord_abc123/late-resolution",
+            json={"resolution": "honoured", "staff_reference": "ref-1"},
+        )
+    assert response.status_code == 401
+    assert response.headers.get("X-Auth-Type") != "public"
+    assert response.json() == {"detail": "Authentication required"}, (
+        "the staff route must be rejected by HybridAuthMiddleware itself "
+        "(detail == 'Authentication required') -- a body shaped like the "
+        "handler's own SESSION_REQUIRED error would mean the middleware let "
+        "an unauthenticated request THROUGH to the handler, i.e. a future "
+        "edit widened a public_endpoints.py entry into a prefix that now "
+        "covers this staff-only path"
+    )


### PR DESCRIPTION
## Summary

Closes the gap flagged in `garuda_portal_auth.py`'s L2 registry entry (PR #4910's own docstring, "DISCOVERED, NOT FIXED HERE"): `/api/visa/voa` (L2 `garuda_voa_public.py` + L3 `garuda_orders_router.py`) had no `public_endpoints.py` registry entry, so `HybridAuthMiddleware` 401'd every anonymous request before it ever reached the handler — the GARUDA VOA public eligibility/checkout funnel was unreachable by a tourist's browser in production even with `GARUDA_PUBLIC_ENABLED=true`.

Confirmed live against `nuzantara-rag.fly.dev` before this fix:
```
/api/visa/voa/eligibility -> 401
/api/visa/voa/check       -> 401
/api/visa/voa/orders      -> 401
/health                   -> 200
```

## Route inventory (verified by reading the decorators/dependencies, not the names)

| Method | Path | Auth shape | File |
|---|---|---|---|
| POST | `/api/visa/voa/eligibility-checks` | anonymous | `garuda_voa_public.py` |
| GET | `/api/visa/voa/eligibility-checks/{result_id}` | anonymous, gated by `garuda_result_session` cookie in-handler | `garuda_voa_public.py` |
| DELETE | `/api/visa/voa/eligibility-checks/{result_id}` | anonymous | `garuda_voa_public.py` |
| POST | `/api/visa/voa/orders` | magic-link session (`garuda_session` cookie, `_require_magic_session_actor`) | `garuda_orders_router.py` |
| GET | `/api/visa/voa/orders/{order_id}` | magic-link session, ownership-filtered | `garuda_orders_router.py` |
| POST | `/api/visa/voa/orders/{order_id}/browser-return-observations` | magic-link session | `garuda_orders_router.py` |
| POST | `/api/visa/voa/webhooks/payment` | Xendit provider signature (`provider.verify_signature`), never team auth | `garuda_orders_router.py` |
| **POST** | **`/api/visa/voa/staff/orders/{order_id}/late-resolution`** | **STAFF ONLY** — `Authorization` header, `_require_staff_actor` | `garuda_orders_router.py` |
| POST | `/api/visa/voa/auth/magic-links` | anonymous (already fixed, PR #4910) | `garuda_portal_auth.py` |
| POST | `/api/visa/voa/auth/sessions` | anonymous (already fixed, PR #4910) | `garuda_portal_auth.py` |

## Matching form chosen, and why it cannot leak the staff path

Every new entry is `match="exact"` or `match="template"` — **never** `match="prefix"`.

- `exact` requires byte-for-byte path equality; the staff path is a different literal string.
- `template` (from `PublicEndpoint.matches()`) requires the **same number** of `/`-separated segments as the registered entry. The staff path (`api/visa/voa/staff/orders/{order_id}/late-resolution`) has **7** segments. The deepest new entry (`.../orders/{order_id}/browser-return-observations`) has 6; the others have 5. No entry here can ever reach 7 segments, so none can structurally match the staff route — this is a property of segment *count*, not of care taken while writing the string, and it survives future edits made the same way.

A blanket `/api/visa/voa/` prefix was explicitly rejected for this reason.

## Tests

New file: `test_garuda_voa_public_root_allowlist.py` (real mounted `main_api.app`, not a bare `FastAPI()+include_router()` double — the PR #4910 note already established that a test double would pass while production 401'd).

- **GUILT** (7 parametrized cases, one per new public route): each request carries no API key / JWT and asserts `X-Auth-Type: public` on the response (the header `HybridAuthMiddleware` sets only on its public-endpoint branch) — decoupled from whatever status the downstream unwired store/provider/pool returns.
- **INNOCENCE** (staff route): asserts `401` **and** the exact failure body `{"detail": "Authentication required"}` — the middleware's own rejection shape, not the handler's `{"code": "SESSION_REQUIRED", ...}`. I verified by hand that this second assertion is load-bearing: temporarily widening one entry to a real `match="prefix"` blanket (`/api/visa/voa/`) makes this test go **red** (503, reached the unwired staff verifier) while a bare `status_code == 401` check would have stayed green throughout.

## Test results

```
backend/tests/app/routers/test_garuda_voa_public_root_allowlist.py .... 8 passed
backend/tests/unit/middleware/test_public_endpoints_registry.py ....... (all passed)
backend/tests/app/routers/test_garuda_voa_public.py ................... (all passed)
backend/tests/app/routers/test_garuda_portal_auth.py .................. (all passed)
backend/tests/app/routers/test_garuda_portal_auth_mounted.py .......... (all passed)
```
Combined run: **72 passed, 0 failed** (`-q` across all 5 files above).

Also ran for collateral effects:
```
backend/tests/setup/test_router_manifest.py ................ (all passed)
backend/tests/setup/test_manifest_registration_parity.py .... (all passed)
backend/tests/security/test_route_authz_coverage.py ......... 3 passed
```

No xdist/Postgres template-race flake encountered in these runs (single-worker, no Postgres-backed tests in this file's scope).

## Scope

Registry-only fix (`public_endpoints.py`) + new test file. No router/handler code touched — L2/L3's own contract-frozen logic is unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>