### PR TITLE
fix(kb): cure 4 refuter findings on gate/probe surface (R1-R4) + 2 secondary

### DIFF
--- a/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_contract.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_contract.py
@@ -221,13 +221,67 @@ def test_a_proven_duplicate_is_not_left_untriaged(inventory):
             )
 
 
+def _proof_is_incomplete(proof: dict | None) -> bool:
+    """True when a `containment_proof` fails to affirmatively declare `complete: true`.
+
+    Replaces `.get("complete") is False` — an identity comparison against a literal
+    — which reads a MISSING `complete` key as complete: `None is False` is `False`,
+    so `{"distinct_fragments_covered": 40, "distinct_fragments_total": 65}` (no
+    `complete` key at all) was never flagged. §4.6's interlock is written for the
+    case where a gap is DECLARED; a proof that is merely silent about completeness
+    is not evidence of completeness, and this campaign's own rule (§4.6, "one
+    uncovered fragment means do not delete") means unknown must fail closed, not
+    open. `None` — no containment_proof at all — is deliberately NOT incomplete
+    by this predicate: a document that never claimed containment in the first
+    place (e.g. disposition=promote_after_repair) is a different question, owned
+    by test_nothing_is_discarded_without_a_containment_proof for
+    disposition == discard_duplicate.
+    """
+    if proof is None:
+        return False
+    return proof.get("complete") is not True
+
+
+def test_guilt_a_containment_proof_missing_complete_is_treated_as_a_gap():
+    """The exact shape measured live: `complete` is a MISSING key, not a declared
+    `false`, sitting next to `decision.deletions_authorized: true`. The old
+    `is False` predicate called this complete; §4.6 says an unproven fragment
+    blocks deletion, so this must be a gap."""
+    assert _proof_is_incomplete(
+        {"distinct_fragments_covered": 40, "distinct_fragments_total": 65}
+    )
+
+
+def test_guilt_a_containment_proof_declaring_false_is_still_a_gap():
+    """The case the old predicate already caught — must not regress."""
+    assert _proof_is_incomplete({"complete": False})
+
+
+def test_innocence_no_containment_proof_at_all_is_not_this_rules_business():
+    """A document that never claimed containment (promote_after_repair,
+    catalogue_only, blocked_identity) is not a gap by THIS predicate — it is the
+    ordinary shape of most rows in a retired_collection inventory, and flagging
+    it would make deletions_authorized:true fail on files with zero discard
+    candidates."""
+    assert _proof_is_incomplete(None) is False
+
+
+def test_innocence_a_containment_proof_declaring_complete_true_is_not_a_gap():
+    assert (
+        _proof_is_incomplete(
+            {"distinct_fragments_covered": 65, "distinct_fragments_total": 65, "complete": True}
+        )
+        is False
+    )
+
+
 def test_deletion_is_interlocked_on_a_complete_proof(inventory):
     """No deletion may be authorized while any containment proof declares a gap."""
     path, data = inventory
     incomplete = [
         doc["document_id"]
         for doc in data["documents"]
-        if (doc.get("containment_proof") or {}).get("complete") is False
+        if _proof_is_incomplete(doc.get("containment_proof"))
     ]
     if incomplete:
         assert data["decision"]["deletions_authorized"] is False, (
@@ -470,6 +524,36 @@ def test_a_retired_collection_is_named_by_no_ingest_entrypoint(inventory):
     assert offenders == [], (
         f"{path.name} declares {retired!r} retired as an ingest target, but these entrypoints still "
         f"name it: {offenders}"
+    )
+
+
+def test_the_retirement_lint_check_is_not_examining_zero_inventories():
+    """Anti-vacuity for the test above, same pattern as
+    test_the_ledger_mirror_check_is_not_examining_zero_findings below.
+
+    The cross-source check above SKIPS twice — once for `kind != retired_collection`
+    (defence in depth; the `inventory` fixture already filters this), once for
+    `decision.choice != retire_as_target`. Nothing forces at least one real file to
+    take the second branch. If none ever did, the lint would never run against a
+    real ingest entrypoint list and every parametrisation would read green while
+    checking nothing — exactly the shape MANDATE.md §4.9 warns against, and the
+    same failure class `test_the_ledger_mirror_check_is_not_examining_zero_findings`
+    already guards for `open_findings`.
+    """
+    retired_as_target = []
+    for path in _inventories():
+        data = _load(path)
+        if data.get("kind") != OWNED_KIND:
+            continue
+        if (data.get("decision") or {}).get("choice") == "retire_as_target":
+            retired_as_target.append(path.name)
+    assert retired_as_target, (
+        "no kb/inventory/*.yaml with kind=retired_collection declares "
+        "decision.choice=retire_as_target, so "
+        "test_a_retired_collection_is_named_by_no_ingest_entrypoint skips on every "
+        "parametrisation and is passing over an empty set. Either no collection is "
+        "currently queued for retirement — delete this pair of tests and say so — "
+        "or the field has been renamed and the gate now points at nothing"
     )
 
 

--- a/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_contract.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_contract.py
@@ -11,6 +11,7 @@ two outputs of one generator, and this repo has already paid for that.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
@@ -48,6 +49,89 @@ def _probe():
     sys.modules["kb_inventory_probe"] = module
     spec.loader.exec_module(module)
     return module
+
+
+# ── AST helpers: a definition/call is a real node, never a textual coincidence ─
+#
+# `"shape_drift(" in source` and `source.count("shape_drift(") >= 3` are both
+# guard-over-match (cicatrix-superscar family #3): a comment naming a function
+# three times satisfies either check with zero real definitions or call sites.
+# `kb/ops/probe_retrieval.py:648-654`'s own comment documents this exact family
+# exploding in this repo's face already. These parse the SOURCE, not grep it.
+
+
+def _defines_function(tree: ast.AST, name: str) -> bool:
+    """True only for a REAL `def name(...)` / `async def name(...)` — never a
+    comment or docstring that merely mentions the name."""
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name
+        for node in ast.walk(tree)
+    )
+
+
+def _call_count(tree: ast.AST, name: str) -> int:
+    """Real `ast.Call` nodes invoking a bare-name function called `name` — not
+    textual occurrences of the string `"name("`, which a comment or a fenced
+    code block in a docstring can inflate for free."""
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    )
+
+
+def _assigns_string_constant(tree: ast.AST, target: str, value: str) -> bool:
+    """True only for a REAL `target = "value"` module-level assignment."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == target for t in node.targets):
+            continue
+        if isinstance(node.value, ast.Constant) and node.value.value == value:
+            return True
+    return False
+
+
+def test_guilt_a_comment_mentioning_a_function_three_times_defines_nothing():
+    tree = ast.parse(
+        "# def check_topic( is mentioned here, and again: def check_topic( "
+        "and once more: def check_topic(\n"
+    )
+    assert _defines_function(tree, "check_topic") is False
+
+
+def test_innocence_a_real_function_definition_is_detected():
+    tree = ast.parse("def check_topic(x):\n    return x\n")
+    assert _defines_function(tree, "check_topic") is True
+
+
+def test_guilt_a_comment_naming_a_call_three_times_is_zero_real_calls():
+    tree = ast.parse(
+        "# shape_drift( shape_drift( shape_drift(\n"
+        "def shape_drift(a, b, c):\n    return []\n"
+    )
+    assert _call_count(tree, "shape_drift") == 0
+
+
+def test_innocence_two_real_call_sites_are_counted():
+    tree = ast.parse(
+        "def shape_drift(a, b, c):\n    return []\n"
+        "shape_drift('topic', {}, {})\n"
+        "shape_drift('read', {}, {})\n"
+    )
+    assert _call_count(tree, "shape_drift") == 2
+
+
+def test_guilt_a_comment_naming_an_assignment_is_not_the_assignment():
+    tree = ast.parse('# the real value used to be OWNED_KIND = "topic" before a rename\n')
+    assert _assigns_string_constant(tree, "OWNED_KIND", "topic") is False
+
+
+def test_innocence_a_real_assignment_is_detected():
+    tree = ast.parse('OWNED_KIND = "topic"\n')
+    assert _assigns_string_constant(tree, "OWNED_KIND", "topic") is True
 
 
 IDENTITY_VERDICTS = frozenset({"consistent", "mistyped", "contradictory", "lost"})
@@ -482,9 +566,16 @@ def test_decision_choice_is_from_the_mandates_three(inventory):
 
 # ── The two cross-source rules ───────────────────────────────────────────────
 
-def test_registry_mapped_claims_match_the_real_registry(inventory):
-    """Cross-source: check the claim against collection_registry.py itself."""
-    sys.path.insert(0, str(ROOT / "apps" / "backend-rag"))
+def test_registry_mapped_claims_match_the_real_registry(inventory, monkeypatch):
+    """Cross-source: check the claim against collection_registry.py itself.
+
+    `monkeypatch.syspath_prepend` (not a bare `sys.path.insert`): pytest restores
+    `sys.path` to its pre-test state automatically at teardown, whichever entry a
+    parametrised run leaves — a bare `sys.path.insert` with no matching `.remove`/
+    `.pop` leaks a path entry into every test that runs after this one, for the
+    rest of the process.
+    """
+    monkeypatch.syspath_prepend(str(ROOT / "apps" / "backend-rag"))
     from backend.core.collection_registry import is_known_collection
 
     path, data = inventory
@@ -618,9 +709,17 @@ def test_the_probe_actually_compares_the_recorded_shapes(inventory):
     """
     del inventory  # gate on the probe source, once per parametrisation
     source = (ROOT / "scripts" / "kb" / "kb_inventory_probe.py").read_text(encoding="utf-8")
-    assert source.count("shape_drift(") >= 3, (
-        "kb_inventory_probe.py must DEFINE shape_drift and CALL it for the topic "
-        "collection and the read collection — found fewer than 3 occurrences"
+    tree = ast.parse(source)
+    assert _defines_function(tree, "shape_drift"), (
+        "kb_inventory_probe.py must DEFINE shape_drift — no real `def shape_drift` "
+        "found (a comment naming it does not count — see _defines_function)"
+    )
+    calls = _call_count(tree, "shape_drift")
+    assert calls >= 2, (
+        f"kb_inventory_probe.py must CALL shape_drift for both the topic collection "
+        f"and the read collection — found {calls} real ast.Call site(s). A comment "
+        f"naming the string three times used to satisfy this check with zero real "
+        f"calls; this counts actual Call nodes, not text occurrences."
     )
     probe = _probe()
     findings = probe.shape_drift("c", {"modern_full": 5}, {"modern_full": 4})
@@ -656,12 +755,18 @@ def test_the_gate_this_module_defers_topic_inventories_to_actually_exists():
         f"judged by nobody"
     )
     source = owner.read_text(encoding="utf-8")
-    assert 'OWNED_KIND = "topic"' in source, (
-        f"{owner.name} exists but no longer claims kind='topic' — the deferral in this "
-        f"module now points at a gate that has stopped owning what it defers"
+    tree = ast.parse(source)
+    assert _assigns_string_constant(tree, "OWNED_KIND", "topic"), (
+        f"{owner.name} exists but no real `OWNED_KIND = \"topic\"` assignment was "
+        f"found — the deferral in this module now points at a gate that has "
+        f"stopped owning what it defers (a comment mentioning the assignment does "
+        f"not count — see _assigns_string_constant)"
     )
-    for rule in ("def check_topic(", "def check_journey(", "def check_topic_inventory("):
-        assert rule in source, f"{owner.name} no longer defines {rule!r}"
+    for rule in ("check_topic", "check_journey", "check_topic_inventory"):
+        assert _defines_function(tree, rule), (
+            f"{owner.name} no longer defines def {rule}( — a comment naming it "
+            f"does not count"
+        )
 
 
 GATED_DIRS = ("topics", "journeys", "inventory")

--- a/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_probe_topic.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_kb_inventory_probe_topic.py
@@ -120,8 +120,12 @@ def _modern_full(doc_id: str) -> dict:
 # to that table cannot silently desync from what this test expects.
 
 
-def test_resolve_physical_maps_the_logical_alias_to_the_live_collection():
-    sys.path.insert(0, str(ROOT / "apps" / "backend-rag"))
+def test_resolve_physical_maps_the_logical_alias_to_the_live_collection(monkeypatch):
+    # monkeypatch.syspath_prepend, not a bare sys.path.insert with no matching
+    # .remove/.pop: pytest restores sys.path at teardown, so this cannot leak a
+    # path entry into every test collected after this one for the rest of the
+    # process (the defect this same cure closes in test_kb_inventory_contract.py).
+    monkeypatch.syspath_prepend(str(ROOT / "apps" / "backend-rag"))
     from backend.core.collection_registry import LOGICAL_TO_PHYSICAL_COLLECTIONS
 
     assert PROBE.resolve_physical("legal_unified") == LOGICAL_TO_PHYSICAL_COLLECTIONS["legal_unified"]

--- a/apps/backend-rag/backend/tests/unit/kb/test_probe_retrieval_refusals.py
+++ b/apps/backend-rag/backend/tests/unit/kb/test_probe_retrieval_refusals.py
@@ -562,3 +562,250 @@ def test_innocence_the_three_real_measured_states_are_unchanged_by_the_fail_clos
     the six individual tests above it, so a future edit that silently narrows
     ANY one of the six is caught by name, not just by absence of an exception."""
     assert PROBE.journey_satisfaction(state, expectation) is expected
+
+
+# ── Section G: a degraded path cannot certify a canary's safety (R2/R3) ───────
+#
+# `warn_if_degraded`'s own docstring says a degraded-path verdict is "a LOWER
+# BOUND on what production retrieves — never an upper one," because disabled
+# query expansion can only narrow what comes back. That is the right direction
+# for `expectation: retrieves`. For `must_not_retrieve` it is inverted: a
+# narrower search can only make a poisoned instrument HARDER to find, so a
+# canary that stayed red under degradation is an UPPER bound on safety, not
+# proof of it. Before this fix a satisfied canary was accepted unconditionally
+# and could feed straight into "AT TARGET ... canaries stayed red" — a positive
+# safety claim the measurement did not support. R3, same finding batch: a
+# `drift` verdict used to make an independent `outstanding` fact (a live
+# regression, or now an unverifiable canary) disappear from both the JSON and
+# the human report, because the two were collapsed into one ordinal exit code.
+
+
+def test_innocence_a_retrieves_journey_is_never_flagged_regardless_of_degradation():
+    assert PROBE.canary_unverifiable_under_degradation("retrieves", True, True) is False
+    assert PROBE.canary_unverifiable_under_degradation("retrieves", False, True) is False
+
+
+def test_innocence_a_canary_is_trusted_when_the_path_is_not_degraded():
+    assert PROBE.canary_unverifiable_under_degradation("must_not_retrieve", True, False) is False
+
+
+def test_innocence_a_violated_canary_is_not_unverifiable_it_is_just_violated():
+    """satisfied=False under degradation is still real evidence — the poison came
+    back despite a narrower search. That branch is handled by the `if not
+    satisfied` arm in run(), never by this predicate."""
+    assert PROBE.canary_unverifiable_under_degradation("must_not_retrieve", False, True) is False
+
+
+def test_guilt_a_satisfied_canary_under_a_degraded_path_is_unverifiable():
+    """The exact shape this fix exists for: the poison stayed red, but the run
+    that measured it was not running production's retrieval path."""
+    assert PROBE.canary_unverifiable_under_degradation("must_not_retrieve", True, True) is True
+
+
+CANARY_DEGRADATION_TABLE = [
+    ("retrieves", True, True, False),
+    ("retrieves", True, False, False),
+    ("retrieves", False, True, False),
+    ("retrieves", False, False, False),
+    ("must_not_retrieve", True, True, True),
+    ("must_not_retrieve", True, False, False),
+    ("must_not_retrieve", False, True, False),
+    ("must_not_retrieve", False, False, False),
+    (None, True, True, False),
+    ("", True, True, False),
+]
+
+
+@pytest.mark.parametrize(
+    "expectation,satisfied,degraded,expected", CANARY_DEGRADATION_TABLE,
+    ids=[f"{e}+sat={s}+deg={d}" for e, s, d, _ in CANARY_DEGRADATION_TABLE],
+)
+def test_the_full_truth_table_has_exactly_one_true_cell(expectation, satisfied, degraded, expected):
+    """Only expectation=must_not_retrieve, satisfied=True, degraded=True is
+    unverifiable — every other combination, including an unrecognised or empty
+    expectation, must fall through False rather than raise or default open."""
+    assert PROBE.canary_unverifiable_under_degradation(expectation, satisfied, degraded) is expected
+
+
+def test_the_predicate_is_wired_into_run_between_grading_and_the_final_verdict():
+    """A predicate nobody calls is decoration (same discipline as Section A/C's
+    wiring tests). It must run inside the per-journey loop, after
+    journey_satisfaction has decided `satisfied`, and its result must land in
+    `outstanding` before the exit code is derived."""
+    import inspect
+
+    src = inspect.getsource(PROBE.run)
+    assert "canary_unverifiable_under_degradation(" in src, (
+        "the degraded-canary predicate is defined but never called from run()"
+    )
+    before_exit_code = src.split("exit_code = 0")[0]
+    assert "canary_unverifiable_under_degradation(" in before_exit_code, (
+        "the predicate must be consulted before exit_code is derived from "
+        "drift/outstanding, or its result cannot affect the verdict"
+    )
+    after_satisfaction = src.split("satisfied = journey_satisfaction(")[1]
+    assert "canary_unverifiable_under_degradation(" in after_satisfaction, (
+        "the predicate needs `satisfied`, computed by journey_satisfaction — it "
+        "must run after that call, not before"
+    )
+
+
+# ── full run() integration, mocked retrieval (no Qdrant) ──────────────────────
+# Section D already establishes the pattern: monkeypatch SearchService so run()
+# never touches production, and drive the real async function end to end. That
+# proves the wiring survives refactors a source-inspection test cannot catch —
+# e.g. the predicate's result computed but never appended to `outstanding`.
+
+
+class _FakeCollectionManager:
+    def get_collection(self, name):  # noqa: D401 - trivial fake
+        return object()
+
+
+class _FakeSearchService:
+    """Answers CONTROL_QUERY with a chunk containing CONTROL_PHRASE, and every
+    other query from a caller-supplied map — the same shape SearchService.search()
+    returns (a dict with a "results" list of chunk dicts)."""
+
+    def __init__(self, hits_by_query):
+        self._hits_by_query = hits_by_query
+        self.collection_manager = _FakeCollectionManager()
+
+    async def search(self, *, query, user_level, limit, collection_override):
+        if query == PROBE.CONTROL_QUERY:
+            return {"results": [{"text": "ketentuan " + PROBE.CONTROL_PHRASE}]}
+        return {"results": self._hits_by_query.get(query, [])}
+
+
+def _install_fake_search_service(monkeypatch, hits_by_query):
+    monkeypatch.setattr(
+        "backend.services.search.search_service.SearchService",
+        lambda: _FakeSearchService(hits_by_query),
+    )
+
+
+def _canary_journeys_file(tmp_path, *, recorded="red"):
+    """One must_not_retrieve canary whose poison phrase is never retrieved."""
+    entry = {
+        "question": "apakah dokumen ini membahas properti",
+        "verbatim_phrase": "klausa properti yang tidak boleh muncul di sini",
+        "instrument_id": "POISON_1_2026",
+        "expectation": "must_not_retrieve",
+        "probe_state": recorded,
+        "probe_run_at": "2026-08-25",
+        "reason": "synthetic poison for the degraded-canary test",
+    }
+    path = tmp_path / "canary.yaml"
+    path.write_text(
+        _json.dumps({"schema_version": 1, "lane": "A", "journeys": [entry]}),
+        encoding="utf-8",
+    )
+    return path, entry["question"]
+
+
+def test_guilt_a_satisfied_canary_under_a_degraded_run_does_not_reach_at_target(
+    tmp_path, monkeypatch, capsys
+):
+    """R2, end to end: the poison never comes back, but the run is degraded — the
+    old code exited 0 with an 'AT TARGET ... canaries stayed red' banner. This
+    must now exit non-zero and name the canary UNVERIFIABLE, in both output
+    modes."""
+    path, question = _canary_journeys_file(tmp_path)
+    _install_fake_search_service(monkeypatch, {question: []})
+    monkeypatch.setattr(PROBE, "detect_degraded", lambda root: "google-genai installed 1.75.0, repo pins 2.18.1")
+    monkeypatch.setattr(PROBE, "warn_if_degraded", lambda root: True)
+
+    json_exit = asyncio.run(PROBE.run([str(path), "--json"]))
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert json_exit == 2, payload
+    assert payload["verdict"] == "outstanding"
+    assert payload["degraded_path"] is True
+    assert any("CANARY UNVERIFIABLE" in item for item in payload["outstanding"])
+
+    human_exit = asyncio.run(PROBE.run([str(path)]))
+    out = capsys.readouterr().out
+    assert human_exit == 2
+    assert "AT TARGET" not in out, "a degraded canary must not reach the safety banner"
+    assert "CANARY UNVERIFIABLE" in out
+
+
+def test_innocence_a_satisfied_canary_on_the_production_path_still_reaches_at_target(
+    tmp_path, monkeypatch, capsys
+):
+    """The cure must not punish the ordinary case — a canary satisfied while the
+    path is NOT degraded is exactly what 'AT TARGET' has always meant."""
+    path, question = _canary_journeys_file(tmp_path)
+    _install_fake_search_service(monkeypatch, {question: []})
+    monkeypatch.setattr(PROBE, "detect_degraded", lambda root: None)
+    monkeypatch.setattr(PROBE, "warn_if_degraded", lambda root: False)
+
+    json_exit = asyncio.run(PROBE.run([str(path), "--json"]))
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert json_exit == 0, payload
+    assert payload["verdict"] == "at_target"
+    assert payload["outstanding"] == []
+
+    human_exit = asyncio.run(PROBE.run([str(path)]))
+    out = capsys.readouterr().out
+    assert human_exit == 0
+    assert "AT TARGET" in out
+
+
+def test_a_drift_verdict_no_longer_hides_a_live_regression(tmp_path, monkeypatch, capsys):
+    """R3, end to end: one journey drifts (recorded state disagrees with
+    production) alongside a canary that is unverifiable under degradation. The
+    exit code stays 1 (drift keeps its historical priority — no consumer's
+    vocabulary changes), but both facts must be visible in the JSON's
+    `outstanding` list and in the human text, not just the collapsed verdict."""
+    stale_question = "berapa lama izin tinggal berlaku untuk pemegang KITAS"
+    canary_path, canary_question = _canary_journeys_file(tmp_path)
+    entries = [
+        {
+            "question": stale_question,
+            "verbatim_phrase": "izin tinggal terbatas berlaku paling lama",
+            "instrument_id": "UU_X_2026",
+            "expectation": "retrieves",
+            # recorded 'red', production now measures 'green' -> DRIFT
+            "probe_state": "red",
+            "probe_run_at": "2026-08-01",
+        },
+        {
+            "question": canary_question,
+            "verbatim_phrase": "klausa properti yang tidak boleh muncul di sini",
+            "instrument_id": "POISON_1_2026",
+            "expectation": "must_not_retrieve",
+            "probe_state": "red",
+            "probe_run_at": "2026-08-25",
+            "reason": "synthetic poison for the drift+outstanding test",
+        },
+    ]
+    path = tmp_path / "drift_and_canary.yaml"
+    path.write_text(
+        _json.dumps({"schema_version": 1, "lane": "A", "journeys": entries}),
+        encoding="utf-8",
+    )
+    hits = {
+        stale_question: [{"text": "izin tinggal terbatas berlaku paling lama dua tahun",
+                           "document_id": "UU_X_2026"}],
+        canary_question: [],
+    }
+    _install_fake_search_service(monkeypatch, hits)
+    monkeypatch.setattr(PROBE, "detect_degraded", lambda root: "mismatch")
+    monkeypatch.setattr(PROBE, "warn_if_degraded", lambda root: True)
+
+    json_exit = asyncio.run(PROBE.run([str(path), "--json"]))
+    payload = _json.loads(capsys.readouterr().out.strip())
+    assert json_exit == 1
+    assert payload["verdict"] == "drift"
+    assert payload["drift"], "the drift list itself must not be dropped"
+    assert any("CANARY UNVERIFIABLE" in item for item in payload["outstanding"]), (
+        "the live outstanding fact must survive next to a 'drift' verdict, not "
+        "be masked by it"
+    )
+
+    human_exit = asyncio.run(PROBE.run([str(path)]))
+    out = capsys.readouterr().out
+    assert human_exit == 1
+    assert "DRIFT" in out
+    assert "OUTSTANDING" in out, "outstanding must print even when drift decides the exit code"
+    assert "CANARY UNVERIFIABLE" in out

--- a/kb/ops/probe_retrieval.py
+++ b/kb/ops/probe_retrieval.py
@@ -323,6 +323,36 @@ def journey_satisfaction(measured_state: str, expectation: str) -> bool:
     return False  # an unrecognised expectation satisfies nothing, ever
 
 
+def canary_unverifiable_under_degradation(
+    expectation: str, satisfied: bool, degraded: bool
+) -> bool:
+    """True when a SATISFIED canary's result is not trustworthy proof of safety.
+
+    `warn_if_degraded`'s own docstring calls a degraded-path verdict "a LOWER
+    BOUND on what production retrieves — never an upper one," because disabled
+    query expansion can only NARROW what comes back. That direction is correct
+    for `expectation: retrieves` (a red measured here may be green in
+    production — the file already prints exactly that caveat). For
+    `must_not_retrieve` it is inverted: a NARROWER search can only make a
+    poisoned instrument HARDER to find, so a canary that stayed red under a
+    degraded path is an UPPER bound on safety, not a lower one — production's
+    wider search could still surface what this run could not. Refuter finding
+    R2 (2026-08-26): the run's final verdict and its `AT TARGET ... canaries
+    stayed red` banner did not carry this distinction at all, so a degraded run
+    could declare a topic safe on evidence that, by this module's own stated
+    logic, proves the opposite of what it is being read as.
+
+    Only a SATISFIED canary is unverifiable this way — a VIOLATED canary
+    (`satisfied=False`) under degradation is still real evidence: the poison
+    came back despite a narrower search, which is if anything stronger proof of
+    a live regression, and that branch already lands in `outstanding`
+    regardless of `degraded`. A `retrieves` journey is never affected, at any
+    value of `satisfied` or `degraded` — the lower-bound direction for it was
+    always sound and is untouched by this predicate.
+    """
+    return expectation == "must_not_retrieve" and satisfied and degraded
+
+
 def locate_phrase(chunks: list[dict], phrase: str, instrument_id: str) -> dict:
     """Where the phrase is, and — the point of this function — WHOSE it is.
 
@@ -840,6 +870,21 @@ async def run(argv=None) -> int:
                     "journey %d: %r is not in the retrieved context for %r"
                     % (i, phrase[:48], question[:48])
                 )
+        elif canary_unverifiable_under_degradation(expectation, satisfied, degraded):
+            # R2 (refuter finding, 2026-08-26): a canary that measured 'safe' while
+            # this run took the DEGRADED path (see warn_if_degraded's docstring) is
+            # not proof of safety — a narrower search can only make a poisoned
+            # instrument HARDER to find, so this is an upper bound, not a lower
+            # one. Landing this in `outstanding` (not silently accepted) is what
+            # stops the AT TARGET banner below from affirming a safety this run
+            # did not actually measure.
+            outstanding.append(
+                "journey %d: CANARY UNVERIFIABLE — %r stayed red, but retrieval ran "
+                "the DEGRADED path (see the banner above): a narrower search can only "
+                "make a poisoned instrument HARDER to find, so this is an upper bound "
+                "on safety, not proof of it. Re-verify on the production retrieval "
+                "path before trusting this canary." % (i, phrase[:48])
+            )
 
     exit_code = 0
     if drift:
@@ -847,6 +892,18 @@ async def run(argv=None) -> int:
     elif outstanding:
         exit_code = 2
 
+    # R3 (refuter finding, 2026-08-26): `drift` and `outstanding` are two
+    # independent facts about this run, and collapsing them into one exit code
+    # was already this campaign's own diagnosed mistake once — see
+    # test_kb_probe_history_contract.py's rule (g), "build_record keeps the two
+    # verdicts DISTINCT, never AND'd". Applying that same lesson here: the exit
+    # code (and therefore VERDICT_BY_EXIT, which kb_inventory_probe.py's --json
+    # mirrors string-for-string, and which probe_history.py's closed vocabulary
+    # is built from) keeps DRIFT's historical priority over OUTSTANDING for
+    # backward compatibility — no consumer's vocabulary changes. What changes is
+    # that a live regression no longer goes INVISIBLE just because drift also
+    # fired this run: both raw lists are reported, in the JSON and in the human
+    # text, regardless of which one decided the exit code.
     if args.json:
         print(json.dumps({
             "journeys_file": str(args.journeys),
@@ -854,6 +911,8 @@ async def run(argv=None) -> int:
             "verdict": VERDICT_BY_EXIT[exit_code],
             "exit_code": exit_code,
             "degraded_path": degraded,
+            "drift": drift,
+            "outstanding": outstanding,
             "journeys": reported,
         }))
         return exit_code
@@ -866,7 +925,6 @@ async def run(argv=None) -> int:
         print()
         print("The journey file is STALE. Update probe_state / probe_run_at by hand —")
         print("this tool deliberately will not write its own expected value back.")
-        return 1
 
     if outstanding:
         print("OUTSTANDING — %d of %d journeys are not satisfied:"
@@ -876,9 +934,14 @@ async def run(argv=None) -> int:
         print()
         print("For a plain 'retrieves' journey, red is the state it is SUPPOSED to be")
         print("in on the day it is written (§3) — work still to do, not a bug in this")
-        print("run. A line above naming a CANARY VIOLATED, or a WRONG instrument, is")
-        print("not routine coverage — it is a live regression the campaign exists to")
+        print("run. A line above naming a CANARY VIOLATED, a WRONG instrument, or a")
+        print("CANARY UNVERIFIABLE (degraded path), is not routine coverage — it is a")
+        print("live regression, or an untrustworthy proof, the campaign exists to")
         print("catch. Read which kind each line is before treating it as expected.")
+
+    if drift:
+        return 1
+    if outstanding:
         return 2
 
     print("AT TARGET — every journey is satisfied: 'retrieves' journeys found their")


### PR DESCRIPTION
## Summary

Cures four cross-family-refuter findings on the KB campaign's gate/probe surface (all pre-diagnosed by the team lead at the code level — this PR is the cure + proof, not the diagnosis), plus two secondary findings from the same pass.

- **R1** — `test_deletion_is_interlocked_on_a_complete_proof` used `.get("complete") is False`, an identity comparison a MISSING `complete` key also satisfies (`None is False` → `False`). A `containment_proof` that never declares `complete` at all passed the §4.6 interlock green next to `deletions_authorized: true`. Extracted `_proof_is_incomplete()` (`is not True`, fail-closed on silence) with guilt/innocence proof, including an innocence case for documents that never claimed containment at all (most rows in a retired_collection inventory).
- **R2** — `probe_retrieval.py`: a `must_not_retrieve` canary satisfied while the retrieval path is degraded (no Gemini query expansion) is an *upper* bound on safety, not proof of it — a narrower search can only make a poison harder to find. The run used to accept a satisfied canary unconditionally and could reach "AT TARGET ... canaries stayed red" on evidence that, by the module's own stated lower-bound logic, proves the opposite. Added `canary_unverifiable_under_degradation()`, wired into the per-journey loop; a violated canary is untouched (still real evidence).
- **R3** — same file: `drift` and `outstanding` were collapsed into one exit code, so a `drift` verdict made an independent `outstanding` fact (including R2's new finding) invisible in both the JSON and the human report. Exit-code priority is unchanged (no consumer's vocabulary — `VERDICT_BY_EXIT`, `kb_inventory_probe.py`'s mirror, `probe_history.py`'s closed vocabulary — moves), but both raw lists are now always reported.
- **R4** — anti-vacuity: `test_a_retired_collection_is_named_by_no_ingest_entrypoint` skips when `decision.choice != retire_as_target`; nothing forced at least one real inventory into that branch, so if the corpus ever reached zero retirement targets the cross-source ingest-entrypoint lint would silently stop running. Added `test_the_retirement_lint_check_is_not_examining_zero_inventories`, reusing this file's own established anti-vacuity pattern.
- **Secondary 1** — two guard-over-match substring/count checks (`source.count("shape_drift(") >= 3`, `'OWNED_KIND = "topic"' in source`, `"def check_topic(" in source`) satisfiable by a comment mentioning the string, with zero real definitions/calls. Replaced with `ast.parse` + real `FunctionDef`/`Call`/`Assign` node matching.
- **Secondary 2** — two `sys.path.insert(0, ...)` with no matching `.remove`/`.pop`, leaking a path entry into every test collected after them. Switched to `monkeypatch.syspath_prepend`, which pytest restores automatically.

All four primary fixes are mutation-proven: each defect was reintroduced via a Python script (never `sed`) against the actual committed fix, a real `git diff` was shown, the relevant guilt test/case was confirmed RED, then restored via `git checkout --` and confirmed `git diff` empty — done as three separate rounds (R1, R4, R2, R3) after each real fix had already landed in a commit, so the restore point was the fix, never the pre-fix state.

## Constraints honored

- Zero writes to Qdrant, zero deletions from any collection.
- `kb/inventory/*.yaml` / `kb/journeys/*.yaml` untouched at rest — `legal_unified_2026.yaml` was mutated only transiently for R4's mutation proof and restored via `git checkout --`, confirmed empty diff.
- No `--no-verify`, no `--amend` on pushed commits.
- **NOT armed for auto-merge** — this branch targets `feature/kb-current`, which has no required context; the team lead merges by hand.

## Test plan

```
cd apps/backend-rag
PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/kb backend/tests/services/ingestion --color=no
```
`475 passed, 72 skipped in ~18-20s` (no `-q` on the CLI — `pyproject.toml` already sets it in `addopts`, and stacking `-qq` would suppress the summary line; anti-vacuity confirmed by the explicit `N passed` line every run).

- [x] Full mandated suite green, summary line captured every run (not just exit code)
- [x] R1 mutation-proven (real diff, guilt test red, restored, empty diff)
- [x] R2 mutation-proven (real diff, both integration tests red, restored, empty diff)
- [x] R3 mutation-proven (real diff, `KeyError` on the dropped JSON field, restored, empty diff)
- [x] R4 mutation-proven (real diff on the real inventory file, anti-vacuity test red, restored via `git checkout --`, empty diff)
- [x] Secondary 1/2 covered by their own guilt/innocence cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>