### PR TITLE
feat(research-os): close P05's live-baseline gap by measuring it — and correct the cause it blamed

### DIFF
--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
@@ -8,6 +8,10 @@ adversarial_review: kimi-k3
 
 ## 1. Live database access was unavailable this session — no live counts anywhere in this bundle
 
+> **Superseded in part 2026-08-26 — see §1.1.** The counts were obtained the next session and the
+> cause attributed below turned out to be wrong. This section is kept verbatim, not rewritten:
+> what it got wrong is the useful part.
+
 `mcp__postgres-nuzantara-local__query` returned `Command failed with no output` on three
 successive attempts, including the trivial `SELECT 1;`. This is a tool/infrastructure failure,
 not a "no rows" result — per this repo's own anti-hallucination discipline ("a grep that returns
@@ -25,6 +29,66 @@ failed at the tool layer.
 Whoever picks this up next should retry the same MCP tool (it may be a transient session issue)
 or fall back to a direct `psql`/`fly ssh` read-only session — this bundle does not diagnose why
 the tool failed beyond confirming it failed identically on a query with zero table dependency.
+
+### 1.1 CLOSED 2026-08-26 — measured directly, and the attributed cause was WRONG
+
+This gap was closed the next session by connecting with `psql` on `127.0.0.1:5432` (never 15432 —
+that is a `flyctl` proxy to PRODUCTION). Two corrections to §1 above, then the numbers.
+
+**Correction A — the database was never down.** §1 reads as though live data was unreachable.
+All four preconditions measured healthy: database `nuzantara_dev` exists, role
+`nuzantara_dev_readonly` exists with `rolcanlogin=t`, the macOS Keychain entry resolves
+(exit 0, non-empty), and a direct connection as that role runs `SELECT 1` successfully. The MCP's
+own launch command, reproduced by hand with a full JSON-RPC handshake, also answered correctly.
+The failure was in the TOOL, not the data layer — exactly the distinction §1 was right to insist
+on, applied one layer deeper than §1 applied it.
+
+**Correction B — the likely cause is a deprecated dependency, and it is a standing fragility.**
+`@modelcontextprotocol/server-postgres` is flagged by npm as **"Package no longer supported"**
+and is not installed globally, so every `npx -y` invocation re-resolves it against the registry
+before the subprocess can emit its first byte. A handshake-readiness timeout expiring during that
+cold start produces precisely the observed symptom: zero output, no auth error, no SQL error.
+This is not a one-session fluke to shrug off — the dependency is orphaned upstream and will keep
+producing silent, contentless failures. Treat a future "Command failed with no output" as a
+suspected cold-start timeout on an unsupported package, not as evidence about the data.
+
+**Measured baseline (aggregates only — no row content, per SYMBIOSIS Law 2):**
+
+| Measure | Value |
+|---|---|
+| Non-template local databases | **89** (67 `my_portal_qa%` + 1 `acc_recon%` throwaways; 21 real) |
+| `nuzantara_dev` — the CONFIGURED LIVE TARGET | full `intel_*` schema, **0 rows in every table** |
+| `nuzantara_prod_snapshot` (static snapshot, NOT live) | `intel_items`=964, `intel_observations`=1600, `intel_lake_audit_log`=3403, `intel_item_nb_pushes`=278, `intel_radar_findings`=2 |
+| Data window (snapshot) | `first_seen_at` / `observed_at` span 2026-05-13 → 2026-07-18; `expires_at` has no non-null values |
+| `routing_status` (enum-like, 4) | `needs_review`=484, `nb-intel`=278, `blog`=171, `archive`=31 |
+| `jurisdiction` (enum-like, 3+null) | `ID-national`=651, `ID-bali`=225, `test`=47, null=41 |
+| `language` (2+null) | `id`=876, `en`=47, null=41 |
+| `is_probe_sandbox` | false=923, true=41 |
+| `source_domain` | 330 distinct — high-cardinality, **count only, values withheld** |
+| `producer_name` | 33 distinct — count only |
+
+**The load-bearing result, and it changes the packet's premise: the live local baseline is EMPTY.**
+The packet's "Live baseline to refresh" section presumes there is a live local corpus to measure.
+There is not — the configured target holds schema and no rows. The only data-bearing copy is a
+static production SNAPSHOT, which can support schema and distribution reasoning but is NOT a live
+baseline and must never be cited as one. Anyone asked to "refresh the live baseline" must first
+settle WHERE it is supposed to live; that question is open, and it is upstream of the counts.
+
+**Two bundle claims re-checked against live schema, both confirmed:**
+
+- "Intel Lake's schema has zero sensitivity/classification column today" — **TRUE**. A schema-wide
+  search for `%sensitiv%`, `%classif%`, `%risk_class%`, `%pii%` matches only unrelated tables
+  (WhatsApp staging, CRM cache); neither `intel_items` nor `intel_observations` has one.
+- "The full producer registry could not be enumerated" — **TRUE, and structurally so.**
+  `intel_observations.producer_name` is free-standing text with **no foreign key** to any
+  registry; its only FK is `item_id → intel_items`. Three loosely-related source tables exist
+  (`regulatory_source_status`=3 rows, `collective_memory_sources`=0, `naga_sources`=637 in the
+  snapshot) and none is wired to Intel Lake. There is no canonical producer registry to
+  enumerate — the gap is a missing relation, not a missing query.
+
+**Still open after this measurement:** the producer registry OUTSIDE the monorepo (`~/scripts/`
+on live Pro), and where the live baseline is meant to live (above). Those remain unknown, and
+unknown still is not zero.
 
 ## 2. Not checked, deliberately, given the read-only/no-implementation scope of this lane
 
@@ -114,6 +178,12 @@ without it.
 
 
 ## Adversarial review
+
+> **Scope note added 2026-08-26.** The Kimi K3 review recorded below covers this bundle as it
+> stood at head `2807f50e9`. **§1.1 was added afterwards and is NOT covered by it** — it is a
+> direct measurement (psql on `127.0.0.1:5432`, aggregates only) by the session that gated this
+> bundle, and it CONTRADICTS §1's attributed cause. Its evidence is the commands it names, not a
+> review verdict; do not read the stamp above as vouching for it.
 
 **Seat:** Kimi K3 (`kimi -m kimi-code/k3`), cross-family — neither the model that wrote this
 bundle nor the session that gated it. Run 2026-08-26 against a FROZEN diff (head `2807f50e9`):


### PR DESCRIPTION
P05 (#4996) shipped with its **single largest gap** open: no live counts anywhere, attributed to `mcp__postgres-nuzantara-local__query` failing with `Command failed with no output` even on `SELECT 1`. Measured directly this session with `psql` on `127.0.0.1:5432` (**never 15432** — that is a `flyctl` proxy to PRODUCTION).

## Correction A — the database was never down

All four preconditions measured healthy: `nuzantara_dev` exists · `nuzantara_dev_readonly` has `rolcanlogin=t` · the Keychain entry resolves (exit 0, non-empty) · a direct connection runs `SELECT 1`. The MCP's own launch command, reproduced by hand with a full JSON-RPC handshake, also answers correctly.

The failure was in the **tool**, not the data layer — which is the same distinction §1 was right to insist on ("a broken tool means *unknown*, not *zero*"), just applied one layer deeper than §1 applied it.

## Correction B — the cause is a standing fragility, not a fluke

`@modelcontextprotocol/server-postgres` is npm-flagged **"Package no longer supported"** and is not installed globally, so every `npx -y` re-resolves it against the registry before the subprocess emits its first byte. A handshake-readiness timeout expiring during that cold start produces *precisely* the observed symptom: zero output, no auth error, no SQL error. The dependency is orphaned upstream and will keep producing silent, contentless failures — a future `Command failed with no output` should be read as a suspected cold-start timeout, never as evidence about the data.

## The result that changes the packet's premise

**The live local baseline is EMPTY.** `nuzantara_dev` — the configured live target — holds the full `intel_*` schema and **zero rows**. The only data-bearing copy is `nuzantara_prod_snapshot`, a *static snapshot* (`intel_items`=964, `intel_observations`=1600, audit_log=3403), which supports schema and distribution reasoning but is **not** a live baseline and must never be cited as one.

The packet's "Live baseline to refresh" section presumes a live local corpus exists. It does not. That task cannot be actioned until someone settles **where the live baseline is supposed to live** — a question upstream of the counts, left open rather than papered over.

## Two bundle claims re-checked against live schema — both CONFIRMED

- *"Intel Lake's schema has zero sensitivity/classification column today"* → **TRUE**. Schema-wide search for `%sensitiv%`/`%classif%`/`%risk_class%`/`%pii%` matches only unrelated tables.
- *"The full producer registry could not be enumerated"* → **TRUE, and structurally so.** `intel_observations.producer_name` is free-standing text with **no FK** to any registry (its only FK is `item_id → intel_items`). Three loosely-related source tables exist, none wired to Intel Lake. It is a **missing relation**, not a missing query.

## Boundaries honoured

- **Aggregates only, no row content** (SYMBIOSIS Law 2): `source_domain` reported as *330 distinct, values withheld*; `producer_name` as *33 distinct*. Only enum-like labels (`routing_status`, `jurisdiction`, `language`) are enumerated. PII sweep on the diff: zero emails, zero URLs.
- **Read-only**: SELECT and catalog queries only; nothing mutated.
- §1 is kept **verbatim** rather than rewritten — what it got wrong is the useful part — and §1.1 carries a scope note stating that the Kimi K3 stamp on this file does **not** vouch for content added after the review.