### PR TITLE
feat(telemetry): daily seat-mix report — the fleet never measured its own LLM levels (sonnet 86%, haiku 0.9%, ollama 1)

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: a64d11324088872cfa252e95f6cdc536be66f31e8cec32c111323d75b1329997
+checksum: 95717ca1541cc59c979473e4971630a31112487a6d9c01ffe2fc05d058711c67
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -2666,5 +2666,26 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/pro.kb_probe_history.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.seat_mix_report
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 108000
+  owner_module: scripts/seat_mix_report.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.seat-mix.daily
+  severity_on_silence: info
+  notes: A7/R12 daily seat-mix telemetry (Agent dispatch model mix + non-Anthropic
+    shell-call mix, joined to PRs), StartCalendarInterval 06:30 WITA. Honors SEAT_MIX_REPORT_ENABLED
+    kill switch (writes status=disabled heartbeat) and an unconditional heartbeat
+    on both the success and failure path (genes imprinted post-birth, PR
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.seat_mix_report.json
     timestamp_field: ts
     status_field: status

--- a/docs/factory/SEAT-MIX.md
+++ b/docs/factory/SEAT-MIX.md
@@ -69,60 +69,63 @@ is tested directly: `test_pii_in_tool_result_and_command_text_never_leaks` feeds
 transcript containing an email, a phone number and an `sk-...`-shaped secret inside a
 `tool_result` block and asserts none of them appear in the emitted JSON or Markdown.
 
-## Day-0 baseline (Pro, `--since 48`, 2026-08-27 00:24 WITA)
+## Day-0 baseline (Pro, `--since 48`, 2026-08-27 00:38 WITA, post cross-family review)
 
 Scoped to this machine's own `~/.claude/projects` only -- not the fleet-wide hand parse this
 script replaces, which spanned M5+Pro+Mini. A per-machine cron on each node is how the two
-become comparable; nothing here sums them.
+become comparable; nothing here sums them. This is the run taken AFTER the mandatory Kimi K3
+adversarial review of the shipping PR (findings and fixes below), not the first draft.
 
 ```
 # Seat-mix daily report
 
-- generated_at: 2026-08-27 00:24:33 WITA
+- generated_at: 2026-08-27 00:38:00 WITA
 - window_hours: 48.0
-- sessions_scanned: 113
+- sessions_scanned: 118
 - files_skipped (over size cap): 0
 
 ## Agent dispatch mix
 
-Total Agent dispatches: 140
+Total Agent dispatches: 148
 
 | model | count | pct |
 |---|---|---|
-| sonnet | 124 | 88.6% |
-| inherit | 14 | 10.0% |
+| sonnet | 127 | 85.8% |
+| inherit | 18 | 12.2% |
+| haiku | 2 | 1.4% |
 | opus | 1 | 0.7% |
-| haiku | 1 | 0.7% |
 
-cheap_seat_share_pct (haiku share): 0.7%
+cheap_seat_share_pct (haiku share): 1.4%
 
 | subagent_type | count |
 |---|---|
-| general-purpose | 109 |
-| Explore | 13 |
+| general-purpose | 113 |
+| Explore | 14 |
 | backend-verifier | 12 |
-| fork | 3 |
+| fork | 5 |
+| unspecified | 2 |
 | spalla-review | 1 |
 | mcp-health | 1 |
-| unspecified | 1 |
 
 ## Non-Anthropic seat calls (Bash)
 
-Total: 96
-Per Anthropic dispatch: 0.69
+Total: 112
+Per Anthropic dispatch: 0.76
 
 | seat | count |
 |---|---|
-| nlm | 20 |
-| seat_build:default | 16 |
-| kimi:k3 | 15 |
-| agy:default | 15 |
-| kimi:default | 9 |
+| nlm | 23 |
+| kimi:k3 | 16 |
+| seat_build:default | 15 |
+| kimi:default | 15 |
+| agy:default | 10 |
+| codex:sol | 8 |
+| tp1 | 8 |
 | codex:default | 7 |
-| codex:sol | 5 |
-| tp1 | 5 |
+| seat_build:codex/unset | 3 |
 | codex:luna | 3 |
-| jules_dispatch | 1 |
+| jules_dispatch | 3 |
+| kimi:kimi-for-coding | 1 |
 
 ## Workflow tool
 
@@ -130,22 +133,48 @@ workflow_runs: 1
 
 ## Per-PR seat counts (best-effort branch join)
 
-unmapped_sessions_with_activity: 28
+unmapped_sessions_with_activity: 35
 
 | PR | agent_dispatches | seat_calls | sessions |
 |---|---|---|---|
+| 5043 | 1 | 0 | 1 |
 | 5037 | 1 | 0 | 1 |
 | 5039 | 0 | 1 | 1 |
 ```
 
-28 of 30 sessions-with-activity are unmapped, and that is a correct reading of this machine's
+Most sessions-with-activity are unmapped, and that is a correct reading of this machine's
 work that day, not a join failure: a metadata-only branch tally (names only, no message
-content) over the same window shows 45 sessions on `main`, 12 on detached `HEAD`, and 39 on the
-long-lived `feature/visa-oracle` integration branch -- none of which a `head:<branch>` PR search
-can ever match, by construction (no PR has `main`/`HEAD` as its head ref, and this repo's
-integration branches are merged by the conducting session directly, per
-`docs/factory/ASSEMBLY-LINE.md`, not through per-lane PRs). The two PRs it did map (#5037,
-#5039) came from short-lived per-lane `agent/...` branches.
+content) over the same window shows the bulk of sessions on `main`, on detached `HEAD`, and on
+the long-lived `feature/visa-oracle` integration branch -- none of which a `head:<branch>` PR
+search can ever match, by construction (no PR has `main`/`HEAD` as its head ref, and this
+repo's integration branches are merged by the conducting session directly, per
+`docs/factory/ASSEMBLY-LINE.md`, not through per-lane PRs). The mapped PRs came from
+short-lived per-lane `agent/...` branches, this report's own PR (#5047 -> #5043 above) included.
+
+### What the cross-family review changed
+
+The mandatory Kimi K3 (`kimi-code/k3`) adversarial pass on this report's own shipping PR found
+two real issues before merge, both fixed and both re-tested:
+
+1. **A secret/PII leak in free-captured flag values.** `--model`/`--seat`/`--tier`/ollama's
+   model argument are captured from arbitrary command text (unlike the codex/kimi tier labels,
+   which come from a fixed enumeration). The output-safety charset is a _superset_ of common
+   secret shapes -- an `sk-...`-style key or a bare-digit phone number is made entirely of
+   letters/digits/hyphens, so it would have survived the sanitizer intact. Fixed with a
+   `_redact_if_sensitive()` check (secret-key prefixes, or >=7 digits) applied before
+   sanitization, replacing the value with the fixed literal `redacted` rather than propagating
+   it in any form.
+2. **Over-counting when a vocabulary script is read/edited, not run.** `cat scripts/seat_build.sh`,
+   `git log -- scripts/jules_dispatch.py`, `grep review_routes -r .` all matched the vocabulary
+   even though nothing was invoked -- a systematic inflation risk in a repo whose daily work is
+   editing these very scripts. Fixed by splitting each command on shell separators and skipping
+   any segment whose own first word is a read/inspect/edit verb (`cat`, `grep`, `git`, `vim`, ...)
+   before running any vocabulary check on it.
+
+Neither finding was a full PII leak of the kind the original PII fixture already covered (that
+one -- email/phone/key inside a `tool_result` or a non-matching command -- was correct from the
+start); both were narrower gaps the refuter located precisely, and both now have their own
+guilt+innocence test coverage in `scripts/tests/test_seat_mix_report.py`.
 
 ## Cron
 

--- a/docs/factory/SEAT-MIX.md
+++ b/docs/factory/SEAT-MIX.md
@@ -1,0 +1,161 @@
+# Seat-mix daily report
+
+Spec: A7/R12 (`/Users/nuzantara/Desktop/2026-08-26-PIANO-SPEC-receptor-live.md` §3 A7, §8
+R12/E5). Script: `scripts/seat_mix_report.py`. Tests: `scripts/tests/test_seat_mix_report.py`.
+
+## Why this exists
+
+The fleet dispatches Claude subagents (the `Agent` tool: model + `subagent_type`) and shells
+out to a whole cross-family arsenal (Codex, Kimi, agy, Ollama, NotebookLM, `seat_build.sh`,
+TP1) from inside Claude Code sessions, but until this script existed nobody had ever counted
+the mix in a repeatable way. A one-off hand parse on 2026-08-26 found 882 Agent dispatches
+fleet-wide in 48h (sonnet 86%, haiku 0.9%, opus the rest), ~512 non-Anthropic shell calls, the
+`Workflow` tool at 0 genuine runs, and only 5 of 20 evidence packs carrying a cross-family
+reviewer. That parse was never published and could not be re-run. This script is the
+repeatable version.
+
+## What it measures
+
+It stream-parses Claude Code's own project transcripts (`~/.claude/projects/**/*.jsonl`, or
+`--projects-root`) inside a lookback window (`--since HOURS`, default 24) and counts, purely
+structurally, three things:
+
+- **Agent dispatch mix** -- every `Agent` tool_use, bucketed by `input.model` (missing model
+  means the subagent inherited the session's model, recorded as `inherit`) and by
+  `input.subagent_type`. `cheap_seat_share_pct` is the haiku share of that total.
+- **Non-Anthropic seat calls** -- every `Bash` tool_use whose `input.command` matches a small,
+  fixed seat vocabulary (`codex exec -m gpt-5.6-{sol,terra,luna}` or the bare default tier,
+  `kimi -m kimi-code/{k3,kimi-for-coding,kimi-for-coding-highspeed}`, `agy --model`,
+  `seat_build.sh --seat/--tier`, `ollama run`, `nlm`/`notebooklm`, `jules_dispatch.py`,
+  `tp1_call`/`review_routes`). Everything else running under `Bash` (`git`, `pytest`, `ls`, ...)
+  is not a "seat" and is not counted. `non_anthropic_seat_calls.per_anthropic_dispatch` is the
+  ratio of that total to total Agent dispatches.
+- **Workflow tool runs** -- a bare count of `Workflow` tool_use blocks.
+
+Each scanned session's `gitBranch` field is best-effort joined to a PR number via
+`gh pr list --search "head:<branch>"` (skipped entirely if `gh` is unavailable, or with
+`--no-map-prs`); sessions with dispatch activity whose branch didn't map to any open PR are
+counted in `unmapped_sessions_with_activity` rather than silently dropped.
+
+## What it does not measure, and why
+
+There are no targets or thresholds anywhere in this report or in this doc. The 2026-08-26
+retro's A5 proposal (imposing a target ratio) was rejected: this is descriptive telemetry, not
+a gate. It tells you what the mix IS; deciding what it SHOULD be is a separate, human
+conversation informed by these numbers, not something the script enforces.
+
+It also does not measure cost or token volume (that is `scripts/usage/seat_usage_collector.py`,
+which parses the same transcript family for `message.usage` token counts per Claude-profile
+seat -- a different join key: profile-dir to account-seat, not branch to PR). The two are
+complementary, not overlapping: this script answers "what got dispatched and where", that one
+answers "how many tokens did each account burn".
+
+## Output
+
+- `~/logs/seat-mix/<YYYY-MM-DD>.json` -- full structured report.
+- `~/logs/seat-mix/<YYYY-MM-DD>.md` -- the same numbers, rendered readable, also printed to
+  stdout by the CLI.
+
+## PII boundary (SYMBIOSIS Law 2)
+
+Transcripts carry real client PII inside `tool_result` blocks and free-text `text` blocks. The
+scanner never reads either -- it only inspects `tool_use` blocks' `name` field and a handful of
+narrow-charset regex captures out of `input.command` / `input.model` / `input.subagent_type`,
+and discards the raw command text immediately after classification. Every string that reaches
+the report additionally passes through a sanitizer (truncate to 120 chars, strip to
+`[A-Za-z0-9 _./:%()\-=,]`) at the point of extraction, and a final `assert_all_strings_safe`
+pass re-walks the whole report as a hard defense-in-depth gate before anything is written. This
+is tested directly: `test_pii_in_tool_result_and_command_text_never_leaks` feeds a fixture
+transcript containing an email, a phone number and an `sk-...`-shaped secret inside a
+`tool_result` block and asserts none of them appear in the emitted JSON or Markdown.
+
+## Day-0 baseline (Pro, `--since 48`, 2026-08-27 00:24 WITA)
+
+Scoped to this machine's own `~/.claude/projects` only -- not the fleet-wide hand parse this
+script replaces, which spanned M5+Pro+Mini. A per-machine cron on each node is how the two
+become comparable; nothing here sums them.
+
+```
+# Seat-mix daily report
+
+- generated_at: 2026-08-27 00:24:33 WITA
+- window_hours: 48.0
+- sessions_scanned: 113
+- files_skipped (over size cap): 0
+
+## Agent dispatch mix
+
+Total Agent dispatches: 140
+
+| model | count | pct |
+|---|---|---|
+| sonnet | 124 | 88.6% |
+| inherit | 14 | 10.0% |
+| opus | 1 | 0.7% |
+| haiku | 1 | 0.7% |
+
+cheap_seat_share_pct (haiku share): 0.7%
+
+| subagent_type | count |
+|---|---|
+| general-purpose | 109 |
+| Explore | 13 |
+| backend-verifier | 12 |
+| fork | 3 |
+| spalla-review | 1 |
+| mcp-health | 1 |
+| unspecified | 1 |
+
+## Non-Anthropic seat calls (Bash)
+
+Total: 96
+Per Anthropic dispatch: 0.69
+
+| seat | count |
+|---|---|
+| nlm | 20 |
+| seat_build:default | 16 |
+| kimi:k3 | 15 |
+| agy:default | 15 |
+| kimi:default | 9 |
+| codex:default | 7 |
+| codex:sol | 5 |
+| tp1 | 5 |
+| codex:luna | 3 |
+| jules_dispatch | 1 |
+
+## Workflow tool
+
+workflow_runs: 1
+
+## Per-PR seat counts (best-effort branch join)
+
+unmapped_sessions_with_activity: 28
+
+| PR | agent_dispatches | seat_calls | sessions |
+|---|---|---|---|
+| 5037 | 1 | 0 | 1 |
+| 5039 | 0 | 1 | 1 |
+```
+
+28 of 30 sessions-with-activity are unmapped, and that is a correct reading of this machine's
+work that day, not a join failure: a metadata-only branch tally (names only, no message
+content) over the same window shows 45 sessions on `main`, 12 on detached `HEAD`, and 39 on the
+long-lived `feature/visa-oracle` integration branch -- none of which a `head:<branch>` PR search
+can ever match, by construction (no PR has `main`/`HEAD` as its head ref, and this repo's
+integration branches are merged by the conducting session directly, per
+`docs/factory/ASSEMBLY-LINE.md`, not through per-lane PRs). The two PRs it did map (#5037,
+#5039) came from short-lived per-lane `agent/...` branches.
+
+## Cron
+
+`infra/launchagents/com.nuzantara.seat-mix.daily.plist` -- `StartCalendarInterval` 06:30, no
+`KeepAlive` (superscar #7: this is a one-shot job, not a long-running daemon). Not installed by
+the PR that ships it (Agent PR Contract): install per machine with
+
+```bash
+cp infra/launchagents/com.nuzantara.seat-mix.daily.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.nuzantara.seat-mix.daily.plist
+```
+
+on both Pro and Mini (the H24 node) -- not on M5, which runs no daemons/cron by design.

--- a/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/brief.yml
@@ -1,0 +1,83 @@
+task_id: seat-mix-report-0826
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  A7/R12 -- ship a daily seat-mix telemetry report that stream-parses Claude
+  Code's own project transcripts and counts Agent tool_use (by model and
+  subagent_type), Bash tool_use (classified against a fixed non-Anthropic
+  seat vocabulary: codex/kimi/agy/seat_build/ollama/nlm/jules_dispatch/tp1),
+  and Workflow tool_use, joined best-effort to PRs via gitBranch. Replaces a
+  one-off, unpublished, unrepeatable hand parse (882 Agent dispatches/48h
+  fleet-wide, ~512 non-Anthropic calls) with a script anyone can re-run.
+
+  Gear 3 by PATH, not by blast radius: the deterministic floor recomputed
+  from this PR's own 4-file changed set is 3, because
+  infra/launchagents/com.nuzantara.seat-mix.daily.plist is hot-zone. The
+  floor is a lower bound computed from the diff, never the conductor's
+  choice, and is honored here rather than argued with.
+constraints:
+  - "PII BOUNDARY (SYMBIOSIS Law 2): the scanner must never read tool_result
+    or free-text content blocks -- only tool_use.name and narrow-charset
+    regex captures out of input.command/input.model/input.subagent_type.
+    Every emitted string passes through a 120-char safe-charset sanitizer at
+    extraction time, re-checked by a hard assert_all_strings_safe() gate
+    before anything is written."
+  - "No secrets, no ANTHROPIC_API_KEY anywhere -- this script shells out to
+    `gh` only, never to any LLM."
+  - "The cron this PR ships (infra/launchagents/com.nuzantara.seat-mix.daily.plist)
+    is NOT installed by this PR -- Agent PR Contract: an agent ships the
+    artifact, the operator/H24 node installs it. StartCalendarInterval, no
+    KeepAlive (superscar #7)."
+  - "No targets or thresholds anywhere in the report or its doc -- the
+    2026-08-26 retro's A5 proposal (impose a target ratio) was rejected;
+    this is descriptive telemetry, not a gate."
+acceptance:
+  - "scripts/tests/test_seat_mix_report.py is green: exact dispatch counts
+    on a fixture (3 Agent: 2 sonnet/1 haiku; 2 Bash seat calls: codex-sol +
+    kimi-k3; 1 Workflow), a PII-leak fixture (email/phone/sk-... inside a
+    tool_result) proven absent from both JSON and Markdown output, and an
+    oversized-file-is-skipped-and-counted case."
+  - "classify_bash_seat has a guilt case AND an innocence case for every
+    vocabulary entry (cicatrix family #3 discipline) -- including the
+    kimi-for-coding vs kimi-for-coding-highspeed longest-alternative-first
+    ordering gotcha, and 'the codex executable'/'codexy exec' must NOT
+    match 'codex exec'."
+  - "The deterministic floor recomputed from the real changed-file
+    enumeration is 3, and this brief declares gear 3 -- never below it."
+  - "infra/launchagents/com.nuzantara.seat-mix.daily.plist passes plutil
+    -lint and scripts/lint_plist_keepalive.py clean."
+  - "The script actually runs against real transcripts on Pro (--since 48)
+    and produces a plausible, PII-free day-0 baseline, pasted verbatim into
+    the PR body and docs/factory/SEAT-MIX.md."
+consumer_map:
+  - "scripts/seat_mix_report.py -- read by nobody yet except its own cron;
+    day-0 baseline is a manual run, folded into docs/factory/SEAT-MIX.md."
+  - "infra/launchagents/com.nuzantara.seat-mix.daily.plist -- BUILT, NOT
+    ARMED. Install command for Pro + Mini is in the PR body; M5 runs no
+    daemons/cron by design and is deliberately excluded."
+  - "~/logs/seat-mix/<date>.{json,md} -- new output location, consumed by
+    nothing yet (first report of its kind)."
+risks:
+  - "The PR->branch join is best-effort and, measured on the real day-0 run,
+    mostly unmapped (28/30 sessions-with-activity) -- NOT a defect: a
+    metadata-only branch tally over the same window shows the bulk of
+    activity sits on `main`, detached `HEAD`, and the long-lived
+    `feature/visa-oracle` integration branch, none of which a
+    `head:<branch>` PR search can ever match by construction. Documented in
+    docs/factory/SEAT-MIX.md rather than left as an unexplained number."
+  - "gh pr list --search is a text search, not an exact-match API guarantee
+    -- a branch name that is itself a substring of another could
+    theoretically over-match. Not observed on the real run; not fenced,
+    because gh's own head: qualifier scopes it to the head ref, which git
+    already treats as unique per open/closed/merged PR in practice."
+grader: |
+  generator != grader: build lane is this session (claude-sonnet-5, per the
+  mandate's per-agent LLM choice for implementer subagents), cross-family
+  adversarial review is Kimi K3 (kimi-code/k3) on the real PR diff, per the
+  mandate's mandatory refuter step. Single build lane -- the lanes:
+  build-seat-diversity rule does not trigger (requires >=2 build lanes).
+budget: |
+  Single-lane implementer task, flat-subscription seats only (Claude Code
+  session + Kimi K3 refuter). No metered API spend.
+pii: none

--- a/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/pack.yml
@@ -13,18 +13,23 @@ lanes:
     seat: kimi-code/k3 (cross-family refuter on the real shipping PR diff, gh pr diff 5047)
 
 diff:
-  files: 6
-  net_lines: 1533
+  files: 7
+  net_lines: 1721
   measured_at: c89706c69
   note: >-
-    git diff --no-renames --numstat against merge-base 63bfa19ec5872519 (origin/main
-    at dispatch time), cumulative across all 3 commits on this branch (feature +
-    evidence pack + refuter-fix round): docs/factory/SEAT-MIX.md +190,
-    evidence/.../brief.yml +83, evidence/.../pack.yml +193 (this file, self-counted
-    per the existing convention), infra/launchagents/com.nuzantara.seat-mix.daily.plist
-    +25, scripts/seat_mix_report.py +595, scripts/tests/test_seat_mix_report.py +447
-    -- 0 net deletions (every file is new relative to origin/main, so intra-branch
-    edits collapse to pure addition against the merge-base).
+    UPDATED 2026-08-27 by the queue-shepherd sweep (organ-genes follow-up
+    fix) -- re-measured for real, not incremented by estimate:
+    `git diff --no-renames --numstat $(git merge-base origin/main HEAD) --
+    .` against merge-base 63bfa19ec5872519 (unchanged, origin/main at
+    original dispatch time): apps/organism/organism/organs_registry.yaml
+    +22/-1 (NEW file for this diff -- the pro.seat_mix_report entry added
+    tonight), docs/factory/SEAT-MIX.md +190, evidence/.../brief.yml +83,
+    evidence/.../pack.yml +316 (this file, self-counted per the existing
+    convention -- grew from the tonight's-fix receipt/dissent/notes
+    additions), infra/launchagents/com.nuzantara.seat-mix.daily.plist +25,
+    scripts/seat_mix_report.py +639 (was +595 -- +44 for the heartbeat
+    helper + kill switch + main() wiring), scripts/tests/test_seat_mix_report.py
+    +447 -- files 6->7, net 1533->1721 (+188 for the organ-genes fix).
 
 pii_scan: clean
 
@@ -160,6 +165,37 @@ receipts:
     ts: 2026-08-27T00:39Z
     seat: session (Pro, implementer lane)
 
+  - claim: >-
+      SAME-NIGHT FOLLOW-UP (queue-shepherd sweep, post-push CI): "Every
+      organ is born with its genes" failed on the pushed head --
+      infra/launchagents/com.nuzantara.seat-mix.daily.plist was a NEW organ
+      missing genes G1_registry, G2_heartbeat, G5_kill_switch. Fixed:
+      SEAT_MIX_REPORT_ENABLED kill switch + _write_heartbeat() (atomic
+      tmp+replace to ~/.organism/last_seen/pro.seat_mix_report.json,
+      status ok/error/disabled, wrapped so a heartbeat write can never
+      raise) wired into scripts/seat_mix_report.py's main(); an
+      `id: pro.seat_mix_report` entry added to
+      apps/organism/organism/organs_registry.yaml (registry checksum
+      regenerated via --update-checksum). No regression: existing test
+      suite and organ-conformance gate both re-run green after the fix.
+    cmd: >-
+      python3 -m py_compile scripts/seat_mix_report.py &&
+      python3 infra/organ-conformance/check_organ_conformance.py &&
+      apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_seat_mix_report.py -q
+    result: >-
+      py_compile: silent success, exit 0. organ-conformance: "✓ organ
+      conformance: 182 plists scanned, 121 grandfathered (report-only), 0
+      regressions, 0 non-conformant births" (no seat-mix mention -- prior
+      run before this fix printed "✗ NEW organ without genes:
+      infra/launchagents/com.nuzantara.seat-mix.daily.plist missing
+      ['G1_registry', 'G2_heartbeat', 'G5_kill_switch']" and exit 1; this
+      run is exit 0). pytest: "52 passed in 0.28s" -- identical count to
+      the pre-fix baseline above, confirming zero regression from the
+      heartbeat/kill-switch addition.
+    exit: 0
+    ts: 2026-08-27T07:45Z
+    seat: session (queue-shepherd sweep, implementer lane)
+
 dissent:
   - seat: session self-refutation (own test suite, caught before any external review)
     objection: >-
@@ -226,6 +262,36 @@ dissent:
       session before the refuter ran -- recorded as external, not
       self-refutation, unlike the two entries above.
 
+  - seat: agy (Gemini 3.1 Pro, cross-family refuter, same-night follow-up fix)
+    objection: >-
+      "launchd ignores user shell exports. Setting SEAT_MIX_REPORT_ENABLED
+      requires updating the plist or running launchctl setenv. A file-based
+      kill switch is far more reliable." Plus 3 related points: hangs/OOM/
+      SIGKILL never reach the heartbeat's error-write path; a pre-init
+      crash (syntax/import/interpreter-lookup error) fails before the
+      heartbeat wrapper ever executes; and the healer must explicitly
+      respect status=disabled, not just timestamp freshness.
+    status: CONFIRMED
+    note: >-
+      All 4 real. Grepped this repo's own launchagents (`grep -l _ENABLED
+      infra/launchagents/*.plist`, then checked EnvironmentVariables blocks
+      by hand): zero plists declare their own kill-switch var inline --
+      every organ using this `<SCOPE>_ENABLED` pattern (e.g.
+      scripts/queue_shepherd.py's QUEUE_SHEPHERD_ENABLED) relies on an
+      operator setting it externally (launchctl setenv, an edited
+      EnvironmentVariables block, or a wrapper). So point 1 is real but is
+      the EXISTING repo-wide convention this fix reused verbatim, not a
+      defect this PR introduced -- fixing it properly (a file-based switch)
+      is a cross-organ design change out of this single PR's scope. Points
+      2+3 are the inherent limit of any heartbeat-on-exit design: this is
+      exactly what genes.json's bridge_source `expected_hb_seconds`
+      staleness check exists to catch (a hung/killed/crashed-before-init
+      organ shows as a STALE heartbeat, not a missing one) -- not a gap in
+      this fix, the designed failure mode of the whole heartbeat mechanism.
+      Point 4 is real and out of scope: this PR ships the ORGAN's own
+      genes (G2/G5), not the healer's read-side logic that consumes them;
+      recorded here as a residual limit, not silently dropped.
+
 tests:
   - "scripts/tests/test_seat_mix_report.py -- 52 collected, 52 passed, rc=0 (backend-rag venv python)."
 
@@ -248,3 +314,8 @@ notes:
     join key) -- not Agent/Bash/Workflow dispatch counts joined to PRs. The two are
     complementary, not duplicative; docs/factory/SEAT-MIX.md says so explicitly so a
     future reader doesn't try to merge them."
+  - "The organ-genes fix (G1/G2/G5) above and its dissent entry were authored by
+    tonight's queue-shepherd sweep session, NOT the original PR author -- a same-night
+    follow-up after the pushed head tripped the pre-existing 'Every organ is born with
+    its genes' gate: the new plist itself was never birthed with a registry entry,
+    heartbeat, or kill switch, which the original authoring pass missed."

--- a/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/pack.yml
@@ -7,18 +7,24 @@ plan_ref: >-
 lanes:
   - lane: seat-mix-report-implementation
     role: build
-    seat: claude-sonnet-5 (this session -- script, tests, plist, doc, real run)
+    seat: claude-sonnet-5 (this session -- script, tests, plist, doc, real runs, and the fix round below)
+  - lane: seat-mix-adversarial-review
+    role: review
+    seat: kimi-code/k3 (cross-family refuter on the real shipping PR diff, gh pr diff 5047)
 
 diff:
-  files: 4
-  net_lines: 1125
-  measured_at: 85b9a1162
+  files: 6
+  net_lines: 1533
+  measured_at: c89706c69
   note: >-
-    git diff --no-renames --numstat against merge-base 63bfa19ec5 (origin/main
-    at dispatch time): docs/factory/SEAT-MIX.md +161, infra/launchagents/
-    com.nuzantara.seat-mix.daily.plist +25, scripts/seat_mix_report.py +536,
-    scripts/tests/test_seat_mix_report.py +403 -- 0 deletions, matching the
-    commit's own "4 files changed, 1125 insertions(+)".
+    git diff --no-renames --numstat against merge-base 63bfa19ec5872519 (origin/main
+    at dispatch time), cumulative across all 3 commits on this branch (feature +
+    evidence pack + refuter-fix round): docs/factory/SEAT-MIX.md +190,
+    evidence/.../brief.yml +83, evidence/.../pack.yml +193 (this file, self-counted
+    per the existing convention), infra/launchagents/com.nuzantara.seat-mix.daily.plist
+    +25, scripts/seat_mix_report.py +595, scripts/tests/test_seat_mix_report.py +447
+    -- 0 net deletions (every file is new relative to origin/main, so intra-branch
+    edits collapse to pure addition against the merge-base).
 
 pii_scan: clean
 
@@ -135,6 +141,25 @@ receipts:
     ts: 2026-08-27T00:24Z
     seat: session (Pro, implementer lane)
 
+  - claim: >-
+      Both Kimi K3 findings (secret-shaped flag values, over-count on
+      read/edit references to vocabulary scripts) are actually fixed, with
+      new guilt+innocence coverage, and the fix did not regress anything.
+    cmd: >-
+      ./apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_seat_mix_report.py -q
+      && python3 scripts/seat_mix_report.py --since 48
+    result: >-
+      52 passed (was 40; +12 for this round: 6 read-verb innocence cases,
+      1 compound-command non-blinding case, 5 redaction guilt cases). Real
+      re-run against real transcripts still rc=0, 118 sessions, 148 Agent
+      dispatches, 112 non-Anthropic seat calls (0.76/dispatch) -- plausible,
+      no crash, no PII in the reviewed output. Pasted into the PR body and
+      docs/factory/SEAT-MIX.md as the post-review baseline, replacing the
+      pre-review numbers.
+    exit: 0
+    ts: 2026-08-27T00:39Z
+    seat: session (Pro, implementer lane)
+
 dissent:
   - seat: session self-refutation (own test suite, caught before any external review)
     objection: >-
@@ -169,8 +194,40 @@ dissent:
       comment to a single hyphen; re-verified plutil, plistlib, and
       lint_plist_keepalive.py all agree (clean) after the fix.
 
+  - seat: kimi-code/k3 (cross-family refuter, on the real PR #5047 diff via gh pr diff)
+    objection: >-
+      (1) The output-safety charset is a superset of common secret shapes --
+      an sk-...-style key or a bare-digit phone number sitting in a matching
+      --model/--seat/--tier/ollama-model flag value is made entirely of
+      letters/digits/hyphens and would survive sanitize_str's charset check
+      intact, contradicting the module's own overstated docstring claim.
+      (2) classify_bash_seat over-matches when a vocabulary script is merely
+      READ or EDITED (cat/grep/git log/vim on seat_build.sh,
+      jules_dispatch.py, review_routes), not invoked -- a systematic
+      inflation risk given this repo's own daily work is editing these
+      scripts, demonstrated with concrete examples the existing test suite
+      did not cover.
+    status: CONFIRMED
+    note: >-
+      Both re-measured against the code, not accepted on the refuter's
+      word: reproduced (1) by hand-tracing `agy --model sk-abc123secretvalue`
+      through _AGY_MODEL_RE + sanitize_str pre-fix and confirming it would
+      have passed both the charset check and assert_all_strings_safe
+      unredacted; reproduced (2) by running `cat scripts/seat_build.sh`
+      through the pre-fix classifier and confirming it returned
+      "seat_build:default" instead of None. Fixed in commit c89706c69:
+      _redact_if_sensitive() (secret-prefix match, or >=7 digits) gates
+      every free-captured flag value before sanitization; a per-segment
+      first-token check against a fixed read/inspect/edit-verb set skips
+      any shell-separator-delimited segment that only references a
+      vocabulary name rather than running it. 12 new guilt+innocence tests
+      added for both, full suite re-run green (52/52), real transcripts
+      re-run rc=0 with plausible output. Not found independently by the
+      session before the refuter ran -- recorded as external, not
+      self-refutation, unlike the two entries above.
+
 tests:
-  - "scripts/tests/test_seat_mix_report.py -- 40 collected, 40 passed, rc=0 (backend-rag venv python)."
+  - "scripts/tests/test_seat_mix_report.py -- 52 collected, 52 passed, rc=0 (backend-rag venv python)."
 
 static:
   - "pre-commit hooks passed on the feature commit (anti-reward-hacking test lint, print()

--- a/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/pack.yml
@@ -1,0 +1,193 @@
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  A7/R12 -- daily seat-mix telemetry joined to PRs, per
+  /Users/nuzantara/Desktop/2026-08-26-PIANO-SPEC-receptor-live.md §3 A7,
+  §8 R12/E5. Single-PR mandate, dispatched as an implementer lane on Pro.
+
+lanes:
+  - lane: seat-mix-report-implementation
+    role: build
+    seat: claude-sonnet-5 (this session -- script, tests, plist, doc, real run)
+
+diff:
+  files: 4
+  net_lines: 1125
+  measured_at: 85b9a1162
+  note: >-
+    git diff --no-renames --numstat against merge-base 63bfa19ec5 (origin/main
+    at dispatch time): docs/factory/SEAT-MIX.md +161, infra/launchagents/
+    com.nuzantara.seat-mix.daily.plist +25, scripts/seat_mix_report.py +536,
+    scripts/tests/test_seat_mix_report.py +403 -- 0 deletions, matching the
+    commit's own "4 files changed, 1125 insertions(+)".
+
+pii_scan: clean
+
+receipts:
+  - claim:
+      The deterministic gear floor recomputed from THIS PR's real changed-file
+      set is 3, matching the declared gear -- infra/launchagents/ is hot-zone.
+    cmd:
+      python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file
+      <4-line file listing docs/factory/SEAT-MIX.md, infra/launchagents/com.nuzantara.seat-mix.daily.plist,
+      scripts/seat_mix_report.py, scripts/tests/test_seat_mix_report.py>
+    result: "floor=3, printed alone on stdout."
+    exit: 0
+    ts: 2026-08-27T00:24Z
+    seat: session (Pro, implementer lane)
+
+  - claim: The new test suite is green, with exact counts on the mandate's own fixture shape.
+    cmd: ./apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_seat_mix_report.py -q
+    result: "40 passed in 0.12s -- includes the exact 3-Agent(2 sonnet/1 haiku)
+      + 2-Bash(codex-sol, kimi-k3) + 1-Workflow fixture, the PII-leak fixture, the
+      oversized-file-skip fixture, and 18 guilt/innocence pairs for classify_bash_seat."
+    exit: 0
+    ts: 2026-08-27T00:20Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      The Bash-seat classifier is exercised for BOTH guilt (matches the real
+      vocabulary) and innocence (does not over-match adjacent words) --
+      cicatrix family #3 discipline, not asserted, run.
+    cmd: >-
+      pytest -k test_classify_bash_seat_guilt or test_classify_bash_seat_innocence -v
+    result: >-
+      18 guilt cases (one per vocabulary entry incl. the kimi-for-coding vs
+      kimi-for-coding-highspeed longest-alternative-first ordering) all pass;
+      9 innocence cases pass including "echo the codex executable path" and
+      "codexy exec foo" (word-boundary: "codex exec" must not match inside a
+      longer word), and "echo mykimi -m kimi-code/k3" (kimi must be its own
+      token). One real bug caught and fixed during authoring: the initial
+      \b(?:nlm|notebooklm)\b regex rejected "python3 notebooklm_bridge.py"
+      because notebooklm is almost always a PREFIX of a real script name in
+      this repo -- relaxed to a leading-boundary-only match for that
+      alternative specifically, with the reasoning recorded in a code comment.
+    exit: 0
+    ts: 2026-08-27T00:19Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      PII inside a tool_result block, and PII embedded inside Bash command
+      text (both matching and non-matching the seat vocabulary), never
+      reaches the JSON or Markdown output.
+    cmd: pytest -k test_pii_in_tool_result_and_command_text_never_leaks -v
+    result: >-
+      1 passed. Fixture carries an email, a phone number, and an
+      sk-...-shaped secret inside a tool_result block, inside a
+      non-matching `echo` Bash command, and inside a matching `agy --model`
+      flag value; the test asserts none of the four literal strings appear
+      in json.dumps(report) or render_markdown(report), and that the one
+      seat_calls entry the agy line does produce does not contain the raw
+      email (only the narrow-charset regex capture survives).
+    exit: 0
+    ts: 2026-08-27T00:19Z
+    seat: session (Pro, implementer lane)
+
+  - claim: The output-safety guard (<=120 chars, fixed charset) is a real, enforced invariant, not a comment.
+    cmd: pytest -k test_guard_rejects_unsafe_strings or test_sanitize_str_strips_disallowed_chars_and_truncates -v
+    result: >-
+      2 passed -- assert_all_strings_safe raises ValueError on a string
+      containing '@' and on a 121-char string, and passes silently on
+      compliant input; sanitize_str strips disallowed characters and
+      truncates to the requested length rather than raising.
+    exit: 0
+    ts: 2026-08-27T00:19Z
+    seat: session (Pro, implementer lane)
+
+  - claim: The plist is structurally valid and keepalive-sane (superscar #7).
+    cmd: >-
+      plutil -lint infra/launchagents/com.nuzantara.seat-mix.daily.plist &&
+      python3 -c "import plistlib; plistlib.load(open('infra/launchagents/com.nuzantara.seat-mix.daily.plist','rb'))" &&
+      python3 scripts/lint_plist_keepalive.py --root infra/launchagents
+    result: >-
+      plutil OK; plistlib parses cleanly; lint_plist_keepalive.py reports
+      0 findings for this plist ("clean -- no KeepAlive=true wrapper shows
+      a one-shot smell"; the 2 pre-existing WARNs listed belong to
+      unrelated wa-codex-broker/wr2.pg-proxy plists, not this PR). One real
+      bug caught: the plist's own header comment used a literal "--" inside
+      an XML comment ("cron -- see the PR body"), which XML forbids inside
+      comments -- plutil accepted it (lenient) but plistlib raised
+      ExpatError "not well-formed (invalid token)". Fixed by rewording to
+      avoid the double-hyphen; re-verified both parsers agree after the fix.
+    exit: 0
+    ts: 2026-08-27T00:24Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      The script runs against real transcripts on Pro and produces a
+      plausible, non-empty, PII-free day-0 baseline -- not just green on
+      fixtures.
+    cmd: python3 scripts/seat_mix_report.py --since 48
+    result: >-
+      rc=0, 5.4s wall. sessions_scanned=113, files_skipped=0, Agent
+      dispatches=140 (sonnet 88.6%/haiku 0.7%/opus 0.7%/inherit 10.0%),
+      non_anthropic_seat_calls=96 (0.69 per Anthropic dispatch), workflow_runs=1,
+      2 sessions mapped to PRs (#5037, #5039), 28 unmapped. Manually
+      re-read the emitted Markdown before pasting it anywhere: no message
+      text, no client identifiers, only counts/labels/branch-derived PR
+      numbers. The 28-unmapped figure was cross-checked (not just accepted)
+      against a separate, branch-name-only scan of the same window: 45
+      sessions on `main`, 12 on detached HEAD, 39 on the long-lived
+      `feature/visa-oracle` integration branch -- none of which a
+      `head:<branch>` PR search can ever match by construction, so the
+      high unmapped count is explained, not hand-waved, in
+      docs/factory/SEAT-MIX.md.
+    exit: 0
+    ts: 2026-08-27T00:24Z
+    seat: session (Pro, implementer lane)
+
+dissent:
+  - seat: session self-refutation (own test suite, caught before any external review)
+    objection: >-
+      The initial nlm classifier regex, \b(?:nlm|notebooklm)\b, silently
+      under-matched the real usage: "python3 notebooklm_bridge.py" returned
+      None instead of "nlm", because a trailing word-boundary after
+      "notebooklm" fails when the next character is "_" (a word char) --
+      exactly the shape of most real script/module names in this repo.
+    status: CONFIRMED
+    note: >-
+      Caught by the guilt/innocence parametrized test itself
+      (test_classify_bash_seat_guilt), not by inspection. Fixed by requiring
+      only a LEADING boundary for the "notebooklm" alternative (it is almost
+      always a prefix of a longer name here), while keeping both boundaries
+      for the short "nlm" token. Re-ran the full suite after the fix: 40/40
+      green, including the case that had failed.
+
+  - seat: session self-refutation (plutil vs plistlib disagreement, caught before push)
+    objection: >-
+      The first draft of infra/launchagents/com.nuzantara.seat-mix.daily.plist
+      passed `plutil -lint` (OK) but failed Python's plistlib.load() with
+      ExpatError "not well-formed (invalid token)" -- a real, silent
+      correctness gap between the two validators this repo relies on.
+    status: CONFIRMED
+    note: >-
+      Root cause: the file's own header XML comment contained a literal
+      "--" ("cron -- see the PR body"), which the XML spec forbids inside
+      comments; plutil is lenient about it, plistlib (via expat) is not, and
+      scripts/lint_plist_keepalive.py uses plistlib -- so a plist that
+      "looks fine" under the tool most people reach for first would have
+      failed the actual lint this PR depends on. Fixed by rewording the
+      comment to a single hyphen; re-verified plutil, plistlib, and
+      lint_plist_keepalive.py all agree (clean) after the fix.
+
+tests:
+  - "scripts/tests/test_seat_mix_report.py -- 40 collected, 40 passed, rc=0 (backend-rag venv python)."
+
+static:
+  - "pre-commit hooks passed on the feature commit (anti-reward-hacking test lint, print()
+    scan, secret scan, python lint, off-limits check)."
+  - "plutil -lint + plistlib.load + scripts/lint_plist_keepalive.py all clean on the new plist."
+
+notes:
+  - "BUILT IS NOT ARMED. infra/launchagents/com.nuzantara.seat-mix.daily.plist is not
+    installed by this PR -- install command for Pro + Mini is in the PR body and in
+    docs/factory/SEAT-MIX.md. M5 is deliberately excluded (no daemons/cron by design)."
+  - "No targets or thresholds are imposed anywhere -- per the 2026-08-26 retro's A5
+    rejection, this report is descriptive telemetry, and this pack does not smuggle one
+    in either."
+  - "scripts/usage/seat_usage_collector.py (Kimi's cited prior art) was read and verified
+    live before writing anything: it IS armed (installed LaunchAgent, log activity as
+    recently as 2026-08-26 23:53, snapshot file present) but measures a different thing
+    (token usage per Claude-profile seat, via seat_map.json's profile-dir-to-account-seat
+    join key) -- not Agent/Bash/Workflow dispatch counts joined to PRs. The two are
+    complementary, not duplicative; docs/factory/SEAT-MIX.md says so explicitly so a
+    future reader doesn't try to merge them."

--- a/infra/launchagents/com.nuzantara.seat-mix.daily.plist
+++ b/infra/launchagents/com.nuzantara.seat-mix.daily.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- A7/R12 daily seat-mix telemetry. NOT installed by this PR (Agent PR Contract:
+     an agent-produced PR ships the artifact, the operator/H24 node installs the
+     cron; see the PR body for the exact install command per machine). -->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.nuzantara.seat-mix.daily</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>/Users/nuzantara/nuzantara/scripts/seat_mix_report.py</string>
+    <string>--since</string>
+    <string>24</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>6</integer>
+    <key>Minute</key><integer>30</integer>
+  </dict>
+  <key>KeepAlive</key><false/>
+  <key>StandardOutPath</key><string>/Users/nuzantara/logs/seat-mix-daily.log</string>
+  <key>StandardErrorPath</key><string>/Users/nuzantara/logs/seat-mix-daily.err.log</string>
+</dict>
+</plist>

--- a/scripts/seat_mix_report.py
+++ b/scripts/seat_mix_report.py
@@ -56,6 +56,37 @@ from typing import Callable, Optional
 
 WITA = timezone(timedelta(hours=8))
 
+# Organism genes (organ-conformance G2/G5, born 2026-08-27): this organ must
+# prove its own liveness every run (heartbeat on BOTH success and failure —
+# superscar #2, esiste != armato) and honor an operator kill switch that
+# leaves a "disabled" heartbeat behind so the healer never resurrects an
+# intentionally-stopped organ (genes.json G5's own stated reason). Same
+# convention as scripts/queue_shepherd.py's SEAT_MIX_REPORT_ENABLED /
+# ORGAN_ID / _write_heartbeat shape.
+SEAT_MIX_REPORT_ENABLED = os.environ.get("SEAT_MIX_REPORT_ENABLED", "true")
+ORGANISM_DIR = Path(os.path.expanduser("~/.organism/last_seen"))
+ORGAN_ID = "pro.seat_mix_report"
+
+
+def _enabled() -> bool:
+    return SEAT_MIX_REPORT_ENABLED.strip().lower() not in ("false", "0", "no", "off")
+
+
+def _write_heartbeat(status: str, metadata: dict) -> None:
+    """Unconditional organism heartbeat sidecar — never raises (a heartbeat
+    write must never break the run it is reporting on). Atomic tmp+replace."""
+    try:
+        ORGANISM_DIR.mkdir(parents=True, exist_ok=True)
+        organ_path = ORGANISM_DIR / f"{ORGAN_ID}.json"
+        organ_tmp = organ_path.with_suffix(f".json.tmp.{os.getpid()}")
+        organ_tmp.write_text(
+            json.dumps({"ts": time.time(), "status": status, "organ_id": ORGAN_ID, "metadata": metadata})
+        )
+        organ_tmp.replace(organ_path)
+    except Exception as exc:  # noqa: BLE001 — heartbeat must never break the run
+        print(f"[seat-mix] organ heartbeat emit failed: {exc}", file=sys.stderr)
+
+
 # ---------------------------------------------------------------------------
 # PII / output guard
 # ---------------------------------------------------------------------------
@@ -553,41 +584,54 @@ def main(argv=None) -> int:
     )
     args = ap.parse_args(argv)
 
-    since_epoch = time.time() - args.since * 3600.0
-    max_file_bytes = int(args.max_file_mb * 1024 * 1024)
+    if not _enabled():
+        # G5 kill switch: leave a "disabled" heartbeat so the healer never
+        # tries to resurrect an intentionally-stopped organ, and still print
+        # a receipt line (superscar #2: a mute cron reads as a dead cron).
+        _write_heartbeat("disabled", {"reason": "SEAT_MIX_REPORT_ENABLED=false"})
+        print("[seat-mix] SEAT_MIX_REPORT_ENABLED=false -- no-op run (receipt line, superscar #2)", file=sys.stderr)
+        return 0
 
-    pr_lookup: Optional[PrLookup] = None
-    if args.map_prs and shutil.which("gh"):
-        pr_lookup = gh_pr_lookup
+    try:
+        since_epoch = time.time() - args.since * 3600.0
+        max_file_bytes = int(args.max_file_mb * 1024 * 1024)
 
-    report = build_report(
-        Path(os.path.expanduser(args.projects_root)),
-        since_epoch=since_epoch,
-        max_file_bytes=max_file_bytes,
-        pr_lookup=pr_lookup,
-    )
-    report["window_hours"] = args.since
+        pr_lookup: Optional[PrLookup] = None
+        if args.map_prs and shutil.which("gh"):
+            pr_lookup = gh_pr_lookup
 
-    assert_all_strings_safe(report)
+        report = build_report(
+            Path(os.path.expanduser(args.projects_root)),
+            since_epoch=since_epoch,
+            max_file_bytes=max_file_bytes,
+            pr_lookup=pr_lookup,
+        )
+        report["window_hours"] = args.since
 
-    date_str = datetime.now(WITA).strftime("%Y-%m-%d")
-    default_dir = Path.home() / "logs" / "seat-mix"
+        assert_all_strings_safe(report)
 
-    json_path = (
-        Path(os.path.expanduser(args.json_out)) if args.json_out else default_dir / f"{date_str}.json"
-    )
-    md_path = Path(os.path.expanduser(args.md_out)) if args.md_out else default_dir / f"{date_str}.md"
+        date_str = datetime.now(WITA).strftime("%Y-%m-%d")
+        default_dir = Path.home() / "logs" / "seat-mix"
 
-    json_path.parent.mkdir(parents=True, exist_ok=True)
-    md_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path = (
+            Path(os.path.expanduser(args.json_out)) if args.json_out else default_dir / f"{date_str}.json"
+        )
+        md_path = Path(os.path.expanduser(args.md_out)) if args.md_out else default_dir / f"{date_str}.md"
 
-    json_path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    md_text = render_markdown(report)
-    md_path.write_text(md_text, encoding="utf-8")
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+
+        json_path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        md_text = render_markdown(report)
+        md_path.write_text(md_text, encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001 — G2: heartbeat the failure path too, then re-raise
+        _write_heartbeat("error", {"error": str(exc)})
+        raise
 
     print(md_text)
     print(f"[seat-mix] json -> {json_path}", file=sys.stderr)
     print(f"[seat-mix] md   -> {md_path}", file=sys.stderr)
+    _write_heartbeat("ok", {"json_path": str(json_path), "md_path": str(md_path)})
     return 0
 
 

--- a/scripts/seat_mix_report.py
+++ b/scripts/seat_mix_report.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""seat_mix_report.py -- A7/R12 daily seat-mix telemetry, joined to PRs.
+
+The fleet dispatches subagents (Agent tool: model + subagent_type) and shells
+out to a whole cross-family arsenal (codex/kimi/agy/ollama/nlm/seat_build/...)
+from inside Claude Code sessions, but until this script existed nobody had
+ever counted the mix -- a one-off hand parse on 2026-08-26 found 882 Agent
+dispatches fleet-wide in 48h (sonnet 86%, haiku 0.9%, opus the rest) and
+~512 non-Anthropic shell calls, never published or repeatable.
+
+This script stream-parses Claude Code's own project transcripts
+(``~/.claude/projects/**/*.jsonl``) inside a time window and counts, purely
+structurally:
+
+  - ``Agent`` tool_use blocks, by ``input.model`` (missing -> "inherit") and
+    by ``input.subagent_type``.
+  - ``Bash`` tool_use blocks, by classifying ``input.command`` against a small
+    fixed SEAT VOCABULARY (codex/kimi/agy/seat_build/ollama/nlm/jules/tp1).
+    The matched LABEL is kept; the raw command text is discarded immediately
+    -- classification never copies free text into the report.
+  - ``Workflow`` tool_use blocks (a bare count).
+
+Session -> PR join is best-effort: the JSONL ``gitBranch`` field (when
+present) is looked up via ``gh pr list --search "head:<branch>"``; failures
+(no gh, no network, no match) just leave that session unmapped.
+
+PII BOUNDARY (SYMBIOSIS Law 2): transcripts carry client PII inside
+``tool_result`` blocks and free-text ``text`` blocks. This module NEVER reads
+either -- it only ever looks at ``message.content[].type == "tool_use"``
+blocks' ``name`` field and a handful of specific, narrow-charset regex
+captures out of ``input.command`` / ``input.model`` / ``input.subagent_type``.
+Every string that reaches the report is additionally passed through
+``sanitize_str`` (truncate + strip to a fixed safe charset) at the point of
+extraction, and ``assert_all_strings_safe`` re-walks the whole report as a
+hard defense-in-depth gate right before anything is written or printed.
+
+Usage:
+  python3 scripts/seat_mix_report.py --since 48
+  python3 scripts/seat_mix_report.py --since 24 --json /tmp/x.json --md /tmp/x.md
+  python3 scripts/seat_mix_report.py --since 24 --no-map-prs   # skip gh entirely
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+WITA = timezone(timedelta(hours=8))
+
+# ---------------------------------------------------------------------------
+# PII / output guard
+# ---------------------------------------------------------------------------
+
+# Deliberately narrow: letters, digits, space, and a small punctuation set
+# that covers paths, ratios, percentages, dates and branch/seat labels. No
+# '@', no '+', no backslash, no quotes -- nothing an email, phone number, or
+# API-key-shaped secret would survive intact.
+SAFE_STRING_RE = re.compile(r"^[A-Za-z0-9 _./:%()\-=,]+$")
+MAX_STRING_LEN = 120
+
+
+def sanitize_str(value, maxlen: int = MAX_STRING_LEN) -> str:
+    """Coerce ``value`` to a string that is guaranteed to satisfy the guard.
+
+    Never raises. Unknown/empty input becomes ``"unknown"``. Any character
+    outside SAFE_STRING_RE's class is replaced with ``_`` rather than
+    dropped, so the length of the informative part is still legible.
+    """
+    if value is None:
+        return "unknown"
+    s = str(value)[:maxlen]
+    s = re.sub(r"[^A-Za-z0-9 _./:%()\-=,]", "_", s)
+    return s if s else "unknown"
+
+
+def assert_all_strings_safe(obj, path: str = "$") -> None:
+    """Recursively assert every string leaf in ``obj`` satisfies the guard.
+
+    Defense-in-depth: everything that reaches the report is already built
+    via ``sanitize_str`` or a narrow-charset regex capture, so this should
+    never fire. It is not wrapped in try/except anywhere -- a violation here
+    means the extraction logic regressed, and the report must not ship
+    silently corrupted (superscar #2: a swallowed exception here would be
+    exactly the "green but wrong" failure mode this script exists to avoid
+    in others).
+    """
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            assert_all_strings_safe(k, f"{path}.{k}")
+            assert_all_strings_safe(v, f"{path}.{k}")
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            assert_all_strings_safe(v, f"{path}[{i}]")
+    elif isinstance(obj, str):
+        if len(obj) > MAX_STRING_LEN or not SAFE_STRING_RE.match(obj):
+            raise ValueError(
+                f"seat_mix_report guard violation at {path}: string of len "
+                f"{len(obj)} fails the output-safety charset"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Bash seat-vocabulary classifier
+# ---------------------------------------------------------------------------
+
+_CODEX_INVOKE_RE = re.compile(r"\bcodex\s+exec\b")
+_CODEX_TIER_RE = re.compile(r"-m\s+[\"']?gpt-5\.6-(sol|terra|luna)\b")
+
+_KIMI_INVOKE_RE = re.compile(r"(?:^|[\s;&|])kimi\s")
+# Longest alternative first (W-class gotcha): "kimi-for-coding" is a strict
+# prefix of "kimi-for-coding-highspeed" -- if the short form were tried
+# first, re.search would stop there and every highspeed call would be
+# misclassified as the plain coding tier.
+_KIMI_MODEL_RE = re.compile(
+    r"-m\s+kimi-code/(kimi-for-coding-highspeed|kimi-for-coding|k3)\b"
+)
+
+_AGY_INVOKE_RE = re.compile(r"(?:^|[\s;&|])agy\s")
+_AGY_MODEL_RE = re.compile(r"--model[= ]([A-Za-z0-9_./\-]+)")
+
+_SEATBUILD_INVOKE_RE = re.compile(r"\bseat_build\.sh\b")
+_SEATBUILD_SEAT_RE = re.compile(r"--seat[= ]([A-Za-z0-9_./\-]+)")
+_SEATBUILD_TIER_RE = re.compile(r"--tier[= ]([A-Za-z0-9_./\-]+)")
+
+_OLLAMA_RUN_RE = re.compile(r"\bollama\s+run\s+([A-Za-z0-9_./:\-]+)")
+
+# "nlm" is a short token and needs both boundaries (avoid matching inside an
+# unrelated longer word). "notebooklm" is almost always a PREFIX of a real
+# script/module name in this repo (notebooklm_bridge.py, notebooklm-mcp, ...)
+# so it only needs a leading boundary -- requiring a trailing one too would
+# systematically under-match the real usage (family #3's UNDER-match twin).
+_NLM_RE = re.compile(r"\bnlm\b|\bnotebooklm")
+_JULES_RE = re.compile(r"\bjules_dispatch\.py\b")
+_TP1_RE = re.compile(r"\b(?:tp1_call|review_routes)\b")
+
+
+def classify_bash_seat(command) -> Optional[str]:
+    """Classify a Bash ``input.command`` string into a seat-vocabulary label.
+
+    Returns ``None`` for anything outside the fixed vocabulary (most Bash
+    calls -- ``ls``, ``git``, ``pytest``, ...) -- those are not "seats" and
+    are not counted. Entity/intent boundaries throughout (``\\b`` anchors,
+    a required invocation token before any flag is inspected) rather than
+    bare substring matching, per cicatrix family #3: "the codex executable"
+    or "kimi-something-else.py" must NOT match.
+    """
+    if not command or not isinstance(command, str):
+        return None
+
+    if _CODEX_INVOKE_RE.search(command):
+        m = _CODEX_TIER_RE.search(command)
+        return f"codex:{m.group(1)}" if m else "codex:default"
+
+    if _KIMI_INVOKE_RE.search(command):
+        m = _KIMI_MODEL_RE.search(command)
+        return f"kimi:{m.group(1)}" if m else "kimi:default"
+
+    if _AGY_INVOKE_RE.search(command):
+        m = _AGY_MODEL_RE.search(command)
+        return f"agy:{sanitize_str(m.group(1), 40)}" if m else "agy:default"
+
+    if _SEATBUILD_INVOKE_RE.search(command):
+        seat = _SEATBUILD_SEAT_RE.search(command)
+        tier = _SEATBUILD_TIER_RE.search(command)
+        if seat or tier:
+            seat_v = sanitize_str(seat.group(1), 30) if seat else "unset"
+            tier_v = sanitize_str(tier.group(1), 30) if tier else "unset"
+            return f"seat_build:{seat_v}/{tier_v}"
+        return "seat_build:default"
+
+    m = _OLLAMA_RUN_RE.search(command)
+    if m:
+        return f"ollama:{sanitize_str(m.group(1), 40)}"
+
+    if _NLM_RE.search(command):
+        return "nlm"
+
+    if _JULES_RE.search(command):
+        return "jules_dispatch"
+
+    if _TP1_RE.search(command):
+        return "tp1"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# PR join (best-effort, injectable for tests)
+# ---------------------------------------------------------------------------
+
+PrLookup = Callable[[str], Optional[str]]
+
+
+def gh_pr_lookup(branch: str) -> Optional[str]:
+    """Best-effort ``gh pr list --search "head:<branch>"`` -> PR number.
+
+    Never raises -- any failure (no gh, no network, no auth, bad JSON, no
+    match) returns None and the caller treats the session as unmapped.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--search",
+                f"head:{branch}",
+                "--state",
+                "all",  # most branches have already merged & closed by report time
+                "--json",
+                "number",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout or "[]")
+        if isinstance(data, list) and data:
+            n = data[0].get("number")
+            if isinstance(n, int):
+                return str(n)
+    except Exception:
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core scan
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_FILE_BYTES = 200 * 1024 * 1024  # 200 MB
+
+
+def build_report(
+    root: Path,
+    *,
+    since_epoch: float,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    pr_lookup: Optional[PrLookup] = None,
+) -> dict:
+    """Scan every ``*.jsonl`` under ``root`` touched since ``since_epoch``.
+
+    Pure function of (filesystem, clock) -- no argparse, no printing, so it
+    is directly unit-testable against a fixture tree.
+    """
+    files = sorted(root.glob("**/*.jsonl")) if root.is_dir() else []
+
+    sessions_scanned = 0
+    files_skipped = 0
+
+    agent_total = 0
+    agent_by_model: Counter = Counter()
+    agent_by_subagent: Counter = Counter()
+
+    seat_calls: Counter = Counter()
+    workflow_runs = 0
+
+    per_pr: dict = defaultdict(lambda: {"agent_dispatches": 0, "seat_calls": 0, "sessions": 0})
+    unmapped_sessions = 0
+    pr_cache: dict = {}
+
+    for fp in files:
+        try:
+            st = fp.stat()
+        except OSError:
+            continue
+
+        if st.st_mtime < since_epoch:
+            continue  # out of window -- not scanned, not "skipped"
+
+        if st.st_size > max_file_bytes:
+            files_skipped += 1
+            continue
+
+        sessions_scanned += 1
+
+        branch = None
+        session_agent_total = 0
+        session_seat_total = 0
+
+        try:
+            with fp.open(encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+
+                    if branch is None:
+                        b = rec.get("gitBranch")
+                        if isinstance(b, str) and b:
+                            branch = b
+
+                    msg = rec.get("message")
+                    if not isinstance(msg, dict):
+                        continue
+                    content = msg.get("content")
+                    if not isinstance(content, list):
+                        continue
+
+                    for block in content:
+                        if not isinstance(block, dict) or block.get("type") != "tool_use":
+                            continue
+                        name = block.get("name")
+                        inp = block.get("input")
+                        if not isinstance(inp, dict):
+                            inp = {}
+
+                        if name == "Agent":
+                            agent_total += 1
+                            session_agent_total += 1
+                            model = inp.get("model") or "inherit"
+                            agent_by_model[sanitize_str(model, 40)] += 1
+                            subagent = inp.get("subagent_type") or "unspecified"
+                            agent_by_subagent[sanitize_str(subagent, 60)] += 1
+
+                        elif name == "Bash":
+                            label = classify_bash_seat(inp.get("command"))
+                            if label:
+                                seat_calls[label] += 1
+                                session_seat_total += 1
+                            # raw command text is never retained past this point
+
+                        elif name == "Workflow":
+                            workflow_runs += 1
+        except OSError:
+            continue
+
+        if session_agent_total or session_seat_total:
+            pr_number = None
+            if pr_lookup and branch:
+                if branch not in pr_cache:
+                    pr_cache[branch] = pr_lookup(branch)
+                pr_number = pr_cache[branch]
+            if pr_number:
+                bucket = per_pr[sanitize_str(pr_number, 20)]
+                bucket["agent_dispatches"] += session_agent_total
+                bucket["seat_calls"] += session_seat_total
+                bucket["sessions"] += 1
+            else:
+                unmapped_sessions += 1
+
+    cheap_dispatches = sum(v for k, v in agent_by_model.items() if "haiku" in k.lower())
+    non_anthropic_total = sum(seat_calls.values())
+
+    by_model_pct = {}
+    if agent_total:
+        for k, v in agent_by_model.items():
+            by_model_pct[k] = round(v * 100.0 / agent_total, 1)
+
+    report = {
+        "generated_at": datetime.now(WITA).strftime("%Y-%m-%d %H:%M:%S WITA"),
+        "window_hours": None,  # filled in by main() -- build_report doesn't know it
+        "sessions_scanned": sessions_scanned,
+        "files_skipped": files_skipped,
+        "agent_dispatches": {
+            "total": agent_total,
+            "by_model": dict(agent_by_model),
+            "by_model_pct": by_model_pct,
+            "by_subagent_type": dict(agent_by_subagent),
+            "cheap_seat_share_pct": (
+                round(cheap_dispatches * 100.0 / agent_total, 1) if agent_total else None
+            ),
+        },
+        "non_anthropic_seat_calls": {
+            "total": non_anthropic_total,
+            "per_anthropic_dispatch": (
+                round(non_anthropic_total / agent_total, 2) if agent_total else None
+            ),
+            "by_seat": dict(seat_calls),
+        },
+        "workflow_runs": workflow_runs,
+        "per_pr": dict(per_pr),
+        "unmapped_sessions_with_activity": unmapped_sessions,
+    }
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def render_markdown(report: dict) -> str:
+    lines = []
+    lines.append("# Seat-mix daily report")
+    lines.append("")
+    lines.append(f"- generated_at: {report['generated_at']}")
+    lines.append(f"- window_hours: {report.get('window_hours')}")
+    lines.append(f"- sessions_scanned: {report['sessions_scanned']}")
+    lines.append(f"- files_skipped (over size cap): {report['files_skipped']}")
+    lines.append("")
+
+    ad = report["agent_dispatches"]
+    lines.append("## Agent dispatch mix")
+    lines.append("")
+    lines.append(f"Total Agent dispatches: {ad['total']}")
+    lines.append("")
+    if ad["by_model"]:
+        lines.append("| model | count | pct |")
+        lines.append("|---|---|---|")
+        for k in sorted(ad["by_model"], key=lambda x: -ad["by_model"][x]):
+            pct = ad["by_model_pct"].get(k, 0)
+            lines.append(f"| {k} | {ad['by_model'][k]} | {pct}% |")
+        lines.append("")
+    cheap = ad.get("cheap_seat_share_pct")
+    lines.append(f"cheap_seat_share_pct (haiku share): {cheap if cheap is not None else 'n/a'}%")
+    lines.append("")
+    if ad["by_subagent_type"]:
+        lines.append("| subagent_type | count |")
+        lines.append("|---|---|")
+        for k in sorted(ad["by_subagent_type"], key=lambda x: -ad["by_subagent_type"][x]):
+            lines.append(f"| {k} | {ad['by_subagent_type'][k]} |")
+        lines.append("")
+
+    nac = report["non_anthropic_seat_calls"]
+    lines.append("## Non-Anthropic seat calls (Bash)")
+    lines.append("")
+    lines.append(f"Total: {nac['total']}")
+    ratio = nac.get("per_anthropic_dispatch")
+    lines.append(f"Per Anthropic dispatch: {ratio if ratio is not None else 'n/a'}")
+    lines.append("")
+    if nac["by_seat"]:
+        lines.append("| seat | count |")
+        lines.append("|---|---|")
+        for k in sorted(nac["by_seat"], key=lambda x: -nac["by_seat"][x]):
+            lines.append(f"| {k} | {nac['by_seat'][k]} |")
+        lines.append("")
+
+    lines.append("## Workflow tool")
+    lines.append("")
+    lines.append(f"workflow_runs: {report['workflow_runs']}")
+    lines.append("")
+
+    lines.append("## Per-PR seat counts (best-effort branch join)")
+    lines.append("")
+    lines.append(f"unmapped_sessions_with_activity: {report['unmapped_sessions_with_activity']}")
+    lines.append("")
+    if report["per_pr"]:
+        lines.append("| PR | agent_dispatches | seat_calls | sessions |")
+        lines.append("|---|---|---|---|")
+        for pr, v in sorted(report["per_pr"].items(), key=lambda kv: -kv[1]["agent_dispatches"]):
+            lines.append(f"| {pr} | {v['agent_dispatches']} | {v['seat_calls']} | {v['sessions']} |")
+        lines.append("")
+    else:
+        lines.append("(no session mapped to a PR in this window)")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--since", type=float, default=24.0, help="lookback window in hours (default 24)")
+    ap.add_argument(
+        "--projects-root",
+        default=str(Path.home() / ".claude" / "projects"),
+        help="root to scan recursively for *.jsonl (default ~/.claude/projects)",
+    )
+    ap.add_argument("--json", dest="json_out", default=None, help="output JSON path")
+    ap.add_argument("--md", dest="md_out", default=None, help="output Markdown path")
+    ap.add_argument(
+        "--max-file-mb",
+        type=float,
+        default=200.0,
+        help="skip (and count) any transcript file larger than this, in MB (default 200)",
+    )
+    ap.add_argument("--map-prs", dest="map_prs", action="store_true", default=True)
+    ap.add_argument(
+        "--no-map-prs",
+        dest="map_prs",
+        action="store_false",
+        help="skip the gh pr list branch->PR join entirely",
+    )
+    args = ap.parse_args(argv)
+
+    since_epoch = time.time() - args.since * 3600.0
+    max_file_bytes = int(args.max_file_mb * 1024 * 1024)
+
+    pr_lookup: Optional[PrLookup] = None
+    if args.map_prs and shutil.which("gh"):
+        pr_lookup = gh_pr_lookup
+
+    report = build_report(
+        Path(os.path.expanduser(args.projects_root)),
+        since_epoch=since_epoch,
+        max_file_bytes=max_file_bytes,
+        pr_lookup=pr_lookup,
+    )
+    report["window_hours"] = args.since
+
+    assert_all_strings_safe(report)
+
+    date_str = datetime.now(WITA).strftime("%Y-%m-%d")
+    default_dir = Path.home() / "logs" / "seat-mix"
+
+    json_path = (
+        Path(os.path.expanduser(args.json_out)) if args.json_out else default_dir / f"{date_str}.json"
+    )
+    md_path = Path(os.path.expanduser(args.md_out)) if args.md_out else default_dir / f"{date_str}.md"
+
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+
+    json_path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    md_text = render_markdown(report)
+    md_path.write_text(md_text, encoding="utf-8")
+
+    print(md_text)
+    print(f"[seat-mix] json -> {json_path}", file=sys.stderr)
+    print(f"[seat-mix] md   -> {md_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seat_mix_report.py
+++ b/scripts/seat_mix_report.py
@@ -62,8 +62,20 @@ WITA = timezone(timedelta(hours=8))
 
 # Deliberately narrow: letters, digits, space, and a small punctuation set
 # that covers paths, ratios, percentages, dates and branch/seat labels. No
-# '@', no '+', no backslash, no quotes -- nothing an email, phone number, or
-# API-key-shaped secret would survive intact.
+# '@', no '+', no backslash, no quotes -- a FULL email or a phone number
+# written with its '+' cannot survive this charset intact.
+#
+# This charset alone is NOT sufficient PII/secret protection by itself, and
+# is not claimed to be: it is a superset of common secret/token shapes
+# (sk-/ghp_-style keys and bare-digit phone numbers are all
+# letters/digits/hyphens, which this class allows). classify_bash_seat's
+# free-form flag captures (--model/--seat/--tier/ollama's model argument)
+# additionally run through _redact_if_sensitive() BEFORE reaching this
+# charset check, specifically because the charset does not catch them (found
+# live by the Kimi K3 refuter on this PR's own diff). The real PII boundary
+# is architectural, not this regex: the scanner never reads tool_result or
+# free-text `text` blocks at all, and codex/kimi tier labels come from a
+# fixed enumeration that can never contain arbitrary captured text.
 SAFE_STRING_RE = re.compile(r"^[A-Za-z0-9 _./:%()\-=,]+$")
 MAX_STRING_LEN = 120
 
@@ -142,6 +154,44 @@ _NLM_RE = re.compile(r"\bnlm\b|\bnotebooklm")
 _JULES_RE = re.compile(r"\bjules_dispatch\.py\b")
 _TP1_RE = re.compile(r"\b(?:tp1_call|review_routes)\b")
 
+# A command segment whose own first word is a read/inspect/edit verb is never
+# an INVOCATION of anything named later in that segment -- "cat seat_build.sh"
+# and "grep review_routes -r ." must not count as seat calls just because a
+# vocabulary token appears as an argument (found live by the Kimi K3 refuter
+# on this PR's own diff: this repo's whole job is editing these very scripts,
+# so this over-match would have been a systematic, not theoretical, inflation
+# source). Interpreters that legitimately RUN a vocabulary script
+# (python3/bash/sh/./) are deliberately NOT on this list.
+_NON_INVOCATION_VERBS = frozenset(
+    {
+        "cat", "grep", "rg", "less", "more", "head", "tail", "vim", "vi",
+        "nano", "code", "open", "git", "find", "wc", "diff", "sed", "awk",
+        "ls", "stat", "file", "cp", "mv", "rm",
+    }
+)
+_SEGMENT_SPLIT_RE = re.compile(r"[;&|]+")
+_FIRST_TOKEN_RE = re.compile(r"^\s*(\S+)")
+
+# Sub-values captured from a free-form flag (--model/--seat/--tier/ollama's
+# model argument) come from ARBITRARY command text, not a fixed enumeration
+# like the codex/kimi tiers above -- so, unlike those, they must be screened
+# for secret/PII shape before they reach the report. A value matching either
+# check is replaced with the fixed literal "redacted" rather than propagated
+# even in sanitized form (found live by the Kimi K3 refuter: the sanitizer's
+# safe charset is a SUPERSET of common secret shapes -- sk-/ghp_-style keys
+# and phone numbers made of digits/hyphens pass the charset check untouched,
+# so the charset guard alone does not close this gap).
+_SECRET_PREFIX_RE = re.compile(
+    r"^(?:sk-|sk_|ghp_|gho_|ghs_|ghr_|github_pat_|akia|xox[a-z]-|eyj)",
+    re.IGNORECASE,
+)
+
+
+def _redact_if_sensitive(raw: str, maxlen: int) -> str:
+    if _SECRET_PREFIX_RE.match(raw) or sum(ch.isdigit() for ch in raw) >= 7:
+        return "redacted"
+    return sanitize_str(raw, maxlen)
+
 
 def classify_bash_seat(command) -> Optional[str]:
     """Classify a Bash ``input.command`` string into a seat-vocabulary label.
@@ -149,46 +199,55 @@ def classify_bash_seat(command) -> Optional[str]:
     Returns ``None`` for anything outside the fixed vocabulary (most Bash
     calls -- ``ls``, ``git``, ``pytest``, ...) -- those are not "seats" and
     are not counted. Entity/intent boundaries throughout (``\\b`` anchors,
-    a required invocation token before any flag is inspected) rather than
-    bare substring matching, per cicatrix family #3: "the codex executable"
-    or "kimi-something-else.py" must NOT match.
+    a required invocation token before any flag is inspected, a first-token
+    invocation-verb check per ``;``/``&&``/``|``-separated segment) rather
+    than bare substring matching, per cicatrix family #3: "the codex
+    executable", "kimi-something-else.py", and "cat seat_build.sh" must NOT
+    match.
     """
     if not command or not isinstance(command, str):
         return None
 
-    if _CODEX_INVOKE_RE.search(command):
-        m = _CODEX_TIER_RE.search(command)
-        return f"codex:{m.group(1)}" if m else "codex:default"
+    for segment in _SEGMENT_SPLIT_RE.split(command):
+        tok = _FIRST_TOKEN_RE.match(segment)
+        if tok:
+            first = tok.group(1).rsplit("/", 1)[-1]
+            if first in _NON_INVOCATION_VERBS:
+                continue  # this segment only READS/EDITS a name, never runs it
 
-    if _KIMI_INVOKE_RE.search(command):
-        m = _KIMI_MODEL_RE.search(command)
-        return f"kimi:{m.group(1)}" if m else "kimi:default"
+        if _CODEX_INVOKE_RE.search(segment):
+            m = _CODEX_TIER_RE.search(segment)
+            return f"codex:{m.group(1)}" if m else "codex:default"
 
-    if _AGY_INVOKE_RE.search(command):
-        m = _AGY_MODEL_RE.search(command)
-        return f"agy:{sanitize_str(m.group(1), 40)}" if m else "agy:default"
+        if _KIMI_INVOKE_RE.search(segment):
+            m = _KIMI_MODEL_RE.search(segment)
+            return f"kimi:{m.group(1)}" if m else "kimi:default"
 
-    if _SEATBUILD_INVOKE_RE.search(command):
-        seat = _SEATBUILD_SEAT_RE.search(command)
-        tier = _SEATBUILD_TIER_RE.search(command)
-        if seat or tier:
-            seat_v = sanitize_str(seat.group(1), 30) if seat else "unset"
-            tier_v = sanitize_str(tier.group(1), 30) if tier else "unset"
-            return f"seat_build:{seat_v}/{tier_v}"
-        return "seat_build:default"
+        if _AGY_INVOKE_RE.search(segment):
+            m = _AGY_MODEL_RE.search(segment)
+            return f"agy:{_redact_if_sensitive(m.group(1), 40)}" if m else "agy:default"
 
-    m = _OLLAMA_RUN_RE.search(command)
-    if m:
-        return f"ollama:{sanitize_str(m.group(1), 40)}"
+        if _SEATBUILD_INVOKE_RE.search(segment):
+            seat = _SEATBUILD_SEAT_RE.search(segment)
+            tier = _SEATBUILD_TIER_RE.search(segment)
+            if seat or tier:
+                seat_v = _redact_if_sensitive(seat.group(1), 30) if seat else "unset"
+                tier_v = _redact_if_sensitive(tier.group(1), 30) if tier else "unset"
+                return f"seat_build:{seat_v}/{tier_v}"
+            return "seat_build:default"
 
-    if _NLM_RE.search(command):
-        return "nlm"
+        m = _OLLAMA_RUN_RE.search(segment)
+        if m:
+            return f"ollama:{_redact_if_sensitive(m.group(1), 40)}"
 
-    if _JULES_RE.search(command):
-        return "jules_dispatch"
+        if _NLM_RE.search(segment):
+            return "nlm"
 
-    if _TP1_RE.search(command):
-        return "tp1"
+        if _JULES_RE.search(segment):
+            return "jules_dispatch"
+
+        if _TP1_RE.search(segment):
+            return "tp1"
 
     return None
 

--- a/scripts/tests/test_seat_mix_report.py
+++ b/scripts/tests/test_seat_mix_report.py
@@ -212,6 +212,13 @@ def test_pii_in_tool_result_and_command_text_never_leaks(tmp_path):
         # A matching seat call whose flag value happens to carry the email --
         # only the narrow-charset capture may survive, never the full string.
         _bash_line(f"agy -p 'hi' --model {SECRET_EMAIL}"),
+        # The gap the Kimi K3 refuter found live on this PR's own diff: an
+        # in-charset secret sitting in a MATCHING flag value would otherwise
+        # survive the sanitizer intact (letters/digits/hyphens are all
+        # "safe" characters). _redact_if_sensitive must catch this before
+        # sanitize_str ever sees it.
+        _bash_line(f"ollama run {SECRET_KEY}"),
+        _bash_line(f"scripts/seat_build.sh --seat sk-livefleettoken --tier {SECRET_PHONE.lstrip('+').replace('-', '')}"),
         _agent_line(model="sonnet"),
     ]
     _write_jsonl(fp, records)
@@ -223,18 +230,25 @@ def test_pii_in_tool_result_and_command_text_never_leaks(tmp_path):
     blob_json = json.dumps(report)
     blob_md = smr.render_markdown(report)
 
-    for secret in (SECRET_EMAIL, SECRET_PHONE, SECRET_KEY, leaking_text):
+    for secret in (SECRET_EMAIL, SECRET_PHONE, SECRET_KEY, leaking_text, "livefleettoken"):
         assert secret not in blob_json
         assert secret not in blob_md
 
     # the non-matching echo command contributed nothing to seat_calls
-    assert report["non_anthropic_seat_calls"]["total"] == 1  # only the agy call
-    # the agy call's --model value could not have survived whole (it fails
-    # the safe charset because of '@' and '.') -- confirm it was sanitized,
-    # not silently included verbatim.
-    seat_keys = list(report["non_anthropic_seat_calls"]["by_seat"].keys())
-    assert len(seat_keys) == 1
-    assert SECRET_EMAIL not in seat_keys[0]
+    assert report["non_anthropic_seat_calls"]["total"] == 3  # agy + ollama + seat_build
+    by_seat = report["non_anthropic_seat_calls"]["by_seat"]
+    # None of the three seat labels contain a FULL secret literal. (The agy
+    # capture stops at '@', so a bare fragment like "john.doe" surviving is
+    # a separate, lower-severity, documented residual -- not what this
+    # assertion checks.)
+    for label in by_seat:
+        for secret in (SECRET_EMAIL, SECRET_PHONE, SECRET_KEY):
+            assert secret not in label
+    # The sk-... key and the phone-shaped tier are made entirely of "safe"
+    # characters and would otherwise have survived sanitize_str's charset
+    # check intact -- they must be REDACTED outright, not merely sanitized.
+    assert by_seat.get("ollama:redacted") == 1
+    assert by_seat.get("seat_build:redacted/redacted") == 1
 
 
 def test_guard_rejects_unsafe_strings():
@@ -298,12 +312,42 @@ def test_classify_bash_seat_guilt(command, expected):
         "codexy exec foo",  # word-boundary: not the literal token "codex"
         "echo mykimi -m kimi-code/k3",  # "kimi" must be its own token, not a substring
         "echo my-agy-wrapper --model x",  # "agy" must be its own token
+        # A vocabulary token appearing as an ARGUMENT to a read/inspect/edit
+        # verb is not an invocation of it (found live by the Kimi K3 refuter:
+        # this repo's whole job is editing these very scripts).
+        "cat scripts/seat_build.sh",
+        "git log -- scripts/jules_dispatch.py",
+        "grep review_routes -r .",
+        "vim scripts/tp1_call.py",
+        "less notebooklm_bridge.py",
+        "cat seat_build.sh && echo done",  # the guard applies per-segment too
         "",
         None,
     ],
 )
 def test_classify_bash_seat_innocence(command):
     assert smr.classify_bash_seat(command) is None
+
+
+def test_non_invocation_verb_guard_does_not_blind_other_segments():
+    # A read-only verb in ONE segment of a compound command must not hide a
+    # real invocation living in another segment of the same line.
+    assert smr.classify_bash_seat("cat notes.txt; kimi -p 'x' -m kimi-code/k3") == "kimi:k3"
+    assert smr.classify_bash_seat("git log -1; codex exec -m gpt-5.6-terra ping") == "codex:terra"
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ("agy -p 'hi' --model sk-abc123secretvalue", "agy:redacted"),
+        ("agy -p 'hi' --model 15551234567", "agy:redacted"),  # >=7 digits: phone-shaped
+        ("scripts/seat_build.sh --seat sk-liveTokenHere --tier gold", "seat_build:redacted/gold"),
+        ("scripts/seat_build.sh --seat A2 --tier 5551234567", "seat_build:A2/redacted"),
+        ("ollama run ghp_abcdEFGH12345678", "ollama:redacted"),
+    ],
+)
+def test_secret_shaped_flag_values_are_redacted(command, expected):
+    assert smr.classify_bash_seat(command) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_seat_mix_report.py
+++ b/scripts/tests/test_seat_mix_report.py
@@ -1,0 +1,403 @@
+"""Tests for scripts/seat_mix_report.py -- A7/R12 daily seat-mix telemetry.
+
+Module is imported via importlib.util.spec_from_file_location (not a package
+import) because scripts/ is a flat bag of standalone tools, not a Python
+package -- same convention as test_pending_arms_report.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import time
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "seat_mix_report.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("seat_mix_report", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+smr = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _agent_line(model=None, subagent_type="general-purpose", branch="main"):
+    inp = {"description": "task", "prompt": "do the thing"}
+    if model is not None:
+        inp["model"] = model
+    if subagent_type is not None:
+        inp["subagent_type"] = subagent_type
+    return {
+        "type": "assistant",
+        "gitBranch": branch,
+        "message": {
+            "model": "claude-sonnet-5",
+            "content": [{"type": "tool_use", "id": "t1", "name": "Agent", "input": inp}],
+        },
+    }
+
+
+def _bash_line(command, branch="main"):
+    return {
+        "type": "assistant",
+        "gitBranch": branch,
+        "message": {
+            "model": "claude-sonnet-5",
+            "content": [
+                {"type": "tool_use", "id": "t2", "name": "Bash", "input": {"command": command}}
+            ],
+        },
+    }
+
+
+def _workflow_line(branch="main"):
+    return {
+        "type": "assistant",
+        "gitBranch": branch,
+        "message": {
+            "model": "claude-sonnet-5",
+            "content": [{"type": "tool_use", "id": "t3", "name": "Workflow", "input": {"script": "..."}}],
+        },
+    }
+
+
+def _tool_result_line(text, branch="main"):
+    """Shape of a captured tool_result -- must NEVER be read by the scanner."""
+    return {
+        "type": "user",
+        "gitBranch": branch,
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": text}],
+        },
+    }
+
+
+def _write_jsonl(path: Path, records) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _touch_recent(path: Path, minutes_ago: float = 1.0) -> None:
+    ts = time.time() - minutes_ago * 60
+    os.utime(path, (ts, ts))
+
+
+def _touch_old(path: Path, hours_ago: float = 999.0) -> None:
+    ts = time.time() - hours_ago * 3600
+    os.utime(path, (ts, ts))
+
+
+# ---------------------------------------------------------------------------
+# The mandate's combined fixture: 3 Agent (2 sonnet, 1 haiku),
+# 2 Bash seat calls (codex-sol, kimi-k3), 1 Workflow.
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_exact_counts(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "proj1" / "session1.jsonl"
+    records = [
+        _agent_line(model="sonnet"),
+        _agent_line(model="sonnet"),
+        _agent_line(model="haiku"),
+        _bash_line('codex exec -m gpt-5.6-sol -c model_reasoning_effort="ultra" --sandbox workspace-write "review"'),
+        _bash_line('kimi -p "review this" -m kimi-code/k3 < /dev/null'),
+        _workflow_line(),
+    ]
+    _write_jsonl(fp, records)
+    _touch_recent(fp)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600)
+
+    assert report["sessions_scanned"] == 1
+    assert report["files_skipped"] == 0
+
+    ad = report["agent_dispatches"]
+    assert ad["total"] == 3
+    assert ad["by_model"] == {"sonnet": 2, "haiku": 1}
+    assert ad["by_model_pct"]["sonnet"] == 66.7
+    assert ad["by_model_pct"]["haiku"] == 33.3
+    assert ad["cheap_seat_share_pct"] == 33.3
+
+    nac = report["non_anthropic_seat_calls"]
+    assert nac["total"] == 2
+    assert nac["by_seat"] == {"codex:sol": 1, "kimi:k3": 1}
+    assert nac["per_anthropic_dispatch"] == round(2 / 3, 2)
+
+    assert report["workflow_runs"] == 1
+
+
+def test_unspecified_model_becomes_inherit(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    _write_jsonl(fp, [_agent_line(model=None, subagent_type=None)])
+    _touch_recent(fp)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600)
+    assert report["agent_dispatches"]["by_model"] == {"inherit": 1}
+    assert report["agent_dispatches"]["by_subagent_type"] == {"unspecified": 1}
+
+
+# ---------------------------------------------------------------------------
+# Window filtering + large-file skip
+# ---------------------------------------------------------------------------
+
+
+def test_out_of_window_file_is_ignored_not_skipped(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "old.jsonl"
+    _write_jsonl(fp, [_agent_line(model="sonnet")])
+    _touch_old(fp, hours_ago=200)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600)  # 1h window
+    assert report["sessions_scanned"] == 0
+    assert report["files_skipped"] == 0
+    assert report["agent_dispatches"]["total"] == 0
+
+
+def test_oversized_file_is_skipped_and_counted(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "huge.jsonl"
+    _write_jsonl(fp, [_agent_line(model="sonnet")])
+    _touch_recent(fp)
+
+    # Use a tiny max_file_bytes instead of writing a literal 200MB fixture.
+    tiny_cap = 4  # our fixture file is far bigger than 4 bytes
+    report = smr.build_report(root, since_epoch=time.time() - 3600, max_file_bytes=tiny_cap)
+
+    assert report["files_skipped"] == 1
+    assert report["sessions_scanned"] == 0
+    assert report["agent_dispatches"]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# PII boundary
+# ---------------------------------------------------------------------------
+
+
+SECRET_EMAIL = "john.doe@example.com"
+SECRET_PHONE = "+1-555-123-4567"
+SECRET_KEY = "sk-abc123secretvalue"
+
+
+def test_pii_in_tool_result_and_command_text_never_leaks(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    leaking_text = f"contact {SECRET_EMAIL} or {SECRET_PHONE}, key {SECRET_KEY}"
+    records = [
+        # A tool_result block: the scanner must never even look at "content"
+        # on a non tool_use block.
+        _tool_result_line(leaking_text),
+        # A Bash command that does NOT match the seat vocabulary but whose
+        # argument text carries the same secrets -- classify_bash_seat must
+        # return None and the raw command must never be retained.
+        _bash_line(f"echo '{leaking_text}'"),
+        # A matching seat call whose flag value happens to carry the email --
+        # only the narrow-charset capture may survive, never the full string.
+        _bash_line(f"agy -p 'hi' --model {SECRET_EMAIL}"),
+        _agent_line(model="sonnet"),
+    ]
+    _write_jsonl(fp, records)
+    _touch_recent(fp)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600)
+    smr.assert_all_strings_safe(report)  # must not raise
+
+    blob_json = json.dumps(report)
+    blob_md = smr.render_markdown(report)
+
+    for secret in (SECRET_EMAIL, SECRET_PHONE, SECRET_KEY, leaking_text):
+        assert secret not in blob_json
+        assert secret not in blob_md
+
+    # the non-matching echo command contributed nothing to seat_calls
+    assert report["non_anthropic_seat_calls"]["total"] == 1  # only the agy call
+    # the agy call's --model value could not have survived whole (it fails
+    # the safe charset because of '@' and '.') -- confirm it was sanitized,
+    # not silently included verbatim.
+    seat_keys = list(report["non_anthropic_seat_calls"]["by_seat"].keys())
+    assert len(seat_keys) == 1
+    assert SECRET_EMAIL not in seat_keys[0]
+
+
+def test_guard_rejects_unsafe_strings():
+    with pytest.raises(ValueError):
+        smr.assert_all_strings_safe({"x": "has an @ sign which is not allowed"})
+    with pytest.raises(ValueError):
+        smr.assert_all_strings_safe({"x": "y" * 121})
+    # compliant input must pass silently
+    smr.assert_all_strings_safe({"x": "codex:sol", "y": ["a-b_c.d/e:f%g(h)i=j,k 1"]})
+
+
+def test_sanitize_str_strips_disallowed_chars_and_truncates():
+    assert smr.sanitize_str(None) == "unknown"
+    assert smr.sanitize_str("plain-ok_1.2") == "plain-ok_1.2"
+    out = smr.sanitize_str("bad@chars#here!")
+    assert smr.SAFE_STRING_RE.match(out)
+    assert "@" not in out and "#" not in out and "!" not in out
+    long_out = smr.sanitize_str("x" * 500, maxlen=10)
+    assert len(long_out) <= 10
+
+
+# ---------------------------------------------------------------------------
+# classify_bash_seat -- guilt AND innocence (cicatrix family #3 discipline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        ('codex exec -m gpt-5.6-sol --sandbox workspace-write "x"', "codex:sol"),
+        ('codex exec -m gpt-5.6-terra --sandbox workspace-write "x"', "codex:terra"),
+        ('codex exec -m gpt-5.6-luna --sandbox workspace-write "x"', "codex:luna"),
+        ("codex exec --sandbox read-only ping", "codex:default"),
+        ('kimi -p "x" -m kimi-code/k3', "kimi:k3"),
+        ('kimi -p "x" -m kimi-code/kimi-for-coding', "kimi:kimi-for-coding"),
+        ('kimi -p "x" -m kimi-code/kimi-for-coding-highspeed', "kimi:kimi-for-coding-highspeed"),
+        ('kimi -p "x" < /dev/null', "kimi:default"),
+        ("agy -p 'hi' --model gemini-3.1-pro", "agy:gemini-3.1-pro"),
+        ("agy -p 'hi'", "agy:default"),
+        ("scripts/seat_build.sh --seat A2 --tier gold", "seat_build:A2/gold"),
+        ("scripts/seat_build.sh", "seat_build:default"),
+        ("ollama run qwen3.5:9b", "ollama:qwen3.5:9b"),
+        ("echo hi && nlm query foo", "nlm"),
+        ("python3 notebooklm_bridge.py", "nlm"),
+        ("python3 scripts/jules_dispatch.py --task x", "jules_dispatch"),
+        ("python3 scripts/tp1_call.py --model x", "tp1"),
+        ("curl http://localhost/review_routes", "tp1"),
+    ],
+)
+def test_classify_bash_seat_guilt(command, expected):
+    assert smr.classify_bash_seat(command) == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls -la",
+        "git status",
+        "pytest -q",
+        "echo the codex executable path",  # "codex exec" must not over-match "executable"
+        "codexy exec foo",  # word-boundary: not the literal token "codex"
+        "echo mykimi -m kimi-code/k3",  # "kimi" must be its own token, not a substring
+        "echo my-agy-wrapper --model x",  # "agy" must be its own token
+        "",
+        None,
+    ],
+)
+def test_classify_bash_seat_innocence(command):
+    assert smr.classify_bash_seat(command) is None
+
+
+# ---------------------------------------------------------------------------
+# PR join (dependency-injected, no real gh/network in tests)
+# ---------------------------------------------------------------------------
+
+
+def test_pr_join_maps_session_activity_to_pr(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    _write_jsonl(
+        fp,
+        [
+            _agent_line(model="sonnet", branch="agent/pro/infra/seat-mix"),
+            _bash_line("codex exec -m gpt-5.6-terra ping", branch="agent/pro/infra/seat-mix"),
+        ],
+    )
+    _touch_recent(fp)
+
+    calls = []
+
+    def fake_lookup(branch):
+        calls.append(branch)
+        return "5099" if branch == "agent/pro/infra/seat-mix" else None
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600, pr_lookup=fake_lookup)
+
+    assert calls == ["agent/pro/infra/seat-mix"]  # called once, cached per branch
+    assert report["per_pr"] == {"5099": {"agent_dispatches": 1, "seat_calls": 1, "sessions": 1}}
+    assert report["unmapped_sessions_with_activity"] == 0
+
+
+def test_pr_join_unmapped_when_lookup_returns_none(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    _write_jsonl(fp, [_agent_line(model="sonnet", branch="scratch/nobody")])
+    _touch_recent(fp)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600, pr_lookup=lambda b: None)
+    assert report["per_pr"] == {}
+    assert report["unmapped_sessions_with_activity"] == 1
+
+
+def test_no_pr_lookup_means_all_unmapped_and_no_calls(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    _write_jsonl(fp, [_agent_line(model="sonnet", branch="whatever")])
+    _touch_recent(fp)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600, pr_lookup=None)
+    assert report["per_pr"] == {}
+    assert report["unmapped_sessions_with_activity"] == 1
+
+
+def test_session_with_no_dispatch_activity_is_scanned_but_not_pr_accounted(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    _write_jsonl(fp, [_tool_result_line("just chatter, no tools")])
+    _touch_recent(fp)
+
+    calls = []
+    report = smr.build_report(
+        root, since_epoch=time.time() - 3600, pr_lookup=lambda b: calls.append(b) or "999"
+    )
+    assert report["sessions_scanned"] == 1
+    assert calls == []  # never even attempted a lookup for a session with no activity
+    assert report["unmapped_sessions_with_activity"] == 0
+    assert report["per_pr"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering sanity
+# ---------------------------------------------------------------------------
+
+
+def test_render_markdown_is_nonempty_and_contains_headline_numbers(tmp_path):
+    root = tmp_path / "projects"
+    fp = root / "p" / "s.jsonl"
+    _write_jsonl(fp, [_agent_line(model="sonnet"), _workflow_line()])
+    _touch_recent(fp)
+
+    report = smr.build_report(root, since_epoch=time.time() - 3600)
+    report["window_hours"] = 24
+    md = smr.render_markdown(report)
+    assert "# Seat-mix daily report" in md
+    assert "Total Agent dispatches: 1" in md
+    assert "workflow_runs: 1" in md
+
+
+def test_empty_root_returns_zeroed_report(tmp_path):
+    root = tmp_path / "does-not-exist"
+    report = smr.build_report(root, since_epoch=time.time() - 3600)
+    assert report["sessions_scanned"] == 0
+    assert report["agent_dispatches"]["total"] == 0
+    assert report["non_anthropic_seat_calls"]["total"] == 0
+    assert report["agent_dispatches"]["cheap_seat_share_pct"] is None
+    assert report["non_anthropic_seat_calls"]["per_anthropic_dispatch"] is None


### PR DESCRIPTION
## Summary

- A one-off, unpublished, unrepeatable hand parse on 2026-08-26 found 882 Agent
  dispatches fleet-wide in 48h (sonnet 86%, haiku 0.9%, opus 12), ~512 non-Anthropic
  shell calls (0.58 per Anthropic dispatch), the `Workflow` tool at 0 genuine runs,
  and 5/20 evidence packs carrying a cross-family reviewer. `scripts/seat_mix_report.py`
  replaces that hand parse with a script anyone can re-run.
- It stream-parses Claude Code's own project transcripts (`~/.claude/projects/**/*.jsonl`)
  inside a lookback window and counts, purely structurally: `Agent` tool_use by
  `input.model` (missing -> `inherit`) and `input.subagent_type`; `Bash` tool_use
  classified against a fixed seat vocabulary (`codex exec -m gpt-5.6-{sol,terra,luna}`,
  `kimi -m kimi-code/{k3,kimi-for-coding,kimi-for-coding-highspeed}`, `agy --model`,
  `seat_build.sh --seat/--tier`, `ollama run`, `nlm`/`notebooklm`, `jules_dispatch.py`,
  `tp1_call`/`review_routes`); `Workflow` tool_use as a bare count. Each session's
  `gitBranch` is best-effort joined to a PR via `gh pr list --search "head:<branch>" --state all`.
- **PII boundary (SYMBIOSIS Law 2)**: the scanner never reads `tool_result` or free-text
  `text` blocks (where client PII lives) -- only a `tool_use` block's `name` and a
  handful of narrow-charset regex captures out of `input.command`/`input.model`/
  `input.subagent_type`. Every emitted string is sanitized to a 120-char safe charset
  at extraction time and re-validated by a hard `assert_all_strings_safe()` gate before
  anything is written.
- No targets or thresholds anywhere in the report or its doc -- per the 2026-08-26
  retro's A5 rejection, this is descriptive telemetry, not a gate.

## Adversarial review (Kimi K3, mandatory refuter round -- completed, findings fixed)

`kimi -m kimi-code/k3` reviewed this PR's real diff (`gh pr diff 5047`) and found two
genuine issues before merge, both fixed in a follow-up commit and both re-tested:

1. **Secret/PII leak**: `--model`/`--seat`/`--tier`/ollama's model argument are captured
   from arbitrary command text. The output-safety charset is a *superset* of common
   secret shapes -- an `sk-...`-style key or a bare-digit phone number is made entirely
   of letters/digits/hyphens, so it would have survived the sanitizer intact, contrary
   to the module's own (now-corrected) docstring claim. **Fixed**: `_redact_if_sensitive()`
   (secret-key prefixes, or >=7 digits) gates every free-captured flag value before
   sanitization, replacing it with the fixed literal `redacted`.
2. **Over-count**: a vocabulary script merely *read or edited*, not run, still matched --
   `cat scripts/seat_build.sh`, `git log -- scripts/jules_dispatch.py`,
   `grep review_routes -r .` all counted as seat calls despite invoking nothing. A
   systematic risk in a repo whose daily work is editing these very scripts. **Fixed**:
   commands are split on shell separators and any segment whose own first word is a
   read/inspect/edit verb (`cat`, `grep`, `git`, `vim`, ...) is skipped before running
   any vocabulary check on it -- scoped per-segment so a read-only verb in one part of a
   compound command doesn't blind a real invocation elsewhere in the same line.

Both findings are recorded as `CONFIRMED` `dissent` entries in the evidence pack
(external, not self-refutation) alongside two issues the session's own test/lint suite
caught before the refuter ever ran (an `nlm` classifier under-match, a
`plutil`-vs-`plistlib` XML-comment disagreement in the plist). 12 new tests added for
the refuter round; full suite re-run green (52/52) and the real `--since 48` run
re-verified against real transcripts post-fix.

## Day-0 baseline (Pro, `--since 48`, post cross-family review)

```
# Seat-mix daily report

- generated_at: 2026-08-27 00:38:00 WITA
- window_hours: 48.0
- sessions_scanned: 118
- files_skipped (over size cap): 0

## Agent dispatch mix

Total Agent dispatches: 148

| model | count | pct |
|---|---|---|
| sonnet | 127 | 85.8% |
| inherit | 18 | 12.2% |
| haiku | 2 | 1.4% |
| opus | 1 | 0.7% |

cheap_seat_share_pct (haiku share): 1.4%

| subagent_type | count |
|---|---|
| general-purpose | 113 |
| Explore | 14 |
| backend-verifier | 12 |
| fork | 5 |
| unspecified | 2 |
| spalla-review | 1 |
| mcp-health | 1 |

## Non-Anthropic seat calls (Bash)

Total: 112
Per Anthropic dispatch: 0.76

| seat | count |
|---|---|
| nlm | 23 |
| kimi:k3 | 16 |
| seat_build:default | 15 |
| kimi:default | 15 |
| agy:default | 10 |
| codex:sol | 8 |
| tp1 | 8 |
| codex:default | 7 |
| seat_build:codex/unset | 3 |
| codex:luna | 3 |
| jules_dispatch | 3 |
| kimi:kimi-for-coding | 1 |

## Workflow tool

workflow_runs: 1

## Per-PR seat counts (best-effort branch join)

unmapped_sessions_with_activity: 35

| PR | agent_dispatches | seat_calls | sessions |
|---|---|---|---|
| 5043 | 1 | 0 | 1 |
| 5037 | 1 | 0 | 1 |
| 5039 | 0 | 1 | 1 |
```

Scoped to Pro's own `~/.claude/projects` only, not the fleet-wide hand parse it replaces
(which spanned M5+Pro+Mini). Most sessions-with-activity are unmapped, and that is a
correct reading of the window, not a join failure: a metadata-only branch tally over the
same window shows the bulk of sessions on `main`, on detached `HEAD`, and on the
long-lived `feature/visa-oracle` integration branch -- none of which a `head:<branch>` PR
search can ever match by construction. Full explanation in `docs/factory/SEAT-MIX.md`.

## Verified before shipping (not asserted)

- `scripts/usage/seat_usage_collector.py` (cited by Kimi as prior art): confirmed LIVE via
  `ls -la` + `launchctl list | grep -i seat` -- it IS an installed, armed LaunchAgent with
  log activity as recently as 2026-08-26 23:53. It measures a *different* thing (token usage
  per Claude-profile seat via `seat_map.json`'s profile-dir-to-account join key), not
  Agent/Bash/Workflow dispatch counts joined to PRs. Documented as complementary, not
  duplicative, in `docs/factory/SEAT-MIX.md` so nobody tries to merge them later.
- `python3 scripts/evidence_pack_lint.py --print-floor` on the real changed-file set
  returns `3` (`infra/launchagents/` is hot-zone) -- Gear-3 evidence pack included at
  `evidence/2026-08/agent-nuzantara-infra-seat-mix-report-0826-85b9a116/`, lints clean.

## Cron install (NOT done by this PR -- Agent PR Contract: ship the artifact, operator/H24 node installs it)

Run on **Pro** and **Mini** (the H24 node) -- **not** on M5, which runs no daemons/cron by design:

```bash
cp infra/launchagents/com.nuzantara.seat-mix.daily.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.nuzantara.seat-mix.daily.plist
```

## Test plan

- [x] `scripts/tests/test_seat_mix_report.py` -- 52 passed (exact-count fixture matching
      the mandate's own shape: 3 Agent dispatches 2 sonnet/1 haiku, 2 Bash seat calls
      codex-sol + kimi-k3, 1 Workflow; PII-leak fixture incl. in-charset secret/phone in a
      matching flag; oversized-file-skip fixture; 24 guilt/innocence pairs for the Bash
      classifier incl. the read/edit-verb over-match guard)
- [x] `plutil -lint` + `plistlib.load()` + `scripts/lint_plist_keepalive.py` all clean on
      the new plist
- [x] Real run on Pro (`--since 48`) against real transcripts, output manually reviewed
      for PII before being pasted into this PR body and into `docs/factory/SEAT-MIX.md`
- [x] Evidence pack lints clean (`scripts/evidence_pack_lint.py`, Gear 3, floor-matched)
- [x] Cross-family refuter (Kimi K3) on this PR's real diff -- 2 real findings, both fixed
      and re-tested, recorded in the evidence pack's `dissent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
