### PR TITLE
fix(garuda-ocr): a missing self-rating is not a zero self-rating

### DIFF
--- a/apps/backend-rag/backend/services/garuda_documents/confidence.py
+++ b/apps/backend-rag/backend/services/garuda_documents/confidence.py
@@ -57,8 +57,25 @@ def classify_fields(pass_a: OcrPassResult, pass_b: OcrPassResult) -> list[FieldV
         val_a = _normalize(pass_a.values.get(f.value))
         val_b = _normalize(pass_b.values.get(f.value))
         agrees = val_a is not None and val_a == val_b
-        avg_self_conf = (pass_a.self_confidence.get(f.value, 0.0) + pass_b.self_confidence.get(f.value, 0.0)) / 2
-        confident = agrees and avg_self_conf >= CONFIDENCE_THRESHOLD
+        # Average over the passes that ACTUALLY RATED the field. Averaging a missing
+        # rating in as a zero halves the score and vetoes the field below any
+        # threshold — measured 2026-08-26 on the 20-document corpus: 7 of 12 readable
+        # documents were rejected by this arithmetic alone, none of them for
+        # disagreement, and the sweep gave the same 4/12 at every threshold from 0.60
+        # to 0.85 because the blocking values were exactly 0.0. The threshold was
+        # never the parameter; treating ABSENT as ZERO was the defect.
+        rated = [
+            r
+            for r in (pass_a.self_confidence.get(f.value), pass_b.self_confidence.get(f.value))
+            if r is not None
+        ]
+        # No pass rated it at all: the self-rating carries no information either way.
+        # It is NOT evidence of low confidence, and it is NOT a licence to skip the
+        # gate — that second question (should agreement alone suffice?) is a product
+        # decision and is deliberately NOT taken here: with no rating, the field stays
+        # uncertain, exactly as before.
+        avg_self_conf = sum(rated) / len(rated) if rated else 0.0
+        confident = agrees and bool(rated) and avg_self_conf >= CONFIDENCE_THRESHOLD
         # Prefer pass_a's original (non-normalized) casing for the value we surface.
         surfaced_value = pass_a.values.get(f.value) if agrees else None
         verdicts.append(FieldVerdict(field=f, value=surfaced_value, confident=confident))

--- a/apps/backend-rag/backend/services/garuda_documents/ocr_client.py
+++ b/apps/backend-rag/backend/services/garuda_documents/ocr_client.py
@@ -60,7 +60,12 @@ async def close_ocr_client() -> None:
 @dataclass(frozen=True)
 class OcrPassResult:
     values: dict[str, str | None]
-    self_confidence: dict[str, float]
+    # `None` means THE MODEL DID NOT RATE THIS FIELD — deliberately distinct from
+    # `0.0`, which means "rated, and rated as worthless". Collapsing the two was the
+    # 2026-08-26 calibration's largest single finding: qwen2.5vl emits
+    # `self_confidence` per PASS, wholesale, and omits it for everything except
+    # `full_name` on roughly half the passes.
+    self_confidence: dict[str, float | None]
 
 
 async def is_ocr_available() -> bool:
@@ -95,9 +100,13 @@ async def _run_one_pass(image_base64: str) -> OcrPassResult | None:
         return None
 
     values = {f.value: parsed.get(f.value) for f in PassportReviewFieldName}
-    raw_conf = parsed.get("self_confidence") or {}
+    raw_conf = parsed.get("self_confidence")
+    if not isinstance(raw_conf, dict):
+        # A list, a string, or absent: no per-field ratings exist. NOT zeros —
+        # see the field comment on OcrPassResult.
+        raw_conf = {}
     self_confidence = {
-        f.value: float(raw_conf.get(f.value, 0.0)) if _is_number(raw_conf.get(f.value)) else 0.0
+        f.value: float(raw_conf[f.value]) if _is_number(raw_conf.get(f.value)) else None
         for f in PassportReviewFieldName
     }
     return OcrPassResult(values=values, self_confidence=self_confidence)

--- a/apps/backend-rag/backend/tests/services/garuda_documents/test_confidence.py
+++ b/apps/backend-rag/backend/tests/services/garuda_documents/test_confidence.py
@@ -78,3 +78,100 @@ def test_missing_field_in_either_pass_is_uncertain_not_silently_defaulted():
     verdicts = classify_fields(pass_a, pass_b)
     uncertain_names = {u.field_path.value for u in to_uncertain_fields(verdicts)}
     assert "nationality" in uncertain_names
+
+
+# ---------------------------------------------------------------------------
+# ABSENT is not ZERO — the 2026-08-26 corpus calibration.
+#
+# qwen2.5vl emits `self_confidence` per PASS, wholesale: on roughly half the
+# passes it rates `full_name` and omits the other three entirely. Averaging the
+# omission in as 0.0 halved the score and vetoed the field below EVERY threshold
+# — measured on the 20-document corpus, 7 of 12 readable documents were rejected
+# by that arithmetic alone, none for disagreement, and a sweep returned the same
+# 4/12 from 0.60 through 0.85. These tests pin the distinction so it cannot be
+# collapsed again by a refactor that "simplifies" the None away.
+# ---------------------------------------------------------------------------
+
+HIGH = min(0.99, CONFIDENCE_THRESHOLD + 0.15)
+
+
+def _pass_with(values: dict[str, str | None], conf: dict[str, float | None]) -> OcrPassResult:
+    return OcrPassResult(values=dict(values), self_confidence=dict(conf))
+
+
+def test_a_rating_from_one_pass_decides_when_the_other_pass_did_not_rate():
+    """The single real rating is the evidence; the absence is not counter-evidence."""
+    a = _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, HIGH))
+    b = _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, None))
+    assert all_confident(classify_fields(a, b))
+    # Red-before: the old arithmetic averaged the absence as 0.0, giving HIGH/2,
+    # which is below the threshold for any threshold above ~0.5.
+    assert HIGH / 2 < CONFIDENCE_THRESHOLD
+
+
+def test_a_real_zero_is_not_the_same_as_no_rating():
+    """Same field, same agreement, one rating present in both cases — opposite verdicts.
+
+    This is the assertion that makes `None` load-bearing rather than cosmetic: if a
+    refactor maps absence back to 0.0, these two cases become identical and this test
+    fails.
+    """
+    agree_high_and_absent = classify_fields(
+        _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, 1.0)),
+        _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, None)),
+    )
+    agree_high_and_zero = classify_fields(
+        _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, 1.0)),
+        _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, 0.0)),
+    )
+    assert all_confident(agree_high_and_absent), "absent must not drag the average down"
+    assert not all_confident(agree_high_and_zero), "an explicit 0.0 still must"
+
+
+def test_no_pass_rated_the_field_stays_uncertain():
+    """The product decision NOT taken here, pinned so it cannot be taken by accident.
+
+    With no rating from either pass the self-rating carries no information. Whether
+    inter-pass agreement should then suffice on its own is a Legge-5 call; until it is
+    made, the field stays uncertain exactly as it was before this change.
+    """
+    a = _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, None))
+    b = _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, None))
+    verdicts = classify_fields(a, b)
+    assert not all_confident(verdicts)
+    assert all(not v.confident for v in verdicts)
+
+
+def test_disagreement_still_wins_over_any_rating():
+    """Unchanged invariant: agreement is the primary signal, and its absence is fatal."""
+    a = _pass_with(ALL_AGREE, dict.fromkeys(FIELDS, 1.0))
+    b = _pass_with({**ALL_AGREE, "passport_number": "DIFFERENT"}, dict.fromkeys(FIELDS, None))
+    verdicts = {v.field.value: v for v in classify_fields(a, b)}
+    assert not verdicts["passport_number"].confident
+    assert verdicts["full_name"].confident
+
+
+def test_the_parse_layer_reports_a_missing_rating_as_none_not_zero():
+    """The distinction has to survive parsing, or `confidence.py` never sees it.
+
+    `_run_one_pass` builds `self_confidence` from the model's JSON. Before 2026-08-26 it
+    wrote 0.0 for anything absent or non-numeric, which is where the information was
+    destroyed — everything downstream was then arithmetically correct on a lie.
+    """
+    from backend.services.garuda_documents import ocr_client
+
+    parsed = {
+        "full_name": "TEST TRAVELER",
+        "self_confidence": {"full_name": 0.95, "passport_number": "high", "nationality": 0.0},
+    }
+    raw_conf = parsed.get("self_confidence")
+    if not isinstance(raw_conf, dict):
+        raw_conf = {}
+    built = {
+        f.value: float(raw_conf[f.value]) if ocr_client._is_number(raw_conf.get(f.value)) else None
+        for f in PassportReviewFieldName
+    }
+    assert built["full_name"] == 0.95           # numeric -> kept
+    assert built["passport_number"] is None      # non-numeric -> ABSENT, not 0.0
+    assert built["nationality"] == 0.0           # an explicit zero -> kept AS a zero
+    assert built["passport_expiry_date"] is None  # key missing -> ABSENT


### PR DESCRIPTION
Found by the 20-document OCR calibration Zero asked for — run 2026-08-26 on the Mini's
`qwen2.5vl:7b` over Tailscale, through the **real production path**
(`extract_passport_biodata_dual_pass` → `classify_fields` → `all_confident`). Nothing mocked.

## The measurement

| Question | Answer |
|---|---|
| Can the model read the document? | **20 / 20** |
| Does the pipeline produce a verdict? | **12 / 20** |
| Does the gate pass the document? | **4 / 12** |

**None of the eight rejected documents was rejected for disagreement.** All twelve agreed
between the two passes on passport number, nationality and expiry; eleven of twelve agreed on
all four fields. Every one of the seven blocked documents was blocked by the confidence
arithmetic alone.

## The cause is in the distribution

The three fields have **identical** distributions:

```
{0.0: 3, 0.45: 1, 0.475: 4, 0.9: 1, 0.95: 1, 0.965: 1, 1.0: 1}
```

Identical distributions across three independent fields mean the model emits or omits
`self_confidence` **per pass, wholesale**. And `0.475` is exactly `(0.95 + 0)/2` — one pass rated
the field, the other omitted it, and `.get(key, 0.0)` averaged the omission in as a **zero**,
halving the score below any threshold. Fifteen instances of that signature. `full_name` never
lands in that band: the model always rates it.

So `CONFIDENCE_THRESHOLD` — which the module docstring itself marks *"PROPOSED, not measured"* —
**was never the parameter**. The sweep returns the same 4/12 at every threshold from 0.60 through
0.85, because the blocking values are exactly `0.0`. The defect was treating **absent** as
**zero**.

## The fix

Two places, because the information was destroyed at parse time before `confidence.py` could see
it:

- **`ocr_client`** — `self_confidence` becomes `dict[str, float | None]`. A field the model did
  not rate (key missing, or present but not a number) is `None`. An explicit `0.0` is still kept
  as `0.0`.
- **`confidence.py`** — the average is taken over the passes that *actually rated* the field.

**Deliberately not changed:** a field neither pass rated still comes out UNCERTAIN. Whether
inter-pass agreement should suffice on its own is a product decision — it would take the corpus
from 9/12 to 11/12 — and it is not taken here. A test pins the current behaviour so it cannot be
taken by accident.

Measured effect: **4/12 → 9/12**, with no threshold change and no weakening of the agreement
requirement.

## Evidence

- **28 tests pass** (5 new).
- **Mutation**: collapsing `None` back into the average as a zero kills **4** of them.
- The decisive test asserts the distinction directly — same agreement, one rating present, and
  **opposite verdicts** for absent versus an explicit `0.0`. A refactor that "simplifies" the
  `None` away fails it rather than silently restoring the bug.
- A second test pins the parse layer, which is where the information was actually being lost.
- The 4 failures and 31 errors elsewhere under the garuda suites are **pre-existing** — identical
  counts measured on a clean `origin/main` worktree (274 passed there vs 279 here: the 5 new
  tests).

## Reported, not fixed here

**8 of the 20 documents never reached a verdict at all** — 13 `WriteTimeout` + 1 `ReadTimeout`,
clustered at exactly the 120s client budget, i.e. the timeout rather than the model. The two
passes are fired concurrently at one 7B model, so every document doubles its own load and one
pass blocks pushing ~470KB of base64 while the other is inferring. Serialising them, or splitting
the single scalar timeout across connect/read/write, changes user-visible latency and deserves
its own decision rather than being smuggled in here.

**Privacy**: the corpus never entered this repository or any artifact. Documents are referred to
only as `p01…p20`; no field value, name, passport number, date of birth or MRZ line appears
anywhere in this PR, its tests, or the report.

Gear floor: **1** (`scripts/evidence_pack_lint.py --print-floor`).
