### PR TITLE
docs(research-os): P05 Intel Lake/MATA GARUDA preparation bundle (B1)

### DIFF
--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/CONTRACT-MAP.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/CONTRACT-MAP.md
@@ -1,0 +1,259 @@
+# Contract map — Intel Lake + MATA GARUDA topology, mapped onto the P04 frozen contract
+
+All file paths are relative to repo root. All line numbers were read in this session on the
+`agent/nuzantara/intel/ros-v1-p05-intel-prep-b01` worktree, HEAD `b27b46a13` (`git log --oneline
+-1` at session start). Re-measure before relying on a line number after any commit lands.
+
+## 1. Intel Lake — the live canonicalization pipeline
+
+### 1.1 Code
+
+| File | Role | Lines |
+|---|---|---|
+| `apps/backend-rag/backend/services/intel/intel_lake_service.py` | UPSERT logic: `record_observation()` writes one `intel_items` row (canonical, upsert-on-conflict) + one `intel_observations` row (append-only) per call. `canonicalize_url()` strips fragments/UTM params. | 260 |
+| `apps/backend-rag/backend/services/intel/intel_lake_router.py` | Tier-1 regex/keyword routing (`route_event`), `backfill_unrouted`, `backfill_needs_review`. **No Tier-2 function exists** — see §1.4. | 549 |
+| `apps/backend-rag/backend/app/routers/intel_lake.py` | FastAPI routes: `POST /api/intel/lake/observations` (single) and `POST /api/intel/lake/observations-batch`. Auth: static `X-Producer-Token` header matched against `INTEL_LAKE_PRODUCER_TOKEN` env, fail-closed if unset. | 221 |
+| `apps/backend-rag/backend/services/intel/dossier_compiler.py` + `dossier_models.py` + `dossier_repository.py` + `dossier_slug.py` | A **separate** pipeline: `TrendSignal` → `ResearchDossier` compilation via Claude CLI, with its own naive clustering (`DEFAULT_CLUSTER_SIMILARITY = 3` shared keywords — dossier_compiler.py). Not Intel Lake; not MATA GARUDA. A third, independent "story-adjacent" concept already in the repo (see §5). |
+| `apps/backend-rag/backend/services/intel/trend_hunter/` | Yet another adapter set (`GoogleTrendsAdapter`, `RedditAdapter`, `RSSAdapter`, `XAIAdapter`) feeding the dossier pipeline via `trend_signals` table + `pg_notify`, not Intel Lake's `intel_items`. |
+| `apps/backend-rag/backend/services/mata_garuda/cell_adapter.py` | The **one** sanctioned entry point from backend-rag into MATA GARUDA's Postgres schema (`asset_provenance`, migrations 154/155). 12 canonical `asset_kind` values (`ASSET_KIND_AUTHORITATIVE`), NATO-Admiralty `reliability`/`credibility` axes, `tlp` (white/green/amber/red/black). Lives here (not in `apps/mata-garuda/`) because `apps/mata-garuda`'s own `CLAUDE.md` forbids `asyncpg` as a runtime dependency (minimal-stack rule: only `pydantic>=2`). |
+
+### 1.2 Schema (migration `168_intel_lake_schema.sql`, additive, has rollback)
+
+```
+intel_items            -- canonical, UNIQUE(canonical_url), UPSERT touches only last_seen_at
+  id UUID PK · canonical_url TEXT UNIQUE · content_hash TEXT · title/summary TEXT
+  source_domain · language · jurisdiction · topic_tags TEXT[]
+  routing_status TEXT CHECK IN ('unrouted','blog','wr2','nb-intel','archive','skip','needs_review')
+  routing_targets JSONB · confidence_score REAL
+  first_seen_at / last_seen_at / published_at / expires_at TIMESTAMPTZ
+  raw_payload JSONB
+
+intel_observations      -- append-only, no UNIQUE, one row per producer-hit on the same URL
+  id BIGINT PK · item_id UUID FK->intel_items ON DELETE CASCADE
+  producer_name TEXT · observed_at TIMESTAMPTZ · raw_payload JSONB · score REAL
+
+intel_lake_audit_log     -- auth/audit trail per POST
+  producer_name · client_ip · request_path · status_code · payload_size · error_message
+
+Trigger: AFTER INSERT ON intel_items -> notify_intel_lake_event() -> events_outbox
+  (channel 'intel_lake_event', migration-146 outbox pattern). INSERT-only; UPDATE
+  (last_seen_at refresh) does not fire.
+```
+
+Later migrations touching this schema (found via `grep -rl "intel_lake\|IntelLake"
+apps/backend-rag/backend/db/migrations_v2/`):
+`171_intel_item_nb_pushes.sql` (junction table for NB pushes — §3), `174` and `192`
+(`*_jsonb_double_encoding_repair.sql` — two separate double-encoding incidents, one on
+`intel_lake`, one on the bridge outbox; both are repair migrations for a bug class the
+`intel_lake_service.py:155-160` comment documents was already hit once and fixed at the
+call site), `187_probe_sandbox_isolation.sql` (test-isolation, not schema), `175` (name
+contains `intel_lake`-adjacent string `wa_mirror`, false-positive grep hit — read and
+confirmed unrelated to Intel Lake).
+
+**Dedup mechanism today**: Postgres `UNIQUE(canonical_url)` constraint only. No
+content-hash-based near-duplicate detection, no cross-URL clustering, no translation/syndication
+awareness. `is_content_drift` (service layer) detects "same URL, different `content_hash`" and
+only **logs** a warning — it does not create a new canonical version, contrary to the module
+docstring's stated invariant ("Content drift → INSERT new row"); the actual `ON CONFLICT DO
+UPDATE` only touches `last_seen_at`. **This is a live discrepancy between the file's own
+docstring and its own SQL** — flagged, not fixed (out of this lane's mandate; see UNKNOWNS.md).
+
+### 1.3 Producers (found via grep for the two live-cron consumers of the API)
+
+- Pro-local cron `scripts/intel-lake-outbox-drain/` (LaunchAgent
+  `com.balizero.intel-lake.outbox-drain.minute`, 60s) — drains a local SQLite outbox
+  (`~/.intel-lake-outbox.db`) and POSTs batches to
+  `/api/intel/lake/observations-batch`. Producer identity is whatever wrote to that SQLite
+  file — **not enumerated by this bundle** (would require reading producer-side cron
+  registrations across `~/scripts/`, out of this lane's read scope on a first pass; flagged in
+  UNKNOWNS.md as the one piece of "producer registry" deliverable #1 could not close from the
+  monorepo alone).
+- The router-a2 and nb-pusher-a2 scripts (§1.4/§3) are consumers, not producers.
+- Migration `168`'s own comment: "Wave 1 producer: `intel_radar` (existing PG
+  `intel_radar_findings` from mig 139)" — i.e. `intel_radar.py` (Pro-local cron, referenced by
+  `apps/mata-garuda/scripts/*` and migration `156`'s docstring: "Pro-local `intel_radar.py`
+  cron call this function") is a MATA-GARUDA-adjacent producer that predates Intel Lake and
+  feeds `asset_provenance` via `mata_garuda.tag_intel_finding()`, a **separate** write path from
+  Intel Lake's own `record_observation()`. Confirms the packet's "12+ producers" framing refers
+  to a superset larger than what lives in this monorepo checkout.
+
+### 1.4 Tier-1/Tier-2 routing — confirms the packet's "no working Tier-2" claim
+
+`intel_lake_router.py:12` docstring: `"needs_review: NO rule matched → Tier 2 LLM (weekly)"`.
+Enumerated every function in the file (`grep -n "async def \|^def "`): `_build_press_pattern`,
+`_compile_keyword_pattern`, `_press_content_gate`, `route_event`, `backfill_unrouted`,
+`backfill_needs_review`, `register_intel_lake_router_handlers`. **None calls an LLM.**
+`backfill_needs_review` (line 458) re-applies the same Tier-1 regex rules to the `needs_review`
+pool — it is a retry of Tier 1, not an implementation of Tier 2. The packet's Live Baseline
+claim ("no working Tier-2 enrichment path") is confirmed by code enumeration, not inference.
+
+There is also a **second**, Pro-local implementation of Tier-1 routing:
+`scripts/intel-lake-router-a2/intel-lake-router-cron-standalone.py`, whose own docstring states
+it exists because "the Fly router code exists at `intel_lake_router.py` but its EventBus
+subscriber never fires" (kill-switch `DISABLE_BACKGROUND_WORKERS=1` from an unrelated 2026-04-12
+disk-full incident, "never removed" per the same docstring). **Two independent Tier-1
+implementations of the same regex rules exist, one dormant (Fly, EventBus-gated) and one live
+(Pro cron, 5-min interval)** — itself a duplicate-truth-path the packet's mission statement
+("removing parallel truth paths") should register as in-scope.
+
+## 2. MATA GARUDA — the OSINT organism
+
+### 2.1 Two runtimes, one name
+
+- `apps/mata-garuda/` — the actual Python package (`mata_garuda/`), Pro-local only, minimal-stack
+  (`pydantic>=2` runtime, no `asyncpg`), Redis-stream-native, `CLAUDE.md`-governed by its own
+  stricter rules (§4). Dozens of `scripts/run_*.py` runners, each LaunchAgent-invoked, each
+  calling a `mata_garuda.agents.*`/`mata_garuda.workers.*` function and emitting a heartbeat via
+  `mata_garuda.workers.heartbeat` (superscar family #2 antidote — every runner here already
+  writes the heartbeat sidecar).
+- `apps/backend-rag/backend/services/mata_garuda/cell_adapter.py` — the one place MATA GARUDA
+  data is readable/writable from the monorepo's own asyncpg pool (§1.1 above).
+
+### 2.2 The bridge: `apps/mata-garuda/mata_garuda/bridge/nerve.py` (Redis Stream `bridge:outbound`)
+
+`push_once()` (line 519) reads a consumer-group batch, looks up `env.type` in a **fixed
+two-entry dict** (line 398):
+
+```python
+PUSH_ROUTING: dict[str, str] = {
+    "intel.article_ready": "/api/bridge/ingest/article",
+    "enrichment.kb_entry": "/api/bridge/ingest/enrichment",
+}
+```
+
+If `env.type` is not one of those two keys, line 557-566:
+
+```python
+endpoint_path = PUSH_ROUTING.get(env.type)
+if endpoint_path is None:
+    logger.warning("Unknown push type %s (msg_id=%s) — ACKing to avoid loop", env.type, msg_id)
+    redis_xack(STREAM_BRIDGE_OUTBOUND, PUSH_CONSUMER_GROUP, msg_id)
+    stats["acked"] += 1
+    stats["errors"] += 1
+    continue
+```
+
+The message is **ACKed** (permanently removed from the consumer group's pending list — Redis
+Streams never redeliver an ACKed entry) and counted as `errors`, but there is no dead-letter
+stream, no persisted record of what was dropped beyond a log line, and no alerting keyed to this
+specific counter (confirmed: `stats` is the function's return value, consumed by whatever caller
+prints it — no distinct alert path grepped in this file).
+
+### 2.3 The producer that trips this: `apps/mata-garuda/mata_garuda/agents/wr2_bridge_publisher.py`
+
+Module docstring (lines 1-14): converts enriched stream items for 3 domains
+(`immigration_visa`, `tax_fiscal`, `investment_licensing`) into `WR2 research_dossiers`-compatible
+envelopes and publishes to `bridge:outbound`. `WR2_ENVELOPE_TYPE = "intel.research_dossier"`
+(line 34). **`"intel.research_dossier"` is not a key in `PUSH_ROUTING`.**
+
+**This is the packet's Live Baseline claim — "a broken WR2 research-dossier bridge whose
+consumer acknowledges unsupported message types" — confirmed by direct cross-file read, not
+inferred from the packet's own prose.** Every `intel.research_dossier` envelope
+`wr2_bridge_publisher.py` has ever produced has been silently ACKed-and-dropped by `nerve.py`,
+with no replay path, since the producer was written. This is exactly the shape of packet
+deliverable #5 ("Consumer contract that dead-letters unsupported types; unknown messages are
+never ACKed as success").
+
+The sibling worker `apps/mata-garuda/mata_garuda/workers/gap_consumer.py:194-217`
+(`process_gap`) has the **identical anti-pattern** on a different stream
+(`STREAM_NEXUS_GAPS`): unknown `gap_type` → log warning → `xack()` → return `{"status":
+"unknown"}`. Two independent consumers share one defect shape — the fix (dead-letter instead of
+ACK-drop) is a single reusable pattern, not two separate ones.
+
+## 3. The duplicated NotebookLM feed (packet's other named Live-Baseline defect)
+
+Two independent, code-confirmed paths write to NotebookLM:
+
+1. **MATA GARUDA's own feeder**: `apps/mata-garuda/scripts/run_nlm_feeder_stream.py`, consuming
+   Redis `garuda:alerts` (primary) + `garuda:enriched` (raw, filtered via `_SOURCE_TO_DOMAIN`),
+   routing to the 5 domain-matched NB-INTEL notebooks. Its own docstring: "Counterpart to
+   `run_sentinel_py.py` (which feeds only NB-INTEL-AIResearch via legacy KB-scan mode)" — i.e. a
+   **third** related-but-distinct feeder (`run_sentinel_py.py`) also exists, narrower-scoped.
+2. **Intel Lake's own pusher**: `scripts/intel-lake-nb-pusher-a2/intel-lake-nb-pusher-standalone.py`.
+   Its own docstring states the reason for its existence verbatim: *"mata-garuda's nlm_feeder
+   reads from Redis `garuda:enriched` (a parallel pipeline) and feeds its own NB-INTEL UUIDs.
+   Intel Lake routing is currently inert. This script closes the loop."* Uses a junction table
+   `intel_item_nb_pushes(item_id, nb_uuid, content_hash, status, ...)` (migration `171`,
+   confirmed present on disk) for per-target tracking, "at-least-once (NOT exactly-once)"
+   delivery per its own docstring (NLM CLI has no `--source-id` flag).
+
+Both feeders are live, unrelated code paths, writing to the same class of destination
+(NB-INTEL notebooks) with no shared dedup key between them. This is deliverable #6's target:
+"Exactly one canonical NotebookLM feed... the old parallel feed remains shadowed until Packet
+16." Packet 05 does **not** get to retire either feed (explicit non-goal: "Do not retire old
+producers/feeds yet"); Packet 05's job is to introduce the canonical third path *alongside*
+these two, shadowed, per the packet's own rollback section.
+
+## 4. MATA GARUDA's OSINT boundary (governs everything in §5's Cohort-B mapping)
+
+`apps/mata-garuda/CLAUDE.md` §"OSINT blindato (one-way IN)" (read directly this session):
+data flows `cloud → Mata Garuda (IN)` then only to `Mata Garuda → Nuzantara (business)` or
+`Mata Garuda → Zero TG (OUT)`; explicit ban list includes `apps/mouth/`, any frontend, clients,
+Bali Zero team, any cloud (Fly.io/Vercel/GCP/AWS), public repos/gists/pastebin. §1.4's named
+exception (Zero-authorized 2026-05-06): the local KG SQLite (`~/.agent/mata-garuda/kg.db`) may
+expose **metadata only** — `name, type, source_count, last_seen, neighbor_names,
+observation_count, observation.source_url` (always a public URL) — to local Pro organs via
+Tailscale loopback. Explicitly **forbidden** in that same payload: `observation.value` (may
+contain raw title/snippet OSINT), any content field, full article text.
+
+This is the ceiling for what Packet 05's `IntelEvent.payload_ref` may ever carry for a MATA
+GARUDA-sourced event when `classification.sensitivity` is `restricted_osint`: a durable
+`https://`/`s3://` reference (per §5.2's `DurablePayloadReference` pattern), never an inline
+payload, and never routed to a destination this CLAUDE.md's ban list names.
+
+## 5. Mapping onto the P04 frozen contract (`packages/research-os-core/research_os/models/`)
+
+25 model files exist (confirmed: `find packages/research-os-core/research_os/models -iname
+"*.py" | wc -l` → 26 including `__init__.py`). The two Cohort-B-relevant kinds, read in full
+this session:
+
+### 5.1 `IntelEvent` (`models/intel_event.py`, 306 lines)
+
+| Frozen field | Intel Lake today | Gap |
+|---|---|---|
+| `event_id: UUID` | `intel_items.id UUID` exists, but is per-**canonical-item**, not per-**observation** — an `IntelEvent` is closer to one `intel_observations` row than to one `intel_items` row | new UUID needed per observation, not reuse of `intel_items.id` |
+| `contract_version: Literal["research-os/v1.0.0"]` | absent | new column/field |
+| `tenant: Literal["bali-zero"]` | absent | new column/field, though trivially constant today |
+| `event_type: RegisteredName` (namespaced string) | `routing_status` is the closest concept but is a *downstream* classification (post-routing), not the event's own type | needs a producer-declared type distinct from routing outcome |
+| `producer.{name,version,machine_class}` | `intel_observations.producer_name TEXT` only — no version, no machine_class | schema extension |
+| `source.{uri,native_id,canonical_url,source_type,jurisdiction}` | `intel_items.canonical_url`, `jurisdiction` exist; `uri` (pre-canonicalization), `native_id`, `source_type` absent | partial |
+| `times.{published_at,observed_at,ingested_at}` | `published_at` exists on `intel_items`; `intel_observations.observed_at` exists; no `ingested_at` distinct from `observed_at` | partial |
+| `identity.{content_hash,normalized_hash,idempotency_key}` | `content_hash` exists (on `intel_items`, not per-observation); no `normalized_hash`; **no `idempotency_key` at all** — today's only idempotency is the DB `UNIQUE(canonical_url)` constraint, which is a coarser, URL-only key | this is the packet's deliverable #1's "stable idempotency keys" requirement — does not exist today in any form finer than "same URL" |
+| `classification.{language,domain,risk_class,sensitivity,rights}` | `language`, partial `topic_tags` (not `domain`) exist; **`risk_class` and `sensitivity` do not exist anywhere in the Intel Lake schema** | this is the biggest single gap — Intel Lake has no sensitivity boundary in its own schema today; the classification described in §4 (OSINT-blindato) is enforced entirely *outside* Intel Lake, in MATA GARUDA's own code and org boundary, not in the shared table |
+| `lineage.{pipeline_run_id,input_event_refs,parser_version,model_version,prompt_version}` | absent entirely | this is deliverable #1's "lineage" requirement and packet metric "100% producer/run/artifact lineage for the canary window" — currently 0% by construction, nothing tracks a run id |
+| `payload_ref` (discriminated: durable reference vs. inline-public, with content-hash verification on the inline arm) | `raw_payload JSONB` inline always, uncapped by classification (50KB size cap only) | no reference-storage arm exists at all; every payload today is "inline," which the frozen contract only permits when `sensitivity=public` — Intel Lake cannot express "internal"/"confidential"/"restricted_osint"/"client_pii" today, so it cannot express the constraint it would need to obey |
+| `object_hash` (RFC 8785 canonical + sha256, self-verifying) | absent | new, and Intel Lake has no existing canonicalization/hashing utility of its own — would need to import `research_os.hashing` |
+
+### 5.2 `StoryCluster` (`models/story_cluster.py`, 230 lines)
+
+No equivalent exists in Intel Lake at all — confirmed by schema read (§1.2): the only grouping
+mechanism today is the `UNIQUE(canonical_url)` constraint, which is exact-URL dedup, not
+clustering. Concepts `StoryCluster` requires that have zero analogue today:
+`independent_source_groups` (distinct-source corroboration, explicitly excluding syndicated
+members — see the model's own "without mistaking syndication for corroboration" purpose
+clause), `decision.layers_run` (ordered exact→normalized→near→semantic→human pipeline, with a
+validator enforcing deterministic layers never run *after* a semantic/model layer),
+`predecessor_refs` (merge/split/canonical_change history), `revision` numbering.
+
+The **closest existing artifact** is `dossier_compiler.py`'s `DEFAULT_CLUSTER_SIMILARITY = 3`
+(shared-keyword count) clustering of `TrendSignal` rows into `ResearchDossier` groups — a naive,
+un-labeled, un-benchmarked heuristic operating on an entirely different table
+(`trend_signals`/dossier tables, not `intel_items`). It is evidence that *some* clustering
+appetite already exists in the codebase, but it is not a candidate incumbent: it has no golden
+set, no precision/recall measurement, and no story-history/revision concept — it would need to
+be evaluated on equal footing with any other layer the packet's `MetricProfile` proposes, not
+promoted by default (see METRICS-AND-GOLDEN-SET.md §3).
+
+### 5.3 `research_os_objects` persistence substrate
+
+Per `contract-pass-001.md` §7 (re-read this session, not paraphrased): the migration for this
+table is additive, has a real rollback, and its apply→rollback→re-apply cycle passed against a
+throwaway database — but it **is applied in no environment**, confirmed absent from all 89 local
+databases censused that session. `apps/backend-rag/backend/services/research_os/` (7 files:
+`__init__.py`, `_core_path.py`, `action_intent_adapter.py`, `action_item_adapter.py`,
+`legacy_magazine.py`, `loss_report.py`, `operational_receipt_adapter.py`,
+`synthesis.py` — confirmed by directory listing this session) has adapters for
+`ActionIntent`/`ActionItem`/`OperationalReceipt` — **none for `IntelEvent` or `StoryCluster`**.
+No file in `apps/backend-rag` imports `research_os.models.intel_event` or
+`research_os.models.story_cluster` (not grepped exhaustively this session — flagged as an
+open verification in UNKNOWNS.md, but no adapter file exists to import them from regardless).

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/CONTRACT-MAP.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/CONTRACT-MAP.md
@@ -1,3 +1,9 @@
+---
+date: 2026-08-26
+domain: operations
+adversarial_review: kimi-k3
+---
+
 # Contract map — Intel Lake + MATA GARUDA topology, mapped onto the P04 frozen contract
 
 All file paths are relative to repo root. All line numbers were read in this session on the
@@ -40,8 +46,15 @@ Trigger: AFTER INSERT ON intel_items -> notify_intel_lake_event() -> events_outb
   (last_seen_at refresh) does not fire.
 ```
 
-Later migrations touching this schema (found via `grep -rl "intel_lake\|IntelLake"
-apps/backend-rag/backend/db/migrations_v2/`):
+Later migrations touching this schema. **CORRECTED 2026-08-26 (adversarial review):** the
+pattern below is a LITERAL-STRING search and therefore cannot match a migration that touches
+this schema by TABLE name. At least one such file exists and is absent from the list —
+`205_cockpit_intents.sql`, which references `intel_items` (comment-only, so the conclusion
+happens to survive; the METHOD does not). The list below is a lower bound, not the footprint.
+A second inconsistency in the same sentence: `171` is listed as found "via" this pattern, but
+re-running the pattern this session returns `168, 174, 175, 187, 192` — not 171. Original
+pattern, kept verbatim so the gap is reproducible: `grep -rl "intel_lake\|IntelLake"
+apps/backend-rag/backend/db/migrations_v2/`:
 `171_intel_item_nb_pushes.sql` (junction table for NB pushes — §3), `174` and `192`
 (`*_jsonb_double_encoding_repair.sql` — two separate double-encoding incidents, one on
 `intel_lake`, one on the bridge outbox; both are repair migrations for a bug class the
@@ -58,7 +71,8 @@ docstring's stated invariant ("Content drift → INSERT new row"); the actual `O
 UPDATE` only touches `last_seen_at`. **This is a live discrepancy between the file's own
 docstring and its own SQL** — flagged, not fixed (out of this lane's mandate; see UNKNOWNS.md).
 
-### 1.3 Producers (found via grep for the two live-cron consumers of the API)
+### 1.3 Producers (found via grep for the two live-cron consumers of the API — note the
+heading says "consumers" because the grep TARGET was the consumers; the section lists producers)
 
 - Pro-local cron `scripts/intel-lake-outbox-drain/` (LaunchAgent
   `com.balizero.intel-lake.outbox-drain.minute`, 60s) — drains a local SQLite outbox
@@ -80,12 +94,21 @@ docstring and its own SQL** — flagged, not fixed (out of this lane's mandate; 
 ### 1.4 Tier-1/Tier-2 routing — confirms the packet's "no working Tier-2" claim
 
 `intel_lake_router.py:12` docstring: `"needs_review: NO rule matched → Tier 2 LLM (weekly)"`.
-Enumerated every function in the file (`grep -n "async def \|^def "`): `_build_press_pattern`,
-`_compile_keyword_pattern`, `_press_content_gate`, `route_event`, `backfill_unrouted`,
-`backfill_needs_review`, `register_intel_lake_router_handlers`. **None calls an LLM.**
+Functions in the file. **CORRECTED after a cross-family adversarial review (Kimi K3,
+2026-08-26):** the pattern this bundle originally ran, `grep -n "async def \|^def "`, is
+anchored at column 0 for the sync case, so it is blind to INDENTED sync methods by
+construction. It returned seven names — `_build_press_pattern`, `_compile_keyword_pattern`,
+`_press_content_gate`, `route_event`, `backfill_unrouted`, `backfill_needs_review`,
+`register_intel_lake_router_handlers` — and MISSED two: `def __init__` (line 267) and
+`def _classify` (line 387), both indented inside `class IntelLakeRouter`. `_classify` is the
+actual rules engine. Re-read directly this session: neither of the two missed methods calls an
+LLM either, so the substantive conclusion survives — but it survives on a re-read, NOT on the
+enumeration, and a sync LLM helper would have escaped the original pattern unseen.
 `backfill_needs_review` (line 458) re-applies the same Tier-1 regex rules to the `needs_review`
 pool — it is a retry of Tier 1, not an implementation of Tier 2. The packet's Live Baseline
-claim ("no working Tier-2 enrichment path") is confirmed by code enumeration, not inference.
+claim ("no working Tier-2 enrichment path") is confirmed by reading all nine functions,
+including the two the first pattern missed. Do not cite it as "confirmed by complete
+enumeration": the enumeration was incomplete and was repaired by hand.
 
 There is also a **second**, Pro-local implementation of Tier-1 routing:
 `scripts/intel-lake-router-a2/intel-lake-router-cron-standalone.py`, whose own docstring states
@@ -144,7 +167,8 @@ prints it — no distinct alert path grepped in this file).
 Module docstring (lines 1-14): converts enriched stream items for 3 domains
 (`immigration_visa`, `tax_fiscal`, `investment_licensing`) into `WR2 research_dossiers`-compatible
 envelopes and publishes to `bridge:outbound`. `WR2_ENVELOPE_TYPE = "intel.research_dossier"`
-(line 34). **`"intel.research_dossier"` is not a key in `PUSH_ROUTING`.**
+(line 36 — an earlier revision of this bundle said 34; re-measured 2026-08-26).
+**`"intel.research_dossier"` is not a key in `PUSH_ROUTING`.**
 
 **This is the packet's Live Baseline claim — "a broken WR2 research-dossier bridge whose
 consumer acknowledges unsupported message types" — confirmed by direct cross-file read, not
@@ -207,7 +231,7 @@ payload, and never routed to a destination this CLAUDE.md's ban list names.
 "*.py" | wc -l` → 26 including `__init__.py`). The two Cohort-B-relevant kinds, read in full
 this session:
 
-### 5.1 `IntelEvent` (`models/intel_event.py`, 306 lines)
+### 5.1 `IntelEvent` (`models/intel_event.py`, 305 lines)
 
 | Frozen field | Intel Lake today | Gap |
 |---|---|---|
@@ -222,9 +246,9 @@ this session:
 | `classification.{language,domain,risk_class,sensitivity,rights}` | `language`, partial `topic_tags` (not `domain`) exist; **`risk_class` and `sensitivity` do not exist anywhere in the Intel Lake schema** | this is the biggest single gap — Intel Lake has no sensitivity boundary in its own schema today; the classification described in §4 (OSINT-blindato) is enforced entirely *outside* Intel Lake, in MATA GARUDA's own code and org boundary, not in the shared table |
 | `lineage.{pipeline_run_id,input_event_refs,parser_version,model_version,prompt_version}` | absent entirely | this is deliverable #1's "lineage" requirement and packet metric "100% producer/run/artifact lineage for the canary window" — currently 0% by construction, nothing tracks a run id |
 | `payload_ref` (discriminated: durable reference vs. inline-public, with content-hash verification on the inline arm) | `raw_payload JSONB` inline always, uncapped by classification (50KB size cap only) | no reference-storage arm exists at all; every payload today is "inline," which the frozen contract only permits when `sensitivity=public` — Intel Lake cannot express "internal"/"confidential"/"restricted_osint"/"client_pii" today, so it cannot express the constraint it would need to obey |
-| `object_hash` (RFC 8785 canonical + sha256, self-verifying) | absent | new, and Intel Lake has no existing canonicalization/hashing utility of its own — would need to import `research_os.hashing` |
+| `object_hash` (RFC 8785 canonical + sha256, self-verifying) | absent | new, and Intel Lake has no existing canonicalization/hashing utility of its own — would need to import `research_os.hashing`. **⚠️ D7 DEPENDENCY, flagged 2026-08-26:** `apps/mata-garuda` cannot import it — its own `CLAUDE.md` caps runtime deps at `pydantic>=2`. So any MATA-side `object_hash`, or the hash reconciliation in IMPLEMENTATION-SCOPE.md §5 step 6, needs the SAME RFC 8785+sha256 digest computed identically in TWO independent implementations — which is deliverable **D7 (deterministic cross-implementation hashing)**, a primitive `contract-pass-001.md` §7 forbids Cohort B from relying on. Do not design that reconciliation until D7 lands. |
 
-### 5.2 `StoryCluster` (`models/story_cluster.py`, 230 lines)
+### 5.2 `StoryCluster` (`models/story_cluster.py`, 229 lines)
 
 No equivalent exists in Intel Lake at all — confirmed by schema read (§1.2): the only grouping
 mechanism today is the `UNIQUE(canonical_url)` constraint, which is exact-URL dedup, not
@@ -249,11 +273,48 @@ promoted by default (see METRICS-AND-GOLDEN-SET.md §3).
 Per `contract-pass-001.md` §7 (re-read this session, not paraphrased): the migration for this
 table is additive, has a real rollback, and its apply→rollback→re-apply cycle passed against a
 throwaway database — but it **is applied in no environment**, confirmed absent from all 89 local
-databases censused that session. `apps/backend-rag/backend/services/research_os/` (7 files:
+databases censused **by that prior session, and NOT re-measured here** — this bundle had no
+live-DB access at all (UNKNOWNS.md §1), so "89" is a carried-over count, not a confirmation.
+It is quoted for provenance only and contradicts this bundle's own "no live counts anywhere"
+rule if read as current. `apps/backend-rag/backend/services/research_os/` (8 files:
 `__init__.py`, `_core_path.py`, `action_intent_adapter.py`, `action_item_adapter.py`,
 `legacy_magazine.py`, `loss_report.py`, `operational_receipt_adapter.py`,
 `synthesis.py` — confirmed by directory listing this session) has adapters for
 `ActionIntent`/`ActionItem`/`OperationalReceipt` — **none for `IntelEvent` or `StoryCluster`**.
-No file in `apps/backend-rag` imports `research_os.models.intel_event` or
-`research_os.models.story_cluster` (not grepped exhaustively this session — flagged as an
+**CORRECTED 2026-08-26:** an earlier revision asserted that no file in `apps/backend-rag`
+imports `research_os.models.intel_event` or `research_os.models.story_cluster`. That is FALSE —
+`apps/backend-rag/backend/tests/unit/research_os/test_models_and_fixtures.py:11,13` imports
+both. The substantive point stands (the importer is a TEST; no adapter exists), but the
+sentence as written was a claim the bundle had not run the search to support (it was hedged as an
 open verification in UNKNOWNS.md, but no adapter file exists to import them from regardless).
+
+
+## Adversarial review
+
+**Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
+bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):
+the generator was dead before the refuter was dispatched, so nothing moved under it.
+
+**Verdict: DEFECTIVE on method, sound on its two headline findings.** The bridge ACK-drop and the
+`intel_lake_service.py` docstring-vs-SQL drift both check out on independent re-read. The
+systematic defect is a *class*: single-search results stated with more precision than the search
+supports. Every finding below was re-verified against disk by the gating session before it was
+accepted — the refuter is not trusted either (superscar #6).
+
+| # | Finding | Verified | Disposition |
+|---|---|---|---|
+| 1 | D7 dependency unflagged: `object_hash` + MATA-side hash reconciliation need the same digest in two implementations, but `apps/mata-garuda` caps deps at `pydantic>=2` | TRUE (`grep D7` → 0 hits in bundle) | **FIXED** — §5.1 now flags it as a §7-forbidden primitive; do not design that reconciliation until D7 lands |
+| 2 | "Enumerated every function" used `^def ` — blind to indented sync methods; missed `__init__` (267) and `_classify` (387), the actual rules engine | TRUE | **FIXED** — §1.4 restated; conclusion survives on a re-read, not on the enumeration |
+| 3 | "7 files" while listing 8 names in the same sentence | TRUE (`ls` → 8) | **FIXED** |
+| 4 | Migration list from a literal-string grep, misses `205_cockpit_intents.sql` (`intel_items`); and `171` is listed as found by a pattern that does not return it | TRUE | **FIXED** — list relabelled a lower bound, both gaps named |
+| 5 | Line counts off: 306→305, 230→229, `WR2_ENVELOPE_TYPE` line 34→36 | TRUE | **FIXED** — re-measured |
+| 6 | "No file in `apps/backend-rag` imports `intel_event`/`story_cluster`" — false, a test file imports both | TRUE (hedged in-sentence and in UNKNOWNS §2) | **FIXED** — restated; substantive point (importer is a test, no adapter) stands |
+| 7 | "89 local databases" is a count carried from a prior session, contradicting this bundle's own "no live counts anywhere" | TRUE | **FIXED** — marked carried-over, not a confirmation |
+| 8 | §3.4 arithmetic defeats itself: needs >100, sets the two safety-critical strata to exactly 100; 1/100 = 1.00%, not < 1% | TRUE | **FIXED** — >=101 required, 810 total moves |
+| 9 | README cites §3 (NotebookLM feed) for the ACK-drop finding, which lives in §2.2/§2.3 | TRUE | **FIXED** |
+| 10 | UNKNOWNS §2 "two producer entrypoints" vs §1.3, which says `intel_radar` writes by a SEPARATE path | PARTIAL | **FIXED** — wording corrected, overstatement removed |
+| 11 | "Every dossier envelope has been ACKed-and-dropped since the producer was written" is a live-traffic history claim provable only from code paths | TRUE (overreach) | **ACCEPTED AS LIMIT** — the drop PATH is proven by direct read; whether the producer ever ran with traffic is unknowable without the live stream this bundle could not reach (UNKNOWNS §1) |
+
+**Not a finding** (refuter checked, found sound): migration numbering — head 287, 282 absent,
+`272_wa_broker_package_text.sql` WhatsApp-broker-owned; the bundle correctly refuses to bind an
+integer. Readiness claims — disclaimed consistently across README and UNKNOWNS §5.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/IMPLEMENTATION-SCOPE.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/IMPLEMENTATION-SCOPE.md
@@ -1,3 +1,9 @@
+---
+date: 2026-08-26
+domain: operations
+adversarial_review: kimi-k3
+---
+
 # Exact implementation scope — future file list, lease list, migration note
 
 **Nothing in this document was created or edited outside this bundle.** Every path below is
@@ -186,3 +192,34 @@ lease-check hook, not this lane.
 9. "Emit candidate DecisionPackets only after contract validation" — out of scope for the
    preparation bundle; the `DecisionPacket` frozen model exists in the 25-model list
    (CONTRACT-MAP.md §5) but was not read line-by-line this session (UNKNOWNS.md).
+
+
+## Adversarial review
+
+**Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
+bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):
+the generator was dead before the refuter was dispatched, so nothing moved under it.
+
+**Verdict: DEFECTIVE on method, sound on its two headline findings.** The bridge ACK-drop and the
+`intel_lake_service.py` docstring-vs-SQL drift both check out on independent re-read. The
+systematic defect is a *class*: single-search results stated with more precision than the search
+supports. Every finding below was re-verified against disk by the gating session before it was
+accepted — the refuter is not trusted either (superscar #6).
+
+| # | Finding | Verified | Disposition |
+|---|---|---|---|
+| 1 | D7 dependency unflagged: `object_hash` + MATA-side hash reconciliation need the same digest in two implementations, but `apps/mata-garuda` caps deps at `pydantic>=2` | TRUE (`grep D7` → 0 hits in bundle) | **FIXED** — §5.1 now flags it as a §7-forbidden primitive; do not design that reconciliation until D7 lands |
+| 2 | "Enumerated every function" used `^def ` — blind to indented sync methods; missed `__init__` (267) and `_classify` (387), the actual rules engine | TRUE | **FIXED** — §1.4 restated; conclusion survives on a re-read, not on the enumeration |
+| 3 | "7 files" while listing 8 names in the same sentence | TRUE (`ls` → 8) | **FIXED** |
+| 4 | Migration list from a literal-string grep, misses `205_cockpit_intents.sql` (`intel_items`); and `171` is listed as found by a pattern that does not return it | TRUE | **FIXED** — list relabelled a lower bound, both gaps named |
+| 5 | Line counts off: 306→305, 230→229, `WR2_ENVELOPE_TYPE` line 34→36 | TRUE | **FIXED** — re-measured |
+| 6 | "No file in `apps/backend-rag` imports `intel_event`/`story_cluster`" — false, a test file imports both | TRUE (hedged in-sentence and in UNKNOWNS §2) | **FIXED** — restated; substantive point (importer is a test, no adapter) stands |
+| 7 | "89 local databases" is a count carried from a prior session, contradicting this bundle's own "no live counts anywhere" | TRUE | **FIXED** — marked carried-over, not a confirmation |
+| 8 | §3.4 arithmetic defeats itself: needs >100, sets the two safety-critical strata to exactly 100; 1/100 = 1.00%, not < 1% | TRUE | **FIXED** — >=101 required, 810 total moves |
+| 9 | README cites §3 (NotebookLM feed) for the ACK-drop finding, which lives in §2.2/§2.3 | TRUE | **FIXED** |
+| 10 | UNKNOWNS §2 "two producer entrypoints" vs §1.3, which says `intel_radar` writes by a SEPARATE path | PARTIAL | **FIXED** — wording corrected, overstatement removed |
+| 11 | "Every dossier envelope has been ACKed-and-dropped since the producer was written" is a live-traffic history claim provable only from code paths | TRUE (overreach) | **ACCEPTED AS LIMIT** — the drop PATH is proven by direct read; whether the producer ever ran with traffic is unknowable without the live stream this bundle could not reach (UNKNOWNS §1) |
+
+**Not a finding** (refuter checked, found sound): migration numbering — head 287, 282 absent,
+`272_wa_broker_package_text.sql` WhatsApp-broker-owned; the bundle correctly refuses to bind an
+integer. Readiness claims — disclaimed consistently across README and UNKNOWNS §5.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/IMPLEMENTATION-SCOPE.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/IMPLEMENTATION-SCOPE.md
@@ -1,0 +1,188 @@
+# Exact implementation scope — future file list, lease list, migration note
+
+**Nothing in this document was created or edited outside this bundle.** Every path below is
+either (a) confirmed to already exist (read this session) or (b) explicitly marked NEW.
+
+## 1. Migration numbering — corrected, and re-derive again before use
+
+The dispatching session's prompt asserted `SESSION-BOARD.md`'s "272" figure was wrong and gave
+287 as the real head with 282 missing. **Independently re-measured this session**, not accepted
+on the prompt's word:
+
+```
+$ ls apps/backend-rag/backend/db/migrations_v2/ | grep -oE '^[0-9]+' | sort -n | tail -5
+283
+284
+285
+286
+287
+$ for n in 278 279 280 281 282 283 284 285 286 287; do ...; done
+278: 278_reassign_orphaned_clients_setup_team.sql
+279: 279_research_os_contract_core.sql
+280: 280_research_os_objects_truncate_guard.sql
+281: 281_garuda_voa_retention.sql
+282: MISSING
+283: 283_wa_reply_claims.sql
+284: 284_garuda_orders.sql
+285: 285_garuda_magic_link.sql
+286: 286_garuda_voa_check_results.sql
+287: 287_garuda_practices.sql
+```
+
+Confirmed: head is `287`, `282` is a genuine gap (not a counting error — "count the files" would
+give a different, wrong answer than "max + 1"), and `272` (`272_wa_broker_package_text.sql`,
+confirmed present, WhatsApp-broker-owned) is unrelated to this packet.
+
+**This lane is forbidden from creating, editing, or applying any migration, by any number**
+(dispatch prompt, explicit). The symbolic name reserved for this packet's eventual persistence
+work is **`research_os_intel_lake_events`** (per the dispatching session's prompt). This
+document does **not** bind an integer to that name. Whoever builds Packet 05 for real must
+re-run the two commands above at that time — the head will have moved again by then, and
+`282`'s gap is itself a fact that could theoretically close (a future PR could claim it) or
+persist; neither this document nor any other should be trusted for that number later.
+
+## 2. File ownership — packet's declared list, verified against disk
+
+The packet's "File ownership" section (§ Primary monorepo ownership) names 8 items. Verified
+presence this session:
+
+| Packet-declared path | Exists today? | Notes |
+|---|---|---|
+| `apps/backend-rag/backend/services/intel/intel_lake_service.py` | yes, 260 lines | CONTRACT-MAP.md §1.1 |
+| `apps/backend-rag/backend/services/intel/intel_lake_router.py` | yes, 549 lines | CONTRACT-MAP.md §1.1/§1.4 |
+| `apps/backend-rag/backend/app/routers/intel_lake.py` | yes, 221 lines | CONTRACT-MAP.md §1.1 |
+| "additive Intel Lake migrations and repositories" | migration `168` + later repairs (`171`,`174`,`192`) exist; no dedicated "repository" module exists yet (Intel Lake's persistence is inline in `intel_lake_service.py`, not a separate repository class like `IntelRepository` for dossiers) | any new repository class is NEW, not a rename |
+| `scripts/intel-lake-outbox-drain/**` | yes, 3 files | CONTRACT-MAP.md §1.3 |
+| `scripts/intel-lake-router-a2/**` | yes, 5 files | CONTRACT-MAP.md §1.4 |
+| `scripts/intel-lake-nb-pusher-a2/**` | yes, 4 files | CONTRACT-MAP.md §3 |
+| "Intel Lake probes and focused tests" | 4 files confirmed (below) | |
+| "MATA GARUDA producer adapters and the specific bridge schema/consumer code required for canonical emission" | `apps/mata-garuda/mata_garuda/bridge/nerve.py` (consumer), `apps/mata-garuda/mata_garuda/agents/wr2_bridge_publisher.py` (the one producer this packet's mission specifically motivates — the broken bridge, CONTRACT-MAP.md §2.3) | scope note below |
+
+Confirmed existing test files (packet says "and focused tests"):
+
+```
+apps/backend-rag/backend/tests/integration/test_intel_lake_e2e_probe_smoke.py
+apps/backend-rag/backend/tests/db/test_migration_168_intel_lake.py
+apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_router.py
+apps/backend-rag/backend/tests/unit/services/intel/test_intel_lake_service.py
+```
+
+## 3. Exact future file list (NEW files an eventual build would create)
+
+Derived from the packet's 9 deliverables + this bundle's gap analysis (CONTRACT-MAP.md §5,
+METRICS-AND-GOLDEN-SET.md). Marked NEW where nothing by this name exists today (checked via
+`find`/`ls` this session); this is a proposal for review, not a claim that these are the only
+correct names.
+
+```
+apps/backend-rag/backend/services/intel/
+  intel_event_adapter.py            NEW — maps intel_items/intel_observations rows to/from
+                                     research_os.models.intel_event.IntelEvent (mirrors the
+                                     existing action_intent_adapter.py pattern, confirmed present
+                                     in apps/backend-rag/backend/services/research_os/)
+  intel_lake_repository.py          NEW — extracts the inline SQL in intel_lake_service.py into
+                                     a named repository, giving deliverable #1's producer
+                                     registry and #8's replay tooling a stable seam to attach to
+  story_cluster_dedup.py            NEW — the "preregistered deterministic dedup incumbent"
+                                     (deliverable #3): exact/canonical-URL/hash/normalized layers
+                                     ONLY at first; near/semantic stay separate per METRICS-AND-
+                                     GOLDEN-SET.md §4
+  story_cluster_repository.py       NEW — StoryCluster persistence (deliverable #4): canonical
+                                     item, member relation, independent-source groups, decision
+                                     trace, reversible split/merge
+
+apps/backend-rag/backend/db/migrations_v2/
+  <NNN>_research_os_intel_lake_events.sql   NEW, symbolic name only (§1) — adds
+                                     classification.sensitivity-equivalent columns Intel Lake
+                                     lacks today (PROTECTED-DATA-BOUNDARY.md §3), idempotency_key,
+                                     lineage columns. Additive per repo migration convention
+                                     (rollback section mandatory, per apps/backend-rag/CLAUDE.md's
+                                     documented migration-runner rollback-stripping behavior).
+
+apps/mata-garuda/mata_garuda/bridge/
+  nerve.py                          TOUCHED — add "intel.research_dossier" (and any other
+                                     currently-unrouted type) to a dead-letter path instead of
+                                     ACK-drop (deliverable #5); PUSH_ROUTING dict itself likely
+                                     gains one more entry once the canonical NB feed exists
+  dead_letter.py                    NEW — the shared consumer-contract module both nerve.py's
+                                     push_once() and workers/gap_consumer.py's process_gap() can
+                                     import, so the fix lands once, not twice (CONTRACT-MAP.md §2.3
+                                     names both call sites as sharing one defect shape)
+
+apps/mata-garuda/mata_garuda/workers/
+  gap_consumer.py                   TOUCHED — same dead-letter fix as nerve.py, via the shared
+                                     module above
+
+scripts/intel-lake-nb-pusher-a2/ AND apps/mata-garuda/scripts/run_nlm_feeder_stream.py
+                                   BOTH TOUCHED (not retired — explicit non-goal) — add a shared
+                                     dedup receipt so deliverable #6's "old and canonical feeds
+                                     reconcile within a declared tolerance" is measurable; the
+                                     exact receipt schema is a design task for the real build, not
+                                     specified here
+
+apps/backend-rag/backend/tests/unit/services/intel/
+  test_intel_event_adapter.py       NEW
+  test_story_cluster_dedup.py       NEW — must exercise the golden-set strata in
+                                     METRICS-AND-GOLDEN-SET.md §3.1, once that set exists
+  test_intel_lake_idempotency.py    NEW — packet's required test "idempotency and unique-key
+                                     races"
+  test_intel_lake_replay.py         NEW — required tests "transaction/outbox crash between write
+                                     and deliver", "replay after partial delivery"
+
+apps/mata-garuda/tests/
+  test_bridge_dead_letter.py        NEW — required test "consumer retry and dead-letter
+                                     behavior", "unknown event type" — covers both nerve.py and
+                                     gap_consumer.py via the shared module
+```
+
+**Explicitly NOT in this list, per the packet's non-goals**: no new message-broker install
+(Kafka/Pulsar), no graph-database promotion of Intel Lake, no retirement of any existing
+producer/feed/bridge file, no publishing/rendering code path.
+
+## 4. Lease list (for the hot-zone pre-commit gate, `docs/runbooks/redis-lease-registry.md`)
+
+Files in the future list above that fall under this repo's documented hot-zone categories
+(migrations, auth/billing/pricing, `.github/workflows/`, sentinel/DLQ scripts — per root
+`CLAUDE.md` §7's `pre-commit lease-check` description) and would need an `agent_lock:<resource>`
+lease held for the duration of real implementation work, so a concurrent lane does not collide:
+
+```
+apps/backend-rag/backend/db/migrations_v2/<NNN>_research_os_intel_lake_events.sql   (migration)
+apps/mata-garuda/mata_garuda/bridge/nerve.py                                        (dead-letter/
+                                                                                       sentinel-adjacent)
+apps/mata-garuda/mata_garuda/bridge/dead_letter.py                                  (new, same class)
+apps/mata-garuda/mata_garuda/workers/gap_consumer.py                                (DLQ-adjacent)
+```
+
+Everything else in the future-file list (adapters, repositories, tests, the two feeder scripts)
+is not currently declared as hot-zone by the lease-check hook's own criteria and would rely on
+ordinary worktree isolation (`scripts/agent_start.py`) rather than an explicit Redis lease — this
+bundle does not recommend widening the hot-zone declaration; that is a call for whoever owns the
+lease-check hook, not this lane.
+
+## 5. Packet's 9-step implementation sequence, re-expressed against files that exist today
+
+1. "Reconcile authoritative production topology and freeze a producer/consumer map" — this
+   bundle (CONTRACT-MAP.md) is a first pass at this step, built without live DB access
+   (UNKNOWNS.md §1); the real freeze needs the live counts this session could not obtain.
+2. "Add canonical adapters and validation with feature flags off" — `intel_event_adapter.py`,
+   `story_cluster_repository.py` (both NEW, §3), flag-gated per this repo's existing feature-flag
+   convention (not inventoried in this session; whoever builds this should locate the repo's
+   standard flag mechanism before inventing a new one).
+3. "Introduce durable idempotency constraints and dead-letter handling" — the
+   `identity.idempotency_key` gap (CONTRACT-MAP.md §5.1) plus the `dead_letter.py` module (§3).
+4. "Build the labeled dedup/story-cluster golden set before semantic clustering" —
+   METRICS-AND-GOLDEN-SET.md §3, not yet built.
+5. "Run exact and deterministic layers, then benchmark near/semantic candidates" —
+   `story_cluster_dedup.py` (§3), against the `MetricProfile` in METRICS-AND-GOLDEN-SET.md §2.
+6. "Shadow MATA-to-Lake emissions and reconcile counts/hashes" — needs the shared dedup-receipt
+   schema from §3's feeder-reconciliation item, not yet designed.
+7. "Shadow the single NB feed while retaining the old feeds" — both existing feeders (§3)
+   instrumented, neither retired.
+8. "Replay a bounded historical window and compare canonical story/source counts" — needs
+   `test_intel_lake_replay.py` (§3) and, per the packet's own metric, needs live counts this
+   session could not obtain (UNKNOWNS.md §1) — flagged as a hard dependency for the real build,
+   not something this bundle can pre-stage.
+9. "Emit candidate DecisionPackets only after contract validation" — out of scope for the
+   preparation bundle; the `DecisionPacket` frozen model exists in the 25-model list
+   (CONTRACT-MAP.md §5) but was not read line-by-line this session (UNKNOWNS.md).

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/METRICS-AND-GOLDEN-SET.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/METRICS-AND-GOLDEN-SET.md
@@ -1,3 +1,9 @@
+---
+date: 2026-08-26
+domain: operations
+adversarial_review: kimi-k3
+---
+
 # Candidate metrics, `MetricProfile` design, and golden-set design
 
 Design only. No golden set was built, no label was assigned, and no benchmark ran this session
@@ -105,9 +111,12 @@ The packet's own range is 500-1,000 pairs/clusters across 8 named categories. §
 floors sum to 810 and give every stratum at least 80 examples — large enough that a single
 mislabel does not swing a stratum's precision/recall by more than ~1.2 percentage points, which
 is inside the packet's own tightest threshold (critical false collapse < 1%, i.e. a stratum
-needs >100 examples before a single-item swing stays under threshold — the
-`independent_corroboration` and `syndication` strata, the two most safety-relevant, are set to
-100 for exactly this reason).
+needs >100 examples before a single-item swing stays under threshold. **CORRECTED 2026-08-26
+(adversarial review): the two most safety-relevant strata, `independent_corroboration` and
+`syndication`, were set to exactly 100 "for exactly this reason" — but 1/100 = 1.00%, which
+does NOT satisfy "< 1%". The rationale's own arithmetic requires >=101.** Treat 100 as the
+floor that FAILS this test; a build lane setting these strata must use >=101, and the 810 total
+moves accordingly.
 
 ## 4. What NOT to promote by default
 
@@ -117,3 +126,34 @@ runs in production on a neighboring table. It has never been measured against a 
 the packet's own rule ("the chosen cascade is the simplest candidate that passes the
 preregistered profile") requires it be evaluated on equal footing with the deterministic
 exact/normalized layer, not given seniority for having shipped first.
+
+
+## Adversarial review
+
+**Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
+bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):
+the generator was dead before the refuter was dispatched, so nothing moved under it.
+
+**Verdict: DEFECTIVE on method, sound on its two headline findings.** The bridge ACK-drop and the
+`intel_lake_service.py` docstring-vs-SQL drift both check out on independent re-read. The
+systematic defect is a *class*: single-search results stated with more precision than the search
+supports. Every finding below was re-verified against disk by the gating session before it was
+accepted — the refuter is not trusted either (superscar #6).
+
+| # | Finding | Verified | Disposition |
+|---|---|---|---|
+| 1 | D7 dependency unflagged: `object_hash` + MATA-side hash reconciliation need the same digest in two implementations, but `apps/mata-garuda` caps deps at `pydantic>=2` | TRUE (`grep D7` → 0 hits in bundle) | **FIXED** — §5.1 now flags it as a §7-forbidden primitive; do not design that reconciliation until D7 lands |
+| 2 | "Enumerated every function" used `^def ` — blind to indented sync methods; missed `__init__` (267) and `_classify` (387), the actual rules engine | TRUE | **FIXED** — §1.4 restated; conclusion survives on a re-read, not on the enumeration |
+| 3 | "7 files" while listing 8 names in the same sentence | TRUE (`ls` → 8) | **FIXED** |
+| 4 | Migration list from a literal-string grep, misses `205_cockpit_intents.sql` (`intel_items`); and `171` is listed as found by a pattern that does not return it | TRUE | **FIXED** — list relabelled a lower bound, both gaps named |
+| 5 | Line counts off: 306→305, 230→229, `WR2_ENVELOPE_TYPE` line 34→36 | TRUE | **FIXED** — re-measured |
+| 6 | "No file in `apps/backend-rag` imports `intel_event`/`story_cluster`" — false, a test file imports both | TRUE (hedged in-sentence and in UNKNOWNS §2) | **FIXED** — restated; substantive point (importer is a test, no adapter) stands |
+| 7 | "89 local databases" is a count carried from a prior session, contradicting this bundle's own "no live counts anywhere" | TRUE | **FIXED** — marked carried-over, not a confirmation |
+| 8 | §3.4 arithmetic defeats itself: needs >100, sets the two safety-critical strata to exactly 100; 1/100 = 1.00%, not < 1% | TRUE | **FIXED** — >=101 required, 810 total moves |
+| 9 | README cites §3 (NotebookLM feed) for the ACK-drop finding, which lives in §2.2/§2.3 | TRUE | **FIXED** |
+| 10 | UNKNOWNS §2 "two producer entrypoints" vs §1.3, which says `intel_radar` writes by a SEPARATE path | PARTIAL | **FIXED** — wording corrected, overstatement removed |
+| 11 | "Every dossier envelope has been ACKed-and-dropped since the producer was written" is a live-traffic history claim provable only from code paths | TRUE (overreach) | **ACCEPTED AS LIMIT** — the drop PATH is proven by direct read; whether the producer ever ran with traffic is unknowable without the live stream this bundle could not reach (UNKNOWNS §1) |
+
+**Not a finding** (refuter checked, found sound): migration numbering — head 287, 282 absent,
+`272_wa_broker_package_text.sql` WhatsApp-broker-owned; the bundle correctly refuses to bind an
+integer. Readiness claims — disclaimed consistently across README and UNKNOWNS §5.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/METRICS-AND-GOLDEN-SET.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/METRICS-AND-GOLDEN-SET.md
@@ -1,0 +1,119 @@
+# Candidate metrics, `MetricProfile` design, and golden-set design
+
+Design only. No golden set was built, no label was assigned, and no benchmark ran this session
+— the packet requires the `MetricProfile` frozen *before* any challenger is inspected (packet
+"Before inspecting challenger results, freeze a `MetricProfile`..."), so producing labels ahead
+of a reviewed profile would itself violate the packet's own sequencing. This document proposes
+the profile shape and the golden-set design for review, per the "golden-set design, dedup
+labels... schema mapping" item in this lane's ALLOWED list.
+
+## 1. Packet exit criteria, restated as measurable candidates
+
+| Packet exit criterion (verbatim) | Candidate metric | Data source (schema mapping) |
+|---|---|---|
+| "zero lost events in bounded replay" | `count(events_submitted) == count(events_persisted) + count(events_dead_lettered)` over a replay window, reconciled by `identity.idempotency_key` | new: requires the idempotency key that does not exist today (CONTRACT-MAP.md §5.1) |
+| "zero duplicate external side effects" | `count(distinct external_effect_id) == count(external_effect_id)` for every downstream call (NB push, WR2 dispatch) keyed by an idempotency/dedup receipt | `intel_item_nb_pushes` (migration 171) already has a per-target status column — reusable pattern, not reusable table (wrong grain: keyed to `intel_items`, not to a new `IntelEvent`) |
+| "exact-duplicate precision at least 99.5%" | precision of the deterministic (exact/normalized) dedup layer against the golden set's exact-duplicate stratum | golden set §3 below |
+| "story-cluster precision at least 95% and recall at least 90%" | precision/recall of the *chosen* incumbent against the golden set's cluster-labeled stratum | golden set §3 below |
+| "critical false collapse below 1%" | rate of golden-set pairs labeled *genuinely independent* that the incumbent nonetheless merges into one cluster | golden set §3, "genuinely independent corroboration" stratum |
+| "100% producer/run/artifact lineage for the canary window" | `count(events with lineage.pipeline_run_id populated) / count(events)` over the canary window | new: `lineage.pipeline_run_id` does not exist in any live table today — this metric is 0% by construction until the field is added, not a bug found by measuring it |
+| "unknown-message success ACKs equal zero" | `count(unknown-type messages ACKed as success)` — target is a literal zero-count, not a rate | directly falsifiable today: CONTRACT-MAP.md §2.2/§2.3 already found this is currently **not** zero (the `intel.research_dossier` ACK-drop) — this metric is the packet's own smoking gun and is already known-failing before any new code ships |
+| "old and canonical feeds reconcile within a declared tolerance for two complete windows" | `abs(count(old_feed_pushes) - count(canonical_feed_pushes)) / count(old_feed_pushes) <= tolerance`, per window, for 2 consecutive windows | needs both feeds instrumented with comparable counters — today `intel-lake-nb-pusher-standalone.py`'s `metrics.json` (mentioned in its own docstring) and MATA GARUDA's `run_nlm_feeder_stream.py` heartbeat metadata are two **different** metric shapes; reconciling them needs a shared schema, itself a small design task |
+| "independent reviewer passes code, data sample, and live receipts" | binary gate, not a metric — process requirement on the eventual builder, not measurable in advance |
+
+## 2. `MetricProfile` design (frozen model exists: `research_os/models/metric_profile.py`,
+listed in CONTRACT-MAP.md §5, not read line-by-line this session — flagged as an open item in
+UNKNOWNS.md since the exact frozen field names were not re-verified against this proposal)
+
+Proposed profile, to be checked against the actual `MetricProfile` model fields before any
+future PR freezes it (do not treat the field names below as already validated against the frozen
+schema — that check is explicitly deferred, see UNKNOWNS.md):
+
+```yaml
+metric_profile:
+  incumbent: "exact_canonical_url_match"          # today's only real behavior, promoted to an
+                                                     # explicit, named baseline instead of an
+                                                     # implicit default
+  labeled_set_version: "p05-golden-v0"             # does not exist yet — §3
+  sample_floors:
+    exact_duplicates: 150
+    tracking_url_variants: 100
+    translations: 80
+    syndication: 100
+    updates: 80
+    same_event_different_angle: 100
+    similar_headline_different_event: 100
+    independent_corroboration: 100
+    # sum = 810, within the packet's stated 500-1,000 range
+  precision_recall_thresholds:
+    exact_duplicate_precision_min: 0.995            # packet exit criterion
+    story_cluster_precision_min: 0.95                # packet exit criterion
+    story_cluster_recall_min: 0.90                   # packet exit criterion
+    critical_false_collapse_max: 0.01                # packet exit criterion
+  latency_cost_privacy_guardrails:
+    max_added_latency_per_event_ms: "not yet set — needs a measured baseline latency for
+      record_observation(), which was not measured this session (Postgres tool unreachable)"
+    cost_per_1k_events: "candidate layers should be free-tier/local-first per repo-wide cost
+      constraint (CLAUDE.md Cost constraint) unless Zero explicitly authorizes a paid per-token
+      call; a semantic/embedding layer must name its exact model+endpoint in its own PR, not here"
+    privacy: "no layer may send restricted_osint/client_pii payload content to any non-local
+      service — PROTECTED-DATA-BOUNDARY.md §3"
+  subgroup_slices:
+    - by_source_domain_class          # regulatory .go.id vs. general news vs. blog
+    - by_language                     # Indonesian vs. English vs. mixed
+    - by_producer                     # Intel Lake API producers vs. MATA GARUDA-originated
+  confidence_treatment: "layers below story_cluster_precision_min on any subgroup slice route to
+    decision.verdict = 'review', never auto-merge — mirrors the frozen StoryClusterDecision.verdict
+    enum's own 'review' option (story_cluster.py:140, read this session)"
+  operating_window: "to be set by the builder against the actual canary window it runs, not
+    predetermined here"
+```
+
+## 3. Golden-set design (labels, strata, provenance — no data yet)
+
+### 3.1 Strata (from the packet's own enumerated list, verbatim)
+
+exact duplicates · tracking-URL variants · translations · syndication · updates · same
+event/different angle · similar headline/different event · genuinely independent corroboration.
+
+### 3.2 Provenance rule (protected-data-boundary-compliant by construction)
+
+Every golden-set pair/cluster must be built from `source.canonical_url` (a public URL) plus a
+short, human-written *paraphrase* of why the pair belongs in its stratum — **never** a copy of
+the article body. This satisfies PROTECTED-DATA-BOUNDARY.md §2's ceiling (public URL, never body
+content) even for MATA-GARUDA-sourced items, and happens to also make the golden set durable
+against link rot in a reviewable way (the paraphrase, not the fetched content, is what a
+reviewer checks).
+
+### 3.3 Labeling process (proposed, not run)
+
+1. Draw candidate pairs from **synthetic, not live**, `canonical_url` sets for this design
+   review — this bundle's write perimeter forbids any real row (dispatch: "Synthetic fixtures
+   only").
+2. Two independent labelers (cross-family per the repo's generator≠grader norm — e.g. one
+   Sonnet-5 pass + one Kimi K3 pass) label each pair against the 8 strata above; disagreement
+   goes to a third, human-adjudicated pass — this mirrors `StoryClusterDecision.decided_by`'s
+   `"deterministic" | "model" | "human"` enum (story_cluster.py:142, read this session) rather
+   than inventing a new adjudication vocabulary.
+3. `labeled_set_version` gets a content hash of the finished set (not a date string) so a
+   `MetricProfile` can pin an exact version — consistent with this repo's general "SHA-anchor,
+   never timestamp" antidote (superscar family #9).
+
+### 3.4 Sample-floor rationale
+
+The packet's own range is 500-1,000 pairs/clusters across 8 named categories. §2's proposed
+floors sum to 810 and give every stratum at least 80 examples — large enough that a single
+mislabel does not swing a stratum's precision/recall by more than ~1.2 percentage points, which
+is inside the packet's own tightest threshold (critical false collapse < 1%, i.e. a stratum
+needs >100 examples before a single-item swing stays under threshold — the
+`independent_corroboration` and `syndication` strata, the two most safety-relevant, are set to
+100 for exactly this reason).
+
+## 4. What NOT to promote by default
+
+`dossier_compiler.py`'s existing `DEFAULT_CLUSTER_SIMILARITY = 3` keyword-count clustering
+(CONTRACT-MAP.md §5.2) must not be treated as a pre-approved incumbent just because it already
+runs in production on a neighboring table. It has never been measured against a golden set, and
+the packet's own rule ("the chosen cascade is the simplest candidate that passes the
+preregistered profile") requires it be evaluated on equal footing with the deterministic
+exact/normalized layer, not given seniority for having shipped first.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/PROTECTED-DATA-BOUNDARY.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/PROTECTED-DATA-BOUNDARY.md
@@ -1,3 +1,9 @@
+---
+date: 2026-08-26
+domain: operations
+adversarial_review: kimi-k3
+---
+
 # Protected-data boundary — Intel Lake / MATA GARUDA consolidation
 
 This document is itself part of the boundary it describes: nothing below quotes a real
@@ -105,3 +111,34 @@ GARUDA-sourced `IntelEvent` into `research_os_objects`:
    is Tigris (this repo's existing S3-compatible store, per the `tigris` skill) and not a bucket
    reachable outside the OSINT-blindato boundary — this bundle did not verify Tigris bucket ACLs
    and does not claim to.
+
+
+## Adversarial review
+
+**Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
+bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):
+the generator was dead before the refuter was dispatched, so nothing moved under it.
+
+**Verdict: DEFECTIVE on method, sound on its two headline findings.** The bridge ACK-drop and the
+`intel_lake_service.py` docstring-vs-SQL drift both check out on independent re-read. The
+systematic defect is a *class*: single-search results stated with more precision than the search
+supports. Every finding below was re-verified against disk by the gating session before it was
+accepted — the refuter is not trusted either (superscar #6).
+
+| # | Finding | Verified | Disposition |
+|---|---|---|---|
+| 1 | D7 dependency unflagged: `object_hash` + MATA-side hash reconciliation need the same digest in two implementations, but `apps/mata-garuda` caps deps at `pydantic>=2` | TRUE (`grep D7` → 0 hits in bundle) | **FIXED** — §5.1 now flags it as a §7-forbidden primitive; do not design that reconciliation until D7 lands |
+| 2 | "Enumerated every function" used `^def ` — blind to indented sync methods; missed `__init__` (267) and `_classify` (387), the actual rules engine | TRUE | **FIXED** — §1.4 restated; conclusion survives on a re-read, not on the enumeration |
+| 3 | "7 files" while listing 8 names in the same sentence | TRUE (`ls` → 8) | **FIXED** |
+| 4 | Migration list from a literal-string grep, misses `205_cockpit_intents.sql` (`intel_items`); and `171` is listed as found by a pattern that does not return it | TRUE | **FIXED** — list relabelled a lower bound, both gaps named |
+| 5 | Line counts off: 306→305, 230→229, `WR2_ENVELOPE_TYPE` line 34→36 | TRUE | **FIXED** — re-measured |
+| 6 | "No file in `apps/backend-rag` imports `intel_event`/`story_cluster`" — false, a test file imports both | TRUE (hedged in-sentence and in UNKNOWNS §2) | **FIXED** — restated; substantive point (importer is a test, no adapter) stands |
+| 7 | "89 local databases" is a count carried from a prior session, contradicting this bundle's own "no live counts anywhere" | TRUE | **FIXED** — marked carried-over, not a confirmation |
+| 8 | §3.4 arithmetic defeats itself: needs >100, sets the two safety-critical strata to exactly 100; 1/100 = 1.00%, not < 1% | TRUE | **FIXED** — >=101 required, 810 total moves |
+| 9 | README cites §3 (NotebookLM feed) for the ACK-drop finding, which lives in §2.2/§2.3 | TRUE | **FIXED** |
+| 10 | UNKNOWNS §2 "two producer entrypoints" vs §1.3, which says `intel_radar` writes by a SEPARATE path | PARTIAL | **FIXED** — wording corrected, overstatement removed |
+| 11 | "Every dossier envelope has been ACKed-and-dropped since the producer was written" is a live-traffic history claim provable only from code paths | TRUE (overreach) | **ACCEPTED AS LIMIT** — the drop PATH is proven by direct read; whether the producer ever ran with traffic is unknowable without the live stream this bundle could not reach (UNKNOWNS §1) |
+
+**Not a finding** (refuter checked, found sound): migration numbering — head 287, 282 absent,
+`272_wa_broker_package_text.sql` WhatsApp-broker-owned; the bundle correctly refuses to bind an
+integer. Readiness claims — disclaimed consistently across README and UNKNOWNS §5.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/PROTECTED-DATA-BOUNDARY.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/PROTECTED-DATA-BOUNDARY.md
@@ -1,0 +1,107 @@
+# Protected-data boundary — Intel Lake / MATA GARUDA consolidation
+
+This document is itself part of the boundary it describes: nothing below quotes a real
+`intel_items`/`intel_observations` row, a real MATA GARUDA OSINT payload, or any client/CRM
+record. Every example is a schema shape, a code comment already on disk, or a synthetic
+placeholder explicitly marked as such.
+
+## 1. Two different boundaries, easy to conflate
+
+The dispatch prompt names one rule ("PII: absolutely no real Intel Lake rows anywhere"). Reading
+the actual code this session surfaced that there are **two distinct boundaries** in play, with
+different owners and different current enforcement, and Packet 05's design must not collapse
+them into one:
+
+1. **Client/CRM PII** (SYMBIOSIS Law 2 / UU PDP, the whole-repo rule) — does not apply to Intel
+   Lake's own domain directly (Intel Lake ingests public news/regulatory items, not client
+   records), but applies absolutely to this lane's own conduct and to any object this packet
+   designs that might later carry a client-facing field.
+2. **MATA GARUDA's OSINT-blindato boundary** (`apps/mata-garuda/CLAUDE.md`, its own, stricter,
+   pre-existing rule, read in full this session) — governs *raw collected OSINT content itself*,
+   independent of whether any of it happens to be PII. Its own stated flow: `cloud → Mata Garuda
+   (IN)`, then only `Mata Garuda → Nuzantara (business)` or `Mata Garuda → Zero TG (OUT)`. This
+   is narrower than "no PII" — it restricts raw *content*, including public-source article text,
+   from ever reaching `apps/mouth/`, any frontend, clients, the Bali Zero team, any cloud
+   provider, or any public repo/gist/pastebin.
+
+Packet 05's consolidation crosses both organs. A design that only checks "is this a client
+record" and clears MATA GARUDA content for wider circulation because it is "just news" would
+violate rule 2 even though it never touches rule 1.
+
+## 2. What MATA GARUDA already permits to leave, and the exact shape of the exception
+
+`apps/mata-garuda/CLAUDE.md` §1.4, "Eccezione Pillar 3 SYMBIOSIS — KG metadata sharing," is the
+**one** named, Zero-authorized (2026-05-06) carve-out. Read verbatim this session:
+
+- **Permitted payload** across the Tailscale-loopback-only KG bridge: `name`, `type`,
+  `source_count`, `last_seen`, `neighbor_names`, `observation_count`, and
+  `observation.source_url` (explicitly noted: "sempre URL pubblico, mai body content" — always a
+  public URL, never body content).
+- **Forbidden payload**, same bridge, same sentence: `observation.value` (may contain raw
+  title/snippet OSINT), any content field, full article text.
+
+This is the ceiling for any Cohort-B design touching MATA GARUDA-sourced data. Concretely, for
+Packet 05's `IntelEvent` mapping (CONTRACT-MAP.md §5.1): an `IntelEvent` whose `source` traces
+back to a MATA GARUDA producer and whose `classification.sensitivity` is `restricted_osint` may
+carry `source.canonical_url` (a public URL — permitted by analogy to `observation.source_url`)
+but its `payload_ref` must be a `DurablePayloadReference`, never an `InlinePublicPayload` — the
+frozen contract's own validator already forbids inline payloads for any sensitivity other than
+`public` (`intel_event.py:278-287`, read this session), which happens to line up with MATA
+GARUDA's own stricter rule for the same case. Where the two rules would conflict (none found
+this session — MATA GARUDA's rule is uniformly stricter than the frozen contract's default), the
+stricter rule governs; SYMBIOSIS Law 2 is explicit that internal minimization policy can exceed
+what the frozen contract's structural validator alone would require.
+
+## 3. Where the classification actually lives today: nowhere in the shared schema
+
+CONTRACT-MAP.md §5.1 already flags this as a modeling gap; restated here as a boundary
+consequence. `intel_items`/`intel_observations` (migration `168`) have **no** `sensitivity`,
+`classification`, or `tlp` column. The only place a TLP-like axis exists in this pipeline is
+`asset_provenance.tlp` (migration 154, consumed via `cell_adapter.py`, `TLP_VALUES = {"white",
+"green", "amber", "red", "black"}`) — a **different** table, reachable only through
+`apps/backend-rag/backend/services/mata_garuda/cell_adapter.py`, not through Intel Lake's own
+API (`routers/intel_lake.py`) at all.
+
+Practical consequence for whoever builds Packet 05 for real: today, nothing stops a producer
+from POSTing MATA-GARUDA-sourced OSINT content as an ordinary `intel_items` row via
+`POST /api/intel/lake/observations` (the only server-side rejection is a 50KB payload-size cap
+and a static bearer token — `intel_lake_service.py:57`, `intel_lake_router.py`
+auth dependency) — the boundary is enforced entirely by *which producer chooses to call which
+endpoint*, not by any structural constraint in the receiving schema. A `classification.
+sensitivity` field cannot be retrofitted onto Intel Lake as a courtesy default; it needs to be a
+`NOT NULL` column with the producer required to declare it, or the gap this paragraph describes
+persists unchanged regardless of how rich the new object model is upstream.
+
+## 4. What this session did and did not touch, in service of the boundary
+
+- **Did**: read code, comments, migration DDL, and two `CLAUDE.md` files. Ran aggregate-only
+  SQL (attempted; the query tool failed before returning any result — see UNKNOWNS.md §1, so in
+  practice **zero rows of any kind, aggregate or otherwise, were read from any live Intel
+  Lake/MATA GARUDA table this session**).
+- **Did not**: read any `raw_payload` JSONB content, any `intel_items.title`/`summary` value, any
+  `asset_provenance` row, any MATA GARUDA Redis stream entry, or any file under a `.gitignore`d
+  MATA GARUDA data directory (`apps/mata-garuda/CLAUDE.md` §"OSINT blindato" lists these as
+  blindato-by-design; this bundle's grep/read commands were scoped to tracked source files only
+  — no `feedback/`, `logs/`, or gitignored data path was opened).
+- **Did not** call any external LLM (cloud or local) with any content from this pipeline. This
+  entire bundle was produced by direct file reads and greps against tracked source, not by
+  summarization of retrieved content through a model.
+
+## 5. Standing requirement for the eventual build (not this lane's job to close, but its job to name)
+
+Any real Packet-05 implementation needs, at minimum, before shadow-writing a single MATA
+GARUDA-sourced `IntelEvent` into `research_os_objects`:
+
+1. A `classification.sensitivity` value assigned by the **producer**, not inferred downstream —
+   consistent with the frozen contract's own declared limit (`intel_event.py:64-75`, read this
+   session: "That responsibility belongs to whichever component assigns
+   `classification.sensitivity` in the first place... not to this structural validator").
+2. A hard rule (test, not just a docstring) that any event whose producer is a MATA GARUDA agent
+   defaults to `restricted_osint` unless explicitly and auditably downgraded — mirroring the
+   `apps/mata-garuda/CLAUDE.md` default of `tlp DEFAULT 'red'` (already flagged in
+   `cell_adapter.py`'s own docstring as "a *safe default*, NOT enforcement").
+3. Confirmation (not assumed here) that the eventual object-storage backend for
+   `DurablePayloadReference.uri` (`https://` or `s3://` only, per `intel_event.py:110`'s pattern)
+   is Tigris (this repo's existing S3-compatible store, per the `tigris` skill) and not a bucket
+   reachable outside the OSINT-blindato boundary — this bundle did not verify Tigris bucket ACLs
+   and does not claim to.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/README.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/README.md
@@ -1,3 +1,9 @@
+---
+date: 2026-08-26
+domain: operations
+adversarial_review: kimi-k3
+---
+
 # P05 Intel Lake / MATA GARUDA — preparation bundle
 
 **Lane:** B1 · `intel` · task `ros-v1-p05-intel-prep-b01` · Wave 1, Cohort B
@@ -39,7 +45,8 @@ concept — it dedups by exact `canonical_url` string match only. MATA GARUDA
 (`apps/mata-garuda/`) is a separate, OSINT-blindato Redis-stream organism that already produces
 a `intel.research_dossier` envelope meant for WR2, but the shared bridge consumer
 (`apps/mata-garuda/mata_garuda/bridge/nerve.py`) does not recognize that envelope type and
-silently ACKs-to-drop it (confirmed by direct read, not inferred — see CONTRACT-MAP.md §3). The
+silently ACKs-to-drop it (confirmed by direct read, not inferred — see CONTRACT-MAP.md §2.2 and
+§2.3; an earlier revision of this line miscited §3, which is the NotebookLM feed). The
 frozen `IntelEvent`/`StoryCluster` contracts from Packet 04 (`packages/research-os-core/
 research_os/models/`) are considerably richer than either live system (`object_hash`,
 `classification.sensitivity`, `lineage.pipeline_run_id`, discriminated payload references) —
@@ -58,3 +65,34 @@ retiring either live path, is the actual size of Packet 05.
 - Does not open, edit, or reserve a migration file. Migration numbering is discussed in
   IMPLEMENTATION-SCOPE.md as a fact to re-measure at integration time, never as a number to bind
   now.
+
+
+## Adversarial review
+
+**Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
+bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):
+the generator was dead before the refuter was dispatched, so nothing moved under it.
+
+**Verdict: DEFECTIVE on method, sound on its two headline findings.** The bridge ACK-drop and the
+`intel_lake_service.py` docstring-vs-SQL drift both check out on independent re-read. The
+systematic defect is a *class*: single-search results stated with more precision than the search
+supports. Every finding below was re-verified against disk by the gating session before it was
+accepted — the refuter is not trusted either (superscar #6).
+
+| # | Finding | Verified | Disposition |
+|---|---|---|---|
+| 1 | D7 dependency unflagged: `object_hash` + MATA-side hash reconciliation need the same digest in two implementations, but `apps/mata-garuda` caps deps at `pydantic>=2` | TRUE (`grep D7` → 0 hits in bundle) | **FIXED** — §5.1 now flags it as a §7-forbidden primitive; do not design that reconciliation until D7 lands |
+| 2 | "Enumerated every function" used `^def ` — blind to indented sync methods; missed `__init__` (267) and `_classify` (387), the actual rules engine | TRUE | **FIXED** — §1.4 restated; conclusion survives on a re-read, not on the enumeration |
+| 3 | "7 files" while listing 8 names in the same sentence | TRUE (`ls` → 8) | **FIXED** |
+| 4 | Migration list from a literal-string grep, misses `205_cockpit_intents.sql` (`intel_items`); and `171` is listed as found by a pattern that does not return it | TRUE | **FIXED** — list relabelled a lower bound, both gaps named |
+| 5 | Line counts off: 306→305, 230→229, `WR2_ENVELOPE_TYPE` line 34→36 | TRUE | **FIXED** — re-measured |
+| 6 | "No file in `apps/backend-rag` imports `intel_event`/`story_cluster`" — false, a test file imports both | TRUE (hedged in-sentence and in UNKNOWNS §2) | **FIXED** — restated; substantive point (importer is a test, no adapter) stands |
+| 7 | "89 local databases" is a count carried from a prior session, contradicting this bundle's own "no live counts anywhere" | TRUE | **FIXED** — marked carried-over, not a confirmation |
+| 8 | §3.4 arithmetic defeats itself: needs >100, sets the two safety-critical strata to exactly 100; 1/100 = 1.00%, not < 1% | TRUE | **FIXED** — >=101 required, 810 total moves |
+| 9 | README cites §3 (NotebookLM feed) for the ACK-drop finding, which lives in §2.2/§2.3 | TRUE | **FIXED** |
+| 10 | UNKNOWNS §2 "two producer entrypoints" vs §1.3, which says `intel_radar` writes by a SEPARATE path | PARTIAL | **FIXED** — wording corrected, overstatement removed |
+| 11 | "Every dossier envelope has been ACKed-and-dropped since the producer was written" is a live-traffic history claim provable only from code paths | TRUE (overreach) | **ACCEPTED AS LIMIT** — the drop PATH is proven by direct read; whether the producer ever ran with traffic is unknowable without the live stream this bundle could not reach (UNKNOWNS §1) |
+
+**Not a finding** (refuter checked, found sound): migration numbering — head 287, 282 absent,
+`272_wa_broker_package_text.sql` WhatsApp-broker-owned; the bundle correctly refuses to bind an
+integer. Readiness claims — disclaimed consistently across README and UNKNOWNS §5.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/README.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/README.md
@@ -1,0 +1,60 @@
+# P05 Intel Lake / MATA GARUDA — preparation bundle
+
+**Lane:** B1 · `intel` · task `ros-v1-p05-intel-prep-b01` · Wave 1, Cohort B
+**Packet:** [`05-intel-lake-v2-mata-consolidation.md`](../../../../../specs/evidence-to-action-freeze-2026-08-15/work-packets/05-intel-lake-v2-mata-consolidation.md)
+**Nature:** preparation only — read-only inventory, design, and scoping. **No implementation
+readiness is claimed.** No Intel/MATA runtime file, migration, queue consumer, NB feeder, flag,
+scheduler, DB row, or stream was edited to produce this bundle.
+
+## What this bundle is
+
+Five documents, each independently re-derivable from the commands/greps/reads cited inline
+(anti-hallucination discipline: every claim below carries the command or `file:line` that
+produced it; nothing is carried over from a prior document without being re-measured):
+
+1. **[CONTRACT-MAP.md](CONTRACT-MAP.md)** — the lossless producer/consumer topology of Intel
+   Lake + MATA GARUDA as they exist on disk today, and a field-by-field mapping from the
+   existing Postgres schema onto the 25 frozen `research-os-core` typed models Cohort B is
+   authorized to build against (`IntelEvent`, `StoryCluster`, receipts).
+2. **[PROTECTED-DATA-BOUNDARY.md](PROTECTED-DATA-BOUNDARY.md)** — what is and is not OSINT/PII
+   in this pipeline, the existing enforcement (or absence of it), and the boundary this bundle
+   itself observed while being written (no real row content is quoted anywhere in this bundle).
+3. **[METRICS-AND-GOLDEN-SET.md](METRICS-AND-GOLDEN-SET.md)** — candidate metrics mapped to the
+   packet's exit criteria, a `MetricProfile` design, and the golden-set design (labels, strata,
+   counts) for the dedup/story-cluster benchmark the packet requires be frozen before any
+   semantic layer is inspected.
+4. **[IMPLEMENTATION-SCOPE.md](IMPLEMENTATION-SCOPE.md)** — the exact future file list (new +
+   touched), a lease list for the hot-zone pre-commit gate, and the packet's 9-step sequence
+   re-expressed against files that actually exist today.
+5. **[UNKNOWNS.md](UNKNOWNS.md)** — everything this session could not close, what was
+   deliberately not checked, and two corrections to frozen/dispatched documents found while
+   grounding this bundle (beyond the two the dispatching session had already found).
+
+## One-line orientation for the reviewer
+
+Intel Lake (`apps/backend-rag/backend/services/intel/`, Postgres `intel_items` /
+`intel_observations`, migration `168`) is a live, flat, single-canonicalization pipeline with
+**no** lineage, no idempotency contract, no sensitivity classification, and **no** story-cluster
+concept — it dedups by exact `canonical_url` string match only. MATA GARUDA
+(`apps/mata-garuda/`) is a separate, OSINT-blindato Redis-stream organism that already produces
+a `intel.research_dossier` envelope meant for WR2, but the shared bridge consumer
+(`apps/mata-garuda/mata_garuda/bridge/nerve.py`) does not recognize that envelope type and
+silently ACKs-to-drop it (confirmed by direct read, not inferred — see CONTRACT-MAP.md §3). The
+frozen `IntelEvent`/`StoryCluster` contracts from Packet 04 (`packages/research-os-core/
+research_os/models/`) are considerably richer than either live system (`object_hash`,
+`classification.sensitivity`, `lineage.pipeline_run_id`, discriminated payload references) —
+none of that richness exists in the live schema today. Closing that gap correctly, without
+retiring either live path, is the actual size of Packet 05.
+
+## What this bundle explicitly does NOT do
+
+- Does not claim any number as a live production count. The `postgres-nuzantara-local` MCP
+  query tool returned `Command failed with no output` on `SELECT 1` in this session (tool
+  infrastructure failure, not a data question) — see UNKNOWNS.md §1. Every quantitative claim
+  in this bundle is either a static code/schema fact (file exists, column exists, function
+  count) or explicitly marked "not measured this session."
+- Does not touch, quote, or reproduce any real Intel Lake row, MATA GARUDA OSINT payload, or
+  client/CRM record. All examples are schema-level or drawn from code comments already on disk.
+- Does not open, edit, or reserve a migration file. Migration numbering is discussed in
+  IMPLEMENTATION-SCOPE.md as a fact to re-measure at integration time, never as a number to bind
+  now.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
@@ -1,3 +1,9 @@
+---
+date: 2026-08-26
+domain: operations
+adversarial_review: kimi-k3
+---
+
 # Explicit unknowns, what was not checked, and corrections found
 
 ## 1. Live database access was unavailable this session — no live counts anywhere in this bundle
@@ -22,7 +28,10 @@ the tool failed beyond confirming it failed identically on a query with zero tab
 
 ## 2. Not checked, deliberately, given the read-only/no-implementation scope of this lane
 
-- **The full producer registry.** CONTRACT-MAP.md §1.3 found the two in-monorepo producer
+- **The full producer registry.** (Wording corrected 2026-08-26: §1.3's two named items are
+  `scripts/intel-lake-outbox-drain/` and `intel_radar.py` — and §1.3 itself says `intel_radar`
+  writes `asset_provenance` by a path SEPARATE from Intel Lake's `record_observation()`, so
+  calling both "Intel Lake producer entrypoints" overstates it.) CONTRACT-MAP.md §1.3 found the two in-monorepo producer
   entrypoints (outbox-drain's SQLite source, whatever writes to it) but did not walk `~/scripts/`
   (outside the repo, a live-Pro filesystem path, not something a worktree-scoped read-only lane
   should be inventorying without the live-count access described in §1 anyway) to enumerate every
@@ -102,3 +111,34 @@ instruction) should treat restoring live Postgres access as its first action, no
 afterthought, because deliverable #1 ("verified producer registry... health") and the packet's
 entire "Live baseline to refresh" section depend on it and neither can be honestly closed
 without it.
+
+
+## Adversarial review
+
+**Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
+bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):
+the generator was dead before the refuter was dispatched, so nothing moved under it.
+
+**Verdict: DEFECTIVE on method, sound on its two headline findings.** The bridge ACK-drop and the
+`intel_lake_service.py` docstring-vs-SQL drift both check out on independent re-read. The
+systematic defect is a *class*: single-search results stated with more precision than the search
+supports. Every finding below was re-verified against disk by the gating session before it was
+accepted — the refuter is not trusted either (superscar #6).
+
+| # | Finding | Verified | Disposition |
+|---|---|---|---|
+| 1 | D7 dependency unflagged: `object_hash` + MATA-side hash reconciliation need the same digest in two implementations, but `apps/mata-garuda` caps deps at `pydantic>=2` | TRUE (`grep D7` → 0 hits in bundle) | **FIXED** — §5.1 now flags it as a §7-forbidden primitive; do not design that reconciliation until D7 lands |
+| 2 | "Enumerated every function" used `^def ` — blind to indented sync methods; missed `__init__` (267) and `_classify` (387), the actual rules engine | TRUE | **FIXED** — §1.4 restated; conclusion survives on a re-read, not on the enumeration |
+| 3 | "7 files" while listing 8 names in the same sentence | TRUE (`ls` → 8) | **FIXED** |
+| 4 | Migration list from a literal-string grep, misses `205_cockpit_intents.sql` (`intel_items`); and `171` is listed as found by a pattern that does not return it | TRUE | **FIXED** — list relabelled a lower bound, both gaps named |
+| 5 | Line counts off: 306→305, 230→229, `WR2_ENVELOPE_TYPE` line 34→36 | TRUE | **FIXED** — re-measured |
+| 6 | "No file in `apps/backend-rag` imports `intel_event`/`story_cluster`" — false, a test file imports both | TRUE (hedged in-sentence and in UNKNOWNS §2) | **FIXED** — restated; substantive point (importer is a test, no adapter) stands |
+| 7 | "89 local databases" is a count carried from a prior session, contradicting this bundle's own "no live counts anywhere" | TRUE | **FIXED** — marked carried-over, not a confirmation |
+| 8 | §3.4 arithmetic defeats itself: needs >100, sets the two safety-critical strata to exactly 100; 1/100 = 1.00%, not < 1% | TRUE | **FIXED** — >=101 required, 810 total moves |
+| 9 | README cites §3 (NotebookLM feed) for the ACK-drop finding, which lives in §2.2/§2.3 | TRUE | **FIXED** |
+| 10 | UNKNOWNS §2 "two producer entrypoints" vs §1.3, which says `intel_radar` writes by a SEPARATE path | PARTIAL | **FIXED** — wording corrected, overstatement removed |
+| 11 | "Every dossier envelope has been ACKed-and-dropped since the producer was written" is a live-traffic history claim provable only from code paths | TRUE (overreach) | **ACCEPTED AS LIMIT** — the drop PATH is proven by direct read; whether the producer ever ran with traffic is unknowable without the live stream this bundle could not reach (UNKNOWNS §1) |
+
+**Not a finding** (refuter checked, found sound): migration numbering — head 287, 282 absent,
+`272_wa_broker_package_text.sql` WhatsApp-broker-owned; the bundle correctly refuses to bind an
+integer. Readiness claims — disclaimed consistently across README and UNKNOWNS §5.

--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
@@ -1,0 +1,104 @@
+# Explicit unknowns, what was not checked, and corrections found
+
+## 1. Live database access was unavailable this session — no live counts anywhere in this bundle
+
+`mcp__postgres-nuzantara-local__query` returned `Command failed with no output` on three
+successive attempts, including the trivial `SELECT 1;`. This is a tool/infrastructure failure,
+not a "no rows" result — per this repo's own anti-hallucination discipline ("a grep that returns
+nothing may mean your grep is broken, not that the world is empty"), the correct read of a
+broken tool is "unknown," not "zero." Consequence: **every quantitative claim in this bundle is
+a static code/schema fact (a file exists, a column exists, a function is or isn't defined), never
+a live count.** The packet's own "Live baseline to refresh" section asks for producer counts,
+event counts, unique-URL counts, review rate, duplicates, outbox pending/abandoned, consumer
+lag, unknown-message-ACK counts, NB submission counts — **none of these were obtained**. This is
+the single largest gap in this bundle relative to the packet's ask, and it is a tooling gap, not
+a scoping choice: this lane's dispatch explicitly allows "aggregate, redacted live counts
+obtained on Pro when the manifest explicitly permits" — the attempt was made, in-scope, and
+failed at the tool layer.
+
+Whoever picks this up next should retry the same MCP tool (it may be a transient session issue)
+or fall back to a direct `psql`/`fly ssh` read-only session — this bundle does not diagnose why
+the tool failed beyond confirming it failed identically on a query with zero table dependency.
+
+## 2. Not checked, deliberately, given the read-only/no-implementation scope of this lane
+
+- **The full producer registry.** CONTRACT-MAP.md §1.3 found the two in-monorepo producer
+  entrypoints (outbox-drain's SQLite source, whatever writes to it) but did not walk `~/scripts/`
+  (outside the repo, a live-Pro filesystem path, not something a worktree-scoped read-only lane
+  should be inventorying without the live-count access described in §1 anyway) to enumerate every
+  process that ultimately posts to `POST /api/intel/lake/observations`. Deliverable #1's
+  "verified producer registry" needs this and this bundle does not close it.
+- **`packages/research-os-core/research_os/models/metric_profile.py` and `decision_packet.py`**
+  were listed by `find` (confirmed present) but not read line-by-line. METRICS-AND-GOLDEN-SET.md
+  §2's proposed profile field names are therefore a **proposal to check against the frozen
+  model**, not a claim that they already match it.
+- **Whether any file in `apps/backend-rag` imports `research_os.models.intel_event` or
+  `research_os.models.story_cluster`.** CONTRACT-MAP.md §5.3 states no adapter file exists to
+  import them from (confirmed, directory listing), but did not run an exhaustive
+  `grep -r "models.intel_event\|models.story_cluster"` across the whole tree — flagged rather
+  than asserted as zero.
+- **Tigris bucket ACLs / actual object-storage backend for a future `DurablePayloadReference`.**
+  PROTECTED-DATA-BOUNDARY.md §5.3 names this as unverified.
+- **This repo's standard feature-flag mechanism**, referenced in IMPLEMENTATION-SCOPE.md §5 step
+  2 as something the eventual builder needs to locate — not inventoried here because it is a
+  BUILD-phase concern, not a preparation-phase one, and inventorying it without a concrete flag
+  to wire would be speculative.
+- **`intel-lake-router-a2/intel-lake-routing-rules.json`'s actual rule content** (58 lines,
+  confirmed present via `wc -l`, not read) — relevant to deliverable #1's "event types" column
+  but reading and transcribing 58 lines of routing rules did not seem load-bearing enough to
+  justify given the tool-call cost measured this session (§4).
+
+## 3. Two corrections found this session, beyond the two the dispatching prompt already supplied
+
+The dispatching prompt supplied two corrections up front (the "272" migration mislabel, and the
+resulting scope-of-prohibition correction). Independently re-verifying rather than trusting them
+(CONTRACT-MAP.md §1.2, IMPLEMENTATION-SCOPE.md §1) confirmed both. Two further corrections
+surfaced during this session's own grounding work, not supplied by any prior document:
+
+1. **`intel_lake_service.py`'s own docstring contradicts its own SQL.** The module docstring
+   (line 10) states "Content drift → INSERT new row (separate canonical version)." The actual
+   `record_observation()` SQL (`ON CONFLICT (canonical_url) DO UPDATE SET last_seen_at = NOW()`)
+   only ever updates `last_seen_at`; it never inserts a second row for the same
+   `canonical_url`, drift or not. `is_content_drift` is computed and logged as a warning
+   (`intel_lake_service.py:217-224`) but has no persistence consequence. This is a live
+   discrepancy in a file this packet explicitly owns — flagged for the eventual builder, not
+   fixed here (out of a preparation lane's remit).
+2. **`intel_lake_router.py`'s Tier-2 claim is aspirational, not implemented — confirmed by
+   function enumeration, not by trusting the packet's Live Baseline prose.** CONTRACT-MAP.md
+   §1.4 lists every function defined in the file; none calls an LLM. This independently confirms
+   (rather than merely repeats) the packet's own claim ("no working Tier-2 enrichment path"),
+   which matters because this lane's discipline requires re-verifying inherited claims, not
+   relaying them.
+
+Additionally, one **duplicate-truth-path** was found that neither the packet's prose nor the
+dispatching prompt named: **two independent, functionally identical Tier-1 routing
+implementations exist** — the Fly-side `intel_lake_router.py` (dormant, gated behind an
+unrelated `DISABLE_BACKGROUND_WORKERS=1` kill-switch from an unrelated 2026-04-12 incident,
+per that script's own docstring) and the Pro-side `intel-lake-router-cron-standalone.py` (live,
+5-minute cron). CONTRACT-MAP.md §1.4 has the detail. This is exactly the class of "parallel
+truth path" the packet's mission statement targets and should be in scope for whoever designs
+the real consolidation, even though the packet's own file-ownership list only names the Fly-side
+file by path.
+
+## 4. A note on session conditions, for calibration of this bundle's thoroughness
+
+This session ran under continuous, high-volume cross-machine fleet-mailbox traffic (dozens of
+messages per tool call, injected via the harness's PostToolUse hook) concerning **other lanes'**
+merge-queue mechanics (PR #4640/#4664/#4706/#4717/#4768/#4803/#4885/#4963/#4974/#4977/#4978,
+none of which are this lane's), none of which bears on Intel Lake or MATA GARUDA. None of it was
+acted on (correctly — it was not addressed to this lane, and this lane's write perimeter forbids
+touching any of those files regardless). It is noted here only because it capped the number of
+investigative tool calls this session could spend efficiently, which is the direct cause of §2's
+scope cuts — those cuts were a deliberate trade against a real cost, not an oversight.
+
+## 5. Summary verdict for the Conductor
+
+This bundle is a **contract map and design proposal**, not a readiness claim. The single largest
+blocker to a real build starting is **not** anything architectural — CONTRACT-MAP.md's gap
+analysis is complete enough to start from — it is that **no live measurement of the current
+Intel Lake/MATA GARUDA state was possible this session** (§1). The next session (this one's
+successor, per the dispatch's "fresh successor manifest and worktree... after P04 integration"
+instruction) should treat restoring live Postgres access as its first action, not an
+afterthought, because deliverable #1 ("verified producer registry... health") and the packet's
+entire "Live baseline to refresh" section depend on it and neither can be honestly closed
+without it.


### PR DESCRIPTION
## Summary

Lane B1 — P05 Intel Lake/MATA GARUDA preparation, Research OS v1.0.0 Cohort B.
Read-only inventory + design bundle per `WAVE-0-DISPATCH.md` B1 dispatch and
`work-packets/05-intel-lake-v2-mata-consolidation.md`.

**No implementation readiness is claimed.** No Intel/MATA runtime file, migration, queue
consumer, NB feeder, flag, scheduler, DB row, or stream was touched. Everything lives under
the declared write perimeter:
`research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/**`

- **CONTRACT-MAP.md** — producer/consumer topology of Intel Lake + MATA GARUDA as they exist
  on disk, mapped field-by-field onto the frozen `IntelEvent`/`StoryCluster` models from
  Packet 04. Confirms by direct file:line read (not inference from the packet's prose): the
  WR2 research-dossier bridge consumer (`nerve.py`) silently ACKs-and-drops
  `"intel.research_dossier"` envelopes because that type is absent from its `PUSH_ROUTING`
  dict — the exact defect the packet's Live Baseline names; the identical anti-pattern
  independently exists in `gap_consumer.py`; the two NB-INTEL feeders (MATA GARUDA's
  `nlm_feeder` and Intel Lake's `nb-pusher`) are genuinely parallel, unreconciled paths;
  Tier-2 LLM enrichment is confirmed absent by enumerating every function in
  `intel_lake_router.py` (none calls an LLM).
- **PROTECTED-DATA-BOUNDARY.md** — the MATA GARUDA OSINT-blindato boundary
  (`apps/mata-garuda/CLAUDE.md`) vs. the repo-wide PII rule, and the fact that Intel Lake's
  own schema has no sensitivity/classification column today (enforcement lives entirely in
  *which producer calls which endpoint*, not in the shared table).
- **METRICS-AND-GOLDEN-SET.md** — packet exit criteria mapped to candidate metrics, a
  `MetricProfile` design, and an 810-pair golden-set design across the packet's 8 named strata.
- **IMPLEMENTATION-SCOPE.md** — exact future file list, hot-zone lease list, and independently
  re-verified migration numbering (head `287`, gap at `282` — re-measured, not trusted from
  the dispatching prompt).
- **UNKNOWNS.md** — the `postgres-nuzantara-local` MCP tool failed on every query this
  session (including `SELECT 1`), so **no live counts appear anywhere in this bundle**; full
  list of what was deliberately not checked and why.

## Corrections found (beyond the two the dispatching prompt supplied)

1. `intel_lake_service.py`'s own docstring ("Content drift → INSERT new row") contradicts its
   own SQL (`ON CONFLICT DO UPDATE` only ever touches `last_seen_at`) — drift is logged, never
   persisted as a new row.
2. Two independent, functionally identical Tier-1 routing implementations exist
   (`intel_lake_router.py`, dormant behind an unrelated kill-switch, and
   `intel-lake-router-cron-standalone.py`, live on a 5-min Pro cron) — a duplicate-truth-path
   the packet's own mission targets but its file-ownership list doesn't name.

## Test plan

- [x] `git status --porcelain` confirms only the declared write-perimeter directory changed
- [x] Pre-commit hooks passed (secrets scan, off-limits-file check, lint) — no code changed
- [x] Pre-push hooks passed; backend suite correctly skipped (docs-only diff, path-aware allowlist)
- [ ] Not armed — per dispatch instruction, this PR is gated by the team lead, not self-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)