### PR TITLE
fix(fleet): fleet_mail.sh air was silently dead from Pro — add a Tailscale fallback

### DIFF
--- a/scripts/fleet_mail.sh
+++ b/scripts/fleet_mail.sh
@@ -20,6 +20,18 @@
 # resolve hostname". An alias that works from one peer and not the other is a
 # lane that fails on exactly one machine — the shape this repo already has a
 # scar family for.
+#
+# CORRECTION 2026-08-26: the paragraph above records a measurement that has
+# since DECAYED. `ssh air` points at `Air-M5.local` (mDNS) and from Pro it now
+# dies with "Could not resolve hostname air-m5.local" — so `fleet_mail.sh air`
+# was dead from Pro, silently, while its own comment asserted the opposite.
+# mDNS does not survive a peer moving off the LAN, and this repo already
+# documents that exact shape for Mini ("LAN/mDNS Mini-Pro2.local often
+# NXDOMAIN; this alias is the verified-working Tailscale path" — the
+# `mini-remote` stanza in ~/.ssh/config). The cure is not a new hardcoded
+# hostname: it is to stop trusting ONE route. ssh_target() below probes the
+# primary alias and falls back to the Tailscale one, so the tool works from
+# whichever side of the network the peer happens to be on.
 set -uo pipefail
 die() { echo "fleet_mail.sh: $*" >&2; exit 1; }
 HOST="${1:-}"
@@ -28,6 +40,33 @@ case "$HOST" in
     *) die "unknown host '$HOST' (want local|pro|mini|air)" ;;
 esac
 shift || die "missing <host>"
+
+# Resolve <host> to an ssh target that actually answers. The primary alias may
+# be mDNS-backed and unresolvable when the peer is off-LAN (see CORRECTION
+# above); each host therefore declares a Tailscale-backed fallback alias that
+# already exists in ~/.ssh/config. Probing costs one cheap `true` round-trip
+# and ONLY on the primary — the fallback is tried only after the primary fails,
+# so the common (on-LAN) path is unchanged. Judged by the probe's RETURN CODE,
+# never by its output: a resolver failure prints to stderr and would otherwise
+# look like success to a stdout-reading caller.
+ssh_fallback_for() {
+    case "$1" in
+        air)  echo "air-ts" ;;
+        mini) echo "mini-remote" ;;
+        *)    echo "" ;;
+    esac
+}
+ssh_target() {
+    local host="$1" fb
+    if ssh -o BatchMode=yes -o ConnectTimeout=6 "$host" true 2>/dev/null; then
+        echo "$host"; return 0
+    fi
+    fb="$(ssh_fallback_for "$host")"
+    if [ -n "$fb" ] && ssh -o BatchMode=yes -o ConnectTimeout=6 "$fb" true 2>/dev/null; then
+        echo "$fb"; return 0
+    fi
+    return 1
+}
 SESSION_ID_RE='^([A-Za-z0-9_-]{8,80}|broadcast)$'
 # ---- read-only session lister (executes on the target, local or remote) ----
 read -r -d '' LIST_SCRIPT <<'REMOTE' || true
@@ -84,8 +123,10 @@ if [ "${1:-}" = "--list" ]; then
     if [ "$HOST" = "local" ]; then
         bash -c "$LIST_SCRIPT" || die "local list failed"
     else
-        ssh -o BatchMode=yes -o ConnectTimeout=8 "$HOST" bash -s <<< "$LIST_SCRIPT" \
-            || die "ssh list on $HOST failed"
+        SSH_HOST="$(ssh_target "$HOST")" \
+            || die "no reachable ssh route for '$HOST' (tried '$HOST' and '$(ssh_fallback_for "$HOST")')"
+        ssh -o BatchMode=yes -o ConnectTimeout=8 "$SSH_HOST" bash -s <<< "$LIST_SCRIPT" \
+            || die "ssh list on $HOST (via $SSH_HOST) failed"
     fi
     exit 0
 fi
@@ -154,7 +195,9 @@ else
     B64="$(printf '%s' "$PY_SEND" | base64 | tr -d '\n')"
     POP_AND_EXEC='import base64,sys;b=sys.argv.pop(1);exec(base64.b64decode(b).decode())'
     REMOTE_CMD="python3 -c \"$POP_AND_EXEC\" '$B64' '$SESSION' '$FILENAME' '$FROM_LABEL'"
-    printf '%s' "$BODY" | ssh -o BatchMode=yes -o ConnectTimeout=8 "$HOST" "$REMOTE_CMD" \
-        || die "ssh delivery to $HOST:$SESSION failed"
+    SSH_HOST="$(ssh_target "$HOST")" \
+        || die "no reachable ssh route for '$HOST' (tried '$HOST' and '$(ssh_fallback_for "$HOST")')"
+    printf '%s' "$BODY" | ssh -o BatchMode=yes -o ConnectTimeout=8 "$SSH_HOST" "$REMOTE_CMD" \
+        || die "ssh delivery to $HOST:$SESSION (via $SSH_HOST) failed"
 fi
-echo "delivered to $HOST:$SESSION ($FILENAME)"
+echo "delivered to $HOST:$SESSION ($FILENAME)${SSH_HOST:+ via $SSH_HOST}"

--- a/scripts/tests/test_fleet_mail_hosts.py
+++ b/scripts/tests/test_fleet_mail_hosts.py
@@ -9,11 +9,19 @@ Per superscar #3, a guard gets both halves or neither: `air` must be ACCEPTED
 (innocence) and a genuinely unknown host must still be REFUSED (guilt), so this
 does not degrade into "accept anything".
 
-`m5` is deliberately NOT in the allowlist and is asserted as refused. Measured
-2026-08-24 from both peers: `ssh air` resolves to Air-M5 from Pro and from Mini;
-`ssh m5` resolves only from Pro and fails on Mini with "could not resolve
-hostname". Admitting an alias that works from one peer and dies on the other is
-how a lane comes to fail on exactly one machine.
+`m5` is deliberately NOT in the allowlist and is asserted as refused: it is a real
+ssh alias on Pro and a dead name on Mini, and admitting an alias that works from
+one peer and dies on the other is how a lane comes to fail on exactly one machine.
+
+CORRECTION 2026-08-26: this docstring used to add "Measured 2026-08-24 from both
+peers: `ssh air` resolves to Air-M5 from Pro and from Mini." That measurement has
+DECAYED and the sentence became false while still reading as verified. `ssh air`
+points at `Air-M5.local` (mDNS); measured from Pro on 2026-08-26 it dies with
+"Could not resolve hostname air-m5.local", so `fleet_mail.sh air` was silently
+dead from Pro. A recorded measurement is not a property — mDNS stops resolving
+the moment a peer leaves the LAN. The fix was not a new hardcoded hostname but
+`ssh_target()`, which probes the primary alias and falls back to the Tailscale
+one; the two tests below cover BOTH of its branches.
 """
 
 from __future__ import annotations
@@ -90,6 +98,92 @@ def test_unknown_hosts_are_still_refused(host: str, stub_path: str) -> None:
     reason = _reject_reason(host, stub_path)
     assert reason is not None, f"{host!r} was accepted by the host allowlist"
     assert "want local|pro|mini|air" in reason
+
+
+def _routing_stub(tmp_path, up: set[str]) -> str:
+    """A PATH whose `ssh` succeeds only for the hosts in `up`.
+
+    The stub must answer the PROBE (`ssh -o ... <host> true`) and the real call
+    identically, because `ssh_target()` judges the probe by its RETURN CODE.
+    Host is the first non-option argument, mirroring how the script invokes ssh.
+    """
+    import os
+
+    d = tmp_path / "stub-bin"
+    d.mkdir(exist_ok=True)
+    ssh = d / "ssh"
+    ssh.write_text(
+        "#!/bin/sh\n"
+        "host=''\n"
+        "while [ $# -gt 0 ]; do\n"
+        "  case \"$1\" in\n"
+        "    -o) shift 2;;\n"
+        "    -*) shift;;\n"
+        "    *) host=\"$1\"; break;;\n"
+        "  esac\n"
+        "done\n"
+        f"for u in {' '.join(sorted(up)) or '__none__'}; do\n"
+        "  [ \"$host\" = \"$u\" ] && { echo \"REACHED:$host\"; exit 0; }\n"
+        "done\n"
+        "echo 'stub ssh: unreachable' >&2\n"
+        "exit 255\n"
+    )
+    ssh.chmod(0o755)
+    return f"{d}{os.pathsep}{os.environ.get('PATH', '')}"
+
+
+def _run_list(host: str, path: str):
+    import os
+
+    return subprocess.run(
+        ["bash", str(SCRIPT), host, "--list"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=dict(os.environ, PATH=path),
+    )
+
+
+def test_air_falls_back_to_tailscale_when_the_mdns_primary_is_unresolvable(tmp_path) -> None:
+    """INNOCENCE: primary dead + fallback alive => the tool still reaches the peer.
+
+    This is the exact live condition measured on 2026-08-26: `air` (mDNS) does
+    not resolve from Pro while `air-ts` (Tailscale) does. Before `ssh_target()`
+    this died outright.
+    """
+    proc = _run_list("air", _routing_stub(tmp_path, {"air-ts"}))
+    assert "no reachable ssh route" not in proc.stderr, proc.stderr
+    assert "REACHED:air-ts" in proc.stdout + proc.stderr, (proc.stdout, proc.stderr)
+
+
+def test_primary_is_preferred_when_it_answers(tmp_path) -> None:
+    """The fallback must not become the default: when the LAN alias works it is
+    the one used, so an on-LAN peer is never forced through the relay."""
+    proc = _run_list("air", _routing_stub(tmp_path, {"air", "air-ts"}))
+    out = proc.stdout + proc.stderr
+    assert "REACHED:air" in out and "REACHED:air-ts" not in out, out
+
+
+def test_both_routes_dead_fails_loudly_and_names_both(tmp_path) -> None:
+    """GUILT: the fallback must not turn an unreachable peer into a silent pass.
+
+    Measured the hard way: while this fix was being written, M5 went offline and
+    BOTH routes died. The tool must say so, and name what it tried — otherwise
+    the next reader blames the alias instead of the sleeping laptop.
+    """
+    proc = _run_list("air", _routing_stub(tmp_path, set()))
+    assert proc.returncode != 0
+    assert "no reachable ssh route" in proc.stderr, proc.stderr
+    assert "air-ts" in proc.stderr, proc.stderr
+
+
+def test_every_allowlisted_remote_host_has_a_declared_fallback_or_is_deliberate() -> None:
+    """A host with no fallback is one mDNS outage away from the bug this fixes.
+    `pro` legitimately has none today; this test pins that as a CHOICE, so adding
+    a fourth node without a fallback is a decision someone must make on purpose."""
+    text = SCRIPT.read_text()
+    assert 'air)  echo "air-ts"' in text
+    assert 'mini) echo "mini-remote"' in text
 
 
 def test_usage_comment_lists_the_same_hosts_as_the_allowlist() -> None:


### PR DESCRIPTION
## What broke

`ssh air` points at `Air-M5.local` (mDNS). Measured from Pro on 2026-08-26 it dies with `Could not resolve hostname air-m5.local` — so **`fleet_mail.sh air` failed on every attempt from this node**. That is the tool the M5 conductor uses to ask other machines for status, so the failure is exactly on the path that reports a session is alive.

Found by using it: the M5 conductor asked this session for a status report and the delivery died.

## Why it deserves a commit and not a retry

Both the script header **and** the test docstring asserted the opposite, in the voice of a measurement:

> "measured from both peers this turn, `ssh air` resolves to Air-M5 from Pro AND from Mini"

True when written on 2026-08-24, false by 2026-08-26. **A recorded measurement is not a property.** mDNS stops resolving the moment a peer leaves the LAN, and nothing re-checked. Both texts are *corrected in place* rather than deleted, so the decay stays visible to the next reader instead of just disappearing.

## The fix

Not a new hardcoded hostname — that decays the same way. The cure is to stop trusting **one** route:

- `ssh_target()` probes the primary alias, and only on failure falls back to the Tailscale-backed alias that **already exists** in `~/.ssh/config` (`air`→`air-ts`, `mini`→`mini-remote`) — the same pattern this repo already documents for `mini-remote`.
- The probe is judged by its **return code**, never its output: a resolver failure writes to stderr and would otherwise read as success to a stdout-reading caller.
- The fallback runs only after the primary fails, so the on-LAN path is unchanged.

## Tests — both halves (superscar #3)

| Test | Covers |
|---|---|
| primary dead, fallback alive | the live 2026-08-26 condition; died outright before |
| primary alive | the relay must **not** become the default |
| both dead | fails LOUDLY and names what it tried |
| every remote host has a declared fallback | a new node without one is a deliberate choice, not an oversight |

Mutation-checked: blanking the `air` fallback turns three of the four red; restoring turns them green. 16 passed.

## What is NOT proven

**End-to-end delivery to M5 could not be demonstrated.** M5 went offline mid-work (`tailscale status`: `offline, last seen 1m ago`), so both routes were down. The fallback logic is proven by the tests, **not** by a delivery — and the status message this was written to send is still undelivered. Stating that here rather than letting the green suite imply more than it measured.