### PR TITLE
fix(garuda): pin the outbox consumer's cancellation contract with tests

### DIFF
--- a/apps/backend-rag/backend/services/garuda_orders/outbox_consumer.py
+++ b/apps/backend-rag/backend/services/garuda_orders/outbox_consumer.py
@@ -189,6 +189,32 @@ async def drain_once(
     not dispatched, and its attempt bump rolled back, so registering the handler
     later picks it up with a full attempt budget rather than one already spent
     down by passes that never even tried to deliver it.
+
+    `batch_size` costs more than linear WHEN JOBS FAIL, and this is worth
+    stating precisely because the obvious reading is wrong. The per-pass
+    exclusion list (see `_claim_one`) is an unindexable `NOT (id = ANY(...))`,
+    but a job that DISPATCHES gets `dispatched_at` set and thereby leaves
+    `idx_garuda_order_outbox_undispatched` — a partial index on `(created_at)
+    WHERE dispatched_at IS NULL` — so the happy path stays linear and the
+    exclusion list never has to be walked for it. What the list actually pays
+    for are the rows this pass touched and LEFT undispatched (failed and
+    unroutable ones): each remains in the index, so every later claim in the
+    same pass scans past all of them. The cost is therefore
+    O(batch_size * undispatched_touched), i.e. quadratic only in a pass that
+    is failing wholesale. At the default of 20 even the worst case is a few
+    hundred comparisons; a caller passing thousands into a failing queue is
+    the one shape where this bites, and should call `drain_once` repeatedly
+    instead. No ceiling is enforced because the right one depends on the
+    deployment.
+
+    CANCELLATION IS NOT A HANDLER FAILURE. The `except Exception` around the
+    handler deliberately does not catch `BaseException`, so an
+    `asyncio.CancelledError` (worker shutdown, task cancellation) propagates
+    out of the transaction — rolling back that job's attempt bump — and then
+    out of `drain_once` itself, abandoning the rest of the batch. That is the
+    intended behaviour: a cancelled worker must stop, not quietly continue
+    delivering customer email, and the interrupted job must not be charged an
+    attempt for work nobody asked it to finish.
     """
 
     if not is_consumer_enabled():
@@ -290,7 +316,16 @@ async def count_undrained(
         """,
         max_attempts,
     )
-    assert row is not None  # a bare aggregate SELECT always returns one row
+    if row is None:
+        # A bare aggregate SELECT always returns exactly one row, so this is
+        # unreachable — which is precisely why it must not be an `assert`.
+        # `python -O` strips asserts, and the stripped version would fall
+        # through to `dict(None)` and raise a bare TypeError instead of saying
+        # what happened. An explicit raise survives every invocation mode.
+        raise RuntimeError(
+            f"aggregate SELECT over {OUTBOX_TABLE} returned no row; "
+            "the database did not answer a query that cannot be empty"
+        )
     return {k: int(v) for k, v in dict(row).items()}
 
 

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
@@ -20,6 +20,7 @@ shape that no longer exists.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
 
@@ -306,6 +307,85 @@ async def test_one_poison_job_does_not_roll_back_a_sibling_that_succeeded(conn):
     assert (await _row(conn, poison_id))["dispatched_at"] is None
     assert (await _row(conn, good_id))["dispatched_at"] is not None
     assert [j.job_type for j in seen] == ["refund_email"]
+
+
+# --------------------------------------------------------------------------
+# cancellation is not a handler failure
+# --------------------------------------------------------------------------
+
+
+async def test_a_raised_cancellation_leaves_the_batch_and_charges_no_attempt(conn):
+    """`except Exception` must not swallow a `CancelledError`.
+
+    Widening that catch to `BaseException` would look harmless in review and be
+    wrong twice over: the interrupted job would be charged an attempt for work
+    nobody asked it to finish, and a worker told to shut down would carry on
+    delivering customer email for the rest of the batch. Both are pinned here.
+
+    This raises the error rather than cancelling the task, so it proves the
+    `except` clause's reach, not the behaviour of a real cancellation while an
+    await is in flight — that is the next test.
+    """
+
+    order_id = await _seed_order(conn)
+    first = await _enqueue(conn, order_id, "payment_paid_email")
+    second = await _enqueue(conn, order_id, "payment_paid_email")
+
+    seen: list[OutboxJob] = []
+
+    async def cancels(job: OutboxJob) -> None:
+        seen.append(job)
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await drain_once(conn, {"payment_paid_email": cancels})
+
+    assert len(seen) == 1, "the pass must stop at the cancelled job, not continue"
+
+    for row_id in (first, second):
+        row = await _row(conn, row_id)
+        assert row["attempts"] == 0, "a cancelled attempt is rolled back, not spent"
+        assert row["dispatched_at"] is None
+
+
+async def test_a_real_task_cancellation_rolls_the_attempt_back(conn):
+    """The same property under an actual `task.cancel()` mid-await.
+
+    The row is observed from a SECOND connection: the cancelled one is unwinding
+    its own transaction, and asking it about the row would be asking the suspect
+    to describe the crime. A `wait_for` bounds the read so a row left locked
+    fails the test instead of hanging the suite.
+    """
+
+    order_id = await _seed_order(conn)
+    row_id = await _enqueue(conn, order_id, "payment_paid_email")
+
+    entered = asyncio.Event()
+
+    async def blocks(job: OutboxJob) -> None:
+        entered.set()
+        await asyncio.sleep(3600)
+
+    task = asyncio.create_task(drain_once(conn, {"payment_paid_email": blocks}))
+    await asyncio.wait_for(entered.wait(), timeout=10)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    observer = await _connect()
+    try:
+        row = await asyncio.wait_for(
+            observer.fetchrow(
+                "SELECT attempts, dispatched_at FROM garuda_order_outbox WHERE id = $1",
+                row_id,
+            ),
+            timeout=10,
+        )
+    finally:
+        await observer.close()
+
+    assert row["attempts"] == 0, "the interrupted attempt must not be charged"
+    assert row["dispatched_at"] is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the adversarial review of #5019 (now on `main`). Three findings, none blocking, all about a claim the module made without evidence.

## 1. `assert` → explicit raise (`count_undrained`)

`assert row is not None` is unreachable — a bare aggregate SELECT always returns exactly one row. That is precisely why it must not be an assert: `python -O` strips assertions, and the stripped build falls through to `dict(None)` and dies with a bare `TypeError` instead of naming what happened. An explicit `raise RuntimeError` survives every invocation mode.

## 2. Cancellation is now a test, not prose

`drain_once` catches `Exception`, deliberately not `BaseException`. So an `asyncio.CancelledError` unwinds the transaction (taking the attempt bump with it) and abandons the batch.

Widening that catch to `BaseException` **looks harmless in review** and is wrong twice over:
- the interrupted job is charged an attempt for work nobody asked it to finish;
- a worker told to shut down keeps delivering customer email for the rest of the batch.

Two tests pin it:
- `test_a_raised_cancellation_leaves_the_batch_and_charges_no_attempt` — raises the error inside the handler; proves the `except` clause's reach.
- `test_a_real_task_cancellation_rolls_the_attempt_back` — issues an actual `task.cancel()` mid-await and reads the row from a **second** connection, because asking the connection that is unwinding its own transaction is asking the suspect to describe the crime. Bounded by `wait_for`, so a row left locked fails instead of hanging the suite.

**Mutation-proved.** `except Exception` → `except BaseException`:

```
FAILED test_a_raised_cancellation_leaves_the_batch_and_charges_no_attempt - DID NOT RAISE CancelledError
FAILED test_a_real_task_cancellation_rolls_the_attempt_back            - DID NOT RAISE CancelledError
2 failed, 21 passed in 0.40s
```

Exactly the two new tests go red; nothing else moves.

## 3. `batch_size` cost — and my first draft of this note was wrong

The exclusion array is an unindexable `NOT (id = ANY(...))`, so the obvious reading is a flat O(batch_size²). It isn't. A **dispatched** row gets `dispatched_at` set and thereby leaves `idx_garuda_order_outbox_undispatched` — a partial index `ON (created_at) WHERE dispatched_at IS NULL` (migration 284) — so the happy path stays linear and the array is never walked for it.

What the array actually pays for are rows this pass touched and left **undispatched** (failed + unroutable): those stay in the index, so every later claim in the same pass scans past all of them. Real cost: `O(batch_size * undispatched_touched)` — quadratic only in a pass that is failing wholesale. I wrote the flat-quadratic version first; reading migration 284 corrected it, and the docstring now says the true thing.

## Verification

```
23 passed in 0.36s
```
(21 pre-existing + 2 new), real Postgres via `INTAKE_TEST_DSN`.

No behaviour change beyond the assert. Gear floor: 1.

## Still open, deliberately not in this PR

The review of #5023 (payment-confirmation email handler, armed) surfaced two non-blockers that live in **that** PR's files and can only be done once it merges:
- `EmailSendFailed` does not distinguish transient (429/5xx) from permanent (401/403 = rotated `NUZANTARA_API_KEY`) failure, so one bad key burns all five attempts of every in-flight row;
- nothing is yet wired to `count_undrained().exhausted`, which is the only surface those dead rows ever appear on (W81b: fourteen DLQ corpses sat unnoticed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015F6trtRZb8RpPDG3PsCg2H