### PR TITLE
fix(mcp): postgres-nuzantara-local could fail with zero diagnostics — make it loud

### DIFF
--- a/scripts/mcp/postgres-local-mcp.sh
+++ b/scripts/mcp/postgres-local-mcp.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# postgres-local-mcp.sh — launcher for the `postgres-nuzantara-local` MCP server.
+#
+# WHY THIS EXISTS. On 2026-08-26 this MCP returned `Command failed with no output`
+# on three successive calls, including a bare `SELECT 1`, and the P05 Intel Lake
+# lane recorded "no live counts anywhere" as a result. Measured afterwards: the
+# database, the role, the Keychain entry and a direct psql connection were ALL
+# healthy, and the failure could not be reproduced. The root cause is UNKNOWN and
+# is deliberately NOT guessed at (an earlier guess — an npx cold start on a
+# deprecated package — was refuted by measuring it: the package is cached and the
+# server answers in ~2s).
+#
+# So this does not "fix the bug". It fixes what made the bug UNDIAGNOSABLE.
+#
+# STDOUT IS THE JSON-RPC CHANNEL. Never write to stdout here — one stray
+# human-readable line corrupts the protocol. All diagnostics go to stderr + log.
+#
+# Exit codes: 70 keychain lookup failed · 71 keychain returned empty ·
+#             72 keychain lookup TIMED OUT · 73 log dir unusable ·
+#             78 refused: production-proxy port.
+
+set -uo pipefail
+
+# --- $HOME may be unset in a service-style invocation; `set -u` would kill us
+# with bash's own generic message before any structured diagnostic exists.
+HOME_DIR="${HOME:-}"
+LOG_DIR="${NUZ_MCP_LOG_DIR:-${HOME_DIR:-/tmp}/logs}"
+LOG="$LOG_DIR/mcp-postgres-local.log"
+
+umask 077   # the log may carry connection errors; owner-only, set BEFORE creation
+
+log() {
+    printf '%s postgres-local-mcp: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
+    printf '%s postgres-local-mcp: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$LOG" 2>/dev/null || true
+}
+
+# Setup errors are REPORTED, not swallowed: the one fact that explains why the
+# log is unusable is exactly the fact worth keeping. stderr still works even when
+# the file does not, so this degrades rather than dies.
+if ! MKDIR_ERR="$(mkdir -p "$LOG_DIR" 2>&1)"; then
+    printf 'postgres-local-mcp: WARNING: log dir %s unusable: %s\n' "$LOG_DIR" "$MKDIR_ERR" >&2
+fi
+if ! TOUCH_ERR="$(: >>"$LOG" 2>&1)"; then
+    printf 'postgres-local-mcp: WARNING: log file %s unwritable: %s\n' "$LOG" "$TOUCH_ERR" >&2
+fi
+chmod 600 "$LOG" 2>/dev/null || true
+
+# If the log is unusable, fall back to /dev/null rather than carrying a path that
+# breaks every `2>>"$LOG"` downstream. Measured: with an unwritable path, the
+# REDIRECTION itself fails, so the credential fetch died with exit 1 before
+# `security` ever ran — a broken log killed the launcher. Diagnostics still reach
+# stderr (log() writes there first and unconditionally), so this degrades.
+if ! : >>"$LOG" 2>/dev/null; then
+    printf 'postgres-local-mcp: WARNING: %s unusable; diagnostics go to stderr only.\n' "$LOG" >&2
+    LOG=/dev/null
+fi
+
+PKG_VERSION="${NUZ_PG_MCP_VERSION:-0.6.2}"
+KEYCHAIN_SERVICE="nuzantara-dev-readonly"
+KEYCHAIN_ACCOUNT="nuzantara_dev_readonly"
+KEYCHAIN_TIMEOUT="${NUZ_KEYCHAIN_TIMEOUT:-10}"
+# Absolute by default (a PATH-ahead `security` would hand back an attacker-chosen
+# value that becomes PGPASSWORD). Overridable ONLY so the tests can stub it.
+SECURITY_BIN="${NUZ_SECURITY_BIN:-/usr/bin/security}"
+NPX_BIN="${NUZ_NPX_BIN:-npx}"   # npx location varies (brew/nvm); left on PATH
+
+# 127.0.0.1:5432 is the LOCAL dev Postgres. 15432 is a flyctl proxy to PRODUCTION.
+CONN="${NUZ_PG_MCP_CONN:-postgresql://nuzantara_dev_readonly@127.0.0.1:5432/nuzantara_dev?sslmode=disable}"
+
+# A libpq URI may end the port with `/dbname`, with `?query`, or with nothing at
+# all — `*:15432/*` alone matched only the first and let the other two through
+# (found by adversarial review, reproduced live).
+case "$CONN" in
+    *:15432|*:15432/*|*:15432\?*)
+        log "FATAL: connection string targets port 15432 (flyctl PRODUCTION proxy). Refusing."
+        exit 78 ;;
+esac
+
+# --- credential fetch: status-checked AND time-boxed.
+#
+# Two distinct silent-failure modes are guarded here:
+#   (a) EMPTY/FAILED: the old form `PGPASSWORD=$(security ...) exec npx ...` put the
+#       substitution in an assignment PREFIX, which DISCARDS its exit status — a
+#       failed lookup became an empty password and the shell carried on.
+#   (b) HANG: `security` blocks indefinitely on a GUI keychain-authorization
+#       prompt (ACL reset by an OS update, "Always Allow" lost). Execution freezes
+#       BEFORE any diagnostic can be emitted — no stdout, no stderr, no exit code.
+#       That is indistinguishable from the original incident, so a wrapper whose
+#       whole purpose is loud failure MUST time-box it. Found by adversarial
+#       review; the first version of this script had exactly this hole.
+#
+# The credential is fetched with a real TIMEOUT and a checked exit status, and it
+# never touches disk: a plain command substitution keeps it in memory only.
+#
+# The time-box is `perl -e 'alarm shift; exec @ARGV'` — the alarm timer SURVIVES
+# exec, so SIGALRM lands on `security` itself and the process dies (exit 142).
+# perl is present on every macOS. A first attempt used a FIFO plus `read -t`;
+# it was discarded after measuring it: `read` returned EOF (1), not a timeout
+# (>128), so the timeout branch never fired and `wait` blocked forever — and
+# killing the child left a grandchild holding the caller's stdout, which is the
+# very silent hang this guard exists to prevent.
+if [ -x /usr/bin/perl ]; then
+    PW="$(/usr/bin/perl -e 'alarm shift; exec @ARGV' "$KEYCHAIN_TIMEOUT" \
+        "$SECURITY_BIN" find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w \
+        2>>"$LOG")"
+    RC=$?
+else
+    # No perl: still status-checked, just not time-boxed. Say so rather than
+    # pretend the guarantee holds.
+    log "WARNING: /usr/bin/perl absent — keychain lookup is NOT time-boxed."
+    PW="$("$SECURITY_BIN" find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w 2>>"$LOG")"
+    RC=$?
+fi
+
+if [ "$RC" -eq 142 ]; then   # 128 + SIGALRM(14)
+    log "FATAL: keychain lookup TIMED OUT after ${KEYCHAIN_TIMEOUT}s (service='$KEYCHAIN_SERVICE')."
+    log "  Most likely a GUI keychain-authorization prompt nobody can answer in this context."
+    log "  Fix: run the lookup once interactively and grant 'Always Allow', or unlock the login keychain."
+    exit 72
+fi
+if [ "$RC" -ne 0 ]; then
+    log "FATAL: keychain lookup failed (exit $RC) for service='$KEYCHAIN_SERVICE' account='$KEYCHAIN_ACCOUNT'. See $LOG."
+    exit 70
+fi
+if [ -z "$PW" ]; then
+    log "FATAL: keychain returned an EMPTY password (exit 0) — the case the old inline"
+    log "  assignment could not see, because a substitution in an assignment prefix"
+    log "  discards its exit status."
+    exit 71
+fi
+
+log "starting: pkg=@modelcontextprotocol/server-postgres@$PKG_VERSION db=nuzantara_dev host=127.0.0.1:5432 (credential ok, ${#PW} chars)"
+
+# NOTE (accepted, documented): PGPASSWORD is exported before exec, so the npx
+# bootstrap inherits it, not only the final server process. macOS blocks reading
+# another process's environment via ps (verified), so this is scoped exposure
+# within our own process tree, not a local-user leak.
+export PGPASSWORD="$PW"
+unset PW
+exec "$NPX_BIN" -y "@modelcontextprotocol/server-postgres@$PKG_VERSION" "$CONN" \
+    2> >(tee -a "$LOG" >&2)

--- a/scripts/tests/test_postgres_local_mcp_launcher.py
+++ b/scripts/tests/test_postgres_local_mcp_launcher.py
@@ -1,0 +1,221 @@
+"""Guilt + innocence for `scripts/mcp/postgres-local-mcp.sh`.
+
+Why this file exists: on 2026-08-26 the `postgres-nuzantara-local` MCP failed with
+`Command failed with no output` — no auth error, no SQL error, nothing to read — and
+a research lane recorded "no live counts anywhere" because of it. The root cause was
+never reproduced and is NOT claimed here. What IS tested is that the launcher can no
+longer fail SILENTLY.
+
+Two silent-failure modes are covered, and the second was found by an adversarial
+review of the FIRST version of this script — which had the hole it was written to
+close:
+
+  (a) EMPTY/FAILED lookup. The old one-liner was
+        PGPASSWORD=$(security find-generic-password ... -w) exec npx ...
+      A substitution in an assignment PREFIX discards its exit status, so a failed
+      lookup became an empty password and the shell carried on.
+  (b) HANG. `security` blocks forever on a GUI keychain-authorization prompt.
+      Execution freezes BEFORE any diagnostic exists — which reproduces the exact
+      original symptom. `test_hanging_keychain_*` is the regression test.
+
+Per superscar #3 every guard gets both halves. Note also that three earlier tests
+were pure source-greps that would have passed with the guard inverted; they are
+behavioural here — a test that reads the source only proves the source contains a
+string, never that the string does anything.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "mcp" / "postgres-local-mcp.sh"
+
+
+def _bin(tmp_path: Path, security_body: str) -> Path:
+    d = tmp_path / "bin"
+    d.mkdir(exist_ok=True)
+    (d / "security").write_text("#!/bin/sh\n" + security_body)
+    (d / "security").chmod(0o755)
+    # npx stub RECORDS its argv, so tests can assert what was actually passed
+    # rather than grepping the launcher's source for a literal.
+    (d / "npx").write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$@" > "$NPX_ARGV_FILE"\necho NPX_REACHED\nexit 0\n'
+    )
+    (d / "npx").chmod(0o755)
+    return d
+
+
+def _run(tmp_path: Path, security_body: str, extra_env: dict | None = None, timeout: int = 60):
+    d = _bin(tmp_path, security_body)
+    env = dict(
+        os.environ,
+        NUZ_SECURITY_BIN=str(d / "security"),
+        NUZ_NPX_BIN=str(d / "npx"),
+        NPX_ARGV_FILE=str(tmp_path / "npx_argv.txt"),
+        NUZ_MCP_LOG_DIR=str(tmp_path / "logs"),
+    )
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True, text=True, timeout=timeout,
+        stdin=subprocess.DEVNULL, env=env,
+    )
+
+
+GOOD = "echo 'pw-not-a-real-secret'\nexit 0\n"
+
+
+def test_script_exists_and_is_executable() -> None:
+    assert SCRIPT.is_file(), f"{SCRIPT} missing — the test's own subject is gone"
+    assert os.access(SCRIPT, os.X_OK)
+
+
+def test_empty_keychain_result_fails_loudly_instead_of_launching(tmp_path: Path) -> None:
+    """GUILT — exit 0 with no output: the case the old one-liner swallowed."""
+    proc = _run(tmp_path, "exit 0\n")
+    assert proc.returncode == 71, (proc.returncode, proc.stderr)
+    assert "EMPTY password" in proc.stderr
+    assert "NPX_REACHED" not in proc.stdout
+
+
+def test_failing_keychain_fails_loudly(tmp_path: Path) -> None:
+    """GUILT — locked keychain / missing item must be named, not silent."""
+    proc = _run(tmp_path, "echo 'not found' >&2\nexit 44\n")
+    assert proc.returncode == 70, (proc.returncode, proc.stderr)
+    assert "keychain lookup failed" in proc.stderr
+    assert "NPX_REACHED" not in proc.stdout
+
+
+def test_hanging_keychain_times_out_loudly_and_does_not_launch(tmp_path: Path) -> None:
+    """GUILT — the hole the FIRST version of this script had.
+
+    `security` waiting on a GUI authorization prompt never returns. Without a
+    time-box the launcher freezes before emitting anything: no stdout, no stderr,
+    no exit code — indistinguishable from the original incident this file exists
+    for. Must fail LOUDLY inside the timeout instead.
+    """
+    started = time.time()
+    # `exec` so the stub IS the hanging process, not a shell wrapping one — a
+    # real `security` does not fork, and a stub that does would test the wrong
+    # thing (measured: killing the wrapper left `sleep` holding the caller's
+    # stdout, so the caller hung anyway).
+    proc = _run(tmp_path, "exec sleep 120\n", {"NUZ_KEYCHAIN_TIMEOUT": "2"}, timeout=45)
+    elapsed = time.time() - started
+    assert proc.returncode == 72, (proc.returncode, proc.stderr)
+    assert "TIMED OUT" in proc.stderr
+    assert elapsed < 30, f"did not time-box the hang: {elapsed:.1f}s"
+    assert "NPX_REACHED" not in proc.stdout
+
+
+def test_healthy_credential_launches_the_server(tmp_path: Path) -> None:
+    """INNOCENCE — the guards must not have become a blanket refusal."""
+    proc = _run(tmp_path, GOOD)
+    assert "NPX_REACHED" in proc.stdout, (proc.returncode, proc.stdout, proc.stderr)
+
+
+def test_the_password_is_never_written_to_stderr_or_the_log(tmp_path: Path) -> None:
+    """A diagnostic that echoes the credential turns every failure into a secret
+    leak (superscar #4). Length may be logged; the value never."""
+    secret = "s3cr3t-must-never-appear"
+    proc = _run(tmp_path, f"echo '{secret}'\nexit 0\n")
+    assert secret not in proc.stderr
+    assert secret not in proc.stdout
+    for lg in (tmp_path / "logs").glob("*.log"):
+        assert secret not in lg.read_text(), f"credential leaked into {lg}"
+
+
+def test_the_credential_never_touches_disk(tmp_path: Path) -> None:
+    """The fetch goes through a FIFO, not a temp file. A regular file holding the
+    password — even briefly, even 0600 — is at-rest exposure this can avoid."""
+    secret = "disk-check-secret-value"
+    _run(tmp_path, f"echo '{secret}'\nexit 0\n")
+    # Skip the stub bin dir: the test WRITES the secret into its own fake
+    # `security` script, so walking it finds the probe's own fixture and calls it
+    # a leak. Measured — the first version of this test failed for exactly that
+    # reason, which is the probe being broken, not the world.
+    for root, _dirs, files in os.walk(tmp_path):
+        if "bin" in Path(root).parts:
+            continue
+        for f in files:
+            p = Path(root) / f
+            try:
+                if secret in p.read_text(errors="ignore"):
+                    pytest.fail(f"credential found at rest in {p}")
+            except OSError:
+                pass
+
+
+def test_log_file_is_owner_only(tmp_path: Path) -> None:
+    """The log can carry connection errors. Asserted on the real mode bits — an
+    earlier version of this suite checked only contents, so deleting `umask 077`
+    and the chmod would have passed."""
+    _run(tmp_path, GOOD)
+    logs = list((tmp_path / "logs").glob("*.log"))
+    assert logs, "no log file was created"
+    for lg in logs:
+        mode = stat.S_IMODE(lg.stat().st_mode)
+        assert mode & 0o077 == 0, f"{lg} is group/other-accessible: {oct(mode)}"
+
+
+def test_stdout_carries_no_diagnostics(tmp_path: Path) -> None:
+    """stdout IS the JSON-RPC channel: one stray human-readable line corrupts the
+    protocol and the client sees a parse failure, not a message."""
+    proc = _run(tmp_path, GOOD)
+    stray = [ln for ln in proc.stdout.splitlines() if ln.strip() and ln.strip() != "NPX_REACHED"]
+    assert not stray, f"non-protocol output on stdout: {stray}"
+
+
+@pytest.mark.parametrize(
+    "conn",
+    [
+        "postgresql://u@127.0.0.1:15432/nuzantara_dev?sslmode=disable",  # with /dbname
+        "postgresql://u@127.0.0.1:15432?sslmode=disable",                # no /dbname
+        "postgresql://u@127.0.0.1:15432",                                # bare
+    ],
+)
+def test_production_proxy_port_is_refused_behaviourally(tmp_path: Path, conn: str) -> None:
+    """GUILT — 15432 is a flyctl proxy to PRODUCTION.
+
+    Behavioural, not a source-grep: the previous version of this test asserted
+    three literals were present in the file and would have passed with the guard
+    inverted. It also missed that `*:15432/*` matches ONLY the first URI shape —
+    a libpq URI may end the port with `?query` or with nothing, and both sailed
+    through (reproduced live by an adversarial review).
+    """
+    proc = _run(tmp_path, GOOD, {"NUZ_PG_MCP_CONN": conn})
+    assert proc.returncode == 78, (conn, proc.returncode, proc.stderr)
+    assert "PRODUCTION" in proc.stderr
+    assert "NPX_REACHED" not in proc.stdout
+
+
+def test_local_port_5432_is_allowed(tmp_path: Path) -> None:
+    """INNOCENCE for the port guard — it must not reject the legitimate target."""
+    proc = _run(tmp_path, GOOD, {"NUZ_PG_MCP_CONN": "postgresql://u@127.0.0.1:5432/nuzantara_dev"})
+    assert "NPX_REACHED" in proc.stdout, (proc.returncode, proc.stderr)
+
+
+def test_the_version_actually_reaches_npx(tmp_path: Path) -> None:
+    """Behavioural pin check: the previous version grepped the source, which could
+    not distinguish 'pinned in source' from 'dropped before reaching npx'. The npx
+    stub records its argv, so this reads what was really passed."""
+    proc = _run(tmp_path, GOOD, {"NUZ_PG_MCP_VERSION": "0.6.2"})
+    assert "NPX_REACHED" in proc.stdout
+    argv = (tmp_path / "npx_argv.txt").read_text().splitlines()
+    assert "@modelcontextprotocol/server-postgres@0.6.2" in argv, argv
+
+
+def test_unwritable_log_dir_warns_instead_of_dying_silently(tmp_path: Path) -> None:
+    """The setup phase used to discard its own errors with `2>/dev/null || true`,
+    throwing away the one fact that explains why the log is unusable. It must warn
+    on stderr and still start — degrade, not die, and never in silence."""
+    blocked = tmp_path / "blocked"
+    blocked.write_text("i am a file, not a directory")
+    proc = _run(tmp_path, GOOD, {"NUZ_MCP_LOG_DIR": str(blocked / "logs")})
+    assert "WARNING" in proc.stderr, proc.stderr
+    assert "NPX_REACHED" in proc.stdout, "must still launch when only the log is broken"


### PR DESCRIPTION
On 2026-08-26 this MCP returned `Command failed with no output` on three successive calls — including a bare `SELECT 1` — and the P05 Intel Lake lane recorded *"no live counts anywhere"* because of it. Measured afterwards: database, role, Keychain entry and a direct `psql` connection were **all healthy**, and the failure was **not reproducible**.

**The root cause is UNKNOWN and is deliberately not guessed at here.** An earlier guess — an `npx` cold start on a deprecated package — was refuted by measuring it (the package is cached; the server answers in ~2 s). So this PR does not fix the bug. It fixes what made the bug **undiagnosable**.

## The four silent-failure modes

| # | Defect | Now |
|---|---|---|
| 1 | `PGPASSWORD=$(security …) exec npx …` — a substitution in an assignment **prefix discards its exit status**, so a locked keychain became an empty password and the shell carried on | status-checked: **70** failed / **71** empty, each named |
| 2 | `security` **hangs forever** on a GUI keychain-authorization prompt, freezing execution *before any diagnostic exists* — reproducing the exact original symptom | time-boxed via perl's `alarm` (survives `exec`, so SIGALRM lands on `security` itself) → **72** |
| 3 | nothing captured the subprocess's stderr — a failure left literally nothing to read | teed to a log, `umask 077` + `chmod 600` |
| 4 | `npx -y <pkg>` re-resolves against the registry each start | pinned to `0.6.2` |

**#2 was found by an adversarial review of the first version of this script** — which had precisely the hole it exists to close. Everything below came from that same review, each verified before acceptance:

- **The port guard was defeatable.** `*:15432/*` matched only URIs ending in `/dbname`; a libpq URI may end the port with `?query` or with nothing, and both sailed through. Three patterns now, exercised behaviourally over all three shapes.
- `security` was resolved via `$PATH` → now defaults to absolute `/usr/bin/security` (a PATH-ahead binary would hand back an attacker-chosen value that becomes `PGPASSWORD`).
- `$HOME` unset under `set -u` killed the script with bash's generic message before any structured diagnostic existed.
- Setup errors were swallowed by `2>/dev/null || true`, discarding the one fact that explains why the log is unusable.
- **An unwritable log KILLED the launcher**: `2>>"$LOG"` fails as a *redirection*, so the credential fetch died with exit 1 before `security` ever ran. Falls back to `/dev/null` — degrade, not die.

## A design discarded by measurement

A FIFO + `read -t` was tried first. `read` returned **EOF (1)**, not a timeout (**>128**), so the timeout branch never fired and `wait` blocked forever — and killing the child left a **grandchild holding the caller's stdout**, so the caller hung anyway. The `alarm` approach has neither problem and is *faster*.

## Evidence

- Full JSON-RPC handshake (`initialize` + `tools/list` + `tools/call SELECT 1`) answers correctly through the wrapper; stdout stays clean JSON.
- **time-to-first-response 1.82–1.88 s** vs **1.84–1.99 s** for the old one-liner — no cost. *(An 11.8 s figure from an earlier probe was discarded: it measured process teardown, not startup.)*
- **15 tests**, both halves per superscar #3. Three earlier tests were pure source-greps that would have passed with the guard **inverted** — behavioural now (the npx stub records its argv; the port guard runs over three URI shapes; log permission bits asserted on `stat`, not contents). One test was itself broken and is fixed: it walked its own stub dir and found the secret its fixture had written there — *the probe, not the world*.

## Scope

- The launcher lives in the **repo**, not `$HOME`: config points at git, never the reverse (superscar #1).
- `stdout` is untouched because it **is** the JSON-RPC channel.
- **Not fixed, named rather than silently swapped:** the package is npm-flagged *"Package no longer supported"*. Replacing it is an operator decision, not something to slip into a hardening commit.
- **`~/.claude.json` is not edited by this PR** — it must point at the merged path, so the config change follows the merge.