### PR TITLE
feat(kb): add --json to kb_inventory_probe.py's topic path

### DIFF
--- a/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_probe_topic.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_probe_topic.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import collections
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -298,18 +299,25 @@ def test_innocence_an_instrument_declared_zero_and_absent_live_is_not_drift():
     assert findings == [], findings
 
 
-TOPIC_DRIFT_GUILT_COUNT = 5  # the five test_guilt_* cases above
+TOPIC_DRIFT_GUILT_COUNT = 5  # the five test_guilt_topic_drift_* cases above
 
 
 def test_the_guilt_matrix_is_not_empty():
     """Anti-vacuity: this file's guilt cases are plain functions, not a
     `pytest.mark.parametrize` table, so nothing collects them automatically —
-    assert the count by hand so deleting a case is loud."""
+    assert the count by hand so deleting a case is loud.
+
+    Scoped to `test_guilt_topic_drift_*` specifically (not the bare
+    `test_guilt_` prefix) because the --json section below adds its own,
+    separately-counted guilt case (`test_guilt_json_*`,
+    `test_the_json_guilt_matrix_is_not_empty`) — a shared bare prefix would
+    make this count silently absorb that unrelated section's cases (or vice
+    versa) the next time either grows."""
     import inspect
 
     guilt_fns = [
         name for name, obj in inspect.getmembers(sys.modules[__name__])
-        if name.startswith("test_guilt_") and inspect.isfunction(obj)
+        if name.startswith("test_guilt_topic_drift_") and inspect.isfunction(obj)
     ]
     assert len(guilt_fns) == TOPIC_DRIFT_GUILT_COUNT, guilt_fns
 
@@ -550,3 +558,214 @@ def test_main_runs_a_real_topic_yaml_end_to_end(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert rc == 0, out
     assert "AT TARGET" in out
+
+
+# ── --json (2026-08-26): one JSON object, same verdict, nothing else on stdout ──
+#
+# Team lead's ask, verbatim reasoning: without --json nothing can make
+# kb/ops/probe_history.py (out of THIS PR's scope — a different lane owns it
+# right now) record a topic inventory's drift rather than just its file's
+# sha256. "Same structure as kb/ops/probe_retrieval.py --json" — proven below
+# by cross-checking the actual VERDICT_BY_EXIT vocabulary in that file, not by
+# import (this module does not depend on probe_retrieval.py at runtime; the
+# two dicts are kept string-identical by convention, and this test is what
+# would catch them drifting apart).
+
+
+def _load_probe_retrieval_for_vocabulary_check():
+    """Test-only import of kb/ops/probe_retrieval.py, same out-of-package
+    pattern kb/ops/probe_history.py itself uses at runtime (`_probe_retrieval_module`)
+    and `test_probe_retrieval_collection_override.py` uses in this same test suite.
+    This is a TEST dependency only — kb_inventory_probe.py itself never imports
+    this file; see the module docstring's --json paragraph for why."""
+    cached = sys.modules.get("kb_probe_retrieval_for_vocab_check")
+    if cached is not None:
+        return cached
+    path = ROOT / "kb" / "ops" / "probe_retrieval.py"
+    assert path.is_file(), f"{path} is missing"
+    spec = importlib.util.spec_from_file_location("kb_probe_retrieval_for_vocab_check", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["kb_probe_retrieval_for_vocab_check"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_verdict_by_exit_matches_probe_retrieval_pys_vocabulary_string_for_string():
+    """"Coherent with kb/ops/probe_retrieval.py" (team lead's requirement) means
+    the same four strings, not just a superficially similar shape. If this ever
+    fails because probe_retrieval.py's dict changed, kb_inventory_probe.py's
+    copy needs a matching edit — that is the point of keeping this asserted
+    rather than only documented in a comment."""
+    probe_retrieval = _load_probe_retrieval_for_vocabulary_check()
+    for exit_code, word in probe_retrieval.VERDICT_BY_EXIT.items():
+        assert PROBE.VERDICT_BY_EXIT[exit_code] == word, (
+            exit_code, PROBE.VERDICT_BY_EXIT[exit_code], word,
+        )
+
+
+def test_run_topic_json_at_target_emits_exactly_one_json_object_and_nothing_else(capsys):
+    client = FakeQdrantClient({
+        "acme_legal_topic": [_modern_id_only("UU_6_2011")] * 7 + [_legacy("Permen_22_2023")] * 3,
+    })
+    rc = PROBE._run_topic(client, _good_topic_inventory(), as_json=True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)  # raises if anything besides the JSON object was printed
+    assert payload["verdict"] == "at_target"
+    assert payload["exit_code"] == 0
+    assert payload["collection"] == "acme_legal_topic"
+    assert payload["collection_live"] is True
+    assert payload["findings"] == []
+    assert {i["id"] for i in payload["instruments"]} == {"UU_6_2011", "Permen_22_2023"}
+    assert all(i["at_target"] for i in payload["instruments"])
+
+
+def test_run_topic_json_drift_case_reports_findings_and_per_instrument_detail(capsys):
+    client = FakeQdrantClient({
+        "acme_legal_topic": [_modern_id_only("UU_6_2011")] * 7,  # Permen_22_2023 is GONE
+    })
+    rc = PROBE._run_topic(client, _good_topic_inventory(), as_json=True)
+    out = capsys.readouterr().out
+    assert rc == 1
+    payload = json.loads(out)
+    assert payload["verdict"] == "drift"
+    assert payload["exit_code"] == 1
+    assert len(payload["findings"]) >= 1
+    assert any("Permen_22_2023" in f for f in payload["findings"])
+    by_id = {i["id"]: i for i in payload["instruments"]}
+    assert by_id["Permen_22_2023"]["live"] == 0
+    assert by_id["Permen_22_2023"]["at_target"] is False
+    assert by_id["UU_6_2011"]["at_target"] is True
+
+
+def test_run_topic_json_absent_collection_reports_collection_live_false(capsys):
+    client = FakeQdrantClient({"some_other_collection": []})
+    rc = PROBE._run_topic(client, _good_topic_inventory(), as_json=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["collection_live"] is False
+    assert payload["verdict"] == "drift"
+
+
+def test_run_topic_json_inventory_file_is_present_when_given_and_null_when_omitted(capsys):
+    client = FakeQdrantClient({
+        "acme_legal_topic": [_modern_id_only("UU_6_2011")] * 7 + [_legacy("Permen_22_2023")] * 3,
+    })
+    PROBE._run_topic(client, _good_topic_inventory(), Path("kb/inventory/immigration.yaml"), as_json=True)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["inventory_file"] == "kb/inventory/immigration.yaml"
+
+    PROBE._run_topic(client, _good_topic_inventory(), as_json=True)  # inventory_path omitted
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["inventory_file"] is None
+
+
+def test_guilt_json_mode_actually_suppresses_the_human_report(capsys):
+    """Mutation-tested: comment out any `if not as_json:` guard around a human
+    `print()` in `_run_topic` and this goes red — `json.loads` raises on the
+    extra text sharing stdout with the JSON object. Proves as_json is WIRED,
+    not merely accepted and ignored."""
+    client = FakeQdrantClient({
+        "acme_legal_topic": [_modern_id_only("UU_6_2011")] * 7 + [_legacy("Permen_22_2023")] * 3,
+    })
+    PROBE._run_topic(client, _good_topic_inventory(), as_json=True)
+    out = capsys.readouterr().out
+    json.loads(out)  # must not raise
+    assert "[live]" not in out
+    assert "INSTRUMENT" not in out
+    assert "AT TARGET" not in out  # the human closing line — JSON says "at_target"
+
+
+JSON_GUILT_COUNT = 1  # test_guilt_json_mode_actually_suppresses_the_human_report
+
+
+def test_the_json_guilt_matrix_is_not_empty():
+    import inspect
+
+    guilt_fns = [
+        name for name, obj in inspect.getmembers(sys.modules[__name__])
+        if name.startswith("test_guilt_json") and inspect.isfunction(obj)
+    ]
+    assert len(guilt_fns) == JSON_GUILT_COUNT, guilt_fns
+
+
+def test_main_json_flag_is_wired_into_the_run_topic_call():
+    import inspect
+
+    src = inspect.getsource(PROBE.main)
+    assert "as_json=args.json" in src
+
+
+def test_main_json_end_to_end_at_target(monkeypatch, tmp_path, capsys):
+    import qdrant_client
+    import yaml
+
+    monkeypatch.setattr(PROBE, "load_env", lambda root: None)
+    monkeypatch.setenv("QDRANT_URL", "http://fake")
+    monkeypatch.setenv("QDRANT_API_KEY", "fake")
+
+    data = _good_topic_inventory()
+    client = FakeQdrantClient({
+        "acme_legal_topic": [_modern_id_only("UU_6_2011")] * 7 + [_legacy("Permen_22_2023")] * 3,
+    })
+    monkeypatch.setattr(qdrant_client, "QdrantClient", lambda *a, **k: client)
+
+    path = tmp_path / "topic.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    rc = PROBE.main([str(path), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    payload = json.loads(out)
+    assert payload["verdict"] == "at_target"
+    assert payload["inventory_file"] == str(path)
+
+
+def test_main_json_refuses_retired_collection_kind_with_a_broken_json_object(
+    monkeypatch, tmp_path, capsys
+):
+    """`--json` combined with `kind: retired_collection` must still print ONE
+    valid JSON object (verdict=broken) — never the human report this flag was
+    explicitly asked NOT to produce, and never a crash."""
+    import qdrant_client
+    import yaml
+
+    monkeypatch.setattr(PROBE, "load_env", lambda root: None)
+    monkeypatch.setenv("QDRANT_URL", "http://fake")
+    monkeypatch.setenv("QDRANT_API_KEY", "fake")
+    monkeypatch.setattr(qdrant_client, "QdrantClient", lambda *a, **k: FakeQdrantClient({}))
+
+    path = tmp_path / "retired.yaml"
+    path.write_text(yaml.safe_dump(_good_retired_inventory()), encoding="utf-8")
+
+    rc = PROBE.main([str(path), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 3, out
+    payload = json.loads(out)
+    assert payload["verdict"] == "broken"
+    assert payload["exit_code"] == 3
+    assert payload["kind"] == "retired_collection"
+    assert payload["reason"] == "json_only_implemented_for_topic"
+
+
+def test_main_json_refuses_unrecognised_kind_with_a_broken_json_object(
+    monkeypatch, tmp_path, capsys
+):
+    import qdrant_client
+    import yaml
+
+    monkeypatch.setattr(PROBE, "load_env", lambda root: None)
+    monkeypatch.setenv("QDRANT_URL", "http://fake")
+    monkeypatch.setenv("QDRANT_API_KEY", "fake")
+    monkeypatch.setattr(qdrant_client, "QdrantClient", lambda *a, **k: FakeQdrantClient({}))
+
+    path = tmp_path / "mystery.yaml"
+    path.write_text(yaml.safe_dump({"schema_version": 1, "kind": "nonsense"}), encoding="utf-8")
+
+    rc = PROBE.main([str(path), "--json"])
+    captured = capsys.readouterr()  # ONE snapshot — a second call would always read "" for both
+    assert rc == 3, captured.out
+    assert captured.err == ""  # the human BROKEN message must NOT also print alongside JSON
+    payload = json.loads(captured.out)
+    assert payload["verdict"] == "broken"
+    assert payload["kind"] == "nonsense"

--- a/scripts/kb/kb_inventory_probe.py
+++ b/scripts/kb/kb_inventory_probe.py
@@ -35,19 +35,41 @@ This is the half that touches production. Dispatches on `data["kind"]`:
   Any other `kind` (or none) -> exit 3, BROKEN, nothing measured — same vocabulary
   as the missing-`.env` case below and as `kb/ops/probe_retrieval.py`.
 
+--json (additive, 2026-08-26): emits ONE JSON object on stdout instead of the
+human report, for a caller (`kb/ops/probe_history.py`) that needs to RECORD a
+verdict rather than have a human read one — the same contract, and the same
+reason, as `kb/ops/probe_retrieval.py`'s own `--json` (grading is identical
+either way; this only serializes it). Wired for `kind: topic` only today
+(`_run_topic`) — `kind: retired_collection` has no `documents:`/disposition
+JSON shape yet, and `main()` refuses with a `broken` JSON object rather than
+silently falling back to the human report a caller that asked for JSON did
+not request. `VERDICT_BY_EXIT` below mirrors `probe_retrieval.py`'s own dict
+by convention (same four strings), not by import — that file belongs to a
+different lane's PR at the moment this was written.
+
 Run it: PYTHONPATH unnecessary; it reads apps/backend-rag/.env for credentials.
     python3 scripts/kb/kb_inventory_probe.py kb/inventory/legal_unified_2026.yaml
     python3 scripts/kb/kb_inventory_probe.py kb/inventory/immigration.yaml
+    python3 scripts/kb/kb_inventory_probe.py kb/inventory/immigration.yaml --json
 """
 from __future__ import annotations
 
 import argparse
 import collections
 import hashlib
+import json
 import os
 import re
 import sys
 from pathlib import Path
+
+# Closed vocabulary for --json's "verdict" field. Matches kb/ops/probe_retrieval.py's
+# own VERDICT_BY_EXIT string-for-string (documented equivalence, not a shared import —
+# see the --json paragraph above). `_run_topic` only ever produces 0/1/3; 2
+# ("outstanding") is `_run_retired_collection`'s disposition concept, which --json
+# does not cover yet — kept here anyway so the full script's exit-code vocabulary is
+# named in one place rather than half of it living only in exit codes nobody strings.
+VERDICT_BY_EXIT = {0: "at_target", 1: "drift", 2: "outstanding", 3: "broken"}
 
 WS = re.compile(r"\s+")
 CTX = re.compile(r"^\[CONTEXT:[^\]]*\]\s*", re.S)
@@ -434,7 +456,9 @@ def _run_retired_collection(client, data: dict) -> int:
     return 0
 
 
-def _run_topic(client, data: dict) -> int:
+def _run_topic(
+    client, data: dict, inventory_path: Path | None = None, *, as_json: bool = False
+) -> int:
     """`kind: topic` — measure ONE collection against the instruments a lane scoped.
 
     No `documents`/`disposition` machinery here: a topic inventory has no target
@@ -445,34 +469,69 @@ def _run_topic(client, data: dict) -> int:
     (exit 1) when production has moved since `measured_at`, AT TARGET (exit 0)
     otherwise — the same two states `shape_drift` already reports for, reused via
     `topic_drift` rather than reimplemented.
+
+    `as_json=True` (module docstring's --json paragraph): suppresses every human
+    print and emits ONE `json.dumps(...)` object on stdout instead, built from the
+    exact same `topic_drift`/`by_doc` data the human report reads — grading does
+    not branch on `as_json` anywhere in this function, only presentation does.
+    `inventory_path` is optional and cosmetic (the `inventory_file` field a
+    caller correlating multiple runs wants) — `topic_drift`'s grading never
+    touches it, so a direct unit-test call omitting it grades identically.
     """
     collection = data["measured_against"]["collection"]
     physical = resolve_physical(collection)
     live = {c.name for c in client.get_collections().collections}
+    collection_live = physical in live
 
-    if physical not in live:
-        print("[live] %s: ABSENT from Qdrant" % collection)
+    if not collection_live:
+        if not as_json:
+            print("[live] %s: ABSENT from Qdrant" % collection)
         by_doc, shapes_by_doc = collections.Counter(), collections.defaultdict(collections.Counter)
     else:
         points, by_doc, _hashes_by_doc, _all_hashes, shapes, shapes_by_doc = census(client, physical)
         # Whole-collection totals, printed for context ONLY — `legal_unified` is
         # SHARED across every lane, so these numbers are never compared against
         # this topic's own `measured_against` (see `topic_drift`'s docstring).
-        print("[live] %-28s %6d points total  %3d docs total  shapes=%s"
-              % (collection, points, len(by_doc), dict(shapes)))
+        if not as_json:
+            print("[live] %-28s %6d points total  %3d docs total  shapes=%s"
+                  % (collection, points, len(by_doc), dict(shapes)))
 
     findings = topic_drift(data, by_doc, shapes_by_doc)
 
-    print()
-    header = "%-28s %10s %10s  %s" % ("INSTRUMENT", "declared", "live", "STATE")
-    print(header)
-    print("-" * len(header))
+    if not as_json:
+        print()
+        header = "%-28s %10s %10s  %s" % ("INSTRUMENT", "declared", "live", "STATE")
+        print(header)
+        print("-" * len(header))
+
+    instruments = []
     for inst in data.get("instruments") or []:
         iid = inst.get("id")
         declared = inst.get("points", 0)
         live_n = by_doc.get(iid, 0)
-        state = "AT TARGET" if live_n == declared else "DRIFT"
-        print("%-28s %10d %10d  %s" % (iid, declared, live_n, state))
+        at_target = live_n == declared
+        instruments.append(
+            {"id": iid, "declared": declared, "live": live_n, "at_target": at_target}
+        )
+        if not as_json:
+            print("%-28s %10d %10d  %s"
+                  % (iid, declared, live_n, "AT TARGET" if at_target else "DRIFT"))
+
+    exit_code = 1 if findings else 0
+
+    if as_json:
+        print(json.dumps({
+            "inventory_file": str(inventory_path) if inventory_path else None,
+            "collection": collection,
+            "physical_collection": physical,
+            "collection_live": collection_live,
+            "measured_at": data.get("measured_at"),
+            "verdict": VERDICT_BY_EXIT[exit_code],
+            "exit_code": exit_code,
+            "instruments": instruments,
+            "findings": findings,
+        }))
+        return exit_code
 
     print()
     if findings:
@@ -493,6 +552,15 @@ def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("inventory", type=Path)
     parser.add_argument("--quiet", action="store_true")
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit one JSON object on stdout instead of the human report (additive; "
+             "grading is identical either way — see the module docstring's --json "
+             "paragraph). Only wired for kind: topic today; any other kind still "
+             "emits ONE JSON object — a 'broken' verdict explaining why — rather "
+             "than silently falling back to the human report a caller that asked "
+             "for JSON did not request.",
+    )
     args = parser.parse_args(argv)
 
     import yaml
@@ -509,7 +577,27 @@ def main(argv=None) -> int:
     )
 
     if kind == "topic":
-        return _run_topic(client, data)
+        return _run_topic(client, data, args.inventory, as_json=args.json)
+
+    if args.json:
+        # --json was requested but this kind has no JSON output yet
+        # (_run_retired_collection's documents:/disposition shape is out of THIS
+        # change's scope). Refuse with a JSON object, not human prose on stdout —
+        # a caller that asked for one JSON object and got two different output
+        # shapes depending on `kind` is the exact silent-divergence class this
+        # probe already refuses for a missing .env / an unrecognised kind.
+        print(json.dumps({
+            "inventory_file": str(args.inventory),
+            "kind": kind,
+            "verdict": VERDICT_BY_EXIT[3],
+            "exit_code": 3,
+            "reason": "json_only_implemented_for_topic",
+            "detail": "--json is only wired for kind: topic; kind=%r has no JSON "
+                      "output yet — rerun without --json for the human report."
+                      % kind,
+        }))
+        return 3
+
     if kind == "retired_collection":
         return _run_retired_collection(client, data)
 


### PR DESCRIPTION
## Summary

`kb/ops/probe_history.py` can currently only record a `kind: topic` inventory's
drift by hashing the file (sha256) — nothing re-measures the inventory's own
point-count/payload-shape claims against production and records a verdict.
`--json` is the piece that makes that possible: it emits ONE JSON object on
stdout instead of the human report, same contract `kb/ops/probe_retrieval.py`'s
own `--json` already makes (grading is identical either way, this only
serializes it).

- `VERDICT_BY_EXIT`: closed vocabulary matching `probe_retrieval.py`'s own dict
  string-for-string (documented equivalence, not a shared import — that file
  belongs to a different lane's PR right now). A new test cross-checks the two
  dicts stay identical by loading `probe_retrieval.py` out-of-package, the same
  pattern `probe_history.py` itself already uses.
- `_run_topic(client, data, inventory_path=None, *, as_json=False)`: every
  human print is now gated on `not as_json`; grading itself never branches on
  it. `inventory_path` is optional/cosmetic (the JSON's `"inventory_file"`
  field), so every existing call site keeps working unchanged.
- `main()`: `--json` combined with any kind other than `topic` still emits
  exactly ONE JSON object — a `"broken"` verdict naming the kind and the reason
  — rather than silently falling back to the human report a caller that asked
  for JSON did not request. `kind: retired_collection` has no
  `documents:`/disposition JSON shape yet; that's out of this PR's scope.

## Mutation testing

Disabled the `if not as_json:` guard around the instrument-table header print
→ 6 tests went red (`json.decoder.JSONDecodeError` — human text interleaved
with the JSON object) → restored via diff-verified byte-identical `cp` →
confirmed green again (35/35).

## Real production result (2026-08-26)

Ran the new `--json` flag against real Qdrant for all 4 real topic inventories:

| Inventory | verdict | exit_code |
|---|---|---|
| `company.yaml` | `at_target` | 0 |
| `immigration.yaml` | `at_target` | 0 |
| `property.yaml` | `at_target` | 0 |
| `tax.yaml` | `at_target` | 0 |

Every instrument's declared count matches live production exactly — no
divergence from the human-mode measurement taken earlier today (PR #4958).

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/unit/kb/test_kb_inventory_probe_topic.py -v` — 35 tests, all green
- [x] `PYTHONPATH=. pytest backend/tests/unit/kb/ -v` — full kb/ suite after fast-forward merge of `origin/feature/kb-current` (tip `9cb41f45a`): 306 passed, 72 skipped, 0 failed
- [x] Ran `--json` against real production Qdrant for all 4 topic inventories (table above)
- [x] Mutation-tested, restore verified byte-identical via `diff`

NOT armed for auto-merge — targets `feature/kb-current`, no required contexts
there. Team lead reviews manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>