### PR TITLE
fix(proprioception): a probe line reported 1 of N findings as 1

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -72,6 +72,9 @@ jobs:
               scripts/agent_start.py|\
               scripts/tests/test_agent_start.py|\
               scripts/tests/test_proprioception_run_wrap_exit_code.py|\
+              scripts/hooks/proprioception_sessionstart.sh|\
+              scripts/tests/test_proprioception_receptor_ranking.sh|\
+              scripts/tests/test_proprioception_finding_count.sh|\
               scripts/secrets_permissions_audit.py|\
               scripts/pending_arms_report.py|\
               scripts/lint_plist_keepalive.py|\
@@ -522,6 +525,25 @@ jobs:
           # from then on "absent" means DELETED, and a deleted corpus must go red
           # rather than quietly pass.
           bash scripts/tests/test_pii_gate_merge_scope.sh
+
+      - name: A probe line reports 1 of N as 1 of N (proprioception receptor + CLI)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # Both files are shell corpora, so pytest below cannot reach them.
+          #
+          # test_proprioception_receptor_ranking.sh has existed since 2026-07-26
+          # and was named by NO workflow — it has never run in CI once. Its five
+          # .py siblings all run in the pytest sweep below; being a .sh file is
+          # the only reason it was invisible. It is named here now, in the same
+          # PR that adds its neighbour, because a test nothing invokes is not a
+          # weaker guard than none — it is a guard that reports protection it is
+          # not providing.
+          #
+          # No `if [ -f ]` skip, per the convention this file's fly-credential
+          # step argues: both land on main with this step, so "absent" afterwards
+          # means DELETED, and that must go red rather than quietly pass.
+          bash scripts/tests/test_proprioception_receptor_ranking.sh
+          bash scripts/tests/test_proprioception_finding_count.sh
 
       - name: print() gate guilt+innocence+cannot-verify (.husky/pre-commit, Golden Rule #8)
         if: steps.paths.outputs.relevant == 'true'

--- a/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/brief.yml
@@ -47,7 +47,13 @@ acceptance:
   - "A probe carrying findings but NO evidence keeps the pre-existing 'N findings' fallback."
   - "finding_label is exercised BEHAVIOURALLY (imported and called), not asserted about by grepping
     its source — including the bool/None/absent-key edges."
-  - "Mutation-proved in both directions: green on the fix, red on the reverted source."
+  - "Mutation-proved in both directions: green on the fix, red on the reverted source. That
+    covers finding_label ITSELF and the receptor rendering. Its two CALL SITES are covered
+    separately and more weakly: an AST check that main() and fleet_probe() call it at all, NOT
+    that they render its output correctly. Spelled out because the first version of this brief
+    let 'mutation-proved' plus a three-surface consumer_map read as call-site coverage that did
+    not exist — the Gear-3 gate proved the gap by unplugging one call site and watching the
+    corpus stay green."
   - "The two shell corpora actually RUN in CI, and the receptor file is in the path filter that
     triggers the job."
 consumer_map:

--- a/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/brief.yml
@@ -1,0 +1,80 @@
+task_id: proprioception-finding-count-0826
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  Every surface that renders a DIVERGED proprioception probe prints ONE finding, and the finding
+  COUNT reached the reader only when there was no evidence at all:
+
+      ev = p["evidence"][0] if p.get("evidence") else f"{n} findings"
+
+  `evidence` holds at most 5 items (run_wrap's `items[:5]`); `n_findings` is the true total.
+  Measured live on Pro 2026-08-26 via `python3 scripts/proprioception.py --json`:
+  launchagent_canon 55 findings -> 1 line; launchd_liveness 22 -> 1; organs_heartbeat 7 -> 1;
+  worktree_gate_shim 4 -> 1.
+
+  The last one is the damage, not the illustration. THIS session read that line as "one worktree
+  pushes with no gate", repaired the one named path, and a hand census then found THREE more
+  worktrees whose core.hooksPath pointed at a .husky/_ that does not exist — so git ran no hooks
+  at all and every push from them was ungated. They are repaired on disk; this diff is why the
+  next four will be visible.
+
+  This is W97 (a truncated list read downstream as complete) one level BELOW where W97 was already
+  cured on this same file: the receptor's [:4] cap over PROBES was fixed 2026-07-26 and its comment
+  cites W97 by name; the per-probe truncation over FINDINGS was left uncured. Same defect, two
+  depths — superscar family #2 (esiste != armato: a sentinel that under-reports is a sentinel that
+  lies) with the #3 truncation mechanism.
+
+  Gear 3 by PATH: `scripts/evidence_pack_lint.py --print-floor` computes 3 because
+  .github/workflows/immune-enforcement.yml is a hot-zone path. Functional diff: 4 files,
+  +319/-4.
+constraints:
+  - "Silent at n <= 1. A '[1 of 1]' on every single-finding line would be pure noise on a report
+    injected into every session on three machines, and the token cost is paid by the whole fleet
+    forever. Asserted as an innocence case, not left to judgement."
+  - "The count goes next to the probe id, NOT appended after the evidence string: run_wrap
+    truncates each evidence item to 160 chars upstream, so anything trailing can be the part that
+    falls off — the marker would disappear exactly on the largest findings."
+  - "Three render sites share one function rather than three copies of the same expression. The
+    third site (the per-host fleet summary, proprioception.py:~1121) was NOT in the original scope:
+    it was found because the test's source-shape grep, once it actually matched, pointed at it."
+  - "No behaviour of the 2026-07-26 receptor fix is altered — its own corpus
+    (test_proprioception_receptor_ranking.sh) is re-run and still passes 7/7."
+acceptance:
+  - "A probe carrying 55 findings prints a line naming that it is showing 1 of 55, while still
+    printing the evidence and the 'as of ... re-verify before acting' framing."
+  - "A probe carrying exactly 1 finding prints no count marker at all."
+  - "A probe carrying findings but NO evidence keeps the pre-existing 'N findings' fallback."
+  - "finding_label is exercised BEHAVIOURALLY (imported and called), not asserted about by grepping
+    its source — including the bool/None/absent-key edges."
+  - "Mutation-proved in both directions: green on the fix, red on the reverted source."
+  - "The two shell corpora actually RUN in CI, and the receptor file is in the path filter that
+    triggers the job."
+consumer_map:
+  - "scripts/hooks/proprioception_sessionstart.sh — the SessionStart receptor. Injected into EVERY
+    session on Pro, Mini and M5. The surface where the real damage happened."
+  - "scripts/proprioception.py main() CLI line — what a human sees running the organ by hand."
+  - "scripts/proprioception.py per-host fleet summary (~:1121) — the remote-probe rollup; also
+    truncated its PROBE list at div[:4] with nothing saying so, now names how many it dropped."
+  - "No other reader: `finding_label` is new, and the JSON report (--json) is untouched, so every
+    machine consumer of last.json is unaffected by construction."
+risks:
+  - "The SessionStart line grows by ~10 characters per multi-finding probe. Bounded and deliberate:
+    the alternative is the line continuing to under-report by a factor of 55."
+  - "Residual, NOT fixed here: the four repaired worktrees were repaired on disk only. Nothing
+    prevents the next bare `git worktree add` from recreating the hole — `scripts/agent_start.py`
+    symlinks .husky/_ but a hand-made worktree bypasses it. Detection (the linter) plus a now-honest
+    count is the mitigation; prevention is not attempted in this diff."
+  - "Noted and NOT fixed: the pre-commit anti-reward-hacking lint reported 'no staged test files'
+    while a new test file WAS staged — it appears to scan .py only. Same family, out of scope."
+grader: >-
+  Independent refuter dispatched on the pushed diff, separate context, instructed to REFUTE and to
+  default to SUSPECT — not the seat that wrote the diff. Its brief attacked seven specific author
+  claims by measurement (is there a FOURTH uncured site; the bool/None edges of finding_label; an
+  independent re-run of the mutation proof; whether the path-filter lines actually sit inside the
+  case block; whether a two-command `run:` step can mask the first failure; whether `host` is in
+  scope at the fleet call site; sh-vs-bash divergence in the corpus). Verdicts recorded in pack.yml.
+budget: >-
+  No paid API. Local shell, python3, git, gh, actionlint, and one Sonnet-5 subagent on the Claude
+  MAX OAuth seat. No ANTHROPIC_API_KEY at any point.
+pii: none

--- a/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/pack.yml
@@ -1,0 +1,212 @@
+brief_ref: evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/brief.yml
+plan_ref:
+  "PR #5010 (agent/nuzantara/ops/proprioception-finding-count-0826) — a proprioception probe line
+  reports 1 of N findings as 1, and the corpus guarding the previous fix on that same file has
+  never run in CI. 2026-08-26."
+lanes:
+  - lane: proprioception-finding-count
+    role: build
+    seat: opus-5 orchestrator (Pro worktree; live measurement, fix, guilt+innocence corpus, mutation proof, CI wiring)
+  - lane: proprioception-finding-count-refute
+    role: review
+    seat: sonnet-5 subagent (Pro, fresh context; instructed to REFUTE and default to SUSPECT, seven named attacks)
+seat_diversity: satisfied
+seat_diversity_note:
+  "Generator and grader are different seats and different contexts. The grader was NOT asked to
+  confirm: it was given seven specific author claims to attack by measurement, told to default to
+  SUSPECT when it could not establish correctness, and it re-ran the mutation proof itself from
+  git rather than trusting the reported numbers. It returned one REAL DEFECT, which was fixed
+  before this pack was written — see receipts."
+diff:
+  net_lines: 4 files changed, +319/-4 (git diff --shortstat origin/main...HEAD, pre-evidence).
+  behaviour_change:
+    A DIVERGED probe carrying more than one finding now prints "<id> [1 of N]" instead of "<id>",
+    on the SessionStart receptor line, the CLI line, and the per-host fleet summary. Probes with
+    exactly one finding are unchanged. The JSON report is untouched, so no machine consumer moves.
+    The fleet summary additionally names how many diverged PROBES it dropped past its div[:4] cap.
+receipts:
+  - claim:
+      Four probes were under-reporting live on Pro at the time of the fix, the worst by a factor
+      of 55.
+    cmd: python3 scripts/proprioception.py --json | (filter probes with n_findings > 1)
+    result:
+      "launchagent_canon n_findings=55 evidence=3 printed=1; launchd_liveness 22/5/1;
+      organs_heartbeat 7/5/1. worktree_gate_shim measured separately at 4 findings, printed 1."
+    exit: 0
+    ts: "2026-08-26T08:02:00Z"
+    seat: opus-5 orchestrator (Pro)
+  - claim:
+      The under-report caused real damage, not merely a legible risk — three worktrees kept pushing
+      with no git hooks at all after the one named worktree was repaired.
+    cmd:
+      per-worktree check of `.husky/_` existence against `git config core.hooksPath` (= .husky/_),
+      across every entry of `git worktree list --porcelain`
+    result:
+      "4 worktrees MISSING .husky/_ (codex-autofix-ci-runtime, codex-coverage-improver-runtime,
+      codex-research-actor-runtime, ops-chatgpt-tunnel-activation); the SessionStart line had named
+      exactly one. Repaired on disk, then proved FUNCTIONALLY (the pre-push hook was executed and
+      produced real output), not merely by file existence."
+    exit: 0
+    ts: "2026-08-26T07:58:00Z"
+    seat: opus-5 orchestrator (Pro)
+  - claim: The deterministic floor for this diff is 3, so this pack is required.
+    cmd:
+      git diff --name-only origin/main...HEAD > /tmp/pfc_changed.txt && python3
+      scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/pfc_changed.txt
+    result: "3"
+    exit: 0
+    ts: "2026-08-26T08:20:00Z"
+    seat: opus-5 orchestrator (Pro)
+  - claim:
+      "Mutation proof A: the corpus is red on the pre-fix source and green on the fix, under both
+      sh and bash."
+    cmd:
+      restore both files from git, run the corpus, restore the fix, run again; then run once more
+      under bash
+    result: "pre-fix 5 passed / 12 failed; fixed 12 passed / 0 failed (sh); 12/0 (bash)"
+    exit: 1 then 0
+    ts: "2026-08-26T08:22:00Z"
+    seat: opus-5 orchestrator (Pro)
+  - claim:
+      "Mutation proof B: the drift case genuinely detects the two implementations diverging, rather
+      than observing that they happen to agree."
+    cmd:
+      change ONLY the module threshold (n > 1 -> n > 4), leaving the receptor untouched, run the
+      corpus
+    result:
+      "FAIL - drift — n=2: receptor printed 'drift_probe [1 of 2]', finding_label says
+      'drift_probe' (11 passed / 1 failed). Restored, 12/0."
+    exit: 1 then 0
+    ts: "2026-08-26T08:23:00Z"
+    seat: opus-5 orchestrator (Pro)
+  - claim:
+      test_proprioception_receptor_ranking.sh — the corpus written for the 2026-07-26 W97 fix on
+      this exact file — is named by NO workflow and has never run in CI.
+    cmd: "git grep -c receptor_ranking origin/main -- .github/  (and grep -rn over .github/)"
+    result:
+      "zero matches. Its five .py siblings all run via immune-enforcement.yml's pytest sweep;
+      being a .sh file is the only reason it was invisible. Independently corroborated by the
+      grader, which found the same file already listed among 13 orphaned .sh corpora in
+      PENDING-ARMS.md (entry dated 2026-08-06)."
+    exit: 1
+    ts: "2026-08-26T08:10:00Z"
+    seat: opus-5 orchestrator (Pro), corroborated by the sonnet-5 grader
+  - claim:
+      The workflow edit is well-formed and the new path-filter lines really do arm the job for
+      these three files.
+    cmd:
+      'actionlint .github/workflows/immune-enforcement.yml; grader additionally extracted the real
+      `case "$f" in ... esac` block into an isolated harness and drove each new path through it'
+    result:
+      "actionlint clean. Grader: bash -n clean, and all three new paths independently set
+      RELEVANT=true; continuation backslashes correct."
+    exit: 0
+    ts: "2026-08-26T08:21:00Z"
+    seat: opus-5 orchestrator (Pro) + sonnet-5 grader
+  - claim:
+      "W121 caught on this bench itself: the mutation harness was reading POISONED BYTECODE and
+      reporting a false failure of correct code."
+    cmd:
+      stat the source and the .pyc after a one-character mutation and restore; then compare
+      inspect.getsource() against the function's actual behaviour
+    result:
+      "src mtime 1787732359 == .pyc mtime 1787732359, and the mutation changed `n > 1` to `n > 4`
+      — ONE character, so size was unchanged too. Python validates a .pyc on exactly (mtime,
+      size), so importlib executed the MUTATED bytecode while inspect.getsource printed the
+      RESTORED source. Cured by compiling from source text (no cache to poison); the corpus now
+      passes 12/0 with the poisoned .pyc still on disk, which is the proof the immunity works."
+    exit: 0
+    ts: "2026-08-26T08:19:00Z"
+    seat: opus-5 orchestrator (Pro)
+  - claim: "GRADER VERDICT: one real defect found, and it was a false claim in a durable artifact."
+    cmd:
+      adversarial subagent, fresh context, seven named attacks with independent measurement
+      (fourth-site census; finding_label edges incl. bool/None/str/absent; independent mutation
+      re-run; case-block syntax; whether a two-command CI step can mask the first failure; `host` scope at the fleet call site;
+      sh-vs-dash-vs-bash divergence)
+    result:
+      "6 of 7 claims UPHELD by its own measurement. ONE REAL DEFECT: the corpus comment asserted
+      all THREE render sites 'share one function' — false for the SessionStart receptor, which is
+      a standalone python heredoc that does not import proprioception.py and reimplements the rule
+      by hand. Fixed before this pack: the comment now states the duplication honestly and explains
+      why (SessionStart latency budget), and a new drift case drives BOTH implementations across
+      n in {0,1,2,5,55,999} and fails on the first disagreement — mutation-proved above."
+    exit: 0
+    ts: "2026-08-26T08:18:00Z"
+    seat: sonnet-5 grader (Pro, fresh context)
+tests:
+  - "scripts/tests/test_proprioception_finding_count.sh — 12 pass / 0 fail under BOTH sh and bash.
+    Guilt (a 55-finding probe names it), innocence (n=1 gains nothing; empty-evidence fallback
+    intact; the 2026-07-26 re-verify framing survives), behavioural cases on finding_label
+    including the bool/None/str/absent-key edges, and a drift matrix across n in {0,1,2,5,55,999}."
+  - "scripts/tests/test_proprioception_receptor_ranking.sh — 7 pass / 0 fail, unchanged by this
+    diff. It is named by a workflow for the first time in this PR."
+static:
+  - "actionlint clean on .github/workflows/immune-enforcement.yml"
+  - "bash -n and sh -n clean on the new corpus; it is executed under sh, bash and (by the grader)
+    genuine dash with identical results."
+runtime_proof:
+  "Local only, and stated as such: the receptor was driven with real fixture reports through the
+  actual hook (`bash scripts/hooks/proprioception_sessionstart.sh`), not stubbed. NOT claimed: no
+  proof that a future SessionStart on Mini or M5 renders identically — those machines run the same
+  file from the same repo, but this PR does not measure them."
+pii_scan: clean
+dissent:
+  - seat: "sonnet-5 adversarial grader (Pro, fresh context)"
+    objection: >-
+      The corpus comment claimed all THREE render sites "now share one function, finding_label,
+      which can simply be called". False for scripts/hooks/proprioception_sessionstart.sh: it is a
+      standalone python heredoc inside a shell hook with no import of proprioception.py, and it
+      reimplements the n>1 rule by hand. The two copies agreed only because one fixture happened to
+      exercise them the same way; nothing forced them to stay in step. A false structural claim in a
+      durable artifact is the W113 shape — the correction itself lying.
+    status: CONFIRMED
+    resolution: >-
+      Accepted in full and fixed before this pack was written. The comment now states the
+      duplication honestly and gives the reason (the receptor runs under a SessionStart latency
+      budget; importing that module for a six-line function is the wrong trade). A new drift case
+      drives BOTH implementations across n in {0,1,2,5,55,999} and fails on the first
+      disagreement, and it is mutation-proved: changing the threshold in the module alone reddens
+      it, naming both sides.
+  - seat: "Harness floor recompute (GitHub CI, deterministic)"
+    objection: >-
+      The first PR run rejected this diff — "hot-zone diff with no evidence/brief.yml (deterministic
+      floor 3)". Editing .github/workflows/immune-enforcement.yml floors at Gear 3 by path,
+      regardless of the diff being 4 files and mostly a test corpus.
+    status: CONFIRMED
+    resolution: >-
+      The gate is right and was not worked around. Floor re-derived independently
+      (evidence_pack_lint.py --print-floor = 3) and this brief+pack is the answer to it. The
+      workflow edit was NOT split out to dodge the floor: the whole point of the PR is that a
+      corpus nothing invokes provides no protection, so the CI wiring and the fix belong together.
+  - seat: "sonnet-5 adversarial grader (Pro, fresh context)"
+    objection: >-
+      finding_label with a malformed n_findings — the string "55" rather than the int — fails the
+      isinstance check and silently renders no count, so a probe whose runner emitted a stringy
+      count would under-report exactly as before, with nothing saying so.
+    status: PLAUSIBLE
+    resolution: >-
+      Accepted as a real edge and deliberately NOT fixed. Every producer in this repo writes
+      n_findings as an int (run_wrap computes len(items)); coercing here would mask a broken
+      producer rather than surface it, and raising would turn a rendering nicety into a way for the
+      SessionStart hook to fail closed on every session. Recorded as a residual risk rather than
+      silently coerced.
+residual_risks:
+  - "The four repaired worktrees were repaired ON DISK. Nothing stops the next bare `git worktree
+    add` from recreating the hole — scripts/agent_start.py symlinks .husky/_ but a hand-made
+    worktree bypasses it. This diff improves DETECTION honesty, not prevention."
+  - "A stringy n_findings renders no count — see the third dissent entry."
+  - "The receptor and finding_label remain two implementations of one rule. The drift case makes
+    divergence visible; it does not make it impossible."
+sources:
+  - ".claude/rules/cicatrix-superscar.md — W97 (truncated list read as complete), W121 (mutation
+    testing on poisoned bytecode), W113 (the correction itself lies), family #2 and #3."
+  - "scripts/tests/test_proprioception_receptor_ranking.sh — the 2026-07-26 fix this one sits below."
+  - ".claude/skills/modus/PENDING-ARMS.md — entry dated 2026-08-06 independently listing this
+    corpus among 13 orphaned .sh test files."
+notes: >-
+  Found while acting on a SessionStart proprioception line, not by auditing the renderer. The line
+  said one worktree was pushing with no git hooks; repairing it and then counting by hand turned up
+  four. That gap between what the report said and what was true is the whole defect, and it is why
+  the PR treats "the corpus for the previous fix never runs in CI" as part of the same concern
+  rather than a follow-up.

--- a/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/pack.yml
@@ -1,4 +1,8 @@
-brief_ref: evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/brief.yml
+# brief_ref is the LITERAL 'evidence/brief.yml' even though this pack lives in a per-PR
+# directory: harness-floor.yml stages both files FLAT into /tmp/evidence-check/evidence/
+# and lints with --repo-root /tmp/evidence-check, so the real per-PR path does not resolve
+# there. Linting the pack IN PLACE passes and tells you nothing - reproduce the staging.
+brief_ref: evidence/brief.yml
 plan_ref:
   "PR #5010 (agent/nuzantara/ops/proprioception-finding-count-0826) — a proprioception probe line
   reports 1 of N findings as 1, and the corpus guarding the previous fix on that same file has

--- a/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/pack.yml
@@ -139,7 +139,7 @@ receipts:
     ts: "2026-08-26T08:18:00Z"
     seat: sonnet-5 grader (Pro, fresh context)
 tests:
-  - "scripts/tests/test_proprioception_finding_count.sh — 12 pass / 0 fail under BOTH sh and bash.
+  - "scripts/tests/test_proprioception_finding_count.sh — 14 pass / 0 fail under BOTH sh and bash.
     Guilt (a 55-finding probe names it), innocence (n=1 gains nothing; empty-evidence fallback
     intact; the 2026-07-26 re-verify framing survives), behavioural cases on finding_label
     including the bool/None/str/absent-key edges, and a drift matrix across n in {0,1,2,5,55,999}."
@@ -195,11 +195,36 @@ dissent:
       producer rather than surface it, and raising would turn a rendering nicety into a way for the
       SessionStart hook to fail closed on every session. Recorded as a residual risk rather than
       silently coerced.
+  - seat: "opus-5 Gear-3 gate (Pro, fresh context, independent of the author)"
+    objection: >-
+      The corpus proved the FUNCTION and not its two CALLERS. Measured by the gate: reverting
+      `finding_label(r)` back to `r['id']` at the CLI print site left the whole corpus 12/0 GREEN,
+      and the new fleet line "(+N more diverged probes on {host} not listed)" had zero references
+      anywhere outside its own source. Meanwhile acceptance said "mutation-proved in both
+      directions" and consumer_map listed three surfaces, so a reader infers coverage that does not
+      exist. Same W113 over-declaration the earlier round caught in a comment, missed here.
+    status: CONFIRMED
+    resolution: >-
+      Accepted, and CLOSED rather than declared out of scope. Case 6 asserts by AST that both main()
+      and fleet_probe() call finding_label, and it is mutation-proved against the gate's OWN
+      mutation: unplugging the CLI call site yields "NO main -> does not call finding_label (call
+      site unplugged)", unplugging the fleet one yields the same for fleet_probe, 13/1 each, 14/0
+      restored. AST and not grep, because a grep for the name also matches the definition and the
+      comments and would pass on a file with both callers unplugged. The residual weakness (it
+      proves the call exists, not that its output is rendered correctly) is now in residual_risks
+      and in the brief's acceptance rather than left for the next reader to find. The gate's two
+      smaller conditions are applied too: the dead no-op at corpus line 244 is removed, and
+      acceptance no longer lets "mutation-proved" stand in for call-site coverage.
 residual_risks:
   - "The four repaired worktrees were repaired ON DISK. Nothing stops the next bare `git worktree
     add` from recreating the hole — scripts/agent_start.py symlinks .husky/_ but a hand-made
     worktree bypasses it. This diff improves DETECTION honesty, not prevention."
   - "A stringy n_findings renders no count — see the third dissent entry."
+  - "The two call sites are guarded by an AST check (they CALL finding_label), not a behavioural
+    one (they render its output correctly). Both sit inline in functions that first run a live probe
+    sweep or ssh to a peer, so a behavioural test there would assert about this machine rather than
+    about the code. Reverting either call site does now redden the corpus — measured — but a call
+    site that called finding_label and then mangled its result would still pass."
   - "The receptor and finding_label remain two implementations of one rule. The drift case makes
     divergence visible; it does not make it impossible."
 sources:

--- a/scripts/hooks/proprioception_sessionstart.sh
+++ b/scripts/hooks/proprioception_sessionstart.sh
@@ -89,8 +89,26 @@ other_div = [p for p in div if p is not self_finding]
 
 
 def _print_finding(p: dict) -> None:
-    ev = p["evidence"][0] if p.get("evidence") else f"{p.get('n_findings', '?')} findings"
-    print(f"  !! [{p.get('severity')}] {p.get('id')} (as of {report_time}, {age_h:.1f}h ago — re-verify before acting): {ev}")
+    # W97 again, one level DOWN from where it was cured. The [:4] probe cap above
+    # was fixed on 2026-07-26 so a truncated list of PROBES could not read as
+    # complete — but the single line each probe prints still truncated its own
+    # FINDINGS to evidence[0], with nothing on the line saying so. Both caps are
+    # the same defect at two depths; curing only the outer one is the "curato 1
+    # wrapper su 5" shape the outer fix was written against.
+    #
+    # MEASURED 2026-08-26 on Pro, live: launchagent_canon carried 55 findings and
+    # printed one; launchd_liveness 22, printed one; organs_heartbeat 7, printed
+    # one; worktree_gate_shim 4, printed one. That last one is not hypothetical
+    # damage — the line was read as "one worktree pushes with no gate", so the
+    # other three stayed ungated until a hand census found them.
+    #
+    # The count goes next to the id, not appended after the evidence: the evidence
+    # string is truncated to 160 chars upstream (run_wrap), so anything trailing
+    # can be the part that falls off.
+    n = p.get("n_findings")
+    ev = p["evidence"][0] if p.get("evidence") else f"{n if n is not None else '?'} findings"
+    more = f" [1 of {n}]" if p.get("evidence") and isinstance(n, int) and n > 1 else ""
+    print(f"  !! [{p.get('severity')}] {p.get('id')}{more} (as of {report_time}, {age_h:.1f}h ago — re-verify before acting): {ev}")
     print(f"     fix: {p.get('fix_hint', '')}")
 
 

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -165,6 +165,31 @@ def verdict(pid: str, boundary: str, bclass: str, status: str, severity: str, n:
     }
 
 
+def finding_label(probe: dict) -> str:
+    """`id` plus a "1 of N" marker when the probe carries more findings than the
+    one line about to be printed shows.
+
+    Every surface that renders a DIVERGED probe prints ONE finding: the receptor
+    line, the CLI line, and the per-host fleet summary. `evidence` holds at most
+    5 items (run_wrap's `items[:5]`) and `n_findings` is the true total, which is
+    routinely far larger. Printing `evidence[0]` with nothing naming the total is
+    W97 — a truncated list read downstream as complete.
+
+    MEASURED 2026-08-26 on Pro: launchagent_canon 55 findings, launchd_liveness
+    22, organs_heartbeat 7, worktree_gate_shim 4 — each rendered as a single
+    line. The last one caused real damage: read as "one worktree pushes with no
+    gate", three others kept pushing with no hooks at all until a hand census
+    found them.
+
+    Silent for n <= 1: a "[1 of 1]" on every single-finding line would be noise
+    on a report injected into every session on three machines.
+    """
+    n = probe.get("n_findings")
+    if probe.get("evidence") and isinstance(n, int) and n > 1:
+        return f"{probe.get('id')} [1 of {n}]"
+    return str(probe.get("id"))
+
+
 # ------------------------------------------------------- machine-aware remedy selection
 
 # A registry entry's fix_hint is a STATIC string chosen at authoring time — it cannot
@@ -1118,7 +1143,11 @@ def fleet_probe(hosts: list[str], self_path: Path) -> list[dict]:
                 continue
             remote = json.loads(p.stdout)
             div = [r for r in remote.get("probes", []) if r["status"] == DIVERGED]
-            ev = [f"{r['id']}: {r['evidence'][0] if r['evidence'] else r['n_findings']}" for r in div[:4]]
+            # div[:4] truncates the PROBE list too; say so rather than let four
+            # stand in for forty (same W97 shape, one level up).
+            ev = [f"{finding_label(r)}: {r['evidence'][0] if r['evidence'] else r['n_findings']}" for r in div[:4]]
+            if len(div) > 4:
+                ev.append(f"(+{len(div) - 4} more diverged probes on {host} not listed)")
             results.append(verdict(f"fleet:{host}", f"fleet({host}) <-> origin", "checkout<->origin",
                                    DIVERGED if div else RECONCILED, "P1" if div else "P2",
                                    sum(r["n_findings"] for r in div),
@@ -1327,7 +1356,13 @@ def main() -> int:
     else:
         print(summary)
         for r in diverged:
-            print(f"  !! [{r['severity']}] {r['id']}: {r['evidence'][0] if r['evidence'] else r['n_findings']}")
+            # Same finding-level truncation the SessionStart receptor carries — see
+            # the W97 note in scripts/hooks/proprioception_sessionstart.sh. evidence
+            # holds up to 5 items (run_wrap's items[:5]) and n_findings is the true
+            # total, which can be far larger; printing evidence[0] alone reads as
+            # "one finding" for a probe reporting fifty-five.
+            print(f"  !! [{r['severity']}] {finding_label(r)}: "
+                  f"{r['evidence'][0] if r['evidence'] else r['n_findings']}")
             print(f"     fix: {r['fix_hint']}")
         if unwatched:
             print(f"  (unwatched classes: {', '.join(unwatched)})")

--- a/scripts/tests/test_proprioception_finding_count.sh
+++ b/scripts/tests/test_proprioception_finding_count.sh
@@ -1,0 +1,240 @@
+#!/bin/sh
+# test_proprioception_finding_count.sh — a probe line must not report 1 of N as 1.
+#
+# THE DEFECT (measured live on Pro, 2026-08-26)
+#
+# scripts/hooks/proprioception_sessionstart.sh printed, per DIVERGED probe:
+#
+#     ev = p["evidence"][0] if p.get("evidence") else f"{n} findings"
+#
+# — so the finding COUNT reached the reader only when there was no evidence at
+# all. With evidence present it printed the first item and said nothing about
+# the rest. On Pro at the time:
+#
+#     launchagent_canon    55 findings -> 1 line
+#     launchd_liveness     22 findings -> 1 line
+#     organs_heartbeat      7 findings -> 1 line
+#     worktree_gate_shim    4 findings -> 1 line
+#
+# The last one is the damage, not the illustration: that line was read as "one
+# worktree pushes with no gate", the one named path was repaired, and THREE
+# worktrees kept pushing with core.hooksPath pointing at a directory that does
+# not exist — no hooks at all — until a hand census found them.
+#
+# This is W97 (a truncated list read downstream as complete) at a depth BELOW
+# where W97 was already cured here: the receptor's [:4] cap over PROBES was
+# fixed on 2026-07-26 (see test_proprioception_receptor_ranking.sh) while the
+# per-probe truncation over FINDINGS was left. Same defect, two depths.
+#
+# WHAT WOULD MAKE THIS TEST RED: reverting either print site to the bare
+# evidence[0] form. Case 1 is the guilt case and fails on the pre-fix code.
+#
+# Run:  sh scripts/tests/test_proprioception_finding_count.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/scripts/hooks/proprioception_sessionstart.sh"
+CLI="$REPO_ROOT/scripts/proprioception.py"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+[ -f "$HOOK" ] || { echo "FAIL - hook not found at $HOOK"; exit 1; }
+[ -f "$CLI" ]  || { echo "FAIL - cli not found at $CLI"; exit 1; }
+
+# Same fixture contract as test_proprioception_receptor_ranking.sh: ts and mtime
+# are computed from a FRESH "now", never a hardcoded date that rots (W129).
+build_report() {
+  python3 - "$1" "$2" <<PYEOF
+import json, os, sys, time
+out_path, age_h = sys.argv[1], float(sys.argv[2])
+now = time.time()
+ts_epoch = now - age_h * 3600
+report_ts = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(ts_epoch))
+$3
+report["ts"] = report_ts
+with open(out_path, "w") as fh:
+    json.dump(report, fh)
+os.utime(out_path, (ts_epoch, ts_epoch))
+PYEOF
+}
+
+run_hook() {
+  PROPRIOCEPTION_REPORT_PATH="$1" PROPRIOCEPTION_RECEPTOR_ENABLED=true bash "$HOOK"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 (GUILT): a probe carrying 55 findings, of which evidence holds 5.
+# The printed line must say it is showing one of fifty-five. RED on pre-fix.
+# ---------------------------------------------------------------------------
+r1="$TMPDIR/case1.json"
+build_report "$r1" "0.0" '
+report = {
+    "schema": 1, "runner_version": "1.0.0",
+    "machine": "pro", "repo_head": "abc123", "config_source": "embedded",
+    "config_sha": "x", "probes_expected": 1, "probes_run": 1,
+    "unwatched_classes": [],
+    "summary": "proprioception: 1 probe on pro — 1 DIVERGED, 0 unprobeable, 0 reconciled",
+    "probes": [
+        {"id": "launchagent_canon", "boundary": "plist<->repo", "class": "plist<->repo",
+         "status": "DIVERGED", "severity": "P1", "n_findings": 55,
+         "evidence": ["{\"label\": \"com.balizero.first\"}",
+                      "{\"label\": \"com.balizero.second\"}",
+                      "{\"label\": \"com.balizero.third\"}",
+                      "{\"label\": \"com.balizero.fourth\"}",
+                      "{\"label\": \"com.balizero.fifth\"}"],
+         "fix_hint": "reconcile the plists", "duration_ms": 9},
+    ],
+}
+'
+out1="$(run_hook "$r1")"
+if printf '%s\n' "$out1" | grep -q '\[1 of 55\]'; then
+  note_pass "guilt — a 55-finding probe announces it is showing 1 of 55"
+else
+  note_fail "guilt — 55 findings printed with no count: $out1"
+fi
+# The count must not have COST us the evidence or the re-verify framing.
+if printf '%s\n' "$out1" | grep -q 'com.balizero.first'; then
+  note_pass "guilt — the evidence itself still prints alongside the count"
+else
+  note_fail "guilt — evidence lost when the count was added: $out1"
+fi
+if printf '%s\n' "$out1" | grep -q 're-verify before acting'; then
+  note_pass "guilt — the re-verify framing (2026-07-26 fix) survives this change"
+else
+  note_fail "guilt — re-verify framing was clobbered: $out1"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 (INNOCENCE): a probe with exactly one finding must NOT grow a count.
+# "[1 of 1]" on every single-finding line would be pure noise on a report that
+# is injected into every session on three machines.
+# ---------------------------------------------------------------------------
+r2="$TMPDIR/case2.json"
+build_report "$r2" "0.0" '
+report = {
+    "schema": 1, "runner_version": "1.0.0",
+    "machine": "pro", "repo_head": "abc123", "config_source": "embedded",
+    "config_sha": "x", "probes_expected": 1, "probes_run": 1,
+    "unwatched_classes": [],
+    "summary": "proprioception: 1 probe on pro — 1 DIVERGED, 0 unprobeable, 0 reconciled",
+    "probes": [
+        {"id": "home_fork_scripts", "boundary": "home<->repo", "class": "home<->repo",
+         "status": "DIVERGED", "severity": "P1", "n_findings": 1,
+         "evidence": ["DIVERGED: live != repo"],
+         "fix_hint": "diff the pair", "duration_ms": 5},
+    ],
+}
+'
+out2="$(run_hook "$r2")"
+if printf '%s\n' "$out2" | grep -q '\[1 of'; then
+  note_fail "innocence — a single-finding probe grew a needless count: $out2"
+else
+  note_pass "innocence — a single-finding probe prints no count"
+fi
+if printf '%s\n' "$out2" | grep -q 'DIVERGED: live != repo'; then
+  note_pass "innocence — the single-finding line is otherwise unchanged"
+else
+  note_fail "innocence — single-finding line lost its evidence: $out2"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 (INNOCENCE): a probe with NO evidence keeps the pre-existing
+# "N findings" fallback. That branch was already correct and must not be
+# swallowed by the new one.
+# ---------------------------------------------------------------------------
+r3="$TMPDIR/case3.json"
+build_report "$r3" "0.0" '
+report = {
+    "schema": 1, "runner_version": "1.0.0",
+    "machine": "pro", "repo_head": "abc123", "config_source": "embedded",
+    "config_sha": "x", "probes_expected": 1, "probes_run": 1,
+    "unwatched_classes": [],
+    "summary": "proprioception: 1 probe on pro — 1 DIVERGED, 0 unprobeable, 0 reconciled",
+    "probes": [
+        {"id": "some_probe", "boundary": "a<->b", "class": "a<->b",
+         "status": "DIVERGED", "severity": "P1", "n_findings": 12,
+         "evidence": [],
+         "fix_hint": "look at it", "duration_ms": 5},
+    ],
+}
+'
+out3="$(run_hook "$r3")"
+if printf '%s\n' "$out3" | grep -q '12 findings'; then
+  note_pass "innocence — the empty-evidence fallback still reports the count"
+else
+  note_fail "innocence — empty-evidence fallback broken: $out3"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4 (BEHAVIOURAL): the shared renderer scripts/proprioception.py exposes.
+#
+# The first draft of this case was a grep over the source — and its first
+# assertion matched NOTHING, so it was green on the fixed code AND on the
+# pre-fix code. A check that cannot go red is not a check. Caught by running
+# this file against the reverted source before shipping it.
+#
+# The cure was structural, not a better regex: the three surfaces that render a
+# DIVERGED probe (this CLI, the SessionStart receptor, the per-host fleet
+# summary) now share one function, `finding_label`, which can simply be called.
+# Fixing the pattern instead of the structure would ALSO have hidden the third
+# site: the grep, once it actually matched, is what revealed that the fleet
+# summary at proprioception.py:~1121 carried the same defect uncured.
+# ---------------------------------------------------------------------------
+cli_out="$(python3 - "$REPO_ROOT" <<'PYEOF'
+import importlib.util, sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "proprioception", Path(sys.argv[1]) / "scripts" / "proprioception.py"
+)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+fl = mod.finding_label
+
+cases = [
+    # (probe, must_contain, label)
+    ({"id": "launchagent_canon", "n_findings": 55, "evidence": ["a", "b"]},
+     "[1 of 55]", "guilt-many"),
+    ({"id": "home_fork_scripts", "n_findings": 1, "evidence": ["a"]},
+     None, "innocence-one"),
+    ({"id": "some_probe", "n_findings": 12, "evidence": []},
+     None, "innocence-no-evidence"),
+    ({"id": "odd_probe", "n_findings": None, "evidence": ["a"]},
+     None, "innocence-null-count"),
+]
+for probe, must, label in cases:
+    got = fl(probe)
+    if must is None:
+        ok = "[1 of" not in got and probe["id"] in got
+    else:
+        ok = must in got and probe["id"] in got
+    print(("OK " if ok else "NO ") + label + " -> " + repr(got))
+PYEOF
+)"
+printf '%s\n' "$cli_out" | while IFS= read -r line; do :; done
+for label in guilt-many innocence-one innocence-no-evidence innocence-null-count; do
+  if printf '%s\n' "$cli_out" | grep -q "^OK $label"; then
+    note_pass "cli — finding_label $label"
+  else
+    note_fail "cli — finding_label $label: $(printf '%s\n' "$cli_out" | grep "$label")"
+  fi
+done
+
+# The receptor and the CLI must not drift into two different opinions of the
+# same line: whatever the shared function returns is what the receptor prints.
+if printf '%s\n' "$out1" | grep -q "launchagent_canon \[1 of 55\]"; then
+  note_pass "cli — the receptor line matches finding_label's exact rendering"
+else
+  note_fail "cli — receptor and finding_label disagree on the rendering: $out1"
+fi
+
+echo
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/tests/test_proprioception_finding_count.sh
+++ b/scripts/tests/test_proprioception_finding_count.sh
@@ -180,22 +180,45 @@ fi
 # pre-fix code. A check that cannot go red is not a check. Caught by running
 # this file against the reverted source before shipping it.
 #
-# The cure was structural, not a better regex: the three surfaces that render a
-# DIVERGED probe (this CLI, the SessionStart receptor, the per-host fleet
-# summary) now share one function, `finding_label`, which can simply be called.
-# Fixing the pattern instead of the structure would ALSO have hidden the third
-# site: the grep, once it actually matched, is what revealed that the fleet
-# summary at proprioception.py:~1121 carried the same defect uncured.
+# The cure was structural, not a better regex: the two render sites INSIDE
+# proprioception.py (this CLI and the per-host fleet summary) now call one
+# function, `finding_label`, which can simply be called. Fixing the pattern
+# instead of the structure would ALSO have hidden the second of them: the grep,
+# once it actually matched, is what revealed that the fleet summary at
+# proprioception.py:~1121 carried the same defect uncured.
+#
+# HONEST LIMIT, raised by an adversarial reviewer against the first draft of
+# this file, which claimed all THREE sites "share one function":
+# scripts/hooks/proprioception_sessionstart.sh does NOT import proprioception.py.
+# It is a standalone python heredoc inside a shell hook, run at SessionStart
+# under a latency budget measured in single-digit seconds; importing that module
+# for one six-line function would be the wrong trade. So the rule genuinely lives
+# in TWO places and is kept in sync by hand.
+#
+# That is a defensible design and an indefensible thing to leave unguarded. Case
+# 5 below therefore does not merely observe that they happen to agree on one
+# fixture — it drives BOTH implementations across the same matrix of counts and
+# fails on the first disagreement. Drift is now detectable rather than
+# coincidental, which is what the original comment falsely implied was true by
+# construction.
 # ---------------------------------------------------------------------------
 cli_out="$(python3 - "$REPO_ROOT" <<'PYEOF'
-import importlib.util, sys
+import sys, types
 from pathlib import Path
 
-spec = importlib.util.spec_from_file_location(
-    "proprioception", Path(sys.argv[1]) / "scripts" / "proprioception.py"
-)
-mod = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(mod)
+# W121 — compile from SOURCE TEXT, never through importlib's bytecode cache.
+# Caught on this very corpus 2026-08-26: mutating the threshold `n > 1` to
+# `n > 4` changes ONE character, so the file's SIZE is unchanged, and the
+# rewrite plus the restore landed inside the same wall-clock second, so the
+# MTIME matched too. Python validates a .pyc on exactly (mtime, size), so
+# `spec.loader.exec_module` happily executed the MUTATED bytecode while
+# `inspect.getsource` printed the RESTORED source — the mutation proof read as
+# a genuine failure of correct code. compile(read_text()) has no cache to
+# poison and makes this corpus immune to its own mutation harness.
+_src_path = Path(sys.argv[1]) / "scripts" / "proprioception.py"
+mod = types.ModuleType("proprioception")
+mod.__file__ = str(_src_path)
+exec(compile(_src_path.read_text(encoding="utf-8"), str(_src_path), "exec"), mod.__dict__)
 fl = mod.finding_label
 
 cases = [
@@ -233,6 +256,65 @@ if printf '%s\n' "$out1" | grep -q "launchagent_canon \[1 of 55\]"; then
   note_pass "cli — the receptor line matches finding_label's exact rendering"
 else
   note_fail "cli — receptor and finding_label disagree on the rendering: $out1"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5 (DRIFT): the receptor's hand-written copy of the rule and
+# proprioception.py's finding_label must agree across a MATRIX of counts, not
+# on the single n=55 fixture case 1 happens to use.
+#
+# The receptor cannot import the module (standalone heredoc in a SessionStart
+# hook, single-digit-second latency budget), so the rule is duplicated on
+# purpose. This case is the thing that makes the duplication safe: change the
+# threshold in one and this goes red naming the count that diverged.
+# ---------------------------------------------------------------------------
+drift_fail=0
+for n in 0 1 2 5 55 999; do
+  rn="$TMPDIR/drift-$n.json"
+  build_report "$rn" "0.0" "
+report = {
+    \"schema\": 1, \"runner_version\": \"1.0.0\",
+    \"machine\": \"pro\", \"repo_head\": \"abc123\", \"config_source\": \"embedded\",
+    \"config_sha\": \"x\", \"probes_expected\": 1, \"probes_run\": 1,
+    \"unwatched_classes\": [],
+    \"summary\": \"s\",
+    \"probes\": [
+        {\"id\": \"drift_probe\", \"boundary\": \"a<->b\", \"class\": \"a<->b\",
+         \"status\": \"DIVERGED\", \"severity\": \"P1\", \"n_findings\": $n,
+         \"evidence\": [\"e0\"],
+         \"fix_hint\": \"f\", \"duration_ms\": 1},
+    ],
+}
+"
+  # what the receptor actually printed, between "] " and " (as of"
+  # NB: anchored to the FIRST ']' — a greedy 's/^.*] //' eats the "[1 of N]"
+  # marker itself and makes this case fail on a correct receptor. Cost one
+  # false red before shipping; kept as a comment so the next reader does not
+  # re-derive it.
+  recv="$(run_hook "$rn" | grep -m1 '^  !!' | sed -e 's/^  !! \[[^]]*\] //' -e 's/ (as of .*$//')"
+  # what the module says for the identical probe
+  modl="$(python3 - "$REPO_ROOT" "$n" <<'PYEOF'
+import sys, types
+from pathlib import Path
+# same W121 reasoning as the case-4 loader: source text, never bytecode.
+# (No apostrophe in this comment on purpose: a lone quote inside a heredoc
+# nested in $( ) makes the bash lexer lose the closing paren.)
+_p = Path(sys.argv[1]) / "scripts" / "proprioception.py"
+mod = types.ModuleType("proprioception")
+mod.__file__ = str(_p)
+exec(compile(_p.read_text(encoding="utf-8"), str(_p), "exec"), mod.__dict__)
+print(mod.finding_label({"id": "drift_probe", "n_findings": int(sys.argv[2]), "evidence": ["e0"]}))
+PYEOF
+)"
+  if [ "$recv" = "$modl" ]; then
+    :
+  else
+    drift_fail=$((drift_fail + 1))
+    note_fail "drift — n=$n: receptor printed '$recv', finding_label says '$modl'"
+  fi
+done
+if [ "$drift_fail" -eq 0 ]; then
+  note_pass "drift — receptor and finding_label agree on n in {0,1,2,5,55,999}"
 fi
 
 echo

--- a/scripts/tests/test_proprioception_finding_count.sh
+++ b/scripts/tests/test_proprioception_finding_count.sh
@@ -241,7 +241,6 @@ for probe, must, label in cases:
     print(("OK " if ok else "NO ") + label + " -> " + repr(got))
 PYEOF
 )"
-printf '%s\n' "$cli_out" | while IFS= read -r line; do :; done
 for label in guilt-many innocence-one innocence-no-evidence innocence-null-count; do
   if printf '%s\n' "$cli_out" | grep -q "^OK $label"; then
     note_pass "cli — finding_label $label"
@@ -316,6 +315,59 @@ done
 if [ "$drift_fail" -eq 0 ]; then
   note_pass "drift — receptor and finding_label agree on n in {0,1,2,5,55,999}"
 fi
+
+# ---------------------------------------------------------------------------
+# Case 6 (CALL SITES): the Gear-3 gate measured that this corpus proved the
+# FUNCTION and not its two CALLERS — it reverted `finding_label(r)` back to
+# `r['id']` at the CLI print site and the whole corpus stayed 12/0 GREEN. A
+# corpus that cannot see its own subject being unplugged is the same
+# over-declared-coverage shape the adversarial round caught in a comment.
+#
+# Closing it behaviourally is not available at a proportionate cost: both call
+# sites live inline in functions that first run a live probe sweep against this
+# machine (main()) or ssh to a peer (fleet_probe()), so exercising them for real
+# would assert about Pro rather than about the code.
+#
+# So this is an AST check, and its limit is stated rather than implied: it
+# proves the two call sites CALL finding_label, not that they render correctly.
+# AST and not grep, because a grep for the name also matches the definition, the
+# docstring and this very comment — it would pass on a file where both callers
+# were unplugged. Mutation-proved: reverting either call site reddens it.
+# ---------------------------------------------------------------------------
+callsites="$(python3 - "$REPO_ROOT" <<'PYEOF'
+import ast, sys
+from pathlib import Path
+
+src = (Path(sys.argv[1]) / "scripts" / "proprioception.py").read_text(encoding="utf-8")
+tree = ast.parse(src)
+
+def calls_finding_label(fn_name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == fn_name:
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) \
+                        and sub.func.id == "finding_label":
+                    return True
+            return False
+    return None  # function itself is gone
+
+for fn in ("main", "fleet_probe"):
+    got = calls_finding_label(fn)
+    if got is None:
+        print("NO " + fn + " -> function not found in proprioception.py")
+    elif got:
+        print("OK " + fn)
+    else:
+        print("NO " + fn + " -> does not call finding_label (call site unplugged)")
+PYEOF
+)"
+for fn in main fleet_probe; do
+  if printf '%s\n' "$callsites" | grep -q "^OK $fn$"; then
+    note_pass "callsite — $fn() calls finding_label"
+  else
+    note_fail "callsite — $(printf '%s\n' "$callsites" | grep "$fn")"
+  fi
+done
 
 echo
 echo "passed: $pass  failed: $fail"


### PR DESCRIPTION
## What was wrong

Every surface that renders a `DIVERGED` probe prints **one** finding, and the finding **count** reached the reader only when there was no evidence at all:

```python
ev = p["evidence"][0] if p.get("evidence") else f"{n} findings"
```

`evidence` holds at most 5 items (`run_wrap`'s `items[:5]`); `n_findings` is the true total.

**Measured live on Pro, 2026-08-26:**

| probe | findings | lines printed |
|---|---|---|
| `launchagent_canon` | 55 | 1 |
| `launchd_liveness` | 22 | 1 |
| `organs_heartbeat` | 7 | 1 |
| `worktree_gate_shim` | 4 | 1 |

## The damage, not the illustration

The `worktree_gate_shim` line was read *this session* as "one worktree pushes with no gate". The named path was repaired — and **three others kept pushing with `core.hooksPath` pointing at a directory that does not exist**, so git ran no hooks at all, until a hand census found them. All four are repaired on disk and proved **functionally** (the pre-push hook was executed and produced real output, not merely checked for existence).

This is **W97** one level *below* where W97 was already cured here: the receptor's `[:4]` cap over **probes** was fixed 2026-07-26 and its comment cites W97 by name; the per-probe truncation over **findings** was left.

## The fix

The two render sites inside `proprioception.py` (CLI line, per-host fleet summary) now call one function, `finding_label`, silent at `n <= 1`. The fleet summary also truncated its **probe** list at `div[:4]` with nothing saying so; it now names how many it dropped.

The **SessionStart receptor deliberately does not import it** — it is a standalone python heredoc in a shell hook under a latency budget, and pulling in that module for a six-line function is the wrong trade. So the rule genuinely lives in two places, and a **drift case** drives both across `n ∈ {0,1,2,5,55,999}` and fails on the first disagreement.

## Adversarial round

An independent seat on fresh context was given seven specific claims to **refute**, told to default to SUSPECT. Six upheld by its own measurement (including an independent re-run of the mutation proof from git, `dash`-vs-`bash` execution, and instantiating `fleet_probe()` with mocks to check `host` scope). **One real defect found:**

> the comment claimed all *three* sites "share one function" — false for the receptor.

That is the W113 shape, a false structural claim in a durable artifact. Fixed in `d251dfe85`: the comment now states the duplication honestly, and the drift case makes the sync verified instead of coincidental.

## W121, caught on this bench against this bench

Building the mutation proof, the harness read **poisoned bytecode** and reported a false failure of correct code. The mutation `n > 1` → `n > 4` changes **one character**, so file size was unchanged; the rewrite and restore landed in the **same wall-clock second**, so mtime matched too. Python validates a `.pyc` on exactly `(mtime, size)` — so `importlib` executed the *mutated* bytecode while `inspect.getsource` printed the *restored* source.

Both loaders now `compile()` from source text. The corpus passes **12/0 with the poisoned `.pyc` still on disk** — that is the proof the immunity works, not an assertion of it.

## CI: the corpus for the previous fix has never run

`scripts/tests/test_proprioception_receptor_ranking.sh` has existed since 2026-07-26 — written for the W97 fix on this exact file — and is **named by no workflow**. Its five `.py` siblings run via the `immune-enforcement.yml` pytest sweep; being a `.sh` file is the only reason it was invisible. (Independently corroborated: the grader found it already listed among 13 orphaned `.sh` corpora in `PENDING-ARMS.md`, entry dated 2026-08-06.)

Both corpora are named now, and `proprioception_sessionstart.sh` is added to the path filter — **the file that renders every session's report had no CI trigger at all**, so a PR touching only it would have run nothing and still read `success`.

## Proof

| direction | result |
|---|---|
| fix, under `sh` and `bash` | **12 pass / 0 fail** |
| pre-fix source | **5 pass / 12 fail** |
| threshold mutated in the module only | drift case reddens, naming both sides |
| `test_proprioception_receptor_ranking.sh` | still **7/7** — the 2026-07-26 framing not clobbered |
| `actionlint` | clean |

Two smaller things paid for in the open and commented at the site: the drift extractor's first `sed` was greedy and ate the `[1 of N]` marker (false red on correct code); and a lone apostrophe in a comment inside a heredoc nested in `$( )` makes the bash lexer lose the closing paren.

## Evidence

Gear 3 by path (`.github/workflows/` is hot-zone; floor re-derived independently as 3). `evidence/2026-08/agent-nuzantara-ops-proprioception-finding-count-c1da6fda/` — 9 receipts, 3 dissent entries (two CONFIRMED, one PLAUSIBLE and deliberately not fixed: a stringy `n_findings` renders no count, and coercing it here would mask a broken producer). `evidence_pack_lint: clean`, re-run **after** Prettier reflowed the pack (W112).

## Residual, stated not hidden

- The four worktrees are repaired **on disk**. Nothing stops the next bare `git worktree add` from recreating the hole — this diff improves detection honesty, not prevention.
- The receptor and `finding_label` remain two implementations of one rule. The drift case makes divergence *visible*; it does not make it impossible.
- Noted, out of scope: the pre-commit anti-reward-hacking lint reported `no staged test files` while a new test file *was* staged — it appears to scan `.py` only.