### PR TITLE
docs(garuda-voa): correct webhook-token comment on public-endpoints entry

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -687,8 +687,16 @@ _VISA_ORACLE = (
         "/api/visa/voa/webhooks/payment",
         Category.WEBHOOK,
         "GARUDA VOA receivePaymentWebhook (L3, garuda_orders_router.py) — inbound "
-        "Xendit callback, authenticated by the provider's own signature header "
-        "(provider.verify_signature), never by team auth or Idempotency-Key",
+        "Xendit Invoices callback. Xendit authenticates it with a static "
+        "`x-callback-token` header compared constant-time against the stored "
+        "verification token (XenditPaymentProvider.verify_signature, "
+        "xendit.py — NOT an HMAC body signature; Xendit Invoices callbacks "
+        "carry none), never by team auth or Idempotency-Key. This route is "
+        "the nastiest of the GARUDA VOA public routes to get wrong: it is not "
+        "part of the visible funnel, so a 401 here fails SILENTLY — the "
+        "customer already paid, Xendit cannot tell us, and the order sits "
+        "unpaid forever while the money has moved, surfacing days later as a "
+        "support case rather than as an obvious broken page.",
         match="exact",
     ),
     PublicEndpoint(


### PR DESCRIPTION
## Summary

Follow-up to #4946 per team-lead review. The `receivePaymentWebhook` registry entry's comment described the auth mechanism generically ("the provider's own signature header"). Verified against `xendit.py` before rewriting it:

- Xendit Invoices callbacks authenticate via a static `x-callback-token` header, compared constant-time (`hmac.compare_digest`) to a stored verification token — **explicitly not an HMAC body signature** (xendit.py's own module docstring: "Xendit Invoices callbacks carry no body signature").
- I could **not** verify team-lead's suggested env-var name (`GARUDA_XENDIT_CALLBACK_TOKEN`) — grepped `service_initializer.py` and the whole `apps/backend-rag/backend` tree, zero hits. `garuda_payment_provider` is not wired onto `app.state` anywhere in production yet (matches `garuda_orders_router.py`'s own docstring: "the orchestrator still owns injecting the real ... PaymentProvider adapters"). Naming an unverified env var in a permanent comment would have been a fabrication, so the comment now names the actual mechanism (`XenditPaymentProvider.verify_signature` / `_callback_verification_token`) instead of an env var that doesn't exist in this codebase.

Also added the explicit silent-failure risk statement team-lead asked for: this route isn't part of the visible funnel, so a 401 fails silently — the customer already paid, Xendit can't tell us, and the order sits unpaid while the money has moved, surfacing days later as a support case.

No test changes — `/api/visa/voa/webhooks/payment` was already covered by the `receive_payment_webhook` guilt case in `test_garuda_voa_public_root_allowlist.py` (#4946), and that test still passes unchanged.

## Test results

```
backend/tests/app/routers/test_garuda_voa_public_root_allowlist.py .... 8 passed
backend/tests/unit/middleware/test_public_endpoints_registry.py ....... all passed
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>