### PR TITLE
fix(kb): instrument-checked grading, satisfiable canaries, inventory floors

### DIFF
--- a/apps/backend-rag/backend/tests/unit/kb/test_kb_topic_contract.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_kb_topic_contract.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 import sys
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,20 @@ LANES = frozenset("ABCDEFP")
 # production today); `untested` means the probe has never been run, which is NOT
 # the same thing and must not be allowed to masquerade as red.
 PROBE_STATES = frozenset({"red", "green", "untested"})
+
+# Whether a journey's phrase is SUPPOSED to come back, or SUPPOSED not to.
+# `retrieves` is what almost every journey means, and what `probe_state` meant on
+# its own before this field existed: prove the phrase comes back. A minority —
+# negative canaries scoped at a POISONED instrument, e.g.
+# kb/journeys/immigration.yaml journeys 2 and 8 — mean the opposite: the phrase
+# coming back, correctly attributed, IS the failure, and `probe_state: red` is
+# deliberately the safe, PERMANENT state (never expected to turn green). Found by
+# a cross-family review (2026-08-25): without this field, MANDATE §8's
+# "at_target sustained 48h" and a canary's forever-red state contradict each
+# other with no valid resolution — a topic carrying a canary could never legally
+# reach at_target under the old all-green definition. The vocabulary is closed so
+# a third meaning cannot be smuggled in as a typo.
+EXPECTATIONS = frozenset({"retrieves", "must_not_retrieve"})
 
 # How the question is worded. Measured 2026-08-25 over 10,929 question-bearing
 # client messages in the Pro-bound WhatsApp mirror: NOT ONE named an instrument.
@@ -215,7 +230,13 @@ def check_journey(data: dict) -> list[str]:
 
     for i, j in enumerate(journeys):
         where = f"journeys[{i}]"
-        if not j.get("question"):
+        # `.strip()`, not bare truthiness: a cross-family review (2026-08-25) found
+        # `question: " "` (whitespace only) passes a bare `not j.get("question")`
+        # check — Python's `not " "` is False, a non-empty string is truthy
+        # regardless of what is IN it. A question with no real content is
+        # indistinguishable from a missing one to every reader downstream.
+        question = j.get("question")
+        if not question or not str(question).strip():
             problems.append(f"{where}: question is required, in the user's own words")
 
         # The assertion target is the RETRIEVED CONTEXT, not the generated answer.
@@ -228,6 +249,18 @@ def check_journey(data: dict) -> list[str]:
                 f"has to appear in the RETRIEVED CONTEXT — a short phrase matches by "
                 f"accident and measures nothing"
             )
+        elif " " not in str(phrase).strip():
+            # Same review, same file: verbatim_phrase: "xxxxxxxxxxxx" (12 of one
+            # repeated character) clears the length floor untouched. Length was
+            # never the property that mattered here either — every real phrase in
+            # this suite is a multi-word SPAN of retrieved text; a single token,
+            # however long or however repeated, is not a span and matches by
+            # accident the same way a too-short phrase does.
+            problems.append(
+                f"{where}: verbatim_phrase {phrase!r} is a single token (no "
+                f"whitespace) — a substantive span of retrieved text is multiple "
+                f"words, not one token however long"
+            )
         if not j.get("instrument_id"):
             problems.append(
                 f"{where}: instrument_id is required — the phrase must be traceable to "
@@ -238,10 +271,41 @@ def check_journey(data: dict) -> list[str]:
             problems.append(
                 f"{where}: probe_state must be one of {sorted(PROBE_STATES)}, got {state!r}"
             )
-        if state in ("red", "green") and not j.get("probe_run_at"):
+        run_at = j.get("probe_run_at")
+        if state in ("red", "green"):
+            if not run_at:
+                problems.append(
+                    f"{where}: probe_state is {state!r} but probe_run_at is missing — a "
+                    f"verdict with no run behind it is 'untested' wearing a costume"
+                )
+            else:
+                # Same review: probe_run_at: never passes a bare presence check —
+                # "never" is truthy. Presence is not the same claim as "this is a
+                # date a run could have happened on"; require the second, not just
+                # the first.
+                try:
+                    date.fromisoformat(str(run_at))
+                except ValueError:
+                    problems.append(
+                        f"{where}: probe_run_at {run_at!r} is not a real date "
+                        f"(expected YYYY-MM-DD) — a truthy string like 'never' "
+                        f"passes a presence check while recording no verifiable run"
+                    )
+
+        # MANDATE §8 vs a negative canary's permanent-red state contradicted each
+        # other with no valid resolution before this field existed (2026-08-25
+        # cross-family review) — see EXPECTATIONS' docstring above.
+        expectation = j.get("expectation")
+        if expectation not in EXPECTATIONS:
             problems.append(
-                f"{where}: probe_state is {state!r} but probe_run_at is missing — a "
-                f"verdict with no run behind it is 'untested' wearing a costume"
+                f"{where}: expectation must be one of {sorted(EXPECTATIONS)}, got "
+                f"{expectation!r}"
+            )
+        elif expectation == "must_not_retrieve" and not j.get("reason"):
+            problems.append(
+                f"{where}: expectation is 'must_not_retrieve' but reason is missing — "
+                f"a canary with no stated reason is indistinguishable from a broken "
+                f"journey someone gave up on"
             )
 
         phrasing = j.get("phrasing")
@@ -331,6 +395,13 @@ def check_topic_inventory(data: dict) -> list[str]:
     points = measured.get("points")
     if not isinstance(points, int):
         problems.append("measured_against.points must be an integer")
+    elif points < 0:
+        # Cross-family review (2026-08-25): points: -1 with payload_shapes summing
+        # to -1 passed every existing check — nothing enforced non-negativity, and
+        # a point count cannot be negative in reality.
+        problems.append(
+            f"measured_against.points must be non-negative, got {points}"
+        )
 
     # §4.1 — the payload shape mix, in the vocabulary the probe measures. A topic
     # inventory that does not record it cannot be drift-checked, and the shape
@@ -359,6 +430,14 @@ def check_topic_inventory(data: dict) -> list[str]:
             problems.append(
                 f"payload_shapes omits {sorted(missing)}. Omission reads as 'absent', and "
                 f"'absent' is indistinguishable from 'never looked' — record a 0"
+            )
+        # Same review as measured_against.points above: every point has exactly
+        # one shape, so no shape's count can be negative either.
+        negative = {k: v for k, v in shapes.items() if not isinstance(v, int) or v < 0}
+        if negative:
+            problems.append(
+                f"payload_shapes has non-negative-integer value(s): "
+                f"{dict(sorted(negative.items()))} — a shape's count cannot be negative"
             )
         if isinstance(points, int) and sum(shapes.values()) != points:
             problems.append(
@@ -471,6 +550,7 @@ def _good_journey() -> dict:
                 "phrasing": "client",
                 "language": "id",
                 "cross_topic": False,
+                "expectation": "retrieves",
                 "probe_state": "red",
                 "probe_run_at": "2026-08-25",
             },
@@ -481,6 +561,7 @@ def _good_journey() -> dict:
                 "phrasing": "client",
                 "language": "en",
                 "cross_topic": False,
+                "expectation": "retrieves",
                 "probe_state": "red",
                 "probe_run_at": "2026-08-25",
             },
@@ -491,6 +572,7 @@ def _good_journey() -> dict:
                 "phrasing": "client",
                 "language": "it",
                 "cross_topic": False,
+                "expectation": "retrieves",
                 "probe_state": "red",
                 "probe_run_at": "2026-08-25",
             },
@@ -505,6 +587,7 @@ def _good_journey() -> dict:
                 "language": "en",
                 "cross_topic": True,
                 "cross_topic_lane": "D",
+                "expectation": "retrieves",
                 "probe_state": "red",
                 "probe_run_at": "2026-08-25",
             },
@@ -585,16 +668,30 @@ def test_guilt_topic(name, mutate, expected):
 JOURNEY_GUILT = [
     ("no journeys", lambda d: d.update(journeys=[]), "non-empty list"),
     ("question missing", lambda d: d["journeys"][0].pop("question"), "question is required"),
+    ("question is whitespace only",
+     lambda d: d["journeys"][0].update(question="   "), "question is required"),
     ("phrase too short to mean anything",
      lambda d: d["journeys"][0].update(verbatim_phrase="visa"), "substantive span"),
     ("phrase missing entirely",
      lambda d: d["journeys"][0].pop("verbatim_phrase"), "substantive span"),
+    ("phrase is a single repeated-character token",
+     lambda d: d["journeys"][0].update(verbatim_phrase="xxxxxxxxxxxx"),
+     "single token"),
     ("phrase not traceable to an instrument",
      lambda d: d["journeys"][0].pop("instrument_id"), "instrument_id is required"),
     ("probe verdict outside vocabulary",
      lambda d: d["journeys"][0].update(probe_state="probably red"), "probe_state must be one of"),
     ("verdict with no run behind it",
      lambda d: d["journeys"][0].pop("probe_run_at"), "wearing a costume"),
+    ("verdict run recorded on a non-date",
+     lambda d: d["journeys"][0].update(probe_run_at="never"), "not a real date"),
+    ("expectation missing",
+     lambda d: d["journeys"][0].pop("expectation"), "expectation must be one of"),
+    ("expectation outside the closed vocabulary",
+     lambda d: d["journeys"][0].update(expectation="maybe"), "expectation must be one of"),
+    ("must_not_retrieve canary with no stated reason",
+     lambda d: d["journeys"][0].update(expectation="must_not_retrieve"),
+     "reason is missing"),
     ("phrasing outside the closed vocabulary",
      lambda d: d["journeys"][0].update(phrasing="colloquial-ish"),
      "phrasing must be one of"),
@@ -654,6 +751,14 @@ INVENTORY_GUILT = [
     ("shape mix does not add up",
      lambda d: d["measured_against"]["payload_shapes"].update(modern_id_only=99),
      "every point has exactly one shape"),
+    # F.3 — non-negativity (found by a cross-family review: `points: -1` with
+    # `payload_shapes: {legacy_metadata_text: -1}` passed every check that
+    # existed before this — nothing enforced that a point count cannot be negative)
+    ("measured_against.points is negative",
+     lambda d: d["measured_against"].update(points=-1), "must be non-negative"),
+    ("a payload_shapes value is negative",
+     lambda d: d["measured_against"]["payload_shapes"].update(modern_id_only=-1),
+     "non-negative-integer value"),
     ("instrument points do not cover the collection",
      lambda d: d["instruments"][0].update(points=4), "does not cover the collection"),
     ("absence claimed from a single lookup",
@@ -708,11 +813,32 @@ def test_the_guilt_matrix_is_not_empty():
     """Anti-vacuity on the anti-vacuity: an emptied parametrisation collects zero
     cases and pytest exits 0. Assert the COUNT, so deleting the cases is loud."""
     assert len(TOPIC_GUILT) >= 11, len(TOPIC_GUILT)
-    assert len(JOURNEY_GUILT) >= 7, len(JOURNEY_GUILT)
-    assert len(INVENTORY_GUILT) >= 14, len(INVENTORY_GUILT)
+    assert len(JOURNEY_GUILT) >= 27, len(JOURNEY_GUILT)
+    assert len(INVENTORY_GUILT) >= 16, len(INVENTORY_GUILT)
 
 
 # ── cross-source rules: three files that must agree, or one of them is fiction ──
+
+
+def journey_satisfied(j: dict) -> bool | None:
+    """Whether j's RECORDED probe_state satisfies its expectation.
+
+    Returns None when probe_state is 'untested' — satisfaction is unknown, not
+    false, because nothing has been measured yet. `hit` is true only for a
+    recorded 'green'; a 'retrieves' journey is satisfied exactly when hit, and a
+    'must_not_retrieve' canary is satisfied exactly when NOT hit — a poisoned
+    instrument staying unretrieved is the safe state, not a failure. This is the
+    STATIC proxy for what probe_retrieval.py computes live against production
+    (same formula, `hit == (expectation == "retrieves")`); it reads the file's
+    own recorded claim, so a stale file and a satisfied file can disagree, which
+    is exactly what probe_retrieval.py's DRIFT exit exists to catch.
+    """
+    state = j.get("probe_state")
+    if state not in ("red", "green"):
+        return None
+    hit = state == "green"
+    expectation = j.get("expectation", "retrieves")
+    return hit == (expectation == "retrieves")
 
 
 def check_agreement(topic: dict, journey: dict, inventory: dict) -> list[str]:
@@ -744,18 +870,50 @@ def check_agreement(topic: dict, journey: dict, inventory: dict) -> list[str]:
                 f"file — the inventory measured a corpus the topic never claimed"
             )
 
+    # The reverse direction of the check above. A cross-family review (2026-08-25)
+    # showed this gate only ever looked for an inventory instrument the topic
+    # DIDN'T scope — it never checked the other way: a scoped instrument the
+    # inventory never mentions at all. `instruments: []` on an inventory whose
+    # topic scopes one real instrument passed every check that existed until now.
+    # Every scoped instrument must appear — present=true with a point count, or
+    # present=false with lookup_attempts (§4.2, already enforced by
+    # check_topic_inventory) is how the inventory "says why it does not" — silent
+    # absence from the list is not a legal way to record either state.
+    inventory_ids = {i.get("id") for i in (inventory.get("instruments") or [])}
+    if scoped:
+        never_measured = sorted(scoped - inventory_ids)
+        if never_measured:
+            problems.append(
+                f"kb/topics scopes instrument(s) {never_measured} that kb/inventory "
+                f"does not list at all — every scoped instrument must appear in the "
+                f"inventory, present=true with a point count or present=false with "
+                f"lookup_attempts, never silently absent from the file"
+            )
+
     # MANDATE §3: the journey suite must fail RED against production on the day it
-    # is written. A journey file whose probes are ALL green on creation day is
+    # is written. A journey file whose probes are ALL SATISFIED on creation day is
     # either measuring something that already worked — in which case there was no
     # work to do — or the probe is not reaching production at all. Both are worth
     # refusing, and the second is the one that actually happens.
-    states = [j.get("probe_state") for j in (journey.get("journeys") or [])]
-    if states and all(s == "green" for s in states):
+    #
+    # SATISFIED, not literal green (2026-08-25 cross-family review): the old rule
+    # checked `all(s == "green" ...)`, which a topic carrying a negative canary
+    # (kb/journeys/immigration.yaml journeys 2/8: safe state is `red`, forever)
+    # could never legitimately trigger even when every journey WAS satisfied on
+    # day one — MANDATE §8's at_target was unreachable for exactly that topic.
+    # `journey_satisfied` derives the same "would this ever need curing" question
+    # `probe_state == "green"` used to answer, but correctly for BOTH
+    # expectations — see its docstring for the formula and why the two can
+    # legitimately disagree.
+    journeys_list = journey.get("journeys") or []
+    satisfaction = [journey_satisfied(j) for j in journeys_list]
+    if satisfaction and all(s is True for s in satisfaction):
         problems.append(
-            "every journey probe is green on a freshly written file — either this "
-            "topic needed no work, or the probe is not reaching production (§3). "
-            "Record the red state first, then cure it"
+            "every journey is already satisfied on a freshly written file — either "
+            "this topic needed no work, or the probe is not reaching production "
+            "(§3). Record the unsatisfied state first, then cure it"
         )
+    states = [j.get("probe_state") for j in journeys_list]
     if states and all(s == "untested" for s in states):
         problems.append(
             "every journey probe is 'untested' — an unrun probe suite is not a red "
@@ -775,7 +933,14 @@ AGREEMENT_GUILT = [
     ("inventory measures an unscoped instrument",
      lambda t, j, v: v["instruments"][0].update(id="UU_Invented_99_2099"),
      "a corpus the topic never claimed"),
-    ("all probes green on day one",
+    # F.3 (reverse direction, cross-family review 2026-08-25): `instruments: []`
+    # on an inventory whose topic scopes one real instrument passed every check
+    # that existed before this — the old rule only ever looked for an unscoped
+    # inventory entry, never for a scoped one that never got an entry at all.
+    ("inventory lists no instruments at all while topic scopes one",
+     lambda t, j, v: v.update(instruments=[]),
+     "does not list at all"),
+    ("all probes satisfied on day one",
      lambda t, j, v: [x.update(probe_state="green") for x in j["journeys"]],
      "not reaching production"),
     ("all probes never run",
@@ -793,6 +958,76 @@ def test_guilt_agreement(name, mutate, expected):
     assert any(expected in p for p in problems), (
         f"{name}: check_agreement did not object. Problems returned: {problems}"
     )
+
+
+# ── journey_satisfied: the pure function, proven directly ────────────────────
+# The formula is small enough to hide a sign error inside `check_agreement`'s
+# list-comprehension proofs above, so it gets its own table — every combination
+# of the two inputs that matters, asserted against the derivation in its
+# docstring rather than against a restatement of the code.
+
+SATISFACTION_TABLE = [
+    ("retrieves + green is satisfied (the ordinary positive case)",
+     {"probe_state": "green", "expectation": "retrieves"}, True),
+    ("retrieves + red is NOT satisfied (ordinary coverage gap)",
+     {"probe_state": "red", "expectation": "retrieves"}, False),
+    ("must_not_retrieve + red is satisfied (the canary is safe)",
+     {"probe_state": "red", "expectation": "must_not_retrieve"}, True),
+    ("must_not_retrieve + green is NOT satisfied (the poison leaked)",
+     {"probe_state": "green", "expectation": "must_not_retrieve"}, False),
+    ("untested is unknown, not false, regardless of expectation",
+     {"probe_state": "untested", "expectation": "retrieves"}, None),
+    ("untested is unknown even for a canary",
+     {"probe_state": "untested", "expectation": "must_not_retrieve"}, None),
+    ("expectation absent defaults to retrieves (pre-existing journeys)",
+     {"probe_state": "green"}, True),
+]
+
+
+@pytest.mark.parametrize("name,journey,expected", SATISFACTION_TABLE,
+                         ids=[c[0] for c in SATISFACTION_TABLE])
+def test_journey_satisfied_table(name, journey, expected):
+    assert journey_satisfied(journey) is expected, name
+
+
+def test_all_satisfied_via_mixed_expectations_is_refused_even_though_not_all_green():
+    """MANDATE §3's day-one refusal is about SATISFACTION, not literal green — the
+    exact contradiction the cross-family review raised: a canary's SAFE state is
+    permanently `red`, so a topic carrying one could never trigger an "all green"
+    rule even on a day when every journey (canary included) was genuinely
+    satisfied. Proven here by a file that is NOT 'all green' (one journey is red)
+    yet must still be refused, because it IS 'all satisfied': a rule that only
+    checked `probe_state == "green"` would let this exact shape through, which is
+    precisely the shape the old rule could never catch for a canary-bearing topic.
+    """
+    t, j, v = _good_topic(), _good_journey(), _good_inventory()
+    t["instruments"].append({
+        "id": "Permen_35_2012_poison",
+        "declared_identity": "Permen 35/2012",
+        "verified_identity": "Permen 35/2012",
+        "identity_verdict": "consistent",
+        "status": "in_force",
+        "source_url": "https://example.org/permen-35-2012",
+        "source_verified": True,
+    })
+    j["journeys"][0].update(
+        verbatim_phrase="TATA NASKAH DINAS DI LINGKUNGAN PEMERINTAH KABUPATEN TEGAL",
+        instrument_id="Permen_35_2012_poison",
+        expectation="must_not_retrieve",
+        reason="green would mean an unrelated poisoned instrument leaked into this "
+               "topic's answer",
+        probe_state="red",
+    )
+    for other in j["journeys"][1:]:
+        other["probe_state"] = "green"
+
+    recorded_states = [x["probe_state"] for x in j["journeys"]]
+    assert recorded_states.count("red") == 1 and recorded_states.count("green") == 3, (
+        "fixture sanity: this must NOT be 'all green', or the test proves nothing"
+    )
+
+    problems = check_agreement(t, j, v)
+    assert any("already satisfied" in p for p in problems), problems
 
 
 # ── the same rules, against whatever real files exist ────────────────────────

--- a/kb/journeys/company.yaml
+++ b/kb/journeys/company.yaml
@@ -50,6 +50,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -61,6 +62,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -74,6 +76,7 @@ journeys:
     language: en
     cross_topic: true
     cross_topic_lane: D
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -90,6 +93,7 @@ journeys:
     phrasing: statute
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -101,6 +105,7 @@ journeys:
     phrasing: client
     language: it
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -114,6 +119,7 @@ journeys:
     phrasing: statute
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -126,6 +132,7 @@ journeys:
     language: es
     cross_topic: true
     cross_topic_lane: D
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -138,6 +145,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -152,6 +160,7 @@ journeys:
     language: id
     cross_topic: true
     cross_topic_lane: C
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -164,6 +173,7 @@ journeys:
     phrasing: statute
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -175,5 +185,6 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"

--- a/kb/journeys/immigration.yaml
+++ b/kb/journeys/immigration.yaml
@@ -24,6 +24,15 @@
 # measures green, that is a regression — the poison has leaked into production —
 # and MANDATE.md §7 decision-log / this topic's kill_criterion both name it directly.
 #
+# `expectation` (2026-08-25, cross-family review finding — MANDATE §8 vs a canary's
+# forever-red state contradicted each other with no valid resolution before this):
+# journeys 2 and 8 carry `expectation: must_not_retrieve` plus a `reason` — for them,
+# `probe_state: red` is SATISFIED, not outstanding, and `at_target` no longer requires
+# them to turn green (they never should). Every other journey here keeps the implicit
+# default, `expectation: retrieves`, which is what `probe_state` always meant before
+# this field existed. `probe_state` itself is UNCHANGED semantics for every journey —
+# it still records exactly what production measured, never what was hoped for.
+#
 # `phrasing`/`language`/`cross_topic` were added to the contract by another lane's
 # landing on feature/kb-current after this file's first draft (measured over 10,929
 # real client WhatsApp messages: not one named an instrument by citation). Every
@@ -68,6 +77,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     measured_rank: 2
@@ -82,10 +92,11 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: must_not_retrieve
     probe_state: red
     probe_run_at: "2026-08-25"
     canary: true
-    canary_meaning: "green would mean the Tegal correspondence-manual poison has leaked into a Golden Visa answer — regression, not progress"
+    reason: "green would mean the Tegal correspondence-manual poison has leaked into a Golden Visa answer — regression, not progress"
 
   # 3 — POSITIVE, client-phrased: current KITAS duration/basis, Permen_22_2023.
   # REWORDED 2026-08-25 second pass: was "Izin Tinggal Terbatas (ITAS)" (official
@@ -99,6 +110,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -130,6 +142,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     measured_rank: 3
@@ -146,6 +159,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -167,6 +181,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -193,6 +208,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     measured_rank: 8
@@ -209,10 +225,11 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: must_not_retrieve
     probe_state: red
     probe_run_at: "2026-08-25"
     canary: true
-    canary_meaning: "green would mean a regency price-schedule PDF has leaked into an answer about the visa/stay-permit regulation — regression, not progress"
+    reason: "green would mean a regency price-schedule PDF has leaked into an answer about the visa/stay-permit regulation — regression, not progress"
 
   # 9 — POSITIVE, client-phrased, CROSS-TOPIC into Lane B (company & KBLI). A real
   # client question: an investor deciding whether to found a PT PMA asks about the
@@ -229,6 +246,7 @@ journeys:
     language: id
     cross_topic: true
     cross_topic_lane: B
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     measured_rank: 1
@@ -252,6 +270,7 @@ journeys:
     language: id
     cross_topic: true
     cross_topic_lane: D
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -272,6 +291,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     measured_rank: 8

--- a/kb/journeys/property.yaml
+++ b/kb/journeys/property.yaml
@@ -71,6 +71,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -85,6 +86,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
 
@@ -96,6 +98,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -109,6 +112,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -122,6 +126,7 @@ journeys:
     phrasing: client
     language: es
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -133,6 +138,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -146,6 +152,7 @@ journeys:
     phrasing: statute
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -160,6 +167,7 @@ journeys:
     phrasing: statute
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
 
@@ -180,5 +188,6 @@ journeys:
     language: en
     cross_topic: true
     cross_topic_lane: A
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"

--- a/kb/journeys/tax.yaml
+++ b/kb/journeys/tax.yaml
@@ -63,6 +63,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     note: >-
@@ -78,6 +79,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -95,6 +97,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     note: >-
@@ -112,6 +115,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: green
     probe_run_at: "2026-08-25"
     note: >-
@@ -132,6 +136,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -148,6 +153,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -166,6 +172,7 @@ journeys:
     phrasing: client
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -188,6 +195,7 @@ journeys:
     phrasing: statute
     language: id
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -229,6 +237,7 @@ journeys:
     phrasing: client
     language: en
     cross_topic: false
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-
@@ -251,6 +260,7 @@ journeys:
     language: en
     cross_topic: true
     cross_topic_lane: B
+    expectation: retrieves
     probe_state: red
     probe_run_at: "2026-08-25"
     note: >-

--- a/kb/ops/probe_retrieval.py
+++ b/kb/ops/probe_retrieval.py
@@ -41,10 +41,49 @@ this exits 3 (BROKEN) and reports no verdicts at all, because a probe that canno
 demonstrate it reached production has no business grading anything.
 
 EXITS (same vocabulary as scripts/kb/kb_inventory_probe.py)
-  0  AT TARGET   — every journey measured green, and the file says green
-  1  DRIFT       — the measurement disagrees with the recorded probe_state
-  2  OUTSTANDING — the file says red and the measurement agrees: work undone
+  0  AT TARGET   — every journey is SATISFIED (see "expectation" below), and the
+                   file's recorded state agrees
+  1  DRIFT       — the recorded probe_state disagrees with what production measured
+  2  OUTSTANDING — at least one journey is not satisfied. For a plain "retrieves"
+                   journey this is the ordinary "work undone" case (§3); it ALSO
+                   fires for a "must_not_retrieve" canary that measures green — a
+                   live regression, not routine coverage — and for a phrase found
+                   in the WRONG instrument (see "instrument-checked grading" below)
   3  BROKEN      — the control query failed; nothing was graded
+
+INSTRUMENT-CHECKED GRADING (2026-08-25, cross-family review finding — grading used
+to be "is the phrase anywhere in the retrieved chunks", full stop, and that let a
+journey go green off a citation inside a DIFFERENT document. Measured live in this
+campaign: tax journey 8's HPP phrase appears verbatim as a citation inside
+Permen_167_2022 and PP_44T_2022 ("...diubah terakhir dengan UU 7/2021 tentang HPP"),
+while UU_7_2021 — the instrument that journey actually scoped — has ZERO points in
+the corpus. The old grading called that green; it was never evidence about
+UU_7_2021 at all. So a hit is now graded against the CHUNK'S OWN identity, read
+from both payload generations (top-level `document_id` and nested
+`metadata.document_id` — see `chunk_instrument()`), not just its text:
+  - green         — the phrase is in a chunk that belongs to the journey's
+                     `instrument_id`.
+  - misattributed — the phrase came back, but every chunk carrying it belongs to a
+                     DIFFERENT instrument. Not a weaker green (it is not evidence
+                     for THIS instrument) and not folded into red (a red says the
+                     phrase never came back at all — a different, better-understood
+                     failure). A right-instrument hit wins over a wrong-instrument
+                     hit regardless of rank: green at rank 7 beats misattributed at
+                     rank 1, because rank measures retrieval quality and instrument
+                     identity measures whether the hit is usable evidence at all.
+  - red           — no chunk at any rank carries the phrase.
+
+EXPECTATION AND SATISFACTION (2026-08-25, cross-family review finding — MANDATE §8's
+"at_target sustained 48h" and a negative canary's permanent-red state contradicted
+each other with no valid resolution: a canary can never legitimately go green, so a
+topic with one could never reach the old definition of at_target). Each journey may
+carry `expectation: retrieves` (the default, and what every journey meant before this
+field existed) or `expectation: must_not_retrieve` (a canary: the phrase coming back,
+correctly attributed, IS the failure — see kb/journeys/immigration.yaml journeys 2 and
+8). `hit` is true only on a "green" grading; SATISFIED is `hit == (expectation ==
+"retrieves")`. `probe_state` keeps recording the raw measured hit (green/red) exactly
+as it always has — satisfaction is derived at report time, never stored, because two
+fields that can disagree are two fields one of which is a lie.
 
 There is deliberately NO --update flag. A probe that writes its own expected value
 back into the file it grades is not a probe. Print the correction; let a human or a
@@ -214,6 +253,67 @@ def phrase_hit(chunks: list[dict], phrase: str) -> tuple[bool, int | None]:
         if needle in normalize(chunk.get("text", "")):
             return True, i
     return False, None
+
+
+def chunk_instrument(chunk: dict) -> str | None:
+    """Which instrument this retrieved chunk's payload actually names, or None.
+
+    Two payload generations coexist in legal_unified (kb_inventory_probe.py's
+    PAYLOAD_SHAPES; MANDATE §4.1): a modern ingest writes `document_id` at the
+    payload's top level; a legacy ingest nests it under
+    `payload["metadata"]["document_id"]` instead. `_extract_point_metadata`
+    (backend/core/qdrant_db.py:192) folds a flat payload's other keys —
+    `document_id` included — into what reaches this probe as `chunk["metadata"]`,
+    and passes a legacy payload's own nested `metadata` dict through unchanged.
+    So by the time a chunk gets here, BOTH generations' identity lives at
+    `chunk["metadata"]["document_id"]`. This also checks `chunk["document_id"]`
+    directly rather than trusting that one normalisation layer never to change
+    shape underneath it. Measured 2026-08-25: 78,486 of legal_unified's 84,283
+    points (93%) carry identity ONLY in the nested form — a check that reads just
+    the flat key is blind to the entire legacy generation, which is the exact
+    failure this function exists not to repeat.
+    """
+    meta = chunk.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    return chunk.get("document_id") or meta.get("document_id") or None
+
+
+def locate_phrase(chunks: list[dict], phrase: str, instrument_id: str) -> dict:
+    """Where the phrase is, and — the point of this function — WHOSE it is.
+
+    See the module docstring's "INSTRUMENT-CHECKED GRADING" section for why a
+    text match alone is not enough (the tax-J8 defect: a phrase citation inside
+    a DIFFERENT instrument used to grade green). Returns a dict with:
+      "state"            — "green" | "misattributed" | "red"
+      "rank"              — 1-based rank of the reported hit, or None for red
+      "found_instrument" — the instrument actually holding the reported hit
+                             (== instrument_id for green; the wrong one for
+                             misattributed; None for red)
+
+    A RIGHT-instrument hit wins over a WRONG-instrument hit regardless of rank
+    — scanned in retrieval order, the first correct-instrument hit is returned
+    immediately; a wrong-instrument hit is only ever a fallback, reported at
+    ITS OWN first-seen rank so a reader can see how early the misattribution
+    would mislead a real answer.
+    """
+    needle = normalize(phrase)
+    wrong_rank: int | None = None
+    wrong_instrument: str | None = None
+    for i, chunk in enumerate(chunks, start=1):
+        if needle not in normalize(chunk.get("text", "")):
+            continue
+        found = chunk_instrument(chunk)
+        if found == instrument_id:
+            return {"state": "green", "rank": i, "found_instrument": found}
+        if wrong_rank is None:
+            wrong_rank, wrong_instrument = i, found
+    if wrong_rank is not None:
+        return {
+            "state": "misattributed",
+            "rank": wrong_rank,
+            "found_instrument": wrong_instrument,
+        }
+    return {"state": "red", "rank": None, "found_instrument": None}
 
 
 def resolve_collection(journey: dict, default: str) -> str:
@@ -394,6 +494,31 @@ async def run(argv=None) -> int:
                "never that this instrument's text did."],
         )
 
+    # Also BEFORE SearchService is constructed, and for the same reason: without
+    # an instrument_id this probe cannot tell a phrase found in the RIGHT document
+    # from one found in the WRONG one — which is exactly the defect it exists to
+    # catch (tax-J8). The topic-contract test requires this field too, but a lane
+    # iterating with this probe by hand never touches that gate.
+    missing_instrument = [
+        (i, j.get("question", ""))
+        for i, j in enumerate(journeys, start=1)
+        if not j.get("instrument_id")
+    ]
+    if missing_instrument:
+        return refuse(
+            args,
+            "missing_instrument_id",
+            "; ".join("journey %d has no instrument_id" % i for i, _ in missing_instrument),
+            ["BROKEN — %d journey(s) carry no instrument_id:" % len(missing_instrument)]
+            + ["  - journey %d (%s)" % (i, (q[:40] or "?")) for i, q in missing_instrument]
+            + ["",
+               "Nothing was graded. Without an instrument_id this probe cannot tell a "
+               "phrase found",
+               "in the RIGHT document from one found in the WRONG one (the tax-J8 "
+               "shape) — grading",
+               "anyway would silently fall back to the old, refuted, text-only check."],
+        )
+
     asked = {resolve_collection(j, args.collection) for j in journeys}
     asked.add(args.collection)
     strangers = unknown_collections(asked)
@@ -515,63 +640,108 @@ async def run(argv=None) -> int:
         print()
 
     # ── the journeys ────────────────────────────────────────────────────────
+    # Display-only shrink for the table; JSON always carries the full word.
+    MEASURED_DISPLAY = {"green": "green", "red": "red", "misattributed": "misattrib"}
+
     drift: list[str] = []
     outstanding: list[str] = []
     reported: list[dict] = []  # per-journey record, built regardless of --json
     if not args.json:
-        header = "%-4s %-9s %-9s %-6s %-16s  %s" % (
-            "#", "RECORDED", "MEASURED", "RANK", "COLLECTION", "QUESTION")
+        header = "%-4s %-9s %-10s %-6s %-4s %-16s  %s" % (
+            "#", "RECORDED", "MEASURED", "RANK", "SAT", "COLLECTION", "QUESTION")
         print(header)
         print("-" * max(len(header), 78))
 
     for i, journey in enumerate(journeys, start=1):
         question = journey.get("question", "")
         phrase = journey.get("verbatim_phrase", "")
+        instrument_id = journey.get("instrument_id", "")
+        expectation = journey.get("expectation", "retrieves")
         recorded = journey.get("probe_state", "untested")
         collection = resolve_collection(journey, args.collection)
         try:
             chunks = await retrieve(service, question, collection, args.limit)
         except Exception as exc:  # noqa: BLE001
             if not args.json:
-                print("%-4d %-9s %-9s %-6s %-16s  %s"
-                      % (i, recorded, "ERROR", "-", collection, question[:44]))
+                print("%-4d %-9s %-10s %-6s %-4s %-16s  %s"
+                      % (i, recorded, "ERROR", "-", "-", collection, question[:44]))
             outstanding.append("journey %d raised %s: %s" % (i, type(exc).__name__, exc))
             reported.append({
                 "index": i, "question": question, "recorded_state": recorded,
                 "measured_state": "error", "rank": None, "collection": collection,
+                "instrument_id": instrument_id, "expectation": expectation,
+                "found_instrument": None, "satisfied": None,
                 "error": "%s: %s" % (type(exc).__name__, exc),
             })
             continue
 
-        hit, rank = phrase_hit(chunks, phrase)
-        measured = "green" if hit else "red"
+        located = locate_phrase(chunks, phrase, instrument_id)
+        measured_state = located["state"]  # "green" | "misattributed" | "red"
+        rank = located["rank"]
+        found_instrument = located["found_instrument"]
+        hit = measured_state == "green"
+        graded = "green" if hit else "red"  # what a human should write into probe_state
+        satisfied = hit == (expectation == "retrieves")
+
         if not args.json:
-            print("%-4d %-9s %-9s %-6s %-16s  %s"
-                  % (i, recorded, measured, rank if rank else "-", collection,
-                     question[:44]))
+            print("%-4d %-9s %-10s %-6s %-4s %-16s  %s"
+                  % (i, recorded, MEASURED_DISPLAY[measured_state],
+                     rank if rank else "-", "yes" if satisfied else "no",
+                     collection, question[:44]))
         reported.append({
             "index": i, "question": question, "recorded_state": recorded,
-            "measured_state": measured, "rank": rank, "collection": collection,
+            "measured_state": measured_state, "rank": rank, "collection": collection,
+            "instrument_id": instrument_id, "expectation": expectation,
+            "found_instrument": found_instrument, "satisfied": satisfied,
             "error": None,
         })
 
+        # DRIFT compares the RECORDED probe_state against the raw measured HIT
+        # (graded), never against satisfaction — probe_state means exactly what
+        # it always meant ("did the phrase come back, correctly attributed"),
+        # regardless of what a journey's expectation makes of that fact.
         if recorded == "untested":
             drift.append(
                 "journey %d is recorded 'untested' but has now been run and measured "
-                "%r — record it, an unrun verdict is not a verdict" % (i, measured)
+                "%r — record it, an unrun verdict is not a verdict" % (i, measured_state)
             )
-        elif recorded != measured:
+        elif recorded != graded:
+            if expectation == "must_not_retrieve":
+                note = (
+                    "REGRESSION: this canary was safe and the poisoned instrument is "
+                    "now retrieved" if graded == "green" else
+                    "the file records a leak that production no longer reproduces — "
+                    "re-verify before declaring it permanently safe"
+                )
+            else:
+                note = (
+                    "the work landed and the file is stale" if graded == "green"
+                    else "REGRESSION: this used to be found and no longer is"
+                )
             drift.append(
                 "journey %d records %r, production measures %r — %s"
-                % (i, recorded, measured,
-                   "the work landed and the file is stale" if measured == "green"
-                   else "REGRESSION: this used to be found and no longer is")
+                % (i, recorded, measured_state, note)
             )
-        if measured == "red":
-            outstanding.append(
-                "journey %d: %r is not in the retrieved context for %r"
-                % (i, phrase[:48], question[:48])
-            )
+
+        if not satisfied:
+            if measured_state == "misattributed":
+                outstanding.append(
+                    "journey %d: %r is retrieved (rank %d) but attributed to %r, "
+                    "not %r — found, WRONG instrument (the tax-J8 shape)"
+                    % (i, phrase[:48], rank, found_instrument, instrument_id)
+                )
+            elif expectation == "must_not_retrieve":
+                outstanding.append(
+                    "journey %d: CANARY VIOLATED — %r is retrieved (rank %d) from "
+                    "the poisoned instrument %r: %s"
+                    % (i, phrase[:48], rank, instrument_id,
+                       journey.get("reason") or "no reason recorded")
+                )
+            else:
+                outstanding.append(
+                    "journey %d: %r is not in the retrieved context for %r"
+                    % (i, phrase[:48], question[:48])
+                )
 
     exit_code = 0
     if drift:
@@ -601,16 +771,20 @@ async def run(argv=None) -> int:
         return 1
 
     if outstanding:
-        print("OUTSTANDING — %d of %d journeys do not retrieve their phrase:"
+        print("OUTSTANDING — %d of %d journeys are not satisfied:"
               % (len(outstanding), len(journeys)))
         for item in outstanding:
             print("  - %s" % item)
         print()
-        print("Red on purpose: the file says red and production agrees. This is the")
-        print("state a journey is SUPPOSED to be in on the day it is written (§3).")
+        print("For a plain 'retrieves' journey, red is the state it is SUPPOSED to be")
+        print("in on the day it is written (§3) — work still to do, not a bug in this")
+        print("run. A line above naming a CANARY VIOLATED, or a WRONG instrument, is")
+        print("not routine coverage — it is a live regression the campaign exists to")
+        print("catch. Read which kind each line is before treating it as expected.")
         return 2
 
-    print("AT TARGET — every journey retrieves its verbatim phrase.")
+    print("AT TARGET — every journey is satisfied: 'retrieves' journeys found their")
+    print("phrase in the right instrument, and 'must_not_retrieve' canaries stayed red.")
     return 0
 
 


### PR DESCRIPTION
## Summary

Fixes three P0 findings from a cross-family adversarial review (GPT-5.6 xhigh, read-only) of this campaign's KB gates. Full findings and reasoning: see the commit message.

1. **P0 — probe never checked instrument identity.** `phrase_hit()` graded on text alone; a phrase found as a citation inside a *different* instrument graded green (live example: tax journey 8's HPP phrase inside `Permen_167_2022`/`PP_44T_2022`, while `UU_7_2021` itself has 0 points). `kb/ops/probe_retrieval.py` now reads the retrieved chunk's own `document_id` (both payload generations — flat and `metadata`-nested) and grades `green` / `misattributed` / `red` accordingly. A right-instrument hit always outranks a wrong-instrument hit, regardless of rank.

2. **P0 — no valid state exists.** MANDATE §8 (`at_target` sustained 48h) and a negative canary's permanent-red safe state contradicted each other. Added a closed-vocabulary `expectation` field (`retrieves` | `must_not_retrieve`) to journeys; `probe_state` keeps recording the raw measured hit exactly as before, but AT_TARGET/OUTSTANDING now derive from `satisfied = hit == (expectation == "retrieves")`. Migrated immigration journeys 2 and 8 (the real canaries) to `must_not_retrieve` with their existing rationale folded into a `reason` field; every other journey across all four topics got the explicit default, `retrieves`. `check_agreement()`'s day-one refusal now checks "all satisfied", not "all green".

3. **P0 — an inventory can declare 100 points and measure nothing.** `instruments: []` passed when the topic scoped a real instrument; negative point counts were never rejected. `check_agreement()` now requires every scoped instrument to appear in the inventory (present=true with points, or present=false with lookup_attempts); `check_topic_inventory()` now rejects negative `points` and negative `payload_shapes` values.

4. **P2 — the deliberately worthless file passed.** `question: " "`, `verbatim_phrase: "xxxxxxxxxxxx"`, and `probe_run_at: never` all now fail their respective checks.

## Verification

- Every new/changed rule proven by anchored mutation: source-text surgery on an `exec`'d copy of the module, verdict **withheld** if the anchor string wasn't found (so a stale anchor can't silently report a false pass). Each mutation kills its guilt case; the real on-disk code restores it. Table in the commit message / final report.
- `backend/tests/unit/kb/` suite: 270 → 287 collected, exit 0.
- Ran `kb/ops/probe_retrieval.py` against production for all four topics (company/immigration/property/tax) — no crashes, no false `misattributed` positives on the current (already-repaired) corpus.
- Immigration specifically: canaries (journeys 2, 8) now report `satisfied: true` and are excluded from OUTSTANDING; the four genuine `retrieves` coverage gaps (3, 5, 6, 10) still correctly drive exit 2.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/unit/kb/ -q` — 287 passed, 32 skipped (unrelated `kind='topic'` deferrals), exit 0
- [x] `python -m py_compile kb/ops/probe_retrieval.py apps/backend-rag/backend/tests/unit/kb/test_kb_topic_contract.py`
- [x] Live probe run against production on all four `kb/journeys/*.yaml`
- [x] Anchored mutation/restore proof for all 11 new/changed rules (7 in `check_journey`, 2 in `check_topic_inventory`, 2 in `check_agreement`, plus `locate_phrase`/`chunk_instrument` and the `missing_instrument_id` guard in `probe_retrieval.py`)

Not touched: `kb/ops/probe_history.py`, `scripts/ci/legal_status_read_lint.py` (another lane's concurrent work).

Auto-merge intentionally NOT armed — `feature/kb-current` has no required contexts, so the orchestrator merges after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>