### PR TITLE
ci(dependabot): serialize Dependabot runs with a per-workflow concurrency group — rule 5 armed

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -29,8 +29,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: actionlint-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('actionlint-{0}', github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   lint:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -30,9 +30,15 @@ permissions:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('actionlint-{0}', github.event.pull_request.number || github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/adversarial-review-gate.yml
+++ b/.github/workflows/adversarial-review-gate.yml
@@ -20,8 +20,14 @@ on:
   merge_group:
 
 # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-# per-run), so their runs queue and drain serially instead of piling up in
-# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# per-run), bounding concurrent Dependabot runs of THIS workflow to <=2
+# (Agent PR Contract rule 5) instead of unbounded parallel.
+# cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+# only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels the
+# pending run rather than queuing behind it — visible in the PR's checks tab
+# (never silent), recoverable with `gh run rerun` (confirmed:
+# docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+# refuter round on PR #5043). Non-Dependabot branch is suffixed by
 # github.run_id, which is unique per run and therefore never collides — the
 # prior no-concurrency-block behavior (every run fully independent) is
 # preserved exactly.

--- a/.github/workflows/adversarial-review-gate.yml
+++ b/.github/workflows/adversarial-review-gate.yml
@@ -19,6 +19,16 @@ on:
   pull_request:
   merge_group:
 
+# Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+# per-run), so their runs queue and drain serially instead of piling up in
+# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# github.run_id, which is unique per run and therefore never collides — the
+# prior no-concurrency-block behavior (every run fully independent) is
+# preserved exactly.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('adversarial-review-gate-{0}-{1}', github.ref, github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   gate:
     name: R1 gate — adversarial review present

--- a/.github/workflows/asyncpg-lint.yml
+++ b/.github/workflows/asyncpg-lint.yml
@@ -24,8 +24,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: asyncpg-lint-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('asyncpg-lint-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   asyncpg-lint:

--- a/.github/workflows/asyncpg-lint.yml
+++ b/.github/workflows/asyncpg-lint.yml
@@ -25,9 +25,15 @@ permissions:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('asyncpg-lint-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -47,8 +47,12 @@ on:
       - ".github/workflows/guard-conformance.yml"
 
 concurrency:
-  group: guard-conformance-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('guard-conformance-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   conformance:

--- a/.github/workflows/guard-conformance.yml
+++ b/.github/workflows/guard-conformance.yml
@@ -48,9 +48,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('guard-conformance-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -212,8 +212,12 @@ on:
     # HEAD_SHA/BASE_SHA fallback chain below now includes.
 
 concurrency:
-  group: harness-floor-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('harness-floor-{0}', github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -213,9 +213,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('harness-floor-{0}', github.event.pull_request.number || github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/hook-innocence-gate.yml
+++ b/.github/workflows/hook-innocence-gate.yml
@@ -43,8 +43,12 @@ on:
       - ".github/workflows/hook-innocence-gate.yml"
 
 concurrency:
-  group: hook-innocence-gate-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('hook-innocence-gate-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   innocence:

--- a/.github/workflows/hook-innocence-gate.yml
+++ b/.github/workflows/hook-innocence-gate.yml
@@ -44,9 +44,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('hook-innocence-gate-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -35,8 +35,12 @@ on:
 
 # Concurrency: cancel stale runs on the same PR ref so latest commit wins
 concurrency:
-  group: hot-zone-pr-gate-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('hot-zone-pr-gate-{0}', github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -36,9 +36,15 @@ on:
 # Concurrency: cancel stale runs on the same PR ref so latest commit wins
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('hot-zone-pr-gate-{0}', github.event.pull_request.number || github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -22,9 +22,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('immune-enforcement-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -21,8 +21,12 @@ on:
   merge_group:
 
 concurrency:
-  group: immune-enforcement-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('immune-enforcement-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   antidotes:

--- a/.github/workflows/npm-lock-sync.yml
+++ b/.github/workflows/npm-lock-sync.yml
@@ -41,9 +41,15 @@ permissions:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('npm-lock-sync-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/npm-lock-sync.yml
+++ b/.github/workflows/npm-lock-sync.yml
@@ -40,8 +40,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: npm-lock-sync-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('npm-lock-sync-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   lock-honors-manifest:

--- a/.github/workflows/organ-conformance.yml
+++ b/.github/workflows/organ-conformance.yml
@@ -61,9 +61,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('organ-conformance-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/organ-conformance.yml
+++ b/.github/workflows/organ-conformance.yml
@@ -60,8 +60,12 @@ on:
       - ".github/workflows/organ-conformance.yml"
 
 concurrency:
-  group: organ-conformance-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('organ-conformance-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   conformance:

--- a/.github/workflows/p1s2-mutation-incremental.yml
+++ b/.github/workflows/p1s2-mutation-incremental.yml
@@ -40,8 +40,12 @@ on:
       - ".github/workflows/p1s2-mutation-incremental.yml"
 
 concurrency:
-  group: p1s2-mutation-incremental-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p1s2-mutation-incremental-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   mutation-gate:

--- a/.github/workflows/p1s2-mutation-incremental.yml
+++ b/.github/workflows/p1s2-mutation-incremental.yml
@@ -41,9 +41,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p1s2-mutation-incremental-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/p3-sandbox-gates.yml
+++ b/.github/workflows/p3-sandbox-gates.yml
@@ -25,6 +25,16 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+# per-run), so their runs queue and drain serially instead of piling up in
+# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# github.run_id, which is unique per run and therefore never collides — the
+# prior no-concurrency-block behavior (every run fully independent) is
+# preserved exactly.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p3-sandbox-gates-{0}-{1}', github.ref, github.run_id) }}
+  cancel-in-progress: false
+
 jobs:
   p3-static-validation:
     name: P3 static validation (enforcing)

--- a/.github/workflows/p3-sandbox-gates.yml
+++ b/.github/workflows/p3-sandbox-gates.yml
@@ -26,8 +26,14 @@ on:
   workflow_dispatch:
 
 # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-# per-run), so their runs queue and drain serially instead of piling up in
-# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# per-run), bounding concurrent Dependabot runs of THIS workflow to <=2
+# (Agent PR Contract rule 5) instead of unbounded parallel.
+# cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+# only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels the
+# pending run rather than queuing behind it — visible in the PR's checks tab
+# (never silent), recoverable with `gh run rerun` (confirmed:
+# docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+# refuter round on PR #5043). Non-Dependabot branch is suffixed by
 # github.run_id, which is unique per run and therefore never collides — the
 # prior no-concurrency-block behavior (every run fully independent) is
 # preserved exactly.

--- a/.github/workflows/p6-federation-parallelize.yml
+++ b/.github/workflows/p6-federation-parallelize.yml
@@ -34,8 +34,12 @@ on:
       - ".github/workflows/p6-federation-parallelize.yml"
 
 concurrency:
-  group: p6-federation-parallelize-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p6-federation-parallelize-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   parallelize-gate:

--- a/.github/workflows/p6-federation-parallelize.yml
+++ b/.github/workflows/p6-federation-parallelize.yml
@@ -35,9 +35,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p6-federation-parallelize-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/p7-lesson-harvester.yml
+++ b/.github/workflows/p7-lesson-harvester.yml
@@ -22,8 +22,14 @@ on:
   workflow_dispatch:
 
 # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-# per-run), so their runs queue and drain serially instead of piling up in
-# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# per-run), bounding concurrent Dependabot runs of THIS workflow to <=2
+# (Agent PR Contract rule 5) instead of unbounded parallel.
+# cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+# only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels the
+# pending run rather than queuing behind it — visible in the PR's checks tab
+# (never silent), recoverable with `gh run rerun` (confirmed:
+# docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+# refuter round on PR #5043). Non-Dependabot branch is suffixed by
 # github.run_id, which is unique per run and therefore never collides — the
 # prior no-concurrency-block behavior (every run fully independent) is
 # preserved exactly.

--- a/.github/workflows/p7-lesson-harvester.yml
+++ b/.github/workflows/p7-lesson-harvester.yml
@@ -21,6 +21,16 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+# per-run), so their runs queue and drain serially instead of piling up in
+# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# github.run_id, which is unique per run and therefore never collides — the
+# prior no-concurrency-block behavior (every run fully independent) is
+# preserved exactly.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p7-lesson-harvester-{0}-{1}', github.ref, github.run_id) }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/p8-brand-api.yml
+++ b/.github/workflows/p8-brand-api.yml
@@ -18,8 +18,14 @@ on:
   workflow_dispatch:
 
 # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-# per-run), so their runs queue and drain serially instead of piling up in
-# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# per-run), bounding concurrent Dependabot runs of THIS workflow to <=2
+# (Agent PR Contract rule 5) instead of unbounded parallel.
+# cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+# only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels the
+# pending run rather than queuing behind it — visible in the PR's checks tab
+# (never silent), recoverable with `gh run rerun` (confirmed:
+# docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+# refuter round on PR #5043). Non-Dependabot branch is suffixed by
 # github.run_id, which is unique per run and therefore never collides — the
 # prior no-concurrency-block behavior (every run fully independent) is
 # preserved exactly.

--- a/.github/workflows/p8-brand-api.yml
+++ b/.github/workflows/p8-brand-api.yml
@@ -17,6 +17,16 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+# per-run), so their runs queue and drain serially instead of piling up in
+# parallel (Agent PR Contract rule 5). Non-Dependabot branch is suffixed by
+# github.run_id, which is unique per run and therefore never collides — the
+# prior no-concurrency-block behavior (every run fully independent) is
+# preserved exactly.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p8-brand-api-{0}-{1}', github.ref, github.run_id) }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/p9-cost-breaker.yml
+++ b/.github/workflows/p9-cost-breaker.yml
@@ -24,8 +24,12 @@ on:
       - ".github/workflows/p9-cost-breaker.yml"
 
 concurrency:
-  group: p9-cost-breaker-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p9-cost-breaker-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   cost-breaker-tests:

--- a/.github/workflows/p9-cost-breaker.yml
+++ b/.github/workflows/p9-cost-breaker.yml
@@ -25,9 +25,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('p9-cost-breaker-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/prepush-guards.yml
+++ b/.github/workflows/prepush-guards.yml
@@ -47,8 +47,12 @@ on:
       - ".github/workflows/prepush-guards.yml"
 
 concurrency:
-  group: prepush-guards-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('prepush-guards-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/prepush-guards.yml
+++ b/.github/workflows/prepush-guards.yml
@@ -48,9 +48,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('prepush-guards-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/root-guard.yml
+++ b/.github/workflows/root-guard.yml
@@ -11,8 +11,12 @@ on:
     branches: [main]
 
 concurrency:
-  group: root-guard-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('root-guard-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   root-guard:

--- a/.github/workflows/root-guard.yml
+++ b/.github/workflows/root-guard.yml
@@ -12,9 +12,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('root-guard-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: security-${{ github.ref }}
+  # Dependabot addition (Agent PR Contract rule 5, 2026-08-27): ALL Dependabot
+  # PRs share one group per workflow (not per-ref) so their runs of this
+  # ~20-billed-minute job queue and drain serially instead of piling up in
+  # parallel. The non-Dependabot branch below is the pre-existing expression
+  # verbatim — the comment trail beneath it about main-vs-PR asymmetry and
+  # merge_group safety is untouched and still governs that branch exactly.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('security-{0}', github.ref) }}
   # Cancel superseded runs on PR branches; NEVER on main.
   #
   # This was a flat `false` since #770 (the bulk "add concurrency groups to 21
@@ -66,7 +72,7 @@ concurrency:
   # onto the existing expression rather than replacing it, so the PR-vs-main
   # asymmetry above is preserved byte-for-byte; only the merge_group case is
   # forced to false.
-  cancel-in-progress: ${{ (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:
   # Path-aware gating (2026-08-20). Before this job existed, all 8 jobs below

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,11 +20,17 @@ on:
 
 concurrency:
   # Dependabot addition (Agent PR Contract rule 5, 2026-08-27): ALL Dependabot
-  # PRs share one group per workflow (not per-ref) so their runs of this
-  # ~20-billed-minute job queue and drain serially instead of piling up in
-  # parallel. The non-Dependabot branch below is the pre-existing expression
-  # verbatim — the comment trail beneath it about main-vs-PR asymmetry and
-  # merge_group safety is untouched and still governs that branch exactly.
+  # PRs share one group per workflow (not per-ref), bounding concurrent
+  # Dependabot runs of this ~20-billed-minute job to <=2 instead of unbounded
+  # parallel. cancel-in-progress:false (below) protects whichever run is
+  # RUNNING; GitHub keeps only one PENDING per group, so a 3rd+
+  # near-simultaneous Dependabot arrival cancels the pending run rather than
+  # queuing behind it — visible in the PR's checks tab (never silent),
+  # recoverable with `gh run rerun` (confirmed: docs.github.com/en/actions/
+  # using-jobs/using-concurrency + kimi-code/k3 refuter round on PR #5043).
+  # The non-Dependabot branch below is the pre-existing expression verbatim —
+  # the comment trail beneath it about main-vs-PR asymmetry and merge_group
+  # safety is untouched and still governs that branch exactly.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('security-{0}', github.ref) }}
   # Cancel superseded runs on PR branches; NEVER on main.
   #

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,9 +81,15 @@ on:
 # cancelling) and forces false only for the new merge_group case.
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('tests-{0}', github.event_name == 'schedule' && 'schedule-main' || github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && (github.event_name == 'schedule' || github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,8 +80,12 @@ on:
 # every other branch (push-to-main stays false, PR refs and schedule keep
 # cancelling) and forces false only for the new merge_group case.
 concurrency:
-  group: tests-${{ github.event_name == 'schedule' && 'schedule-main' || github.ref }}
-  cancel-in-progress: ${{ (github.event_name == 'schedule' || github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('tests-{0}', github.event_name == 'schedule' && 'schedule-main' || github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && (github.event_name == 'schedule' || github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 # S11: the coverage-collection decision lives HERE, once, and nowhere else.
 # It used to be a per-shard step that wrote its answer to a file the fan-in read

--- a/.github/workflows/verify-the-verifiers.yml
+++ b/.github/workflows/verify-the-verifiers.yml
@@ -30,9 +30,15 @@ on:
 
 concurrency:
   # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
-  # per-ref), so their runs queue and drain serially instead of piling up in
-  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
-  # the pre-existing expression — untouched.
+  # per-ref), bounding concurrent Dependabot runs of THIS workflow to <=2
+  # (Agent PR Contract rule 5) instead of unbounded parallel.
+  # cancel-in-progress:false protects whichever run is RUNNING; GitHub keeps
+  # only one PENDING per group, so a 3rd+ near-simultaneous arrival cancels
+  # the pending run rather than queuing behind it — visible in the PR's
+  # checks tab (never silent), recoverable with `gh run rerun` (confirmed:
+  # docs.github.com/en/actions/using-jobs/using-concurrency + kimi-code/k3
+  # refuter round on PR #5043). Non-Dependabot branch is byte-for-byte the
+  # pre-existing expression — untouched.
   group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('verify-the-verifiers-{0}', github.ref) }}
   cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 

--- a/.github/workflows/verify-the-verifiers.yml
+++ b/.github/workflows/verify-the-verifiers.yml
@@ -29,8 +29,12 @@ on:
       - "scripts/tests/conftest.py"
 
 concurrency:
-  group: verify-the-verifiers-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # Dependabot branch: ALL Dependabot PRs share one group per workflow (not
+  # per-ref), so their runs queue and drain serially instead of piling up in
+  # parallel (Agent PR Contract rule 5). Non-Dependabot branch is byte-for-byte
+  # the pre-existing expression — untouched.
+  group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || format('verify-the-verifiers-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && github.event_name != 'merge_group' }}
 
 jobs:
   verify-the-verifiers:

--- a/evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/brief.yml
@@ -1,0 +1,82 @@
+task_id: dependabot-serial-0826
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Arm CLAUDE.md Agent PR Contract rule 5 ("Serialize Dependabot PRs that
+  share a lockfile. Arm them one at a time.") — it had no machinery. 13
+  Dependabot PRs arrived as a batch on 2026-08-24 (oldest three within a
+  2-minute window, all 13 within 13 minutes) and ran every required check
+  in full N-way parallel.
+
+  Add a Dependabot-only branch to the `concurrency.group` (and, where the
+  original expression needs it, `cancel-in-progress`) of every workflow
+  that is BOTH (a) unconditional on `pull_request:` — no `paths:` filter,
+  so it fires on every one of the 13 regardless of ecosystem — and (b) a
+  required status check on main. All Dependabot runs of a given workflow
+  share one group; the non-Dependabot branch of every ternary is the
+  pre-existing expression, byte-for-byte, so ordinary PRs are unaffected.
+
+  Gear 3 by PATH, not by blast radius: `.github/workflows/**` is Gear-3 by
+  construction (deterministic floor recomputed from this PR's 21-file
+  changed set = 3, confirmed via `evidence_pack_lint.py --print-floor`).
+constraints:
+  - "Only touch workflows that are BOTH always-triggering on pull_request
+    AND a required status check on main (verified via `gh api
+    repos/Bali-Zero/Teman2/branches/main/protection`, not assumed from job
+    names) — narrows 30 always-trigger candidates to 21, keeping the diff
+    to a single mechanical concern instead of a repo-wide sweep."
+  - "The non-Dependabot branch of every changed expression must be
+    byte-for-byte the pre-existing behavior — this PR must not change what
+    happens to a single ordinary (non-Dependabot) PR."
+  - "No secrets, no PII — pure CI-workflow YAML."
+acceptance:
+  - "actionlint clean (rc=0) on all 21 changed files."
+  - "All 21 changed files parse as valid YAML with `concurrency.group`
+    referencing `dependabot[bot]`."
+  - "Deterministic gear floor recomputed from the real changed-file set is
+    3, and this brief declares gear 3 — never below it."
+  - "An independent cross-family adversarial review (generator != grader)
+    ran on the actual diff, and any CONFIRMED finding was either fixed in
+    a follow-up commit or explicitly accepted as a documented trade-off."
+consumer_map:
+  - "The 21 workflow files themselves — GitHub Actions reads `concurrency:`
+    directly; no other file in the repo references these expressions."
+  - "Dependabot PRs (opened weekly, `.github/dependabot.yml`, 3 ecosystems)
+    are the intended beneficiary — every future batch, starting with the
+    2026-08-31 run, is the first live test of the mechanism."
+risks:
+  - "GitHub Actions concurrency groups hold at most one RUNNING + one
+    PENDING run per group (confirmed: docs.github.com/en/actions/
+    using-jobs/using-concurrency). `cancel-in-progress: false` protects
+    only the running job. A 3rd+ near-simultaneous Dependabot arrival on
+    one workflow cancels the pending run rather than queuing behind it —
+    visible in the PR's checks tab, recoverable with `gh run rerun`, never
+    silent. This bounds the mechanism to <=2 concurrent per workflow, not
+    unbounded serial drain. Found by the adversarial-review round; fixed
+    by correcting the claim in all 21 files' comments (no logic change —
+    `cancel-in-progress: false` remains the right choice; `true` would
+    additionally kill the RUNNING job on every new arrival)."
+  - "`github.actor` is the triggering actor, not the PR author — a human
+    re-run or a maintainer push to a Dependabot branch escapes the shared
+    group for that one run. Low-frequency, does not cross-cancel anything,
+    accepted rather than engineered around (a PR-author-based
+    discriminator adds complexity for a rare case)."
+  - "Cannot live-test the drain mechanism today: all 13 Dependabot PRs that
+    motivated this mandate were closed 2026-08-26T16:17-16:18Z, before
+    this session started and not by this PR. Next batch ~2026-08-31."
+grader: |
+  generator != grader. Cross-family refuter seat kimi-code/k3 (Kimi K3,
+  non-Anthropic) reviewed the actual PR diff (`gh pr diff`) in round 1 of a
+  max-2-round budget. One real, CONFIRMED finding (the "drain serially"
+  overclaim, detailed in risks above) was fixed in a second commit on the
+  same PR, re-verified with actionlint + YAML parse after the fix. Two
+  further CONFIRMED-but-informational findings (actor-identity edge case;
+  cosmetic group-name nit) were accepted as documented trade-offs rather
+  than driving further code changes, per the reasoning in the PR's
+  Adversarial review section.
+budget: |
+  Single-lane infra fix. Flat-subscription seats only (Claude Code Opus 5
+  session for the build + Kimi K3 flat-quota for the refuter round); no
+  metered API spend.
+pii: none

--- a/evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/pack.yml
@@ -1,0 +1,180 @@
+brief_ref: evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/brief.yml
+plan_ref: >-
+  PR #5043 (agent/nuzantara/infra/dependabot-serialize-concurrency -> main) —
+  arms CLAUDE.md Agent PR Contract rule 5. Mandate from the orchestrating
+  session (X2 — Dependabot serialization), spec pointer
+  /Users/nuzantara/Desktop/2026-08-26-PIANO-SPEC-receptor-live.md §3 X2.
+
+lanes:
+  - lane: dependabot-concurrency-build
+    role: build
+    seat: claude-sonnet-5 (this implementer session — scoped the 21-file
+      required-check set from branch protection, wrote/edited the
+      concurrency ternaries, fixed the round-1 adversarial finding)
+  - lane: dependabot-concurrency-refute
+    role: review
+    seat: kimi-code/k3 (Kimi K3, non-Anthropic — cross-family refuter on the
+      actual PR diff via `gh pr diff`)
+
+diff:
+  files: 21
+  net_lines: 236
+  measured_at: 86dc06342
+  note: >-
+    `git diff --stat origin/main -- .github/workflows` at the second (fix) commit reports
+    270 insertions(+), 34 deletions(-) = 304 lines of raw churn across 21 files; net
+    (insertions-deletions) = 236. All 21 files are workflow YAML under .github/workflows/,
+    zero files outside that directory.
+
+pii_scan: clean
+
+receipts:
+  - claim:
+      The deterministic gear floor recomputed from THIS PR's real changed-file set is 3,
+      matching the declared gear.
+    cmd:
+      git -C <worktree> diff --name-only origin/main HEAD > /tmp/L3-changed.txt &&
+      python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/L3-changed.txt
+    result: "21 files enumerated (all under .github/workflows/), floor=3."
+    exit: 0
+    ts: "2026-08-26T16:24:10Z"
+    seat: session (Pro, implementer lane)
+
+  - claim:
+      All 21 changed workflow files pass actionlint (schema + every ${{ }} expression),
+      both before and after the round-1 adversarial-review fix commit.
+    cmd: actionlint .github/workflows/<21 files>
+    result: "rc=0, zero findings, both runs (pre-fix commit 7eabad767 and post-fix commit 86dc06342)."
+    exit: 0
+    ts: "2026-08-26T16:29:40Z"
+    seat: session (Pro, implementer lane)
+
+  - claim:
+      All 21 changed files parse as valid YAML and every one's concurrency.group
+      expression references dependabot[bot].
+    cmd: >-
+      python3 -c inline script: yaml.safe_load each file, assert 'concurrency' in doc and
+      dependabot[bot] in doc['concurrency']['group']
+    result: "OK 21/21 parsed, all reference dependabot[bot] in concurrency.group."
+    exit: 0
+    ts: "2026-08-26T16:15:05Z"
+    seat: session (Pro, implementer lane)
+
+  - claim:
+      The 21-file target set is exactly (always-trigger pull_request workflow) AND
+      (required status check on main) — not guessed from job/file names.
+    cmd:
+      gh api repos/Bali-Zero/Teman2/branches/main/protection --jq '.required_status_checks.contexts[]'
+      ; then grep -rl 'E2E Tests (Playwright)|Frontend Tests (Next.js)|MCP Server Tests|guilt AND innocence|organ is born with its genes' .github/workflows/*.yml
+    result: >-
+      27 required contexts enumerated. 3 of them (E2E Tests (Playwright), Frontend Tests
+      (Next.js), MCP Server Tests) turned out to live inside tests.yml alongside Backend
+      Tests (Python) rather than separate files — found by grep, not assumed. guard-conformance.yml
+      and organ-conformance.yml confirmed as the homes of "Every guard proves guilt AND
+      innocence" and "Every organ is born with its genes" respectively. 9 always-trigger
+      workflows confirmed NOT required (docs-guardian, docs-sync, garuda-contract-parity,
+      migration-lint, prettier-changed-files, runbook-section-numbers, token-lint,
+      worker-plane-review-tests, frontend-typecheck) and excluded from scope.
+    exit: 0
+    ts: "2026-08-26T16:05:30Z"
+    seat: session (Pro, implementer lane)
+
+  - claim:
+      GitHub Actions concurrency groups hold at most one RUNNING and one PENDING run per
+      group — the basis for the round-1 adversarial finding and its fix.
+    cmd:
+      WebFetch https://docs.github.com/en/actions/using-jobs/using-concurrency
+      (independent confirmation of the kimi-code/k3 finding, not accepted on the refuter's word alone)
+    result: >-
+      "By default, any existing pending job or workflow in the same concurrency group will
+      be canceled and the new queued job or workflow will take its place." Confirms the
+      refuter's finding; comment text in all 21 files corrected accordingly in commit 86dc06342.
+    exit: 0
+    ts: "2026-08-26T16:31:00Z"
+    seat: session (Pro, implementer lane)
+
+  - claim:
+      Pre-commit and pre-push hooks pass clean on both commits (lease-check, anti-reward-hacking
+      lint, secret scan, prettier, actionlint, off-limits check).
+    cmd: git commit -F <msg> (x2); git push (x2)
+    result: >-
+      Both commits: "All pre-commit checks passed!". Both pushes: "All pre-push checks
+      passed!" — prettier OK, actionlint OK on .github/workflows/, no off-limits files touched.
+    exit: 0
+    ts: "2026-08-26T16:30:50Z"
+    seat: session (Pro, implementer lane)
+
+dissent:
+  - seat: kimi-code/k3 (cross-family refuter, round 1)
+    objection: >-
+      The PR's claim that Dependabot runs "queue and drain serially" overstates GitHub
+      Actions' actual concurrency-group guarantee. GitHub holds at most one RUNNING and one
+      PENDING run per group; cancel-in-progress:false protects only the running job. A 3rd+
+      near-simultaneous Dependabot arrival on the same workflow cancels the pending run
+      rather than queuing behind it — plausible for security.yml (~20 billed minutes) and
+      tests.yml given the 2026-08-24 batch arrived at roughly 1 PR/minute.
+    status: CONFIRMED
+    note: >-
+      Independently re-verified against docs.github.com/en/actions/using-jobs/using-concurrency
+      before accepting (receipt above) rather than taking the refuter's word alone. Fixed in
+      commit 86dc06342: reworded the explanatory comment in all 21 files to state the real,
+      bounded guarantee (<=2 concurrent per workflow) and the documented, visible (checks-tab,
+      not silent), `gh run rerun`-recoverable failure mode beyond that. No group/cancel-in-progress
+      logic changed — cancel-in-progress:false remains correct (the alternative, true, would
+      additionally kill the RUNNING job on every new arrival, which is strictly worse).
+
+  - seat: kimi-code/k3 (cross-family refuter, round 1)
+    objection: >-
+      github.actor is the triggering actor, not the PR author. A human clicking "re-run
+      failed jobs" on a Dependabot run, or a maintainer pushing a commit to a Dependabot
+      branch, flips that one run's actor away from dependabot[bot] — it then uses the
+      per-ref (non-Dependabot) group instead of the shared Dependabot group, silently
+      losing the serialization guarantee for that one run.
+    status: CONFIRMED
+    note: >-
+      Accepted as a documented, low-frequency edge case rather than fixed. It does not
+      cross-cancel any other run (the two groups are distinct), so the failure mode is
+      "one run's guarantee lapses," not "another PR's check breaks." A PR-author-based
+      discriminator (github.event.pull_request.user.login == 'dependabot[bot]', with a
+      head-ref fallback for push events) would close it but adds real complexity for a
+      case that only bites on a manual re-run or a maintainer push — judged not worth it
+      for this PR's scope. Recorded here rather than silently dropped.
+
+  - seat: kimi-code/k3 (cross-family refuter, round 1)
+    objection: >-
+      The shared group name `dependabot-lockfile-{workflow}` says "lockfile" but the group
+      catches ALL Dependabot activity for that workflow, not only lockfile-specific bumps —
+      cosmetic, but surfaces in the Actions UI cancellation messages.
+    status: CONFIRMED
+    note: >-
+      Kept as-is rather than renamed: the exact string was specified by the orchestrating
+      session's mandate, and renaming touches all 21 files again for a purely cosmetic gain.
+      Recorded so the naming choice reads as deliberate, not overlooked.
+
+tests:
+  - "No test suite applies — this PR is pure GitHub Actions workflow YAML (concurrency
+    stanzas + comments), no Python/JS/TS source changed."
+
+static:
+  - "actionlint on all 21 changed files — rc=0, both before and after the fix commit."
+  - "python3 -m yaml (safe_load) on all 21 changed files — rc=0, all parse; every
+    concurrency.group references dependabot[bot]."
+  - "pre-commit hooks (lease-check, anti-reward-hacking test lint, secret scan, python
+    lint, off-limits check) — passed on both commits."
+  - "pre-push hooks (prettier, actionlint, path-aware suite classification) — passed on
+    both pushes."
+
+notes:
+  - "LIVE-DRAIN PROOF NOT EXECUTABLE TODAY. All 13 Dependabot PRs that motivated this
+    mandate (#4838-#4851) were independently closed 2026-08-26T16:17:56Z-16:18:03Z — before
+    this session started, and not by this PR or anything in it (verified via `gh pr view
+    --json state,mergedAt,closedAt` on each of the 13 numbers individually, not inferred
+    from a list query). `.github/dependabot.yml` runs weekly/monday for all 3 ecosystems, so
+    there are zero open Dependabot PRs to test the drain mechanism against; the next batch
+    lands ~2026-08-31 and is the first live test."
+  - "The mandate's step-4 verification ('arm the oldest Dependabot PR only, report its state
+    2 minutes later') has no subject to run against today. Not fabricated, not skipped
+    silently — reported as not-executable in both the PR body and here."
+  - "Zero writes to any external system. This PR changes only .github/workflows/*.yml
+    comments and concurrency keys plus this evidence pack; nothing deploys, nothing mutates
+    production state."

--- a/evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/pack.yml
@@ -1,4 +1,4 @@
-brief_ref: evidence/2026-08/agent-nuzantara-infra-dependabot-serialize-concu-d0e8e846/brief.yml
+brief_ref: evidence/brief.yml
 plan_ref: >-
   PR #5043 (agent/nuzantara/infra/dependabot-serialize-concurrency -> main) —
   arms CLAUDE.md Agent PR Contract rule 5. Mandate from the orchestrating


### PR DESCRIPTION
## Summary

CLAUDE.md Agent PR Contract rule 5 — *"Serialize Dependabot PRs that share a lockfile. Arm them one at a time."* — had no enforcement machinery. This PR arms it with a per-workflow `concurrency:` group so that Dependabot-authored runs of a given required-check workflow **bound their peak parallelism to <=2** instead of running fully in parallel, N-deep.

**Mechanism.** Every workflow's `concurrency.group` becomes a ternary on `github.actor`:

```yaml
group: ${{ github.actor == 'dependabot[bot]' && format('dependabot-lockfile-{0}', github.workflow) || <pre-existing expression, byte-for-byte> }}
cancel-in-progress: ${{ github.actor != 'dependabot[bot]' && <pre-existing expression, byte-for-byte> }}
```

- **Dependabot branch**: all Dependabot PRs collapse onto ONE group per workflow (not per-ref/per-PR), with `cancel-in-progress: false` — the currently-*running* Dependabot job is never killed by a later arrival. **Corrected claim (see Adversarial review below)**: GitHub Actions concurrency groups hold at most one RUNNING + one PENDING run per group — a 3rd+ near-simultaneous arrival replaces (cancels) the pending run rather than queuing behind it. So this bounds concurrent Dependabot runs of one workflow to <=2, and for exactly 2 it behaves as a true queue; beyond that the excess is cancelled (visibly, in the PR's checks tab — recoverable with `gh run rerun`), not silently dropped or delayed. See the in-file comments for the full citation.
- **Non-Dependabot branch**: identical to what was already there. Ordinary PRs are unaffected — verified by re-deriving each workflow's original expression and keeping it verbatim as the `||` fallback.

## Scope: which 21 workflows, and why not more

Scoped to workflows that are **both**:
1. Unconditional on `pull_request:` (no `paths:` filter) — so it runs on literally every one of the 13 Dependabot PRs regardless of ecosystem (github_actions / pip / npm_and_yarn), and
2. A **required status check** on `main` (`gh api repos/Bali-Zero/Teman2/branches/main/protection --jq '.required_status_checks.contexts[]'`).

21 files qualify: `actionlint`, `adversarial-review-gate` (R1 gate), `asyncpg-lint`, `guard-conformance`, `harness-floor`, `hook-innocence-gate`, `hot-zone-pr-gate`, `immune-enforcement`, `npm-lock-sync`, `organ-conformance`, `p1s2-mutation-incremental`, `p3-sandbox-gates`, `p6-federation-parallelize`, `p7-lesson-harvester`, `p8-brand-api`, `p9-cost-breaker`, `prepush-guards`, `root-guard`, `security` (CodeQL×2/Bandit/Detect Secrets), `tests` (Backend/E2E/Frontend/MCP Server Tests), `verify-the-verifiers`.

4 of those (`adversarial-review-gate`, `p3-sandbox-gates`, `p7-lesson-harvester`, `p8-brand-api`) had **no prior `concurrency:` block**. Their non-Dependabot branch is suffixed with `github.run_id` (unique per run, never collides), which reproduces "no concurrency restriction" for ordinary PRs exactly rather than inventing new behavior.

**Deliberately excluded** (always-trigger but NOT a required check, so they don't gate merge and don't affect drain rate — including them would double this PR's footprint for zero effect on rule 5): `docs-guardian`, `docs-sync`, `garuda-contract-parity`, `migration-lint`, `prettier-changed-files`, `runbook-section-numbers`, `token-lint`, `worker-plane-review-tests`, `frontend-typecheck`.

`security.yml` and `tests.yml` carry pre-existing composed `cancel-in-progress` expressions (main-vs-PR asymmetry, schedule handling, merge_group safety) with substantial explanatory comments; those are extended with `github.actor != 'dependabot[bot]' &&` rather than rewritten, so every existing branch and its documentation stays intact.

`adversarial-review-gate.yml`'s own R1 gate (`scripts/check_adversarial_review.py`) is scoped to `research/**/*.md` — this PR touches none, so it is out of scope for that gate by construction (0-files-in-scope PASS), independent of this section existing.

## BEFORE / AFTER

- **BEFORE**: 13 open Dependabot PRs (#4838–#4851), oldest three created 2026-08-24T15:36–15:38Z, all 13 within a 13-minute window — arriving and running required checks as a batch, fully in parallel, no cap.
- **AFTER (mechanism)**: Dependabot runs of the same required-check workflow are capped at 2 concurrent (1 running + 1 pending); a 3rd+ near-simultaneous arrival cancels the pending one rather than queuing indefinitely (GitHub's own concurrency-group limit — see Adversarial review).
- **AFTER (measured, honest caveat)**: all 13 of the PRs above were independently **closed by 2026-08-26T16:17:56–16:18:03Z** — before this session started, and not by this PR or anything in it. `.github/dependabot.yml` runs `weekly`/`monday` for all three ecosystems, so there are currently **zero open Dependabot PRs** to drain-test against; the next batch lands ~2026-08-31. I am not claiming a live drain proof — see Verification below for what was actually run, and the mandate's step-4 live-drain check (arm the oldest, observe state 2 minutes later) is **not executable today** for lack of a subject. It is directly testable against Monday's batch.
- **DRAIN PROOF DEFERRED: GitHub Actions outage.** Independently of the point above, GitHub Actions itself is in a major outage as of this PR (githubstatus incident, ~16:14Z 2026-08-26 — `startup_failure` runs from 15:06Z, queued runs with 0 jobs picked up, no Actions check-suite created on this PR's head at all — confirmed live on `gh pr view 5043 --json statusCheckRollup`, only a non-Actions `Vercel Agent Review` check reporting). Do not read missing/red required checks on this PR tonight as this diff's fault. The 13-PR jam this mandate fixes predates the outage by two days (created 2026-08-24, outage started 2026-08-26) — X2 stays valid regardless of tonight's Actions availability; the fix is orthogonal to the outage and will run its first live test against the 2026-08-31 Dependabot batch once Actions recovers.

## Scope note

The 13 Dependabot PRs (#4838–#4851) referenced in BEFORE above were closed via the shared `gh` identity `Balizero1987` (the identity every session in this fleet authenticates as) at 2026-08-26T16:17:56Z–16:18:03Z — 13 closes in 7 seconds, no PR comment, no ledger row, no fleet broadcast on any of them. This closure is not part of this mandate or this lane. Numbers and times only; no claim is made here about which sibling session ran it.

Plainly: **live drain proof has no subject until the next Dependabot batch (~2026-08-31, Monday)** — there are zero open Dependabot PRs today, independent of the GitHub Actions outage noted below.

## Verification

- `actionlint` on all 21 changed files: **rc=0**, clean (both before and after the comment-correction commit).
- `python3 -c "import yaml..."`: all 21 files parse as valid YAML; `concurrency.group` references `dependabot[bot]` on every one.
- `git diff --stat origin/main`: 21 files, +270/−34 (304-line footprint, under the ~400-net-line guidance for a single mechanical concern).
- Required-check mapping cross-checked against `gh api .../branches/main/protection` contexts, not assumed from job names — 3 required contexts (`E2E Tests (Playwright)`, `Frontend Tests (Next.js)`, `MCP Server Tests`) turned out to live inside `tests.yml` alongside `Backend Tests (Python)`, found by grepping for the literal context strings across all workflow files rather than guessing from `tests.yml`'s own job names.
- `python3 scripts/evidence_pack_lint.py --print-floor`: gear floor = 3, matching the declared gear (`.github/workflows/**` is Gear-3 by construction).

## Adversarial review

**Seat: kimi-code/k3** (cross-family, Kimi CLI `kimi -m kimi-code/k3`), round 1 of max 2, on the full PR diff via `gh pr diff`.

**Finding (CONFIRMED, fixed in the second commit)**: the original PR body and in-file comments claimed Dependabot runs would "queue and drain serially" without qualification. Kimi found this overstates GitHub Actions' actual concurrency-group guarantee: at most one RUNNING and one PENDING run per group; a 3rd+ arrival cancels the pending one rather than queuing behind it (even with `cancel-in-progress: false`, which protects only the running job). Independently verified against `docs.github.com/en/actions/using-jobs/using-concurrency` ("any existing pending job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place"). Fix applied: reworded the explanatory comment in all 21 files to state the real, bounded guarantee (<=2 concurrent) and the documented, visible (not silent), `gh run rerun`-recoverable failure mode beyond that. No group/cancel-in-progress logic changed — `cancel-in-progress: false` was and remains the correct choice (the alternative, `true`, would additionally kill the RUNNING job on every new arrival, which is strictly worse).

**Findings (CONFIRMED, no code change needed — informational)**:
- `github.actor` is the *triggering* actor, not the PR author: a human "re-run failed jobs" click or a maintainer push to a Dependabot branch flips that one run out of the shared Dependabot group (it uses the per-ref group instead). This does not cross-cancel any other run (the groups differ) — it just means that one re-run's serialization guarantee silently lapses for that run. Accepted as a known, low-frequency edge case; a PR-author-based discriminator (`github.event.pull_request.user.login`) would close it but adds complexity and a non-PR-event fallback for a benefit that applies only to manually re-triggered runs.
- The shared group name `dependabot-lockfile-{workflow}` is slightly misleading (it groups all Dependabot activity for a workflow, not only lockfile-specific bumps). Cosmetic; kept as originally specified in the mandate rather than renamed mid-flight.

**PLAUSIBLE / accepted trade-off**: for `security.yml` specifically (~20 billed minutes per run), a burst beyond 2 concurrent Dependabot PRs means excess runs are cancelled rather than executed — real compute savings, but achieved by dropping runs, not by queuing them to completion. Documented in-file rather than engineered around, since GitHub's concurrency primitive cannot express true N-deep FIFO queuing without external tooling (a scope Kimi itself flagged as "the wrong primitive" for guaranteed serialization) — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


