### PR TITLE
docs(evidence): land orphaned L1 retention evidence pack (garuda-voa)

### DIFF
--- a/evidence/2026-08/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/brief.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/brief.yml
@@ -1,0 +1,38 @@
+task_id: garuda-l1-retention-0824
+gear: 3
+l_level: L1
+gate_class: hot-zone-migration
+objective: >
+  Extend the single retention authority (visa_decision_retention_policies,
+  ARCHITECTURE.md decision D2) with a policy_scope discriminator to cover
+  garuda_voa_checks: fail-closed insert (no active policy => write rejected),
+  bounded purge, legal-hold, self-service deletion, and PII-free aggregate
+  evidence — without creating a parallel policy table and without seeding
+  any policy row (a policy is a Zero-approved business decision, never a
+  migration default).
+constraints:
+  - Extend visa_decision_retention_policies, do not create a second table (D2).
+  - Trigger functions needing elevated privilege must be SECURITY DEFINER
+    from birth (migration 268 exists because 264's weren't).
+  - Never edit an applied migration (264) in place.
+  - Never reserve a migration number in advance (scar W40) — bind the
+    highest free number at commit time.
+  - No policy row may be seeded — every insert must fail until Zero
+    approves a real policy.
+acceptance: products/garuda-voa/journeys/retention-fail-closed.feature
+consumer_map:
+  - L2 (public API) and L7 (self-service deletion) consume
+    backend/services/garuda_flow/retention.py directly.
+  - All GARUDA lanes persisting a row into garuda_voa_checks depend on this
+    PR merging first (L1 is the prerequisite lane per LANES.md).
+risks:
+  - A trigger guard with a gap that only a table-owner connection exercises
+    (found and closed via a dedicated isolating test, see dissent).
+  - Legacy-row backfill colliding with the mutation guard's carve-out list
+    (found and closed, see dissent).
+grader: team-lead (integration-branch merger, generator!=grader — this
+  lane's own session never grades its own diff)
+budget: ~950 SQL lines (1 migration) + ~1100 Python/test lines across 3
+  files; 20 real-database tests, 2 bite-proof RED/GREEN cycles.
+pii: none — schema/trigger/test code only, no client data touched or
+  transcribed.

--- a/evidence/2026-08/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/pack.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/pack.yml
@@ -1,0 +1,81 @@
+brief_ref: "evidence/brief.yml"
+lanes:
+  - lane: L1
+    role: build
+    seat: sonnet-5
+receipts:
+  - claim: >
+      Migration 281 applies clean through the self-contained
+      GARUDA_MIGRATION_NUMBERS chain against a throwaway sandbox DB/role.
+    cmd: >
+      TEST_DATABASE_URL=postgresql://test@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/scripts/visa_engine/test_garuda_voa_retention.py -q
+    exit: 0
+    ts: "2026-08-25T00:00:00Z"
+    seat: sonnet-5
+  - claim: >
+      The Python retention surface (backend/services/garuda_flow/retention.py)
+      passes its own 7-test suite against the same sandbox.
+    cmd: >
+      TEST_DATABASE_URL=postgresql://test@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_flow/test_retention.py -q
+    exit: 0
+    ts: "2026-08-25T00:00:00Z"
+    seat: sonnet-5
+  - claim: >
+      squawk (the exact 13 --exclude rules from migration-lint.yml) finds
+      zero issues on 281_garuda_voa_retention.sql after the two suppression
+      comments were placed on the correct lines.
+    cmd: >
+      squawk --exclude=require-concurrent-index-creation
+      --exclude=require-timeout-settings
+      --exclude=require-concurrent-index-deletion --exclude=ban-drop-table
+      --exclude=ban-drop-column --exclude=ban-char-field
+      --exclude=prefer-bigint-over-smallint --exclude=prefer-text-field
+      --exclude=prefer-robust-stmts --exclude=constraint-missing-not-valid
+      --exclude=prefer-bigint-over-int --exclude=prefer-identity
+      --exclude=disallowed-unique-constraint
+      apps/backend-rag/backend/db/migrations_v2/281_garuda_voa_retention.sql
+    exit: 0
+    ts: "2026-08-25T00:39:00Z"
+    seat: sonnet-5
+  - claim: >
+      A pre-fix run of the same squawk command found the 2 real issues
+      (adding-not-nullable-field, identifier-too-long) this receipt's
+      sibling shows now suppressed with reason.
+    cmd: "gh run view 32751835979 --log-failed"
+    exit: 1
+    ts: "2026-08-25T00:10:00Z"
+    seat: sonnet-5
+dissent:
+  - seat: sonnet-5 (self, bite-proof — generator!=grader holds even
+      against one's own guard code)
+    objection: >
+      test_direct_delete_is_rejected_and_only_bounded_purge_may_delete
+      still passed with the guard's deeper
+      "OLD.retention_until < clock_timestamp() AND legal_hold=FALSE"
+      branch deleted outright, because that test's connecting role is
+      never the table owner — the earlier current_user<>table_owner
+      check already blocks it, leaving the deeper branch untested and
+      effectively dead code.
+    status: RETRACTED
+  - seat: sonnet-5 (self, bite-proof)
+    objection: >
+      bind_legacy_garuda_voa_checks_retention_policy's backfill UPDATE
+      was rejected by guard_garuda_voa_checks_retention_mutation with
+      "may only change view_count/share_count or legal_hold" — the
+      guard had no carve-out for the NULL->NOT NULL retention-column
+      transition the backfill performs, so the one function the
+      migration ships specifically to backfill legacy rows could not
+      run against its own migration.
+    status: RETRACTED
+  - seat: squawk-cli (external tool, CI run 32751835979)
+    objection: >
+      adding-not-nullable-field on the environment backfill (read-blocking
+      table scan) and identifier-too-long on the rollback-only EXCLUDE
+      constraint name (truncates silently at 63 bytes) — both genuine
+      findings against the raw migration, not suppressed without reason.
+    status: RETRACTED
+pii_scan: clean


### PR DESCRIPTION
## Summary

Lands the orphaned GARUDA VOA **L1 retention** evidence pack (`evidence/2026-08/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/{brief,pack}.yml`), verbatim from `origin/feature/garuda-voa`. The lane's CODE already merged; only its assembly-line evidence record was still stranded on the (soon-to-be-deleted) integration branch.

This is 1 of 5 sibling PRs landing 5 orphaned evidence directories — split into separate PRs (not one bundled docs PR) because bundling them makes this repo's own CI resolve them ambiguously (see below).

## Adversarial review

Four facts re-derived independently before touching anything:

1. **Resolver globs, doesn't scan.** `scripts/ci/evidence_paths.py::resolve_evidence_path` matches `^evidence/.*/{kind}\.yml$` only against **this PR's own changed-files list** (from `hotzone_changed_files.sh`, merge-base anchored) — never a directory scan. Confirmed by reading the source at `origin/main:scripts/ci/evidence_paths.py`.
2. **`main` already carries 38 evidence files across 20 distinct slug dirs**, coexisting fine: `git ls-tree -r --name-only origin/main -- evidence/ | wc -l` → 38.
3. **No name collision.** `comm -12` between main's 20 slugs and the 5 orphan slugs → empty.
4. **CORRECTION to the original brief**: the claim "PR #4959 carries its own evidence directory (`agent-m5-garuda-voa-train-02-backend-42e9f228`)" is **false as currently stated** — that directory does not exist on `origin/main` or `origin/feature/garuda-voa` HEAD. `gh pr view 4959 --json files` shows zero `evidence/` files in the merged diff; the pack only survives on the side branch `agent/m5/garuda-voa/train-02-backend` (commit `5b8a4a61a`). It is a **6th true orphan**, out of scope for this batch (not one of the 5 named), flagged for the requester to decide on separately. Does not affect this PR's own facts 1-3.

**Deeper check — can these 5 additions ever make `resolve_evidence_path` ambiguous for a FUTURE branch?** No: a future PR's own diff only lists files IT changed; it would have to independently touch two of these five existing directories' `pack.yml`/`brief.yml` files in the same PR to collide, which is not a plausible authoring pattern (nobody edits someone else's landed evidence pack). The five names cannot poison another branch's resolution.

**But it DOES break the landing PR itself if bundled.** Verified empirically: a synthetic changed-files list containing all 5 `pack.yml` (or all 5 `brief.yml`) paths raises `AmbiguousEvidencePathError` from `evidence_paths.py --resolve` — this is exactly what `harness-floor.yml` Step 2b runs, unconditionally, for every PR, before gear/floor is even computed. That is why this lands as **5 separate single-directory PRs** instead of the originally-specified single bundle — each PR's diff touches exactly one `pack.yml` + one `brief.yml`, so `--resolve` finds exactly one match and the pre-existing Gear-3 pack itself becomes this PR's own evidence (no new pack needed, no infinite-recursion problem).

**Gear floor for this diff**: `scripts/evidence_pack_lint.py::compute_floor` — neither `evidence/2026-08/.../brief.yml` nor `pack.yml` matches any `HOTZONE_PATTERNS` entry → **floor 1**. The landed pack self-declares `gear: 3` (≥ floor, allowed). Ceiling check (rule 7): `.yml` is not in `DOCS_LEDGER_EXTENSIONS` (`.md`/`.json` only) and this diff (119 net lines) exceeds `CEILING_SMALL_DIFF_MAX_NET_LINES` (60), so it is not "Gear-1-shaped" — no ceiling violation.

**Verified locally end-to-end**: staged this pack+brief into a synthetic `/tmp/evidence-check/evidence/{pack,brief}.yml` tree (mirroring CI's Step 7b) and ran `scripts/evidence_pack_lint.py <path> --repo-root /tmp/evidence-check --changed-files-file <2-file list>` → `evidence_pack_lint: clean`, exit 0.

**Content fidelity**: `git diff origin/feature/garuda-voa -- evidence/2026-08/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3` is empty — byte-identical to the source branch, untouched by any formatter.

Nothing found that needed fixing beyond the split-into-5 adjustment described above.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
