### PR TITLE
feat(client-bot): seat probe/sentinel distinguish quota exhaustion (I DUE BOT lane S1.5-quota-observable)

### DIFF
--- a/scripts/tests/test_wa_codex_seat_probe.py
+++ b/scripts/tests/test_wa_codex_seat_probe.py
@@ -54,6 +54,53 @@ def test_guilt_nonzero_without_auth_signature_is_other_failure() -> None:
     assert verdict == probe.VERDICT_OTHER_FAILURE
 
 
+# ------------------------------------------------------- GUILT (S1.5 quota)
+
+
+def test_guilt_exec_429_structured_on_stderr_is_quota_exhausted() -> None:
+    verdict = probe.classify(
+        0, "Logged in using ChatGPT\n", "", 1, "", "Error: 429 Too Many Requests"
+    )
+    assert verdict == probe.VERDICT_QUOTA_EXHAUSTED
+
+
+def test_guilt_exec_insufficient_quota_structured_token_is_quota_exhausted() -> None:
+    verdict = probe.classify(
+        0, "Logged in using ChatGPT\n", "", 1, "", '{"error":{"code":"insufficient_quota"}}'
+    )
+    assert verdict == probe.VERDICT_QUOTA_EXHAUSTED
+
+
+def test_guilt_exec_prose_usage_limit_reached_is_quota_exhausted() -> None:
+    verdict = probe.classify(
+        0, "Logged in using ChatGPT\n", "", 1, "", "You've hit your usage limit reached for today."
+    )
+    assert verdict == probe.VERDICT_QUOTA_EXHAUSTED
+
+
+def test_guilt_login_status_side_can_also_carry_the_quota_signature() -> None:
+    """Symmetric with the auth-death guilt test above (login status side) —
+    `classify()` scans BOTH login streams when login_rc failed, not just
+    exec's stderr."""
+    verdict = probe.classify(1, "", "rate limit reached, try again later", 0, "pong", "")
+    assert verdict == probe.VERDICT_QUOTA_EXHAUSTED
+
+
+def test_guilt_auth_signature_outranks_a_coexisting_quota_signature() -> None:
+    """Fixed two-step priority (S1.5 docstring): auth checked before quota.
+    A stderr that happens to carry BOTH signatures resolves to auth_death,
+    never to quota_exhausted."""
+    verdict = probe.classify(
+        0,
+        "Logged in using ChatGPT\n",
+        "",
+        1,
+        "",
+        "error 401: unauthorized — also rate limit reached",
+    )
+    assert verdict == probe.VERDICT_AUTH_DEATH
+
+
 # --------------------------------------------------------------- INNOCENCE
 
 
@@ -82,12 +129,65 @@ def test_innocence_healthy_login_status_output_does_not_match() -> None:
     assert probe.classify(0, "Logged in using ChatGPT\n", "", 0, "pong", "") == probe.VERDICT_OK
 
 
-def test_fallback_regex_is_byte_identical_to_the_daemon_detector() -> None:
-    """Superscar #1 applicata a una regex: la copia fallback DEVE restare
-    byte-identica a `_AUTH_DEATH_RE` del daemon, o i due rilevatori
-    divergono sullo stesso testo. Questo test confronta pattern e flag
-    contro la fonte nel repo (il probe sul host importa la copia runtime;
-    qui nel repo le due definizioni devono combaciare)."""
+# ------------------------------------------------- INNOCENCE (S1.5 quota)
+
+
+def test_innocence_healthy_exec_answer_discussing_a_sponsor_quota_is_ok() -> None:
+    """A successful exec (rc=0) whose model answer legitimately discusses a
+    KITAS sponsor's "quota" must never classify quota_exhausted — same
+    family-#3 discipline as the auth innocence test above: a rc=0 command's
+    output is never scanned at all."""
+    answer = "Your sponsor's quota exceeded this year's KITAS allocation."
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 0, answer, "")
+    assert verdict == probe.VERDICT_OK
+
+
+def test_innocence_failed_exec_stdout_quota_prose_is_not_scanned_only_stderr() -> None:
+    """Same R26 discipline as the existing auth innocence test: a FAILED
+    exec's STDOUT (a partial model answer) is never scanned, even if it
+    happens to carry quota-shaped prose — only stderr counts."""
+    partial_answer = "...the client's monthly credits exhausted her visa portal quota"
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 1, partial_answer, "boom")
+    assert verdict == probe.VERDICT_OTHER_FAILURE
+
+
+def test_innocence_bare_quota_word_alone_does_not_fire() -> None:
+    """Bare "quota"/"exhausted"/"limit" are ordinary immigration-consultancy
+    vocabulary (R28-1 in the daemon's own word class) — deliberately
+    excluded as standalone alternatives. A failed exec whose stderr merely
+    contains the bare word must not false-positive quota_exhausted."""
+    verdict = probe.classify(
+        0, "Logged in using ChatGPT\n", "", 1, "", "the client's quota question is unresolved"
+    )
+    assert verdict == probe.VERDICT_OTHER_FAILURE
+
+
+def test_innocence_quota_regex_does_not_bleed_across_command_boundary() -> None:
+    """Mirrors the daemon's per-text (never concatenated) scanning discipline
+    — a quota phrase split across the login-status and exec texts must not
+    combine into a false match; each text is searched independently."""
+    verdict = probe.classify(1, "", "rate limit", 1, "", "reached tomorrow")
+    assert verdict != probe.VERDICT_QUOTA_EXHAUSTED
+
+
+def test_fallback_regexes_are_byte_identical_to_the_daemon_detectors() -> None:
+    """Superscar #1 applicata a una regex: OGNI copia fallback in
+    scripts/wa_codex_seat_probe.py DEVE restare byte-identica al suo gemello
+    nel daemon, o i due rilevatori divergono sullo stesso testo.
+
+    S1.5 (2026-08-26): this test used to check a single `_AUTH_DEATH_RE`.
+    That symbol no longer exists in the daemon — B2b's confidence-tier SPEC
+    split it into `_AUTH_STRUCTURED_RE`/`_AUTH_PROSE_RE` (the daemon's
+    module-level names, both without a leading underscore stripped on
+    import — same shape quota already had) and this test had gone RED,
+    silently, because it could not even find the old name to compare
+    against (verified live on this branch's HEAD before this fix: the old
+    assertion failed at "daemon _AUTH_DEATH_RE definition not found", not
+    at a content mismatch). Now covers all four regexes the probe
+    imports-with-fallback: auth (structured+prose) and quota
+    (structured+prose, S1.5's own addition)."""
+    import re as _re
+
     daemon_src = (
         Path(__file__).parents[2]
         / "apps"
@@ -98,23 +198,47 @@ def test_fallback_regex_is_byte_identical_to_the_daemon_detector() -> None:
     )
     # Textual extraction, not import: the daemon module pulls in backend.*
     # and this comparison is about the SOURCE definitions staying identical.
-    import re as _re
-
-    text = daemon_src.read_text()
-    match = _re.search(r"_AUTH_DEATH_RE[^=]*= re\.compile\((.*?)\n\)", text, _re.DOTALL)
-    assert match is not None, "daemon _AUTH_DEATH_RE definition not found"
-    daemon_body = "".join(_re.findall(r'r"([^"]*)"', match.group(1)))
+    daemon_text = daemon_src.read_text()
     probe_text = _MODULE_PATH.read_text()
-    probe_match = _re.search(
-        r"AUTH_DEATH_RE = re\.compile\((.*?)\n    \)", probe_text, _re.DOTALL
-    )
-    assert probe_match is not None, "probe fallback AUTH_DEATH_RE definition not found"
-    probe_body = "".join(_re.findall(r'r"([^"]*)"', probe_match.group(1)))
-    assert probe_body == daemon_body, (
-        "the probe's fallback regex drifted from the daemon's _AUTH_DEATH_RE — "
-        "update the copy in scripts/wa_codex_seat_probe.py"
-    )
-    # Flags too (Kimi r1 m9): dropping re.IGNORECASE on either side keeps the
-    # bodies identical while the detectors diverge on case.
-    assert "re.IGNORECASE" in match.group(1), "daemon regex lost re.IGNORECASE"
-    assert "re.IGNORECASE" in probe_match.group(1), "probe fallback lost re.IGNORECASE"
+
+    def _extract(text: str, pattern: str, label: str) -> tuple[str, bool]:
+        # `^`-anchored + MULTILINE (never DOTALL on the anchor): the naive
+        # "name, then anything, then = re.compile(" shape used before this
+        # fix matched a COMMENT mentioning the name earlier in the file and
+        # then walked forward across `[^=]*` (which spans newlines) into a
+        # LATER, unrelated regex's own `= re.compile(` — reproduced live:
+        # `_QUOTA_STRUCTURED_RE` was preceded by a same-named mention in a
+        # comment two definitions above it, and the ungoverned search
+        # silently bound to `_AUTH_STRUCTURED_RE`'s body instead. Anchoring
+        # to an actual start-of-line assignment (never inside a comment,
+        # which starts with `#`) makes that mis-bind structurally
+        # impossible instead of merely unlikely.
+        match = _re.search(pattern, text, _re.DOTALL | _re.MULTILINE)
+        assert match is not None, f"{label} definition not found"
+        body = "".join(_re.findall(r'r"([^"]*)"', match.group(1)))
+        return body, "re.IGNORECASE" in match.group(1)
+
+    for daemon_name, probe_name in (
+        ("_AUTH_STRUCTURED_RE", "AUTH_STRUCTURED_RE"),
+        ("_AUTH_PROSE_RE", "AUTH_PROSE_RE"),
+        ("_QUOTA_STRUCTURED_RE", "QUOTA_STRUCTURED_RE"),
+        ("_QUOTA_PROSE_RE", "QUOTA_PROSE_RE"),
+    ):
+        daemon_body, daemon_ic = _extract(
+            daemon_text,
+            rf"^{daemon_name}:\s*re\.Pattern\[str\]\s*=\s*re\.compile\((.*?)\n\)",
+            f"daemon {daemon_name}",
+        )
+        probe_body, probe_ic = _extract(
+            probe_text,
+            rf"^    {probe_name} = re\.compile\((.*?)\n    \)",
+            f"probe fallback {probe_name}",
+        )
+        assert probe_body == daemon_body, (
+            f"the probe's fallback {probe_name} drifted from the daemon's "
+            f"{daemon_name} — update the copy in scripts/wa_codex_seat_probe.py"
+        )
+        # Flags too (Kimi r1 m9): dropping re.IGNORECASE on either side keeps
+        # the bodies identical while the detectors diverge on case.
+        assert daemon_ic, f"daemon {daemon_name} lost re.IGNORECASE"
+        assert probe_ic, f"probe fallback {probe_name} lost re.IGNORECASE"

--- a/scripts/tests/test_wa_codex_seat_sentinel.py
+++ b/scripts/tests/test_wa_codex_seat_sentinel.py
@@ -63,6 +63,33 @@ def test_guilt_auth_death_is_red_with_the_relogin_command() -> None:
     assert "sudo -u zantara-codex" in v.message
 
 
+def test_guilt_quota_exhausted_is_red_and_distinct_from_auth_death() -> None:
+    """S1.5 (2026-08-26), owner packet item 13: the probe's new
+    `quota_exhausted` verdict must reach the same severity as `auth_death`
+    (the OpenAI/Codex leg is fully blocked either way) but through its own
+    condition and its own message — never collapsed into `auth_death`'s
+    dedup key or its re-login wording, which is actively WRONG advice for
+    a quota-exhausted seat."""
+    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    assert len(verdicts) == 1
+    v = verdicts[0]
+    assert v.level == wa.RED
+    assert v.condition == "quota_exhausted"
+    assert v.condition != "auth_death"
+    assert "QUOTA EXHAUSTED" in v.message
+    assert "codex login" not in v.message
+    assert "do not re-login" in v.message
+
+
+def test_guilt_quota_exhausted_message_names_wait_or_switch_not_relogin() -> None:
+    """The remedy is the whole point of distinguishing this verdict: waiting
+    for the usage window or switching seats, never `codex login` (that IS
+    the auth_death remedy, and applying it to a healthy-but-quota-exhausted
+    seat wastes an operator's time chasing the wrong fix)."""
+    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    assert "wait" in verdicts[0].message.lower() or "switch" in verdicts[0].message.lower()
+
+
 def test_guilt_missing_probe_file_is_red_naming_probe_silent() -> None:
     """`probe_status=None` — il caso "file assente": deve nominare la causa,
     non limitarsi a un generico 'qualcosa non va'."""
@@ -118,11 +145,33 @@ def test_guilt_other_failure_verdict_is_warn_not_red() -> None:
 
 def test_guilt_unrecognized_probe_verdict_falls_visibly_as_warn_never_silent() -> None:
     """W116: un finale non mappato (un probe futuro che scrive p.es.
-    "quota_exhausted") deve cadere VISIBILE, mai nel secchio sano."""
-    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    "policy_blocked", non ancora conosciuto da questo reader) deve cadere
+    VISIBILE, mai nel secchio sano.
+
+    S1.5 (2026-08-26): "quota_exhausted" used to be THIS test's example of
+    an unmapped verdict — it has since graduated to its own explicit branch
+    (see test_guilt_quota_exhausted_is_red_and_distinct_from_auth_death)
+    and no longer exercises this generic fallback path, so the example had
+    to change or this test would silently stop testing the fallback at
+    all and start testing the new specific branch instead — a genuinely
+    unmapped token is required here to prove the FORWARD-compat contract:
+    a status file from a probe newer than this sentinel (naming a verdict
+    this reader has never heard of) must still degrade to a visible WARN,
+    never to silence and never to a crash."""
+    verdicts = wa.evaluate(_probe("policy_blocked", 0, 1), 10.0, _gauge(), NOW)
     assert len(verdicts) == 1
     assert verdicts[0].level == wa.WARN
-    assert "quota_exhausted" in verdicts[0].message
+    assert verdicts[0].condition == "other_failure"
+    assert "policy_blocked" in verdicts[0].message
+
+
+def test_innocence_quota_exhausted_no_longer_reaches_the_generic_fallback() -> None:
+    """Companion to the test above: `quota_exhausted` must NOT also produce
+    a second, generic `other_failure` verdict alongside its own — `evaluate`
+    returns exactly one verdict for it, from the new explicit branch."""
+    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    assert len(verdicts) == 1
+    assert verdicts[0].condition == "quota_exhausted"
 
 
 def test_guilt_never_seen_daemon_null_staleness_parses_to_daemon_silent() -> None:

--- a/scripts/wa_codex_seat_probe.py
+++ b/scripts/wa_codex_seat_probe.py
@@ -21,11 +21,26 @@ This organ manufactures a signal independent of job traffic: `codex login
 status` plus a 1-token synthetic `codex exec`, on the plist's own
 StartInterval, regardless of whether the broker has anything to claim.
 
-CLASSIFICATION — declared limit: quota exhaustion (CodexQuotaError-shaped
-failures in backend/llm/codex_exec_client.py) is NOT distinguished from any
-other non-auth, non-invocation failure here — both land in `other_failure`.
-S1.5 owns sharpening that bucket further. This probe answers exactly one
-question: is the seat's LOGIN dead, yes or no.
+CLASSIFICATION (S1.5, 2026-08-26 — sharpens the bucket the paragraph above
+used to describe): quota exhaustion is now its OWN verdict,
+`VERDICT_QUOTA_EXHAUSTED` ("quota_exhausted"), distinct from `auth_death`
+and from the generic `other_failure` bucket it used to fall into — the twin,
+on the probe side, of `wa_codex_daemon.py`'s `CodexExecQuotaError` arm
+(B2b). Detection REUSES the daemon's own quota word class
+(`_QUOTA_STRUCTURED_RE`/`_QUOTA_PROSE_RE` in `backend/llm/codex_exec_client.py`)
+via the same import-with-degraded-fallback pattern as `AUTH_STRUCTURED_RE`/
+`AUTH_PROSE_RE` below — never a second, drifting definition. Priority is a
+FIXED two-step order — auth checked first, quota second — deliberately
+simpler than the daemon's full per-word-class confidence-tier SPEC
+(`_classify_stderr` in that same
+module): this probe's `guilty_texts` are the output of a single synthetic,
+domain-free "ping" prompt (see `_PROBE_PROMPT` below), not a real client
+payload, so the domain-overload ambiguity that SPEC exists to resolve (a
+KITAS sponsor's own "quota", an immigration client's own "unauthorized")
+cannot occur here — there is no real prompt for either word class to
+collide with. This probe still answers only what it can: is the seat's
+LOGIN dead, or its usage quota exhausted, or something else non-zero — never
+a full replay of the daemon's SPEC.
 
 LEAK SURFACE (Law 2 / scar family #4 — secret/PII in the clear): the status
 file carries ONLY the verdict enum, the two raw exit codes, and a UTC
@@ -58,7 +73,8 @@ from typing import Final, Mapping, Sequence
 
 logger = logging.getLogger("wa_codex_seat_probe")
 
-# --- auth-death detection: REUSE the daemon's own detector -----------------
+# --- auth-death + quota-exhaustion detection: REUSE the daemon's own -------
+# --- detectors ---------------------------------------------------------
 # Primary path: scripts/provision_zantara_codex.sh already installs a
 # root-owned copy of backend/llm/codex_exec_client.py under
 # /usr/local/lib/wa-codex-broker/backend/llm/ for the daemon itself, and
@@ -67,28 +83,54 @@ logger = logging.getLogger("wa_codex_seat_probe")
 # the import below resolves against that SAME runtime tree, not a repo
 # checkout the zantara-codex user does not have.
 #
+# S1.5 (2026-08-26) FOUND AND FIXED, adjacent to the quota work: the
+# single combined `_AUTH_DEATH_RE` this block used to import no longer
+# exists in codex_exec_client.py — B2b's confidence-tier SPEC split it into
+# `_AUTH_STRUCTURED_RE`/`_AUTH_PROSE_RE` (the same two-tier shape quota
+# already had) without updating this probe's import, which meant the
+# "primary path" below had been silently dead — ImportError on every run,
+# unconditionally falling to the copy — since B2b landed, undetected because
+# the fallback is functionally byte-identical. Verified live (not assumed):
+# `PYTHONPATH=apps/backend-rag python3 -c "from backend.llm.codex_exec_client
+# import _AUTH_DEATH_RE"` raises ImportError on this branch's HEAD. Now
+# imports the same two symbols the daemon actually exports.
+#
 # If that import ever fails (runtime tree not provisioned, or provisioning
 # drifted from the daemon's), fall back to a LOCAL COPY of the same pattern,
-# marked below. The copy MUST be kept byte-identical to
-# backend/llm/codex_exec_client.py::_AUTH_DEATH_RE or the two detectors will
-# disagree about the same log line — superscar #1 (HOME-fork drift) applied
-# to a regex instead of a whole script. The import is PRIMARY; this copy is
-# a degraded fallback, never the source of truth.
+# marked below. The copies MUST be kept byte-identical to
+# backend/llm/codex_exec_client.py::_AUTH_STRUCTURED_RE /
+# ::_AUTH_PROSE_RE / ::_QUOTA_STRUCTURED_RE / ::_QUOTA_PROSE_RE or the two
+# detectors will disagree about the same log line — superscar #1 (HOME-fork
+# drift) applied to a regex instead of a whole script. The import is
+# PRIMARY; this copy is a degraded fallback, never the source of truth.
+# This fallback is also why promoting THIS file to the runtime tree does
+# not require promoting codex_exec_client.py in lockstep — a stale runtime
+# tree (one that predates the quota word class, or even the current
+# auth-split) still gets correct detection from the local copy; see memory
+# `dark-describes-the-branch-not-the-deployment` for why promoting
+# codex_exec_client.py/wa_codex_daemon.py together is its own, separate,
+# entangled decision this change does not need to make.
 try:
-    from backend.llm.codex_exec_client import _AUTH_DEATH_RE as AUTH_DEATH_RE
+    from backend.llm.codex_exec_client import _AUTH_PROSE_RE as AUTH_PROSE_RE
+    from backend.llm.codex_exec_client import (
+        _AUTH_STRUCTURED_RE as AUTH_STRUCTURED_RE,
+    )
+    from backend.llm.codex_exec_client import _QUOTA_PROSE_RE as QUOTA_PROSE_RE
+    from backend.llm.codex_exec_client import (
+        _QUOTA_STRUCTURED_RE as QUOTA_STRUCTURED_RE,
+    )
 
     _AUTH_DEATH_SOURCE: Final[str] = "import"
 except ImportError:  # pragma: no cover — exercised only when the runtime
     # tree is missing/stale; kept in sync by hand with the primary above.
-    AUTH_DEATH_RE = re.compile(
+    AUTH_STRUCTURED_RE = re.compile(
+        r"\b401\s+unauthorized\b|\berror\s+401\b|\b401\s+error\b|\bhttp\s+401\b|"
+        r"token_revoked|refresh_token(?:_reused|_revoked|_expired)?",
+        re.IGNORECASE,
+    )
+    AUTH_PROSE_RE = re.compile(
         r"\b(?:"
-        r"401\s+unauthorized|"
-        r"error\s+401\b|"
-        r"401\s+error\b|"
-        r"http\s+401\b|"
         r"unauthorized|"
-        r"token_revoked|"
-        r"refresh_token(?:_reused|_revoked|_expired)?|"
         r"token\s+has\s+expired|"
         r"not\s+logged\s+in|"
         r"login\s+required|"
@@ -97,6 +139,22 @@ except ImportError:  # pragma: no cover — exercised only when the runtime
         r"session\s+invalidated|"
         r"auth(?:entication)?\s+(?:failed|error|required|expired)|"
         r"run\s+`?codex\s+login`?"
+        r")(?!\w)",
+        re.IGNORECASE,
+    )
+    QUOTA_STRUCTURED_RE = re.compile(
+        r"\b429\s+too\s+many\s+requests\b|insufficient_quota|rate_limit_exceeded",
+        re.IGNORECASE,
+    )
+    QUOTA_PROSE_RE = re.compile(
+        r"\b(?:"
+        r"rate[- ]limit(?:ed)?\s+exceeded|"
+        r"rate\s+limit\s+reached|"
+        r"usage\s+limit(?:\s+reached)?|"
+        r"exceeded\s+your\s+current\s+quota|"
+        r"monthly\s+credits\s+exhausted|"
+        r"credits\s+exhausted|"
+        r"out\s+of\s+extra\s+usage"
         r")(?!\w)",
         re.IGNORECASE,
     )
@@ -122,6 +180,11 @@ _UNRUN_RC: Final[int] = -1
 
 VERDICT_OK: Final[str] = "ok"
 VERDICT_AUTH_DEATH: Final[str] = "auth_death"
+# S1.5 (2026-08-26): the token name is fixed by
+# scripts/wa_codex_seat_sentinel.py's own forward-compat comment (it names
+# this exact string as the example of a future verdict a reader must not
+# swallow into silence) — do not rename without updating that reader too.
+VERDICT_QUOTA_EXHAUSTED: Final[str] = "quota_exhausted"
 VERDICT_OTHER_FAILURE: Final[str] = "other_failure"
 VERDICT_PROBE_ERROR: Final[str] = "probe_error"
 
@@ -214,6 +277,20 @@ def _run(binary: str, args: Sequence[str], env: Mapping[str, str]) -> tuple[int,
         return _UNRUN_RC, "", ""
 
 
+def _auth_detected(text: str) -> bool:
+    """True if `text` matches either tier of the daemon's auth-death word
+    class (structured token OR prose phrase)."""
+    return bool(AUTH_STRUCTURED_RE.search(text) or AUTH_PROSE_RE.search(text))
+
+
+def _quota_detected(text: str) -> bool:
+    """True if `text` matches either tier of the daemon's quota-exhaustion
+    word class (structured token OR domain-safe prose phrase — see the
+    import block above for why both tiers are safe to OR together here,
+    unlike in the daemon's real-prompt classifier)."""
+    return bool(QUOTA_STRUCTURED_RE.search(text) or QUOTA_PROSE_RE.search(text))
+
+
 def classify(
     login_rc: int,
     login_out: str,
@@ -224,37 +301,42 @@ def classify(
 ) -> str:
     """Pure — no I/O, so this is where a future unit test would live.
 
-    Priority: an auth-death signature on EITHER command outranks a generic
-    nonzero (a `login status` that spawns fine but `exec` correctly reports
-    401 is still auth_death, not other_failure). The regex is searched on
-    EACH text independently — never concatenated — matching the discipline
-    of the upstream `_auth_death_detected`: joining texts with any separator
-    risks the regex's `\\s+` alternatives bridging two innocent fragments
-    across the seam into a false match.
+    Priority (S1.5, 2026-08-26): auth-death outranks quota-exhaustion
+    outranks a generic nonzero. Fixed two-step order, not the daemon's full
+    per-word-class confidence-tier SPEC — see the module docstring's
+    CLASSIFICATION section for why that's a safe simplification here (this
+    probe's guilty_texts come from one synthetic, domain-free "ping", never
+    a real client prompt the two word classes could collide inside). Each
+    regex is searched on EACH text independently — never concatenated —
+    matching the discipline of the upstream `_auth_death_detected`: joining
+    texts with any separator risks a `\\s+` alternative bridging two
+    innocent fragments across the seam into a false match.
 
     Scanning discipline imitates the daemon's R26 rule: only a FAILED
     command's text is scanned — a succeeding command's output is a status
     line or a model answer whose vocabulary is innocent by construction
-    (family #3: "unauthorized"/"login"/"expired" are ordinary visa-domain
-    words in a legitimate answer). Per-command surface: for `login status`
-    BOTH streams (measured 2026-08-20 on the live CLI: the logged-out
-    marker "Not logged in" arrives on STDOUT, rc=1; healthy prints "Logged
-    in using ChatGPT", rc=0, no match); for `exec` STDERR ONLY (the
-    daemon's measured evidence places codex's own diagnostics on stderr,
-    and exec stdout may carry a partial model answer discussing a CLIENT's
-    login/credential).
+    (family #3: "unauthorized"/"login"/"quota"/"expired" are ordinary
+    visa-domain words in a legitimate answer). Per-command surface: for
+    `login status` BOTH streams (measured 2026-08-20 on the live CLI: the
+    logged-out marker "Not logged in" arrives on STDOUT, rc=1; healthy
+    prints "Logged in using ChatGPT", rc=0, no match); for `exec` STDERR
+    ONLY (the daemon's measured evidence places codex's own diagnostics on
+    stderr, and exec stdout may carry a partial model answer discussing a
+    CLIENT's login/credential/quota).
 
     Only if NEITHER command produced a real exit code at all is this a
     probe_error (we could not observe anything, auth-dead or otherwise).
-    Any other nonzero combination is other_failure (declared limit: not
-    further distinguished from quota exhaustion — see module docstring)."""
+    Any other nonzero combination that matches neither word class is
+    other_failure."""
     guilty_texts: list[str] = []
     if login_rc not in (0, _UNRUN_RC):
         guilty_texts.extend((login_out, login_err))
     if exec_rc not in (0, _UNRUN_RC):
         guilty_texts.append(exec_err)
-    if any(AUTH_DEATH_RE.search(t) for t in guilty_texts if t):
+    if any(_auth_detected(t) for t in guilty_texts if t):
         return VERDICT_AUTH_DEATH
+    if any(_quota_detected(t) for t in guilty_texts if t):
+        return VERDICT_QUOTA_EXHAUSTED
     if login_rc == _UNRUN_RC and exec_rc == _UNRUN_RC:
         return VERDICT_PROBE_ERROR
     if login_rc != 0 or exec_rc != 0:

--- a/scripts/wa_codex_seat_sentinel.py
+++ b/scripts/wa_codex_seat_sentinel.py
@@ -83,6 +83,19 @@ BREAKER_MSG: Final[str] = (
     "sudo grep 'AUTH DEATH' /Users/zantara-codex/logs/wa-codex-broker.err"
 )
 DAEMON_SILENT_MSG: Final[str] = "daemon silent (dead / version-pin pause / host down)"
+# S1.5 (2026-08-26), owner packet item 13 — twin of AUTH_DEATH_MSG for the
+# probe's `quota_exhausted` verdict (scripts/wa_codex_seat_probe.py). The
+# remedy differs (wait, or switch seats — never "re-login"), which is
+# exactly why this is its own message and its own dedup condition rather
+# than reusing AUTH_DEATH_MSG's wording or BREAKER_MSG's sudo-grep hint (the
+# daemon's own AUTH DEATH/QUOTA EXHAUSTED log lines live in the same
+# cron-unreadable file — see wa_codex_daemon.py's B2b arm — so this message
+# does not point there either; the probe's own status file already carries
+# the actionable verdict without needing that file read).
+QUOTA_EXHAUSTED_MSG: Final[str] = (
+    "codex seat QUOTA EXHAUSTED — wait for the usage window to reset, or "
+    "switch seats (this is not an auth failure — do not re-login)"
+)
 
 
 @dataclass(frozen=True)
@@ -115,12 +128,23 @@ def _probe_side(
         probe_verdict = probe_status.get("verdict")
         if probe_verdict == "auth_death":
             verdicts.append(Verdict(RED, "auth_death", AUTH_DEATH_MSG))
+        elif probe_verdict == "quota_exhausted":
+            # S1.5 (2026-08-26): distinct from auth_death (fix = re-login)
+            # and from the generic other_failure bucket below (fix = wait /
+            # switch seats) — twin, on the read side, of the daemon's own
+            # CodexExecQuotaError arm (wa_codex_daemon.py B2b). RED, same
+            # severity as auth_death: either way the OpenAI/Codex leg is
+            # fully blocked for every subsequent job, even though the
+            # remedy differs.
+            verdicts.append(Verdict(RED, "quota_exhausted", QUOTA_EXHAUSTED_MSG))
         elif probe_verdict != "ok":
             # other_failure, probe_error, AND any vocabulary this reader does
-            # not know yet (a future probe adding e.g. "quota_exhausted" must
-            # fall somewhere VISIBLE, never into silence — W116: an unmapped
-            # finale that lands in the healthy bucket is how the next real
-            # signal gets lost).
+            # not know yet (e.g. a future probe adding a POLICY_BLOCKED
+            # verdict) must fall somewhere VISIBLE, never into silence —
+            # W116: an unmapped finale that lands in the healthy bucket is
+            # how the next real signal gets lost. "quota_exhausted" used to
+            # be the example named here; it graduated to its own branch
+            # above (S1.5) and no longer reaches this one.
             verdicts.append(
                 Verdict(
                     WARN,


### PR DESCRIPTION
## Summary

Owner packet item 13's stated purpose was "do not close the promotion to primary while both legs are quota-blind." B2b (76b91eab4) taught the daemon to SAY it ran out; nothing could HEAR it — `wa_codex_seat_sentinel.py`'s only channel across the user boundary (`wa_codex_seat_probe.py`'s status file) collapsed quota exhaustion into the same generic `other_failure` bucket as any other non-auth failure.

- `wa_codex_seat_probe.py`: `classify()` now returns a distinct `VERDICT_QUOTA_EXHAUSTED` (`"quota_exhausted"`) verdict, reusing the daemon's own quota word class (`_QUOTA_STRUCTURED_RE`/`_QUOTA_PROSE_RE` from `codex_exec_client.py`) via the same import-with-degraded-fallback pattern already used for auth-death. Fixed two-step priority (auth checked first, quota second) — a deliberate simplification of the daemon's full confidence-tier SPEC, safe here because the probe's `guilty_texts` come from one synthetic `"ping"` prompt, never a real client payload the two word classes could collide inside.
- **Adjacent pre-existing break found and fixed**: the probe's `_AUTH_DEATH_RE` import has been silently `ImportError`-ing (always falling to the byte-identical local copy) since B2b split that symbol into `_AUTH_STRUCTURED_RE`/`_AUTH_PROSE_RE` in `codex_exec_client.py` without updating this probe. Verified live before the fix. The corresponding byte-identity test was already RED for the same reason. Rewrote the extraction to anchor on real start-of-line definitions instead of a bare substring search — a comment mentioning a regex's name earlier in the file could hijack the old search into comparing against the WRONG regex's body (reproduced live for `_QUOTA_STRUCTURED_RE` while writing this PR).
- `wa_codex_seat_sentinel.py`: `_probe_side()` gives `quota_exhausted` its own RED verdict + condition + message ("wait / switch seats" — never "re-login", which is the wrong remedy) — same severity as `auth_death` (the leg is fully blocked either way) but never collapsed into its dedup key or wording. The generic-fallback forward-compat test is repointed at a still-genuinely-unmapped example now that `quota_exhausted` has its own branch.
- `wa_broker.ALLOWED_ERROR_CLASSES` untouched (per mandate) — this is the probe's own status-file channel, not the job wire.

## Test plan

- [x] `PYTHONPATH=apps/backend-rag python3 -m pytest scripts/tests/test_wa_codex_seat_probe.py scripts/tests/test_wa_codex_seat_sentinel.py --junitxml=...` → 42/42 pass, junit-parsed (0 failures/errors/skipped)
- [x] Guilt: quota-shaped structured/prose stderr on either command → `quota_exhausted`; sentinel alerts RED, distinct condition/message from `auth_death`
- [x] Innocence: auth-death still reports/alerts exactly as before; a healthy seat still reports `ok`; bare "quota" word and cross-command bleed do not false-positive; a genuinely-unmapped future verdict still degrades to visible WARN
- [x] `ruff check` clean on all 4 changed files
- [x] `apps/backend-rag/backend/tests/llm/test_codex_exec_client.py` unaffected (not modified, still green)

## Promotion (not attempted — Pro-only, reported per mandate)

- `scripts/wa_codex_seat_sentinel.py` runs **in-place from the repo checkout** on Pro (no `declared-pairs.json` entry) — a `git pull`/merge to whatever branch Pro's checkout tracks is sufficient, no separate copy step.
- `scripts/wa_codex_seat_probe.py` **does** have a HOME-fork pair: `/usr/local/lib/wa-codex-broker/seat_probe.py` (declared, `pro` only), installed by `scripts/provision_zantara_codex.sh` (`install -o root -g wheel -m 0644 scripts/wa_codex_seat_probe.py /usr/local/lib/wa-codex-broker/seat_probe.py`, or re-run the whole idempotent script).
- **`codex_exec_client.py`'s live copy does *not* need to be promoted in lockstep.** Per memory `dark-describes-the-branch-not-the-deployment`, that promotion is its own separate, entangled decision (shared runtime root with the daemon). The probe's fallback-copy safety net (same pattern as the pre-existing `AUTH_DEATH_RE` fallback) means quota detection works correctly even against a stale `codex_exec_client.py` on the runtime tree — verified by the byte-identity test and by construction of the `try/except ImportError` block.
- Byte-verify after promoting `seat_probe.py`: `cmp -s scripts/wa_codex_seat_probe.py /usr/local/lib/wa-codex-broker/seat_probe.py` (mode 0644, world-readable) or `python3 scripts/lint_home_fork.py --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)