### PR TITLE
docs(garuda-voa): archive 5 orphaned lane evidence packs

### DIFF
--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/README.md
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/README.md
@@ -1,0 +1,24 @@
+# lane-evidence
+
+These are the assembly-line Evidence Packs (`brief.yml` + `pack.yml` per lane)
+for five of the build lanes behind the GARUDA VOA product: L1 retention, L3
+checkout, L4 practice, L4 store follow-up, and the L2/VOA composition seam.
+Their CODE already merged into `main`, across PRs #4950, #4952, #4955, #4959,
+#4960, #4968, #4972.
+
+They are preserved here — verbatim, byte-identical to the copies that lived
+on `feature/garuda-voa` — because that integration branch is dead and will be
+deleted, and this is otherwise the only record of how each lane's work was
+built and adversarially reviewed at the time.
+
+**This directory is archival, not live evidence for any open PR.** That is
+also why it does not live under `evidence/` at the repo root: this repo's
+evidence-resolution machinery (`scripts/ci/evidence_paths.py`,
+`scripts/evidence_pack_lint.py`, wired into `harness-floor.yml`) treats
+anything under `evidence/*/pack.yml` as a claim that THIS diff needs a real
+Gear-3 gate verdict. Every one of these five packs self-declares `gear: 3`
+(true of the original work) — landing them under `evidence/` would demand
+five independent graders adjudicate five file copies that change no
+behavior, which is ceremony without adjudication. Putting them here instead,
+beside this plan's `MANDATE.md`, keeps the record without spending a gate on
+it.

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/brief.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/brief.yml
@@ -1,0 +1,38 @@
+task_id: garuda-l1-retention-0824
+gear: 3
+l_level: L1
+gate_class: hot-zone-migration
+objective: >
+  Extend the single retention authority (visa_decision_retention_policies,
+  ARCHITECTURE.md decision D2) with a policy_scope discriminator to cover
+  garuda_voa_checks: fail-closed insert (no active policy => write rejected),
+  bounded purge, legal-hold, self-service deletion, and PII-free aggregate
+  evidence — without creating a parallel policy table and without seeding
+  any policy row (a policy is a Zero-approved business decision, never a
+  migration default).
+constraints:
+  - Extend visa_decision_retention_policies, do not create a second table (D2).
+  - Trigger functions needing elevated privilege must be SECURITY DEFINER
+    from birth (migration 268 exists because 264's weren't).
+  - Never edit an applied migration (264) in place.
+  - Never reserve a migration number in advance (scar W40) — bind the
+    highest free number at commit time.
+  - No policy row may be seeded — every insert must fail until Zero
+    approves a real policy.
+acceptance: products/garuda-voa/journeys/retention-fail-closed.feature
+consumer_map:
+  - L2 (public API) and L7 (self-service deletion) consume
+    backend/services/garuda_flow/retention.py directly.
+  - All GARUDA lanes persisting a row into garuda_voa_checks depend on this
+    PR merging first (L1 is the prerequisite lane per LANES.md).
+risks:
+  - A trigger guard with a gap that only a table-owner connection exercises
+    (found and closed via a dedicated isolating test, see dissent).
+  - Legacy-row backfill colliding with the mutation guard's carve-out list
+    (found and closed, see dissent).
+grader: team-lead (integration-branch merger, generator!=grader — this
+  lane's own session never grades its own diff)
+budget: ~950 SQL lines (1 migration) + ~1100 Python/test lines across 3
+  files; 20 real-database tests, 2 bite-proof RED/GREEN cycles.
+pii: none — schema/trigger/test code only, no client data touched or
+  transcribed.

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/pack.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/pack.yml
@@ -1,0 +1,81 @@
+brief_ref: "evidence/brief.yml"
+lanes:
+  - lane: L1
+    role: build
+    seat: sonnet-5
+receipts:
+  - claim: >
+      Migration 281 applies clean through the self-contained
+      GARUDA_MIGRATION_NUMBERS chain against a throwaway sandbox DB/role.
+    cmd: >
+      TEST_DATABASE_URL=postgresql://test@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/scripts/visa_engine/test_garuda_voa_retention.py -q
+    exit: 0
+    ts: "2026-08-25T00:00:00Z"
+    seat: sonnet-5
+  - claim: >
+      The Python retention surface (backend/services/garuda_flow/retention.py)
+      passes its own 7-test suite against the same sandbox.
+    cmd: >
+      TEST_DATABASE_URL=postgresql://test@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_flow/test_retention.py -q
+    exit: 0
+    ts: "2026-08-25T00:00:00Z"
+    seat: sonnet-5
+  - claim: >
+      squawk (the exact 13 --exclude rules from migration-lint.yml) finds
+      zero issues on 281_garuda_voa_retention.sql after the two suppression
+      comments were placed on the correct lines.
+    cmd: >
+      squawk --exclude=require-concurrent-index-creation
+      --exclude=require-timeout-settings
+      --exclude=require-concurrent-index-deletion --exclude=ban-drop-table
+      --exclude=ban-drop-column --exclude=ban-char-field
+      --exclude=prefer-bigint-over-smallint --exclude=prefer-text-field
+      --exclude=prefer-robust-stmts --exclude=constraint-missing-not-valid
+      --exclude=prefer-bigint-over-int --exclude=prefer-identity
+      --exclude=disallowed-unique-constraint
+      apps/backend-rag/backend/db/migrations_v2/281_garuda_voa_retention.sql
+    exit: 0
+    ts: "2026-08-25T00:39:00Z"
+    seat: sonnet-5
+  - claim: >
+      A pre-fix run of the same squawk command found the 2 real issues
+      (adding-not-nullable-field, identifier-too-long) this receipt's
+      sibling shows now suppressed with reason.
+    cmd: "gh run view 32751835979 --log-failed"
+    exit: 1
+    ts: "2026-08-25T00:10:00Z"
+    seat: sonnet-5
+dissent:
+  - seat: sonnet-5 (self, bite-proof — generator!=grader holds even
+      against one's own guard code)
+    objection: >
+      test_direct_delete_is_rejected_and_only_bounded_purge_may_delete
+      still passed with the guard's deeper
+      "OLD.retention_until < clock_timestamp() AND legal_hold=FALSE"
+      branch deleted outright, because that test's connecting role is
+      never the table owner — the earlier current_user<>table_owner
+      check already blocks it, leaving the deeper branch untested and
+      effectively dead code.
+    status: RETRACTED
+  - seat: sonnet-5 (self, bite-proof)
+    objection: >
+      bind_legacy_garuda_voa_checks_retention_policy's backfill UPDATE
+      was rejected by guard_garuda_voa_checks_retention_mutation with
+      "may only change view_count/share_count or legal_hold" — the
+      guard had no carve-out for the NULL->NOT NULL retention-column
+      transition the backfill performs, so the one function the
+      migration ships specifically to backfill legacy rows could not
+      run against its own migration.
+    status: RETRACTED
+  - seat: squawk-cli (external tool, CI run 32751835979)
+    objection: >
+      adding-not-nullable-field on the environment backfill (read-blocking
+      table scan) and identifier-too-long on the rollback-only EXCLUDE
+      constraint name (truncates silently at 63 bytes) — both genuine
+      findings against the raw migration, not suppressed without reason.
+    status: RETRACTED
+pii_scan: clean

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/brief.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/brief.yml
@@ -1,0 +1,90 @@
+task_id: garuda-l3-checkout-0825
+gear: 3
+l_level: L3
+gate_class: hot-zone-migration
+objective: >
+  Fix 3 own-diff defects found on L3's checkout/orders PR before it can
+  merge: (1) garuda_orders_router.py existed but had no manifest entry and
+  no include_router call, so the whole checkout funnel 404'd from routing;
+  (2) the lane's own money-path integration tests failed closed with
+  PersistencePolicyUnavailable because no GARUDA_ORDER retention policy row
+  existed and no test fixture installed one; (3) migration
+  284_garuda_orders.sql (renumbered from 282 -- see constraints) puts this
+  PR in the hot-zone Gear-3 floor, which requires its own evidence pack --
+  this pair is that pack.
+constraints:
+  - No retention policy row may be seeded by a migration (per
+    products/garuda-voa/DECISIONS.md, a policy is a Zero-approved business
+    decision). Tests must install their own fixture policy, mirroring L1's
+    _insert_garuda_check_policy pattern -- never insert a GARUDA_ORDER
+    policy via migrations_v2.
+  - Do not edit the already-merged 281_garuda_voa_retention.sql migration.
+  - Renumber ONLY on a real, currently-verified collision (scar W40) --
+    originally 282, verified free against origin/feature/garuda-voa AND
+    origin/agent/air-m5/backend-rag/garuda-l3-checkout-0825 at that time.
+    Team-lead's independent verification found 282 subsequently claimed by
+    an unmerged sibling branch's own 282_wa_reply_claims.sql, and 283
+    already taken on origin/main by a DIFFERENT wa_reply_claims migration
+    that landed there -- so 284 is the number bound at THIS landing
+    attempt, not reserved in advance.
+  - Router registration in this backend is NOT manifest-driven -- both
+    router_manifest.py (RouterEntry) AND router_registration.py
+    (include_routers + include_light_routers) need editing, mirroring how
+    L2's garuda_voa_public router was wired (commit 20ef324d1).
+acceptance: >
+  backend/tests/setup/test_router_manifest.py +
+  backend/tests/setup/test_manifest_registration_parity.py green (router
+  registered); backend/tests/services/garuda_orders/ collects and passes a
+  non-zero count of real tests against a migrated Postgres, including the
+  money-path tests in test_repository_integration.py that previously failed
+  closed on PersistencePolicyUnavailable, run TWICE back-to-back on the
+  same fresh database to prove the fixture leaves zero live policy state
+  behind (scar W96) and does not collide with itself on a second run.
+consumer_map:
+  - L4 (portal/magic-link auth) and L7 (documents) will wire real
+    app.state.garuda_magic_session_verifier / garuda_order_repository
+    adapters onto this router at orchestrator-composition time; until then
+    every route fails closed (503 SERVICE_UNAVAILABLE / SESSION_REQUIRED),
+    never a silent bypass.
+  - Any future GARUDA_ORDER-scope reader/writer depends on this PR's
+    manifest + registration entries to actually receive HTTP traffic in
+    prod (main_api / include_light_routers).
+risks:
+  - The router file's own docstring claimed mounting was deliberately left
+    to "the orchestrator" -- this PR overrides that reading because
+    test_router_manifest.py structurally requires every router file to
+    have a manifest entry (or an explicit dead-code whitelist entry), so
+    "orchestrator wires it later" was never actually optional here.
+  - Real adapter injection (EligibilityCheckLookup / PaymentProvider /
+    magic-session verifier) is still unwired -- mounting the router does
+    NOT make the funnel live end-to-end, only routable; it 503s/401s until
+    L4/L7 finish their part.
+  - This PR's own git history includes a sibling-race incident (cicatrix
+    family 5) -- a `git reset --hard` issued against the wrong worktree
+    moved the shared `feature/garuda-voa` branch, and a subsequent recovery force-push
+    briefly reverted a same-moment merge artifact of this exact branch.
+    team-lead's independent verification (`gh api` merge-record + compare)
+    established the base branch was never actually corrupted -- the
+    "merge" was itself an artifact of the same accidental push, not a real
+    reviewed merge -- and this branch's own 3 commits were never lost. This
+    PR lands through a normal fresh PR as a result, per team-lead's
+    decision, not by restoring anything.
+grader: team-lead (integration-branch merger, generator!=grader -- this
+  lane's own session never grades its own diff)
+budget: ~15 net lines (router_manifest.py + router_registration.py x2 +
+  docstring correction) + ~90 net lines (one test fixture, revised twice
+  under review to close two further real defects the review surfaced -- an
+  environment='PRODUCTION' label reused a naive DELETE-based teardown that
+  a live append-only guard trigger rejects outright, and a first UPDATE-
+  based redesign still self-collided via the EXCLUDE constraint until the
+  fixture's lower-bound backdating -- copied uncritically from L1's
+  throwaway-sandbox convention -- was removed) + 1 migration rename
+  (282->284, touched only the file + its own header comment + this pack's
+  own prose; no other file hardcoded the old number).
+  6 pytest gate invocations run against real Postgres across 4 throwaway
+  databases (manifest/parity gate on the shared dev DB; garuda_orders suite
+  first exposed the append-only-guard defect, then the self-collision
+  defect, then verified clean twice back-to-back on two separate fresh
+  databases), all dropped after verification.
+pii: none -- schema/router-registration/test-fixture code only, no client
+  data touched or transcribed.

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/pack.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/pack.yml
@@ -1,0 +1,208 @@
+brief_ref: "evidence/brief.yml"
+lanes:
+  - lane: L3
+    role: build
+    seat: sonnet-5
+receipts:
+  - claim: >
+      Router manifest + registration parity gates pass with
+      garuda_orders_router registered (_API, no mount-time condition,
+      mirroring garuda_voa_public) -- 370 tests, zero failures.
+    cmd: >
+      cd apps/backend-rag && PYTHONPATH=.:../crm-cell .venv/bin/python -m
+      pytest backend/tests/setup/test_router_manifest.py
+      backend/tests/setup/test_manifest_registration_parity.py -q
+    exit: 0
+    ts: "2026-08-25T07:05:00Z"
+    seat: sonnet-5
+  - claim: >
+      Migration 284_garuda_orders.sql (renamed from 282 after team-lead's
+      independently-verified number collision) applies cleanly immediately
+      after 281_garuda_voa_retention.sql on three separate freshly-created
+      Postgres databases -- no rename fallout in any dependent statement.
+    cmd: >
+      createdb garuda_l3_verify7_<pid> && JWT_SECRET_KEY=... API_KEYS=...
+      DATABASE_URL=postgresql://localhost:5432/garuda_l3_verify7_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m backend.db.migrate
+      apply-all
+    exit: 0
+    ts: "2026-08-25T07:51:24Z"
+    seat: sonnet-5
+  - claim: >
+      An early fixture draft (bare `DELETE FROM
+      visa_decision_retention_policies` in teardown) fails outright: the
+      table carries a live BEFORE UPDATE OR DELETE trigger
+      (guard_visa_decision_retention_policy_mutation, migration 264) that
+      unconditionally raises RaiseError('visa_decision_retention_policies
+      is append-only') on any DELETE. 10 of 10
+      test_repository_integration.py tests errored with this exception on
+      first real run against a freshly migrated database -- proving the
+      review's DELETE-based fallback was not actually implementable here,
+      before any redesign was attempted.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://localhost:5432/garuda_l3_verify2_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/ -v
+    exit: 1
+    ts: "2026-08-25T07:44:00Z"
+    seat: sonnet-5
+  - claim: >
+      A second fixture draft (UPDATE-based close with a per-run uuid4
+      policy_version, no lower-bound change) silently reuses a stale
+      leftover open row instead of installing a fresh one: on a database
+      contaminated by the failed first draft's leftover open row, this
+      draft's own bare `ON CONFLICT DO NOTHING` swallowed the EXCLUDE-
+      constraint conflict between the new row's backdated (-1 day) lower
+      bound and the just-closed old row's window, so the test still passed
+      but against the WRONG (stale) row -- reproduced live by querying the
+      table directly after a run: 1 row total, unclosed, version still
+      reading the old fixed string, though the executing code had already
+      switched to uuid4 versions.
+    cmd: >
+      psql postgresql://localhost:5432/garuda_l3_verify2_<pid> -c
+      "SELECT policy_version, upper(effective_period) IS NOT NULL AS
+      closed FROM visa_decision_retention_policies WHERE
+      policy_scope='GARUDA_ORDER';"
+    exit: 0
+    ts: "2026-08-25T07:47:00Z"
+    seat: sonnet-5
+  - claim: >
+      Removing the copied-uncritically 1-day lower-bound backdate (the
+      actual root cause: any two open-ended-or-recently-closed
+      GARUDA_ORDER/TEST rows within a day of each other still overlap
+      under the EXCLUDE constraint even after a close) fixes the
+      self-collision. Re-run against the SAME already-contaminated
+      database: self-heals the stale row (closes it), inserts a genuinely
+      fresh row, all 47 tests pass, and a direct query shows every row the
+      run touched is closed with none left open.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://localhost:5432/garuda_l3_verify2_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/ -v
+      && psql postgresql://localhost:5432/garuda_l3_verify2_<pid> -c
+      "SELECT count(*), count(*) FILTER (WHERE upper(effective_period) IS
+      NOT NULL) AS closed, count(*) FILTER (WHERE upper(effective_period)
+      IS NULL) AS still_open FROM visa_decision_retention_policies WHERE
+      policy_scope='GARUDA_ORDER';"
+    exit: 0
+    ts: "2026-08-25T07:56:00Z"
+    seat: sonnet-5
+  - claim: >
+      Final design verified clean on TWO separate freshly-created Postgres
+      databases, each run TWICE back-to-back (proving both first-run
+      correctness on a pristine database and idempotent non-collision on a
+      repeat run against the same database, the CI-realistic shape): 47
+      collected, 47 passed, 0 skipped, 0 errors on all 4 invocations. Final
+      policy-table state after 2 runs on the same database: 20 total rows
+      (10 test functions x 2 runs), 20 closed, 0 still open -- proving the
+      fixture leaves zero live GARUDA_ORDER policy state behind (scar W96)
+      on either run.
+    cmd: >
+      createdb garuda_l3_verify7_<pid> && (migrate apply-all through 284)
+      && for i in 1 2; do INTAKE_TEST_DSN=postgresql://localhost:5432/garuda_l3_verify7_<pid>
+      PYTHONPATH=.:../crm-cell .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/ -q; done
+      && psql ... -c "SELECT count(*), count(*) FILTER (...) AS closed,
+      count(*) FILTER (...) AS still_open FROM
+      visa_decision_retention_policies WHERE policy_scope='GARUDA_ORDER';"
+    exit: 0
+    ts: "2026-08-25T07:58:00Z"
+    seat: sonnet-5
+  - claim: >
+      Router manifest + registration parity gates re-verified green after
+      all fixture/migration edits (unaffected by them, checked anyway
+      since the same PR touches router_manifest.py) -- 370 tests, zero
+      failures.
+    cmd: >
+      cd apps/backend-rag && PYTHONPATH=.:../crm-cell .venv/bin/python -m
+      pytest backend/tests/setup/test_router_manifest.py
+      backend/tests/setup/test_manifest_registration_parity.py -q
+    exit: 0
+    ts: "2026-08-25T08:01:00Z"
+    seat: sonnet-5
+dissent:
+  - seat: sonnet-5 (self, bite-proof -- generator!=grader holds even
+      against one's own reading of the router file's docstring)
+    objection: >
+      garuda_orders_router.py's own module docstring stated mounting was
+      "orchestrator-scoped per LANES.md" and deliberately NOT this lane's
+      job. Read literally, editing router_registration.py here contradicts
+      the file's own stated intent.
+    status: RETRACTED
+    resolution: >
+      test_router_manifest.py structurally requires every router file
+      under backend/app/routers/ to have either a manifest entry or an
+      explicit NON_ROUTER_FILES/DEAD_ROUTER_FILE_HASHES whitelist entry --
+      "orchestrator wires it later" was never a state this repo's own gate
+      allows a live router file to sit in indefinitely. Mirrored the exact
+      shape L2 used for garuda_voa_public (commit 20ef324d1) and updated
+      the stale docstring to match.
+  - seat: sonnet-5 (self, bite-proof)
+    objection: >
+      Before reading repository.py and the migration, considered whether
+      PersistencePolicyUnavailable might indicate the DB function
+      active_garuda_order_policy_available() itself was broken or reading
+      the wrong scope -- i.e. that the defect was in product code.
+    status: RETRACTED
+    resolution: >
+      The function is correctly defined (mirrors L1's
+      active_garuda_check_policy_available exactly). The only thing
+      missing was a policy row, which per DECISIONS.md must never come
+      from a migration -- the fix is the test-fixture pattern L1's own
+      suite already established for GARUDA_CHECK, applied here for
+      GARUDA_ORDER.
+  - seat: team-lead (external reviewer, round 1 -- 3 pointed questions on
+      the first fixture draft)
+    objection: >
+      (1) Does the policy row live only in the test database, and could it
+      reach a real one via INTAKE_TEST_DSN misconfiguration? (2) Does the
+      fixture remove the row afterward, or leave production-shaped state
+      behind (scar W96)? (3) Does bare ON CONFLICT DO NOTHING swallow more
+      than the intended duplicate, and does the test still fail correctly
+      for a different cause?
+    status: CONFIRMED
+    resolution: >
+      All three were real gaps in the first draft: (1) same DSN-misroute
+      exposure as the file's pre-existing TRUNCATE, mitigated but not
+      eliminated by an environment='TEST' label (was 'PRODUCTION', changed
+      this round); (2) the draft never deleted the row -- confirmed via
+      direct inspection, not assumed; (3) verified the actual constraint
+      set on visa_decision_retention_policies (PK + 2 unique/exclusion
+      constraints) and confirmed CHECK/NOT NULL are outside ON CONFLICT's
+      scope, so (3) alone was already sound. (1) and (2) required the
+      redesign captured in the receipts above -- and that redesign then
+      surfaced two FURTHER real defects (the append-only guard rejecting
+      DELETE outright, and the EXCLUDE-constraint self-collision from a
+      copied backdated lower bound) that neither the review nor the first
+      redesign attempt had anticipated. Both are now closed and verified
+      live, not merely reasoned about.
+  - seat: sonnet-5 (self, bite-proof, round 2)
+    objection: >
+      Is there any remaining scenario where a crashed test run (not a
+      clean teardown) leaves a dangling open GARUDA_ORDER/TEST policy row
+      that a LATER run cannot self-heal past -- specifically, could two
+      concurrent pytest-xdist workers race the self-heal-then-insert
+      sequence against the SAME database and reintroduce the silent-swallow
+      round 1's fix closed for the sequential case?
+    status: RETRACTED
+    resolution: >
+      Checked the actual CI wiring rather than assuming: this repo's own
+      backend/tests/conftest.py (lines ~347-386) already solves exactly
+      this class of problem for a DIFFERENT reason (a prior, unrelated
+      xdist flake dated 2026-08-21, referenced in tests.yml's own comment)
+      -- at import time, when `PYTEST_XDIST_WORKER` is set, it clones a
+      throwaway per-worker database and REWRITES `INTAKE_TEST_DSN` (and
+      `TEST_DATABASE_URL`/`DATABASE_URL`) to point at that worker's own
+      isolated clone, before any test module's DSN read. Two xdist workers
+      therefore never share one physical database at all -- this
+      fixture's self-heal-then-insert sequence cannot race a sibling
+      worker's, because there is no shared table to race over. Separately,
+      `--dist loadfile` (tests.yml) keeps this file's 10 tests together on
+      ONE worker regardless, which is the exact shape already verified
+      live above (two full runs back-to-back on one database, sequential,
+      self-healing, zero rows left open). The self-heal's coverage is
+      therefore for the case actually exercised in this repo (a crashed
+      run's leftover row, on the same worker's own database on a later
+      run) -- not a hypothetical concurrent-worker race that this
+      codebase's own isolation mechanism already forecloses.
+pii_scan: clean

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-practice-0825-7f136829b/brief.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-practice-0825-7f136829b/brief.yml
@@ -1,0 +1,81 @@
+task_id: garuda-l4-practice-0825
+gear: 3
+l_level: L4
+gate_class: hot-zone-migration
+objective: >
+  Close the L4 practice-serving gap `garuda_orders_router.py::
+  get_order_and_practice` and `garuda_ops/synthetic_probe.py::
+  ReceivedPracticeStage` both named ("no garuda_portal/practice package
+  exists yet"): implement PR-01 (not_started -> Received on a paid order,
+  STATE-MACHINE.md line 84) and serve the real practice view instead of a
+  hardcoded null, filtered by the same order-ownership predicate PR4910
+  closed.
+constraints:
+  - Serve the frontend's ALREADY-COMMITTED contract shape
+    (apps/mouth/src/app/visa/voa/orders/types.ts) verbatim — never invent
+    a parallel shape.
+  - Every practice read must filter on (order_id, result_id_ref) — the
+    SAME predicate PR4910 closed the order-ownership IDOR with. Extending
+    that filter, not racing it (rebased onto feature/garuda-voa AFTER
+    PR4910 and PR4912 merged).
+  - No PII in logs, error messages, test fixtures, or commit messages.
+  - Only the published D-7 checkpoint may ever be customer-visible —
+    internal Safe Clock checkpoints never surface (this PR does not touch
+    that surface, but the constraint bound the design -- practice.py never
+    reads/serializes any internal checkpoint field).
+  - Prices from PricingTool only — this PR does not touch pricing at all
+    (price_idr passes through from garuda_orders unchanged).
+  - Bind the migration number (287) at commit time, not in advance (scar
+    W40) — re-checked against both main and feature/garuda-voa immediately
+    before this migration was written; PR4920 (open) claims 286.
+  - Deliberately scope out PR-02..PR-11 (staff transition engine) — no
+    staff UI/auth surface exists anywhere in this codebase to drive it,
+    and shipping an unreachable staff write path is the "green mascherava
+    organi morti" shape cicatrix-superscar.md family 2 (guard-over-match cluster) warns against.
+acceptance: products/garuda-voa/journeys/blocked-practice.feature (PR-01's
+  prerequisite half only — the block/resume/reject scenarios in that
+  feature file require PR-02..PR-11, out of scope here and explicitly
+  flagged as such in the PR body)
+consumer_map:
+  - apps/mouth/src/app/visa/voa/orders/ (OrderTracker.tsx,
+    useOrderTracking.ts) already calls GET /api/visa/voa/orders/{order_id}
+    and renders `practice` when non-null (L6, merged PR4876) — this PR is
+    the first thing that can ever make that field non-null in production.
+  - garuda_ops/synthetic_probe.py::ReceivedPracticeStage (L7) — corrected,
+    not unblocked -- the probe still cannot reach this stage because
+    sandbox_checkout/signed_webhook_paid block first on the orchestrator's
+    own composition gap (garuda_order_repository/garuda_payment_provider
+    unwired onto app.state). Flagged to team-lead, not fixed here — that
+    gap is outside L4's file ownership (garuda_orders_router.py's
+    get_repository()/app.state wiring is the orchestrator's own
+    composition step per that file's own module docstring).
+  - garuda_ops/crm_handoff.py (L7, merged, tested only against fakes)
+    consumes a PR-01 `practice.received` EventEnvelope with
+    aggregate_type=practice — this PR is the first thing that actually
+    appends that journal row in production; `CrmHandoffService` is not
+    yet constructed with a real adapter anywhere (ports.py's own
+    docstring -- nothing here may import asyncpg directly), so the CRM-
+    handoff half of "one Received practice" is still not wired end-to-end,
+    independent of this PR.
+risks:
+  - Lazy-on-read PR-01 (rather than an async outbox-job worker) was a
+    deliberate scope decision -- NO production code anywhere in this repo
+    consumes garuda_order_outbox for ANY job_type yet (checked —
+    payment_paid_email and staff_page_duplicate_charge are equally
+    unconsumed), so building a dedicated worker for one job_type would be
+    a unilateral infra decision this lane should not make. Flagged, not
+    silently substituted.
+  - The concurrency test (test_concurrent_reads_of_a_paid_order_never_
+    duplicate_pr01) gathers 5 coroutines against a pool with max_size=2 —
+    proves idempotency under connection-pool overlap, not a true N-way
+    simultaneous-commit race at the database level. The UNIQUE constraint
+    on source_paid_journal_event_id is what actually makes the invariant
+    structural; the test is corroborating evidence, not the proof.
+grader: team-lead (integration-branch merger, generator!=grader — this
+  lane's own session never grades its own diff)
+budget: ~170 SQL lines (1 migration) + ~285 Python lines (practice.py) +
+  ~330 test lines (test_practice.py, 8 real-database tests) + small edits
+  to garuda_orders_router.py / synthetic_probe.py / its staleness test.
+pii: none — schema/service/test code only. No client PII in any fixture,
+  log line, or commit message (test fixtures use synthetic result_id/
+  order_id strings, never real identifiers).

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-practice-0825-7f136829b/pack.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-practice-0825-7f136829b/pack.yml
@@ -1,0 +1,138 @@
+brief_ref: "evidence/brief.yml"
+lanes:
+  - lane: L4
+    role: build
+    seat: sonnet-5
+receipts:
+  - claim: >
+      Migration 287's forward DDL applies clean against a local Postgres
+      already carrying migrations through 284/285 (garuda_orders,
+      garuda_magic_link).
+    cmd: >
+      psql postgresql://balizero@localhost:5432/nuzantara_test
+      -f /tmp/287_forward.sql
+    exit: 0
+    ts: "2026-08-25T13:15:00Z"
+    seat: sonnet-5
+  - claim: >
+      PracticeRepository's 8-test integration suite passes against a real
+      Postgres, driving orders through the ACTUAL production repository
+      (GarudaOrderRepository.create_order_and_checkout /
+      handle_paid_event) rather than a hand-rolled row — covering: unpaid
+      order has no practice, first paid read mints Received (with journal
+      + outbox rows asserted), second read is idempotent (no duplicate
+      practice/journal/outbox), ownership filter hides another customer's
+      practice and does not side-effect one into existence, 5 concurrent
+      reads of the same paid order never mint two practices, a
+      nonexistent order returns None, and the "no OP-02 event" defensive
+      branch (unit-stubbed after the DB itself proved it unreachable via
+      the append-only journal trigger — see dissent).
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. .venv/bin/pytest
+      backend/tests/services/garuda_portal/test_practice.py -q
+    exit: 0
+    ts: "2026-08-25T13:45:00Z"
+    seat: sonnet-5
+  - claim: >
+      The full related-suite regression (ownership IDOR tests, L3 order
+      repository, L4 magic-link, L4 practice, L7 probe/staleness tripwire)
+      stays green after wiring get_order_and_practice and rewriting
+      ReceivedPracticeStage's reason.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. .venv/bin/pytest
+      backend/tests/app/routers/test_garuda_orders_ownership.py
+      backend/tests/services/garuda_orders/
+      backend/tests/services/garuda_portal/
+      backend/tests/services/garuda_ops/
+      backend/tests/app/routers/test_garuda_portal_auth.py
+      backend/tests/app/routers/test_garuda_portal_auth_mounted.py -q
+    exit: 0
+    ts: "2026-08-25T13:47:00Z"
+    seat: sonnet-5
+  - claim: >
+      The rewritten test_received_practice_claim_is_still_true (staleness
+      tripwire) passes, together with its two upstream siblings it now
+      shares a predicate shape with (sandbox_checkout, signed_webhook_paid).
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. .venv/bin/pytest
+      backend/tests/services/garuda_ops/test_blocked_stage_staleness.py -q
+    exit: 0
+    ts: "2026-08-25T13:46:00Z"
+    seat: sonnet-5
+  - claim: >
+      The FastAPI import chain (dependencies.py, and specifically
+      garuda_orders_router.py's new import of PracticeRepository) is
+      clean — no circular import, no rogue-AI import removal.
+    cmd: >
+      PYTHONPATH=. python -c
+      "from backend.app.dependencies import get_current_user;
+      from backend.app.routers.garuda_orders_router import router;
+      print('OK')"
+    exit: 0
+    ts: "2026-08-25T13:20:00Z"
+    seat: sonnet-5
+  - claim: >
+      Pre-commit hooks (migration-number uniqueness, migration ROLLBACK
+      marker presence, anti-reward-hacking lint, secret scan, Python
+      lint, FastAPI import-chain check, OFF-LIMITS file check) all pass
+      on the committed diff.
+    cmd: "git commit (pre-commit hook output captured in full)"
+    exit: 0
+    ts: "2026-08-25T13:48:12Z"
+    seat: sonnet-5
+dissent:
+  - seat: sonnet-5 (self, bite-proof — generator!=grader holds even
+      against one's own guard code)
+    objection: >
+      The first version of the "no OP-02 journal event" defensive-branch
+      test tried to force the anomaly by DELETEing the OP-02 row after a
+      real payment. That raised
+      `asyncpg.exceptions.CheckViolationError: garuda_order_journal is
+      append-only -- DELETE is forbidden` from migration 284's own guard
+      trigger. The scenario `_create_received_practice`'s docstring
+      claims is "structurally unreachable" is unreachable more strongly
+      than assumed (enforced by the database, not merely by the
+      application code's own transactional discipline) — but that also
+      means the defensive branch cannot be exercised end-to-end through
+      the public PracticeRepository surface with a real Postgres at all.
+      Replaced with a narrow unit test stubbing the connection directly
+      against `_create_received_practice`, which does exercise the
+      "logs and returns None" behavior, but is weaker evidence than an
+      integration test would have been for a scenario that (correctly)
+      cannot occur in production.
+    status: RETRACTED
+  - seat: sonnet-5 (self, bite-proof)
+    objection: >
+      test_concurrent_reads_of_a_paid_order_never_duplicate_pr01 gathers
+      5 coroutines against a pool fixture with min_size=1, max_size=2 —
+      this proves idempotency across overlapping/interleaved reads through
+      a shared pool, but with only 2 real connections available the 5
+      calls cannot all be truly simultaneous at the Postgres transaction
+      level the way 5 independent OS processes would be. The actual
+      structural guarantee is the UNIQUE constraint on
+      `garuda_practices.source_paid_journal_event_id` (migration 287),
+      which the test's assertions (exactly 1 practice row, exactly 1
+      PR-01 journal event, exactly 1 practice_id across all 5 results)
+      correctly pin regardless of how the pool scheduled the underlying
+      connections — but the test's own docstring should not be read as
+      "proved under true N-way DB-level concurrency", only "proved the
+      constraint the code relies on actually holds and the ON CONFLICT
+      fallback path actually returns the winner's row".
+    status: PLAUSIBLE
+  - seat: sonnet-5 (self, cross-check against a peer PR)
+    objection: >
+      Verified before writing any router code that PR4910 (order-ownership
+      IDOR fix) had actually MERGED into feature/garuda-voa, not merely
+      opened, and rebased this branch onto the refreshed integration
+      branch before touching garuda_orders_router.py — per the team-lead
+      brief's explicit instruction to extend PR4910's filter, not race it.
+      Also verified PR4912 (staleness-tripwire correction on the same
+      synthetic_probe.py file) had merged first, so this PR's edit to
+      ReceivedPracticeStage builds on PR4912's corrected sandbox_checkout/
+      signed_webhook_paid reasons rather than the stale ones they
+      replaced.
+    status: RETRACTED
+pii_scan: clean

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-store-followu-5026dd0a/brief.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-store-followu-5026dd0a/brief.yml
@@ -1,0 +1,155 @@
+task_id: garuda-l4-store-followup-0825
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  Follow-up to PR #4901 (GARUDA VOA L4 magic-link auth persistence, merged past
+  its own CI — hot-zone gate arrived only after that merge). Two spec
+  additions from a team-lead security review, plus a live migration
+  regression the merge itself introduced, all landed on one branch
+  (agent/air-m5/backend-rag/garuda-l4-store-followup-0825) per the Agent PR
+  Contract's "one PR, one concern" latitude for a follow-up fixing its own
+  predecessor:
+
+  1. RATE_LIMITED (429) was declared in the frozen contract for both
+     requestMagicLink and exchangeMagicLink but unreachable on every code
+     path. Implemented store-side, issue() only (email-scoped, 5/15min,
+     reuses the existing (email, created_at) index) -- exchange() left
+     unimplemented on purpose (IP-scoped brute-force concern, no client IP
+     in the store's Protocol signature; belongs at router/middleware,
+     documented in-code).
+
+  2. Timing-equivalence across exchange()'s three deny paths (unknown /
+     expired / consumed). The existing single-UPDATE implementation already
+     had the right structural discipline; added a structural
+     statement-count test (primary, CI-stable) and an advisory empirical
+     timing test (30 trials, 5x tolerance, explicitly not a constant-time
+     certification).
+
+  3. Migration regression, diagnosed by the team-lead: migration 285 (this
+     lane) added a third FK onto visa_decision_retention_policies, after
+     264 (owner) and 281 (GARUDA-VOA's first two FKs). A shared
+     visa_engine test helper (conftest.py:
+     unwind_garuda_voa_retention_fk/restore_garuda_voa_retention_fk) only
+     knew about 281's FK -- it was built after this exact bug was found
+     TWICE before, with a docstring literally asking the next migration's
+     author to register there. 285 was the third occurrence. Generalized
+     the hardcoded single-migration guard into a registry
+     (_GARUDA_VOA_RETENTION_FK_DEPENDENTS) of (migration_number, filename,
+     marker_table, marker_column), unwound in reverse / restored in
+     ascending order, and added a static tripwire test
+     (test_visa_engine_retention_fk_registry.py) that scans every
+     migration for a fresh FK onto that table and fails CI if it is not
+     registered -- so a FOURTH occurrence fails at PR-authoring time, not
+     three lanes downstream. Generalizing the fix then surfaced a SECOND,
+     independent bug: 285's own rollback unconditionally narrows a CHECK
+     constraint on an APPEND-ONLY table (264's guard trigger blocks
+     UPDATE/DELETE/TRUNCATE unconditionally) -- once any row uses the value
+     being removed, narrowing always fails. Fixed to skip the narrowing
+     (RAISE NOTICE, leave it widened) when such a row exists.
+
+  4. An independent adversarial review (Kimi K3, cross-family, dispatched
+     specifically because this diff touches a hot-zone migration and the
+     PR's own author cannot grade its own diff) found a real defect in the
+     NEW rate-limit code from item 1: the per-email count query used exact
+     string equality, so varying the email's case alone
+     (a@x.com/A@x.com/a@X.COM -- all the same mailbox per RFC 5321) let a
+     caller multiply its own throttle window. Fixed with
+     lower(email) = lower($1) on the count query only (not the stored
+     value, not the INSERT, not email delivery) -- narrow, does not touch
+     #4901's frozen issue()/exchange() semantics elsewhere.
+
+  Gear 3 by the deterministic floor (migrations_v2/*.sql touched), not by
+  the conductor's choice or by blast radius -- the diff is 8 files,
+  +577/-48.
+constraints:
+  - "No change to migration 285's forward SQL, table/column/FK shapes, or
+    to migration 264/281's forward OR rollback SQL. Only 285's own
+    ROLLBACK section is edited (a rollback-safety bugfix, not a schema
+    change -- 285 has never actually been rolled back in any real
+    database, forward-only usage is unaffected)."
+  - "conftest.py's public function signatures
+    (unwind_garuda_voa_retention_fk/restore_garuda_voa_retention_fk) are
+    unchanged -- test_evaluate_endpoint.py, test_shadow_evidence.py,
+    test_shadow_match.py (the three visa_engine test files that call them)
+    needed zero edits."
+  - "The email-case fix touches only the NEW rate-limit query added in
+    this same PR, not the stored email column, not issue()'s INSERT, not
+    exchange()'s token lookup, not email delivery -- avoids reopening
+    #4901's already-merged, already-tested issue()/exchange() core paths."
+  - "Not a branch-protection or CI-gate change. This PR was blocked by
+    Harness floor recompute (hot-zone floor 3, no evidence pack) after the
+    code/test fix was already pushed and verified green locally -- this
+    pack answers that gate, it does not touch the gate itself."
+acceptance:
+  - "backend/tests/services/garuda_portal/ + both garuda_portal_auth
+    router test files + backend/tests/services/visa_engine/ all pass on a
+    freshly created local Postgres (migrate.py apply-all, no leftover
+    state) -- 0 failed, 0 errors, 1 pre-existing unrelated skip."
+  - "test_visa_engine_retention_fk_registry.py passes and would fail if a
+    future migration added an FK onto visa_decision_retention_policies
+    without registering it (verified by construction: it statically
+    scans every migrations_v2/*.sql file)."
+  - "The two originally-red tests
+    (test_evaluate_endpoint.py::test_retention_policy_is_unseeded_and_new_decision_insert_fails_closed,
+    test_shadow_evidence.py::test_collect_filters_environment_and_uses_half_open_window)
+    pass even against a database carrying 51 leftover GARUDA_MAGIC_LINK
+    policy rows from repeated local test runs -- the append-only table's
+    natural long-run state, not a freshly-seeded best case."
+  - "ruff clean on every touched Python file; the FastAPI import chain
+    (backend.app.dependencies.get_current_user) still imports cleanly."
+consumer_map:
+  - "backend/tests/services/visa_engine/conftest.py -- shared fixture
+    helper consumed by test_evaluate_endpoint.py, test_shadow_evidence.py,
+    test_shadow_match.py (none of the three touch GARUDA-VOA code; all
+    three broke as bystanders when 285 merged)."
+  - "backend/db/migrations_v2/285_garuda_magic_link.sql -- rollback
+    section only; forward SQL (already deployed via PR #4901) untouched."
+  - "backend/services/garuda_portal/magic_link_store.py -- the rate-limit
+    count query, issue() only."
+  - "backend/app/routers/garuda_portal_auth.py,
+    backend/services/garuda_portal/magic_link.py -- RATE_LIMITED
+    exception + router wiring from item 1 (unchanged since the prior
+    commit on this branch, already independently tested)."
+risks:
+  - "The registry-based fix generalizes a pattern that previously failed
+    silently twice before this PR (per conftest.py's own docstring) --
+    residual risk is a FOURTH migration adding a dependency this registry
+    does not anticipate (e.g. an FK onto a DIFFERENT table this whole
+    apparatus does not cover). The tripwire test only covers FKs onto
+    visa_decision_retention_policies specifically, by design (that is the
+    table with the documented history), not a general migration-dependency
+    linter."
+  - "Kimi K3's adversarial review (dissent below) raised a structural
+    concern about restore_garuda_voa_retention_fk being unconditional
+    (replays ALL registered forwards) while unwind is per-entry
+    conditional -- tracked via a single aggregate bool, not per-migration
+    state. This is UNCHANGED behaviour from the pre-existing 281-only
+    version (same aggregate-bool shape, just now covering two entries
+    instead of one) and was not newly introduced by this PR; verified this
+    is not currently reachable by any of the three call sites (all three
+    only ever run in a database where the full deployed schema, both 281
+    and 285 forward-applied, is already live going in) but is a real edge
+    case if a future skewed-schema test DB exists. Not fixed here --
+    would require per-entry restore tracking, judged out of scope for a
+    regression-fix PR and ledgered as a follow-up rather than silently
+    left undocumented."
+  - "A 51-row leftover-policy scenario was hit and fixed for local dev,
+    but a CI worker sharing one Postgres clone across garuda_portal AND
+    visa_engine test FILES in the same pytest-xdist worker (alphabetical:
+    garuda_portal < visa_engine) could still exercise the exact
+    CheckViolationError this PR fixes, on a worker's FIRST run -- this is
+    precisely why the fix is a skip-not-fail, not an avoidance of ever
+    accumulating such rows."
+grader: |
+  Independent adversarial review by Kimi K3 (kimi-code/k3, Moonshot,
+  cross-family -- generator != grader relative to this PR's own author,
+  who is Anthropic-seated) against the full diff (784-line patch). Six
+  findings raised; see dissent below for each with independently-verified
+  status. One (email case-insensitivity) was CONFIRMED and fixed in this
+  same PR before this pack was written. The rest are PLAUSIBLE-but-
+  pre-existing-or-out-of-scope, documented rather than silently dropped.
+budget: 1 build lane (this session, code+test fix) + 1 independent review lane
+  (Kimi K3, one dispatch, ~5min wall) -- a regression fix + spec-addition
+  follow-up, not a fresh architectural decision needing council.
+pii: none

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-store-followu-5026dd0a/pack.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-l4-store-followu-5026dd0a/pack.yml
@@ -1,0 +1,212 @@
+brief_ref: evidence/brief.yml
+plan_ref: "PR #4902 (agent/air-m5/backend-rag/garuda-l4-store-followup-0825 -> feature/garuda-voa), 2026-08-25 -- team-lead's diagnosis of the 264/285 rollback regression on top of the two independently-verified spec additions (RATE_LIMITED reachability, exchange() timing-equivalence)."
+lanes:
+  - lane: garuda-l4-store-followup
+    role: build
+    seat: "claude-opus-5 (this conducting session -- authored the RATE_LIMITED/timing follow-up, diagnosed and fixed the 264/285 rollback regression, generalized the FK-dependent registry, fixed the email-case rate-limit gap found by review)"
+  - lane: garuda-l4-store-followup-review
+    role: review
+    seat: "kimi-code/k3 (Moonshot Kimi K3, cross-family, non-Anthropic -- independent adversarial review of the full 784-line diff, generator != grader)"
+seat_diversity: satisfied
+seat_diversity_note: >-
+  One build lane (Anthropic) + one review lane (Moonshot, non-Anthropic) --
+  the D3 floor (>=2 build lanes, one non-Anthropic) does not fire on a
+  single-build-lane pack, but declared explicitly rather than left to read
+  as satisfied by omission.
+diff:
+  net_lines: >-
+    9 files, +577/-48 (+ the security registry entries below) measured by
+    `git diff --numstat origin/feature/garuda-voa...HEAD`. Touches one
+    migration's ROLLBACK section only (285_garuda_magic_link.sql), one shared
+    test fixture (conftest.py), one new static tripwire test file, one
+    security-registry test file (declaring, not fixing, two now-public
+    mutating routes), and the store/router/test files from this PR's first
+    commit (RATE_LIMITED + timing-equivalence, already independently tested
+    before the regression fix was added on top).
+  behaviour_change: >-
+    Production forward-path behaviour change: the issue() rate-limit count
+    query now compares lower(email) instead of raw email (closes a real
+    throttle-bypass found by review). No other production runtime behaviour
+    changes -- the migration edit is rollback-only (285 has never been rolled
+    back in any real database), the test/fixture changes affect only the
+    test suite's own setup/teardown, never a served request path, and the
+    security-registry entries are a DECLARATION of pre-existing router
+    behaviour (both routes were already public via public_endpoints.py since
+    #4901; this PR adds the accounting, not a code change to reachability).
+receipts:
+  - claim: "The two tests the team-lead reported red (test_evaluate_endpoint.py::test_retention_policy_is_unseeded_and_new_decision_insert_fails_closed[SHADOW/ENFORCE], test_shadow_evidence.py::test_collect_filters_environment_and_uses_half_open_window) pass after the registry+rollback fix, even against a local DB carrying 51 leftover GARUDA_MAGIC_LINK policy rows from prior runs (the append-only table's real long-run state)."
+    cmd: 'PYTHONPATH=. pytest "backend/tests/services/visa_engine/test_evaluate_endpoint.py::test_retention_policy_is_unseeded_and_new_decision_insert_fails_closed" "backend/tests/services/visa_engine/test_shadow_evidence.py::test_collect_filters_environment_and_uses_half_open_window" -v'
+    exit: 0
+    ts: "2026-08-25T17:52:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "New static tripwire test (scans every migrations_v2/*.sql for an FK onto visa_decision_retention_policies and asserts registration) passes."
+    cmd: "PYTHONPATH=. pytest backend/tests/services/visa_engine/test_visa_engine_retention_fk_registry.py -v"
+    exit: 0
+    ts: "2026-08-25T17:47:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "Full garuda_portal + both garuda_portal_auth router test files + the entire visa_engine directory pass together on a database created fresh via migrate.py apply-all (dropdb/createdb, no leftover state) -- 0 failed, 0 errors, 1 pre-existing unrelated skip (visa_activation_executor role absent, documented since before this PR)."
+    cmd: "PYTHONPATH=. pytest backend/tests/services/garuda_portal/ backend/tests/app/routers/test_garuda_portal_auth.py backend/tests/app/routers/test_garuda_portal_auth_mounted.py backend/tests/services/visa_engine/ -q"
+    exit: 0
+    ts: "2026-08-25T19:08:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "New regression test proving the email-case rate-limit bypass Kimi K3 found is closed."
+    cmd: "PYTHONPATH=. pytest backend/tests/services/garuda_portal/test_magic_link_store_integration.py::test_issue_rate_limit_counts_across_email_case_variants -v"
+    exit: 0
+    ts: "2026-08-25T19:08:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "ruff clean on every Python file touched by this PR's second commit."
+    cmd: "ruff check backend/tests/services/visa_engine/conftest.py backend/tests/services/visa_engine/test_visa_engine_retention_fk_registry.py backend/services/garuda_portal/magic_link_store.py backend/tests/services/garuda_portal/test_magic_link_store_integration.py"
+    exit: 0
+    ts: "2026-08-25T19:08:30+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "FastAPI import chain still resolves cleanly (anti-rogue-AI smoke check)."
+    cmd: 'PYTHONPATH=. python -c "from backend.app.dependencies import get_current_user; print(''OK'')"'
+    exit: 0
+    ts: "2026-08-25T18:20:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "285_garuda_magic_link.sql's edited ROLLBACK section still parses correctly under the real migration runner's own splitter (not a hand-approximation)."
+    cmd: 'PYTHONPATH=. python3 -c "from backend.db.migration_base import split_migration_sql; from pathlib import Path; fwd, rb = split_migration_sql(Path(''backend/db/migrations_v2/285_garuda_magic_link.sql'').read_text()); assert ''garuda_285_narrow_policy_scope'' in rb; print(''OK'')"'
+    exit: 0
+    ts: "2026-08-25T19:00:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "test_mutating_routes_are_gated.py (the whole-app public-mutation accounting security gate) passes with the two new GARUDA VOA magic-link routes declared in INTENTIONALLY_PUBLIC_MUTATIONS -- re-run after correcting the /magic-links reason text per the team-lead's finding below."
+    cmd: "PYTHONPATH=. pytest backend/tests/security/test_mutating_routes_are_gated.py -v"
+    exit: 0
+    ts: "2026-08-25T20:05:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "ruff clean on the security registry test file."
+    cmd: "ruff check backend/tests/security/test_mutating_routes_are_gated.py"
+    exit: 0
+    ts: "2026-08-25T20:05:15+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: >-
+      RED-FIRST proof for the restore/unwind asymmetry fix (dissent #3,
+      CONFIRMED below): with restore_garuda_voa_retention_fk() temporarily
+      reverted to its old unconditional body, the new regression test fails
+      with asyncpg.exceptions.DuplicateColumnError on
+      'column "policy_scope" of relation "visa_decision_retention_policies"
+      already exists' -- exactly the failure the fix prevents.
+    cmd: "PYTHONPATH=. pytest backend/tests/services/visa_engine/test_visa_engine_retention_fk_registry.py::test_restore_only_reapplies_the_entry_that_was_actually_unwound -v"
+    exit: 1
+    ts: "2026-08-25T19:41:10+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: >-
+      GREEN after restoring the fix: all 3 tests in the FK-registry tripwire
+      file pass, including the new restore-only-reapplies-what-was-unwound
+      regression test, on a database created fresh via migrate.py
+      apply-all.
+    cmd: "PYTHONPATH=. pytest backend/tests/services/visa_engine/test_visa_engine_retention_fk_registry.py -v"
+    exit: 0
+    ts: "2026-08-25T19:41:45+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: >-
+      Full visa_engine directory (all files, not just the FK-registry test)
+      passes on a clean database, confirming the restore-side fix regresses
+      nothing else in the suite.
+    cmd: "PYTHONPATH=. pytest backend/tests/services/visa_engine/ -q"
+    exit: 0
+    ts: "2026-08-25T19:42:30+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: >-
+      garuda_portal integration tests still pass unaffected by the
+      restore-side fix.
+    cmd: "PYTHONPATH=. pytest backend/tests/services/garuda_portal/ -q"
+    exit: 0
+    ts: "2026-08-25T19:43:00+08:00"
+    seat: "claude-opus-5 (this session)"
+  - claim: "ruff clean after the restore-side fix and its new regression test."
+    cmd: "ruff check backend/tests/services/visa_engine/conftest.py backend/tests/services/visa_engine/test_visa_engine_retention_fk_registry.py"
+    exit: 0
+    ts: "2026-08-25T19:43:30+08:00"
+    seat: "claude-opus-5 (this session)"
+dissent:
+  - seat: "kimi-code/k3"
+    objection: >-
+      The new per-email rate-limit count query used exact string equality
+      (`WHERE email = $1`) against a column that is never case-normalized on
+      write. Email local/domain parts are case-insensitive in practice for
+      every major provider and per RFC 5321's domain rules, so a caller could
+      multiply its own 5-per-15-minute throttle by varying case alone
+      (a@x.com / A@x.com / a@X.COM all land in different count buckets while
+      being the same mailbox).
+    status: CONFIRMED
+  - seat: "kimi-code/k3"
+    objection: >-
+      TOCTOU between the rate-limit COUNT and the token INSERT: two
+      concurrent issue() calls with distinct Idempotency-Keys for the same
+      email can both pass the count check under READ COMMITTED before either
+      commits its INSERT, so the limit can be exceeded by roughly the
+      concurrency factor. No advisory lock or serializing constraint enforces
+      the count.
+    status: CONFIRMED
+  - seat: "kimi-code/k3 + team-lead (human-conducted session, independent convergence)"
+    objection: >-
+      restore_garuda_voa_retention_fk() unconditionally replayed the forward
+      SQL of every registered dependent migration, while
+      unwind_garuda_voa_retention_fk() rolled back only the entries whose
+      marker column was currently present, and reported success as a single
+      aggregate boolean rather than per-migration state. With ONE registered
+      dependent (migration 281) this was safe by construction: the aggregate
+      bool was unambiguous. Generalizing the registry to TWO entries (281 +
+      285, this PR) broke that -- in a database where only SOME registered
+      dependents are applied going in, an unconditional restore could
+      re-apply a migration unwind never actually rolled back, silently
+      mutating schema beyond the state the caller found. The team-lead
+      independently flagged this exact asymmetry (before re-reading Kimi's
+      finding) and argued the "no cheap already-applied check exists"
+      reasoning in restore's old docstring no longer held, because unwind's
+      own marker-column probe (information_schema.columns on
+      marker_table/marker_column) already IS that cheap check -- it just
+      was not being reused on restore's side.
+    status: CONFIRMED
+    resolution: >-
+      Fixed (this round): restore_garuda_voa_retention_fk() now probes each
+      registry entry's marker column for ABSENCE before re-applying its
+      forward SQL, mirroring unwind's own probe -- restore puts back exactly
+      what unwind actually took away, no more, regardless of how many
+      entries the registry grows to. The docstring now states explicitly
+      that this is a DELIBERATE OVERRIDE of the earlier "no cheap check
+      exists" decision. Red-first proof: a new regression test
+      (test_restore_only_reapplies_the_entry_that_was_actually_unwound)
+      manually unwinds ONLY 285, leaving 281 applied, then asserts restore
+      touches only 285. Confirmed this test fails with
+      asyncpg.exceptions.DuplicateColumnError against the OLD unconditional
+      restore body (285's forward SQL correctly re-applies, but 281's
+      unguarded ADD COLUMN policy_scope collides with the column already
+      live) before the fix was restored and the suite re-run green.
+  - seat: "kimi-code/k3"
+    objection: >-
+      A full unwind(285-then-281)->restore(281-then-285) round trip loses
+      data: 281's rollback DROPs the policy_scope column entirely (losing any
+      row's scope value along with it), and restoring 281's forward SQL
+      re-adds the column with a default that is not 'GARUDA_MAGIC_LINK' -- so
+      a policy row scoped GARUDA_MAGIC_LINK before the cycle would read a
+      different scope value after it.
+    status: PLAUSIBLE
+  - seat: "kimi-code/k3"
+    objection: >-
+      exchangeMagicLink is deliberately not rate-limited (documented,
+      accepted in this PR), but every exchange attempt -- including an
+      unauthenticated caller submitting a random invalid token under a fresh
+      Idempotency-Key -- permanently inserts a row into
+      garuda_magic_link_idempotency. An attacker could grow that table
+      unboundedly, a disk-fill concern distinct from the RATE_LIMITED
+      contract gap this PR closes.
+    status: PLAUSIBLE
+  - seat: "team-lead (human-conducted session, verified against handler source)"
+    objection: >-
+      The first draft of the INTENTIONALLY_PUBLIC_MUTATIONS reason for
+      POST /api/visa/voa/auth/magic-links asserted the unknown/not-owned
+      case "returns before the store is ever touched, so it costs the same
+      as the real path" -- self-contradictory (an early return costs LESS,
+      not the same) and factually wrong: the router's only early return
+      fires on "no ResultSession cookie" or "malformed result_id", both
+      caller-known facts requiring no server lookup. A well-formed but
+      unknown/not-owned result_id does NOT short-circuit -- it reaches
+      store.issue() exactly like a real match. Enumeration safety rests on
+      the STORE returning an identical outcome for unknown/not-owned/real,
+      not on the router skipping work for the unknown case; the original
+      text would have misled a future reviewer into trusting a property the
+      code does not actually provide by itself.
+    status: CONFIRMED
+pii_scan: clean

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-voa-composition0825-f6c83e10/brief.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-voa-composition0825-f6c83e10/brief.yml
@@ -1,0 +1,144 @@
+task_id: garuda-voa-composition-0825
+gear: 3
+l_level: L1
+gate_class: hot-zone-migration
+objective: >
+  Wire the GARUDA VOA composition last mile: seven lanes (L1-L7) had merged
+  individually into feature/garuda-voa but nothing was connected
+  end-to-end. This PR (#4920) stands up the real persistence for L2's
+  CheckStore Protocol and L3's EligibilityCheckLookup Protocol, closing the
+  gap between "seven lanes merged" and "the seam between them has ever
+  executed once". Concretely: migration 286 adds garuda_voa_check_results
+  (a new, standalone table keyed by the product-era result_id, NOT an
+  extension of the retired garuda_voa_checks archive -- see the migration's
+  own header and ARCHITECTURE.md D2 for why), PostgresCheckStore implements
+  the CheckStore port with idempotent create/get/delete, and
+  PostgresEligibilityCheckLookup implements the L3 lookup port. A follow-up
+  commit (dissent #1 from team-lead's review) adds
+  purge_expired_garuda_voa_check_results, the Python caller for migration
+  286's own purge_garuda_voa_check_results SQL function, which shipped
+  with zero callers otherwise (family #2, esiste != armato).
+constraints:
+  - >
+    Extend the retention authority by SCOPE REUSE, not a new authority --
+    the new table binds to the existing GARUDA_CHECK policy_scope
+    (migration 281), never a second one (ARCHITECTURE.md D2).
+  - >
+    No PII columns on garuda_voa_check_results by design, mirroring the
+    "shape of this table IS the safety argument" convention from the
+    retired archive table's own header.
+  - >
+    session_secret is stored HASHED (sha256) only; the raw value is
+    returned to the caller exactly once (on create) and never persisted.
+  - >
+    Do not touch service_initializer.py in this PR -- PR #4910 was
+    concurrently editing the same function block (garuda_staff_session_
+    verifier wiring); the composition wiring commit is deliberately
+    deferred to a follow-up once #4910 merges, per explicit sequencing
+    instruction from the orchestrating session.
+  - >
+    Never assign an async callable to app.state without confirming its
+    reader is `async def` and awaits it (team-lead's async-without-await
+    auth-bypass warning on this exact class of wiring) -- verified by grep
+    against every call site this diff touches; see dissent below.
+  - >
+    Take the next free migration number at file-creation time, never
+    reserve in advance (scar W40) -- checked immediately before writing,
+    re-checked before push after the branch moved under the task and a
+    rebase was required.
+acceptance:
+  - >
+    A check created through L2's real PostgresCheckStore is fetchable by
+    L3's real PostgresEligibilityCheckLookup and turns into an order -- the
+    seam that had never once executed -- proven in
+    test_check_to_order_journey.py against real Postgres with migrations
+    applied through 286.
+  - >
+    A result_id that does not exist, one belonging to another session, and
+    a malformed one each produce the contract's non-enumerating shape
+    (None / 404, never an exception, never a different error for
+    "exists but not yours" vs "does not exist").
+  - >
+    purge_expired_garuda_voa_check_results (dissent fix) rejects
+    out-of-range input, deletes an expired row via the bounded DB
+    primitive, and stays inert (0 rows) with no signed GARUDA_CHECK
+    policy -- proven against real Postgres in test_check_store_purge.py.
+  - >
+    The visa_engine retention FK registry tripwire
+    (test_visa_engine_retention_fk_registry.py) passes with 286 registered
+    in _GARUDA_VOA_RETENTION_FK_DEPENDENTS.
+  - >
+    ruff clean on every touched Python file; pre-commit/pre-push hooks
+    (anti-reward-hacking lint, secret scan, FastAPI import-chain check)
+    all pass.
+consumer_map:
+  - >
+    backend/app/routers/garuda_voa_public.py -- get_garuda_check_store()
+    reads app.state.garuda_check_store (this PR's wiring point), falling
+    back to UnconfiguredCheckStore until service_initializer.py's deferred
+    follow-up commit sets it.
+  - >
+    backend/services/garuda_orders/repository.py --
+    GarudaOrderRepository.create_order_and_checkout() awaits
+    self._lookup.get_reviewed_check(result_id); once wired, this will be
+    PostgresEligibilityCheckLookup.get_reviewed_check().
+  - >
+    backend/tests/services/visa_engine/conftest.py --
+    _GARUDA_VOA_RETENTION_FK_DEPENDENTS registry (shared tripwire, also
+    consumed by test_evaluate_endpoint.py, test_shadow_evidence.py,
+    test_shadow_match.py -- none of which touch GARUDA-VOA code directly).
+  - >
+    garuda_voa_check_results and garuda_voa_check_idempotency (migration
+    286) currently have NO production writer -- the composition wiring
+    commit that will make PostgresCheckStore.create() the first live
+    writer is explicitly deferred (see constraints). Today these tables
+    are reachable only from this PR's own test suite.
+  - >
+    services/garuda_ops/synthetic_probe.py -- NOT modified by this PR.
+    PersistenceStage, SandboxCheckoutStage and the other stages remain
+    BLOCKED; unblocking them is scoped to the deferred
+    service_initializer.py follow-up commit, once the real blockers this
+    PR removes are actually load-bearing in production.
+risks:
+  - >
+    The composition wiring commit (app.state.garuda_check_store,
+    garuda_order_repository, garuda_payment_provider) is NOT in this PR --
+    it is a known, declared gap, not an oversight. Consequence: this PR
+    alone does not make GARUDA VOA live; a follow-up PR is required and
+    is blocked on PR #4910 merging first (same service_initializer.py
+    function block).
+  - >
+    purge_expired_garuda_voa_check_results (dissent fix) has no
+    scheduler/cron wiring -- the erasure CAPABILITY exists and is tested,
+    but nothing invokes it on a cadence yet. This mirrors the archive
+    table's own purge primitive before it (also caller-less until wired),
+    not a new gap this PR introduces.
+  - >
+    The L1 fail-closed data gap -- no migration seeds a GARUDA_CHECK-scope
+    retention policy row. Today this means garuda_voa_check_results is
+    completely unreachable (every INSERT trigger-rejects), which is the
+    correct fail-closed state -- but it also means the new purge wrapper
+    is currently a no-op in every environment. Signing that policy row is
+    a Zero business decision (Legge 5), not something this PR can or
+    should fabricate.
+grader: >
+  team-lead (integration-branch merger, generator != grader -- this
+  lane's own session never grades its own diff)
+budget: >
+  1 migration (286, ~476 lines) + 2 new adapters (check_store.py,
+  eligibility_lookup.py) + 1 dissent-fix addition (purge wrapper, ~35
+  lines) + 2 new test files (journey test, purge test) + 1 conftest
+  registry line; 1 build lane (this session, Opus-5-seated), 1 independent
+  adversarial review lane (team-lead, this integration-branch orchestrator).
+pii: >
+  garuda_voa_check_results holds one row per anonymous eligibility check --
+  result_id (opaque >=128-bit id, not a credential), a hashed session
+  secret (sha256, raw value never persisted), nationality (3-letter ISO
+  code), entry/passport-expiry/VOA-expiry dates, case_type, purpose,
+  traveller count, decision, and price. No name, no passport number, no
+  email, no phone, no document image, no free-text field. This mirrors
+  the "no PII columns by design" convention from the retired
+  garuda_voa_checks archive table's own header. No cleartext PII appears
+  in any log, test fixture, migration comment, or this evidence pack --
+  the test fixtures use synthetic result_ids and a fixed test nationality
+  (USA) with no real client data anywhere in this diff.

--- a/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-voa-composition0825-f6c83e10/pack.yml
+++ b/docs/plans/2026-08-24-garuda-voa-live/lane-evidence/agent-air-m5-backend-rag-garuda-voa-composition0825-f6c83e10/pack.yml
@@ -1,0 +1,232 @@
+brief_ref: "evidence/brief.yml"
+lanes:
+  - lane: L2-composition
+    role: build
+    seat: opus-5
+receipts:
+  - claim: >
+      The L2<->L3 seam (a check created through PostgresCheckStore fetched
+      by PostgresEligibilityCheckLookup and turned into an order) actually
+      executes end-to-end against real Postgres, migrations applied
+      through 286 -- the seam that had never once run before this PR.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py -v
+    exit: 0
+    ts: "2026-08-25T12:10:00Z"
+    seat: opus-5
+  - claim: >
+      Non-existent, wrong-session, and malformed result_id each produce
+      the contract's non-enumerating shape (None, never a distinguishing
+      exception) across both the CheckStore.get() and
+      EligibilityCheckLookup.get_reviewed_check() paths.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py::test_a_result_id_that_does_not_exist_produces_the_contracts_non_enumerating_shape
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py::test_get_with_the_wrong_session_secret_is_non_enumerating
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py::test_lookup_returns_none_for_malformed_or_absent_result_id
+      -v
+    exit: 0
+    ts: "2026-08-25T12:12:00Z"
+    seat: opus-5
+  - claim: >
+      Dissent-fix receipt: purge_expired_garuda_voa_check_results rejects
+      out-of-range input, deletes an expired row via the bounded DB
+      primitive, and stays inert (0 rows) with no signed GARUDA_CHECK
+      policy -- the fail-closed state today.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_flow/test_check_store_purge.py -v
+    exit: 0
+    ts: "2026-08-25T13:05:00Z"
+    seat: opus-5
+  - claim: >
+      Full relevant suite (journey + purge + router + orders) is green
+      together, 74 tests total, no regressions from either the base
+      composition commit or the dissent-fix follow-up.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_flow/test_check_store_purge.py
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py
+      backend/tests/app/routers/test_garuda_voa_public.py
+      backend/tests/services/garuda_orders/ -q
+    exit: 0
+    ts: "2026-08-25T13:08:00Z"
+    seat: opus-5
+  - claim: >
+      No async-without-await auth-bypass pattern (team-lead's landmine
+      warning) exists anywhere in this PR's diff -- every call site that
+      invokes an async CheckStore/EligibilityCheckLookup method is itself
+      `await`ed, verified by direct grep against the call sites, not by
+      assertion.
+    cmd: >
+      grep -n "\.create(\|\.get(\|\.delete(\|get_reviewed_check("
+      backend/app/routers/garuda_voa_public.py
+      backend/app/routers/garuda_orders_router.py
+      backend/services/garuda_orders/repository.py
+    exit: 0
+    ts: "2026-08-25T11:50:00Z"
+    seat: opus-5
+  - claim: >
+      ruff is clean on every Python file touched by this PR, including the
+      dissent-fix follow-up commit.
+    cmd: >
+      ruff check backend/services/garuda_flow/check_store.py
+      backend/services/garuda_orders/eligibility_lookup.py
+      backend/tests/services/garuda_flow/test_check_store_purge.py
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py
+    exit: 0
+    ts: "2026-08-25T13:10:00Z"
+    seat: opus-5
+  - claim: >
+      Dissent #3 fix (static success/failure redirect URLs replaced by a
+      single per-order, per-nonce return URL): 4 new regression tests, and
+      confirmed each goes RED against the pre-fix constructor shape
+      (TypeError on the removed success_redirect_url/failure_redirect_url
+      kwargs) before going green against the fix -- not just written and
+      trusted.
+    cmd: >
+      PYTHONPATH=. pytest
+      backend/tests/services/payments/test_xendit_checkout_redirect.py -v
+    exit: 0
+    ts: "2026-08-25T14:05:00Z"
+    seat: opus-5
+  - claim: >
+      Full payments + garuda_orders + garuda_ops + ownership-router surface
+      is green after the Dissent #3 fix, 109 passed / 33 skipped (the
+      pre-existing, unrelated `role "nuzantara" does not exist` scar on
+      this M5 checkout), 0 failed.
+    cmd: >
+      PYTHONPATH=. pytest
+      backend/tests/services/payments/
+      backend/tests/services/garuda_orders/
+      backend/tests/services/garuda_ops/
+      backend/tests/app/routers/test_garuda_orders_ownership.py
+      --color=no
+    exit: 0
+    ts: "2026-08-25T14:07:00Z"
+    seat: opus-5
+  - claim: >
+      Corrected GARUDA_PUBLIC_BASE_URL default from https://www.balizero.com
+      to the canonical apex https://balizero.com (team-lead measured live:
+      apex is canonical, www. 308-redirects to it preserving the query
+      string) and re-cited the SSOT as apps/mouth's own canonical-URL
+      emitters (sitemap.ts, layout.tsx's NEXT_PUBLIC_PUBLIC_URL fallback)
+      rather than the README badge. Full surface still green after the
+      change, 109 passed / 33 skipped / 0 failed. Deliberately did NOT wire
+      NEXT_PUBLIC_PUBLIC_URL itself into the backend read -- it is a
+      frontend build-time var on a different deploy platform (Vercel vs
+      Fly); named it as the comment's cross-reference instead of coupling
+      by variable name.
+    cmd: >
+      PYTHONPATH=. pytest
+      backend/tests/services/payments/
+      backend/tests/services/garuda_orders/
+      backend/tests/services/garuda_ops/
+      backend/tests/app/routers/test_garuda_orders_ownership.py
+      --color=no
+    exit: 0
+    ts: "2026-08-25T14:35:00Z"
+    seat: opus-5
+  - claim: >
+      Fixed all 6 CodeQL alerts on b56cec23c in one commit. The real one
+      (Log Injection, eligibility_lookup.py): result_id is now validated
+      against the same _RESULT_ID_PATTERN the migration 285/286 CHECK
+      constraints and the two router copies already enforce, before it
+      reaches either the query or the log line; new regression test
+      proves a newline-bearing payload and a too-short/wrong-charset
+      payload both resolve to None. The 2 dead-store/uninitialized-var
+      test-fixture findings use the identical `raise` convention #4910
+      already established for the same CodeQL false-positive shape. The
+      dead assignment in test_a_declined_check_cannot_become_an_order was
+      confirmed genuinely dead (would have violated the 286 CHECK
+      constraint) before deleting, not assumed. The unused `logger` in
+      check_store.py was confirmed to have no missing warning -- the
+      purge path's audit trail lives in Postgres
+      (visa_decision_retention_batches), same as the sibling
+      retention.py module which has no logger either -- before removing
+      both the global and the now-unused `import logging`. The dual
+      import in test_check_to_order_journey.py's repository fixture was
+      replaced with monkeypatch's string-target form, matching
+      test_garuda_orders_ownership.py's identical fixture verbatim.
+    cmd: >
+      INTAKE_TEST_DSN=postgresql://balizero@localhost:5432/nuzantara_test
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_orders/test_check_to_order_journey.py
+      backend/tests/services/garuda_flow/test_check_store_purge.py
+      -v --color=no
+    exit: 0
+    ts: "2026-08-25T15:10:00Z"
+    seat: opus-5
+dissent:
+  - seat: team-lead (integration-branch orchestrator, cross-review of the
+      base composition commit)
+    objection: >
+      purge_garuda_voa_check_results (migration 286) shipped with ZERO
+      Python callers, while the sibling archive table's purge primitive
+      (purge_garuda_voa_checks) already had one wired in
+      garuda_flow.retention -- family #2, esiste != armato. The erasure
+      path for the table that will actually receive live traffic was less
+      wired than the archive table that receives none.
+    status: CONFIRMED
+  - seat: opus-5 (self, responding to team-lead's separate
+      async-without-await auth-bypass warning -- generator != grader holds
+      even against one's own new adapters)
+    objection: >
+      Checked whether this PR introduces any async callable assigned to
+      app.state (or any port) whose reader calls it without `await`,
+      matching the exact class of bug found live in
+      garuda_orders_router.py's _require_staff_actor. Grepped every call
+      site this diff touches (store.create/get/delete,
+      get_reviewed_check) -- all four are correctly awaited, and this
+      diff never touches _require_staff_actor or
+      garuda_staff_session_verifier.
+    status: RETRACTED
+  - seat: >
+      team-lead (structural review of the L3 order/payment wiring, the
+      third dissent)
+    objection: >
+      The chosen GARUDA_CHECKOUT_SUCCESS_URL/GARUDA_CHECKOUT_FAILURE_URL
+      static env vars can never work: orderId is a dynamic Next.js route
+      segment (`[orderId]/return`) that no fixed string can carry, the
+      configured host/path (kita.balizero.com/garuda-voa/*) doesn't exist
+      in apps/mouth at all, and a two-URL success/failure split
+      contradicts the return route's own contract ("the browser return is
+      an OBSERVATION, not a truth" -- there must be exactly one route).
+      Not a naming preference -- structurally cannot reach the frontend as
+      built.
+    status: CONFIRMED
+  - seat: >
+      team-lead (mutation-test critique of the third dissent's RED-first
+      evidence)
+    objection: >
+      The RED-first proof for test_xendit_checkout_redirect.py's 5 tests
+      was a TypeError on a removed constructor kwarg -- a vacuous red
+      (proves only that a signature changed, never reaches the
+      order-id-in-URL assertion). Team-lead mutated the fix instead
+      (dropped the order_id from the URL builder on the actual fixed
+      head) and re-ran: exit 0 -> exit 1, confirming the tests bite for
+      the right reason. Also confirmed the 308 apex redirect preserves
+      the query string, retracting a hazard opus-5 had not raised but
+      would have needed to rule out.
+    status: CONFIRMED
+  - seat: >
+      team-lead (CodeQL scan on b56cec23c, posted after the Gear-3 PASS
+      had already been issued -- verdict voided by team-lead's own
+      admission)
+    objection: >
+      6 new CodeQL alerts, one real (medium, Log Injection,
+      eligibility_lookup.py:67): get_reviewed_check's guard tested only
+      emptiness, so a client-supplied result_id containing newlines
+      reached both the SQL query and a logger.warning call on the
+      PostgresError path -- on a product whose PII boundary explicitly
+      covers logs. The code's own comment already claimed a "malformed
+      never reaches the DB/log" guarantee it did not provide; the
+      schema's own definition of malformed is the CHECK-constraint
+      pattern in migrations 285/286, not mere non-emptiness.
+    status: CONFIRMED
+pii_scan: clean


### PR DESCRIPTION
## Summary

Archives 5 orphaned GARUDA VOA lane evidence packs (L1 retention, L3 checkout, L4 practice, L4 store follow-up, L2/VOA composition) verbatim under `docs/plans/2026-08-24-garuda-voa-live/lane-evidence/<slug>/{brief,pack}.yml`, beside `MANDATE.md` where this product's other records live. Their code already merged (#4950/#4952/#4955/#4959/#4960/#4968/#4972); their only remaining home was `feature/garuda-voa`, a dead integration branch. Adds a `lane-evidence/README.md` explaining what these are and why they live here instead of under `evidence/`.

**Supersedes #4983–#4987** (closed, branches deleted). Those PRs landed the same content under `evidence/2026-08/<slug>/` — correct per the original ask, but each pack self-declares `gear: 3` (true of the original build work), and this repo's evidence machinery treats anything under `evidence/*/pack.yml` as a live claim needing a genuine Gear-3 gate verdict. Landing five such directories in one repo (even as 5 separate PRs, per the resolver-ambiguity fix from that round) would still cost 5 independent grader verdicts to adjudicate 5 byte-identical file copies that change no behavior — ceremony with no adjudication in it. Relocating avoids spending that.

## Adversarial review

**The honest trade-off, not sold as free**: relocating these packs out of `evidence/` gives up discoverability by evidence-slug — the entire reason the `evidence/<YYYY-MM>/<slug>/` convention (`scripts/ci/evidence_paths.py`) exists. We accept that specifically because these five packs are archival: they are not live evidence for any open PR, so the discoverability the convention buys has no consumer here. The alternative — landing under `evidence/` and paying for 5 Gear-3 verdicts on inert file copies — devalues the verdicts that do adjudicate real risk, which this repo has its own audit findings about (token-ceremony cost, `research/operations/2026-08-21-token-ceremony-ci-system-audit.md`).

**Content unchanged, only relocated.** Not a single field was edited — not `gear:`, not `lanes:`, nothing — because editing a record to fit a guard is exactly the thing this session would refuse to accept from anyone else. `cmp` against `origin/feature/garuda-voa`, all 10 files:

```
OK  agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/brief.yml
OK  agent-air-m5-backend-rag-garuda-l1-retention-082-6785ece3/pack.yml
OK  agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/brief.yml
OK  agent-air-m5-backend-rag-garuda-l3-checkout-0825-e6bbb7d0/pack.yml
OK  agent-air-m5-backend-rag-garuda-l4-practice-0825-7f136829b/brief.yml
OK  agent-air-m5-backend-rag-garuda-l4-practice-0825-7f136829b/pack.yml
OK  agent-air-m5-backend-rag-garuda-l4-store-followu-5026dd0a/brief.yml
OK  agent-air-m5-backend-rag-garuda-l4-store-followu-5026dd0a/pack.yml
OK  agent-air-m5-backend-rag-garuda-voa-composition0825-f6c83e10/brief.yml
OK  agent-air-m5-backend-rag-garuda-voa-composition0825-f6c83e10/pack.yml
```

**Floor verified as 1, resolver verified as untouched by this diff.** `scripts/evidence_pack_lint.py --print-floor --changed-files-file <this PR's 11 changed files>` → `1` (nothing here matches `HOTZONE_PATTERNS`). `scripts/ci/evidence_paths.py --resolve pack|brief --changed-files-file <same list>` → falls straight through to the ROOT fallback (`evidence/pack.yml` / `evidence/brief.yml`, zero-match default) — none of the 11 files under `docs/plans/...` match `^evidence/.*/{kind}\.yml$`, so the resolver never sees them as candidates, ambiguous or otherwise. This diff carries no `evidence/brief.yml` at all, so `harness-floor.yml`'s Step 4 reads "no brief, floor 1" and does not demand a Gear-3 verdict.

Nothing else found needing a fix. Content is a pure relocation; the #4959-evidence-directory correction from the earlier round stands as already reported (not part of this batch).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
