### PR TITLE
fix(ci): frontend-tests must survive a cancelled Change map

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1565,20 +1565,18 @@ jobs:
   frontend-tests:
     name: Frontend Tests (Next.js)
     needs: [changes]
-    # NO job-level `if:` here — deliberately, unlike the other five heavy
-    # jobs (red-team CRITICAL-2, 2026-08-14). `frontend-tests` is the only
-    # MATRIX job among the six, and `jobs.<id>.if` is evaluated BEFORE the
-    # matrix expands: a false job-level `if` means the matrix never
-    # instantiates, so the required check
-    # `Frontend Tests (Next.js) (mouth, true)` (infra/required.d/contexts.json)
-    # never gets CREATED at all — not "skipped" (which GitHub treats as
-    # satisfying a required check), but permanently absent, leaving branch
-    # protection stuck on "Expected — Waiting for status to be reported"
-    # forever on a backend-only or docs-only PR. The fix is a job that ALWAYS
-    # runs (so both matrix legs always get created) with an early-exit DECIDE
-    # step gating every real step below — the check always gets a genuine
-    # conclusion (success, fast, when skipped by design; the real test result
-    # otherwise), never a missing context.
+    # LOAD-BEARING: a job with `needs` and no status-function condition inherits
+    # an implicit `success()` gate. On PR #4706 / run 32866302767, `changes`
+    # concluded `cancelled`, so GitHub skipped this job BEFORE matrix expansion
+    # and never created the required context
+    # `Frontend Tests (Next.js) (mouth, true)` (infra/required.d/contexts.json).
+    # `!cancelled()` replaces that implicit success-only gate: an upstream
+    # failure/cancellation no longer suppresses the matrix, while cancellation
+    # of the workflow run itself still stops work. Do NOT move the path predicate
+    # here: a false job-level condition would again erase the matrix contexts.
+    # The first step below keeps the normal path filter and fails open to RUN
+    # when `changes` is non-successful or its output is missing.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     env:
       HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}

--- a/evidence/2026-08/agent-m5-ops-tests-yml-cancelled-matrix-3abb643b/brief.yml
+++ b/evidence/2026-08/agent-m5-ops-tests-yml-cancelled-matrix-3abb643b/brief.yml
@@ -52,6 +52,5 @@ grader: |
   per the PR body) — re-ran actionlint on the actual modified file, and independently queried
   GitHub's own job-history API for the cited incident run/attempt rather than trusting the PR
   body's citation verbatim, and recomputed the deterministic floor from the real diff.
-budget:
-  1 evidence-authoring lane (no code change) — a 1-file, +12/-14 CI-wiring diff.
+budget: 1 evidence-authoring lane (no code change) — a 1-file, +12/-14 CI-wiring diff.
 pii: none

--- a/evidence/2026-08/agent-m5-ops-tests-yml-cancelled-matrix-3abb643b/brief.yml
+++ b/evidence/2026-08/agent-m5-ops-tests-yml-cancelled-matrix-3abb643b/brief.yml
@@ -1,0 +1,57 @@
+task_id: ops-tests-yml-cancelled-matrix-evidence
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  Supply the missing Evidence Pack for PR #5000 (agent/m5/ops/tests-yml-cancelled-matrix), which
+  was green everywhere except "Harness floor recompute" (no evidence/brief.yml in the diff — the
+  PR's only touched file is `.github/workflows/*`, a declared hot-zone path, so the deterministic
+  floor is 3 regardless of the change being a single-file, +12/-14 fix). No code/workflow edits are
+  made by this task — the fix was already authored and pushed; this task independently re-verifies
+  the incident and the fix, and authors the evidence pack only.
+
+  The underlying bug: `frontend-tests` in `.github/workflows/tests.yml` had `needs: [changes]` with
+  no job-level `if:`, which inherits GitHub's implicit `success()` gate. When the `changes` job
+  concludes `cancelled` (live incident: PR #4706, run 32866302767, attempt 1), GitHub skips
+  `frontend-tests` BEFORE its matrix expands, so the required check
+  "Frontend Tests (Next.js) (mouth, true)" is never CREATED (absent, not merely skipped) — branch
+  protection then blocks the PR forever on "Expected — Waiting for status" until a human reruns.
+  The fix adds `if: ${{ !cancelled() }}` at the job level so the matrix always instantiates; an
+  early per-step DECIDE guard inside the job still short-circuits real work when the path filter or
+  upstream state says so.
+constraints:
+  - "No code/workflow changes made by this evidence-authoring task — the fix is already merged into
+    this PR's own diff; every receipt below independently re-verifies the incident and the fix on
+    the PR's actual head sha."
+  - "The change must not move the job-level condition onto anything but `!cancelled()` — a bare
+    path-filter predicate at job level would reopen the exact same erasure the PR fixes (per the
+    PR's own in-file comment, re-read and confirmed against the diff)."
+acceptance:
+  - "actionlint accepts the modified workflow file."
+  - "The original incident is independently reproducible from GitHub's own job history, not merely
+    quoted from the PR body: attempt 1 of run 32866302767 (PR #4706) shows `Change map` concluding
+    `cancelled` and `Frontend Tests (Next.js)` concluding `skipped` (matrix never expanded) — the
+    exact defect this PR's `if:` fixes."
+  - "The deterministic gear floor recomputed from this PR's actual changed-file set is 3 (single
+    `.github/workflows/*` file), matching the declared gear and the Harness floor recompute check's
+    own FAIL message."
+consumer_map:
+  - ".github/workflows/tests.yml — `frontend-tests` job's job-level `if:` condition; both matrix
+    legs (`mouth, true` / `admin-dashboard, false`) depend on this job actually instantiating."
+  - "Branch protection required_status_checks — `Frontend Tests (Next.js) (mouth, true)` is a
+    required context this fix keeps from silently disappearing whenever an upstream `changes` job
+    is cancelled (queue congestion, concurrency-group supersession, etc.)."
+risks:
+  - "This task authors evidence only — it does not re-review whether `!cancelled()` is the ideal
+    predicate versus some narrower alternative; the PR's own in-file comment already documents why
+    a job-level path filter specifically must not be reintroduced, and this task takes that
+    reasoning as given rather than re-deriving it."
+grader: |
+  Independent verification by this session, generator != grader relative to the PR's diagnosis
+  (fix-4706 lane) and implementation (codex gpt-5.6-sol seat, committed by the conductor session
+  per the PR body) — re-ran actionlint on the actual modified file, and independently queried
+  GitHub's own job-history API for the cited incident run/attempt rather than trusting the PR
+  body's citation verbatim, and recomputed the deterministic floor from the real diff.
+budget:
+  1 evidence-authoring lane (no code change) — a 1-file, +12/-14 CI-wiring diff.
+pii: none

--- a/evidence/2026-08/agent-m5-ops-tests-yml-cancelled-matrix-3abb643b/pack.yml
+++ b/evidence/2026-08/agent-m5-ops-tests-yml-cancelled-matrix-3abb643b/pack.yml
@@ -1,0 +1,82 @@
+brief_ref: evidence/brief.yml
+plan_ref: "PR #5000 (agent/m5/ops/tests-yml-cancelled-matrix) — frontend-tests must survive a cancelled Change map. Evidence pack authored separately from the workflow diff (PR was green on everything except Harness floor recompute for lacking one)."
+lanes:
+  - lane: ops-tests-yml-cancelled-matrix
+    role: build
+    seat: "diag/fix-4706 lane diagnosis; codex gpt-5.6-sol implementation; conductor session commit (sandbox blocked the seat's own git access, per PR body)"
+  - lane: ops-tests-yml-cancelled-matrix-evidence
+    role: review
+    seat: "session (this task — evidence pack authored + every claim independently re-verified against the actual diff and GitHub's own job-history API, generator != grader relative to the build lane)"
+seat_diversity: not_applicable
+seat_diversity_note: >-
+  Single build lane declared by the PR body itself (diagnosis + Codex implementation +
+  conductor commit already form a cross-seat chain) — the D3 seat-diversity floor for a
+  *council* dispatch does not apply to this narrow evidence-authoring task.
+diff:
+  net_lines: "1 file, +12/-14 measured by `git diff --stat origin/main...HEAD` on the PR's own head sha."
+  behaviour_change: >-
+    `.github/workflows/tests.yml`'s `frontend-tests` job gains `if: ${{ !cancelled() }}` at the
+    job level, replacing the implicit `success()` gate that comes from having `needs: [changes]`
+    with no job-level condition at all. No change to the job's internal DECIDE/path-filter step.
+receipts:
+  - claim: "Deterministic gear floor recomputed from THIS PR's actual diff is 3 — matches the declared gear, and matches the Harness floor recompute check's own FAIL message"
+    cmd: "git diff --name-only origin/main...HEAD > /tmp/changed-5000.txt && python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/changed-5000.txt"
+    exit: 0
+    ts: "2026-08-26T09:20:00Z"
+    seat: "session (evidence-pack task)"
+  - claim: "actionlint accepts the modified workflow file"
+    cmd: "actionlint .github/workflows/tests.yml"
+    result: "no output (clean)"
+    exit: 0
+    ts: "2026-08-26T09:21:00Z"
+    seat: "session (evidence-pack task)"
+  - claim: "The cited incident is independently reproducible from GitHub's own API, not merely quoted from the PR body: run 32866302767 (PR #4706) attempt 1 shows Change map=cancelled, Frontend Tests (Next.js)=skipped — the matrix job never instantiated, exactly the defect this fix addresses. Attempt 2 (post-fix rerun) shows both green."
+    cmd: "gh api repos/Bali-Zero/Teman2/actions/runs/32866302767/attempts/1/jobs --paginate | jq -r '.jobs[] | select(.name|test(\"Change map|Frontend\")) | \"\\(.name)|\\(.conclusion)\"'"
+    result: "Change map|cancelled ; Frontend Tests (Next.js)|skipped (attempt 1). run_attempt=2 overall conclusion=success."
+    exit: 0
+    ts: "2026-08-26T09:23:00Z"
+    seat: "session (evidence-pack task)"
+pii_scan: clean
+dissent:
+  - seat: "Harness floor recompute (CI, deterministic)"
+    objection: >-
+      PR #5000 touches only `.github/workflows/tests.yml`, which is hot-zone by path — floors at
+      Gear 3 regardless of the diff's small size (1 file, +12/-14) — and the PR shipped with no
+      `evidence/brief.yml`/`evidence/pack.yml` in its own diff, so the check correctly FAILED with
+      "this diff touches a hot-zone path (deterministic floor 3) but carries no evidence/brief.yml".
+    status: CONFIRMED
+    note: >-
+      Verified independently, not accepted on the FAIL message alone: recomputed the floor from
+      the PR's actual changed-file list via `evidence_pack_lint.py --print-floor` and got 3,
+      matching the check. Answered here by supplying both files, never by editing the check
+      (CLAUDE.md Agent PR Contract rule 3 precedent).
+  - seat: "session (this evidence-authoring task), against its own first instinct"
+    objection: >-
+      The mandate/PR body cites "Live incident: PR #4706, run 32866302767" as sufficient grounding
+      for the bug's reality. Quoting that citation verbatim without independently querying the run
+      would have been citing a tool output this turn never actually executed — the anti-
+      hallucination failure mode CLAUDE.md §6 exists to prevent, applied to a prior claim rather
+      than to memory. (First query against the run's LATEST state returned all-success, which
+      would have been a false negative had it been accepted uncritically — attempt history had to
+      be checked explicitly.)
+    status: RETRACTED
+    note: >-
+      Queried the run's attempt-1 job history directly via `gh api .../attempts/1/jobs` rather than
+      the bare run (which reflects only the latest, post-fix rerun attempt and shows success).
+      Attempt 1 matched the claimed failure mode exactly (Change map cancelled, frontend-tests
+      matrix skipped). Retracted because the underlying claim held up under independent, correctly
+      -scoped verification.
+tests: []
+static:
+  - "actionlint .github/workflows/tests.yml -> clean"
+notes:
+  - >-
+    This PR is deliberately narrow in this task's own scope: it is the evidence pack ONLY, for a PR
+    whose workflow diff was already committed and pushed. No workflow logic was authored or edited
+    as part of writing this pack — every receipt above is this task independently RE-VERIFYING the
+    incident and the fix, on the PR's actual head sha, in a dedicated worktree separate from any
+    other lane touching this repo (cicatrix-superscar.md family #5, sibling-race discipline).
+  - >-
+    `tests:` is empty because this fix has no unit-testable runtime logic of its own (a GitHub
+    Actions job-level conditional expression) — the acceptance criterion is structural (actionlint)
+    plus the independently-reproduced historical incident, not a pytest file.


### PR DESCRIPTION
A cancelled `Change map` job silently erased the required matrix context `Frontend Tests (Next.js) (mouth, true)` — the job had `needs: [changes]` with no job-level `if:`, which inherits GitHub's implicit `success()` gate and skips the job BEFORE matrix expansion. The required check is then never created (not skipped — absent), and the PR blocks forever until a human reruns. Live incident: PR #4706, run 32866302767.

Fix: `if: ${{ !cancelled() }}` on the job + rewrite of the comment that claimed the opposite semantics. The DECIDE step keeps the path-filter fast path and fails open toward running tests. backend/mcp/e2e jobs already carry status-aware guards. actionlint clean.

Diagnosed by the fix-4706 lane; implemented via codex gpt-5.6-sol seat (routing floor); committed by the conductor session after sandbox blocked the seat's git access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCtR9Zz5kaHRDr9zqEyZS9