### PR TITLE
fix(kb): retire STATUS_PATTERNS — legal_status derivation was category-wrong

### DIFF
--- a/apps/backend-rag/backend/core/legal/constants.py
+++ b/apps/backend-rag/backend/core/legal/constants.py
@@ -211,11 +211,38 @@ TOPIC_PATTERN = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
-# Status indicators
-STATUS_PATTERNS = {
-    "dicabut": re.compile(r"DICABUT|TIDAK BERLAKU|DIGANTI", re.IGNORECASE),
-    "berlaku": re.compile(r"BERLAKU|MASIH BERLAKU", re.IGNORECASE),
-}
+# Status indicators — RETIRED 2026-08-25 (Lane P, kb-p2-status-retire-0825).
+# `STATUS_PATTERNS` used to derive a document-level "berlaku"/"dicabut" fact
+# from a bare regex over CHUNK text (DICABUT|TIDAK BERLAKU|DIGANTI vs
+# BERLAKU|MASIH BERLAKU, dict-order first match wins). The two patterns
+# OVERLAP — "TIDAK BERLAKU" contains "BERLAKU" — and neither has any way to
+# tell what the matched words refer to. Measured against all 84,283 points of
+# legal_unified_hybrid_hybrid, sampled directly against production text: it
+# fired on a provision not applying to a class of PERSON ("tidak berlaku bagi
+# warga negara asing"), on a guarantor being substituted ("digantikan"), on an
+# individual permit expiring, and — the mechanism behind a live production
+# defect — on a law's OWN closing clause revoking its PREDECESSOR, which read
+# the CURRENT, still-valid law as revoked (kb/inventory/immigration.yaml,
+# finding LANE-A-1).
+#
+# This is a retirement, not a repair, because no fix at this layer can be
+# correct for the revoked direction: whether instrument X is CURRENTLY
+# revoked is always established by a LATER, DIFFERENT instrument (the one
+# that revokes X) — X's own text, written before its own repeal existed,
+# cannot attest to it. The one shape that looks like a counter-example — a
+# commencement clause such as "Peraturan Menteri ini mulai berlaku pada
+# tanggal diundangkan" — is a true statement about the document's own
+# commencement and a false inference about its PRESENT status: a law that
+# commenced in 2011 may well be dead by the time anyone asks. There is no
+# guilt/innocence split to preserve here, because the innocent-looking case
+# is exactly the trap.
+#
+# The one place a document's current status IS trustworthy: `kb/topics/
+# <topic>.yaml` — per document, sourced, `source_verified`, gated by the KB
+# current-live campaign's G3 contract. `scripts/ci/legal_status_read_lint.py`
+# refuses any code that reads the `legal_status` payload field this pattern
+# used to write (writing is still legal — nothing reads it, per the same
+# audit, so nothing downstream needed updating).
 
 # ============================================================================
 # STRUCTURE MARKERS - Indonesian Legal Hierarchy

--- a/apps/backend-rag/backend/core/legal/metadata_extractor.py
+++ b/apps/backend-rag/backend/core/legal/metadata_extractor.py
@@ -14,7 +14,6 @@ from backend.core.legal.constants import (
     LEGAL_TYPE_ABBREV,
     LEGAL_TYPE_PATTERN,
     NUMBER_PATTERN,
-    STATUS_PATTERNS,
     TITLE_BLOCK_FALLBACK_CHARS,
     TOPIC_PATTERN,
     YEAR_PATTERN,
@@ -97,7 +96,13 @@ def extract_title_identity(text: str) -> dict[str, str] | None:
 class LegalMetadataExtractor:
     """
     Extracts metadata from Indonesian legal documents before processing.
-    Identifies document type, number, year, topic, and status.
+    Identifies document type, number, year, and topic.
+
+    Does NOT identify current legal status (in force / revoked) — that
+    derivation was retired 2026-08-25 (see constants.py's tombstone comment
+    above `# Status indicators`). No text-pattern mechanism reading only a
+    document's own body can answer that question correctly for the revoked
+    direction: revocation is always stated in a LATER, different instrument.
     """
 
     def __init__(self) -> None:
@@ -119,9 +124,9 @@ class LegalMetadataExtractor:
                 "number": str,         # "12", "12A", etc.
                 "year": str,           # "2024"
                 "topic": str,          # Topic text after "TENTANG"
-                "status": str,         # "berlaku", "dicabut", or None
                 "full_title": str,     # Full document title
             }
+            No "status" key — retired 2026-08-25, see class docstring.
         """
         if not text or not text.strip():
             logger.warning("Empty text provided to metadata extractor")
@@ -189,16 +194,13 @@ class LegalMetadataExtractor:
             logger.warning("Could not extract topic")
             metadata["topic"] = "UNKNOWN"
 
-        # Extract status (berlaku/dicabut)
-        status = None
-        for status_key, pattern in STATUS_PATTERNS.items():
-            if pattern.search(text):
-                status = status_key
-                break
-
-        metadata["status"] = status
-        if status:
-            logger.debug("Extracted status: %s", status)
+        # Status (berlaku/dicabut) extraction was RETIRED here 2026-08-25 — see
+        # constants.py's tombstone comment above `# Status indicators`. `metadata`
+        # deliberately carries no "status" key; `legal_ingestion_service.py` no
+        # longer writes a `legal_status` payload field for new ingests, which
+        # makes the field genuinely ABSENT (not a lingering `None`) — the same
+        # shape 15,756 legacy points already carry (kb/inventory/immigration.yaml
+        # LANE-A-1), so this introduces no new payload state.
 
         # Build full title
         metadata["full_title"] = self._build_full_title(metadata)

--- a/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
+++ b/apps/backend-rag/backend/services/ingestion/legal_ingestion_service.py
@@ -923,7 +923,14 @@ Return ONLY valid JSON, no markdown."""
                 "legal_number": metadata.get("number"),
                 "legal_year": metadata.get("year"),
                 "legal_topic": metadata.get("topic"),
-                "legal_status": metadata.get("status"),
+                # `legal_status` write RETIRED 2026-08-25 (Lane P,
+                # kb-p2-status-retire-0825) — see
+                # backend/core/legal/constants.py's tombstone comment above
+                # `# Status indicators`. The key is now genuinely absent from
+                # every new point, not present-and-None: `metadata` no longer
+                # carries a "status" entry at all, so there is nothing here to
+                # write. scripts/ci/legal_status_read_lint.py enforces that
+                # nothing reads the field this line used to populate.
                 "retrieval_scope": retrieval_scope,
                 # CRITICAL: Keep original keys for LegalChunker context injection
                 "type_abbrev": metadata.get("type_abbrev"),

--- a/apps/backend-rag/backend/tests/unit/core/legal/test_constants.py
+++ b/apps/backend-rag/backend/tests/unit/core/legal/test_constants.py
@@ -11,6 +11,7 @@ backend_path = Path(__file__).parent.parent.parent.parent.parent / "backend"
 if str(backend_path) not in sys.path:
     sys.path.insert(0, str(backend_path))
 
+import backend.core.legal.constants as legal_constants
 from backend.core.legal.constants import (
     AYAT_PATTERN,
     BAB_PATTERN,
@@ -25,7 +26,6 @@ from backend.core.legal.constants import (
     PARAGRAF_PATTERN,
     PASAL_PATTERN,
     PENJELASAN_PATTERN,
-    STATUS_PATTERNS,
     TOPIC_PATTERN,
     WHITESPACE_FIXES,
     YEAR_PATTERN,
@@ -72,10 +72,11 @@ class TestLegalConstants:
         match = TOPIC_PATTERN.search(text)
         assert match is not None
 
-    def test_status_patterns(self):
-        """Test status patterns"""
-        assert STATUS_PATTERNS["dicabut"].search("DICABUT")
-        assert STATUS_PATTERNS["berlaku"].search("BERLAKU")
+    def test_status_patterns_retired(self):
+        """STATUS_PATTERNS was retired 2026-08-25 — it must not silently return.
+        A bare regex over chunk text cannot correctly derive a document's current
+        legal status (see the tombstone comment in constants.py)."""
+        assert not hasattr(legal_constants, "STATUS_PATTERNS")
 
     def test_konsiderans_markers(self):
         """Test konsiderans markers"""

--- a/apps/backend-rag/backend/tests/unit/core/legal/test_metadata_extractor.py
+++ b/apps/backend-rag/backend/tests/unit/core/legal/test_metadata_extractor.py
@@ -142,75 +142,114 @@ DENGAN RAHMAT TUHAN YANG MAHA ESA"""
 
         assert len(result["topic"]) <= 200  # Should be truncated
 
-    def test_extract_status_berlaku(self):
-        """Test extracting status 'berlaku'"""
+    # `status` extraction was RETIRED 2026-08-25 (Lane P, kb-p2-status-retire-0825):
+    # a bare regex over chunk text cannot correctly answer "is this document
+    # currently revoked" — that fact is always established by a LATER, different
+    # instrument, never by the document's own body. See constants.py's tombstone
+    # comment above `# Status indicators` and kb/inventory/immigration.yaml
+    # LANE-A-1 for the measured damage this replaced.
+    #
+    # GUILT: each of these sentences used to set a status. None of them may set
+    # one now — that is the whole retirement, and each represents a distinct real
+    # false-positive shape found in production, not a hypothetical.
+    def test_extract_does_not_set_status_on_class_exemption(self):
+        """A provision not applying to a class of PERSON must not mark the
+        document revoked. Measured live in UU_6_2011's own penjelasan."""
         text = """UNDANG-UNDANG REPUBLIK INDONESIA
 NOMOR 12 TAHUN 2024
 TENTANG TEST
 
-BERLAKU sejak tanggal ditetapkan."""
+Ketentuan ini tidak berlaku bagi warga negara asing."""
         extractor = LegalMetadataExtractor()
         result = extractor.extract(text)
 
-        assert result["status"] == "berlaku"
+        assert "status" not in result
 
-    def test_extract_status_masih_berlaku(self):
-        """Test extracting status 'berlaku' with MASIH BERLAKU"""
+    def test_extract_does_not_set_status_on_substituted_guarantor(self):
+        """DIGANTI matching inside "digantikan" must not mark the document
+        revoked. Measured live in Permen_22_2023 (a guarantor being replaced)."""
         text = """UNDANG-UNDANG REPUBLIK INDONESIA
 NOMOR 12 TAHUN 2024
 TENTANG TEST
 
-MASIH BERLAKU hingga saat ini."""
+Penjamin dapat digantikan oleh penjamin lain."""
         extractor = LegalMetadataExtractor()
         result = extractor.extract(text)
 
-        assert result["status"] == "berlaku"
+        assert "status" not in result
 
-    def test_extract_status_dicabut(self):
-        """Test extracting status 'dicabut'"""
+    def test_extract_does_not_set_status_on_predecessor_revocation(self):
+        """A law's OWN closing clause revoking its PREDECESSOR must not mark
+        the CURRENT, still-valid law as revoked. This is the live PP_31_2013
+        defect (kb/inventory/immigration.yaml LANE-A-1) reproduced directly."""
         text = """UNDANG-UNDANG REPUBLIK INDONESIA
 NOMOR 12 TAHUN 2024
 TENTANG TEST
 
-DICABUT dengan undang-undang baru."""
+Pada saat Peraturan ini mulai berlaku, Keputusan Presiden Nomor 31
+Tahun 1998 dicabut dan dinyatakan tidak berlaku."""
         extractor = LegalMetadataExtractor()
         result = extractor.extract(text)
 
-        assert result["status"] == "dicabut"
+        assert "status" not in result
 
-    def test_extract_status_tidak_berlaku(self):
-        """Test extracting status 'dicabut' with TIDAK BERLAKU"""
+    def test_extract_does_not_set_status_on_commencement_clause(self):
+        """The standard commencement clause is a TRUE statement about when the
+        document took effect and a FALSE inference about whether it is still
+        in force today — a law that commenced in 2011 may be dead by now. This
+        is the shape that looks like a legitimate self-referential status
+        statement and is exactly the trap: no fix aimed only at `dicabut`
+        would have caught it, because it matches `berlaku`."""
         text = """UNDANG-UNDANG REPUBLIK INDONESIA
 NOMOR 12 TAHUN 2024
 TENTANG TEST
 
-TIDAK BERLAKU lagi."""
+Peraturan Menteri ini mulai berlaku pada tanggal diundangkan."""
         extractor = LegalMetadataExtractor()
         result = extractor.extract(text)
 
-        assert result["status"] == "dicabut"
+        assert "status" not in result
 
-    def test_extract_status_diganti(self):
-        """Test extracting status 'dicabut' with DIGANTI"""
+    # INNOCENCE: the retirement is surgical — every OTHER field the extractor
+    # produced before is unchanged on the same input, and a document with none
+    # of the guilt sentences above still gets no status key either (there is no
+    # "correct" case left to preserve — see the constants.py tombstone comment).
+    def test_extract_other_fields_unchanged_when_status_sentence_present(self):
+        """Removing status extraction must not touch type/number/year/topic/
+        full_title — the retirement's whole point is that it changes ONLY the
+        one field that was wrong."""
         text = """UNDANG-UNDANG REPUBLIK INDONESIA
 NOMOR 12 TAHUN 2024
-TENTANG TEST
+TENTANG PENGUJIAN METADATA
 
-DIGANTI dengan peraturan baru."""
+DENGAN RAHMAT TUHAN YANG MAHA ESA
+
+Pada saat Peraturan ini mulai berlaku, Keputusan Presiden Nomor 31
+Tahun 1998 dicabut dan dinyatakan tidak berlaku."""
         extractor = LegalMetadataExtractor()
         result = extractor.extract(text)
 
-        assert result["status"] == "dicabut"
+        assert result["type"] == "UNDANG-UNDANG"
+        assert result["type_abbrev"] == "UU"
+        assert result["number"] == "12"
+        assert result["year"] == "2024"
+        assert result["topic"] == "PENGUJIAN METADATA"
+        assert result["full_title"] == "UU No 12 Tahun 2024 Tentang PENGUJIAN METADATA"
+        assert "status" not in result
 
     def test_extract_no_status(self):
-        """Test extracting metadata without status"""
+        """A document with none of the guilt sentences still gets no status
+        key — there was never a positive case worth preserving (see the
+        constants.py tombstone comment: no fix aimed only at the revoked
+        direction survives, since even the innocent-looking commencement
+        clause is a trap)."""
         text = """UNDANG-UNDANG REPUBLIK INDONESIA
 NOMOR 12 TAHUN 2024
 TENTANG TEST"""
         extractor = LegalMetadataExtractor()
         result = extractor.extract(text)
 
-        assert result["status"] is None
+        assert "status" not in result
 
     def test_extract_missing_type(self):
         """Test extracting metadata when type is missing"""

--- a/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/ingestion/test_legal_ingestion_service.py
@@ -183,6 +183,63 @@ class TestIngestSuccess:
             assert result["legal_metadata"]["type_abbrev"] == "UU"
 
     @pytest.mark.asyncio
+    async def test_base_metadata_has_no_legal_status_key(self, service: MagicMock) -> None:
+        """`legal_status` write was RETIRED 2026-08-25 (STATUS_PATTERNS was a bare
+        regex over chunk text, measured wrong at scale — see
+        backend/core/legal/constants.py's tombstone comment and
+        kb/inventory/immigration.yaml LANE-A-1). The real LegalMetadataExtractor
+        no longer produces a "status" key at all, so the mock here matches that
+        shape (no "status" key) rather than the pre-retirement fixtures elsewhere
+        in this file that still carry one. The point of this test is the
+        DOWNSTREAM effect: `base_metadata` — what actually reaches the indexer,
+        and from there the Qdrant payload — must not carry a `legal_status` key
+        either. Absence is not a new state: 15,756 legacy points already have no
+        `legal_status` field at all, so this is the shape production has always
+        been able to handle, not a novel one this retirement introduces."""
+        service.cleaner.clean.return_value = "cleaned text with enough content for testing"
+        service.metadata_extractor.extract.return_value = {
+            "type": "Undang-Undang",
+            "type_abbrev": "UU",
+            "number": "6",
+            "year": "2023",
+            "topic": "Immigration",
+            "full_title": "UU 6/2023 tentang Imigrasi",
+            # deliberately no "status" key — this is what the retired extractor
+            # actually returns now (verified directly against the real class).
+        }
+        service.classifier.classify_book_tier.return_value = MagicMock(value="golden")
+        service.classifier.get_min_access_level.return_value = "member"
+        service.indexer.index_legal_document = AsyncMock(
+            return_value={
+                "chunks_indexed": 10,
+                "parent_documents": 3,
+                "total_bab": 2,
+                "total_pasal": 8,
+            }
+        )
+
+        p1, p2, p3, p4 = _common_ingest_patches()
+        with p1, p2 as mock_logger, p3, p4:
+            mock_logger.start_ingestion.return_value = "doc_002"
+
+            result = await service.ingest_legal_document(
+                file_path="/tmp/test.pdf",
+                title="UU 6/2023",
+                category="01_immigrazione",
+            )
+
+        assert result["success"] is True
+        metadata = service.indexer.index_legal_document.await_args.kwargs["metadata"]
+        assert "legal_status" not in metadata
+        # Innocence: every OTHER legal-specific field this line's neighbours
+        # write is still present and correct — the retirement touched only the
+        # one key.
+        assert metadata["legal_type"] == "UU"
+        assert metadata["legal_number"] == "6"
+        assert metadata["legal_year"] == "2023"
+        assert metadata["legal_topic"] == "Immigration"
+
+    @pytest.mark.asyncio
     async def test_archives_in_dedicated_legal_root_idempotently(
         self, service: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary
Follow-up to PR #4944 (audit) — team-lead refused the narrow row-patch repair (nobody reads `legal_status`, so writing corrected values would change nothing observable) and asked for the actual cure: retire the parser-level derivation.

**Why this is a retirement, not a repair**: whether an instrument is currently revoked is always established by a LATER, different instrument — a document's own text, written before its own repeal existed, cannot attest to it. `STATUS_PATTERNS` (bare regex over chunk text: `DICABUT|TIDAK BERLAKU|DIGANTI` vs `BERLAKU|MASIH BERLAKU`) tried anyway. The one shape that looks like a legitimate self-referential exception — a commencement clause ("Peraturan ini mulai berlaku pada tanggal diundangkan") — is the trap: true about commencement, false as an inference about present status. There is no guilt/innocence split to preserve.

**Consumer map, widened to the whole repo** (not just `apps/backend-rag/backend`, per team-lead's ask): `grep -rIn legal_status` across the entire monorepo (excluding `.git`/`node_modules`/`.venv`/build dirs) finds hits only in `kb/`, `scripts/`, `docs/plans/`, and `apps/backend-rag/backend/{services/ingestion,tests}`. Zero hits in `apps/mouth`, `apps/crm-cell`, `packages/`, `infra/`. Confirms: one write site (now retired), zero live readers anywhere.

## Changes
- `constants.py`: `STATUS_PATTERNS` replaced with a tombstone comment explaining the retirement and pointing at the evidence.
- `metadata_extractor.py`: status extraction block removed; `metadata` no longer carries a `"status"` key at all (not a lingering `None`). Docstrings updated.
- `legal_ingestion_service.py`: `legal_status` key removed from `base_metadata`'s dict literal — new points genuinely lack the field, joining the same shape 15,756 legacy points already have (no new payload state introduced).
- 4 guilt tests in `test_metadata_extractor.py` (class-exemption, substituted-guarantor, predecessor-revocation, commencement-clause — each a distinct real false-positive shape found in production) + 1 rewritten `test_extract_no_status`.
- 1 guilt test in `test_constants.py` (`STATUS_PATTERNS` must not silently return).
- 1 innocence test in `test_metadata_extractor.py` (every other field — type/type_abbrev/number/year/topic/full_title — unchanged on the same input).
- 1 innocence test in `test_legal_ingestion_service.py` (`base_metadata` carries no `legal_status` key downstream, and every other `legal_*` field is still correct — proves the retirement is surgical, not collateral).

## Mutation proof (real, not asserted)
1. Saved a patch of the 3 production files, reverted them to pre-fix state (test files stayed edited).
2. Ran the 7 new/rewritten tests: **7 failed / 43 passed** — RED. Each failure is exactly the reason the test claims (e.g. `test_extract_does_not_set_status_on_commencement_clause` failed because `status == 'berlaku'` was actually present).
3. Re-applied the patch, re-ran: **0 failed / 50 passed** — GREEN.
4. `git diff` after restoration is byte-identical to the saved patch (no partial re-apply).

## Test plan
- [x] `python3 scripts/ci/legal_status_read_lint.py` — exit 0, "clean — 0 reads."
- [x] `cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/kb/ -q --color=no` — exit 1, single pre-existing failure `test_real_journey_files_obey_the_contract[tax]` (lane C's, not in scope here).
- [x] `cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/core/legal/ backend/tests/unit/services/ingestion/test_legal_ingestion_service.py backend/tests/unit/kb/test_legal_status_read_lint.py -q --color=no` — exit 0, fully green (the exact surface touched).
- [x] Mutation proof above, run twice, both directions verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)