### PR TITLE
fix(garuda-arm): GARUDA_ENVIRONMENT must be a DB-legal value, not SANDBOX

### DIFF
--- a/.github/workflows/garuda-arm.yml
+++ b/.github/workflows/garuda-arm.yml
@@ -62,14 +62,25 @@ on:
       garuda_environment:
         description: >-
           GARUDA_ENVIRONMENT (domain-vocabulary string read by
-          magic_link_store.py / check_store.py / GarudaOrderRepository;
-          code default is PRODUCTION, we want SANDBOX while the Xendit
-          account is a sandbox account).
+          magic_link_store.py / check_store.py / GarudaOrderRepository and
+          persisted verbatim into an `environment TEXT CHECK (environment
+          IN ('TEST','STAGING','PRODUCTION'))` column). This tags ROWS
+          with the deployment they belong to — it does NOT select payment
+          mode. Xendit sandbox-ness is carried entirely by
+          `GARUDA_XENDIT_SECRET_KEY` (the provider itself refuses any key
+          not prefixed `xnd_development_`), so a dark launch against the
+          Xendit sandbox still writes real rows for real people on the
+          production database, and PRODUCTION is the correct tag for that
+          even while payments are sandboxed. "SANDBOX" is NOT a value the
+          schema accepts — arming with it would violate the CHECK
+          constraint on the very first magic-link/eligibility-check write
+          and break the funnel on first use while /health stays green.
         required: true
-        default: "SANDBOX"
+        default: "PRODUCTION"
         type: choice
         options:
-          - "SANDBOX"
+          - "TEST"
+          - "STAGING"
           - "PRODUCTION"
       stage_only:
         description: >-

--- a/.github/workflows/lint-garuda-environment-values.yml
+++ b/.github/workflows/lint-garuda-environment-values.yml
@@ -1,0 +1,71 @@
+name: Lint — GARUDA_ENVIRONMENT workflow value matches DB schema
+
+# Fails the PR if `.github/workflows/garuda-arm.yml`'s `garuda_environment`
+# workflow_dispatch choice list (or its default) ever offers a value the
+# database's `environment TEXT CHECK (environment IN (...))` columns
+# reject — the class of defect fixed 2026-08-26: the workflow used to offer
+# SANDBOX/PRODUCTION (default SANDBOX) while every migration constrains the
+# column to TEST/STAGING/PRODUCTION. Arming with the default would have
+# violated the CHECK constraint on the first magic-link insert or
+# eligibility-check write while /health stayed green (cicatrix-superscar.md
+# family #2, "esiste != armato").
+#
+# The check delegates to the regression test directly so the rules stay in
+# lock-step (same regex, same intersection logic) — same pattern as
+# lint-golden-rule-10.yml / test_no_httpx_violators.py.
+#
+# Reference test: apps/backend-rag/backend/tests/app/setup/test_garuda_environment_matches_schema.py
+#
+# Deliberately NOT scoped to only `apps/backend-rag/backend/db/migrations_v2/**`
+# — a change to garuda-arm.yml ALONE (no migration touched) is exactly the
+# shape of the original defect, so this must also trigger on the workflow
+# file changing by itself.
+
+on:
+  pull_request:
+    paths:
+      - "apps/backend-rag/backend/db/migrations_v2/**"
+      - "apps/backend-rag/backend/tests/app/setup/test_garuda_environment_matches_schema.py"
+      - ".github/workflows/garuda-arm.yml"
+      - ".github/workflows/lint-garuda-environment-values.yml"
+
+concurrency:
+  group: lint-garuda-environment-values-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: garuda_environment options are schema-legal
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # pytest-asyncio is required even though this test module is sync:
+          # apps/backend-rag/pytest.ini declares asyncio_default_fixture_loop_scope,
+          # an ini option only the pytest-asyncio plugin registers (same trap
+          # documented in lint-golden-rule-10.yml).
+          python -m pip install pytest "pytest-asyncio>=1.3.0" "pydantic>=2.12.5" "pyyaml>=6.0"
+
+      - name: Run regression test (single source of truth)
+        working-directory: apps/backend-rag
+        run: |
+          PYTHONPATH=. python -m pytest \
+            backend/tests/app/setup/test_garuda_environment_matches_schema.py \
+            -v --tb=short
+
+      - name: Show fix guidance on failure
+        if: failure()
+        run: |
+          echo "::error::garuda_environment offers a value the DB schema rejects, or the default is schema-illegal."
+          echo "Fix: set garuda-arm.yml's garuda_environment 'options:' (and 'default:') to values present in EVERY 'CHECK (environment IN (...))' clause under apps/backend-rag/backend/db/migrations_v2/*.sql."
+          echo "Reference test: apps/backend-rag/backend/tests/app/setup/test_garuda_environment_matches_schema.py"

--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -160,6 +160,7 @@ on:
       - Content lint — reasoning-leak in published MDX
       - Lint Cross-Import
       - Golden Rule
+      - Lint — GARUDA_ENVIRONMENT workflow value matches DB schema
       - Lint i18n providers
       - Migration number uniqueness lint
       - Migration ROLLBACK marker lint

--- a/apps/backend-rag/backend/tests/app/setup/test_garuda_environment_matches_schema.py
+++ b/apps/backend-rag/backend/tests/app/setup/test_garuda_environment_matches_schema.py
@@ -1,0 +1,190 @@
+"""Tripwire: the `garuda_environment` workflow_dispatch choice list must be a
+SUBSET of what the database's `environment` CHECK constraints actually accept.
+
+WHY THIS EXISTS (2026-08-26). `.github/workflows/garuda-arm.yml` used to offer
+`SANDBOX`/`PRODUCTION` (default `SANDBOX`) for `garuda_environment`, whose
+value is written straight through (no remapping) into
+`GARUDA_ENVIRONMENT`, which `service_initializer.py` hands to
+`PostgresMagicLinkStore`/`PostgresCheckStore`/`GarudaOrderRepository`, which
+persist it verbatim into an `environment` column. Every migration that
+defines such a column constrains it to `CHECK (environment IN ('TEST',
+'STAGING', 'PRODUCTION'))` — `SANDBOX` is not a member. Arming with the
+workflow's own DEFAULT would therefore violate that CHECK constraint on the
+very first magic-link insert or eligibility-check write. `/health` only
+polls the app-wide health endpoint (see garuda-arm.yml's own verification
+step), so the app comes back up green and the break is discovered one failed
+INSERT at a time — cicatrix-superscar.md family #2 ("esiste != armato"): the
+probe reads something other than the thing that is broken.
+
+This test parses BOTH sides live, every run — it does not hardcode either
+one, because the whole failure mode this guards against is the two DRIFTING
+APART:
+
+  1. every `CHECK (environment IN (...))` clause under
+     `apps/backend-rag/backend/db/migrations_v2/*.sql` (repo-wide — not
+     scoped to a specific migration number, because the specific GARUDA
+     migrations that will eventually carry this constraint on `main` are, as
+     of this test's authorship, still on feature branches and get
+     renumbered on landing; a filename-scoped test would go stale silently
+     exactly the way the workflow's own header warns migration authors
+     about); and
+  2. the `options:` list of the `garuda_environment` workflow_dispatch input
+     in `.github/workflows/garuda-arm.yml`.
+
+If a future migration widens or narrows the accepted set, this test's
+computed `_environment_check_intersection()` follows it automatically —
+nothing here needs to change. If NO migration anywhere defines an
+`environment` CHECK, the test fails closed (does not silently pass on an
+empty sweep — cicatrix W84: "an empty sweep is not a pass").
+
+Cost: <100ms locally — pure file reads + regex/yaml parsing, no DB, no app
+import.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# tests/app/setup/test_garuda_environment_matches_schema.py
+#   parents[0] = setup
+#   parents[1] = app
+#   parents[2] = tests
+#   parents[3] = backend
+#   parents[4] = apps/backend-rag
+#   parents[5] = apps
+#   parents[6] = repo root
+REPO_ROOT = Path(__file__).resolve().parents[6]
+MIGRATIONS_DIR = REPO_ROOT / "apps" / "backend-rag" / "backend" / "db" / "migrations_v2"
+GARUDA_ARM_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "garuda-arm.yml"
+
+# Matches e.g.  CHECK (environment IN ('TEST', 'STAGING', 'PRODUCTION'))
+# across the (possibly multi-line) column-definition CHECK clauses this repo
+# uses for every `environment` column (250, 252, 264, and the not-yet-landed
+# GARUDA 285/286). Deliberately anchored on the column name `environment` so
+# an unrelated `CHECK (... IN (...))` on a different column is not swept in.
+_ENV_CHECK_RE = re.compile(
+    r"CHECK\s*\(\s*environment\s+IN\s*\(([^)]*)\)\s*\)",
+    re.IGNORECASE,
+)
+_QUOTED_LITERAL_RE = re.compile(r"'([^']*)'")
+
+
+def _environment_check_sets() -> list[frozenset[str]]:
+    """One frozenset of accepted values per `CHECK (environment IN (...))`
+    clause found anywhere under migrations_v2/."""
+    sets: list[frozenset[str]] = []
+    for sql_path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        text = sql_path.read_text(encoding="utf-8")
+        for match in _ENV_CHECK_RE.finditer(text):
+            literals = frozenset(_QUOTED_LITERAL_RE.findall(match.group(1)))
+            if literals:
+                sets.append(literals)
+    return sets
+
+
+def _environment_check_intersection() -> frozenset[str]:
+    sets = _environment_check_sets()
+    if not sets:
+        # Fail closed (W84): no CHECK clause found anywhere is a broken
+        # sweep, not "anything goes". If this ever fires because the last
+        # `environment` CHECK column was legitimately dropped, that is the
+        # moment to delete this test, not to make it pass silently.
+        pytest.fail(
+            "No `CHECK (environment IN (...))` clause found under "
+            f"{MIGRATIONS_DIR} — cannot verify garuda-arm.yml's "
+            "garuda_environment options against anything. Either the sweep "
+            "regex broke, or every environment-tagged table was removed "
+            "(update/delete this test deliberately if so)."
+        )
+    intersection = sets[0]
+    for s in sets[1:]:
+        intersection &= s
+    return intersection
+
+
+def _workflow_dispatch_inputs(workflow: dict) -> dict:
+    # PyYAML's default (non-1.2) resolver parses the bare `on:` mapping key
+    # as the boolean `True`, not the string "on" — GitHub Actions workflow
+    # YAML hits this on every file. Read whichever key actually landed.
+    on_block = workflow.get("on", workflow.get(True))
+    assert on_block is not None, "workflow has neither an 'on' nor a True key"
+    return on_block["workflow_dispatch"]["inputs"]
+
+
+def _garuda_environment_options() -> list[str]:
+    workflow = yaml.safe_load(GARUDA_ARM_WORKFLOW.read_text(encoding="utf-8"))
+    inputs = _workflow_dispatch_inputs(workflow)
+    garuda_env_input = inputs.get("garuda_environment")
+    assert garuda_env_input is not None, (
+        f"{GARUDA_ARM_WORKFLOW} no longer declares a `garuda_environment` "
+        "workflow_dispatch input — update this test if the input was "
+        "intentionally renamed/removed."
+    )
+    assert garuda_env_input.get("type") == "choice", (
+        "garuda_environment stopped being a `type: choice` input — this "
+        "test only knows how to validate a closed choice list, not free "
+        "text."
+    )
+    options = garuda_env_input.get("options")
+    assert options, "garuda_environment has no `options:` list."
+    return list(options)
+
+
+def test_garuda_arm_workflow_and_migrations_files_exist():
+    """Guard the guard: if either input path silently disappears, every
+    other assertion below would vacuously pass on nothing (W84)."""
+    assert GARUDA_ARM_WORKFLOW.is_file(), f"missing: {GARUDA_ARM_WORKFLOW}"
+    assert MIGRATIONS_DIR.is_dir(), f"missing: {MIGRATIONS_DIR}"
+    assert list(MIGRATIONS_DIR.glob("*.sql")), f"no .sql files under {MIGRATIONS_DIR}"
+
+
+def test_environment_check_clauses_are_internally_consistent():
+    """Every `environment` CHECK clause in this repo is expected to define
+    the SAME domain vocabulary (TEST/STAGING/PRODUCTION) — if a future
+    migration deliberately narrows or widens it, the workflow test below
+    will catch the mismatch, but this asserts the premise (a non-empty
+    intersection) is even meaningful to compute."""
+    sets = _environment_check_sets()
+    assert sets, "no environment CHECK clauses found — see the intersection helper"
+    intersection = _environment_check_intersection()
+    assert intersection, (
+        f"the {len(sets)} `environment` CHECK clauses found under "
+        f"{MIGRATIONS_DIR} share NO common accepted value — "
+        f"per-clause sets: {sets}"
+    )
+
+
+def test_garuda_environment_workflow_options_are_schema_legal():
+    """The actual regression: every option the workflow lets an operator
+    pick for `garuda_environment` must be a value the database's own
+    `environment` CHECK constraints accept. This is what would have failed
+    on the merged `SANDBOX`/`PRODUCTION` options (SANDBOX is schema-illegal)."""
+    options = _garuda_environment_options()
+    allowed = _environment_check_intersection()
+    illegal = set(options) - allowed
+    assert not illegal, (
+        f"garuda-arm.yml's garuda_environment options include values the "
+        f"database's `environment` CHECK constraints reject: {sorted(illegal)}. "
+        f"Schema-legal values (intersection across all CHECK clauses found): "
+        f"{sorted(allowed)}. Arming with an illegal value violates the CHECK "
+        f"constraint on the first write while /health stays green "
+        f"(cicatrix-superscar.md family #2)."
+    )
+
+
+def test_garuda_environment_default_is_schema_legal():
+    """The DEFAULT is the most dangerous slot — it is what an operator gets
+    by just accepting the form, so it must never be the illegal one."""
+    workflow = yaml.safe_load(GARUDA_ARM_WORKFLOW.read_text(encoding="utf-8"))
+    default = _workflow_dispatch_inputs(workflow)["garuda_environment"]["default"]
+    allowed = _environment_check_intersection()
+    assert default in allowed, (
+        f"garuda_environment default={default!r} is not in the schema-legal "
+        f"set {sorted(allowed)} — the default is the value an operator gets "
+        f"by accepting the workflow_dispatch form as-is, so it must never be "
+        f"the illegal one."
+    )

--- a/evidence/2026-08/agent-air-m5-ops-garuda-arm-env-0826-cd236292/brief.yml
+++ b/evidence/2026-08/agent-air-m5-ops-garuda-arm-env-0826-cd236292/brief.yml
@@ -1,0 +1,147 @@
+task_id: garuda-arm-env-0826
+gear: 3
+l_level: L1
+gate_class: opus
+objective: >-
+  Fix a live configuration trap in
+  `.github/workflows/garuda-arm.yml`'s `garuda_environment`
+  workflow_dispatch input: it offered `SANDBOX`/`PRODUCTION`
+  (default `SANDBOX`), and wrote that value straight through — no
+  remapping — into the `GARUDA_ENVIRONMENT` Fly secret. That secret
+  is read by `service_initializer.py` and handed to
+  `PostgresMagicLinkStore`/`PostgresCheckStore`/`GarudaOrderRepository`,
+  which persist it verbatim into an `environment TEXT CHECK
+  (environment IN ('TEST','STAGING','PRODUCTION'))` column (migrations
+  285/286). `SANDBOX` is not a member of that set: arming with the
+  workflow's own DEFAULT would violate the CHECK constraint on the
+  very first magic-link insert or eligibility-check write, while the
+  workflow's own post-arm verification only polls `/health` — so the
+  app comes back green and the funnel looks armed right up until the
+  first real write fails. Classic cicatrix-superscar.md family #2
+  ("esiste != armato" — the probe reads something other than the
+  thing that is actually broken).
+
+  Root cause, not just symptom: whoever wrote `SANDBOX` was reaching
+  for the *payment mode*, not the *row tag*. This field tags ROWS
+  with the deployment they belong to; Xendit sandbox-ness is carried
+  entirely by `GARUDA_XENDIT_SECRET_KEY` (the provider itself refuses
+  any key not prefixed `xnd_development_`). A dark launch against the
+  Xendit sandbox still writes real rows for real people on the
+  production database — `PRODUCTION` is the correct tag even while
+  payments are sandboxed.
+
+  Gear 3 by PATH, not by blast radius: this diff touches
+  `.github/workflows/*`, a literal HOTZONE_PATTERNS entry — the floor
+  is the deterministic one computed from the changed-file set, not
+  this session's judgment call (confirmed 3, receipt below).
+constraints:
+  - >-
+    Fix must be the value mapping and the input's own description
+    text — no unrelated behaviour change to the workflow (no touching
+    the Xendit-secret-skip logic, the `stage_only` input, or the
+    `/health` verification step, none of which this defect concerns).
+  - >-
+    The tripwire must parse BOTH sides live, every run — the actual
+    workflow YAML options/default AND the actual `CHECK (environment
+    IN (...))` clauses under `migrations_v2/*.sql` — never hardcode
+    either side as a literal in the test, because the whole failure
+    mode this guards against is the two drifting apart (this repo has
+    a named scar family, #9 "state-schema mutation drift", for
+    exactly that shape).
+  - >-
+    Must not hardcode migration filenames 285/286: at authorship time
+    those files did not exist on `main` (the GARUDA backend wiring
+    landed separately in PR #4959, merged to `main` mid-task as
+    `9ed601a7d`, after this branch's base). A filename-scoped test
+    would either not exist yet or go stale the moment the migration
+    author's own header-comment renumbering warning fires. The test
+    instead globs `migrations_v2/*.sql` and intersects every
+    `CHECK (environment IN (...))` clause found, so it self-applies
+    the instant the real migrations land — which they since have.
+  - >-
+    The new CI wiring must actually run per-PR (not only nightly/
+    report-only): this repo has a measured scar
+    (`discovery_a_test_directory_under_a_new_top_level_dir_is_run_by_
+    nobody_2026_08_25` in the fleet memory, and the `scripts/tests/`
+    sweep documented in `scripts-tests-sweep.yml` as schedule-only,
+    report-only, `continue-on-error: true`) for a test file that
+    exists on disk but nothing in `.github/workflows/` names it. A
+    named, targeted workflow that runs the exact test module directly
+    (mirroring `lint-golden-rule-10.yml` →
+    `test_no_httpx_violators.py`) closes that gap for this test.
+  - >-
+    Any new workflow added must be registered in
+    `main-push-failure-watch.yml`'s `workflows:` list —
+    `scripts/check_watcher_coverage.py` is a required CI check on this
+    exact point and was RED on the first push (see receipts) before
+    this brief/pack were added; fixed in a follow-up commit on the
+    same branch.
+acceptance:
+  - >-
+    `garuda-arm.yml`'s `garuda_environment` options and default are
+    both members of the intersection of every `CHECK (environment IN
+    (...))` clause found under `migrations_v2/*.sql` in this repo,
+    verified by a pytest tripwire that reads both sources live.
+  - >-
+    The tripwire was proven RED (SANDBOX reintroduced into both
+    `options:` and `default:`) before being proven GREEN on the fix —
+    a test never seen failing is not a test.
+  - "`actionlint -shellcheck=` accepts every touched/new workflow file."
+  - >-
+    `scripts/check_watcher_coverage.py` exits 0 — the new
+    `lint-garuda-environment-values.yml` workflow is registered with
+    the meta-watcher, per the independent Gear-3 gate's REWORK-BUILD
+    finding on this PR's first head SHA.
+consumer_map:
+  - >-
+    `garuda-arm.yml`'s `arm` job writes `GARUDA_ENVIRONMENT` as a Fly
+    secret on `nuzantara-rag` via `flyctl secrets set` — the only
+    consumer of the value this PR changes.
+  - >-
+    `apps/backend-rag/backend/app/setup/service_initializer.py` reads
+    `GARUDA_ENVIRONMENT` at process startup (now present on `main` as
+    of PR #4959, absent when this task started — see the dissent
+    entry below) and hands it to the three GARUDA store/repository
+    constructors, which persist it into the `environment` column
+    constrained by migrations 285/286.
+  - >-
+    `main-push-failure-watch.yml` now also watches
+    `lint-garuda-environment-values.yml` for a push/schedule-to-main
+    failure (this PR's own second commit).
+risks:
+  - >-
+    This workflow was NOT run against production — arming
+    `GARUDA_ENVIRONMENT` for real is an `operator[business]`/
+    `workflow_dispatch` action the codeowner or a future dispatch
+    performs; this PR only fixes what value that dispatch is allowed
+    to choose from.
+  - >-
+    The three read-sites the original mandate named
+    (`PostgresMagicLinkStore`/`PostgresCheckStore`/
+    `GarudaOrderRepository` construction) did not exist on `main` when
+    this branch was created (`origin/main` at `92ca871e5`) — confirmed
+    by `grep -in garuda service_initializer.py` returning zero matches
+    at that commit. They landed on `main` mid-task via PR #4959
+    (`9ed601a7d`), on a branch this PR's base does not include. No
+    fail-closed guard was added at those sites in this PR: doing so
+    now would mean editing files this branch has never seen and that
+    are not part of the diff the Gear-3 gate is grading — out of
+    scope for this fix, flagged to the orchestrating session as a
+    follow-up instead of silently expanded into.
+grader: >-
+  Generator != grader. This session authored the fix, the tripwire,
+  and this evidence pack; the Gear-3 on-disk gate (independent seat)
+  grades the diff, and the orchestrating session (team-lead) decides
+  merge timing — neither is this session, per CLAUDE.md §13/Agent PR
+  Contract ("the diff's author never gates its own diff"). The gate's
+  first verdict on this PR (REWORK-BUILD, head `d7b52539`) correctly
+  identified this brief/pack were missing and did NOT dispute the
+  code or the tripwire (six mutations run against it, reported
+  sound) — this pack is the requested completion, not a response to a
+  code defect.
+budget: >-
+  1 build lane (this session), no council, no cross-family dispatch —
+  a workflow-value fix plus one self-contained pytest tripwire whose
+  verification (actionlint + a live RED/GREEN pytest run) is fully
+  reproducible without a Fly credential, a database, or a live run.
+pii: none

--- a/evidence/2026-08/agent-air-m5-ops-garuda-arm-env-0826-cd236292/pack.yml
+++ b/evidence/2026-08/agent-air-m5-ops-garuda-arm-env-0826-cd236292/pack.yml
@@ -1,0 +1,203 @@
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  PR #4982 (agent/air-m5/ops/garuda-arm-env-0826) — fixes the
+  garuda_environment SANDBOX-default trap in
+  .github/workflows/garuda-arm.yml, adds a live dual-source pytest
+  tripwire, wires it into a named per-PR workflow, and registers that
+  workflow with main-push-failure-watch.yml per the gate's
+  REWORK-BUILD verdict on the first head SHA.
+lanes:
+  - lane: garuda-arm-env-fix
+    role: build
+    seat: >-
+      session (dispatched by team-lead per CLAUDE.md §5 implementer
+      routing)
+  - lane: garuda-arm-env-gate
+    role: review
+    seat: >-
+      independent Gear-3 on-disk gate — REWORK-BUILD on the first
+      head SHA (generator != grader, CLAUDE.md §13/Agent PR Contract)
+seat_diversity: not_applicable
+seat_diversity_note: >-
+  Single build lane — a workflow-value fix plus one test file, not a
+  cross-family council dispatch. The D3 seat-diversity floor (>=2
+  build lanes) does not fire.
+diff:
+  net_lines: >-
+    4 files changed across 2 commits, measured by
+    `git diff --numstat origin/main...HEAD`: garuda-arm.yml (+16/-5),
+    lint-garuda-environment-values.yml (+71/-0),
+    main-push-failure-watch.yml (+1/-0),
+    test_garuda_environment_matches_schema.py (+190/-0). Net +278/-5.
+  behaviour_change: >-
+    garuda_environment's workflow_dispatch options change from
+    SANDBOX/PRODUCTION (default SANDBOX) to TEST/STAGING/PRODUCTION
+    (default PRODUCTION) — no other step in the arm job is touched.
+    Two new files: a pytest tripwire and the CI workflow that runs it
+    per-PR. One line added to an existing file registering that new
+    workflow with the meta-watcher.
+receipts:
+  - claim: >-
+      Deterministic gear floor recomputed from this PR's real 3-dot
+      diff (origin/main...HEAD, not a stale two-dot diff — W102) is 3:
+      .github/workflows/* is hot-zone by path.
+    cmd: >-
+      git diff --name-only origin/main...HEAD >
+      /tmp/garuda-changed.txt && python3 scripts/evidence_pack_lint.py
+      --print-floor --changed-files-file /tmp/garuda-changed.txt
+    result: "3"
+    exit: 0
+    ts: "2026-08-26T00:45:00Z"
+    seat: "session (this task, Air-M5 worktree)"
+  - claim: >-
+      actionlint accepts all three touched/new workflow files
+      together.
+    cmd: >-
+      actionlint -color -shellcheck= .github/workflows/garuda-arm.yml
+      .github/workflows/lint-garuda-environment-values.yml
+      .github/workflows/main-push-failure-watch.yml
+    result: "no output (clean)"
+    exit: 0
+    ts: "2026-08-26T00:45:05Z"
+    seat: "session (this task, Air-M5 worktree)"
+  - claim: >-
+      Tripwire proven RED before proven GREEN. With SANDBOX
+      reintroduced into both `options:` and `default:` on the real
+      workflow file, 2 of 4 tests fail with a precise diagnostic
+      naming the illegal value and the schema-legal set; both other
+      tests still pass (the sweep itself is not broken).
+    cmd: >-
+      (SANDBOX temporarily reintroduced) cd apps/backend-rag &&
+      PYTHONPATH=. python -m pytest
+      backend/tests/app/setup/test_garuda_environment_matches_schema.py
+      -v --tb=short
+    result: >-
+      collected 4 items; ....FF; FAILED
+      test_garuda_environment_workflow_options_are_schema_legal -
+      AssertionError: options include values the database's
+      `environment` CHECK constraints reject: ['SANDBOX']. Schema-legal
+      values: ['PRODUCTION', 'STAGING', 'TEST']. FAILED
+      test_garuda_environment_default_is_schema_legal - AssertionError:
+      default='SANDBOX' is not in the schema-legal set. 2 failed, 2
+      passed in 0.12s
+    exit: 1
+    ts: "2026-08-26T00:15:00Z"
+    seat: "session (this task, Air-M5 worktree)"
+  - claim: "Tripwire GREEN on the actual fix, real fresh run."
+    cmd: >-
+      cd apps/backend-rag && PYTHONPATH=. python -m pytest
+      backend/tests/app/setup/test_garuda_environment_matches_schema.py
+      -v --tb=short
+    result: "collected 4 items; ....; 4 passed in 0.11s"
+    exit: 0
+    ts: "2026-08-26T00:45:10Z"
+    seat: "session (this task, Air-M5 worktree)"
+  - claim: >-
+      main-push-failure-watch.yml registration for the new workflow
+      is present and correctly formed — the exact gap the gate's
+      REWORK-BUILD verdict on the first head SHA did NOT ask about
+      (that verdict was about the missing evidence pack), but which
+      `scripts/check_watcher_coverage.py` (a separate required check)
+      caught on the same PR's `check` job before this pack was
+      written, and which is now fixed on this branch.
+    cmd: python3 scripts/check_watcher_coverage.py
+    result: >-
+      ::warning::stale entry in watcher's workflows: list, no matching
+      workflow: `AI PR review (advisory)` (pre-existing, out of scope
+      — see notes below) | ✓ watcher-coverage: all 102 live
+      workflow(s) covered by main-push-failure-watch.yml
+    exit: 0
+    ts: "2026-08-26T00:45:15Z"
+    seat: "session (this task, Air-M5 worktree)"
+  - claim: >-
+      The GARUDA backend wiring the original mandate cited
+      (`PostgresMagicLinkStore`/`PostgresCheckStore`/
+      `GarudaOrderRepository`, migrations 285/286) did NOT exist on
+      `main` when this branch was created — confirmed at the exact
+      base commit, not assumed from the mandate's description.
+    cmd: >-
+      git show 92ca871e51540361e315182f83ecac927c33bad9:apps/backend-
+      rag/backend/app/setup/service_initializer.py | grep -ic garuda
+    result: "0"
+    exit: 0
+    ts: "2026-08-26T00:00:00Z"
+    seat: "session (this task, Air-M5 worktree)"
+pii_scan: clean
+dissent:
+  - seat: "independent Gear-3 on-disk gate (first pass, head d7b52539)"
+    objection: >-
+      REWORK-BUILD: floor-3 diff carries no evidence/brief.yml+pack.yml.
+      Code and tripwire independently verified sound (6 mutations run
+      against the tripwire, none survived).
+    status: CONFIRMED
+    note: >-
+      The pack was genuinely absent on that head — not a false
+      finding. Answered by adding this brief.yml + pack.yml at this
+      PR's own per-branch evidence path
+      (evidence/2026-08/agent-air-m5-ops-garuda-arm-env-0826-cd236292/),
+      obtained from `scripts/ci/evidence_paths.py`, never constructed
+      by hand.
+  - seat: "session, self-check on scope creep"
+    objection: >-
+      The GARUDA backend wiring landed on `main` via PR #4959 mid-task
+      — should this PR now also add the fail-closed guard at
+      service_initializer.py's three GARUDA read-sites, since the code
+      to guard now exists?
+    status: RETRACTED
+    note: >-
+      Investigated rather than assumed out of scope by default: those
+      three call sites are not part of THIS branch's diff (it is based
+      on the pre-#4959 `main`, and rebasing onto post-#4959 `main` to
+      pull them in was not requested and would silently widen a
+      Gear-3 PR the gate is already grading). One PR, one concern
+      (CLAUDE.md Agent PR Contract #1) — flagged to the orchestrating
+      session as a named follow-up (see brief.yml risks) rather than
+      folded into this diff.
+  - seat: "session, self-check on the intersection design"
+    objection: >-
+      Does scanning ALL `CHECK (environment IN (...))` clauses
+      repo-wide (not scoped to GARUDA tables) risk a false pass if an
+      unrelated table's `environment` column legitimately uses a
+      DIFFERENT vocabulary?
+    status: RETRACTED
+    note: >-
+      Checked, not assumed safe: `test_environment_check_clauses_are_
+      internally_consistent` asserts the intersection across every
+      clause found is non-empty as its OWN standalone check — if a
+      future migration narrowed or widened the set incompatibly, that
+      test fails first with a message naming the disagreement, before
+      the workflow-vs-schema assertion even runs. Re-verified live: as
+      of this pack, migrations 250/252/264 (pre-existing, visa_engine)
+      and 285/286 (GARUDA, landed via #4959) all declare the identical
+      {'TEST','STAGING','PRODUCTION'} set — confirmed by grep, not
+      assumed from the migration authors' intent.
+tests:
+  - >-
+    Tripwire RED/GREEN pair on the real workflow file — receipts
+    above.
+  - >-
+    actionlint on all three touched/new workflow files together —
+    receipt above.
+  - "check_watcher_coverage.py exit 0 — receipt above."
+static:
+  - "actionlint -shellcheck= -> clean (binary at /opt/homebrew/bin/actionlint)"
+notes:
+  - >-
+    `brief_ref:` names the literal `evidence/brief.yml` (not this
+    pack's own real per-PR path) because `harness-floor.yml` stages
+    both files under canonical names before linting — same pattern as
+    `evidence/2026-08/agent-air-m5-ops-garuda-arming-workflow-0825-
+    a4279106/pack.yml`.
+  - >-
+    The stale `AI PR review (advisory)` entry in
+    `main-push-failure-watch.yml`'s `workflows:` list (surfaced by
+    `check_watcher_coverage.py`'s warning line, receipt above) was
+    reported to the team-lead and deliberately NOT removed here — it
+    names a workflow deliberately disabled 2026-08-20
+    (`ai-pr-review.yml.disabled-2026-08-20-...`), and touching it is a
+    separate, unrelated concern from this PR's fix (Agent PR Contract
+    #1, one PR one concern).
+  - >-
+    This pack does not post a `harness/fable-gate` commit status —
+    that is the gate's own next action after re-reading this pack
+    (generator != grader).


### PR DESCRIPTION
## What

`garuda-arm.yml`'s `garuda_environment` workflow_dispatch input offered `SANDBOX`/`PRODUCTION` (default `SANDBOX`) and wrote that value straight through — no remapping — into `GARUDA_ENVIRONMENT`, read by `service_initializer.py` and handed to `PostgresMagicLinkStore`/`PostgresCheckStore`/`GarudaOrderRepository`, which persist it verbatim into an `environment TEXT CHECK (environment IN ('TEST','STAGING','PRODUCTION'))` column.

`SANDBOX` is not in that set. Arming with the workflow's own DEFAULT would violate the CHECK constraint on the very first magic-link insert or eligibility-check write. `/health` only polls the app-wide health endpoint (the workflow's own verification step), so the app comes back up green and the funnel looks armed while every real write fails — cicatrix-superscar.md family #2 ("esiste != armato"): the probe reads something other than the thing that's broken.

Root cause: whoever wrote `SANDBOX` was reaching for the *payment mode*, not the row tag. This value tags rows with the deployment they belong to; Xendit sandbox-ness is carried entirely by `GARUDA_XENDIT_SECRET_KEY` (the provider itself refuses any key not prefixed `xnd_development_`). A dark launch against the Xendit sandbox still writes real rows for real people on the production database — `PRODUCTION` is the correct tag even while payments are sandboxed.

## Fix

1. `garuda_environment` options: `TEST`/`STAGING`/`PRODUCTION`, default `PRODUCTION`. Description text now states the row-tag-vs-payment-mode distinction explicitly.
2. New tripwire `apps/backend-rag/backend/tests/app/setup/test_garuda_environment_matches_schema.py`: parses BOTH sides live, every run — every `CHECK (environment IN (...))` clause under `migrations_v2/*.sql` (repo-wide, not scoped to a filename — the actual GARUDA migrations that will carry this constraint are still on feature branches as of this PR and will be renumbered on landing, so hardcoding a filename would go stale silently), intersected across all clauses found, checked against the workflow's `options:` AND its `default:`. If a future migration widens/narrows the set, the test follows automatically.
3. New `.github/workflows/lint-garuda-environment-values.yml` runs that test directly (same pattern as `lint-golden-rule-10.yml` → `test_no_httpx_violators.py`) on any PR touching the workflow file, the test file, or `migrations_v2/**` — including a PR that touches ONLY the workflow file, which is exactly the shape of the original defect.

## Fail-closed guard at service_initializer.py — NOT included, and why

The three read-sites named in the mandate (`PostgresMagicLinkStore`/`PostgresCheckStore`/`GarudaOrderRepository` construction with `environment=...`) do not exist on `main` yet. Verified: `grep -in garuda apps/backend-rag/backend/app/setup/service_initializer.py` on this branch's base returns **zero** matches — the GARUDA backend wiring (migrations 285/286, the three store/repo classes) is still on unmerged feature branches (`feature/garuda-voa` and several `agent/air-m5/backend-rag/garuda-*` branches), confirmed via `git merge-base --is-ancestor <commit> origin/main` returning false for all of them. There is nothing to touch on `main` today. When that backend wiring lands, the guard belongs in that PR (or a fast follow), not retrofitted onto files this repo state doesn't have.

## Adversarial review

Tried to break my own fix:
- **Is the intersection computed correctly if migrations disagree?** Added `test_environment_check_clauses_are_internally_consistent` to assert the intersection is non-empty as a standalone check, separate from the workflow-vs-schema assertion — so a future migration that narrows the set to something not matching the workflow fails with a clear message pointing at *which* side is wrong.
- **Does the test fail closed on an empty sweep?** Yes — `_environment_check_intersection()` calls `pytest.fail(...)` explicitly if zero `CHECK (environment IN (...))` clauses are found anywhere, rather than vacuously passing (W84 — "an empty sweep is not a pass").
- **PyYAML's `on:` key gotcha** — PyYAML's default (non-1.2) resolver parses the bare `on:` mapping key as the boolean `True`. First run of the test hit `KeyError: 'on'` on the real file for exactly this reason; fixed by reading `workflow.get("on", workflow.get(True))`.
- **Does the test only catch the exact old defect, or the general class?** It diffs `options` (a set) against the schema intersection AND separately asserts the `default` is legal — the default is the more dangerous slot (what an operator gets by accepting the form as-is) and needed its own assertion since a value can be a legal *option* while still not being checked as the default.
- **Could hardcoding migration 285/286 by filename have looked more "precise"?** Deliberately avoided — those files don't exist on `main` yet and will be renumbered on landing (their own header says so). A filename-scoped test would either not exist yet (false safety) or go stale the moment the number changes. Scanning the whole `migrations_v2/*.sql` glob for the `CHECK (environment IN (...))` shape is what makes the tripwire follow the schema, not a snapshot of it.
- **Proved RED, not just asserted it**: temporarily reintroduced `SANDBOX` into both `options:` and `default:` on this exact file, ran the test, captured 2 real failures with precise diagnostic messages, then restored and reran to green (`collected 4 items`, `4 passed`). See PR description's sibling report to the requester for the literal pytest output.

## Test plan

- [x] `actionlint -color -shellcheck=` on both touched workflow files: clean (exit 0), and full-repo `actionlint` sweep also exit 0.
- [x] Tripwire RED reproduced (SANDBOX reintroduced) → 2 failures with diagnostic messages naming the illegal value and the schema-legal set.
- [x] Tripwire GREEN restored → `collected 4 items`, `4 passed in 0.08s`.
- [ ] CI required checks (this PR will be auto-merged on green, naked `gh pr merge --auto`, per repo ship-lifecycle rule).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>