### PR TITLE
fix(arsenal): the probe was killing two seats and then certifying the corpses

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -50,6 +50,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -335,21 +336,51 @@ class ProbeResult:
 
 
 def run_probe_cmd(
-    cmd: list[str], timeout: float, env: Optional[dict] = None, stdin_devnull: bool = True
+    cmd: list[str],
+    timeout: float,
+    env: Optional[dict] = None,
+    stdin_devnull: bool = True,
+    capture_via_files: bool = False,
 ) -> ProbeResult:
     """Run a probe subprocess. stdin_devnull defaults to True — NON-NEGOTIABLE (2026-08-07
     incident): every seat probe must never inherit an open stdin, because a hook/launchd/
     agent-harness caller can hand this process a pipe that is never explicitly closed. No
     caller in this file opts out; the parameter survives only so a test can override it.
+
+    ``capture_via_files=True`` gives the child real FILES for stdout/stderr instead of
+    pipes, and reads them back after the wait returns — timeout or not.
+
+    WHY THAT MATTERS (measured 2026-08-26, Pro, and it is not a micro-optimisation):
+    a CLI that leaves a detached grandchild holding the inherited stdout fd never lets
+    ``communicate()`` see EOF, so ``subprocess.run`` blocks until its own timeout AND
+    ``TimeoutExpired.stdout`` comes back **empty** — the bytes are sitting unread in the
+    pipe buffer. That is the exact shape of ``agy``: with a file it answered PONG in
+    **11 s**; through a pipe the same call was still hanging past **120 s**. The
+    consequence is worse than a slow probe — it silently defeats the "judge the REPLY,
+    not the exit code" mitigation this file already carries (scar W104), because the
+    reply the mitigation is supposed to read is exactly what the pipe withholds. A file
+    fd duplicated into a lingering grandchild does not block the parent from reading the
+    file, so both the answer and the seat's true latency survive.
     """
     try:
-        kwargs: dict[str, Any] = dict(
-            capture_output=True, text=True, timeout=timeout, env=env
-        )
+        kwargs: dict[str, Any] = dict(timeout=timeout, env=env)
         if stdin_devnull:
             kwargs["stdin"] = subprocess.DEVNULL
-        p = subprocess.run(cmd, **kwargs)
-        return ProbeResult(p.returncode, p.stdout, p.stderr)
+        if not capture_via_files:
+            p = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+            return ProbeResult(p.returncode, p.stdout, p.stderr)
+        with tempfile.TemporaryDirectory(prefix="arsenal-probe-") as td:
+            out_path = Path(td) / "stdout"
+            err_path = Path(td) / "stderr"
+            with open(out_path, "w+b") as fout, open(err_path, "w+b") as ferr:
+                try:
+                    p = subprocess.run(cmd, stdout=fout, stderr=ferr, **kwargs)
+                    rc, timed_out = p.returncode, False
+                except subprocess.TimeoutExpired:
+                    rc, timed_out = -1, True
+            out = out_path.read_text(encoding="utf-8", errors="replace")
+            err = err_path.read_text(encoding="utf-8", errors="replace")
+            return ProbeResult(rc, out, err, timed_out=timed_out)
     except subprocess.TimeoutExpired as e:
         out = e.stdout.decode() if isinstance(e.stdout, (bytes, bytearray)) else (e.stdout or "")
         err = e.stderr.decode() if isinstance(e.stderr, (bytes, bytearray)) else (e.stderr or "")
@@ -597,16 +628,18 @@ def probe_agy(timeout: float) -> tuple[str, str, int]:
     binp, via_path = resolve_bin("agy", ["~/.local/bin/agy"])
     if not binp:
         return NOT_INSTALLED, "agy binary not found (checked $PATH + common install dirs)", 0
-    res = run_probe_cmd([binp, "-p", PONG_PROMPT], timeout=timeout)
+    # capture_via_files: NOT optional for this seat. The 2026-08-07 incident diagnosed
+    # the grandchild-holds-the-pipe defect correctly but cured it only halfway — "judge
+    # the reply, not the exit" cannot fire when the pipe withholds the reply. Re-measured
+    # 2026-08-26 on Pro: through a pipe this call was still hanging past 120 s with EMPTY
+    # stdout, which is why the fleet digest read `agy TIMEOUT` for a seat that was fine;
+    # through a file the same call returned PONG, rc=0, in 11 s — comfortably inside the
+    # 15 s budget below. The file is what makes the W104 mitigation reachable at all.
+    res = run_probe_cmd([binp, "-p", PONG_PROMPT], timeout=timeout, capture_via_files=True)
     latency_ms = int((time.monotonic() - t0) * 1000)
     ev = _path_note(via_path) + evidence_tail(res.stdout + " " + res.stderr)
     live = "PONG" in res.stdout
-    # THE 2026-08-07 incident: agy's own process exits in ~1s but a detached
-    # grandchild keeps stdout's pipe fd open, so subprocess.run's communicate()
-    # never sees EOF — this probe ALWAYS hit its full timeout (verified live at
-    # 12s/15s/45s, PONG present in partial stdout every time) even though the
-    # seat is genuinely LIVE. Judge the reply, not the fact that the process
-    # never cleanly exited.
+    # Judge the reply, not the fact that the process never cleanly exited.
     if res.timed_out and not live:
         return TIMEOUT, ev or "probe timed out", latency_ms
     status = classify_generic(res.stdout + res.stderr, live, "agy", is_ssh_context())
@@ -805,21 +838,43 @@ def probe_qwen_cloud_code(timeout: float) -> tuple[str, str, int]:
     # Still deliberately NOT in REQUIRED_SEATS on any machine: machine-scoped candidate
     # seat (M5 only) whose promotion into required-fleet status is a separate operator+
     # Claude-lane decision from the PROBATION->ARMED promotion recorded in FLEET_TOPOLOGY.json.
+    # CORRECTED 2026-08-26 — this probe was REPORTING ITS OWN CREDENTIAL, NOT THE SEAT'S.
+    #
+    # It used to (a) hard-gate on the Keychain entry, returning AUTH_DEAD without ever
+    # invoking the CLI when Keychain was locked, and (b) when it did run, INJECT that
+    # Keychain token into the child's env — overriding the credential the CLI reads on
+    # its own from `~/.qwen/settings.json`. Measured on Pro 2026-08-26: the Keychain copy
+    # answered `401 Invalid API-key provided` (that verbatim string is what the fleet
+    # digest was reporting as a dead seat), while the same binary invoked WITHOUT the
+    # injection answered PONG on the first try. The seat was alive the whole time; the
+    # probe was killing it and then certifying the corpse.
+    #
+    # The rule this encodes: a probe measures the path PRODUCTION uses. Production uses
+    # settings.json (this file's own 2026-08-14 note records ~1330 calls / ~212M tokens
+    # through it, "independent of this probe"), so the probe must too. Nothing is
+    # weakened by dropping the injection — the credential's protection is the file's
+    # 0600 mode, never this probe's choice of env var. The Keychain read survives ONLY
+    # as a diagnostic breadcrumb attached to the evidence, and can no longer decide a
+    # verdict on its own.
     token, cred_note = load_keychain_token("qwen-cloud-code-token")
-    if not token:
-        return (
-            AUTH_DEAD,
-            path_note + f"keychain gate: {cred_note} — seat cannot authenticate at probe time (keychain locked/absent on this host)",
-            0,
-        )
+    keychain_note = "" if token else f"[keychain: {cred_note}] "
     env = dict(os.environ)
-    env["BAILIAN_TOKEN_PLAN_API_KEY"] = token
     # --safe-mode: this build boots MCP servers/hooks/skills on every invocation
     # (measured: pushed the 1-token probe past the 15 s fleet mandate); safe-mode
     # disables all customizations, which a probe does not need.
-    res = run_probe_cmd([binp, "-p", PONG_PROMPT, "--safe-mode"], timeout=timeout, env=env)
+    res = run_probe_cmd(
+        [binp, "-p", PONG_PROMPT, "--safe-mode"],
+        timeout=timeout,
+        env=env,
+        capture_via_files=True,
+    )
     latency_ms = int((time.monotonic() - t0) * 1000)
-    ev = path_note + evidence_tail(res.stdout + " " + res.stderr, extra_secrets=[token])
+    # extra_secrets still carries the Keychain value when there is one: it is no longer
+    # injected, but it may legitimately appear in CLI output, and the scrubber's job is
+    # to redact any secret it can name — not only the ones this process chose to use.
+    ev = path_note + keychain_note + evidence_tail(
+        res.stdout + " " + res.stderr, extra_secrets=[t for t in [token] if t]
+    )
     live = "PONG" in res.stdout
     if res.timed_out and not live:
         return TIMEOUT, ev or "probe timed out", latency_ms

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -934,7 +934,11 @@ def test_tp1_probe_max_tokens_budget_is_at_least_256():
 
 def test_probe_agy_pong_is_live(monkeypatch):
     monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/agy", True))
-    monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "PONG\n", ""))
+    # Patched at run_probe_cmd, not subprocess.run: since 2026-08-26 probe_agy captures
+    # via FILES (the grandchild-holds-the-pipe cure), so a fake that only fills a
+    # _FakeProc's .stdout attribute would be read back from an empty temp file and this
+    # test would fail for a reason that has nothing to do with agy's liveness.
+    monkeypatch.setattr(ap, "run_probe_cmd", lambda *a, **k: ap.ProbeResult(0, "PONG\n", ""))
     status, ev, latency = ap.probe_agy(timeout=5)
     assert status == ap.LIVE
 
@@ -2040,3 +2044,162 @@ def test_probe_claude_strips_custom_anthropic_session_env(monkeypatch):
     assert "ANTHROPIC_API_KEY" not in captured_env
     assert "ANTHROPIC_AUTH_TOKEN" not in captured_env
     assert "ANTHROPIC_BASE_URL" not in captured_env
+
+
+# ---------------------------------------------------------------------------
+# 2026-08-26 — the probe was lying about three LIVE seats. These cover the two
+# lies that were defects IN THE INSTRUMENT (the third, nlm, was a stale record,
+# not a code fault).
+#
+# DELIBERATE EXCEPTION to this module's "every subprocess boundary is
+# monkeypatched" rule, and it is load-bearing: the pipe-leak pair below spawns a
+# REAL local `/bin/sh` (no network, no LLM, no credentials). A monkeypatched
+# subprocess cannot reproduce a detached grandchild holding an inherited stdout
+# fd — the fake and the code would share the same imagination (scar W114) and
+# the test would pass against the very bug it exists to catch.
+# ---------------------------------------------------------------------------
+
+
+def test_run_probe_cmd_via_files_captures_what_a_pipe_would_lose():
+    """GUILT: a child that leaves a grandchild holding stdout.
+
+    Through a pipe, `communicate()` never sees EOF: the call burns its whole
+    timeout and hands back EMPTY stdout even though the answer was written
+    immediately. That is what made the fleet digest report `agy TIMEOUT` for a
+    seat answering in 11 s — and what silently defeated the "judge the REPLY"
+    mitigation, since the reply is exactly what the pipe withholds.
+    """
+    module = _load_module()
+    # Writes the answer at once, then leaves a background sleeper holding stdout.
+    # The direct child exits immediately; only the grandchild keeps the fd.
+    cmd = ["/bin/sh", "-c", "echo PONG; sleep 30 & exit 0"]
+    budget = 3.0
+
+    t0 = time.monotonic()
+    piped = module.run_probe_cmd(cmd, timeout=budget)
+    piped_wall = time.monotonic() - t0
+
+    # THE DEFECT, as a falsifiable property: through a pipe the call CANNOT return
+    # before its own timeout, because EOF never arrives — the answer was on disk in
+    # milliseconds but the probe still burns its entire budget and reports timed_out.
+    # (Whether the buffered bytes are also recoverable afterwards is platform-dependent
+    # and NOT the invariant: on Pro 2026-08-26 the real agy call returned nothing at all
+    # and hung past 120 s. The timeout is the part that is always true, so it is the
+    # part asserted here.)
+    assert piped.timed_out, (
+        "the pipe path did not time out — the grandchild-holds-the-fd defect is not "
+        "being reproduced on this platform, so the paired assertion below proves nothing"
+    )
+    assert piped_wall >= budget * 0.9
+
+    t0 = time.monotonic()
+    via_files = module.run_probe_cmd(cmd, timeout=budget, capture_via_files=True)
+    files_wall = time.monotonic() - t0
+
+    assert "PONG" in via_files.stdout
+    assert not via_files.timed_out
+    assert files_wall < budget * 0.5, (
+        f"file capture took {files_wall:.2f}s of a {budget}s budget — it should return "
+        "as soon as the DIRECT child exits, regardless of the lingering grandchild"
+    )
+
+
+def test_run_probe_cmd_via_files_is_transparent_for_an_ordinary_command():
+    """INNOCENCE: file capture must not change the reading of a well-behaved
+    child — same stdout, same stderr, same returncode, no timeout."""
+    module = _load_module()
+    cmd = ["/bin/sh", "-c", "echo PONG; echo noise >&2; exit 0"]
+
+    piped = module.run_probe_cmd(cmd, timeout=10)
+    via_files = module.run_probe_cmd(cmd, timeout=10, capture_via_files=True)
+
+    assert via_files.stdout.strip() == piped.stdout.strip() == "PONG"
+    assert "noise" in via_files.stderr and "noise" in piped.stderr
+    assert via_files.returncode == piped.returncode == 0
+    assert not via_files.timed_out and not piped.timed_out
+
+
+def _qwen_harness(monkeypatch, module, *, keychain, stdout, stderr=""):
+    """Wire probe_qwen_cloud_code to a fake CLI and capture the env it is handed."""
+    seen: dict = {}
+    monkeypatch.setattr(module, "resolve_bin", lambda *a, **k: ("/fake/qwen", True))
+    monkeypatch.setattr(
+        module, "load_keychain_token", lambda *a, **k: (keychain, "not found")
+    )
+
+    def fake_run(cmd, timeout, env=None, **kwargs):
+        seen["env"] = env or {}
+        return module.ProbeResult(0, stdout, stderr)
+
+    monkeypatch.setattr(module, "run_probe_cmd", fake_run)
+    return seen
+
+
+def test_probe_qwen_does_not_inject_the_keychain_token_into_the_child_env(monkeypatch):
+    """The bug, stated as an assertion: the probe used to OVERRIDE the credential
+    the CLI reads for itself from ~/.qwen/settings.json. On Pro the Keychain copy
+    answered `401 Invalid API-key` while the un-overridden CLI answered PONG — so
+    the probe was measuring its own credential, not the seat."""
+    module = _load_module()
+    monkeypatch.delenv("BAILIAN_TOKEN_PLAN_API_KEY", raising=False)
+    seen = _qwen_harness(monkeypatch, module, keychain="stale-keychain-value", stdout="PONG")
+
+    status, _ev, _ms = module.probe_qwen_cloud_code(15)
+
+    assert status == module.LIVE
+    assert seen["env"].get("BAILIAN_TOKEN_PLAN_API_KEY") != "stale-keychain-value"
+
+
+def test_probe_qwen_unreadable_keychain_no_longer_forces_auth_dead(monkeypatch):
+    """A locked/absent Keychain is a fact about THIS HOST, never a verdict on the
+    seat. It used to return AUTH_DEAD without invoking the CLI at all."""
+    module = _load_module()
+    seen = _qwen_harness(monkeypatch, module, keychain=None, stdout="PONG")
+
+    status, ev, _ms = module.probe_qwen_cloud_code(15)
+
+    assert status == module.LIVE
+    assert seen["env"] is not None
+    assert "keychain" in ev.lower(), "the Keychain miss must survive as a breadcrumb"
+
+
+def test_probe_qwen_still_reports_auth_dead_when_the_seat_itself_401s(monkeypatch):
+    """GUILT pair for the two tests above: loosening the Keychain gate must not
+    make this probe blind to a REAL credential failure. The string is the verbatim
+    one Alibaba returned on 2026-08-25."""
+    module = _load_module()
+    _qwen_harness(
+        monkeypatch,
+        module,
+        keychain=None,
+        stdout="",
+        stderr="[API Error: 401 Invalid API-key provided.]",
+    )
+
+    status, _ev, _ms = module.probe_qwen_cloud_code(15)
+
+    assert status == module.AUTH_DEAD
+
+
+def test_probe_agy_asks_for_file_capture_not_a_pipe(monkeypatch):
+    """Without this, nothing stops probe_agy silently going back to a pipe.
+
+    `test_probe_agy_pong_is_live` patches run_probe_cmd itself, and the pipe-leak
+    pair exercises run_probe_cmd directly — so both stay green if this seat's
+    call loses the flag. This is the only assertion that fails on that
+    regression, which is exactly the bug that produced `agy TIMEOUT` in the fleet
+    digest for a seat answering in 11 s.
+    """
+    module = _load_module()
+    seen: dict = {}
+    monkeypatch.setattr(module, "resolve_bin", lambda *a, **k: ("/fake/agy", True))
+
+    def fake_run(cmd, timeout, env=None, **kwargs):
+        seen.update(kwargs)
+        return module.ProbeResult(0, "PONG\n", "")
+
+    monkeypatch.setattr(module, "run_probe_cmd", fake_run)
+    status, _ev, _ms = module.probe_agy(timeout=15)
+
+    assert status == module.LIVE
+    assert seen.get("capture_via_files") is True


### PR DESCRIPTION
The fleet digest reported `agy TIMEOUT`, `qwen-cloud-code AUTH_DEAD`, `nlm AUTH_DEAD`. All three seats were alive. Two of the three lies were defects in the instrument.

## Measured on Pro before touching anything

| seat | measurement |
|---|---|
| `agy` | PONG, rc=0, in **11s** to a FILE. Through a **pipe**, still hanging past **120s**. |
| `qwen` | PONG on the first try with its own credential. The probe's evidence was a verbatim Alibaba `401 Invalid API-key provided`. |
| `nlm` | `nlm notebook list` returns live data (NB-INTEL-Tax, 288 sources). |

## Lie 1 — agy: the probe reads through a pipe a grandchild holds open

`communicate()` never sees EOF, so the call burns its full 15s budget and reports TIMEOUT.

This file had **already diagnosed** the defect and cured it halfway: *"judge the REPLY, not the exit code"* (W104). That mitigation cannot fire — the reply is exactly what the pipe withholds. The comment claimed *"PONG present in partial stdout every time"*; yesterday's record has empty stdout.

`run_probe_cmd` now takes `capture_via_files`: the child gets real files, and an fd duplicated into a lingering grandchild does not stop the parent reading the file.

## Lie 2 — qwen: the probe was reporting its own credential, not the seat's

It hard-gated on a Keychain entry (AUTH_DEAD **without ever invoking the CLI** when Keychain was locked) and, when it did run, **injected that token over** the one the CLI reads from `~/.qwen/settings.json`. The Keychain copy 401s; the un-overridden CLI answers PONG.

A probe measures the path **production** uses — this file's own 2026-08-14 note records ~1330 calls / ~212M tokens through `settings.json`, *"independent of this probe"*. Nothing is weakened by dropping the injection: the credential's protection is that file's `0600` mode (verified), never this probe's choice of env var. The Keychain read survives as a breadcrumb in the evidence and can no longer decide a verdict alone.

## Not a code fault — nlm

The probe was **right** at `2026-08-25T05:12Z`; the successful `nlm login` came after. The lie is the digest presenting a 19h-old verdict with no age attached. Deliberately left out of this PR rather than bundled in.

## After

```
agy  TIMEOUT   -> LIVE  11214ms
qwen AUTH_DEAD -> LIVE   4920ms
nlm  AUTH_DEAD -> LIVE   2076ms
```

## Tests — 173 pass, each fix mutation-checked to exactly one red

- **pipe-leak guilt/innocence pair.** Spawns a **real** local `/bin/sh` — a deliberate exception to this module's "every subprocess boundary is monkeypatched" rule, because a monkeypatched subprocess cannot reproduce a grandchild holding an fd: the fake and the code would share the same imagination (W114) and the test would pass against the very bug it exists to catch. No network, no LLM, no credentials. It asserts the invariant that is *always* true (the pipe path cannot return before its timeout), not the platform-dependent one, and carries a self-check that fails loudly if the defect stops reproducing — so it can never silently prove nothing.
- **`probe_agy` must pass `capture_via_files`** — nothing else catches a regression to pipes, since the other two tests stay green either way.
- **qwen**: no injection; a locked Keychain is not a verdict; and the guilt pair — a real 401 from the seat still reads AUTH_DEAD.

One pre-existing test was **repaired, not deleted**: `test_probe_agy_pong_is_live` patched `ap.subprocess.run`, which no longer sees agy's output now that capture goes through files. It now patches `run_probe_cmd`, testing probe_agy's logic instead of capture internals.

Scar family: #2 (esiste ≠ armato) inverted — armed but reported dead, which makes every session route around a working seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)