### PR TITLE
chore(regulatory-watcher): emit 2026-08-26 delta (0 new)

### DIFF
--- a/research/regulatory/2026-08-26-delta.json
+++ b/research/regulatory/2026-08-26-delta.json
@@ -1,0 +1,93 @@
+{
+  "run_at": "2026-08-26T07:52:25+08:00",
+  "today": "2026-08-26",
+  "yesterday_seen_count": 22,
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "http_403",
+      "note": "WAF/Cloudflare block (HTTP 403), persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://muc.co.id/article",
+      "reason": "http_403",
+      "note": "HTTP 403, persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ortax.org/news",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but 'Artikel tidak ditemukan' SPA shell, no extractable content (same as 2026-08-24/25)"
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/peraturan",
+      "reason": "timeout",
+      "note": "Connection timed out after 30s, persisted after 1 retry"
+    }
+  ],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "Freshest dated item 24 Agu 2026 (PMK 44/2026, KPP helpdesk consult procedure) already in seen_citations; PP 20/2026 mention also duplicate; PP 49/2022 cited in an unrelated gold-bullion VAT article, not new"
+    },
+    {
+      "url": "https://ikpi.or.id/berita/",
+      "reason": "checked_no_new",
+      "note": "Freshest items dated 25/08/2026 are LCC competition coverage + IKPI internal digital-infra/anniversary news, no numbered regulation promulgated"
+    },
+    {
+      "url": "https://peraturan.go.id",
+      "reason": "outside_window",
+      "note": "Newest entries (Permen Pendidikan Dasar Menengah 20/2026, Permen PANRB 15/16/2026, Permen LH 11/2026, Permenag 17/2026) dated 'diundangkan 1 minggu yang lalu' (~14-19 Aug 2026), outside 48h window"
+    },
+    {
+      "url": "https://peraturan.bpk.go.id/Search?type=PerundangUndangan&jenis=PMK&tahun=2026",
+      "reason": "outside_window",
+      "note": "Newest result PP Nomor 31 Tahun 2026, 'berlaku mulai sebulan yang lalu', outside 48h window"
+    },
+    {
+      "url": "https://www.imigrasi.go.id",
+      "reason": "checked_no_new",
+      "note": "Freshest Siaran Pers dated 25 Agu 2026 is an enforcement/deportation press release (Russian national filming KNPB demonstration in Wamena) citing existing UU Nomor 6 Tahun 2011 tentang Keimigrasian Pasal 122 huruf a — no new regulation"
+    },
+    {
+      "url": "https://www.pajak.go.id/peraturan",
+      "reason": "outside_window",
+      "note": "Newest regulatory entry still PER-8/PJ/2026 dated 2026-07-28 (already in seen_citations); no entries within 48h window"
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/peraturan",
+      "reason": "checked_no_new",
+      "note": "2,567 results, default sort is hierarchy not date; no Permenaker/Permenkes item dated within 48h window found in the visible listing"
+    }
+  ],
+  "nb_query_errors": [],
+  "deltas": [],
+  "seen_citations": [
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 28 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "PMK Nomor 44 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026",
+    "Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026",
+    "PMK Nomor 57 Tahun 2026"
+  ],
+  "note": "All 4 NB-INTEL queries succeeded (auth restored — 2026-08-25's auth_expired is resolved), all returned 'nessuna novità'. Web cross-check ran on all 11 sources (5 primary + 6 backup); zero deltas matching the Step-4 service-line filter found within the 48h window. All web-source freshest items either duplicate seen_citations, fall outside the 48h window, or are non-regulatory content (enforcement press releases, LCC competition news)."
+}


### PR DESCRIPTION
## Summary
- Daily regulatory-watcher run for 2026-08-26 (WITA)
- All 4 NB-INTEL queries succeeded (auth restored from 2026-08-25's auth_expired), all returned "nessuna novità"
- All 11 web sources checked (5 primary + 6 backup): 4 unreachable (http_403 x2, empty_shell, timeout), 7 checked with no new delta
- `new_today_count: 0` — no Telegram alert sent per spec
- Data-only research capture per CLAUDE.md §15 convention, ad-hoc / not promoted to KB

## Test plan
- [x] JSON validated (`python3 -c "import json; json.load(...)"`)
- [x] Schema matches regulatory-watcher.md spec (all required arrays present, closed vocabulary respected)
- [x] Pre-commit hooks passed (secrets scan, lint, off-limits check)