### PR TITLE
fix(research-os): retract the MCP root cause PR #5009 asserted — measuring it refuted it

### DIFF
--- a/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
+++ b/research/operations/execution/research-os-v1.0.0/evidence/p05/ros-v1-p05-intel-prep-b01/UNKNOWNS.md
@@ -43,14 +43,39 @@ own launch command, reproduced by hand with a full JSON-RPC handshake, also answ
 The failure was in the TOOL, not the data layer — exactly the distinction §1 was right to insist
 on, applied one layer deeper than §1 applied it.
 
-**Correction B — the likely cause is a deprecated dependency, and it is a standing fragility.**
-`@modelcontextprotocol/server-postgres` is flagged by npm as **"Package no longer supported"**
-and is not installed globally, so every `npx -y` invocation re-resolves it against the registry
-before the subprocess can emit its first byte. A handshake-readiness timeout expiring during that
-cold start produces precisely the observed symptom: zero output, no auth error, no SQL error.
-This is not a one-session fluke to shrug off — the dependency is orphaned upstream and will keep
-producing silent, contentless failures. Treat a future "Command failed with no output" as a
-suspected cold-start timeout on an unsupported package, not as evidence about the data.
+**Correction B — RETRACTED 2026-08-26, same day. The root cause is UNKNOWN.**
+An earlier revision of this section stated that the likely cause was an `npx` cold start on a
+deprecated package overrunning the MCP handshake timeout, and called it "a standing fragility"
+that "will keep producing silent, contentless failures." **That was reasoning presented as a
+finding, and measuring it refuted it.** Two measured facts:
+
+- `@modelcontextprotocol/server-postgres` IS npm-flagged **"Package no longer supported"**
+  (registry, v`0.6.2`) and is NOT installed globally. That much stands, and it is a genuine
+  standing fragility: an orphaned upstream dependency on this tool's only read path.
+- But it is **already cached** — two resolved copies under `~/.npm/_npx/` — and the server's
+  time-to-first-JSON-RPC-response measures **~2 s**. That is not a handshake-timeout-scale
+  stall, so the deprecation does **not** explain the observed failure.
+
+What is established: the database, the role, the Keychain entry and a direct `psql` connection
+are all healthy and MEASURED. The MCP failure was **not reproducible** at any layer — the
+launch command reproduced by hand answered, and so did the live registered tool. **Why the
+original three calls returned "Command failed with no output" is unknown**, and it is recorded
+as unknown rather than closed with a plausible story.
+
+*How this correction was reached* is the part worth carrying forward. The wrong cause did not
+come from a bad measurement; it came from a **relay**. The investigating subagent wrote
+"since I could not reproduce the failure now, this points to a **transient** condition ...
+**not a persistent break**." Compressing that into this document dropped both hedges and
+promoted an unreproduced hypothesis into a finding. No adversarial review would have caught it:
+a reviewer reads the artefact, not the subagent's report, so the discrepancy lived on a boundary
+no check crosses. **A cause you have not reproduced is not written as a cause.**
+
+*What a future session can do that this one did not*: capture the MCP subprocess's own stderr at
+the moment of failure instead of reasoning backwards from the client's empty result. That is now
+possible — `scripts/mcp/postgres-local-mcp.sh` (added the same day) tees the server's stderr to
+`~/logs/mcp-postgres-local.log` and turns a failed or empty Keychain lookup into a loud, named
+exit instead of an empty password. The old inline form could not express that failure at all: a
+command substitution in an assignment prefix discards its exit status.
 
 **Measured baseline (aggregates only — no row content, per SYMBIOSIS Law 2):**
 


### PR DESCRIPTION
#5009 (merged minutes ago) stated the MCP failure's likely cause was an `npx` cold start on a deprecated package overrunning the handshake timeout, and called it a *"standing fragility"* that *"will keep producing silent, contentless failures."*

**That was reasoning presented as a finding. Measuring it refuted it.**

| Claim | Measurement |
|---|---|
| package re-resolves from the registry each start | **already cached** — two resolved copies under `~/.npm/_npx/` |
| cold start overruns the handshake timeout | **time-to-first-JSON-RPC-response ≈ 2 s** — not a timeout-scale stall |

**What survives:** `@modelcontextprotocol/server-postgres` IS npm-flagged "Package no longer supported" (registry, v0.6.2) and is not installed globally — a real standing fragility on this tool's only read path.
**What is retracted:** that it caused this failure.

The root cause is now recorded as **UNKNOWN**. The failure was not reproducible at any layer, and a transient failure with no captured diagnostics leaves nothing to conclude from.

## How the wrong cause got in — recorded in the file, because it generalises

Not a bad measurement. A **relay**. The investigating subagent wrote:

> "since I could not reproduce the failure now, this points to a **transient** condition … **not a persistent break**"

Compressing that into the bundle dropped both hedges and promoted an unreproduced hypothesis into a finding. **No adversarial review would have caught it** — a reviewer reads the artefact, not the subagent's report, so the discrepancy lived on a boundary no check crosses. The rule that falls out: *a cause you have not reproduced is not written as a cause.*

## Why a follow-up PR and not an amend

#5009 was already `queued to merge` when the error was found, and the queue freezes an armed branch — `--disable-auto` was refused. Per the repo's own rule ("arm means freeze; put every follow-up in a new PR from a fresh `origin/main`"), this is that PR. It is the better outcome anyway: the retraction stays visible in history instead of vanishing into a rewritten commit.

## Companion

The diagnostic gap this exposes is closed separately: `scripts/mcp/postgres-local-mcp.sh` tees the MCP subprocess's own stderr to a log and turns a failed or empty Keychain lookup into a loud, named exit — the failure class the old inline `PGPASSWORD=$(…)` form could not express at all, because a command substitution in an assignment prefix discards its exit status.