### PR TITLE
fix(garuda): a paid VOA order was headed for a practice type that does not exist

### DIFF
--- a/apps/backend-rag/backend/services/crm/assignment.py
+++ b/apps/backend-rag/backend/services/crm/assignment.py
@@ -461,8 +461,35 @@ ASSIGNABLE_ROLES = {
     "Tax Manager",
 }
 
-# Map practice types to departments for specialty routing
+# Map practice types to departments for specialty routing.
+#
+# MEASURED 2026-08-26, and the lookup below is EXACT (`.get(practice_type_code)`,
+# no prefix or substring match): NONE of the twelve legacy keys under this
+# comment — `kitas`, `kitap`, `pt_pma`, `investor_visa`, `work_permit`,
+# `company_setup`, `visa`, `immigration`, `tax`, `tax_reporting`,
+# `tax_registration`, `npwp` — is seeded as a `practice_types.code` by ANY
+# migration in `db/migrations_v2/`. The real catalogue codes are shaped
+# `visa_*` / `ext_*` / `tax_*` / `other_*` / `merp_*` (e.g. `visa_bridging`,
+# `ext_c1_tourism`, `tax_annual_pkg_a`). So for every catalogue practice the
+# department branch below has been dead and assignment has silently fallen
+# through to the round-robin least-workload fallback — which draws from ALL
+# assignable roles, tax included.
+#
+# Stated narrowly on purpose: this says no MIGRATION seeds those keys. Whether
+# prod holds out-of-band rows with those codes is a separate question this
+# lane did not measure, and the twelve keys are therefore left in place rather
+# than deleted. Curing the other ~51 codes is a CRM-lane job with a real
+# business call behind it (which department owns `other_lapor_lahir_under`?),
+# tracked in `.claude/skills/modus/PENDING-ARMS.md`; do NOT "fix" it here with
+# a prefix match — `visa_*`->setup and `tax_*`->tax would look right and
+# `other_*` would still be a guess.
+#
+# The two GARUDA VOA entries below are this lane's own obligation and are
+# catalogue-real: both are seeded by
+# `db/migrations_v2/221_practice_types_b1_voa.sql`.
 PRACTICE_DEPARTMENT_MAP: dict[str, str] = {
+    "visa_b1_voa": "setup",
+    "ext_b1_voa": "setup",
     "kitas": "setup",
     "kitap": "setup",
     "pt_pma": "setup",

--- a/apps/backend-rag/backend/services/garuda_ops/crm_handoff.py
+++ b/apps/backend-rag/backend/services/garuda_ops/crm_handoff.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from backend.app.utils.logging_utils import get_logger
+from backend.services.garuda_flow.intake import CaseType
 from backend.services.garuda_ops.ports import (
     CrmWriter,
     EventEnvelope,
@@ -38,12 +39,38 @@ from backend.services.garuda_ops.ports import (
 
 logger = get_logger(__name__)
 
-# The practice_type_code this handoff writes against. Not yet seeded in
-# `practice_types` (that migration is L1's exclusive path,
-# `apps/backend-rag/backend/db/migrations_v2/`) — kept as a named constant
-# so the concrete `PostgresCrmWriter` fails with a clear, attributable error
-# rather than a silent wrong-row insert if the row is still missing.
-GARUDA_VOA_PRACTICE_TYPE_CODE = "garuda_voa"
+# RULED by Zero, 2026-08-26: a paid GARUDA order enters the CRM as one of the
+# two B1-VOA services the catalogue ALREADY holds — never a new `garuda_voa`
+# type. Both rows are seeded by
+# `db/migrations_v2/221_practice_types_b1_voa.sql`, so no migration and no new
+# catalogue entry belong to this lane.
+#
+# This replaces a single hardcoded `GARUDA_VOA_PRACTICE_TYPE_CODE =
+# "garuda_voa"`, whose own comment conceded the row was "not yet seeded in
+# `practice_types`". That constant was not merely unseeded, it was WRONG:
+# issuance and extension are different products at different prices
+# (Rp 750,000 vs Rp 850,000, migration 221), and one shared code would have
+# priced, reported and routed them as one service.
+#
+# Derived per ORDER, never per SERVICE INSTANCE: there is deliberately no
+# constructor override any more. An override is exactly how one code silently
+# reclaims both case types again — the bug this constant already was.
+PRACTICE_TYPE_CODE_BY_CASE_TYPE: dict[str, str] = {
+    CaseType.ISSUANCE.value: "visa_b1_voa",
+    CaseType.EXTENSION.value: "ext_b1_voa",
+}
+
+
+class UnmappedCaseType(ValueError):
+    """`OrderSnapshot.case_type` names a case with no CRM service behind it.
+
+    Raised, not returned as a `HandoffOutcome`, and the distinction is
+    load-bearing. A `HandoffOutcome` is a resolved state the consumer marks
+    dispatched; this is a code/data defect that no retry can fix and that
+    must stay VISIBLE — a paid order with no CRM practice is a customer who
+    paid and whom nobody is working for. Raising lets the outbox record the
+    failed attempt and surface the job instead of retiring it green.
+    """
 
 
 class HandoffOutcome(str, Enum):
@@ -64,11 +91,9 @@ class CrmHandoffService:
         *,
         order_snapshots: OrderSnapshotProvider,
         crm_writer: CrmWriter,
-        practice_type_code: str = GARUDA_VOA_PRACTICE_TYPE_CODE,
     ) -> None:
         self._order_snapshots = order_snapshots
         self._crm_writer = crm_writer
-        self._practice_type_code = practice_type_code
 
     async def handle_practice_received(self, event: EventEnvelope) -> HandoffResult:
         if event.transition_id != "PR-01" or event.aggregate_type != "practice":
@@ -100,10 +125,21 @@ class CrmHandoffService:
             )
             return HandoffResult(HandoffOutcome.ORDER_SNAPSHOT_MISSING, None)
 
+        practice_type_code = PRACTICE_TYPE_CODE_BY_CASE_TYPE.get(snapshot.case_type)
+        if practice_type_code is None:
+            # Neither the case_type value nor any order identifier goes into
+            # this message: SM-G03 bans order/account identifiers as log
+            # fields, and this string reaches a log through the raise.
+            msg = (
+                "GARUDA order snapshot carries a case_type with no CRM practice "
+                "type mapped to it; see PRACTICE_TYPE_CODE_BY_CASE_TYPE"
+            )
+            raise UnmappedCaseType(msg)
+
         crm_practice_id = await self._crm_writer.create_client_and_practice(
             snapshot,
             source_idempotency_key=idempotency_key,
-            practice_type_code=self._practice_type_code,
+            practice_type_code=practice_type_code,
         )
         logger.info(
             "garuda_ops.crm_handoff.created",

--- a/apps/backend-rag/backend/tests/services/crm/test_lead_assignment_agent.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_lead_assignment_agent.py
@@ -218,3 +218,35 @@ async def test_trigger_lead_assignment_returns_failure_state_when_workflow_raise
     assert result["success"] is False
     assert result["assigned_lead"] is None
     assert result["errors"] == ["workflow failed"]
+
+
+# --------------------------------------------------------------------------
+# GARUDA VOA specialty routing (Zero ruling 2026-08-26)
+# --------------------------------------------------------------------------
+
+
+def test_both_garuda_voa_codes_route_to_the_setup_department() -> None:
+    """RED-if-wrong: `assign_lead` looks the code up EXACTLY
+    (`PRACTICE_DEPARTMENT_MAP.get(practice_type_code)`), with no prefix or
+    substring match. Before these two entries existed, both GARUDA codes
+    missed the map and every paid VOA order fell through to the round-robin
+    fallback, which draws from ALL assignable roles — tax included. Both
+    codes are catalogue-real: seeded by
+    `db/migrations_v2/221_practice_types_b1_voa.sql`."""
+    from backend.services.crm.assignment import PRACTICE_DEPARTMENT_MAP
+
+    assert PRACTICE_DEPARTMENT_MAP.get("visa_b1_voa") == "setup"
+    assert PRACTICE_DEPARTMENT_MAP.get("ext_b1_voa") == "setup"
+
+
+def test_the_garuda_codes_match_the_handoff_mapping_exactly() -> None:
+    """The two maps live in different packages and would drift silently:
+    `crm_handoff` decides WHICH code a paid order gets, `assignment` decides
+    WHO works it. A code present in the first and absent from the second is
+    an order routed by round-robin — the exact defect above, reintroduced.
+    RED if either side gains a code the other lacks."""
+    from backend.services.crm.assignment import PRACTICE_DEPARTMENT_MAP
+    from backend.services.garuda_ops.crm_handoff import PRACTICE_TYPE_CODE_BY_CASE_TYPE
+
+    unrouted = set(PRACTICE_TYPE_CODE_BY_CASE_TYPE.values()) - PRACTICE_DEPARTMENT_MAP.keys()
+    assert unrouted == set(), f"GARUDA practice types with no department: {sorted(unrouted)}"

--- a/apps/backend-rag/backend/tests/services/garuda_ops/test_crm_handoff.py
+++ b/apps/backend-rag/backend/tests/services/garuda_ops/test_crm_handoff.py
@@ -11,9 +11,10 @@ from datetime import date, datetime, timezone
 import pytest
 
 from backend.services.garuda_ops.crm_handoff import (
-    GARUDA_VOA_PRACTICE_TYPE_CODE,
+    PRACTICE_TYPE_CODE_BY_CASE_TYPE,
     CrmHandoffService,
     HandoffOutcome,
+    UnmappedCaseType,
 )
 from backend.services.garuda_ops.ports import EventEnvelope, IdempotencyIdentity, OrderSnapshot
 
@@ -117,11 +118,11 @@ class AtomicFakeCrmWriter(FakeCrmWriter):
             )
 
 
-def _snapshot(order_id: str = "practice-order-1") -> OrderSnapshot:
+def _snapshot(order_id: str = "practice-order-1", case_type: str = "issuance") -> OrderSnapshot:
     return OrderSnapshot(
         order_aggregate_id=order_id,
         customer_email="traveller@example.com",
-        case_type="issuance",
+        case_type=case_type,
         purpose="tourism",
         nationality="AUS",
         entry_date=date(2026, 9, 1),
@@ -144,7 +145,7 @@ async def test_creates_crm_practice_from_order_snapshot_with_zero_retyping() -> 
     assert len(writer.created) == 1
     snapshot, source_idempotency_key, practice_type_code = writer.created[0]
     assert source_idempotency_key == event.idempotency_identity.key_digest
-    assert practice_type_code == GARUDA_VOA_PRACTICE_TYPE_CODE
+    assert practice_type_code == "visa_b1_voa"
     assert snapshot.customer_email == "traveller@example.com"
 
 
@@ -336,3 +337,80 @@ async def test_atomic_writer_closes_the_race_under_true_concurrency() -> None:
         service.handle_practice_received(_pr01_event()),
     )
     assert len(writer.created) == 1
+
+
+# --------------------------------------------------------------------------
+# The practice type is DERIVED FROM THE ORDER, not hardcoded (Zero, 2026-08-26)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("case_type", "expected_code"),
+    [("issuance", "visa_b1_voa"), ("extension", "ext_b1_voa")],
+)
+@pytest.mark.asyncio
+async def test_each_case_type_writes_its_own_catalogue_service(
+    case_type: str, expected_code: str
+) -> None:
+    """RED-if-wrong: the version this replaces passed ONE constant
+    (`"garuda_voa"`) for both case types. Issuance and extension are separate
+    products at separate prices in `practice_types` — Rp 750,000 vs
+    Rp 850,000, migration 221 — so a shared code prices, reports and routes
+    them as one service. Parametrized precisely so re-hardcoding either side
+    reddens exactly one case, not the pair."""
+    writer = FakeCrmWriter()
+    service = CrmHandoffService(
+        order_snapshots=FakeOrderSnapshots(
+            {"practice-order-1": _snapshot(case_type=case_type)}
+        ),
+        crm_writer=writer,
+    )
+    result = await service.handle_practice_received(_pr01_event())
+    assert result.outcome is HandoffOutcome.CREATED
+    _, _, practice_type_code = writer.created[0]
+    assert practice_type_code == expected_code
+
+
+def test_the_two_case_types_do_not_share_one_code() -> None:
+    """Guards the shape, not one value: a future edit that collapses both
+    rows onto a single code reddens here even if each row still "looks"
+    populated."""
+    codes = set(PRACTICE_TYPE_CODE_BY_CASE_TYPE.values())
+    assert len(codes) == len(PRACTICE_TYPE_CODE_BY_CASE_TYPE) == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unmapped_case_type_raises_and_writes_nothing() -> None:
+    """A paid order whose case_type has no CRM service must NOT be retired
+    green. `drain_once` reads a returned value as success and marks the job
+    dispatched; only a raise keeps the job visible. The second assertion is
+    the one that matters — no half-written practice."""
+    writer = FakeCrmWriter()
+    service = CrmHandoffService(
+        order_snapshots=FakeOrderSnapshots(
+            {"practice-order-1": _snapshot(case_type="renewal")}
+        ),
+        crm_writer=writer,
+    )
+    with pytest.raises(UnmappedCaseType):
+        await service.handle_practice_received(_pr01_event())
+    assert writer.created == []
+
+
+@pytest.mark.asyncio
+async def test_the_unmapped_error_leaks_no_order_identifier_or_case_value() -> None:
+    """SM-G03 bans order/account identifiers as log fields, and this message
+    reaches a log through the raise. RED if someone "helpfully" interpolates
+    the case_type or the aggregate id into the text."""
+    service = CrmHandoffService(
+        order_snapshots=FakeOrderSnapshots(
+            {"practice-order-1": _snapshot(case_type="renewal")}
+        ),
+        crm_writer=FakeCrmWriter(),
+    )
+    with pytest.raises(UnmappedCaseType) as excinfo:
+        await service.handle_practice_received(_pr01_event())
+    text = str(excinfo.value)
+    assert "renewal" not in text
+    assert "practice-order-1" not in text
+    assert "traveller@example.com" not in text


### PR DESCRIPTION
## What was wrong

`crm_handoff.py` wrote every practice against one hardcoded constant,
`GARUDA_VOA_PRACTICE_TYPE_CODE = "garuda_voa"`, whose own comment conceded the row
was *"not yet seeded in `practice_types`"*. Two defects in one line:

1. **The code names no catalogue row.** The first real handoff would have hit the
   adapter's `UnknownPracticeType` — a customer who paid, and no practice.
2. **Worse if it HAD been seeded.** Issuance and extension are separate products at
   separate prices — Rp 750,000 vs Rp 850,000, seeded by migration 221. One shared
   code would have priced, reported and routed them as one service.

## What this does

**Ruled by Zero, 2026-08-26.** Derive the type from the order's `case_type` onto the
two B1-VOA rows migration 221 **already** seeds: `issuance` → `visa_b1_voa`,
`extension` → `ext_b1_voa`. No new practice type, no migration.

The `practice_type_code` constructor parameter is **removed, not re-pointed**. An
override is exactly how one code silently reclaims both case types again — which is
the bug the constant already was.

An unmapped `case_type` raises `UnmappedCaseType` rather than returning a
`HandoffOutcome`. `drain_once` reads a return as success and marks the job
`dispatched`; only a raise keeps a paid-but-unworked order visible. The message
carries neither the case value nor any order identifier (SM-G03).

## Measured while here, cured only for this lane

`assign_lead` looks its key up **exactly** (`PRACTICE_DEPARTMENT_MAP.get(code)`, no
prefix or substring match), and **none of the twelve legacy keys** — `kitas`,
`kitap`, `pt_pma`, `investor_visa`, `work_permit`, `company_setup`, `visa`,
`immigration`, `tax`, `tax_reporting`, `tax_registration`, `npwp` — is seeded as a
`practice_types.code` by any migration in `db/migrations_v2/`. The real catalogue
codes are shaped `visa_*` / `ext_*` / `tax_*` / `other_*` / `merp_*`.

So the department-matching branch has been **dead for every catalogue practice**, and
assignment silently fell through to the round-robin fallback — which draws from ALL
assignable roles, tax included. The two GARUDA codes are added here.

The other ~51 are **not** patched: that is a CRM-lane job with a business call behind
it (which department owns `other_lapor_lahir_under`?), and a prefix match would look
right for `visa_*` and still be a guess for `other_*`.

**Stated narrowly on purpose:** this says no *migration* seeds those twelve keys.
Whether prod holds out-of-band rows with them is unmeasured, so the keys stay in
place rather than being deleted.

## Proof

Baseline 22 passed; both source files byte-identical to pre-mutation after restore.

| mutation | result |
|---|---|
| collapse both case types onto one code | 2 failed |
| `raise` → silent `return` | 2 failed |
| interpolate `case_type` into the error text | 1 failed |
| drop `ext_b1_voa` from the department map | 2 failed |

Wider suites: `garuda_ops/` + `crm/` + `garuda_orders/` → 360 passed, 44 skipped. The
52 errors are all `crm/partners/**` with `asyncpg: role "nuzantara" does not exist` —
environmental on this machine (user `balizero`), outside this diff.

Gear floor for this file set: **1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Residual risk, measured and NOT closed

The department half of this PR fixes the **map**. It does not prove the map now
resolves to a person.

- **CONFIRMED (measured twice, two independent probes):** none of the twelve legacy
  keys is seeded as a `practice_types.code` by any migration, so the
  department-matching branch never fires for a catalogue practice.
- **UNMEASURED:** whether any active `team_members` row actually carries
  `department = 'setup'`. `'setup'` appears as a literal in **no migration and no
  seed script anywhere in this repo** — `team_members.department` is populated
  out-of-band, and this session has no read-only DB access to settle it.

If no active member has that department, the two new entries still miss and
assignment still falls through to the round-robin fallback. That would make this half
**inert, not wrong** — the handoff, the practice type and the CRM row are unaffected
either way, and the round-robin fallback is exactly today's behaviour.

Settling it needs one read against prod:
`SELECT department, count(*) FROM team_members WHERE active GROUP BY 1;`
