### PR TITLE
fix(garuda-voa): dark-by-flag ordering, env-var reader agreement, auth allowlist scope

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -699,12 +699,33 @@ _VISA_ORACLE = (
         "support case rather than as an obvious broken page.",
         match="exact",
     ),
+    # CORRECTED (Gear-3 gate finding E, PR #4959): this used to be a single
+    # `/api/visa/voa/auth/` PREFIX entry (no `match=` given, and
+    # `PublicEndpoint.match` defaults to "prefix") — directly contradicting
+    # this file's own module docstring above ("Every entry below is EXACT
+    # or TEMPLATE, never PREFIX"). Measured:
+    # `is_public_path("/api/visa/voa/auth/anything-future-added-here")`
+    # returned `True`. No live leak today (`garuda_portal_auth.py` mounts
+    # exactly two routes under this prefix and the staff late-resolution
+    # path is disjoint from it), but any future route landed under
+    # `/api/visa/voa/auth/` would become anonymous with no review. Two
+    # EXACT entries for the two real routes instead — same posture as
+    # every other GARUDA VOA entry in this block.
     PublicEndpoint(
-        "/api/visa/voa/auth/",
+        "/api/visa/voa/auth/magic-links",
         Category.AUTH,
-        "GARUDA VOA magic-link issue+exchange — anonymous by design, contract-frozen "
-        "(products/garuda-voa/contracts/openapi.yaml), GARUDA_PUBLIC_ENABLED re-checked "
-        "per-request by the handler itself",
+        "GARUDA VOA requestMagicLink (L4, garuda_portal_auth.py) — anonymous by "
+        "design, contract-frozen (products/garuda-voa/contracts/openapi.yaml), "
+        "GARUDA_PUBLIC_ENABLED re-checked per-request by the handler itself",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/visa/voa/auth/sessions",
+        Category.AUTH,
+        "GARUDA VOA exchangeMagicLink (L4, garuda_portal_auth.py) — anonymous by "
+        "design, contract-frozen (products/garuda-voa/contracts/openapi.yaml), "
+        "GARUDA_PUBLIC_ENABLED re-checked per-request by the handler itself",
+        match="exact",
     ),
 )
 

--- a/apps/backend-rag/backend/app/routers/garuda_orders_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_orders_router.py
@@ -13,7 +13,10 @@ design in full).
 
 Registered in `router_manifest.py` / `router_registration.py` (_API, mirrors
 L2's `garuda_voa_public` — mount unconditionally, GARUDA_PUBLIC_ENABLED
-re-checked per-request by this module's own `_require_flag`). The orchestrator
+re-checked per-request by this module's own `_require_flag`, wired as a
+ROUTER-LEVEL dependency so it resolves before every other Depends() and
+before body validation — see the comment above `router = APIRouter(...)`
+below). The orchestrator
 still owns injecting the real `EligibilityCheckLookup` / `PaymentProvider`
 adapters onto `app.state` at composition time — `get_repository()` above
 fails closed with 503 until that happens.
@@ -45,13 +48,22 @@ from backend.services.garuda_orders.repository import GarudaOrderRepository
 from backend.services.garuda_portal.practice import PracticeRepository
 from backend.services.payments.port import WebhookSignatureInvalid, WebhookUnparseable
 
-router = APIRouter(prefix="/api/visa/voa", tags=["garuda-orders"])
-
 _FLAG_ENV_VAR = "GARUDA_PUBLIC_ENABLED"
 
 
 def _flag_enabled() -> bool:
-    return os.environ.get(_FLAG_ENV_VAR, "false").lower() == "true"
+    # CORRECTED (Gear-3 gate finding D, PR #4959): this used to read
+    # `os.environ.get(_FLAG_ENV_VAR, "false").lower() == "true"` — a
+    # strict-exact-"true" reader that disagreed with the permissive reader
+    # `garuda_voa_public._public_enabled()` / `garuda_portal_auth._public_
+    # enabled()` already use (trimmed, case-insensitive, accepts "1"/"yes").
+    # `GARUDA_PUBLIC_ENABLED=1` opened L2/L4 and left L3 dark — a customer
+    # could get a quote and then never check out. All three readers now
+    # share this exact body (kept as local per-file copies, not a shared
+    # import, per LANES.md file-ownership discipline); see
+    # `test_garuda_public_enabled_readers_agree.py` for the value matrix
+    # that pins the three copies identical.
+    return os.environ.get(_FLAG_ENV_VAR, "").strip().lower() in {"1", "true", "yes"}
 
 
 def _require_flag() -> None:
@@ -59,6 +71,29 @@ def _require_flag() -> None:
         raise HTTPException(
             status_code=404, detail={"code": "GARUDA_PUBLIC_DISABLED", "retryable": False}
         )
+
+
+# CORRECTED (Gear-3 gate finding B, PR #4959): `_require_flag()` used to be
+# the first statement INSIDE each handler body below. That is too late —
+# FastAPI resolves a path-operation's parameter dependencies (here, every
+# handler's `Depends(get_repository)`) BEFORE the handler function ever
+# runs, and `get_repository` 503s when `app.state.garuda_order_repository`
+# is unset (production's state until the orchestrator wires it). Net
+# effect: with the flag OFF and no repository wired, every route here
+# leaked a live 503 instead of a dark 404 — an anonymous existence-and-
+# liveness oracle.
+#
+# A router-level `dependencies=` entry is solved BEFORE a path operation's
+# own parameter dependencies (`fastapi/routing.py::_build_dependant_with_
+# parameterless_dependencies` inserts router-level deps at index 0 of the
+# dependant's dependency list; `fastapi/dependencies/utils.py::solve_
+# dependencies` walks that list in order and raises immediately on the
+# first exception) — proved empirically, not assumed, by
+# `test_garuda_voa_flag_ordering.py`, which fails red against the OLD
+# per-handler-body placement and passes green here.
+router = APIRouter(
+    prefix="/api/visa/voa", tags=["garuda-orders"], dependencies=[Depends(_require_flag)]
+)
 
 
 def _privacy_headers(response: Response) -> None:
@@ -161,7 +196,6 @@ async def create_order_from_check(
     idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
     repository: GarudaOrderRepository = Depends(get_repository),
 ) -> dict:
-    _require_flag()
     _privacy_headers(response)
     actor = await _require_magic_session_actor(request)
     key = _idempotency_key(idempotency_key)
@@ -243,7 +277,6 @@ async def get_order_and_practice(
     response: Response,
     repository: GarudaOrderRepository = Depends(get_repository),
 ) -> dict:
-    _require_flag()
     _privacy_headers(response)
     actor = await _require_magic_session_actor(request)
     pool = getattr(request.app.state, "garuda_db_pool", None)
@@ -277,7 +310,6 @@ async def observe_payment_browser_return(
     idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
     repository: GarudaOrderRepository = Depends(get_repository),
 ) -> None:
-    _require_flag()
     _privacy_headers(response)
     actor = await _require_magic_session_actor(request)
     _idempotency_key(idempotency_key)
@@ -313,7 +345,6 @@ async def receive_payment_webhook(
     # `$ref` here is the orchestrator's fix (frozen contract, not this
     # lane's to edit) -- this router-side removal is the corresponding fix
     # on the implementation.
-    _require_flag()
     _privacy_headers(response)
     raw_body = await request.body()
     provider = getattr(request.app.state, "garuda_payment_provider", None)
@@ -361,7 +392,6 @@ async def resolve_late_order(
     idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
     repository: GarudaOrderRepository = Depends(get_repository),
 ) -> dict:
-    _require_flag()
     _privacy_headers(response)
     actor = await _require_staff_actor(request, authorization)
     key = _idempotency_key(idempotency_key)

--- a/apps/backend-rag/backend/app/routers/garuda_portal_auth.py
+++ b/apps/backend-rag/backend/app/routers/garuda_portal_auth.py
@@ -52,6 +52,13 @@ from backend.services.garuda_portal.magic_link import (
 logger = get_logger(__name__)
 
 
+class _FeatureDisabled(Exception):
+    """Sentinel raised by the router-level `_require_public_enabled`
+    dependency below — identical rationale to `garuda_voa_public.py`'s
+    twin, duplicated rather than imported per LANES.md file-ownership
+    discipline."""
+
+
 class _ContractErrorRoute(APIRoute):
     """Rewrite FastAPI's default 422 body into the frozen `errors.yaml` shape.
 
@@ -59,6 +66,10 @@ class _ContractErrorRoute(APIRoute):
     duplicated rather than imported because `garuda_voa*.py` is L2's file and
     this lane does not couple to another lane's private implementation
     detail (LANES.md file-ownership discipline).
+
+    Also catches `_FeatureDisabled` (Gear-3 gate finding B, PR #4959) —
+    both handlers below take a Pydantic body model, validated BEFORE the
+    handler runs; see `_require_public_enabled`'s docstring.
     """
 
     def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
@@ -69,15 +80,11 @@ class _ContractErrorRoute(APIRoute):
                 return await downstream(request)
             except RequestValidationError:
                 return _error("INVALID_REQUEST")
+            except _FeatureDisabled:
+                return _error("GARUDA_PUBLIC_DISABLED")
 
         return handler
 
-
-router = APIRouter(
-    prefix="/api/visa/voa/auth",
-    tags=["garuda-voa-magic-link"],
-    route_class=_ContractErrorRoute,
-)
 
 _FEATURE_FLAG_ENV = "GARUDA_PUBLIC_ENABLED"
 _RESULT_SESSION_COOKIE = "garuda_result_session"
@@ -123,6 +130,31 @@ def _error(code: str) -> JSONResponse:
 
 def _public_enabled() -> bool:
     return os.environ.get(_FEATURE_FLAG_ENV, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _require_public_enabled() -> None:
+    """Router-level dependency (Gear-3 gate finding B, PR #4959) — identical
+    rationale to `garuda_voa_public._require_public_enabled`: both handlers
+    below take a Pydantic body model (`MagicLinkRequest` / `MagicLinkExchange`),
+    validated by FastAPI BEFORE the handler function runs, so the
+    `if not _public_enabled(): return _error(...)` that used to open each
+    handler body was too late — an empty/malformed body with the flag OFF
+    leaked a 422 INVALID_REQUEST instead of the dark-launch 404. A
+    router-level `dependencies=` entry is solved before body validation;
+    see the sibling docstring for the exact FastAPI mechanics and the test
+    that proves the ordering empirically
+    (`test_garuda_voa_flag_ordering.py`).
+    """
+    if not _public_enabled():
+        raise _FeatureDisabled()
+
+
+router = APIRouter(
+    prefix="/api/visa/voa/auth",
+    tags=["garuda-voa-magic-link"],
+    route_class=_ContractErrorRoute,
+    dependencies=[Depends(_require_public_enabled)],
+)
 
 
 class _IdempotencyKeyAbsent(Exception):
@@ -279,9 +311,6 @@ async def request_magic_link(
     """Always 202 for an unknown or non-owned result and never returns the
     token (contract, verbatim). Exact replay returns the original 202
     without another email."""
-    if not _public_enabled():
-        return _error("GARUDA_PUBLIC_DISABLED")
-
     try:
         key = _require_idempotency_key(idempotency_key)
     except _IdempotencyKeyAbsent:
@@ -360,9 +389,6 @@ async def exchange_magic_link(
     indistinguishable to the caller). An exact Idempotency-Key replay returns
     the original 204 but creates no second session and emits no second
     Set-Cookie; a consumed token under a new key is invalid."""
-    if not _public_enabled():
-        return _error("GARUDA_PUBLIC_DISABLED")
-
     try:
         key = _require_idempotency_key(idempotency_key)
     except _IdempotencyKeyAbsent:

--- a/apps/backend-rag/backend/app/routers/garuda_voa_public.py
+++ b/apps/backend-rag/backend/app/routers/garuda_voa_public.py
@@ -64,12 +64,25 @@ from backend.services.garuda_flow.public_api import (
 
 logger = get_logger(__name__)
 
+class _FeatureDisabled(Exception):
+    """Sentinel raised by the router-level `_require_public_enabled`
+    dependency below — see that function's docstring for why this exists
+    instead of raising `HTTPException` directly."""
+
+
 class _ContractErrorRoute(APIRoute):
     """Rewrite FastAPI's default 422 body into the frozen `errors.yaml` shape.
 
     `ErrorResponse` is a closed 3-field tuple (`code`/`retryable`/`message_key`)
     — FastAPI's default `{"detail": [...]}` is not contract-valid and would
     echo the field path back to the caller.
+
+    Also catches `_FeatureDisabled` (Gear-3 gate finding B, PR #4959):
+    `_require_public_enabled` is a router-level dependency, resolved before
+    Pydantic validates the request body — see that function's docstring —
+    so it must raise something this same route class can translate into
+    the contract's `GARUDA_PUBLIC_DISABLED` shape, exactly like the
+    `RequestValidationError` case below already does for a malformed body.
     """
 
     def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
@@ -80,17 +93,56 @@ class _ContractErrorRoute(APIRoute):
                 return await downstream(request)
             except RequestValidationError:
                 return _error("INVALID_REQUEST")
+            except _FeatureDisabled:
+                return _error("GARUDA_PUBLIC_DISABLED")
 
         return handler
+
+
+_FEATURE_FLAG_ENV = "GARUDA_PUBLIC_ENABLED"
+
+
+def _public_enabled() -> bool:
+    return os.environ.get(_FEATURE_FLAG_ENV, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _require_public_enabled() -> None:
+    """Router-level dependency (Gear-3 gate finding B, PR #4959).
+
+    Every handler below used to open with
+    `if not _public_enabled(): return _error("GARUDA_PUBLIC_DISABLED")` as
+    its FIRST statement — too late for `create_eligibility_check`, whose
+    `payload: EligibilityCheckRequest` is a Pydantic body model that FastAPI
+    validates BEFORE the handler function ever runs. An empty/malformed
+    body with the flag OFF therefore leaked a 422 INVALID_REQUEST — a
+    response shape only a live, mounted GARUDA route can ever produce —
+    instead of the dark-launch 404.
+
+    A router-level `dependencies=` entry is solved before a path
+    operation's OWN parameter dependencies AND before body validation
+    (`fastapi/dependencies/utils.py::solve_dependencies` walks
+    `dependant.dependencies` — router-level entries inserted at index 0 by
+    `fastapi/routing.py::_build_dependant_with_parameterless_dependencies`
+    — to completion, raising immediately on the first exception, before it
+    ever reaches the `if dependant.body_params:` block) — proved
+    empirically, not assumed, by `test_garuda_voa_flag_ordering.py`, which
+    fails red against the OLD per-handler-body placement and passes green
+    here. Raises `_FeatureDisabled` rather than returning a `Response`
+    directly because a dependency's return value cannot short-circuit route
+    execution the way a handler's `return` can; `_ContractErrorRoute`
+    converts it to the contract's `GARUDA_PUBLIC_DISABLED` body.
+    """
+    if not _public_enabled():
+        raise _FeatureDisabled()
 
 
 router = APIRouter(
     prefix="/api/visa/voa",
     tags=["garuda-voa-public"],
     route_class=_ContractErrorRoute,
+    dependencies=[Depends(_require_public_enabled)],
 )
 
-_FEATURE_FLAG_ENV = "GARUDA_PUBLIC_ENABLED"
 _RESULT_SESSION_COOKIE = "garuda_result_session"
 
 #: `#/components/schemas/ResultId` verbatim.
@@ -246,10 +298,6 @@ def strip_unreachable_validation_errors(schema: dict) -> dict:
     return schema
 
 
-def _public_enabled() -> bool:
-    return os.environ.get(_FEATURE_FLAG_ENV, "").strip().lower() in {"1", "true", "yes"}
-
-
 def _valid_idempotency_key(value: str | None) -> str | None:
     if value is None:
         return None
@@ -396,9 +444,6 @@ async def create_eligibility_check(
     idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
     store: CheckStore = Depends(get_garuda_check_store),
 ) -> Response:
-    if not _public_enabled():
-        return _error("GARUDA_PUBLIC_DISABLED")
-
     key = _valid_idempotency_key(idempotency_key)
     if key is None:
         return _error("IDEMPOTENCY_KEY_REQUIRED")
@@ -457,9 +502,6 @@ async def get_eligibility_result(
     garuda_result_session: Annotated[str | None, Cookie()] = None,
     store: CheckStore = Depends(get_garuda_check_store),
 ) -> Response:
-    if not _public_enabled():
-        return _error("GARUDA_PUBLIC_DISABLED")
-
     # Non-enumerating: malformed id, absent cookie, and a real-but-unbound id
     # all take the identical path to RESULT_NOT_FOUND (contract, verbatim).
     if _RESULT_ID_PATTERN.fullmatch(result_id) is None or garuda_result_session is None:
@@ -491,9 +533,6 @@ async def delete_eligibility_result(
     garuda_result_session: Annotated[str | None, Cookie()] = None,
     store: CheckStore = Depends(get_garuda_check_store),
 ) -> Response:
-    if not _public_enabled():
-        return _error("GARUDA_PUBLIC_DISABLED")
-
     key = _valid_idempotency_key(idempotency_key)
     if key is None:
         return _error("IDEMPOTENCY_KEY_REQUIRED")

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_public_enabled_readers_agree.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_public_enabled_readers_agree.py
@@ -1,0 +1,65 @@
+"""GARUDA VOA `GARUDA_PUBLIC_ENABLED` — three readers, one verdict.
+
+Gear-3 gate finding D (PR #4959): `garuda_orders_router._flag_enabled()`
+used to read `os.environ.get(..., "false").lower() == "true"` (strict,
+exact "true") while `garuda_voa_public._public_enabled()` and
+`garuda_portal_auth._public_enabled()` read
+`os.environ.get(..., "").strip().lower() in {"1", "true", "yes"}`
+(permissive, trimmed, case-insensitive). `GARUDA_PUBLIC_ENABLED=1` opened
+L2 (eligibility funnel) and L4 (magic-link auth) while leaving L3 (orders/
+checkout) dark — a customer could get a quote and never be able to check
+out.
+
+All three readers now share the exact same body (kept as local per-file
+copies, not a shared import, per LANES.md file-ownership discipline). This
+test pins them identical across the value matrix the finding named: unset,
+empty, "0", "false", "on", "1", "true", "TRUE", "yes".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.app.routers import garuda_orders_router, garuda_portal_auth, garuda_voa_public
+
+_READERS = (
+    ("garuda_voa_public", garuda_voa_public._public_enabled),
+    ("garuda_orders_router", garuda_orders_router._flag_enabled),
+    ("garuda_portal_auth", garuda_portal_auth._public_enabled),
+)
+
+# (env value or None for unset, expected verdict)
+_VALUE_MATRIX: list[tuple[str | None, bool]] = [
+    (None, False),
+    ("", False),
+    ("0", False),
+    ("false", False),
+    ("on", False),
+    ("1", True),
+    ("true", True),
+    ("TRUE", True),
+    ("yes", True),
+]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    _VALUE_MATRIX,
+    ids=[repr(v) for v, _ in _VALUE_MATRIX],
+)
+def test_all_three_readers_agree(
+    value: str | None, expected: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if value is None:
+        monkeypatch.delenv("GARUDA_PUBLIC_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", value)
+
+    results = {name: reader() for name, reader in _READERS}
+
+    assert results == {name: expected for name, _ in _READERS}, (
+        f"readers disagree for GARUDA_PUBLIC_ENABLED={value!r}: {results} "
+        f"(all expected {expected}) — this is exactly the class of bug "
+        f"finding D caught: one router opens while a sibling stays dark "
+        f"for the same env value."
+    )

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_flag_ordering.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_flag_ordering.py
@@ -1,0 +1,114 @@
+"""GARUDA VOA "dark by flag" ordering — Gear-3 gate finding B (PR #4959).
+
+With `GARUDA_PUBLIC_ENABLED` unset (production default), every GARUDA VOA
+route across all three lanes must answer 404 `GARUDA_PUBLIC_DISABLED`
+*before* touching anything downstream — no `Depends(get_repository)` 503,
+no Pydantic-body-validation 422.
+
+Two structural causes the gate measured on PR #4959, both proven wrong here
+by exercising the REAL failure conditions rather than a body that happens
+to validate:
+
+1. `garuda_orders_router.py`'s handlers all take
+   `repository: GarudaOrderRepository = Depends(get_repository)`, and
+   FastAPI resolves parameter dependencies BEFORE the handler body runs —
+   `_require_flag()` as the first statement inside the handler is too late.
+   This app is built with NO `app.state.garuda_order_repository` at all
+   (the finding's own words: "including the orders routes with no
+   repository wired"), so before the fix these 503 instead of 404.
+
+2. `garuda_voa_public.py`'s `create_eligibility_check` takes
+   `payload: EligibilityCheckRequest` as a Pydantic body model — FastAPI
+   validates the body before the handler runs too. An EMPTY body (`{}`)
+   fails that validation, and `_ContractErrorRoute` turns
+   `RequestValidationError` into a 422 INVALID_REQUEST — a response shape
+   only a live, mounted GARUDA route can ever produce. Before the fix, a
+   deliberately empty/invalid body proves this; the sibling test
+   `test_garuda_voa_public.py::test_flag_disabled_by_default_returns_404_
+   for_all_three_ops` stayed green throughout because it happens to POST a
+   fully VALID body, so it never exercised this ordering bug.
+
+Every route is hit with the crudest possible input on purpose — an empty
+JSON body for POSTs, an arbitrary path segment for path params — because
+the whole point is that NONE of that should matter: the flag gate must
+answer before body shape or repository wiring are even considered.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.routers import garuda_orders_router, garuda_portal_auth, garuda_voa_public
+
+# (case id, method, path, kwargs) — deliberately malformed/empty bodies and
+# an app with NOTHING wired onto app.state: no repository, no check store
+# override, no session verifier, no payment provider, no magic-link store.
+GARUDA_ROUTES: list[tuple[str, str, str, dict]] = [
+    ("create_eligibility_check", "POST", "/api/visa/voa/eligibility-checks", {"json": {}}),
+    ("get_eligibility_result", "GET", "/api/visa/voa/eligibility-checks/" + "r" * 22, {}),
+    ("delete_eligibility_result", "DELETE", "/api/visa/voa/eligibility-checks/" + "r" * 22, {}),
+    ("create_order_from_check", "POST", "/api/visa/voa/orders", {"json": {}}),
+    ("get_order_and_practice", "GET", "/api/visa/voa/orders/ord_abc123", {}),
+    (
+        "observe_payment_browser_return",
+        "POST",
+        "/api/visa/voa/orders/ord_abc123/browser-return-observations",
+        {"json": {}},
+    ),
+    ("receive_payment_webhook", "POST", "/api/visa/voa/webhooks/payment", {"content": b"{}"}),
+    (
+        "resolve_late_order",
+        "POST",
+        "/api/visa/voa/staff/orders/ord_abc123/late-resolution",
+        {"json": {}},
+    ),
+    ("request_magic_link", "POST", "/api/visa/voa/auth/magic-links", {"json": {}}),
+    ("exchange_magic_link", "POST", "/api/visa/voa/auth/sessions", {"json": {}}),
+]
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(garuda_voa_public.router)
+    app.include_router(garuda_orders_router.router)
+    app.include_router(garuda_portal_auth.router)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _garuda_public_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GARUDA_PUBLIC_ENABLED", raising=False)
+
+
+@pytest.mark.parametrize(
+    "case_id,method,path,kwargs",
+    GARUDA_ROUTES,
+    ids=[case[0] for case in GARUDA_ROUTES],
+)
+def test_dark_by_flag_beats_body_validation_and_repository_wiring(
+    case_id: str, method: str, path: str, kwargs: dict
+) -> None:
+    client = TestClient(_app())
+    response = client.request(method, path, **kwargs)
+    assert response.status_code == 404, (
+        f"{case_id} ({method} {path}) answered {response.status_code} with "
+        f"GARUDA_PUBLIC_ENABLED unset — body {response.text!r}. A dark-"
+        f"launched route must 404 before it ever reaches body validation or "
+        f"a Depends() that needs app.state wiring; anything else is an "
+        f"anonymous existence-and-liveness oracle on a route this same PR "
+        f"is adding to the public allowlist."
+    )
+    # Two contract-error-body shapes coexist on purpose here, and unifying
+    # them is a separate, out-of-scope concern from this test's ordering
+    # claim: `garuda_voa_public.py` / `garuda_portal_auth.py` use the
+    # `_ContractErrorRoute` + `_error()` shape (`{"code": ..., ...}` at the
+    # top level); `garuda_orders_router.py` raises a bare `HTTPException`,
+    # whose default FastAPI envelope nests the same payload under
+    # `"detail"`. Both are asserted here because this test's job is
+    # "flag beats body validation and repository wiring", not "all three
+    # GARUDA routers share one error envelope".
+    body = response.json()
+    code = body.get("code") or (body.get("detail") or {}).get("code")
+    assert code == "GARUDA_PUBLIC_DISABLED", body

--- a/apps/backend-rag/backend/tests/unit/middleware/test_public_endpoints_registry.py
+++ b/apps/backend-rag/backend/tests/unit/middleware/test_public_endpoints_registry.py
@@ -327,3 +327,31 @@ class TestVisaCheckPublicRegistration:
         call_next.assert_awaited_once()
         assert result is response
         assert result.headers["X-Auth-Type"] == "public"
+
+
+class TestGarudaVoaAuthAllowlistIsExactNotPrefix:
+    """Gear-3 gate finding E (PR #4959): the block comment above the GARUDA
+    VOA entries claims "Every entry below is EXACT or TEMPLATE, never
+    PREFIX" -- the `/api/visa/voa/auth/` entry used to omit `match=`, which
+    defaults to "prefix", directly contradicting that claim. No live leak
+    (the staff late-resolution path is a disjoint literal string), but any
+    future route mounted under `/api/visa/voa/auth/` would have become
+    anonymous with no review.
+    """
+
+    def test_the_two_real_auth_routes_are_public(self):
+        assert is_public_path("/api/visa/voa/auth/magic-links")
+        assert is_public_path("/api/visa/voa/auth/sessions")
+
+    def test_an_unrelated_future_path_under_the_same_root_is_not_public(self):
+        """The literal repro from the finding -- this must be False now."""
+        assert not is_public_path("/api/visa/voa/auth/anything-future-added-here")
+
+    def test_no_entry_under_the_garuda_voa_auth_root_uses_prefix_matching(self):
+        for entry in PUBLIC_ENDPOINTS:
+            if entry.prefix.startswith("/api/visa/voa/auth"):
+                assert entry.match in ("exact", "template"), (
+                    f"{entry.prefix!r} uses match={entry.match!r} -- a PREFIX "
+                    f"entry under this root can leak any future route mounted "
+                    f"under it, exactly the finding-E defect this test guards."
+                )


### PR DESCRIPTION
## Summary
Fixes three Gear-3 adversarial gate findings measured against PR #4959.

- **Finding B**: `GARUDA_PUBLIC_ENABLED` off leaked a live 503 (`Depends(get_repository)` resolving before the flag check) or 422 (Pydantic body validation preceding it) instead of a dark 404. Fixed by moving the flag check to a **router-level dependency** on all three GARUDA VOA routers (`garuda_voa_public`, `garuda_orders_router`, `garuda_portal_auth`) -- FastAPI resolves router-level `dependencies=` before a path operation's own `Depends()` and before body validation.
- **Finding D**: `garuda_orders_router` used a strict `== "true"` env reader while the other two routers used a permissive trimmed/case-insensitive one -- `GARUDA_PUBLIC_ENABLED=1` could open L2/L4 while leaving L3 (checkout) dark. All three readers now share the identical permissive body.
- **Finding E**: the `/api/visa/voa/auth/` allowlist entry was an undeclared PREFIX match, contradicting the file's own "EXACT or TEMPLATE, never PREFIX" comment. Split into two EXACT entries for the two real routes (`magic-links`, `sessions`).

## Test plan
- [x] New test `test_garuda_voa_flag_ordering.py` -- proven red against pre-fix code (8/10 routes leaked 503/422), green after the fix (10/10 return 404 GARUDA_PUBLIC_DISABLED), including the orders routes with no repository wired.
- [x] New test `test_garuda_public_enabled_readers_agree.py` -- pins all three env-var readers identical across the value matrix (unset, "", "0", "false", "on", "1", "true", "TRUE", "yes").
- [x] New tests in `test_public_endpoints_registry.py::TestGarudaVoaAuthAllowlistIsExactNotPrefix` -- pins the two real auth routes public and the literal repro path (`/api/visa/voa/auth/anything-future-added-here`) NOT public.
- [x] Full GARUDA surface (`backend/tests/app/routers/`, `test_mutating_routes_are_gated.py`, `garuda_flow/`, `garuda_orders/`): 435 passed, 0 failed, 63 skipped + 7 errors (all pre-existing local-Postgres-role scar, `role "nuzantara" does not exist" -- unrelated to this change).

Router-level-dependencies-resolve-before-body-validation claim verified empirically by reading `fastapi==0.139.0`'s own `solve_dependencies`/`_build_dependant_with_parameterless_dependencies` source (see code comments) and confirmed by the red/green test transition, not assumed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>