### PR TITLE
feat(kbli): make the Quick chips actually run the search

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -232,26 +232,17 @@ export default async function KBLIHomePage({
           id="search"
           className="sticky top-14 z-40 -mx-4 px-4 py-4 backdrop-blur-2xl bg-[#141416]/80 border border-white/[0.05] sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8 shadow-[0_10px_40px_rgba(0,0,0,0.4),inset_0_1px_0_rgba(255,255,255,0.03)] rounded-3xl mb-8"
         >
-          <KBLISearch autoFocus initialQuery={initialQuery} />
-          <div className="mt-4 flex flex-wrap items-center gap-2 justify-center lg:justify-start">
-            <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mr-2">
-              Quick:
-            </span>
-            {[
+          <KBLISearch
+            autoFocus
+            initialQuery={initialQuery}
+            quickFilters={[
               "Restaurant",
               "Tech",
               "Real Estate",
               "Retail",
               "Manufacturing",
-            ].map((filter) => (
-              <button
-                key={filter}
-                className="px-3.5 py-1.5 rounded-full text-xs font-medium text-zinc-400 bg-white/[0.04] backdrop-blur-md border border-white/[0.06] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] hover:bg-white/[0.07] hover:text-white transition-all duration-300 hover:border-red-500/30 hover:shadow-[0_0_20px_rgba(220,38,38,0.08),inset_0_1px_0_rgba(255,255,255,0.06)]"
-              >
-                {filter}
-              </button>
-            ))}
-          </div>
+            ]}
+          />
         </div>
 
         {/* ── SECTORS ── */}

--- a/apps/mouth/src/components/kbli/KBLISearch.quick-filters.test.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.quick-filters.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { KBLISearch } from "./KBLISearch";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+
+const search = vi.fn();
+vi.mock("@/lib/api/kbli.api", () => ({
+  kbliApi: { search: (q: string) => search(q) },
+  apiPmaStatusLabel: () => "Open",
+  isApiPmaVerdictVerified: () => true,
+}));
+vi.mock("@/lib/analytics", () => ({ trackKBLISearch: vi.fn() }));
+
+const FILTERS = ["Restaurant", "Tech"];
+
+describe("KBLISearch quick filters", () => {
+  beforeEach(() => {
+    push.mockReset();
+    search.mockReset();
+    search.mockResolvedValue([
+      {
+        code: "56101",
+        title: "Restoran",
+        description: "Restaurants",
+        risk_category: "MR",
+      },
+    ]);
+  });
+
+  it("writes the chip term into the search input", () => {
+    render(<KBLISearch quickFilters={FILTERS} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: "Search Restaurant" }));
+    expect(input.value).toBe("Restaurant");
+  });
+
+  it("actually runs the search for the chip term", async () => {
+    render(<KBLISearch quickFilters={FILTERS} />);
+    fireEvent.click(screen.getByRole("button", { name: "Search Tech" }));
+
+    await waitFor(() => expect(search).toHaveBeenCalledWith("Tech"), {
+      timeout: 2000,
+    });
+    expect(await screen.findByText("Restoran")).toBeInTheDocument();
+  });
+
+  it("replaces a previous term instead of appending to it", () => {
+    render(<KBLISearch quickFilters={FILTERS} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "villa" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search Tech" }));
+    expect(input.value).toBe("Tech");
+  });
+
+  it("marks the active chip as pressed, and only that one", () => {
+    render(<KBLISearch quickFilters={FILTERS} />);
+    fireEvent.click(screen.getByRole("button", { name: "Search Restaurant" }));
+
+    expect(
+      screen.getByRole("button", { name: "Search Restaurant" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Search Tech" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("renders no chip row when the caller passes none", () => {
+    render(<KBLISearch />);
+    expect(screen.queryByText("Quick:")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/components/kbli/KBLISearch.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.tsx
@@ -20,6 +20,12 @@ interface Props {
   placeholder?: string;
   /** Pre-fill the search input from ?q= URL param (homepage → KBLI deep-link). */
   initialQuery?: string;
+  /**
+   * One-tap starting points rendered under the input. Clicking one writes the
+   * term into the query, which is what actually runs the search — the chips
+   * own no state of their own.
+   */
+  quickFilters?: string[];
 }
 
 export function KBLISearch({
@@ -28,6 +34,7 @@ export function KBLISearch({
   className,
   placeholder = "Search KBLI codes (e.g. restaurant, villas, consulting)...",
   initialQuery = "",
+  quickFilters,
 }: Props) {
   const [query, setQuery] = React.useState(initialQuery);
   const [results, setResults] = React.useState<KBLISearchResult[]>([]);
@@ -37,6 +44,7 @@ export function KBLISearch({
   const [searchError, setSearchError] = React.useState<string | null>(null);
   const router = useRouter();
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   // Sync initialQuery on mount only (URL ?q= pre-fill).
   // Not in dep array — intentional: user can freely edit after mount.
@@ -118,6 +126,17 @@ export function KBLISearch({
     }
   };
 
+  /**
+   * Quick chip → the query itself. The debounced effect above sees the new
+   * query and runs the same search a typed term would, so there is exactly one
+   * search path, not two.
+   */
+  const handleQuickFilter = (term: string) => {
+    setQuery(term);
+    setActiveIndex(-1);
+    inputRef.current?.focus();
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -148,6 +167,7 @@ export function KBLISearch({
           )}
         </div>
         <input
+          ref={inputRef}
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
@@ -174,6 +194,31 @@ export function KBLISearch({
           </button>
         )}
       </div>
+
+      {quickFilters && quickFilters.length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center gap-2 justify-center lg:justify-start">
+          <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mr-2">
+            Quick:
+          </span>
+          {quickFilters.map((filter) => (
+            <button
+              key={filter}
+              type="button"
+              onClick={() => handleQuickFilter(filter)}
+              aria-label={`Search ${filter}`}
+              aria-pressed={query === filter}
+              className={cn(
+                "px-3.5 py-1.5 rounded-full text-xs font-medium backdrop-blur-md border shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-all duration-300",
+                query === filter
+                  ? "text-white bg-white/[0.10] border-red-500/30 shadow-[0_0_20px_rgba(220,38,38,0.08),inset_0_1px_0_rgba(255,255,255,0.06)]"
+                  : "text-zinc-400 bg-white/[0.04] border-white/[0.06] hover:bg-white/[0.07] hover:text-white hover:border-red-500/30 hover:shadow-[0_0_20px_rgba(220,38,38,0.08),inset_0_1px_0_rgba(255,255,255,0.06)]",
+              )}
+            >
+              {filter}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Results dropdown — also shown when there is a search error */}
       {isOpen && (results.length > 0 || searchError) && (


### PR DESCRIPTION
# Insight

The five **Quick** chips under the KBLI search box ("Restaurant", "Tech", "Real Estate",
"Retail", "Manufacturing") were dead buttons — no `onClick` at all, so clicking one did
nothing. This makes a chip write its term into the query, so the existing debounced
effect runs exactly the same search a typed term would. One search path, not two.

---

# Studio

## Source / Reference

- `apps/mouth/src/app/kbli/page.tsx` — the chip block on `origin/main`, lines 236–254
- `apps/mouth/src/components/kbli/KBLISearch.tsx` — owner of the `query` state and the
  debounced effect (`React.useEffect(..., [query])`)
- Route affected: `/kbli`
- Sibling PR: #5016 (sector table view) — a different hunk of the same `page.tsx`

## Methodology

- `git show origin/main:apps/mouth/src/app/kbli/page.tsx | sed -n '236,254p' | grep -c onClick`
  — establish the "dead button" claim from the source, not from memory
- `npx vitest run src/components/kbli/KBLISearch.quick-filters.test.tsx` — 5 new cases;
  `next/navigation`, `kbliApi.search` and `trackKBLISearch` are mocked
- **Mutation check**: three mutants — (M1) remove `setQuery(term)`,
  (M2) turn it into `setQuery((q) => q + term)`, (M3) force `aria-pressed={false}`
- `npx tsc --noEmit` and `npx vitest run src/components/kbli/` **on this branch alone**,
  without the files belonging to #5016, to test whether this PR stands on its own

## Raw Observations

```
git show origin/main:.../page.tsx | sed -n '236,254p' | grep -c "onClick"  → 0
```

```
baseline : Tests  5 passed (5)
M1       : Tests  4 failed | 1 passed (5)
M2       : Tests  1 failed | 4 passed (5)
M3       : Tests  1 failed | 4 passed (5)
restore  : Tests  5 passed (5)
```

```
this branch, isolated from #5016:
  TSC_RC=0
  Test Files  11 passed (11)
  Tests  73 passed (73)
```

```
diffstat: 3 files changed, 128 insertions(+), 15 deletions(-)
files: page.tsx, KBLISearch.tsx, KBLISearch.quick-filters.test.tsx
grep "KBLISectorBrowser|KBLISectorGrid" on this branch's page.tsx → 2
```

## Reasoning Path

- `grep -c onClick` = 0 on `origin/main` turns this PR's premise into a measured fact
  rather than an assumption: the chips genuinely could never do anything.
- M1 takes down 4 of the 5 tests at once. That is what shows `setQuery` is the sole
  mechanism — if the chips had a search path of their own alongside the query, killing
  `setQuery` would only have taken down some of them.
- M2 (append) and M3 (`aria-pressed`) each take down exactly one test → those two
  behaviours are genuinely covered separately, not masked by another assertion.
- 73 = 72 (suite before either PR) + 5 (chips) − 4 (belonging to #5016). That number is
  what proves this branch passes without its sibling's files, rather than "green on my
  machine".
- The 2 in the last grep is the `KBLISectorGrid` that `main` already had and this PR
  leaves alone → none of #5016's change leaked in here.

## Risk / Implication

- The chip row moves out of `page.tsx` into `KBLISearch`. The prop is optional, so a
  caller passing no `quickFilters` renders no row — but this does hand more presentation
  responsibility to the search component.
- A chip **replaces** the term, it does not append. If someone has typed something and
  then hits a chip, their typing is gone. Deliberate; if that is unwanted, the behaviour
  lives in one function (`handleQuickFilter`).
- Not verified: whether the five terms return *relevant* results. That depends on the
  search backend, not on this code. If a term misses, what needs changing is the term
  (e.g. "Tech" → "software"), not the wiring.
- `page.tsx` is also touched by #5016 in a different hunk; whichever lands second needs
  `gh pr update-branch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
