### PR TITLE
fix(crm): correct the department-map census that #5032 landed

### DIFF
--- a/apps/backend-rag/backend/services/crm/assignment.py
+++ b/apps/backend-rag/backend/services/crm/assignment.py
@@ -463,26 +463,38 @@ ASSIGNABLE_ROLES = {
 
 # Map practice types to departments for specialty routing.
 #
-# MEASURED 2026-08-26, and the lookup below is EXACT (`.get(practice_type_code)`,
-# no prefix or substring match): NONE of the twelve legacy keys under this
-# comment — `kitas`, `kitap`, `pt_pma`, `investor_visa`, `work_permit`,
-# `company_setup`, `visa`, `immigration`, `tax`, `tax_reporting`,
-# `tax_registration`, `npwp` — is seeded as a `practice_types.code` by ANY
-# migration in `db/migrations_v2/`. The real catalogue codes are shaped
-# `visa_*` / `ext_*` / `tax_*` / `other_*` / `merp_*` (e.g. `visa_bridging`,
-# `ext_c1_tourism`, `tax_annual_pkg_a`). So for every catalogue practice the
-# department branch below has been dead and assignment has silently fallen
-# through to the round-robin least-workload fallback — which draws from ALL
-# assignable roles, tax included.
+# THIS TABLE SPANS TWO CATALOGUE GENERATIONS, and the lookup below is EXACT
+# (`.get(practice_type_code)`, no prefix or substring match), so a key from the
+# wrong generation simply never fires. Measured 2026-08-26 across BOTH migration
+# systems — 135 legacy `backend/migrations/*.py` and 169 `db/migrations_v2/*.sql`:
 #
-# Stated narrowly on purpose: this says no MIGRATION seeds those keys. Whether
-# prod holds out-of-band rows with those codes is a separate question this
-# lane did not measure, and the twelve keys are therefore left in place rather
-# than deleted. Curing the other ~51 codes is a CRM-lane job with a real
-# business call behind it (which department owns `other_lapor_lahir_under`?),
-# tracked in `.claude/skills/modus/PENDING-ARMS.md`; do NOT "fix" it here with
-# a prefix match — `visa_*`->setup and `tax_*`->tax would look right and
-# `other_*` would still be a guess.
+#   SEEDED, so these four keys DO route:
+#     `visa`, `kitas`, `tax`   -> migration_044_seed_practice_types.py:23/:40/:57
+#     `tax_registration`       -> migration_066_populate_practice_types_from_pricing.py:614
+#   NOT SEEDED ANYWHERE, so these eight are dead weight:
+#     `kitap`, `pt_pma`, `investor_visa`, `work_permit`, `company_setup`,
+#     `immigration`, `tax_reporting`, `npwp`
+#
+# The four live ones are all LEGACY short codes. Not one key here is seeded by
+# `migrations_v2/`, which is where today's catalogue lives and whose codes are
+# shaped `visa_*` / `ext_*` / `tax_*` / `other_*` / `merp_*` (`visa_bridging`,
+# `ext_c1_tourism`, `tax_annual_pkg_a`). So the department branch fires for the
+# old generation and is dead for the whole new one, which silently falls through
+# to the round-robin least-workload fallback — drawing from ALL assignable
+# roles, tax included.
+#
+# An earlier version of this comment claimed no migration seeded ANY of the
+# twelve. That was measured against `migrations_v2/` only and read as "the map
+# is entirely dead", which is wrong for four keys and for whatever practices
+# still carry them. The correction cost one broken probe: the first census
+# grepped for single-quoted `'visa'` while the legacy seeds are Python dicts
+# writing `"code": "visa"`, so it reported ABSENT and was believed.
+#
+# Curing the ~51 modern codes is a CRM-lane job with a real business call behind
+# it (which department owns `other_lapor_lahir_under`?), tracked in
+# `.claude/skills/modus/PENDING-ARMS.md`. Do NOT "fix" it here with a prefix
+# match: `visa_*`->setup and `tax_*`->tax would look right and `other_*` would
+# still be a guess.
 #
 # The two GARUDA VOA entries below are this lane's own obligation and are
 # catalogue-real: both are seeded by

--- a/apps/backend-rag/backend/tests/services/crm/test_lead_assignment_agent.py
+++ b/apps/backend-rag/backend/tests/services/crm/test_lead_assignment_agent.py
@@ -250,3 +250,41 @@ def test_the_garuda_codes_match_the_handoff_mapping_exactly() -> None:
 
     unrouted = set(PRACTICE_TYPE_CODE_BY_CASE_TYPE.values()) - PRACTICE_DEPARTMENT_MAP.keys()
     assert unrouted == set(), f"GARUDA practice types with no department: {sorted(unrouted)}"
+
+
+def test_setup_is_a_real_department_with_assignable_people_behind_it() -> None:
+    """Turns the open question this lane carried into a measured one.
+
+    Mapping a practice type to a department only helps if someone IS in that
+    department with an assignable role — otherwise `assign_lead`'s Strategy 1
+    finds nobody and falls through to the same round-robin the mapping was
+    meant to replace, making the entry inert rather than wrong.
+
+    `team_members.department` is populated out-of-band (no migration writes it),
+    so the closest checkable source is the seeded roster the loader reads:
+    `backend/data/team_members.json` via `backend/scripts/seed_users.py`. RED if
+    the `setup` department disappears from that roster, or if everyone left in
+    it holds a role `assign_lead` will not assign to.
+    """
+
+    import json
+    from pathlib import Path as _Path
+
+    import backend
+    from backend.services.crm.assignment import ASSIGNABLE_ROLES
+
+    # Anchored on the package, not on `__file__`'s parent count: this suite is
+    # run from several worktrees and a miscounted `parents[n]` fails as a
+    # FileNotFoundError that reads like a missing roster.
+    roster_path = _Path(backend.__file__).resolve().parent / "data" / "team_members.json"
+    assert roster_path.is_file(), f"seeded roster not where expected: {roster_path}"
+    roster = json.loads(roster_path.read_text())
+    setup_assignable = [
+        m
+        for m in roster
+        if m.get("department") == "setup" and m.get("role") in ASSIGNABLE_ROLES
+    ]
+    assert setup_assignable, (
+        "no seeded team member is in department 'setup' with an assignable role — "
+        "the GARUDA VOA department mapping would resolve to nobody"
+    )


### PR DESCRIPTION
Follow-up to #5032, as its own PR from a fresh `origin/main` rather than a push
onto a branch already in the merge queue (agent PR contract rule 2 — arm means
freeze).

## What #5032 got wrong

Its comment on `PRACTICE_DEPARTMENT_MAP` said no migration seeds any of its twelve
keys. Measured against `db/migrations_v2/` only, that sentence is **literally true**
— and it reads as *"the map is entirely dead"*, which is **false**.

Re-measured across **both** migration systems (135 legacy `backend/migrations/*.py`
+ 169 `db/migrations_v2/*.sql`), four of the twelve **are** seeded:

| key | seeded at |
|---|---|
| `visa`, `kitas`, `tax` | `migration_044_seed_practice_types.py:23` / `:40` / `:57` |
| `tax_registration` | `migration_066_populate_practice_types_from_pricing.py:614` |

All four are **legacy short codes**. The remaining eight — `kitap`, `pt_pma`,
`investor_visa`, `work_permit`, `company_setup`, `immigration`, `tax_reporting`,
`npwp` — are seeded nowhere at all.

## The real shape

A table spanning **two catalogue generations**. The department branch fires for the
old short codes and is dead for the whole `migrations_v2` generation (`visa_*`,
`ext_*`, `tax_*`, `other_*`, `merp_*`) — which is where today's catalogue lives.

The consequence for GARUDA is unchanged; that is why #5032's two entries were
needed. But the diagnosis around it was overstated and would have misled whoever
picks up the CRM-lane cure.

## The broken probe, recorded so the next census does not repeat it

The first pass grepped for single-quoted `'visa'` while the legacy seeds are Python
dicts writing `"code": "visa"`. It reported ABSENT and was believed. A cross-family
refuter caught it; a deterministic Python probe settled it. That story is now in the
comment, not just in this description.

## Also closes the residual risk #5032 left open

`'setup'` **is** a real department: `backend/data/team_members.json:71`, loaded by
`backend/scripts/seed_users.py`, with six roster members in it — two holding roles
that are in `ASSIGNABLE_ROLES`. The mapping resolves to real people and is **not
inert**, which #5032's description had to leave as an open question.

`test_setup_is_a_real_department_with_assignable_people_behind_it` pins it, anchored
on the `backend` package rather than a `parents[n]` count (the first draft miscounted
and failed as a `FileNotFoundError` that read like a missing roster).

## Proof

Mutation: rename the roster's `setup` department → **1 failed**. Baseline and restored
both 23 passed; roster byte-identical after restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)