### PR TITLE
feat(garuda): give garuda_order_outbox the consumer it has never had

### DIFF
--- a/apps/backend-rag/backend/services/garuda_orders/outbox_consumer.py
+++ b/apps/backend-rag/backend/services/garuda_orders/outbox_consumer.py
@@ -1,0 +1,308 @@
+"""Drains `garuda_order_outbox` — the queue that has never had a consumer.
+
+`journal.enqueue_outbox` has ten callers in `repository.py` (checkout_ready_email,
+payment_paid_email, payment_failed_email, refund_email, practice_release and the
+five staff_page_* jobs). Nothing anywhere in this repository has ever SELECTed
+that table outside a test. Every row written since the table shipped is still
+sitting there with `dispatched_at IS NULL`: a customer who pays today receives no
+confirmation, because there is no code that could send one. This module is the
+missing half.
+
+WHY THE LOCK IS HELD ACROSS THE HANDLER (the one design decision that matters).
+`UNIQUE (journal_event_id, job_type)` makes "email once" structural on the WRITE
+side; nothing makes it structural on the DISPATCH side. If this consumer bumped
+`attempts`, committed, and only then ran the handler, the row would be unlocked
+while the email was in flight and a second worker could claim and send it again.
+So one job = one transaction, and the transaction spans the handler. The cost is
+paid honestly: a handler that raises has its `attempts` bump committed (the
+`except` is INSIDE the transaction, so the bump survives), while a hard process
+crash mid-send rolls the bump back and the job is retried. Duplicate-send is the
+worse failure for a customer-facing email, so it is the one we exclude.
+
+WHAT THIS MODULE REFUSES TO DO SILENTLY (superscar #2 / W81b — the DLQ corpses
+nobody ever cleaned, and W53 — the missing TERMINAL gate). A job that exhausts
+`max_attempts` is NOT deleted, NOT marked dispatched, and NOT quietly filtered
+out of existence. It stops being claimed, and `count_undrained` reports it under
+`exhausted` so a probe can go red. The same holds for a job whose `job_type` has
+no registered handler: it is counted as `unroutable` and logged by name, never
+consumed. An outbox that empties itself by forgetting is worse than one that
+never ran, because the first looks healthy.
+
+WHY THERE IS NO AGE-BASED DROP. The house pattern next door
+(`war_room/wr2_outbox_consumer.py`) filters `created_at > NOW() - INTERVAL '72
+hours'`, which means a job older than three days silently ceases to exist while
+the stats call it `skipped_stale`. For a customer's payment confirmation that is
+a lost email with a green log line. Age here only ever *reports* (see
+`count_undrained`); it never excludes.
+
+ARMED STATE. `is_consumer_enabled()` fails closed: anything but the literal
+string "true" leaves this disarmed, matching the frontend's
+`isGarudaVoaPublicEnabled`. Nothing schedules this module yet — wiring a worker
+or a cron to it is a separate, deliberate act. Built is not armed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger("garuda.orders.outbox_consumer")
+
+OUTBOX_TABLE = "garuda_order_outbox"
+
+DEFAULT_BATCH_SIZE = 20
+DEFAULT_MAX_ATTEMPTS = 5
+
+KILL_SWITCH_ENV = "GARUDA_OUTBOX_CONSUMER_ENABLED"
+
+
+def is_consumer_enabled(env: dict[str, str] | None = None) -> bool:
+    """True only for the exact string "true" — every other value disarms.
+
+    Fail-closed on purpose: an unset variable, a typo, "1", "yes" and "TRUE"
+    all leave the consumer off. A queue that starts draining because someone
+    exported a truthy-looking string is not a queue anyone controls.
+    """
+
+    source = os.environ if env is None else env
+    return source.get(KILL_SWITCH_ENV) == "true"
+
+
+@dataclass(frozen=True, slots=True)
+class OutboxJob:
+    """One claimed row, decoded. `attempts` is the value AFTER this claim's bump."""
+
+    id: int
+    order_id: str
+    journal_event_id: str
+    job_type: str
+    payload: dict[str, Any]
+    attempts: int
+
+
+Handler = Callable[["OutboxJob"], Awaitable[None]]
+"""A handler signals success by returning and failure by RAISING.
+
+There is deliberately no boolean return channel. `return False` makes "I did
+nothing" and "I failed" indistinguishable at the call site, and the neighbouring
+WR2 consumer shows where that leads: a handler that quietly returns a falsy
+value is counted as `failed` with no exception, no traceback and no reason in
+the log. Raise, and the reason is recorded.
+"""
+
+
+class _Rollback(Exception):
+    """Internal: abort one job's transaction without failing the drain pass."""
+
+
+@dataclass(frozen=True, slots=True)
+class DrainStats:
+    """Outcome of one drain pass. Every claimed job lands in exactly one bucket."""
+
+    claimed: int = 0
+    dispatched: int = 0
+    failed: int = 0
+    unroutable: int = 0
+    unroutable_types: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def accounted(self) -> int:
+        return self.dispatched + self.failed + self.unroutable
+
+
+async def _claim_one(
+    conn: asyncpg.Connection, *, max_attempts: int, exclude_ids: list[int]
+) -> asyncpg.Record | None:
+    """Claim the oldest undispatched, non-exhausted row and bump its attempt count.
+
+    `FOR UPDATE SKIP LOCKED` is what makes more than one worker safe: a row another
+    transaction already holds is stepped over rather than waited on. `LIMIT 1` is
+    not a throughput oversight — batching several rows into one transaction would
+    let a single poison job roll back its innocent siblings.
+
+    `exclude_ids` carries the rows this drain pass has already touched, and it is
+    load-bearing rather than an optimisation. A failed job stays `dispatched_at
+    IS NULL` and an unroutable one has its attempt bump rolled back, so without
+    this filter both are immediately eligible again on the very next iteration:
+    one poisoned job would burn its whole `max_attempts` budget inside a single
+    pass in milliseconds (destroying the point of a retry limit, which is to
+    spread attempts over TIME), and one unroutable job would be re-claimed for
+    every slot in the batch, starving every other job behind it. Measured on the
+    first run of this module's own suite: 5 attempts consumed in 0.03s, and 20
+    claims of one unroutable row in a batch of 20.
+    """
+
+    return await conn.fetchrow(
+        f"""
+        UPDATE {OUTBOX_TABLE} AS o
+           SET attempts = o.attempts + 1
+         WHERE o.id = (
+                SELECT c.id
+                  FROM {OUTBOX_TABLE} AS c
+                 WHERE c.dispatched_at IS NULL
+                   AND c.attempts < $1
+                   AND NOT (c.id = ANY($2::bigint[]))
+                 ORDER BY c.created_at ASC, c.id ASC
+                 LIMIT 1
+                 FOR UPDATE SKIP LOCKED
+               )
+     RETURNING o.id, o.order_id, o.journal_event_id, o.job_type,
+               o.payload, o.attempts
+        """,
+        max_attempts,
+        exclude_ids,
+    )
+
+
+def _decode(row: asyncpg.Record) -> OutboxJob:
+    raw = row["payload"]
+    payload = json.loads(raw) if isinstance(raw, str) else (raw or {})
+    return OutboxJob(
+        id=row["id"],
+        order_id=row["order_id"],
+        journal_event_id=row["journal_event_id"],
+        job_type=row["job_type"],
+        payload=payload,
+        attempts=row["attempts"],
+    )
+
+
+async def drain_once(
+    conn: asyncpg.Connection,
+    handlers: dict[str, Handler],
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> DrainStats:
+    """Claim and dispatch up to `batch_size` jobs, one transaction each.
+
+    Returns without touching the database when the kill switch is off — an
+    explicitly disarmed consumer must not hold connections or take locks.
+
+    A job whose `job_type` is absent from `handlers` is left exactly as found:
+    not dispatched, and its attempt bump rolled back, so registering the handler
+    later picks it up with a full attempt budget rather than one already spent
+    down by passes that never even tried to deliver it.
+    """
+
+    if not is_consumer_enabled():
+        logger.debug("outbox consumer disarmed (%s != 'true')", KILL_SWITCH_ENV)
+        return DrainStats()
+
+    claimed = dispatched = failed = unroutable = 0
+    unroutable_types: set[str] = set()
+    # Every row this pass has already touched. See `_claim_one`: a failed or
+    # unroutable row is still eligible the instant its transaction ends, so
+    # without this list one job monopolises the batch and spends its whole
+    # retry budget in a single pass.
+    touched_ids: list[int] = []
+    # Log each unroutable job_type once per pass rather than once per row.
+    logged_types: set[str] = set()
+
+    for _ in range(batch_size):
+        try:
+            async with conn.transaction():
+                row = await _claim_one(conn, max_attempts=max_attempts, exclude_ids=touched_ids)
+                if row is None:
+                    break
+                job = _decode(row)
+                claimed += 1
+                touched_ids.append(job.id)
+
+                handler = handlers.get(job.job_type)
+                if handler is None:
+                    unroutable += 1
+                    unroutable_types.add(job.job_type)
+                    if job.job_type not in logged_types:
+                        logged_types.add(job.job_type)
+                        logger.error(
+                            "outbox job_type=%s has no registered handler; "
+                            "job id=%s order_id=%s left undispatched",
+                            job.job_type,
+                            job.id,
+                            job.order_id,
+                        )
+                    raise _Rollback  # undo the attempt bump: nothing was tried
+
+                try:
+                    await handler(job)
+                except Exception:
+                    # Caught INSIDE the transaction on purpose: the attempt bump
+                    # must survive a handled failure, or a job that always fails
+                    # would never reach `max_attempts` and never become visible.
+                    failed += 1
+                    logger.exception(
+                        "outbox handler failed job_type=%s id=%s order_id=%s attempt=%s/%s",
+                        job.job_type,
+                        job.id,
+                        job.order_id,
+                        job.attempts,
+                        max_attempts,
+                    )
+                else:
+                    await conn.execute(
+                        f"UPDATE {OUTBOX_TABLE} "
+                        "SET dispatched_at = statement_timestamp() WHERE id = $1",
+                        job.id,
+                    )
+                    dispatched += 1
+        except _Rollback:
+            continue
+
+    return DrainStats(
+        claimed=claimed,
+        dispatched=dispatched,
+        failed=failed,
+        unroutable=unroutable,
+        unroutable_types=frozenset(unroutable_types),
+    )
+
+
+async def count_undrained(
+    conn: asyncpg.Connection, *, max_attempts: int = DEFAULT_MAX_ATTEMPTS
+) -> dict[str, int]:
+    """The numbers a probe needs to go red. Reports; never deletes, never hides.
+
+    `exhausted` is the one that matters: those rows will never be claimed again
+    by `drain_once`, so without this count they are invisible — which is exactly
+    how fourteen DLQ corpses once sat unnoticed (W81b).
+    """
+
+    row = await conn.fetchrow(
+        f"""
+        SELECT
+            count(*) FILTER (WHERE dispatched_at IS NULL)             AS undispatched,
+            count(*) FILTER (WHERE dispatched_at IS NULL
+                               AND attempts >= $1)                     AS exhausted,
+            count(*) FILTER (WHERE dispatched_at IS NULL
+                               AND created_at < statement_timestamp()
+                                                - INTERVAL '1 hour')   AS older_than_1h,
+            count(*) FILTER (WHERE dispatched_at IS NULL
+                               AND created_at < statement_timestamp()
+                                                - INTERVAL '24 hours') AS older_than_24h
+          FROM {OUTBOX_TABLE}
+        """,
+        max_attempts,
+    )
+    assert row is not None  # a bare aggregate SELECT always returns one row
+    return {k: int(v) for k, v in dict(row).items()}
+
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_MAX_ATTEMPTS",
+    "KILL_SWITCH_ENV",
+    "OUTBOX_TABLE",
+    "DrainStats",
+    "Handler",
+    "OutboxJob",
+    "count_undrained",
+    "drain_once",
+    "is_consumer_enabled",
+]

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
@@ -1,0 +1,435 @@
+"""Real-database tests for the `garuda_order_outbox` consumer.
+
+Real Postgres, not a fake, and deliberately so: every claim this consumer makes
+lives in SQL, not in Python. `FOR UPDATE SKIP LOCKED`, the attempt bump that must
+survive a handled exception, the rollback that must NOT let an unroutable job
+spend its budget — a hand-written double would test the author's mental model of
+Postgres rather than Postgres, which is how a fake and the code it stands in for
+come to share the same imagination (W114).
+
+DSN resolution follows the sibling money-path suite (`test_repository_integration.py`):
+`INTAKE_TEST_DSN` is what CI actually sets, `GARUDA_L3_TEST_DSN` is an optional
+local override. In CI a connection failure FAILS rather than skips — a skip in a
+gate is a fail-open.
+
+Rows are written through the production writers (`journal.append_event`,
+`journal.enqueue_outbox`) rather than by hand, so a schema change that breaks the
+real enqueue path breaks these tests too instead of leaving them green against a
+shape that no longer exists.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from backend.services.garuda_orders import journal
+from backend.services.garuda_orders.outbox_consumer import (
+    DEFAULT_MAX_ATTEMPTS,
+    KILL_SWITCH_ENV,
+    OutboxJob,
+    count_undrained,
+    drain_once,
+    is_consumer_enabled,
+)
+
+_DSN = (
+    os.environ.get("GARUDA_L3_TEST_DSN")
+    or os.environ.get("INTAKE_TEST_DSN")
+    or "postgresql://localhost:5432/garuda_outbox_test_0826"
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+
+async def _connect() -> asyncpg.Connection:
+    try:
+        return await asyncpg.connect(_DSN)
+    except (OSError, asyncpg.PostgresError) as exc:
+        if os.environ.get("CI"):
+            pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
+        pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+
+
+@pytest.fixture
+async def conn():
+    c = await _connect()
+    try:
+        await c.execute("TRUNCATE garuda_order_outbox, garuda_order_journal, garuda_orders CASCADE")
+        yield c
+    finally:
+        await c.close()
+
+
+@pytest.fixture(autouse=True)
+def armed(monkeypatch):
+    """Every test but the disarmed ones runs with the kill switch ON."""
+
+    monkeypatch.setenv(KILL_SWITCH_ENV, "true")
+
+
+async def _seed_order(conn: asyncpg.Connection) -> str:
+    order_id = f"ord_{uuid.uuid4().hex}"
+    await conn.execute(
+        """
+        INSERT INTO garuda_orders
+            (order_id, result_id_ref, case_type, applicant_full_name,
+             applicant_email, applicant_phone, applicant_passport_number,
+             price_idr, price_catalogue_key)
+        VALUES ($1, $2, 'issuance', 'SPECIMEN TRAVELLER',
+                'specimen@example.invalid', '+000000000000', 'X0000000',
+                790000, 'B1 Visa on Arrival (VOA)')
+        """,
+        order_id,
+        f"chk_{uuid.uuid4().hex}",
+    )
+    return order_id
+
+
+async def _enqueue(conn: asyncpg.Connection, order_id: str, job_type: str, payload=None) -> int:
+    """Enqueue through the PRODUCTION writers, then return the outbox row id."""
+
+    event_id = await journal.append_event(
+        conn,
+        event_name="payment.paid",
+        aggregate_type="order",
+        aggregate_id=order_id,
+        transition_id="OP-02",
+        customer_visible=True,
+    )
+    await journal.enqueue_outbox(
+        conn,
+        order_id=order_id,
+        journal_event_id=event_id,
+        job_type=job_type,
+        payload=payload,
+    )
+    return await conn.fetchval(
+        "SELECT id FROM garuda_order_outbox WHERE journal_event_id = $1", event_id
+    )
+
+
+async def _row(conn: asyncpg.Connection, row_id: int):
+    return await conn.fetchrow(
+        "SELECT attempts, dispatched_at FROM garuda_order_outbox WHERE id = $1", row_id
+    )
+
+
+def _recording_handler(seen: list[OutboxJob]):
+    async def handler(job: OutboxJob) -> None:
+        seen.append(job)
+
+    return handler
+
+
+async def _always_fails(job: OutboxJob) -> None:
+    raise RuntimeError("handler blew up")
+
+
+# --------------------------------------------------------------------------
+# the kill switch
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "yes", "TRUE", "True", "", "false", " true"])
+def test_kill_switch_accepts_only_the_literal_true(value):
+    assert is_consumer_enabled({KILL_SWITCH_ENV: value}) is False
+
+
+def test_kill_switch_arms_on_exactly_true():
+    assert is_consumer_enabled({KILL_SWITCH_ENV: "true"}) is True
+
+
+def test_kill_switch_is_off_when_unset():
+    assert is_consumer_enabled({}) is False
+
+
+async def test_a_disarmed_consumer_does_not_touch_a_single_row(conn, monkeypatch):
+    """Disarmed must mean disarmed: no claim, no attempt bump, no dispatch.
+
+    Goes red if `drain_once` ever consults the database before checking the
+    switch — which is the difference between a kill switch and a log line.
+    """
+
+    monkeypatch.delenv(KILL_SWITCH_ENV, raising=False)
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "payment_paid_email")
+
+    seen: list[OutboxJob] = []
+    stats = await drain_once(conn, {"payment_paid_email": _recording_handler(seen)})
+
+    assert (stats.claimed, stats.dispatched, stats.accounted) == (0, 0, 0)
+    assert seen == []
+    row = await _row(conn, row_id)
+    assert row["attempts"] == 0
+    assert row["dispatched_at"] is None
+
+
+# --------------------------------------------------------------------------
+# the happy path, and the fact that it happens exactly once
+# --------------------------------------------------------------------------
+
+
+async def test_a_handled_job_is_marked_dispatched_and_never_claimed_again(conn):
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "payment_paid_email", {"to": "redacted"})
+
+    seen: list[OutboxJob] = []
+    first = await drain_once(conn, {"payment_paid_email": _recording_handler(seen)})
+
+    assert (first.claimed, first.dispatched, first.failed) == (1, 1, 0)
+    assert [j.job_type for j in seen] == ["payment_paid_email"]
+    assert seen[0].payload == {"to": "redacted"}, "payload must arrive decoded"
+    assert seen[0].order_id == order_id
+
+    row = await _row(conn, row_id)
+    assert row["dispatched_at"] is not None
+    assert row["attempts"] == 1
+
+    second = await drain_once(conn, {"payment_paid_email": _recording_handler(seen)})
+    assert (second.claimed, second.dispatched) == (0, 0)
+    assert len(seen) == 1, "a dispatched job must never be handed to a handler twice"
+
+
+async def test_batch_size_bounds_one_pass(conn):
+    order_id = await _seed_order(conn)
+    for _ in range(5):
+        await _enqueue(conn, order_id, "payment_paid_email")
+
+    seen: list[OutboxJob] = []
+    stats = await drain_once(conn, {"payment_paid_email": _recording_handler(seen)}, batch_size=2)
+    assert (stats.claimed, stats.dispatched) == (2, 2)
+    assert len(seen) == 2
+
+
+# --------------------------------------------------------------------------
+# failure: the attempt must be SPENT, or exhaustion can never be reached
+# --------------------------------------------------------------------------
+
+
+async def test_a_failing_handler_spends_the_attempt_and_leaves_the_job_pending(conn):
+    """The single most load-bearing behaviour in the module.
+
+    The `except` sits INSIDE the transaction so the attempt bump commits. If it
+    were moved outside — the natural-looking refactor — the bump would roll back
+    with the exception, `attempts` would stay 0 forever, and a permanently
+    poisoned job would retry until the end of time while `count_undrained`
+    reported zero exhausted rows. This test goes red the moment that happens.
+    """
+
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "payment_paid_email")
+
+    stats = await drain_once(conn, {"payment_paid_email": _always_fails})
+
+    assert (stats.claimed, stats.dispatched, stats.failed) == (1, 0, 1)
+    row = await _row(conn, row_id)
+    assert row["dispatched_at"] is None, "a failed job must stay claimable"
+    assert row["attempts"] == 1, "the attempt must be recorded, not rolled back"
+
+
+async def test_a_failing_job_spends_ONE_attempt_per_pass_not_its_whole_budget(conn):
+    """The retry limit must bound attempts over TIME, not over one loop.
+
+    This is a regression pin for a defect this suite caught on its first run: a
+    failed row stays claimable the moment its transaction ends, so with no
+    per-pass exclusion the same job was re-claimed on every iteration and burned
+    all five attempts in 0.03 seconds. The batch is sized deliberately larger
+    than `DEFAULT_MAX_ATTEMPTS` so that removing the exclusion fails here.
+    """
+
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "payment_paid_email")
+
+    stats = await drain_once(
+        conn,
+        {"payment_paid_email": _always_fails},
+        batch_size=DEFAULT_MAX_ATTEMPTS + 3,
+    )
+
+    assert stats.claimed == 1, "one pass must claim a given job at most once"
+    assert stats.failed == 1
+    assert (await _row(conn, row_id))["attempts"] == 1
+
+
+async def test_a_job_stops_being_claimed_at_max_attempts_and_is_reported_exhausted(
+    conn,
+):
+    """Exhaustion is visible, not silent. W81b: corpses nobody could see."""
+
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "payment_paid_email")
+
+    for expected in range(1, DEFAULT_MAX_ATTEMPTS + 1):
+        stats = await drain_once(conn, {"payment_paid_email": _always_fails})
+        assert stats.failed == 1
+        assert (await _row(conn, row_id))["attempts"] == expected
+
+    spent = await drain_once(conn, {"payment_paid_email": _always_fails})
+    assert spent.claimed == 0, "an exhausted job must stop being retried"
+
+    counts = await count_undrained(conn)
+    assert counts["exhausted"] == 1, "an exhausted job must remain COUNTABLE"
+    assert counts["undispatched"] == 1
+
+    still_there = await _row(conn, row_id)
+    assert still_there is not None, "counting must never delete"
+    assert still_there["dispatched_at"] is None, "counting must never mark dispatched"
+
+
+async def test_one_poison_job_does_not_roll_back_a_sibling_that_succeeded(conn):
+    """One transaction per job. A shared batch transaction fails this."""
+
+    order_id = await _seed_order(conn)
+    poison_id = await _enqueue(conn, order_id, "payment_paid_email")
+    good_id = await _enqueue(conn, order_id, "refund_email")
+
+    seen: list[OutboxJob] = []
+    stats = await drain_once(
+        conn,
+        {
+            "payment_paid_email": _always_fails,
+            "refund_email": _recording_handler(seen),
+        },
+    )
+
+    assert (stats.claimed, stats.dispatched, stats.failed) == (2, 1, 1)
+    assert (await _row(conn, poison_id))["dispatched_at"] is None
+    assert (await _row(conn, good_id))["dispatched_at"] is not None
+    assert [j.job_type for j in seen] == ["refund_email"]
+
+
+# --------------------------------------------------------------------------
+# unroutable: counted and named, never consumed, budget untouched
+# --------------------------------------------------------------------------
+
+
+async def test_an_unroutable_job_is_reported_and_keeps_its_whole_attempt_budget(conn):
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "practice_release")
+
+    stats = await drain_once(conn, {})
+
+    assert stats.unroutable == 1
+    assert stats.dispatched == 0
+    assert "practice_release" in stats.unroutable_types
+    row = await _row(conn, row_id)
+    assert row["dispatched_at"] is None, "an unrouted job must never look delivered"
+    assert row["attempts"] == 0, (
+        "the attempt bump must be rolled back — a job nobody tried to deliver "
+        "must not burn its budget while waiting for its handler to be written"
+    )
+
+
+async def test_an_unroutable_job_does_not_starve_the_rest_of_the_batch(conn):
+    """Goes red if the unroutable row is re-claimed for the whole batch."""
+
+    order_id = await _seed_order(conn)
+    await _enqueue(conn, order_id, "practice_release")
+    await _enqueue(conn, order_id, "payment_paid_email")
+
+    seen: list[OutboxJob] = []
+    stats = await drain_once(conn, {"payment_paid_email": _recording_handler(seen)}, batch_size=5)
+
+    assert stats.unroutable == 1
+    assert stats.dispatched == 1
+    assert [j.job_type for j in seen] == ["payment_paid_email"]
+
+
+async def test_registering_the_handler_later_delivers_the_previously_unroutable_job(
+    conn,
+):
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "practice_release")
+
+    await drain_once(conn, {})
+    seen: list[OutboxJob] = []
+    stats = await drain_once(conn, {"practice_release": _recording_handler(seen)})
+
+    assert stats.dispatched == 1
+    assert (await _row(conn, row_id))["attempts"] == 1, (
+        "the delivered attempt is the FIRST one — earlier unrouted passes must "
+        "not have counted against it"
+    )
+
+
+# --------------------------------------------------------------------------
+# concurrency: the "email once" claim, actually exercised
+# --------------------------------------------------------------------------
+
+
+async def test_a_job_locked_by_another_worker_is_skipped_not_waited_on(conn):
+    """`FOR UPDATE SKIP LOCKED`, proven rather than asserted in a docstring.
+
+    Worker A holds an open transaction on the only job. Worker B must come back
+    empty-handed IMMEDIATELY and must not hand that job to its handler — if the
+    lock were a plain `FOR UPDATE`, B would block until A finished and this test
+    would hang; if there were no lock at all, B would dispatch a second copy of
+    a customer email and `seen` would be non-empty.
+    """
+
+    order_id = await _seed_order(conn)
+    await _enqueue(conn, order_id, "payment_paid_email")
+
+    other = await _connect()
+    try:
+        tx = other.transaction()
+        await tx.start()
+        held = await other.fetchrow(
+            """
+            SELECT id FROM garuda_order_outbox
+             WHERE dispatched_at IS NULL
+             ORDER BY created_at ASC, id ASC
+             LIMIT 1 FOR UPDATE SKIP LOCKED
+            """
+        )
+        assert held is not None, "worker A should have taken the only job"
+
+        seen: list[OutboxJob] = []
+        stats = await drain_once(conn, {"payment_paid_email": _recording_handler(seen)})
+        assert stats.claimed == 0
+        assert seen == [], "the same job must never be dispatched twice"
+
+        await tx.rollback()
+    finally:
+        await other.close()
+
+    seen_after: list[OutboxJob] = []
+    after = await drain_once(conn, {"payment_paid_email": _recording_handler(seen_after)})
+    assert after.dispatched == 1, "once released, the job is claimable again"
+    assert len(seen_after) == 1
+
+
+# --------------------------------------------------------------------------
+# the probe itself
+# --------------------------------------------------------------------------
+
+
+async def test_count_undrained_reports_every_bucket_and_deletes_nothing(conn):
+    order_id = await _seed_order(conn)
+    await _enqueue(conn, order_id, "payment_paid_email")
+    await _enqueue(conn, order_id, "refund_email")
+
+    before = await count_undrained(conn)
+    assert before["undispatched"] == 2
+    assert before["exhausted"] == 0
+    assert before["older_than_1h"] == 0
+    assert before["older_than_24h"] == 0
+
+    seen: list[OutboxJob] = []
+    await drain_once(conn, {"payment_paid_email": _recording_handler(seen)})
+
+    after = await count_undrained(conn)
+    assert after["undispatched"] == 1, "a dispatched job leaves the undispatched count"
+    assert await conn.fetchval("SELECT count(*) FROM garuda_order_outbox") == 2, (
+        "reporting must never remove a row"
+    )


### PR DESCRIPTION
## What this closes

`journal.enqueue_outbox` has ten callers in `repository.py` (`payment_paid_email`, `payment_failed_email`, `refund_email`, `checkout_ready_email`, `practice_release`, five `staff_page_*`). **Nothing in this repository has ever SELECTed that table outside a test.** Every row written since the table shipped still has `dispatched_at IS NULL`.

In plain terms: a customer who pays today receives no confirmation, because no code exists that could send one. The gap is already recorded in two places in-repo — the comment at `services/garuda_portal/practice.py:23` and a standing `PENDING-ARMS.md` entry. This PR adds the missing drain half.

**This PR does not arm anything.** Nothing schedules the module, no handler is registered, and `is_consumer_enabled()` fails closed on anything but the literal string `"true"`. Built is not armed — arming is a separate, deliberate act later in this lane.

## Three decisions, each pinned by a test that goes red without it

**1 — the row lock is held across the handler.** `UNIQUE (journal_event_id, job_type)` makes "email once" structural on the *write* side; nothing makes it structural on the *dispatch* side. Bumping `attempts`, committing, and only then sending would leave the row unlocked while the email is in flight, so a second worker could send a duplicate. One job = one transaction, and the transaction spans the handler. The cost is paid openly: a *handled* exception commits its attempt bump (the `except` sits inside the transaction), while a *hard crash* mid-send rolls the bump back and the job retries. Duplicate-send is the worse failure for a customer-facing email, so it is the one excluded.

**2 — exhausted and unroutable jobs are counted, never hidden** (superscar #2 / W81b, W53). A job at `max_attempts` stops being claimed but stays visible via `count_undrained()['exhausted']`, so a probe can go red. An unroutable `job_type` is logged by name and keeps its full attempt budget, so registering its handler later delivers it with a clean count. Deliberately unlike the house pattern next door (`war_room/wr2_outbox_consumer.py`), which drops anything older than 72h and reports it as `skipped_stale` — for a payment confirmation that is a lost email with a green log line. Age here only ever *reports*; it never excludes.

**3 — one transaction per job, and no row is claimed twice in the same pass.** The second half was **not** in the first draft, and this suite caught it on its first run:

- a failing job was re-claimed on every loop iteration and burned all 5 attempts in **0.03s** — defeating the entire point of a retry limit, which is to spread attempts over *time*;
- one unroutable row was claimed for all **20** slots of a batch, starving every job behind it.

Both were real defects in my own code, found because the tests were written to be able to fail. `test_a_failing_job_spends_ONE_attempt_per_pass_not_its_whole_budget` is the regression pin.

## How it is verified

Real Postgres, not a fake — every claim this module makes lives in SQL (`FOR UPDATE SKIP LOCKED`, the attempt bump that must survive a handled exception, the rollback that must not spend an unrouted job's budget). A hand-written double would test my mental model of Postgres rather than Postgres, which is how a fake and the code it stands in for come to share the same imagination (W114).

- DSN via `INTAKE_TEST_DSN` — the variable CI actually sets — following the sibling money-path suite. In CI a connection failure **fails** rather than skips: a skip in a gate is a fail-open.
- Rows are seeded through the **production writers** (`journal.append_event`, `journal.enqueue_outbox`), so a schema change breaks these tests instead of leaving them green against a shape that no longer exists.
- `SKIP LOCKED` is exercised with a **second connection holding the row**, not asserted in a docstring. Under a plain `FOR UPDATE` that test hangs; with no lock it dispatches a duplicate.

Locally, against a database built exactly the way CI builds it (`ci_bootstrap_schema.py` then `migrate apply-all`): **21 new tests pass, 78 pass across the whole `garuda_orders` family**, ruff clean and formatted.

## Scope note

+743 lines, above the ~400 the PR contract asks for: 435 of them are the test module and a large share of the rest is docstring explaining the two decisions above. The production surface is one new file that nothing imports yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F6trtRZb8RpPDG3PsCg2H