### PR TITLE
fix(llm): the Gemini streaming path raised on every call, and a mock hid it

### DIFF
--- a/apps/backend-rag/backend/llm/genai_client.py
+++ b/apps/backend-rag/backend/llm/genai_client.py
@@ -942,11 +942,21 @@ class GenAIClient:
         t0 = time.perf_counter()
         chunk_count = 0
         try:
-            async for chunk in self._client.aio.models.generate_content_stream(
+            # google-genai's AsyncModels.generate_content_stream is a COROUTINE
+            # FUNCTION -- it must be awaited to obtain the AsyncIterator, even
+            # though its return annotation reads AsyncIterator[...]. Iterating the
+            # call directly raises `TypeError: 'async for' requires an object with
+            # __aiter__ method, got coroutine` on EVERY call, which the caller
+            # catches and logs as "LLM stream failed", so the path degrades in
+            # silence instead of failing loudly. Measured on google-genai 1.75.0:
+            # inspect.iscoroutinefunction(...) is True. Tripwire:
+            # test_genai_stream_awaits_the_sdk_coroutine.py.
+            stream = await self._client.aio.models.generate_content_stream(
                 model=model,
                 contents=contents,
                 config=config,
-            ):
+            )
+            async for chunk in stream:
                 if chunk.text:
                     chunk_count += 1
                     yield chunk.text

--- a/apps/backend-rag/backend/tests/unit/llm/test_genai_client.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_genai_client.py
@@ -71,11 +71,23 @@ class TestGenAIClient:
         mock_chunk2 = MagicMock()
         mock_chunk2.text = "chunk2"
 
+        # CORRECTED 2026-08-26. This mock used to be an async GENERATOR function,
+        # with a comment asserting the mock "must return async generator directly".
+        # The real SDK has never had that shape: on both google-genai 1.75.0 (local
+        # venv) and 2.18.1 (the version requirements.lock.txt and
+        # requirements-prod.lock.txt pin, i.e. what CI and production actually run),
+        # `AsyncModels.generate_content_stream` is a COROUTINE FUNCTION --
+        # inspect.iscoroutinefunction() is True and isasyncgenfunction() is False.
+        # So this test was green over a call path that raised TypeError on every
+        # real invocation. The mock now matches the SDK: a coroutine that resolves
+        # to the async iterator.
         async def mock_stream(*args, **kwargs):
-            yield mock_chunk1
-            yield mock_chunk2
+            async def _chunks():
+                yield mock_chunk1
+                yield mock_chunk2
 
-        # Mock must return async generator directly, not wrapped in AsyncMock
+            return _chunks()
+
         genai_client._client.aio.models.generate_content_stream = mock_stream
 
         chunks = []

--- a/apps/backend-rag/backend/tests/unit/llm/test_genai_stream_awaits_the_sdk_coroutine.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_genai_stream_awaits_the_sdk_coroutine.py
@@ -1,0 +1,183 @@
+"""The Gemini streaming call must AWAIT the SDK coroutine before iterating it.
+
+WHY THIS FILE EXISTS
+
+`GenAIClient.generate_content_stream` used to do:
+
+    async for chunk in self._client.aio.models.generate_content_stream(...):
+
+`google-genai`'s `AsyncModels.generate_content_stream` is a **coroutine
+function** -- it must be awaited to obtain the `AsyncIterator`, despite a return
+annotation that reads `AsyncIterator[...]`. Iterating the call directly raises
+`TypeError: 'async for' requires an object with __aiter__ method, got coroutine`
+on EVERY invocation. The caller catches it, logs "LLM stream failed", and
+degrades in silence -- so the path was 100% broken with nothing red anywhere.
+
+WHY CI DID NOT CATCH IT, WHICH IS THE MORE IMPORTANT HALF
+
+`test_genai_client.py::test_generate_content_stream` mocked the SDK entrypoint
+with an async GENERATOR function, and carried a comment asserting the mock
+"must return async generator directly". The real SDK has never had that shape
+in either version this repo touches. The test therefore answered where
+production raised -- a mock that contradicts the contract is not a test, it is
+a second implementation that only the test suite ever runs.
+
+So a second mock, however carefully shaped, cannot be the whole guard here:
+whatever shape we write is a shape WE chose. The first test below therefore
+asserts against the INSTALLED SDK rather than against anything this repo wrote,
+so a future SDK that flips the contract makes noise instead of silently
+reverting us to the broken form.
+
+MEASURED 2026-08-26, both versions in play:
+
+  google-genai 1.75.0 (the apps/backend-rag/.venv on Pro)
+  google-genai 2.18.1 (pinned by requirements.lock.txt AND
+                       requirements-prod.lock.txt -- i.e. CI and production)
+
+  iscoroutinefunction(AsyncModels.generate_content_stream) -> True   (both)
+  isasyncgenfunction (AsyncModels.generate_content_stream) -> False  (both)
+
+The import below is deliberately hard, not `importorskip`: google-genai is a
+pinned dependency of this app, so "the SDK is absent" is a broken environment,
+not a reason to pass. A skip here would restore exactly the silence this file
+was written to end.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.genai import models as genai_models
+
+backend_path = Path(__file__).parent.parent.parent.parent.parent / "backend"
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))
+
+from backend.llm.genai_client import GenAIClient  # noqa: E402
+
+
+def test_the_sdk_streaming_entrypoint_is_still_a_coroutine_function():
+    """Drift tripwire on the SDK itself, not on anything this repo wrote.
+
+    If a future google-genai makes this an async generator function again, the
+    awaited form in genai_client.py becomes the wrong one and this test says so
+    with the reason, instead of the streaming path going quietly dead a second
+    time.
+    """
+    fn = genai_models.AsyncModels.generate_content_stream
+    assert inspect.iscoroutinefunction(fn), (
+        "google-genai's AsyncModels.generate_content_stream is no longer a "
+        "coroutine function. genai_client.py awaits it before iterating, which "
+        "is correct ONLY while this holds. Re-check the SDK version pinned in "
+        "requirements.lock.txt and adjust the call site — do NOT adjust this "
+        "assertion to match a mock."
+    )
+    assert not inspect.isasyncgenfunction(fn), (
+        "AsyncModels.generate_content_stream is now an async generator function. "
+        "The call site must iterate it directly instead of awaiting it."
+    )
+
+
+@pytest.fixture
+def client():
+    with (
+        patch("backend.llm.genai_client.genai") as mock_genai,
+        patch("backend.llm.genai_client.types"),
+        patch("backend.llm.genai_client.GENAI_AVAILABLE", True),
+    ):
+        mock_client = MagicMock()
+        mock_genai.Client.return_value = mock_client
+        c = GenAIClient(api_key="test-key")
+        c._client = mock_client
+        c._available = True
+        return c
+
+
+@pytest.mark.asyncio
+async def test_the_wrapper_awaits_the_coroutine_and_yields_every_chunk(client):
+    """GUILT: this is red on the pre-2026-08-26 call site.
+
+    The mock's shape is copied from the SDK's real one -- a coroutine function
+    resolving to an async iterator -- rather than chosen to make the code pass.
+    Against the old `async for chunk in <coroutine>` form this raises TypeError
+    and the wrapper re-raises it, so the test fails loudly rather than yielding
+    nothing.
+    """
+    chunks_in = []
+    for text in ("alpha", "beta", "gamma"):
+        c = MagicMock()
+        c.text = text
+        chunks_in.append(c)
+
+    awaited = {"count": 0}
+
+    async def sdk_shaped_stream(*args, **kwargs):
+        awaited["count"] += 1
+
+        async def _iterator():
+            for c in chunks_in:
+                yield c
+
+        return _iterator()
+
+    client._client.aio.models.generate_content_stream = sdk_shaped_stream
+
+    out = [chunk async for chunk in client.generate_content_stream("q")]
+
+    assert out == ["alpha", "beta", "gamma"], (
+        "the wrapper did not yield the SDK's chunks in order — if this is empty, "
+        "the call site is iterating the coroutine instead of awaiting it"
+    )
+    assert awaited["count"] == 1, "the SDK entrypoint should be called exactly once"
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_with_no_text_is_skipped_not_yielded_as_none(client):
+    """INNOCENCE: the fix must not change which chunks reach the caller.
+
+    google-genai emits chunks whose `.text` is None (tool-call and safety
+    metadata frames). Those were skipped before and must still be skipped —
+    yielding None here would push a None into every consumer's string
+    concatenation.
+    """
+    good = MagicMock()
+    good.text = "kept"
+    empty = MagicMock()
+    empty.text = None
+
+    async def sdk_shaped_stream(*args, **kwargs):
+        async def _iterator():
+            yield empty
+            yield good
+            yield empty
+
+        return _iterator()
+
+    client._client.aio.models.generate_content_stream = sdk_shaped_stream
+
+    out = [chunk async for chunk in client.generate_content_stream("q")]
+
+    assert out == ["kept"], f"textless chunks leaked into the output: {out!r}"
+
+
+@pytest.mark.asyncio
+async def test_an_sdk_failure_still_propagates_rather_than_yielding_nothing(client):
+    """INNOCENCE: the wrapper re-raises. A stream that dies must not look empty.
+
+    This is what made the original defect invisible for so long — the caller
+    logged "LLM stream failed" and carried on. The wrapper's own contract is to
+    re-raise; that must survive the fix, or a dead Gemini becomes an empty
+    answer instead of an error.
+    """
+
+    async def failing_stream(*args, **kwargs):
+        raise RuntimeError("upstream refused")
+
+    client._client.aio.models.generate_content_stream = failing_stream
+
+    with pytest.raises(RuntimeError, match="upstream refused"):
+        [chunk async for chunk in client.generate_content_stream("q")]

--- a/apps/backend-rag/backend/tests/unit/llm/test_genai_stream_awaits_the_sdk_coroutine.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_genai_stream_awaits_the_sdk_coroutine.py
@@ -82,6 +82,84 @@ def test_the_sdk_streaming_entrypoint_is_still_a_coroutine_function():
     )
 
 
+def test_the_installed_sdk_matches_the_version_the_lockfile_pins():
+    """The tripwire above measures the INSTALLED SDK. This one measures whether
+    the installed SDK is the one CI and production actually run.
+
+    Raised by a cross-family refuter against the first draft of this file: an
+    SDK-shape assertion reads whatever is in the venv, so a drifted venv makes it
+    green while saying nothing about the pinned version — the assertion silences
+    itself exactly when it matters.
+
+    That is not hypothetical. Measured 2026-08-26 on Pro: the
+    apps/backend-rag/.venv carried google-genai 1.75.0 while
+    requirements.lock.txt pinned 2.18.1. The contract happens to be identical in
+    both, so the fix this file guards is right either way — but that was luck,
+    established only by installing 2.18.1 into a throwaway venv to check. Local
+    test results do not transfer to CI until this passes.
+
+    Green in CI, which installs requirements.lock.txt. Red on a drifted
+    workstation, which is the point: the cure is to reinstall the venv from the
+    lockfile, NEVER to loosen this assertion.
+    """
+    import google.genai
+
+    lock = Path(__file__).parents[4] / "requirements.lock.txt"
+    assert lock.is_file(), f"requirements.lock.txt not found at {lock}"
+
+    pinned = None
+    for line in lock.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("google-genai=="):
+            pinned = stripped.split("==", 1)[1].split()[0].rstrip(" \\")
+            break
+    assert pinned, "requirements.lock.txt does not pin google-genai with '=='"
+
+    installed = google.genai.__version__
+    assert installed == pinned, (
+        f"google-genai drift: this environment has {installed}, "
+        f"requirements.lock.txt pins {pinned}. Every result from this file — and "
+        f"from any other test touching the Gemini SDK — is about a version CI and "
+        f"production do not run. Reinstall the venv from the lockfile. Do not "
+        f"relax this assertion: it exists because a shape tripwire reads whatever "
+        f"is installed and therefore goes quiet on exactly the drifted machine "
+        f"where it was needed."
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_sdk_call_returns_something_awaitable_that_then_iterates():
+    """BEHAVIOURAL form of the shape tripwire, and the stronger of the two.
+
+    Also raised by the refuter: asserting `iscoroutinefunction` on the CLASS
+    ATTRIBUTE is an implementation detail Google may flip in a patch release, and
+    it is not necessarily the object the production call site reaches —
+    instrumentation (openinference-instrumentation-google-genai is installed and
+    wraps this very method) or per-instance patching could diverge from the class.
+
+    What the call site actually depends on is narrower and more stable: the call
+    returns something awaitable, and awaiting it gives something iterable with
+    `async for`. That is asserted here against a REAL client object rather than
+    the class, with no network: the SDK builds the coroutine eagerly and only
+    performs I/O once awaited, so constructing it and checking `isawaitable` is
+    free. The coroutine is closed rather than awaited, so nothing is sent.
+    """
+    from google import genai
+
+    sdk = genai.Client(api_key="not-a-real-key-nothing-is-sent")
+    call = sdk.aio.models.generate_content_stream(
+        model="gemini-2.0-flash-lite", contents="ping"
+    )
+    try:
+        assert inspect.isawaitable(call), (
+            "aio.models.generate_content_stream no longer returns an awaitable. "
+            "genai_client.py awaits it before iterating; that call site must change "
+            "with this contract, and the change must be made there, not here."
+        )
+    finally:
+        call.close()
+
+
 @pytest.fixture
 def client():
     with (


### PR DESCRIPTION
Found while running `kb/ops/probe_history.py` against production **before** arming its LaunchAgent. Every probe run printed the same TypeError twice, followed by `Gemini query expansion failed`. The KB probes have been retrieving on **unexpanded queries** this whole time.

## The defect

```python
async for chunk in self._client.aio.models.generate_content_stream(...)
```

`google-genai`'s `AsyncModels.generate_content_stream` is a **coroutine function**. It must be awaited to obtain the `AsyncIterator`, despite a return annotation reading `AsyncIterator[...]`. Iterating the call raises `TypeError: 'async for' requires an object with __aiter__ method, got coroutine` on **every** invocation. The wrapper re-raises, the caller catches and logs `"LLM stream failed"`, and the path degrades in silence.

Measured on **both** versions in play, because measuring only the local one would have proved nothing about production:

| Version | Where | `iscoroutinefunction` | `isasyncgenfunction` |
|---|---|---|---|
| 1.75.0 | `apps/backend-rag/.venv` on Pro | **True** | False |
| 2.18.1 | `requirements.lock.txt` **and** `requirements-prod.lock.txt` — CI and production | **True** | False |

The SDK's own docstring at 2.18.1 reads `async for chunk in await client.aio.models.generate_content_stream(` — verified directly, not taken from the reviewer.

## Why CI was green over it — the more important half

`test_genai_client.py::test_generate_content_stream` mocked the entrypoint with an async **generator** function, under a comment asserting the mock *"must return async generator directly, not wrapped in AsyncMock"*. The SDK has never had that shape in either version this repo touches. Someone hit the mismatch and moved the **mock** to match the **code** instead of moving the code to match the SDK — so the suite exercised a second implementation that only the tests ever ran.

That mock is corrected here. And because any mock's shape is a shape *we* chose, a mock alone cannot be the guard: the new file asserts against the **installed SDK** and against **real client behaviour**.

## Proven by mutation, not by assertion

Restoring the pre-fix call site turns **4 tests red** — the three behavioural ones plus the corrected existing one — with `LLM stream failed` in the captured log, exactly the production symptom. The SDK tripwire correctly stays **green** under that mutation, since it measures the SDK and not this code.

Innocence kept explicit: textless chunks (tool-call and safety frames, `.text is None`) are still skipped rather than yielded as `None`, and an SDK failure still propagates rather than surfacing as an empty answer.

## Cross-family adversarial round (`kimi` / Kimi K3)

| # | Finding | Disposition |
|---|---|---|
| 1 | Could the old code have worked anyway (instrumentation, Vertex path, monkeypatch)? | **No** — the reviewer checked `openinference`'s wrapper: its `__call__` is itself `async def` returning a coroutine. Both Vertex and Gemini-API paths use the same `AsyncModels`. |
| 2 | Does awaiting inside an async generator change semantics? | **No** — the body doesn't run until the consumer's first `__anext__` either way; laziness, cancellation, `GeneratorExit` and the timeout config are unchanged. |
| 3 | A shape tripwire reads whatever is in the venv → **a drifted venv silences it** | **UPHELD.** Not hypothetical: this machine had 1.75.0 against a 2.18.1 pin. New test asserts installed == pinned. Green in CI, red on a drifted workstation, cure named in the message. |
| 4 | Asserting on the **class attribute** isn't necessarily the object production reaches | **UPHELD.** Added the behavioural form against a real client object (no network — the coroutine is closed, not awaited). |
| — | `genai_client.py:1181` is possibly the same bug | **NOT UPHELD**, checked rather than dismissed. There `self._client` is typed `client: GenAIClient` (line 1071), constructed `client=self` (line 1019); `GenAIClient.generate_content_stream` contains `yield`, so it IS an async generator and direct iteration is correct. Two same-named attributes in two classes. |

**Its strongest objection stands and this PR does not close it:** since the TypeError fired on every call, the true streaming path has **never served a production request**. Operationally this is a launch, not a repair — new latency profile, new partial-failure modes, real `APIError`/`httpx` exceptions reaching callers where only a uniform `TypeError` ever appeared. Recorded for post-merge PROVE-LIVE on the WhatsApp path rather than argued away.

## Verification

- `backend/tests/unit/llm/` + `backend/tests/services/llm_clients/`: **448 passed, 1 skipped**, plus the 1 deliberate red (the venv-drift test — 1.75.0 ≠ 2.18.1 on Pro; **green in CI**, which installs the lockfile).
- Mutation proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nj6VttXkPqpHRovdeUNBjd