### PR TITLE
docs(evidence): land orphaned L3 checkout evidence pack (garuda-voa)

### DIFF
--- a/evidence/2026-08/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/brief.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/brief.yml
@@ -1,0 +1,90 @@
+task_id: garuda-l3-checkout-0825
+gear: 3
+l_level: L3
+gate_class: hot-zone-migration
+objective: >
+  Fix 3 own-diff defects found on L3's checkout/orders PR before it can
+  merge: (1) garuda_orders_router.py existed but had no manifest entry and
+  no include_router call, so the whole checkout funnel 404'd from routing;
+  (2) the lane's own money-path integration tests failed closed with
+  PersistencePolicyUnavailable because no GARUDA_ORDER retention policy row
+  existed and no test fixture installed one; (3) migration
+  284_garuda_orders.sql (renumbered from 282 -- see constraints) puts this
+  PR in the hot-zone Gear-3 floor, which requires its own evidence pack --
+  this pair is that pack.
+constraints:
+  - No retention policy row may be seeded by a migration (per
+    products/garuda-voa/DECISIONS.md, a policy is a Zero-approved business
+    decision). Tests must install their own fixture policy, mirroring L1's
+    _insert_garuda_check_policy pattern -- never insert a GARUDA_ORDER
+    policy via migrations_v2.
+  - Do not edit the already-merged 281_garuda_voa_retention.sql migration.
+  - Renumber ONLY on a real, currently-verified collision (scar W40) --
+    originally 282, verified free against origin/feature/garuda-voa AND
+    origin/agent/air-m5/backend-rag/garuda-l3-checkout-0825 at that time.
+    Team-lead's independent verification found 282 subsequently claimed by
+    an unmerged sibling branch's own 282_wa_reply_claims.sql, and 283
+    already taken on origin/main by a DIFFERENT wa_reply_claims migration
+    that landed there -- so 284 is the number bound at THIS landing
+    attempt, not reserved in advance.
+  - Router registration in this backend is NOT manifest-driven -- both
+    router_manifest.py (RouterEntry) AND router_registration.py
+    (include_routers + include_light_routers) need editing, mirroring how
+    L2's garuda_voa_public router was wired (commit 20ef324d1).
+acceptance: >
+  backend/tests/setup/test_router_manifest.py +
+  backend/tests/setup/test_manifest_registration_parity.py green (router
+  registered); backend/tests/services/garuda_orders/ collects and passes a
+  non-zero count of real tests against a migrated Postgres, including the
+  money-path tests in test_repository_integration.py that previously failed
+  closed on PersistencePolicyUnavailable, run TWICE back-to-back on the
+  same fresh database to prove the fixture leaves zero live policy state
+  behind (scar W96) and does not collide with itself on a second run.
+consumer_map:
+  - L4 (portal/magic-link auth) and L7 (documents) will wire real
+    app.state.garuda_magic_session_verifier / garuda_order_repository
+    adapters onto this router at orchestrator-composition time; until then
+    every route fails closed (503 SERVICE_UNAVAILABLE / SESSION_REQUIRED),
+    never a silent bypass.
+  - Any future GARUDA_ORDER-scope reader/writer depends on this PR's
+    manifest + registration entries to actually receive HTTP traffic in
+    prod (main_api / include_light_routers).
+risks:
+  - The router file's own docstring claimed mounting was deliberately left
+    to "the orchestrator" -- this PR overrides that reading because
+    test_router_manifest.py structurally requires every router file to
+    have a manifest entry (or an explicit dead-code whitelist entry), so
+    "orchestrator wires it later" was never actually optional here.
+  - Real adapter injection (EligibilityCheckLookup / PaymentProvider /
+    magic-session verifier) is still unwired -- mounting the router does
+    NOT make the funnel live end-to-end, only routable; it 503s/401s until
+    L4/L7 finish their part.
+  - This PR's own git history includes a sibling-race incident (cicatrix
+    family 5) -- a `git reset --hard` issued against the wrong worktree
+    moved the shared `feature/garuda-voa` branch, and a subsequent recovery force-push
+    briefly reverted a same-moment merge artifact of this exact branch.
+    team-lead's independent verification (`gh api` merge-record + compare)
+    established the base branch was never actually corrupted -- the
+    "merge" was itself an artifact of the same accidental push, not a real
+    reviewed merge -- and this branch's own 3 commits were never lost. This
+    PR lands through a normal fresh PR as a result, per team-lead's
+    decision, not by restoring anything.
+grader: team-lead (integration-branch merger, generator!=grader -- this
+  lane's own session never grades its own diff)
+budget: ~15 net lines (router_manifest.py + router_registration.py x2 +
+  docstring correction) + ~90 net lines (one test fixture, revised twice
+  under review to close two further real defects the review surfaced -- an
+  environment='PRODUCTION' label reused a naive DELETE-based teardown that
+  a live append-only guard trigger rejects outright, and a first UPDATE-
+  based redesign still self-collided via the EXCLUDE constraint until the
+  fixture's lower-bound backdating -- copied uncritically from L1's
+  throwaway-sandbox convention -- was removed) + 1 migration rename
+  (282->284, touched only the file + its own header comment + this pack's
+  own prose; no other file hardcoded the old number).
+  6 pytest gate invocations run against real Postgres across 4 throwaway
+  databases (manifest/parity gate on the shared dev DB; garuda_orders suite
+  first exposed the append-only-guard defect, then the self-collision
+  defect, then verified clean twice back-to-back on two separate fresh
+  databases), all dropped after verification.
+pii: none -- schema/router-registration/test-fixture code only, no client
+  data touched or transcribed.

--- a/evidence/2026-08/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/pack.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/pack.yml
@@ -1,0 +1,208 @@
+brief_ref: "evidence/brief.yml"
+lanes:
+  - lane: L3
+    role: build
+    seat: sonnet-5
+receipts:
+  - claim: >
+      Router manifest + registration parity gates pass with
+      garuda_orders_router registered (_API, no mount-time condition,
+      mirroring garuda_voa_public) -- 370 tests, zero failures.
+    cmd: >
+      cd apps/backend-rag && PYTHONPATH=.:../crm-cell .venv/bin/python -m
+      pytest backend/tests/setup/test_router_manifest.py
+      backend/tests/setup/test_manifest_registration_parity.py -q
+    exit: 0
+    ts: "2026-08-25T07:05:00Z"
+    seat: sonnet-5
+  - claim: >
+      Migration 284_garuda_orders.sql (renamed from 282 after team-lead's
+      independently-verified number collision) applies cleanly immediately
+      after 281_garuda_voa_retention.sql on three separate freshly-created
+      Postgres databases -- no rename fallout in any dependent statement.
+    cmd: >
+      createdb garuda_l3_verify7_<pid> && JWT_SECRET_KEY=... API_KEYS=...
+      DATABASE_URL=postgresql://localhost:5432/garuda_l3_verify7_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m backend.db.migrate
+      apply-all
+    exit: 0
+    ts: "2026-08-25T07:51:24Z"
+    seat: sonnet-5
+  - claim: >
+      An early fixture draft (bare `DELETE FROM
+      visa_decision_retention_policies` in teardown) fails outright: the
+      table carries a live BEFORE UPDATE OR DELETE trigger
+      (guard_visa_decision_retention_policy_mutation, migration 264) that
+      unconditionally raises RaiseError('visa_decision_retention_policies
+      is append-only') on any DELETE. 10 of 10
+      test_repository_integration.py tests errored with this exception on
+      first real run against a freshly migrated database -- proving the
+      review's DELETE-based fallback was not actually implementable here,
+      before any redesign was attempted.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://localhost:5432/garuda_l3_verify2_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/ -v
+    exit: 1
+    ts: "2026-08-25T07:44:00Z"
+    seat: sonnet-5
+  - claim: >
+      A second fixture draft (UPDATE-based close with a per-run uuid4
+      policy_version, no lower-bound change) silently reuses a stale
+      leftover open row instead of installing a fresh one: on a database
+      contaminated by the failed first draft's leftover open row, this
+      draft's own bare `ON CONFLICT DO NOTHING` swallowed the EXCLUDE-
+      constraint conflict between the new row's backdated (-1 day) lower
+      bound and the just-closed old row's window, so the test still passed
+      but against the WRONG (stale) row -- reproduced live by querying the
+      table directly after a run: 1 row total, unclosed, version still
+      reading the old fixed string, though the executing code had already
+      switched to uuid4 versions.
+    cmd: >
+      psql postgresql://localhost:5432/garuda_l3_verify2_<pid> -c
+      "SELECT policy_version, upper(effective_period) IS NOT NULL AS
+      closed FROM visa_decision_retention_policies WHERE
+      policy_scope='GARUDA_ORDER';"
+    exit: 0
+    ts: "2026-08-25T07:47:00Z"
+    seat: sonnet-5
+  - claim: >
+      Removing the copied-uncritically 1-day lower-bound backdate (the
+      actual root cause: any two open-ended-or-recently-closed
+      GARUDA_ORDER/TEST rows within a day of each other still overlap
+      under the EXCLUDE constraint even after a close) fixes the
+      self-collision. Re-run against the SAME already-contaminated
+      database: self-heals the stale row (closes it), inserts a genuinely
+      fresh row, all 47 tests pass, and a direct query shows every row the
+      run touched is closed with none left open.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://localhost:5432/garuda_l3_verify2_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/ -v
+      && psql postgresql://localhost:5432/garuda_l3_verify2_<pid> -c
+      "SELECT count(*), count(*) FILTER (WHERE upper(effective_period) IS
+      NOT NULL) AS closed, count(*) FILTER (WHERE upper(effective_period)
+      IS NULL) AS still_open FROM visa_decision_retention_policies WHERE
+      policy_scope='GARUDA_ORDER';"
+    exit: 0
+    ts: "2026-08-25T07:56:00Z"
+    seat: sonnet-5
+  - claim: >
+      Final design verified clean on TWO separate freshly-created Postgres
+      databases, each run TWICE back-to-back (proving both first-run
+      correctness on a pristine database and idempotent non-collision on a
+      repeat run against the same database, the CI-realistic shape): 47
+      collected, 47 passed, 0 skipped, 0 errors on all 4 invocations. Final
+      policy-table state after 2 runs on the same database: 20 total rows
+      (10 test functions x 2 runs), 20 closed, 0 still open -- proving the
+      fixture leaves zero live GARUDA_ORDER policy state behind (scar W96)
+      on either run.
+    cmd: >
+      createdb garuda_l3_verify7_<pid> && (migrate apply-all through 284)
+      && for i in 1 2; do INTAKE_TEST_DSN=postgresql://localhost:5432/garuda_l3_verify7_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/ -q; done
+      && psql ... -c "SELECT count(*), count(*) FILTER (...) AS closed,
+      count(*) FILTER (...) AS still_open FROM
+      visa_decision_retention_policies WHERE policy_scope='GARUDA_ORDER';"
+    exit: 0
+    ts: "2026-08-25T07:58:00Z"
+    seat: sonnet-5
+  - claim: >
+      Router manifest + registration parity gates re-verified green after
+      all fixture/migration edits (unaffected by them, checked anyway
+      since the same PR touches router_manifest.py) -- 370 tests, zero
+      failures.
+    cmd: >
+      cd apps/backend-rag && PYTHONPATH=.:../crm-cell .venv/bin/python -m
+      pytest backend/tests/setup/test_router_manifest.py
+      backend/tests/setup/test_manifest_registration_parity.py -q
+    exit: 0
+    ts: "2026-08-25T08:01:00Z"
+    seat: sonnet-5
+dissent:
+  - seat: sonnet-5 (self, bite-proof -- generator!=grader holds even
+      against one's own reading of the router file's docstring)
+    objection: >
+      garuda_orders_router.py's own module docstring stated mounting was
+      "orchestrator-scoped per LANES.md" and deliberately NOT this lane's
+      job. Read literally, editing router_registration.py here contradicts
+      the file's own stated intent.
+    status: RETRACTED
+    resolution: >
+      test_router_manifest.py structurally requires every router file
+      under backend/app/routers/ to have either a manifest entry or an
+      explicit NON_ROUTER_FILES/DEAD_ROUTER_FILE_HASHES whitelist entry --
+      "orchestrator wires it later" was never a state this repo's own gate
+      allows a live router file to sit in indefinitely. Mirrored the exact
+      shape L2 used for garuda_voa_public (commit 20ef324d1) and updated
+      the stale docstring to match.
+  - seat: sonnet-5 (self, bite-proof)
+    objection: >
+      Before reading repository.py and the migration, considered whether
+      PersistencePolicyUnavailable might indicate the DB function
+      active_garuda_order_policy_available() itself was broken or reading
+      the wrong scope -- i.e. that the defect was in product code.
+    status: RETRACTED
+    resolution: >
+      The function is correctly defined (mirrors L1's
+      active_garuda_check_policy_available exactly). The only thing
+      missing was a policy row, which per DECISIONS.md must never come
+      from a migration -- the fix is the test-fixture pattern L1's own
+      suite already established for GARUDA_CHECK, applied here for
+      GARUDA_ORDER.
+  - seat: team-lead (external reviewer, round 1 -- 3 pointed questions on
+      the first fixture draft)
+    objection: >
+      (1) Does the policy row live only in the test database, and could it
+      reach a real one via INTAKE_TEST_DSN misconfiguration? (2) Does the
+      fixture remove the row afterward, or leave production-shaped state
+      behind (scar W96)? (3) Does bare ON CONFLICT DO NOTHING swallow more
+      than the intended duplicate, and does the test still fail correctly
+      for a different cause?
+    status: CONFIRMED
+    resolution: >
+      All three were real gaps in the first draft: (1) same DSN-misroute
+      exposure as the file's pre-existing TRUNCATE, mitigated but not
+      eliminated by an environment='TEST' label (was 'PRODUCTION', changed
+      this round); (2) the draft never deleted the row -- confirmed via
+      direct inspection, not assumed; (3) verified the actual constraint
+      set on visa_decision_retention_policies (PK + 2 unique/exclusion
+      constraints) and confirmed CHECK/NOT NULL are outside ON CONFLICT's
+      scope, so (3) alone was already sound. (1) and (2) required the
+      redesign captured in the receipts above -- and that redesign then
+      surfaced two FURTHER real defects (the append-only guard rejecting
+      DELETE outright, and the EXCLUDE-constraint self-collision from a
+      copied backdated lower bound) that neither the review nor the first
+      redesign attempt had anticipated. Both are now closed and verified
+      live, not merely reasoned about.
+  - seat: sonnet-5 (self, bite-proof, round 2)
+    objection: >
+      Is there any remaining scenario where a crashed test run (not a
+      clean teardown) leaves a dangling open GARUDA_ORDER/TEST policy row
+      that a LATER run cannot self-heal past -- specifically, could two
+      concurrent pytest-xdist workers race the self-heal-then-insert
+      sequence against the SAME database and reintroduce the silent-swallow
+      round 1's fix closed for the sequential case?
+    status: RETRACTED
+    resolution: >
+      Checked the actual CI wiring rather than assuming: this repo's own
+      backend/tests/conftest.py (lines ~347-386) already solves exactly
+      this class of problem for a DIFFERENT reason (a prior, unrelated
+      xdist flake dated 2026-08-21, referenced in tests.yml's own comment)
+      -- at import time, when `PYTEST_XDIST_WORKER` is set, it clones a
+      throwaway per-worker database and REWRITES `INTAKE_TEST_DSN` (and
+      `TEST_DATABASE_URL`/`DATABASE_URL`) to point at that worker's own
+      isolated clone, before any test module's DSN read. Two xdist workers
+      therefore never share one physical database at all -- this
+      fixture's self-heal-then-insert sequence cannot race a sibling
+      worker's, because there is no shared table to race over. Separately,
+      `--dist loadfile` (tests.yml) keeps this file's 10 tests together on
+      ONE worker regardless, which is the exact shape already verified
+      live above (two full runs back-to-back on one database, sequential,
+      self-healing, zero rows left open). The self-heal's coverage is
+      therefore for the case actually exercised in this repo (a crashed
+      run's leftover row, on the same worker's own database on a later
+      run) -- not a hypothetical concurrent-worker race that this
+      codebase's own isolation mechanism already forecloses.
+pii_scan: clean


### PR DESCRIPTION
## Summary

Lands the orphaned GARUDA VOA **L3 checkout** evidence pack (`evidence/2026-08/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/{brief,pack}.yml`), verbatim from `origin/feature/garuda-voa`. Sibling PR of #4983 — see that PR for the full re-derivation of the shared facts (resolver semantics, no collision on main, the split-into-5 rationale, the #4959 correction). Repeated here for this PR's own gate:

## Adversarial review

- `scripts/ci/evidence_paths.py::resolve_evidence_path` matches against THIS PR's own changed-files list only (never a directory scan) — verified by reading `origin/main:scripts/ci/evidence_paths.py`.
- `main` carries 38 evidence files / 20 slugs today; this slug collides with none of them (`comm -12` empty).
- Bundling all 5 orphan directories into one PR self-triggers `AmbiguousEvidencePathError` in `harness-floor.yml` Step 2b (5 `pack.yml` matches) — verified empirically against a synthetic changed-files list. That's why this is 1 of 5 separate single-directory PRs, each touching exactly one `pack.yml` + one `brief.yml` so `--resolve` finds exactly one match and the landed Gear-3 pack serves as this PR's own evidence.
- Gear floor: neither file matches `HOTZONE_PATTERNS` → floor 1; pack self-declares `gear: 3` (≥ floor, fine). Ceiling: `.yml` isn't in `DOCS_LEDGER_EXTENSIONS`, and net lines (298) exceed the 60-line small-diff threshold, so not Gear-1-shaped — no ceiling violation.
- Verified locally: staged into a synthetic `/tmp/evidence-check/evidence/{pack,brief}.yml` tree and ran `scripts/evidence_pack_lint.py <path> --repo-root ... --changed-files-file <2-file list>` → `evidence_pack_lint: clean`, exit 0.
- Content fidelity: `git diff origin/feature/garuda-voa -- evidence/2026-08/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0` is empty.

Nothing found here beyond what #4983 already reports.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
