### PR TITLE
fix(crm): email lookup matches the BTRIM unique index; duplicate error carries a readable id

### DIFF
--- a/apps/backend-rag/backend/services/crm/assignment.py
+++ b/apps/backend-rag/backend/services/crm/assignment.py
@@ -134,14 +134,18 @@ class ClientIdentityResolver:
         if not email:
             return None
 
+        normalized_email = email.strip().lower()
+        if not normalized_email:
+            return None
+
         async with self.db_pool.acquire() as conn:
             return await conn.fetchval(
                 """
                 SELECT id
                 FROM clients
-                WHERE LOWER(email) = LOWER($1)
+                WHERE LOWER(BTRIM(email)) = $1
             """,
-                email,
+                normalized_email,
             )
 
     @cache_invalidating(
@@ -364,21 +368,24 @@ async def check_duplicates(
     resolver = ClientIdentityResolver(db_pool)
 
     async with db_pool.acquire() as conn:
-        # 1. Check email exact match (case-insensitive)
+        # 1. Check email exact match (case-insensitive, matching the unique index)
         if email := client_data.get("email"):
-            existing = await conn.fetchrow(
-                "SELECT id, assigned_to FROM clients WHERE LOWER(email) = LOWER($1) AND id != $2",
-                email,
-                client_id,
-            )
-            if existing:
-                state["is_duplicate"] = True
-                state["matched_client_id"] = existing["id"]
-                state["assigned_lead"] = existing["assigned_to"]
-                logger.info(
-                    f"🔍 Duplicate detected: client_id={client_id} matches existing client_id={existing['id']} (email)",
+            normalized_email = email.strip().lower()
+            if normalized_email:
+                existing = await conn.fetchrow(
+                    "SELECT id, assigned_to FROM clients "
+                    "WHERE LOWER(BTRIM(email)) = $1 AND id != $2",
+                    normalized_email,
+                    client_id,
                 )
-                return state
+                if existing:
+                    state["is_duplicate"] = True
+                    state["matched_client_id"] = existing["id"]
+                    state["assigned_lead"] = existing["assigned_to"]
+                    logger.info(
+                        f"🔍 Duplicate detected: client_id={client_id} matches existing client_id={existing['id']} (email)",
+                    )
+                    return state
 
         # 2. Check phone exact match (normalized - remove spaces, dashes, + prefix)
         if phone := client_data.get("phone"):

--- a/apps/backend-rag/backend/services/crm/client_core.py
+++ b/apps/backend-rag/backend/services/crm/client_core.py
@@ -683,8 +683,8 @@ class EnhancedCRMService:
             existing = await self._find_duplicate_client(validated.model_dump())
             if existing:
                 raise ValidationError(
-                    "Client already exists with email or phone",
-                    {"existing_id": existing},
+                    f"Client already exists with email or phone (existing_id={existing})",
+                    field="email",
                 )
 
             async with self.db_pool.acquire() as conn, conn.transaction():

--- a/apps/backend-rag/backend/tests/services/crm/test_client_identity_resolver.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_client_identity_resolver.py
@@ -104,7 +104,20 @@ async def test_find_client_by_email_short_circuits_empty_email() -> None:
 
     assert await resolver.find_client_by_email("") is None
     assert await resolver.find_client_by_email("Client@Example.com") == 789
-    assert conn.fetchval_calls[0][1] == ("Client@Example.com",)
+    assert conn.fetchval_calls[0][1] == ("client@example.com",)
+
+
+@pytest.mark.asyncio
+async def test_find_client_by_email_matches_btrim_normalized_stored_email() -> None:
+    """The lookup must match the BTRIM-based clients email unique index."""
+    conn = FakeConn(fetchvals=[790])
+    resolver = ClientIdentityResolver(FakePool(conn))
+
+    assert await resolver.find_client_by_email(" X@Y.com ") == 790
+
+    query, args = conn.fetchval_calls[0]
+    assert "LOWER(BTRIM(email)) = $1" in query
+    assert args == ("x@y.com",)
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/services/crm/test_assignment.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm/test_assignment.py
@@ -191,8 +191,13 @@ class TestCheckDuplicates:
         conn = AsyncMock()
         conn.fetchrow.return_value = {"id": 99, "assigned_to": "lead@x.com"}
         pool, _ = _make_pool(conn)
-        result = await check_duplicates(self._make_state(), pool)
+        result = await check_duplicates(
+            self._make_state(client_data={"email": " J@X.COM ", "phone": None}), pool
+        )
         assert result["is_duplicate"] is True
+        query, email, _ = conn.fetchrow.await_args.args
+        assert "LOWER(BTRIM(email)) = $1" in query
+        assert email == "j@x.com"
 
     async def test_no_duplicate(self):
         from backend.services.crm.assignment import check_duplicates

--- a/apps/backend-rag/backend/tests/unit/services/crm/test_client_core_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/services/crm/test_client_core_coverage.py
@@ -573,13 +573,16 @@ async def test_create_client_duplicate_raises(crm_service, mock_pool):
     pool, conn = mock_pool
     conn.fetchval = AsyncMock(return_value=42)  # Duplicate found
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         await service.create_client(
             {
                 "full_name": "John Doe",
                 "email": "john@example.com",
             }
         )
+
+    assert exc_info.value.details["field"] == "email"
+    assert "existing_id=42" in exc_info.value.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two measured defects found by the garuda_ops recon (independent session, origin/main):

1. `find_client_by_email` searched `LOWER(email)` while migration 166's unique index is `ON clients (LOWER(BTRIM(email)))` — an email stored with whitespace was invisible to lookup and collided on insert. Lookup + `check_duplicates` now use the exact index expression and normalize the parameter.
2. The duplicate-client `ValidationError` passed a dict into `field: str | None`, burying `existing_id` where repo-wide grep found zero readers. Now `field="email"` with the id readable in the message.

Tests RED-first (4 red pre-fix), 127 passed on touched files, 192 on the CRM sweep, ruff clean. Built via codex gpt-5.6-terra seat; committed by the conductor (sandbox blocked the seat's git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCtR9Zz5kaHRDr9zqEyZS9