### PR TITLE
feat(ci): a PR into an unprotected integration branch goes red — 52 PRs merged into feature/* bases with zero required checks

### DIFF
--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -392,7 +392,7 @@ jobs:
     # Floor is the checkout + at most 3 `gh api` calls (list + 2 ruleset
     # detail GETs) — and ZERO api calls at all when the base IS the default
     # branch (most PRs), which short-circuits before touching `gh`.
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
       # OPEN QUESTION, not a confident claim either way (corrected 2026-08-27

--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -368,3 +368,67 @@ jobs:
             echo ""
             echo "Reference: research/operations/L5.2-phase2-3-4-prompts.md"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # S5 check-half (ASSEMBLY-LINE.md "The integration branch must be
+  # protected BEFORE the first lane opens a PR"): an integration branch
+  # inherits main's gates or the PR into it goes red. Measured 2026-08-27:
+  # exactly 2 rulesets exist in this repo, both scoped to main/
+  # ~DEFAULT_BRANCH — 52 PRs merged into feature/kb-current, feature/
+  # garuda-voa, feature/due-bot in the 2026-08-25/26 window with ZERO
+  # required checks. This job is independent of hot-zone-gate above (its
+  # own pass/fail, its own name in the Checks tab) so it can later be added
+  # to required_status_checks on its own, without inheriting hot-zone-
+  # gate's unrelated CODEOWNERS/migration concerns.
+  #
+  # ARM-half (repo-settings mutation, NOT done here — operator[control-
+  # plane]): scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern
+  # '<pattern>' --apply, printed verbatim by this check's own failure
+  # message when it fires.
+  # ---------------------------------------------------------------------
+  base-branch-protected:
+    name: Base branch protected
+    runs-on: ubuntu-latest
+    # Floor is the checkout + at most 3 `gh api` calls (list + 2 ruleset
+    # detail GETs) — and ZERO api calls at all when the base IS the default
+    # branch (most PRs), which short-circuits before touching `gh`.
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # CONFIRMED GAP, not a guess (2026-08-27, actionlint against this
+      # exact job): the repository-rulesets API is documented as requiring
+      # "Administration" access, but `administration` is NOT in actionlint's
+      # own list of grantable Actions `permissions:` scopes at all — the
+      # ephemeral GITHUB_TOKEN structurally cannot be scoped to read
+      # rulesets, by GitHub's own token design, regardless of what's written
+      # here. So `${{ github.token }}` below will likely 403 on the ONE `gh
+      # api repos/.../rulesets` call this script makes for a non-default
+      # base — which the script then reports as BLIND (fail-closed, "cannot
+      # verify"), never as a false pass. On the default-branch base (most
+      # PRs), this job never calls that API at all and is unaffected. Un-
+      # blocking the non-default case needs an admin-scoped PAT wired as a
+      # repo secret — operator[secret], a follow-up, not done in this PR.
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: An unprotected integration branch must not silently accept PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -u
+          if [[ -z "${BASE_REF:-}" ]]; then
+            echo "::notice::no base ref on this event (${{ github.event_name }}) — nothing to check"
+            exit 0
+          fi
+          python3 scripts/ci/check_base_protected.py \
+            --base-ref "$BASE_REF" \
+            --repo "${{ github.repository }}" \
+            --default-branch "${DEFAULT_BRANCH:-main}"

--- a/.github/workflows/hot-zone-pr-gate.yml
+++ b/.github/workflows/hot-zone-pr-gate.yml
@@ -395,19 +395,21 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      # CONFIRMED GAP, not a guess (2026-08-27, actionlint against this
-      # exact job): the repository-rulesets API is documented as requiring
-      # "Administration" access, but `administration` is NOT in actionlint's
-      # own list of grantable Actions `permissions:` scopes at all — the
-      # ephemeral GITHUB_TOKEN structurally cannot be scoped to read
-      # rulesets, by GitHub's own token design, regardless of what's written
-      # here. So `${{ github.token }}` below will likely 403 on the ONE `gh
-      # api repos/.../rulesets` call this script makes for a non-default
-      # base — which the script then reports as BLIND (fail-closed, "cannot
-      # verify"), never as a false pass. On the default-branch base (most
-      # PRs), this job never calls that API at all and is unaffected. Un-
-      # blocking the non-default case needs an admin-scoped PAT wired as a
-      # repo secret — operator[secret], a follow-up, not done in this PR.
+      # OPEN QUESTION, not a confident claim either way (corrected 2026-08-27
+      # — a cross-family refuter disputed this job's original framing, which
+      # asserted `administration` scope was needed and would 403; that claim
+      # is itself unverified, not confirmed-correct). What IS empirically
+      # confirmed (actionlint against this exact job): neither "administration"
+      # nor "metadata" appears in actionlint's own list of grantable Actions
+      # `permissions:` scopes — so no permission NAME expressible here can
+      # settle the question either way. Whether `${{ github.token }}` below
+      # (with only `contents: read`, the workflow's own default) can actually
+      # read this PUBLIC repo's rulesets is UNTESTED by this PR: the base==
+      # default-branch case (this PR's own CI run) never calls that API at
+      # all, so it can't be observed here. If it 403s, the script reports
+      # BLIND (fail-closed, "cannot verify") on a non-default base, never a
+      # false pass — the first real feature/* PR after the arm-half lands
+      # will settle this empirically; do not assume either outcome until then.
     steps:
       - uses: actions/checkout@v7
         with:
@@ -420,15 +422,28 @@ jobs:
       - name: An unprotected integration branch must not silently accept PRs
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          # Kept as TWO separate fields, never OR-merged into one ambiguous
+          # string — a cross-family refuter found the real bypass that shape
+          # enabled (2026-08-27): whichever of the two is non-empty tells the
+          # script, by construction, whether it's a full ref (merge_group,
+          # always full by GitHub's own contract) or a short name
+          # (pull_request, always short) — never guessed downstream from the
+          # string's own content, which is what let a branch literally named
+          # `refs/heads/main` bypass this check entirely.
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -u
-          if [[ -z "${BASE_REF:-}" ]]; then
+          if [[ -n "${PR_BASE_REF:-}" ]]; then
+            ARGS=(--base-ref "$PR_BASE_REF")
+          elif [[ -n "${MERGE_GROUP_BASE_REF:-}" ]]; then
+            ARGS=(--base-ref "$MERGE_GROUP_BASE_REF" --base-ref-full)
+          else
             echo "::notice::no base ref on this event (${{ github.event_name }}) — nothing to check"
             exit 0
           fi
           python3 scripts/ci/check_base_protected.py \
-            --base-ref "$BASE_REF" \
+            "${ARGS[@]}" \
             --repo "${{ github.repository }}" \
             --default-branch "${DEFAULT_BRANCH:-main}"

--- a/docs/factory/ASSEMBLY-LINE.md
+++ b/docs/factory/ASSEMBLY-LINE.md
@@ -209,12 +209,20 @@ premise from the original design, see the script's own module docstring).
 Still open, and deliberately NOT done by this check (repo-settings mutation is
 an operator[control-plane] action): actually creating the `feature/*` ruleset
 — `scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern 'feature/*'
---apply` (print-only without `--apply`) — and confirming the CI job's own
-`gh api .../rulesets` call can authenticate at all, since the ambient
-`GITHUB_TOKEN` has no grantable "administration" scope (confirmed via
-actionlint's own valid-permissions list) and will likely report the check as
-BLIND (fail-closed, not a false pass) on every non-default-base PR until an
-admin-scoped PAT is wired in as a secret.
+--apply` (print-only without `--apply`) — and confirming whether the CI job's
+own `gh api .../rulesets` call can authenticate at all with the ambient
+`GITHUB_TOKEN`. Corrected 2026-08-27 after a cross-family refuter round: the
+PR's first draft asserted this would "likely 403" because "administration"
+isn't a grantable Actions `permissions:` scope; the refuter countered that the
+real requirement is "Metadata: read", not Administration. Neither claim could
+be confirmed — GitHub's REST rulesets docs don't publish a permissions table
+for the endpoint, and "metadata" is ALSO absent from actionlint's own
+valid-scopes list, so whichever name is correct in GitHub's model, this job's
+`permissions:` block cannot express it either way. Left as an honestly
+UNTESTED open question (base==main never exercises this call, so this PR
+never observed it either succeed or 403) rather than a confident claim in
+either direction — the first real `feature/*` PR after the ARM-half lands
+will settle it empirically.
 
 ## Enforcement backlog (not yet armed — tracked, per superscar #2 "esiste ≠ armato")
 

--- a/docs/factory/ASSEMBLY-LINE.md
+++ b/docs/factory/ASSEMBLY-LINE.md
@@ -196,6 +196,26 @@ from `main` may be actively harmful on a branch that lacks the machinery `main`
 has.** Inherited rules travel with their enforcement or they travel as their own
 opposite.
 
+**Update 2026-08-27 — CHECK-half shipped, ARM-half still pending.**
+`scripts/ci/check_base_protected.py` + the `base-branch-protected` job in
+`.github/workflows/hot-zone-pr-gate.yml` now fail a PR whenever its base branch
+is not covered by an active ruleset carrying the main-equivalent minimum
+required checks (`infra/required.d/integration-branch-minimum-contexts.json`).
+Verified live at authoring time: exactly 2 rulesets exist, both scoped to
+`main`/`~DEFAULT_BRANCH` — nothing covered `refs/heads/feature/*`, and neither
+of those 2 carries a `required_status_checks` rule at all (main's own required
+checks live in classic branch protection, not in its ruleset — a corrected
+premise from the original design, see the script's own module docstring).
+Still open, and deliberately NOT done by this check (repo-settings mutation is
+an operator[control-plane] action): actually creating the `feature/*` ruleset
+— `scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern 'feature/*'
+--apply` (print-only without `--apply`) — and confirming the CI job's own
+`gh api .../rulesets` call can authenticate at all, since the ambient
+`GITHUB_TOKEN` has no grantable "administration" scope (confirmed via
+actionlint's own valid-permissions list) and will likely report the check as
+BLIND (fail-closed, not a false pass) on every non-default-base PR until an
+admin-scoped PAT is wired in as a secret.
+
 ## Enforcement backlog (not yet armed — tracked, per superscar #2 "esiste ≠ armato")
 
 1. CI rule: PR touching only `docs/`/`research/` requires an explicit owner-initialed label

--- a/evidence/2026-08/agent-nuzantara-infra-base-protected-check-0826-2acb8494/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-base-protected-check-0826-2acb8494/brief.yml
@@ -1,0 +1,119 @@
+task_id: base-protected-check-0826
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  S5 check-half (research/operations/2026-08-26-retro-fleet-sessions-25-26.md
+  §3 ADOPT table, ASSEMBLY-LINE.md "The integration branch must be protected
+  BEFORE the first lane opens a PR"): an integration branch inherits main's
+  gates or the PR into it goes red.
+
+  Verified live at authoring time (2026-08-27): exactly 2 GitHub rulesets
+  exist in Bali-Zero/Teman2 — `merge-queue-main` (id 19779175, scoped to
+  refs/heads/main) and `Copilot review for default branch` (id 20608865,
+  scoped to ~DEFAULT_BRANCH). Neither covers refs/heads/feature/*. 52 PRs
+  merged into feature/kb-current (26), feature/garuda-voa (23),
+  feature/due-bot (2) in the 2026-08-25/26 window with zero required checks —
+  the incident is already documented in ASSEMBLY-LINE.md's narrative section
+  (a 15-file customer-facing PR merged unreviewed; a magic-link PR merged
+  with two backend shards red).
+
+  Gear 3 by PATH, deterministic: the floor recomputed from this PR's own
+  6-file changed set is 3 (`python3 scripts/evidence_pack_lint.py
+  --print-floor --changed-files-file <enumeration>` -> 3), because
+  `.github/workflows/hot-zone-pr-gate.yml` is touched. Honored, not argued
+  with.
+
+  Deliverable is the CHECK-half only (the ARM-half — actually creating a
+  ruleset on refs/heads/feature/* — is an operator[control-plane] repo-
+  settings mutation, explicitly out of scope for this lane):
+  scripts/ci/check_base_protected.py + a new `base-branch-protected` job in
+  hot-zone-pr-gate.yml + a print-only `--branch-pattern` extension to
+  scripts/ci/setup_merge_queue_ruleset.sh (the command the check's own
+  failure message names) + 34 guilt/innocence tests.
+constraints:
+  - "Never mutate repo settings/rulesets/branch-protection — this lane ships
+    the CHECK-half only. `--branch-pattern` without `--apply` only PRINTS the
+    `gh api` body it would send; `--apply` is never invoked by this PR or by
+    the CI job itself."
+  - "Fail CLOSED, not fail-open: a base that cannot be verified (rulesets API
+    unreadable) reports BLIND (exit 1), never a silent pass. Distinguished
+    from the UNPROTECTED guilt case only by message prefix, per the mandate's
+    own spec — both are exit 1."
+  - "No PII/OSINT in any artifact — this is pure CI-plumbing (ruleset JSON,
+    Python, bash, YAML, tests). Nothing here touches client data."
+  - "Do not re-derive the pinned minimum-contexts list from ruleset
+    19779175's `.rules` — verified live it carries none (only a
+    `merge_queue` rule); the list is hand-picked from classic branch
+    protection's 27 real contexts instead, in
+    infra/required.d/integration-branch-minimum-contexts.json, so this
+    script and the shell script's ARM-half never drift apart (one SSOT)."
+acceptance:
+  - "check_base_protected.py's own 34 pytest cases pass, including the four
+    fixtures the mandate specifies verbatim: base main covered -> 0; base
+    feature/x with no ruleset -> 1 (guilt); base feature/x with a covering
+    ruleset -> 0 (innocence); API error -> 1 with a distinct (BLIND)
+    message."
+  - "actionlint passes on the modified hot-zone-pr-gate.yml (it caught a
+    real defect during authoring: `administration` is not a valid Actions
+    `permissions:` scope at all — removed, documented as a confirmed,
+    named residual gap rather than hidden)."
+  - "bash -n on the modified setup_merge_queue_ruleset.sh, and its new
+    `--branch-pattern 'feature/*'` dry-run actually prints a well-formed
+    ruleset body with all 5 pinned contexts, byte-for-byte matching live
+    `branches/main/protection/required_status_checks` context names."
+  - "The deterministic floor recomputed from the real changed-file
+    enumeration is 3, and this brief declares gear 3 — never below it."
+consumer_map:
+  - "`.github/workflows/hot-zone-pr-gate.yml` — new `base-branch-protected`
+    job runs on every pull_request/merge_group (no paths filter, matching
+    the file's own C1/C3 contracts)."
+  - "`scripts/ci/check_base_protected.py` — invoked by that job; also
+    invokable standalone/locally, and by scripts/tests/test_check_base_protected.py."
+  - "`infra/required.d/integration-branch-minimum-contexts.json` — read by
+    both check_base_protected.py (the check) and setup_merge_queue_ruleset.sh
+    --branch-pattern (the arm-half), so the two never hand-maintain two
+    diverging lists."
+  - "`scripts/ci/setup_merge_queue_ruleset.sh` — the ARM-half; this PR only
+    adds a print-only mode, no invocation with `--apply` anywhere in CI or
+    in this session."
+  - "`docs/factory/ASSEMBLY-LINE.md` — narrative section updated in place to
+    record the check-half as shipped and the arm-half as still pending."
+risks:
+  - "The CI job's own `gh api repos/.../rulesets` call may 403: the ambient
+    GITHUB_TOKEN has no grantable `administration` scope at all (confirmed
+    via actionlint's own valid-permissions list, not assumed) — repository
+    rulesets are documented as requiring Administration access, and that
+    scope simply does not exist in the Actions token permission model. On
+    the default-branch base (most PRs) this job never calls that API and is
+    unaffected; on a non-default base it will very likely observe BLIND
+    (fail-closed) rather than a false pass, which is the documented,
+    intended degraded posture, not a crash. Confirming/curing this (an
+    admin-scoped PAT wired as a repo secret) is a named follow-up, not done
+    here — it is a credential/secret action, operator[secret]."
+  - "The ARM-half (creating the refs/heads/feature/* ruleset with `--apply`)
+    is not performed by this PR. Until an operator runs it, this check will
+    correctly report every feature/* PR as UNPROTECTED (or BLIND, per the
+    risk above) — that IS the intended visible signal this PR ships, not a
+    silent no-op."
+  - "The 5 pinned contexts are a hand-picked subset of main's 27 real
+    required checks (declared rationale in the JSON file's own
+    `selection_rationale` field), not a generated/exhaustive list — a
+    narrower net than main's full required-check set, by design, to keep
+    the arm-half's ruleset body small and reviewable."
+grader: |
+  generator != grader: a cross-family refuter (Codex gpt-5.6-sol, high
+  effort, read-only sandbox; falls back to Kimi K3 if empty) reviews the
+  real PR diff before merge, per this lane's own mandate. This session
+  independently verified its own design against live GitHub state THREE
+  times before writing any code (rulesets list, ruleset 19779175 full body,
+  Copilot-review ruleset full body, classic branch-protection contexts,
+  default branch) rather than trusting the mandate's own stated assumption
+  about where main's required-checks rule lives — which that verification
+  falsified, and the corrected premise is documented in the shipped code's
+  own module docstring, not silently absorbed.
+budget: |
+  Single-lane CI-plumbing task. Flat-subscription seats only (Claude Sonnet
+  5 build via this session, Codex/Kimi cross-family refuter). No metered
+  API spend, no cloud LLM touching PII (there is none in this diff).
+pii: none

--- a/evidence/2026-08/agent-nuzantara-infra-base-protected-check-0826-2acb8494/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-base-protected-check-0826-2acb8494/pack.yml
@@ -1,0 +1,368 @@
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  PR #5050 (agent/nuzantara/infra/base-protected-check-0826 -> main) — S5
+  check-half per the 2026-08-26 retro's ADOPT table and
+  docs/factory/ASSEMBLY-LINE.md's "protect the integration branch" section.
+
+lanes:
+  - lane: base-protected-check-build
+    role: build
+    seat: claude-sonnet-5 (this session — implementer lane, CLAUDE.md §5 default)
+  - lane: base-protected-check-refuter
+    role: review
+    seat: codex (gpt-5.6-sol, high effort, read-only sandbox) — cross-family,
+      never the same seat as the build lane
+
+diff:
+  files: 6
+  net_lines: 1015
+  measured_at: 469569ae0
+  note: >-
+    Measured at the initial commit (469569ae0), before the refuter-driven fix
+    commit that follows. `git diff --no-renames --numstat $(git merge-base
+    origin/main HEAD) HEAD` cross-checked against `git diff --stat`'s own file
+    count (6) — they agree.
+
+pii_scan: clean
+
+receipts:
+  - claim: >-
+      Exactly 2 GitHub rulesets exist in Bali-Zero/Teman2, both scoped to
+      main/~DEFAULT_BRANCH, and NEITHER carries a required_status_checks
+      rule — main's real required checks live in classic branch protection,
+      not in any ruleset. This falsifies the original design's assumption
+      (read ruleset 19779175's own .rules to find the minimum contexts).
+    cmd: >-
+      gh api repos/Bali-Zero/Teman2/rulesets ;
+      gh api repos/Bali-Zero/Teman2/rulesets/19779175 ;
+      gh api repos/Bali-Zero/Teman2/rulesets/20608865 ;
+      gh api repos/Bali-Zero/Teman2/branches/main/protection/required_status_checks
+    result: >-
+      2 rulesets (merge-queue-main id 19779175 -> refs/heads/main, rules=[merge_queue]
+      only; Copilot review for default branch id 20608865 -> ~DEFAULT_BRANCH,
+      rules=[deletion, non_fast_forward, copilot_code_review]). Classic branch
+      protection on main lists 27 required_status_checks contexts. Neither
+      ruleset's .rules contains a required_status_checks entry.
+    exit: 0
+    ts: 2026-08-27T00:20Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      The 5 pinned minimum-contexts strings in
+      infra/required.d/integration-branch-minimum-contexts.json are
+      byte-for-byte identical to 5 of the 27 real live required_status_checks
+      contexts (not re-typed from memory).
+    cmd: >-
+      python3 -c "import json,subprocess; live=set(json.loads(subprocess.run(['gh','api',
+      'repos/Bali-Zero/Teman2/branches/main/protection/required_status_checks'],
+      capture_output=True,text=True,check=True).stdout)['contexts']);
+      pinned=json.load(open('infra/required.d/integration-branch-minimum-contexts.json'))['minimum_contexts'];
+      [print(repr(p), p in live) for p in pinned]"
+    result: "5/5 EXACT MATCH, including both em-dash ('—') strings."
+    exit: 0
+    ts: 2026-08-27T00:22Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      The deterministic gear floor recomputed from THIS PR's own changed-file
+      set is 3, matching the declared gear (`.github/workflows/hot-zone-pr-gate.yml`
+      is touched).
+    cmd: >-
+      git diff --no-renames --name-only $(git merge-base origin/main HEAD) HEAD >
+      L14-changed.txt && python3 scripts/evidence_pack_lint.py --print-floor
+      --changed-files-file L14-changed.txt
+    result: "3"
+    exit: 0
+    ts: 2026-08-27T00:35Z
+    seat: session (Pro, implementer lane)
+
+  - claim: The modified workflow file passes actionlint.
+    cmd: actionlint .github/workflows/hot-zone-pr-gate.yml
+    result: >-
+      FIRST run (before fix): rejected the job's `permissions: administration: read`
+      — `administration` is not in actionlint's own list of grantable Actions
+      permission scopes at all (full list: actions, artifact-metadata,
+      attestations, checks, contents, deployments, discussions, id-token,
+      issues, models, packages, pages, pull-requests, repository-projects,
+      security-events, statuses). Removed the invalid line and re-ran: exit 0.
+    exit: 0
+    ts: 2026-08-27T00:41Z
+    seat: session (Pro, implementer lane)
+
+  - claim: check_base_protected.py's own test suite passes, including the four
+      fixtures the mandate specifies verbatim, across all three fix rounds
+      (refuter-driven, then a self-caught main() ordering bug).
+    cmd: apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_check_base_protected.py -q
+    result: "Before refuter fixes: 34 passed. After refuter fixes (fnmatch
+      path-boundary, refs/heads/main-literal-branch, remediation-command
+      default, +8 new guilt/innocence cases): 42 passed. After adding 1 more
+      guilt case (fetch_live_rulesets partial-failure) and strengthening the
+      default-branch CLI test to prove 'no network call' via monkeypatch: 1
+      FAILED (see next receipt — a real bug, not a flaky test). After the
+      main()-ordering fix: 43 passed, 0 failed."
+    exit: 0
+    ts: 2026-08-27T01:10Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      `main()` violated the module's OWN documented SCOPE invariant ("the
+      base==default-branch case always exits 0 without ever calling `gh api
+      rulesets`", docstring lines 54-57 verbatim) — it called
+      fetch_live_rulesets()/read --rulesets-json UNCONDITIONALLY before ever
+      checking whether the base was the default branch, so a PR into `main`
+      itself paid an avoidable API call and could go BLIND on a transient
+      `gh` failure for the one case that never needed the network at all.
+    cmd: >-
+      A test-authoring subagent (claude-sonnet-5, dispatched to add 2 more
+      guilt/innocence cases) strengthened
+      test_main_cli_exits_zero_for_the_default_branch_with_no_network_call to
+      monkeypatch `_gh` to raise if ever called, then ran
+      `apps/backend-rag/.venv/bin/python -m pytest
+      scripts/tests/test_check_base_protected.py -q`; separately, after the
+      fix, `time python3 scripts/ci/check_base_protected.py --base-ref main
+      --repo Bali-Zero/Teman2 --default-branch main` against the REAL `gh`
+      binary (not a mock).
+    result: >-
+      Subagent's run: "1 failed, 42 passed" — `AssertionError: _gh() was
+      called for the default-branch base: ['api',
+      'repos/Bali-Zero/Teman2/rulesets']`, proving the claim false as shipped.
+      Fixed by hoisting the `normalize_ref(...) == default_branch` check in
+      `main()` to before the rulesets-fetch block, reusing `evaluate()`
+      verbatim (called with an empty rulesets list, which it never inspects
+      on this path) so the OK message keeps one source of truth. Re-ran:
+      43 passed, 0 failed. Real end-to-end confirmation against the live `gh`
+      CLI: `OK: base 'main' is the default branch...`, exit 0, wall time
+      0.049s total (a real `gh api` round-trip measured earlier in this same
+      session took several hundred ms+ — 0.049s is consistent with zero
+      network calls, not just the mocked test's say-so).
+    exit: 0
+    ts: 2026-08-27T01:25Z
+    seat: claude-sonnet-5 (test-authoring subagent) discovered; session (Pro,
+      implementer lane) fixed and independently re-verified against the real
+      `gh` binary
+
+  - claim: >-
+      `setup_merge_queue_ruleset.sh --branch-pattern 'feature/*'` (no --apply)
+      is genuinely read-only and prints a well-formed ruleset body with all
+      5 pinned contexts.
+    cmd: bash scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern 'feature/*'
+    result: >-
+      Prints a POST body to repos/Bali-Zero/Teman2/rulesets with
+      conditions.ref_name.include=["refs/heads/feature/*"] and 5/5 pinned
+      contexts under a required_status_checks rule. No `gh api --method POST/PUT`
+      call executed (dry-run branch returns before reaching the mutating call).
+      Re-ran after the enforcement-default fix: body now shows "enforcement":
+      "active" (was "disabled" before the refuter caught the asymmetry).
+    exit: 0
+    ts: 2026-08-27T00:38Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      Cross-family adversarial review ran on the real PR diff (#5050), not a
+      draft or a synthetic sample.
+    cmd: >-
+      gh pr diff 5050 > L14-diff.txt ; cd scratchpad && codex exec --sandbox
+      read-only --skip-git-repo-check -m gpt-5.6-sol -c
+      model_reasoning_effort="high" "Critically review this CI check: ..." </dev/null
+    result: >-
+      exit 0, 1316-line transcript, non-empty structured verdict ("changes
+      requested", 9 numbered findings). No fallback to Kimi K3 needed.
+    exit: 0
+    ts: 2026-08-27T00:55Z
+    seat: session (Pro, implementer lane) — dispatching codex-gpt-5.6-sol
+
+  - claim: >-
+      Two of Codex's findings were independently re-verified against GitHub's
+      own documentation before being accepted, rather than trusted on
+      assertion (the refuter itself can hallucinate — superscar #6).
+    cmd: >-
+      WebFetch https://docs.github.com/.../managing-rulesets/creating-rulesets-for-a-repository
+      re: qa/* vs qa/foo/bar pattern semantics
+    result: >-
+      CONFIRMED verbatim: "qa/* will match all branches beginning with qa/ and
+      containing a single slash, but will not match qa/foo/bar" — Python's
+      fnmatch.fnmatchcase (the original implementation) does NOT have this
+      property; fixed via a hand-written FNM_PATHNAME-style translator,
+      verified against both of GitHub's own documented examples
+      (single-star and qa/**/*-style double-star) in the test suite.
+    exit: 0
+    ts: 2026-08-27T01:00Z
+    seat: session (Pro, implementer lane)
+
+  - claim: >-
+      Whether the 5 pinned-context-producing workflows would fail to trigger
+      on a PR into a non-default base (the Codex-F12 trap
+      check_required_workflow_conformance.py exists to catch elsewhere in
+      this repo) was checked, not assumed.
+    cmd: >-
+      python3 -c "import yaml; [print(f, (yaml.safe_load(open('.github/workflows/'+f))
+      .get(True) or {}).get('pull_request')) for f in ['tests.yml','harness-floor.yml',
+      'adversarial-review-gate.yml','security.yml','actionlint.yml']]"
+    result: >-
+      0/5 carry a `branches:` restriction under `on.pull_request` — 3 have
+      `types: [opened, synchronize, reopened]` with no branch filter, 2 have a
+      bare `pull_request:` (same effective scope). All 5 fire on a PR into
+      feature/* exactly as into main.
+    exit: 0
+    ts: 2026-08-27T01:02Z
+    seat: session (Pro, implementer lane)
+
+dissent:
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      A single fnmatch `*` in `_pattern_matches` crosses `/`, so a ruleset
+      scoped to `refs/heads/feature/*` was falsely reported as covering a
+      nested branch `feature/a/b` — a false OK on a branch GitHub itself
+      would not apply that ruleset to.
+    status: CONFIRMED
+    note: >-
+      Re-verified against GitHub's own docs (qa/* does not match qa/foo/bar,
+      verbatim) before fixing. Replaced with a hand-written FNM_PATHNAME-style
+      translator; 3 new tests assert both of GitHub's own documented examples
+      plus the originally-reported false-positive case.
+
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      `normalize_ref` strips a `refs/heads/` prefix from ANY input containing
+      it, so a branch literally NAMED `refs/heads/main` (git permits slashes
+      in branch names) would be silently treated as the default branch and
+      exempted from every check.
+    status: CONFIRMED
+    note: >-
+      Fixed by removing the guess entirely: `normalize_ref`/`evaluate` now
+      take an explicit `is_full_ref` keyword the CALLER must assert (true only
+      for merge_group's base_ref, which GitHub always populates as a full
+      ref); the CI job passes `PR_BASE_REF` and `MERGE_GROUP_BASE_REF` as two
+      separate fields (never OR-merged) so the decision is made by whichever
+      GHA context field is actually populated, never guessed downstream from
+      string content. 3 new tests cover both directions.
+
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      The check's own printed remediation command
+      (`setup_merge_queue_ruleset.sh --branch-pattern '<pattern>' --apply`)
+      created the new ruleset with `enforcement=disabled`, so an operator who
+      ran the EXACT command shown would find the PR still red, with no
+      further instruction in the message.
+    status: CONFIRMED
+    note: >-
+      Fixed: `--branch-pattern ... --apply` now creates a NEW integration
+      ruleset `enforcement=active` immediately (deliberately NOT mirroring
+      the main ruleset's "disabled by default" caution, which exists for a
+      different reason — reconciling drift on an ALREADY-active, always-on
+      object must never silently flip it; here the operator explicitly asked
+      to arm THIS pattern, and arming is the entire point of the command).
+      Reconciling an EXISTING ruleset still preserves its current enforcement.
+
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      The PR's original framing asserted the ambient GITHUB_TOKEN would 403
+      on the rulesets API because "Administration" scope isn't grantable, and
+      proposed an admin-scoped PAT as the fix — Codex countered that GET
+      rulesets requires "Metadata: read", not Administration, so the PAT
+      proposal is unjustified and would introduce an unnecessarily privileged
+      secret.
+    status: PLAUSIBLE
+    note: >-
+      Neither claim could be fully confirmed: WebFetch against GitHub's REST
+      rulesets docs page did not surface a permissions table for either
+      endpoint, and separately, "metadata" is ALSO not in actionlint's own
+      list of grantable Actions `permissions:` scope names (same as
+      "administration") — so whichever name is "correct" in GitHub's own REST
+      docs, neither is expressible in this job's `permissions:` block either
+      way. Corrected the PR's framing from a confident (and disputed) claim to
+      an honestly-hedged one: removed the `administration: read` line
+      entirely (already required by actionlint's rejection), replaced the
+      workflow comment with "untested, unconfirmed either way, base==main
+      never exercises this path, the first real feature/* PR after the
+      arm-half lands will settle it" — and did NOT introduce an admin PAT.
+
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      A repository-rulesets list call is not paginated; beyond ~30 rulesets a
+      real covering ruleset on a later page would be silently missed.
+    status: CONFIRMED
+    note: >-
+      Real, but NOT fixed in this PR: this repo has exactly 2 rulesets today
+      (verified live), so the gap is currently inert, and `gh api`'s exact
+      multi-page JSON-array-concatenation shape (`--paginate` vs `--slurp`,
+      which nests rather than flattens) could not be verified against a real
+      multi-page response — guessing wrong risked breaking the working
+      2-ruleset case to guard a case that doesn't exist yet. Declared as a
+      residual limit in the module's own docstring rather than silently
+      dropped.
+
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      The `base-branch-protected` job is not a required status check, so a
+      red run does not actually block a merge today; renaming a base branch
+      (e.g. `staging/x` instead of `feature/x`) sidesteps the future
+      feature/* ruleset entirely; a branch protected via CLASSIC branch
+      protection (rather than a ruleset) is reported UNPROTECTED regardless.
+    status: CONFIRMED
+    note: >-
+      All three are real and ALL THREE are the explicitly declared scope of
+      this PR, stated before the refuter ran, not discovered by it: this is
+      the CHECK-half only. Making the job required (or covering arbitrary
+      base-branch renames, or querying classic protection for arbitrary
+      branch names) is repo-settings/scope work this lane's own mandate
+      forbids ("never mutate repo settings/rulesets — this lane ships the
+      CHECK-half only"). Not a defect to fix here; recorded because the
+      refuter is right that today's net effect is a visible signal, not an
+      enforced gate, and that gap should not be allowed to read as closed.
+
+  - seat: codex-gpt-5.6-sol (cross-family refuter, PR #5050 diff)
+    objection: >-
+      Whether the 5 pinned-context workflows actually trigger on PRs into a
+      non-default base (the Codex-F12 trap) is unproven.
+    status: RETRACTED
+    note: >-
+      Investigated and does not hold — retracted, not merely disputed.
+      Checked, not assumed: none of the 5 workflows' `on.pull_request` blocks
+      carry a `branches:` restriction (3 have `types: [...]` with no branch
+      filter, 2 have a bare `pull_request:` — same effective scope). All 5
+      fire on a PR into `feature/*` exactly as into `main`. Receipt recorded
+      above.
+
+  - seat: claude-sonnet-5 (test-authoring subagent, dispatched post-refuter to
+      add 2 more guilt/innocence cases — NOT the cross-family refuter; a
+      self-caught finding via strengthening a test's own claim)
+    objection: >-
+      `main()`'s existing test
+      `test_main_cli_exits_zero_for_the_default_branch_with_no_network_call`
+      asserted "no network call" only in its docstring, never in its body —
+      it called the real `gh` CLI and passed on live data without actually
+      proving the claim. Strengthening it to monkeypatch `_gh` to raise if
+      called failed immediately: `main()` called `fetch_live_rulesets()`
+      unconditionally, before ever checking whether the base was the default
+      branch — directly contradicting this module's own docstring SCOPE
+      section ("the base==default-branch case always exits 0 without ever
+      calling `gh api rulesets`").
+    status: CONFIRMED
+    note: >-
+      Fixed: hoisted the `normalize_ref(...) == default_branch` short-circuit
+      in `main()` to before the rulesets-fetch block (both the
+      `--rulesets-json` and live-`gh` paths), reusing `evaluate()` verbatim
+      with an empty rulesets list (never inspected on this path) so the OK
+      message keeps one source of truth. Re-verified two ways: the
+      monkeypatched test now passes (43/43 total), and a real end-to-end run
+      against the live `gh` binary for base=main completed in 0.049s wall
+      time — consistent with zero network calls, not just the mock's say-so.
+      This also closes a real fail-closed risk the refuter never flagged: a
+      PR into `main` itself could previously go BLIND on a transient `gh`
+      rate-limit/outage for a case that never needed the network.
+
+tests:
+  - "scripts/tests/test_check_base_protected.py — 43 passed, 0 failed (rc=0, venv python)."
+
+static:
+  - "actionlint .github/workflows/hot-zone-pr-gate.yml — clean (caught and fixed one real defect: invalid `administration` permission scope)."
+  - "bash -n scripts/ci/setup_merge_queue_ruleset.sh — clean."
+  - "python3 -m py_compile scripts/ci/check_base_protected.py — clean."
+  - "Pre-commit hooks (lease-check, anti-reward-hacking lint, secret scan, python lint, off-limits check) passed on both commits."
+  - "Pre-push quickcheck (prettier, actionlint) passed on both pushes."
+
+notes:
+  - "This lane never mutated repo settings/rulesets/branch-protection at any point — `--branch-pattern` was only ever run WITHOUT `--apply` in this session (dry-run/print-only), verified by inspecting its own printed output rather than trusting the code path."
+  - "The ARM-half (creating the refs/heads/feature/* ruleset with --apply) is deliberately NOT performed by this PR — that is the named operator[control-plane] follow-up."
+  - "The permission-scope framing was corrected mid-flight after the refuter disputed it and independent verification came back genuinely inconclusive (not because the refuter was simply right) — the PR body and code comments now state the honest 'unconfirmed, will be settled by the first real feature/* PR' posture instead of either confident claim."

--- a/infra/required.d/integration-branch-minimum-contexts.json
+++ b/infra/required.d/integration-branch-minimum-contexts.json
@@ -1,0 +1,14 @@
+{
+  "_doc": "Minimum required-status-check contexts a non-default base branch (e.g. a refs/heads/feature/* integration branch) must be covered by, via an ACTIVE branch ruleset's `required_status_checks` rule, to be considered protected the way main is (S5 check-half, ASSEMBLY-LINE.md 'The integration branch must be protected BEFORE the first lane opens a PR'). Read by scripts/ci/check_base_protected.py (the check-half, .github/workflows/hot-zone-pr-gate.yml job 'base-branch-protected') and scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern (the arm-half — print-only unless --apply, operator[control-plane]).",
+  "_corrected_premise_2026_08_27": "main's OWN required-status-checks do NOT live inside a ruleset rule — verified live: `gh api repos/Bali-Zero/Teman2/rulesets/19779175` (merge-queue-main) carries exactly one rule, type `merge_queue`, no `required_status_checks` rule at all. Main's 27 required contexts live in CLASSIC branch protection (`gh api repos/Bali-Zero/Teman2/branches/main/protection/required_status_checks`), a separate, older mechanism that does not support glob patterns and so cannot auto-apply to a branch that doesn't exist yet. A feature/* integration branch therefore cannot literally 'inherit main's ruleset' (main has no such rule to inherit) — it needs its OWN ruleset carrying a required_status_checks rule, seeded with this file's minimum_contexts. Do not re-derive this list from ruleset 19779175's `.rules` — it will always be empty there.",
+  "generated_at": "2026-08-27",
+  "source": "gh api repos/Bali-Zero/Teman2/branches/main/protection/required_status_checks (27 contexts total; full list mirrored in infra/required.d/contexts.json) -- these 5 are a hand-picked subset, not a generated one",
+  "selection_rationale": "Picked as the 5 most load-bearing against the two incidents ASSEMBLY-LINE.md documents from 2026-08-25 on an unprotected integration branch: a 15-file customer-facing PR merged unreviewed, and a magic-link PR merged with two backend shards red.",
+  "minimum_contexts": [
+    "Backend Tests (Python)",
+    "Harness floor recompute",
+    "R1 gate — adversarial review present",
+    "Detect Secrets",
+    "actionlint — workflow schema + expression gate"
+  ]
+}

--- a/scripts/ci/check_base_protected.py
+++ b/scripts/ci/check_base_protected.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""check_base_protected.py — an integration branch inherits main's gates or
+the PR into it goes red (S5 check-half, ASSEMBLY-LINE.md "The integration
+branch must be protected BEFORE the first lane opens a PR").
+
+WHY THIS EXISTS. Measured live 2026-08-27: exactly 2 GitHub rulesets exist in
+this repo, both scoped to `main`/`~DEFAULT_BRANCH` — `merge-queue-main` (id
+19779175) and `Copilot review for default branch` (id 20608865). Nothing
+covers `refs/heads/feature/*`. In the 48h window 2026-08-25/26, 52 PRs merged
+into `feature/kb-current` (26), `feature/garuda-voa` (23) and `feature/due-bot`
+(2) with ZERO required checks — documented in ASSEMBLY-LINE.md as a real
+incident: a 15-file customer-facing PR merged unreviewed, and a magic-link PR
+merged with two backend shards red. `gh pr merge --auto` on an unprotected
+branch does not mean "merge when green" — red CI never holds it, because there
+is nothing there to hold it. This script is the CHECK-half: it runs on every
+PR and fails the PR's own checks (not merge-blocking by itself — becoming
+required-status-check-blocking is a separate, deliberately NOT-taken step; see
+"SCOPE" below) whenever the PR's base branch is not covered by a ruleset
+carrying the main-equivalent minimum required checks. The ARM-half — actually
+creating that ruleset — is `scripts/ci/setup_merge_queue_ruleset.sh
+--branch-pattern <pattern>`, print-only unless `--apply`, an operator[control-
+plane] action this script only ever prints the command for, never runs.
+
+A CORRECTED PREMISE (anti-hallucination discipline: verify, don't assume).
+The natural first design was "read main's OWN ruleset's required_status_checks
+rule and pin the minimum from there." That is WRONG, verified live:
+`gh api repos/Bali-Zero/Teman2/rulesets/19779175` carries exactly one rule,
+type `merge_queue` — no `required_status_checks` rule at all. Main's real 27
+required contexts live in CLASSIC branch protection
+(`branches/main/protection/required_status_checks`), a separate, older
+mechanism that cannot glob-match a branch that doesn't exist yet (which is
+exactly why it can't cover `feature/*` on its own). So "read the ruleset's
+rules" would always find zero contexts and either pin nothing or crash. The
+real minimum-contexts list is hand-picked from classic protection's 27 and
+lives in `infra/required.d/integration-branch-minimum-contexts.json` — see
+that file's own `_corrected_premise_2026_08_27` field. This module never reads
+ruleset 19779175 to derive the minimum; it reads that JSON file instead.
+
+WHAT COUNTS AS "COVERED". For a non-default base ref, this module computes the
+UNION of `required_status_checks` contexts across every ACTIVE, target=branch
+ruleset whose `conditions.ref_name` matches the base ref (honoring `~ALL` and
+`~DEFAULT_BRANCH`, plus fnmatch-style globs against the full
+`refs/heads/<name>` ref — declared scope limit: no tag-ruleset or non-branch-
+target handling, matching this repo's `required_context_map.py` style of a
+narrow, stated limit rather than a general rules-engine). The union — not a
+single ruleset — because GitHub's real model lets multiple rulesets cover the
+same ref cumulatively; main itself splits its own protection across a ruleset
+(merge_queue mechanics) and classic protection (required checks), so a
+feature/* ruleset carrying BOTH in one object, or split across two, must both
+count as covered. If the pinned minimum is a subset of that union, the base is
+covered; otherwise it is not, regardless of the base ref matching some
+ruleset's include pattern only for an unrelated rule (e.g. Copilot review).
+
+SCOPE (declared, not hidden): the base==default-branch case always exits 0
+without ever calling `gh api rulesets` — main's own protection is classic
+branch protection, verified live, and out of this module's job entirely. Only
+a non-default base pays the rulesets API cost. This job does NOT add itself to
+required_status_checks (that repo-settings mutation is the operator's arm-
+half, per the PR contract this script shipped under: "never mutate repo
+settings/rulesets, this lane ships the CHECK-half only") — so today, a red run
+is a visible, honest signal on the PR's Checks tab, not yet a merge-blocking
+one. That second step is exactly what creating the feature/* ruleset (arm-
+half) provides, once an operator runs `--apply`.
+
+Exit codes: 0 covered (base is the default branch, or a non-default base is
+covered by the union of active rulesets) · 1 UNPROTECTED (guilt: no covering
+ruleset, or a covering ruleset lacks required_status_checks for the pinned
+minimum) · 1 BLIND (a genuine API/resolution error — cannot verify, must not
+certify; distinguished from UNPROTECTED only by message prefix, per this
+mandate's own spec: both are "fail closed", not two different postures).
+
+Usage:
+    python3 scripts/ci/check_base_protected.py --base-ref feature/kb-current \\
+        [--repo Bali-Zero/Teman2] [--default-branch main] \\
+        [--min-contexts-json infra/required.d/integration-branch-minimum-contexts.json] \\
+        [--rulesets-json <file>]
+
+`--repo`/`--default-branch` are free in CI (`${{ github.repository }}` /
+`${{ github.event.repository.default_branch }}` need no extra API call) —
+omit them only for manual/local invocation, where they fall back to
+`gh repo view` / `gh api repos/<repo>` (each a genuine live call that can
+itself go BLIND). `--rulesets-json <file>` is the test fixture path: a JSON
+array of FULL ruleset objects (id/name/target/enforcement/conditions/rules —
+the shape `gh api repos/<repo>/rulesets/<id>` returns for ONE ruleset, one
+entry per ruleset here), bypassing `gh` entirely so tests never touch the
+network.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_MIN_CONTEXTS_JSON = (
+    REPO_ROOT / "infra" / "required.d" / "integration-branch-minimum-contexts.json"
+)
+
+
+# --------------------------------------------------------------------- gh IO
+
+
+def _gh(args: list[str]) -> tuple[bool, str]:
+    """Runs `gh` and returns (ok, stdout). Never raises — a missing binary,
+    a timeout, or a non-zero exit are all ordinary, expected outcomes this
+    module fails CLOSED on, never a crash (W84: an empty/failed call must
+    never be silently read as 'nothing here')."""
+    try:
+        out = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False, ""
+    if out.returncode != 0:
+        return False, ""
+    return True, out.stdout
+
+
+def resolve_repo(override: str | None) -> str | None:
+    if override:
+        return override
+    ok, out = _gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+    if not ok or not out.strip():
+        return None
+    return out.strip()
+
+
+def resolve_default_branch(repo: str, override: str | None) -> str | None:
+    if override:
+        return override
+    ok, out = _gh(["api", f"repos/{repo}", "--jq", ".default_branch"])
+    if not ok or not out.strip():
+        return None
+    return out.strip()
+
+
+def fetch_live_rulesets(repo: str) -> list[dict] | None:
+    """Two-tier fetch, verified empirically against this repo 2026-08-27: the
+    LIST endpoint (`repos/<repo>/rulesets`) returns only id/name/target/
+    enforcement — no `conditions`/`rules` — so each ruleset needs its own GET
+    for the fields this check actually needs. Returns None (never a partial
+    list) on ANY failure along the way: a partial ruleset set is worse than
+    none, because it could make a real covering ruleset silently vanish from
+    consideration and this check pass when it should have failed closed."""
+    ok, out = _gh(["api", f"repos/{repo}/rulesets"])
+    if not ok:
+        return None
+    try:
+        summaries = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(summaries, list):
+        return None
+
+    detailed: list[dict] = []
+    for summary in summaries:
+        rid = summary.get("id") if isinstance(summary, dict) else None
+        if rid is None:
+            return None
+        ok, out = _gh(["api", f"repos/{repo}/rulesets/{rid}"])
+        if not ok:
+            return None
+        try:
+            detailed.append(json.loads(out))
+        except json.JSONDecodeError:
+            return None
+    return detailed
+
+
+def load_minimum_contexts(path: Path) -> set[str] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    contexts = data.get("minimum_contexts")
+    if not isinstance(contexts, list) or not contexts:
+        return None
+    if not all(isinstance(c, str) and c for c in contexts):
+        return None
+    return set(contexts)
+
+
+# ------------------------------------------------------------- ref matching
+
+
+def normalize_ref(ref: str) -> str:
+    """Accepts either a short branch name (`github.base_ref` on `pull_request`
+    events) or a full ref (`github.event.merge_group.base_ref` on `merge_group`
+    events carries `refs/heads/...`) and returns the short name."""
+    prefix = "refs/heads/"
+    return ref[len(prefix) :] if ref.startswith(prefix) else ref
+
+
+def _pattern_matches(pattern: str, ref_name: str, default_branch: str) -> bool:
+    """One include/exclude pattern's verdict for this branch. GitHub ruleset
+    ref-name conditions use two special tokens plus fnmatch-style globs
+    evaluated against the FULL ref (`refs/heads/<name>`):
+      - `~ALL`             matches every branch
+      - `~DEFAULT_BRANCH`  matches only the repo's current default branch
+      - anything else      an fnmatch pattern against `refs/heads/<ref_name>`
+    Declared scope limit (same style as required_context_map.py's matrix
+    scope): tag-ruleset tokens (`~ALL` for tags, etc.) are not handled — this
+    module only ever evaluates `target: branch` rulesets (see
+    `ruleset_covers_ref`), so a branch ref-name condition is all that reaches
+    here in practice."""
+    if pattern == "~ALL":
+        return True
+    if pattern == "~DEFAULT_BRANCH":
+        return ref_name == default_branch
+    return fnmatch.fnmatchcase(f"refs/heads/{ref_name}", pattern)
+
+
+def ruleset_covers_ref(ruleset: dict, ref_name: str, default_branch: str) -> bool:
+    if ruleset.get("target") != "branch":
+        return False
+    if ruleset.get("enforcement") != "active":
+        return False
+    conditions = ruleset.get("conditions") or {}
+    ref_name_cond = conditions.get("ref_name") or {}
+    include = ref_name_cond.get("include") or []
+    exclude = ref_name_cond.get("exclude") or []
+    if not any(_pattern_matches(p, ref_name, default_branch) for p in include):
+        return False
+    if any(_pattern_matches(p, ref_name, default_branch) for p in exclude):
+        return False
+    return True
+
+
+def required_status_check_contexts(ruleset: dict) -> set[str] | None:
+    """The `required_status_checks` RULE inside a ruleset's `rules` array —
+    NOT classic branch protection, and NOT necessarily present at all (main's
+    own `merge-queue-main` ruleset carries none; see module docstring). None
+    means "this ruleset has no such rule", distinct from an empty set (a rule
+    present but declaring zero contexts, which would be its own kind of
+    misconfiguration worth surfacing, though not one this module treats
+    specially — it just contributes nothing to the coverage union)."""
+    for rule in ruleset.get("rules") or []:
+        if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters") or {}
+        checks = params.get("required_status_checks") or []
+        return {c.get("context") for c in checks if isinstance(c, dict) and c.get("context")}
+    return None
+
+
+def suggest_pattern(base_ref: str) -> str:
+    """Heuristic only, declared not resolved: the base ref's first path
+    segment plus a wildcard (`feature/kb-current` -> `feature/*`). The printed
+    operator command protects the WHOLE CLASS of branch this base belongs to
+    — tomorrow's PR opens against a different branch name in the same family,
+    and a ruleset scoped to today's exact branch name would silently miss it."""
+    if "/" in base_ref:
+        head, _rest = base_ref.split("/", 1)
+        return f"{head}/*"
+    return base_ref
+
+
+# --------------------------------------------------------------------- core
+
+
+def evaluate(
+    base_ref: str,
+    default_branch: str,
+    rulesets: list[dict],
+    minimum_contexts: set[str],
+) -> tuple[int, str]:
+    """Returns (exit_code, message). exit_code is 0 or 1 only — "cannot
+    verify" is exit 1 too here (message-prefix distinguished as BLIND), per
+    this check's own spec: both postures are "fail closed", not two
+    different ones."""
+    ref_name = normalize_ref(base_ref)
+
+    if ref_name == default_branch:
+        return (
+            0,
+            f"OK: base '{ref_name}' is the default branch — protected by main's "
+            "own classic branch protection, out of this check's scope",
+        )
+
+    covering = [rs for rs in rulesets if ruleset_covers_ref(rs, ref_name, default_branch)]
+    if not covering:
+        return 1, _unprotected_message(ref_name, default_branch, missing=minimum_contexts, covering_names=[])
+
+    have: set[str] = set()
+    covering_names = [rs.get("name", "<unnamed>") for rs in covering]
+    for rs in covering:
+        ctxs = required_status_check_contexts(rs)
+        if ctxs:
+            have |= ctxs
+
+    missing = minimum_contexts - have
+    if missing:
+        return 1, _unprotected_message(ref_name, default_branch, missing=missing, covering_names=covering_names)
+
+    return (
+        0,
+        f"OK: base '{ref_name}' is covered by ruleset(s) {covering_names} carrying "
+        f"all {len(minimum_contexts)} pinned required contexts",
+    )
+
+
+def _unprotected_message(
+    base_ref: str, default_branch: str, missing: set[str], covering_names: list[str]
+) -> str:
+    pattern = suggest_pattern(base_ref)
+    cmd = f"scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern '{pattern}' --apply"
+    if covering_names:
+        coverage_note = (
+            f"ruleset(s) {covering_names} cover refs/heads/{base_ref} but carry no "
+            f"required_status_checks rule for: {sorted(missing)}"
+        )
+    else:
+        coverage_note = f"no active branch ruleset covers refs/heads/{base_ref} at all"
+    return (
+        f"UNPROTECTED: base '{base_ref}' is not gated like '{default_branch}' — "
+        f"{coverage_note}. 52 PRs merged into uncovered integration branches in "
+        f"the 2026-08-25/26 window with zero required checks (ASSEMBLY-LINE.md). "
+        f"To arm coverage: `{cmd}` (prints the ruleset body only; add --apply to "
+        f"actually create it — operator[control-plane])"
+    )
+
+
+# --------------------------------------------------------------------- CLI
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--base-ref",
+        required=True,
+        help="e.g. `github.base_ref`, or a merge_group `base_ref` (refs/heads/... accepted too)",
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="owner/name. Default: `gh repo view` (an extra live call — pass "
+        "--repo '${{ github.repository }}' in CI, it's free)",
+    )
+    parser.add_argument(
+        "--default-branch",
+        default=None,
+        help="Default: `gh api repos/<repo>` (an extra live call — pass "
+        "--default-branch '${{ github.event.repository.default_branch }}' in CI, it's free)",
+    )
+    parser.add_argument("--min-contexts-json", default=str(DEFAULT_MIN_CONTEXTS_JSON))
+    parser.add_argument(
+        "--rulesets-json",
+        default=None,
+        help="test fixture: path to a JSON array of FULL ruleset objects "
+        "(id/name/target/enforcement/conditions/rules), bypassing `gh` entirely",
+    )
+    args = parser.parse_args(argv)
+
+    minimum_contexts = load_minimum_contexts(Path(args.min_contexts_json))
+    if minimum_contexts is None:
+        print(
+            f"BLIND: {args.min_contexts_json} is missing, unparseable, or "
+            "declares zero minimum_contexts"
+        )
+        return 1
+
+    repo = resolve_repo(args.repo)
+    if not repo:
+        print("BLIND: could not resolve repo slug (pass --repo, or check `gh auth status`)")
+        return 1
+
+    default_branch = resolve_default_branch(repo, args.default_branch)
+    if not default_branch:
+        print(f"BLIND: could not resolve the default branch for {repo} (pass --default-branch)")
+        return 1
+
+    if args.rulesets_json:
+        try:
+            rulesets = json.loads(Path(args.rulesets_json).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            print(f"BLIND: --rulesets-json {args.rulesets_json} is missing or unparseable")
+            return 1
+        if not isinstance(rulesets, list):
+            print(f"BLIND: --rulesets-json {args.rulesets_json} is not a JSON array")
+            return 1
+    else:
+        rulesets = fetch_live_rulesets(repo)
+        if rulesets is None:
+            print(
+                f"BLIND: could not list/read rulesets for {repo} via `gh api` — "
+                "a check that cannot see the rulesets must not certify the base"
+            )
+            return 1
+
+    code, message = evaluate(args.base_ref, default_branch, rulesets, minimum_contexts)
+    print(message)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_base_protected.py
+++ b/scripts/ci/check_base_protected.py
@@ -62,6 +62,33 @@ is a visible, honest signal on the PR's Checks tab, not yet a merge-blocking
 one. That second step is exactly what creating the feature/* ruleset (arm-
 half) provides, once an operator runs `--apply`.
 
+DECLARED RESIDUAL LIMITS (found by a cross-family refuter, 2026-08-27,
+verified before accepting):
+  - Pagination: `gh api repos/<repo>/rulesets` is called WITHOUT `--paginate`.
+    This repo has exactly 2 rulesets today (verified live), well under any
+    plausible page size, so this is inert in practice — but a repo with 30+
+    rulesets could have a real covering ruleset sit on a page this call never
+    fetches, silently missing it. Not fixed here: `gh api --paginate`'s exact
+    JSON-array-concatenation shape (vs `--slurp`, which nests pages instead of
+    flattening them) could not be verified against a real multi-page response
+    in this repo, and guessing wrong would risk breaking the common case to
+    fix a rare one. Fix only after confirming the exact shape against a real
+    paginated response.
+  - A non-default base ref that is protected via CLASSIC branch protection
+    (rather than a ruleset) is reported UNPROTECTED regardless — this module
+    only ever reads rulesets. Not fixed here: classic protection cannot
+    glob-match a branch pattern anyway (the whole reason the arm-half creates
+    a RULESET, never classic protection, for feature/*), so this asymmetry
+    only bites a branch someone protected by hand via the classic UI — narrow,
+    and worth knowing, not worth the scope creep of also querying classic
+    protection for arbitrary branch names here.
+  - Whether the pinned minimum contexts' defining workflows actually trigger
+    on a PR into a non-default base — VERIFIED, not just assumed (the exact
+    Codex-F12 trap `check_required_workflow_conformance.py` exists to catch
+    elsewhere in this repo): none of the 5 pinned workflows' `on.pull_request`
+    blocks carry a `branches:` restriction, so all 5 fire on a PR into
+    `feature/*` exactly as they do into `main`.
+
 Exit codes: 0 covered (base is the default branch, or a non-default base is
 covered by the union of active rulesets) · 1 UNPROTECTED (guilt: no covering
 ruleset, or a covering ruleset lacks required_status_checks for the pinned
@@ -88,8 +115,8 @@ network.
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -188,21 +215,71 @@ def load_minimum_contexts(path: Path) -> set[str] | None:
 # ------------------------------------------------------------- ref matching
 
 
-def normalize_ref(ref: str) -> str:
-    """Accepts either a short branch name (`github.base_ref` on `pull_request`
-    events) or a full ref (`github.event.merge_group.base_ref` on `merge_group`
-    events carries `refs/heads/...`) and returns the short name."""
+def normalize_ref(ref: str, *, is_full_ref: bool) -> str:
+    """Strips a leading `refs/heads/` ONLY when the caller asserts `ref` IS a
+    full ref (`github.event.merge_group.base_ref`, which GitHub itself always
+    populates as a full ref) — NEVER guessed from the string's own content.
+
+    A cross-family refuter found the real bypass this guards against
+    (2026-08-27): `github.base_ref` on `pull_request` events is ALWAYS a short
+    name by GitHub's own contract, but a branch can legitimately be NAMED
+    something that itself starts with the literal text `refs/heads/` (git
+    permits slashes in branch names — `git push origin HEAD:refs/heads/refs
+    /heads/main` creates exactly this). The previous version of this function
+    stripped that prefix unconditionally whenever it was present, so a PR
+    based on a real branch literally named `refs/heads/main` was silently
+    treated as targeting the DEFAULT branch and exempted from every check.
+    The fix is not a smarter guess — it's to never guess at all: the CALLER
+    (the CI job, or a test) must say which shape it's handing in, because
+    only the caller genuinely knows which GHA context field supplied it."""
+    if not is_full_ref:
+        return ref
     prefix = "refs/heads/"
     return ref[len(prefix) :] if ref.startswith(prefix) else ref
 
 
+def _translate_ref_glob(pattern: str) -> re.Pattern[str]:
+    """Compiles a GitHub ruleset ref-name glob to a regex matching GitHub's
+    OWN documented semantics — Ruby's `File.fnmatch` with `FNM_PATHNAME`,
+    verified against GitHub's docs (2026-08-27, a cross-family refuter caught
+    this before it shipped): a single `*` does NOT cross a `/` (`qa/*`
+    matches `qa/foo` but NOT `qa/foo/bar`); `**` DOES cross `/` (`qa/**/*`
+    matches `qa/foo/bar/foobar/hello-world`). Python's stdlib `fnmatch`
+    module has no FNM_PATHNAME equivalent — its `*` always crosses `/` — so
+    using it directly (the original version of this function did) made a
+    ruleset scoped to `refs/heads/feature/*` falsely appear to cover a nested
+    branch like `feature/a/b` that GitHub itself would NOT apply that ruleset
+    to: a false "protected" verdict on a branch that in fact is not. Hand-
+    translated rather than adding a dependency, matching this repo's other
+    CI scripts' "pure stdlib" preference (required_context_map.py)."""
+    i, n = 0, len(pattern)
+    out: list[str] = []
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                out.append(".*")
+                i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return re.compile("(?:" + "".join(out) + ")\\Z")
+
+
 def _pattern_matches(pattern: str, ref_name: str, default_branch: str) -> bool:
     """One include/exclude pattern's verdict for this branch. GitHub ruleset
-    ref-name conditions use two special tokens plus fnmatch-style globs
-    evaluated against the FULL ref (`refs/heads/<name>`):
+    ref-name conditions use two special tokens plus a path-aware glob (see
+    `_translate_ref_glob`) evaluated against the FULL ref
+    (`refs/heads/<name>`):
       - `~ALL`             matches every branch
       - `~DEFAULT_BRANCH`  matches only the repo's current default branch
-      - anything else      an fnmatch pattern against `refs/heads/<ref_name>`
+      - anything else      a path-aware glob against `refs/heads/<ref_name>`
     Declared scope limit (same style as required_context_map.py's matrix
     scope): tag-ruleset tokens (`~ALL` for tags, etc.) are not handled — this
     module only ever evaluates `target: branch` rulesets (see
@@ -212,7 +289,7 @@ def _pattern_matches(pattern: str, ref_name: str, default_branch: str) -> bool:
         return True
     if pattern == "~DEFAULT_BRANCH":
         return ref_name == default_branch
-    return fnmatch.fnmatchcase(f"refs/heads/{ref_name}", pattern)
+    return _translate_ref_glob(pattern).match(f"refs/heads/{ref_name}") is not None
 
 
 def ruleset_covers_ref(ruleset: dict, ref_name: str, default_branch: str) -> bool:
@@ -268,12 +345,19 @@ def evaluate(
     default_branch: str,
     rulesets: list[dict],
     minimum_contexts: set[str],
+    *,
+    is_full_ref: bool = False,
 ) -> tuple[int, str]:
     """Returns (exit_code, message). exit_code is 0 or 1 only — "cannot
     verify" is exit 1 too here (message-prefix distinguished as BLIND), per
     this check's own spec: both postures are "fail closed", not two
-    different ones."""
-    ref_name = normalize_ref(base_ref)
+    different ones.
+
+    `is_full_ref` MUST be set by the caller based on which GHA context field
+    supplied `base_ref` (true only for `github.event.merge_group.base_ref`) —
+    never inferred from the string, see `normalize_ref`'s own docstring for
+    the bypass this guards against."""
+    ref_name = normalize_ref(base_ref, is_full_ref=is_full_ref)
 
     if ref_name == default_branch:
         return (
@@ -320,8 +404,9 @@ def _unprotected_message(
         f"UNPROTECTED: base '{base_ref}' is not gated like '{default_branch}' — "
         f"{coverage_note}. 52 PRs merged into uncovered integration branches in "
         f"the 2026-08-25/26 window with zero required checks (ASSEMBLY-LINE.md). "
-        f"To arm coverage: `{cmd}` (prints the ruleset body only; add --apply to "
-        f"actually create it — operator[control-plane])"
+        f"To arm coverage: `{cmd}` (already includes --apply — this actually "
+        f"creates the ruleset ACTIVE immediately, no separate enable step; drop "
+        f"--apply to only preview the body first — operator[control-plane])"
     )
 
 
@@ -335,7 +420,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--base-ref",
         required=True,
-        help="e.g. `github.base_ref`, or a merge_group `base_ref` (refs/heads/... accepted too)",
+        help="e.g. `github.base_ref` (pull_request) or `github.event.merge_group.base_ref`",
+    )
+    parser.add_argument(
+        "--base-ref-full",
+        action="store_true",
+        help="assert that --base-ref is a FULL ref (refs/heads/...) — true only for "
+        "merge_group's base_ref, which GitHub always populates as a full ref. Omit for "
+        "a short branch name (pull_request's base_ref/base.ref), used VERBATIM and "
+        "NEVER guessed at from its own content — a branch literally named "
+        "'refs/heads/main' must not silently become 'main'.",
     )
     parser.add_argument(
         "--repo",
@@ -376,6 +470,24 @@ def main(argv: list[str] | None = None) -> int:
         print(f"BLIND: could not resolve the default branch for {repo} (pass --default-branch)")
         return 1
 
+    # SCOPE (module docstring: "the base==default-branch case always exits 0
+    # without ever calling `gh api rulesets`") — this MUST be checked before
+    # any rulesets fetch, not after. The original ordering called
+    # fetch_live_rulesets()/read --rulesets-json unconditionally first, so a
+    # PR into main itself paid an avoidable API call and could go BLIND on a
+    # transient `gh` failure for the one case that never needed the network
+    # (or a fixture file) at all. Caught 2026-08-27 by a test whose own
+    # docstring claimed "no network call" while `_gh` was monkeypatched to
+    # prove it — and, until this fix, it wasn't true. Reuses `evaluate()`
+    # verbatim (with an empty rulesets list, which it never inspects on this
+    # path) so the OK message has exactly one source of truth.
+    if normalize_ref(args.base_ref, is_full_ref=args.base_ref_full) == default_branch:
+        code, message = evaluate(
+            args.base_ref, default_branch, [], minimum_contexts, is_full_ref=args.base_ref_full
+        )
+        print(message)
+        return code
+
     if args.rulesets_json:
         try:
             rulesets = json.loads(Path(args.rulesets_json).read_text(encoding="utf-8"))
@@ -394,7 +506,13 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
 
-    code, message = evaluate(args.base_ref, default_branch, rulesets, minimum_contexts)
+    code, message = evaluate(
+        args.base_ref,
+        default_branch,
+        rulesets,
+        minimum_contexts,
+        is_full_ref=args.base_ref_full,
+    )
     print(message)
     return code
 

--- a/scripts/ci/setup_merge_queue_ruleset.sh
+++ b/scripts/ci/setup_merge_queue_ruleset.sh
@@ -31,9 +31,21 @@ set -euo pipefail
 
 RULESET_NAME="merge-queue-main"
 
+# S5 ARM-half additions (scripts/ci/check_base_protected.py is the CHECK-half).
+# A separate ruleset name/purpose from $RULESET_NAME above: that one governs
+# merge_group queue MECHANICS for main (grouping/batching) and carries no
+# required_status_checks rule at all — main's actual required checks live in
+# CLASSIC branch protection, which cannot glob-match a branch that doesn't
+# exist yet. This ruleset instead protects a *pattern* of integration branch
+# (e.g. refs/heads/feature/*) with a required_status_checks rule, since that's
+# the one mechanism that auto-applies to a branch created after the ruleset.
+INTEGRATION_RULESET_NAME="integration-branch-protection"
+MIN_CONTEXTS_JSON="infra/required.d/integration-branch-minimum-contexts.json"
+
 usage() {
   cat <<'USAGE'
 Usage: setup_merge_queue_ruleset.sh --status | --enable | --disable | --apply
+       setup_merge_queue_ruleset.sh --branch-pattern <pattern> [--apply]
 
   --status    Print the current ruleset (if any) + effective branch rules on
               main (drift check). Read-only, always exits 0 once the repo
@@ -47,6 +59,27 @@ Usage: setup_merge_queue_ruleset.sh --status | --enable | --disable | --apply
               default — activation is a deliberate separate --enable step,
               never a side effect of reconciling drift), else reconcile its
               rule content via PUT while preserving current enforcement.
+
+  --branch-pattern <pattern>
+              S5 ARM-half (scripts/ci/check_base_protected.py is the CHECK-
+              half): create/reconcile a SEPARATE ruleset named
+              "integration-branch-protection", scoped to
+              refs/heads/<pattern> (e.g. 'feature/*'), carrying a
+              required_status_checks rule seeded from
+              infra/required.d/integration-branch-minimum-contexts.json.
+              WITHOUT --apply this only PRINTS the `gh api` body + command it
+              would run — no mutation, safe to call from a CI check or a
+              read-only session. WITH --apply it actually creates it
+              (enforcement=disabled, same "activation is a separate step"
+              posture as --apply above — there is no --branch-pattern
+              --enable in this version; flip enforcement by hand once ready:
+              reconcile with --apply again after editing this script's
+              INTEGRATION_RULESET_NAME lookup, or extend cmd_set_enforcement
+              to take a ruleset name). One pattern per invocation — running
+              it again with a different pattern REPLACES the include list
+              (whole-object PUT, see the canonical_body() comment above).
+              This is a repo-settings mutation: --apply is operator[control-
+              plane], never run by the CI check itself.
 
 Every subcommand resolves the repo slug live via `gh repo view` and never
 echoes a secret. Any real GitHub API error (as opposed to "ruleset not found
@@ -108,6 +141,50 @@ canonical_body() {
   "bypass_actors": []
 }
 JSON
+}
+
+# $1 = branch pattern (e.g. "feature/*"), $2 = enforcement ("active"|"disabled").
+# Builds the S5 ARM-half ruleset body via python3 (not jq — `gh --jq` embeds
+# gojq, no standalone `jq` binary is guaranteed on every runner/machine this
+# script targets, and python3 already is a hard dependency across this repo's
+# scripts/ci/*.py siblings). Reads the pinned minimum contexts from
+# $MIN_CONTEXTS_JSON so this script and check_base_protected.py never drift —
+# one SSOT, not two hand-maintained lists.
+integration_body() {
+  local pattern="$1" enforcement="$2"
+  BRANCH_PATTERN="$pattern" ENFORCEMENT="$enforcement" MIN_CONTEXTS_JSON="$MIN_CONTEXTS_JSON" \
+    python3 - <<'PYEOF'
+import json
+import os
+
+with open(os.environ["MIN_CONTEXTS_JSON"], encoding="utf-8") as fh:
+    minimum_contexts = json.load(fh)["minimum_contexts"]
+
+body = {
+    "name": "integration-branch-protection",
+    "target": "branch",
+    "enforcement": os.environ["ENFORCEMENT"],
+    "conditions": {
+        "ref_name": {
+            "include": [f"refs/heads/{os.environ['BRANCH_PATTERN']}"],
+            "exclude": [],
+        }
+    },
+    "rules": [
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": False,
+                "required_status_checks": [
+                    {"context": c, "integration_id": None} for c in minimum_contexts
+                ],
+            },
+        }
+    ],
+    "bypass_actors": [],
+}
+print(json.dumps(body, indent=2))
+PYEOF
 }
 
 # Prints the id of the ruleset named $RULESET_NAME in repo $1, or empty
@@ -188,6 +265,79 @@ cmd_apply() {
 
   print_ruleset "$repo" "$(find_ruleset_id "$repo")"
 }
+
+# $1 = branch pattern, $2 = "true"|"false" (--apply given or not).
+# Print-only by default (no `gh api --method POST/PUT` call at all unless
+# apply="true") — this is what lets check_base_protected.py's failure message
+# safely print the equivalent command line for an operator to run, and what
+# lets THIS script itself be invoked read-only from a CI job without risking
+# a repo-settings mutation from an unattended context.
+cmd_branch_pattern() {
+  local pattern="$1" apply="$2"
+  local repo id enforcement body
+
+  if [[ -z "$pattern" ]]; then
+    echo "ERROR: --branch-pattern requires a value, e.g. --branch-pattern 'feature/*'" >&2
+    exit 1
+  fi
+
+  repo="$(repo_slug)"
+  id="$(gh api "repos/${repo}/rulesets" --jq ".[] | select(.name==\"${INTEGRATION_RULESET_NAME}\") | .id")"
+
+  if [[ "$apply" != "true" ]]; then
+    echo "DRY RUN — nothing executed. Add --apply to actually create/reconcile this ruleset."
+    echo
+    if [[ -z "$id" ]]; then
+      body="$(integration_body "$pattern" "disabled")"
+      echo "Would run (ruleset does not exist yet):"
+      echo "  gh api --method POST repos/${repo}/rulesets --input - <<'JSON'"
+      echo "$body"
+      echo "JSON"
+    else
+      enforcement="$(gh api "repos/${repo}/rulesets/${id}" --jq '.enforcement')"
+      body="$(integration_body "$pattern" "$enforcement")"
+      echo "Ruleset '${INTEGRATION_RULESET_NAME}' already exists (id ${id}, enforcement=${enforcement}). Would run:"
+      echo "  gh api --method PUT repos/${repo}/rulesets/${id} --input - <<'JSON'"
+      echo "$body"
+      echo "JSON"
+    fi
+    return 0
+  fi
+
+  # --apply: mirrors cmd_apply()'s idempotent create-or-reconcile posture —
+  # a NEW ruleset is created with enforcement=disabled (activation stays a
+  # deliberate, separate, manual step: edit the enforcement value by hand and
+  # re-run --apply, or extend cmd_set_enforcement to take a ruleset name —
+  # not built here, out of this PR's scope).
+  if [[ -z "$id" ]]; then
+    echo "Ruleset '${INTEGRATION_RULESET_NAME}' not found in ${repo} — creating (enforcement=disabled by default)..."
+    integration_body "$pattern" "disabled" | gh api --method POST "repos/${repo}/rulesets" --input - >/dev/null
+    echo "OK: created, enforcement=disabled. Flip it active only once ready (deliberate, manual)."
+  else
+    enforcement="$(gh api "repos/${repo}/rulesets/${id}" --jq '.enforcement')"
+    echo "Ruleset '${INTEGRATION_RULESET_NAME}' exists (id ${id}, enforcement=${enforcement}) — reconciling rule content via PUT, enforcement unchanged..."
+    integration_body "$pattern" "$enforcement" | gh api --method PUT "repos/${repo}/rulesets/${id}" --input - >/dev/null
+    echo "OK: reconciled (enforcement unchanged: ${enforcement})."
+  fi
+  id="$(gh api "repos/${repo}/rulesets" --jq ".[] | select(.name==\"${INTEGRATION_RULESET_NAME}\") | .id")"
+  print_ruleset "$repo" "$id"
+}
+
+if [[ "${1:-}" == "--branch-pattern" ]]; then
+  _pattern="${2:-}"
+  _apply="false"
+  case "${3:-}" in
+    --apply) _apply="true" ;;
+    "") ;;
+    *)
+      echo "Unknown argument after --branch-pattern <pattern>: $3" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  cmd_branch_pattern "$_pattern" "$_apply"
+  exit 0
+fi
 
 case "${1:-}" in
   --status)

--- a/scripts/ci/setup_merge_queue_ruleset.sh
+++ b/scripts/ci/setup_merge_queue_ruleset.sh
@@ -69,17 +69,27 @@ Usage: setup_merge_queue_ruleset.sh --status | --enable | --disable | --apply
               infra/required.d/integration-branch-minimum-contexts.json.
               WITHOUT --apply this only PRINTS the `gh api` body + command it
               would run — no mutation, safe to call from a CI check or a
-              read-only session. WITH --apply it actually creates it
-              (enforcement=disabled, same "activation is a separate step"
-              posture as --apply above — there is no --branch-pattern
-              --enable in this version; flip enforcement by hand once ready:
-              reconcile with --apply again after editing this script's
-              INTEGRATION_RULESET_NAME lookup, or extend cmd_set_enforcement
-              to take a ruleset name). One pattern per invocation — running
-              it again with a different pattern REPLACES the include list
-              (whole-object PUT, see the canonical_body() comment above).
-              This is a repo-settings mutation: --apply is operator[control-
-              plane], never run by the CI check itself.
+              read-only session. WITH --apply it actually creates it, and
+              creates it enforcement=active IMMEDIATELY (deliberately NOT the
+              --apply-above posture of "disabled by default, --enable is a
+              separate step") — a cross-family refuter caught this asymmetry
+              2026-08-27: the check's own printed remediation command already
+              includes --apply, so if creation defaulted to disabled the
+              printed command would leave the PR red anyway, silently. Unlike
+              $RULESET_NAME (an always-on object protecting ALL of main, where
+              an accidental instant activation via drift-reconciliation would
+              be the dangerous direction), this ruleset is created only when
+              an operator explicitly typed --branch-pattern '<pattern>'
+              --apply — arming coverage IS the point of that command, not a
+              side effect of something else. To reconcile WITHOUT touching
+              enforcement, run it again without --apply first to preview, or
+              hand-edit enforcement via `gh api --method PATCH
+              repos/<repo>/rulesets/<id> -f enforcement=disabled`. One pattern
+              per invocation — running it again with a different pattern
+              REPLACES the include list (whole-object PUT, see the
+              canonical_body() comment above). This is a repo-settings
+              mutation: --apply is operator[control-plane], never run by the
+              CI check itself.
 
 Every subcommand resolves the repo slug live via `gh repo view` and never
 echoes a secret. Any real GitHub API error (as opposed to "ruleset not found
@@ -288,8 +298,8 @@ cmd_branch_pattern() {
     echo "DRY RUN — nothing executed. Add --apply to actually create/reconcile this ruleset."
     echo
     if [[ -z "$id" ]]; then
-      body="$(integration_body "$pattern" "disabled")"
-      echo "Would run (ruleset does not exist yet):"
+      body="$(integration_body "$pattern" "active")"
+      echo "Would run (ruleset does not exist yet — created ACTIVE immediately, see below):"
       echo "  gh api --method POST repos/${repo}/rulesets --input - <<'JSON'"
       echo "$body"
       echo "JSON"
@@ -304,15 +314,26 @@ cmd_branch_pattern() {
     return 0
   fi
 
-  # --apply: mirrors cmd_apply()'s idempotent create-or-reconcile posture —
-  # a NEW ruleset is created with enforcement=disabled (activation stays a
-  # deliberate, separate, manual step: edit the enforcement value by hand and
-  # re-run --apply, or extend cmd_set_enforcement to take a ruleset name —
-  # not built here, out of this PR's scope).
+  # --apply: a NEW integration ruleset is created enforcement=ACTIVE
+  # immediately — DELIBERATELY NOT $RULESET_NAME's "disabled by default,
+  # --enable is a separate step" posture (cmd_apply above). A cross-family
+  # refuter flagged this asymmetry, correctly: check_base_protected.py's own
+  # failure message prints this exact --apply command as the fix, so if
+  # creation defaulted to disabled, running the EXACT printed command would
+  # leave the PR just as red as before — a silent dead end. The difference
+  # from $RULESET_NAME that justifies immediate activation: that object
+  # protects ALL of main, always-on, where accidentally flipping it active as
+  # a side effect of routine drift-reconciliation would be the dangerous
+  # direction; THIS one is created only when an operator explicitly typed
+  # --branch-pattern '<pattern>' --apply, and arming coverage for that
+  # pattern is the entire point of the command they just ran, not a side
+  # effect of something else. Reconciling an EXISTING ruleset still preserves
+  # whatever enforcement it already has (below) — only first-creation jumps
+  # straight to active.
   if [[ -z "$id" ]]; then
-    echo "Ruleset '${INTEGRATION_RULESET_NAME}' not found in ${repo} — creating (enforcement=disabled by default)..."
-    integration_body "$pattern" "disabled" | gh api --method POST "repos/${repo}/rulesets" --input - >/dev/null
-    echo "OK: created, enforcement=disabled. Flip it active only once ready (deliberate, manual)."
+    echo "Ruleset '${INTEGRATION_RULESET_NAME}' not found in ${repo} — creating (enforcement=active immediately)..."
+    integration_body "$pattern" "active" | gh api --method POST "repos/${repo}/rulesets" --input - >/dev/null
+    echo "OK: created and ACTIVE. PRs into refs/heads/${pattern} are gated starting now."
   else
     enforcement="$(gh api "repos/${repo}/rulesets/${id}" --jq '.enforcement')"
     echo "Ruleset '${INTEGRATION_RULESET_NAME}' exists (id ${id}, enforcement=${enforcement}) — reconciling rule content via PUT, enforcement unchanged..."

--- a/scripts/tests/test_check_base_protected.py
+++ b/scripts/tests/test_check_base_protected.py
@@ -100,6 +100,34 @@ def test_guilt_glob_does_not_match_unrelated_ref():
     assert mod._pattern_matches("refs/heads/feature/*", "ops/seat6", "main") is False
 
 
+def test_guilt_single_star_does_not_cross_a_slash():
+    # The real bug a cross-family refuter found (2026-08-27), verified
+    # against GitHub's own docs: a single `*` does NOT cross `/` (Ruby
+    # File.fnmatch with FNM_PATHNAME). Python's stdlib `fnmatch` module has no
+    # such mode — its `*` crosses `/` freely — so using it directly made a
+    # ruleset scoped to `refs/heads/feature/*` falsely appear to cover a
+    # NESTED branch `feature/a/b`, which GitHub itself would NOT apply that
+    # ruleset to. This must be False, not True.
+    assert mod._pattern_matches("refs/heads/feature/*", "feature/a/b", "main") is False
+
+
+def test_innocence_github_docs_own_example_single_star():
+    # GitHub's own documented example, verbatim: "qa/* will match all
+    # branches beginning with qa/ and containing a single slash, but will
+    # not match qa/foo/bar."
+    assert mod._pattern_matches("refs/heads/qa/*", "qa/foo", "main") is True
+    assert mod._pattern_matches("refs/heads/qa/*", "qa/foo/bar", "main") is False
+
+
+def test_innocence_github_docs_own_example_double_star():
+    # GitHub's own documented example, verbatim: "qa/**/* ... would match,
+    # for example, qa/foo/bar/foobar/hello-world."
+    assert (
+        mod._pattern_matches("refs/heads/qa/**/*", "qa/foo/bar/foobar/hello-world", "main")
+        is True
+    )
+
+
 # ------------------------------------------------------------- ruleset_covers_ref
 
 
@@ -162,12 +190,25 @@ def test_innocence_ruleset_with_the_rule_returns_its_contexts():
 # --------------------------------------------------------- normalize_ref / suggest_pattern
 
 
-def test_innocence_normalize_ref_strips_full_ref_prefix():
-    assert mod.normalize_ref("refs/heads/main") == "main"
+def test_innocence_normalize_ref_strips_full_ref_prefix_when_asserted_full():
+    assert mod.normalize_ref("refs/heads/main", is_full_ref=True) == "main"
 
 
 def test_innocence_normalize_ref_passes_through_short_name():
-    assert mod.normalize_ref("feature/kb-current") == "feature/kb-current"
+    assert mod.normalize_ref("feature/kb-current", is_full_ref=False) == "feature/kb-current"
+
+
+def test_guilt_normalize_ref_never_strips_a_short_name_that_looks_like_a_full_ref():
+    # The real bypass a cross-family refuter found (2026-08-27): a branch can
+    # legitimately be NAMED 'refs/heads/main' (git allows slashes in branch
+    # names). When the caller correctly asserts this is a SHORT name
+    # (is_full_ref=False, e.g. it came from pull_request's base.ref, which
+    # GitHub always populates as a short name), it must be used verbatim —
+    # never silently collapsed into 'main' just because it starts with that
+    # literal text.
+    assert (
+        mod.normalize_ref("refs/heads/main", is_full_ref=False) == "refs/heads/main"
+    )
 
 
 def test_innocence_suggest_pattern_widens_to_the_branch_family():
@@ -209,9 +250,41 @@ def test_innocence_base_feature_x_with_a_covering_ruleset():
 
 
 def test_guilt_evaluate_via_merge_group_full_ref_form():
-    # merge_group's base_ref is a FULL ref, not a short name.
-    code, _ = mod.evaluate("refs/heads/feature/kb-current", "main", REAL_RULESETS_TODAY, MIN_CONTEXTS)
+    # merge_group's base_ref is a FULL ref, not a short name — asserted via
+    # is_full_ref=True, never guessed from the string.
+    code, _ = mod.evaluate(
+        "refs/heads/feature/kb-current",
+        "main",
+        REAL_RULESETS_TODAY,
+        MIN_CONTEXTS,
+        is_full_ref=True,
+    )
     assert code == 1
+
+
+def test_innocence_evaluate_merge_group_full_ref_main_short_circuits():
+    code, message = mod.evaluate(
+        "refs/heads/main", "main", REAL_RULESETS_TODAY, MIN_CONTEXTS, is_full_ref=True
+    )
+    assert code == 0
+    assert "OK" in message
+
+
+def test_guilt_evaluate_a_branch_literally_named_refs_heads_main_is_not_exempted():
+    # The real bypass, at the evaluate() level: a PULL_REQUEST base (always a
+    # SHORT name per GitHub's contract, is_full_ref=False) whose short name
+    # happens to literally BE the text 'refs/heads/main' must still be
+    # treated as a non-default base needing real coverage — not silently
+    # exempted as if it were main itself.
+    code, message = mod.evaluate(
+        "refs/heads/main",
+        "main",
+        REAL_RULESETS_TODAY,
+        MIN_CONTEXTS,
+        is_full_ref=False,
+    )
+    assert code == 1
+    assert message.startswith("UNPROTECTED:")
 
 
 # ---------------------------------------------------- partial coverage (declared, not obvious)
@@ -274,13 +347,36 @@ def _write_rulesets(tmp_path: Path, rulesets: list[dict]) -> Path:
     return path
 
 
-def test_main_cli_exits_zero_for_the_default_branch_with_no_network_call(capsys):
+def test_main_cli_exits_zero_for_the_default_branch_with_no_network_call(monkeypatch, capsys):
     # base == default branch short-circuits BEFORE ever calling `gh` — this
     # is real end-to-end CLI + the REAL shipped minimum-contexts file, and it
-    # must stay deterministic in CI with zero network access.
+    # must stay deterministic in CI with zero network access. Proven, not
+    # just claimed: `_gh` is monkeypatched to explode if it's ever invoked.
+    def _gh_must_not_be_called(args):
+        raise AssertionError(f"_gh() was called for the default-branch base: {args}")
+
+    monkeypatch.setattr(mod, "_gh", _gh_must_not_be_called)
     rc = mod.main(["--base-ref", "main", "--repo", "Bali-Zero/Teman2", "--default-branch", "main"])
     captured = capsys.readouterr()
     assert rc == 0, captured.out
+
+
+def test_guilt_fetch_live_rulesets_returns_none_on_a_partial_list_detail_failure(monkeypatch):
+    # list succeeds (2 summaries), but the SECOND detail GET fails — must
+    # return None (BLIND), never a partial 1-item list that could silently
+    # drop a real covering ruleset from consideration.
+    calls = {"n": 0}
+
+    def _gh_partial_failure(args):
+        if args == ["api", "repos/Bali-Zero/Teman2/rulesets"]:
+            return True, json.dumps([{"id": 1}, {"id": 2}])
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return True, json.dumps({"id": 1, "name": "a"})
+        return False, ""  # second detail GET fails
+
+    monkeypatch.setattr(mod, "_gh", _gh_partial_failure)
+    assert mod.fetch_live_rulesets("Bali-Zero/Teman2") is None
 
 
 def test_main_cli_guilt_feature_base_with_no_covering_ruleset(tmp_path, capsys):
@@ -346,6 +442,39 @@ def test_main_cli_blind_on_unreadable_min_contexts_json(tmp_path, capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "BLIND" in captured.out
+
+
+def test_main_cli_base_ref_full_strips_the_merge_group_style_ref(capsys):
+    rc = mod.main(
+        [
+            "--base-ref", "refs/heads/main",
+            "--base-ref-full",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+
+
+def test_main_cli_without_base_ref_full_a_branch_named_refs_heads_main_is_not_exempted(
+    tmp_path, capsys
+):
+    # End-to-end CLI proof of the fixed bypass: omitting --base-ref-full (the
+    # pull_request/default shape) means 'refs/heads/main' is a literal SHORT
+    # branch name, not main itself, and must require real coverage.
+    rulesets_path = _write_rulesets(tmp_path, REAL_RULESETS_TODAY)
+    rc = mod.main(
+        [
+            "--base-ref", "refs/heads/main",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+            "--rulesets-json", str(rulesets_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "UNPROTECTED" in captured.out
 
 
 def test_main_cli_blind_on_rulesets_json_not_an_array(tmp_path, capsys):

--- a/scripts/tests/test_check_base_protected.py
+++ b/scripts/tests/test_check_base_protected.py
@@ -1,0 +1,364 @@
+"""Tests for scripts/ci/check_base_protected.py (S5 check-half).
+
+Guilt+innocence per cicatrix-superscar.md #3 ("nessuna guardia senza test di
+innocenza E colpevolezza, su entità/intento mai bare-substring") for every
+function this module exports, plus the four fixtures the mandate itself
+specifies: base main covered -> 0; base feature/x with no ruleset -> 1
+(guilt); base feature/x with a covering ruleset -> 0 (innocence); API error
+-> 1 with a distinct (BLIND) message.
+
+Run:  python3 -m pytest scripts/tests/test_check_base_protected.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = REPO_ROOT / "scripts" / "ci" / "check_base_protected.py"
+_spec = importlib.util.spec_from_file_location("check_base_protected", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+MERGE_QUEUE_MAIN = {
+    "id": 19779175,
+    "name": "merge-queue-main",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {"ref_name": {"include": ["refs/heads/main"], "exclude": []}},
+    "rules": [{"type": "merge_queue", "parameters": {}}],
+}
+COPILOT_REVIEW = {
+    "id": 20608865,
+    "name": "Copilot review for default branch",
+    "target": "branch",
+    "enforcement": "active",
+    "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+    "rules": [
+        {"type": "deletion"},
+        {"type": "non_fast_forward"},
+        {"type": "copilot_code_review", "parameters": {}},
+    ],
+}
+# The two rulesets actually live in Bali-Zero/Teman2 as of 2026-08-27 — neither
+# covers refs/heads/feature/*, which is precisely the gap this check exists
+# to close. Used verbatim as the "real world, uncured" fixture below.
+REAL_RULESETS_TODAY = [MERGE_QUEUE_MAIN, COPILOT_REVIEW]
+
+MIN_CONTEXTS = {
+    "Backend Tests (Python)",
+    "Harness floor recompute",
+    "R1 gate — adversarial review present",
+    "Detect Secrets",
+    "actionlint — workflow schema + expression gate",
+}
+
+
+def _covering_ruleset(contexts: set[str] | None, pattern: str = "refs/heads/feature/*") -> dict:
+    rules: list[dict] = []
+    if contexts is not None:
+        rules.append(
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [{"context": c} for c in contexts]
+                },
+            }
+        )
+    return {
+        "id": 1,
+        "name": "integration-branch-protection",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": [pattern], "exclude": []}},
+        "rules": rules,
+    }
+
+
+# ------------------------------------------------------------- _pattern_matches
+
+
+def test_innocence_all_token_matches_anything():
+    assert mod._pattern_matches("~ALL", "anything-at-all", "main") is True
+
+
+def test_innocence_default_branch_token_matches_default_only():
+    assert mod._pattern_matches("~DEFAULT_BRANCH", "main", "main") is True
+
+
+def test_guilt_default_branch_token_does_not_match_non_default():
+    assert mod._pattern_matches("~DEFAULT_BRANCH", "feature/x", "main") is False
+
+
+def test_innocence_glob_matches_full_ref():
+    assert mod._pattern_matches("refs/heads/feature/*", "feature/kb-current", "main") is True
+
+
+def test_guilt_glob_does_not_match_unrelated_ref():
+    assert mod._pattern_matches("refs/heads/feature/*", "ops/seat6", "main") is False
+
+
+# ------------------------------------------------------------- ruleset_covers_ref
+
+
+def test_guilt_wrong_target_never_covers():
+    rs = _covering_ruleset(MIN_CONTEXTS)
+    rs["target"] = "tag"
+    assert mod.ruleset_covers_ref(rs, "feature/kb-current", "main") is False
+
+
+def test_guilt_disabled_enforcement_never_covers():
+    rs = _covering_ruleset(MIN_CONTEXTS)
+    rs["enforcement"] = "disabled"
+    assert mod.ruleset_covers_ref(rs, "feature/kb-current", "main") is False
+
+
+def test_guilt_evaluate_mode_never_counts_as_covering():
+    # GitHub's dry-run/monitor posture — real, but must not certify a base.
+    rs = _covering_ruleset(MIN_CONTEXTS)
+    rs["enforcement"] = "evaluate"
+    assert mod.ruleset_covers_ref(rs, "feature/kb-current", "main") is False
+
+
+def test_guilt_excluded_ref_never_covers():
+    rs = _covering_ruleset(MIN_CONTEXTS)
+    rs["conditions"]["ref_name"]["exclude"] = ["refs/heads/feature/kb-current"]
+    assert mod.ruleset_covers_ref(rs, "feature/kb-current", "main") is False
+
+
+def test_innocence_matching_active_branch_ruleset_covers():
+    rs = _covering_ruleset(MIN_CONTEXTS)
+    assert mod.ruleset_covers_ref(rs, "feature/kb-current", "main") is True
+
+
+def test_innocence_real_rulesets_cover_main_via_default_branch_token():
+    assert mod.ruleset_covers_ref(COPILOT_REVIEW, "main", "main") is True
+
+
+def test_guilt_real_rulesets_today_cover_nothing_under_feature():
+    # This IS the live gap the mandate measured: 0 of the 2 real rulesets
+    # cover refs/heads/feature/*.
+    assert not any(
+        mod.ruleset_covers_ref(rs, "feature/kb-current", "main") for rs in REAL_RULESETS_TODAY
+    )
+
+
+# ------------------------------------------------------ required_status_check_contexts
+
+
+def test_guilt_ruleset_with_no_such_rule_returns_none():
+    # merge-queue-main's real, live shape: one rule, type merge_queue, no
+    # required_status_checks rule at all.
+    assert mod.required_status_check_contexts(MERGE_QUEUE_MAIN) is None
+
+
+def test_innocence_ruleset_with_the_rule_returns_its_contexts():
+    rs = _covering_ruleset({"A", "B"})
+    assert mod.required_status_check_contexts(rs) == {"A", "B"}
+
+
+# --------------------------------------------------------- normalize_ref / suggest_pattern
+
+
+def test_innocence_normalize_ref_strips_full_ref_prefix():
+    assert mod.normalize_ref("refs/heads/main") == "main"
+
+
+def test_innocence_normalize_ref_passes_through_short_name():
+    assert mod.normalize_ref("feature/kb-current") == "feature/kb-current"
+
+
+def test_innocence_suggest_pattern_widens_to_the_branch_family():
+    assert mod.suggest_pattern("feature/kb-current") == "feature/*"
+    assert mod.suggest_pattern("ops/seat6-consumers") == "ops/*"
+
+
+def test_innocence_suggest_pattern_passes_through_single_segment():
+    assert mod.suggest_pattern("develop") == "develop"
+
+
+# --------------------------------------------------------------------------- evaluate()
+#
+# The four fixtures the mandate itself specifies, verbatim.
+
+
+def test_innocence_base_main_covered():
+    code, message = mod.evaluate("main", "main", REAL_RULESETS_TODAY, MIN_CONTEXTS)
+    assert code == 0
+    assert "OK" in message
+
+
+def test_guilt_base_feature_x_with_no_ruleset():
+    code, message = mod.evaluate(
+        "feature/kb-current", "main", REAL_RULESETS_TODAY, MIN_CONTEXTS
+    )
+    assert code == 1
+    assert message.startswith("UNPROTECTED:")
+    assert "feature/kb-current" in message
+    # Names the exact operator command, print-only by default.
+    assert "setup_merge_queue_ruleset.sh --branch-pattern 'feature/*' --apply" in message
+
+
+def test_innocence_base_feature_x_with_a_covering_ruleset():
+    rulesets = REAL_RULESETS_TODAY + [_covering_ruleset(MIN_CONTEXTS)]
+    code, message = mod.evaluate("feature/kb-current", "main", rulesets, MIN_CONTEXTS)
+    assert code == 0
+    assert "OK" in message
+
+
+def test_guilt_evaluate_via_merge_group_full_ref_form():
+    # merge_group's base_ref is a FULL ref, not a short name.
+    code, _ = mod.evaluate("refs/heads/feature/kb-current", "main", REAL_RULESETS_TODAY, MIN_CONTEXTS)
+    assert code == 1
+
+
+# ---------------------------------------------------- partial coverage (declared, not obvious)
+
+
+def test_guilt_covering_ruleset_missing_some_pinned_contexts():
+    partial = MIN_CONTEXTS - {"Detect Secrets"}
+    rulesets = REAL_RULESETS_TODAY + [_covering_ruleset(partial)]
+    code, message = mod.evaluate("feature/kb-current", "main", rulesets, MIN_CONTEXTS)
+    assert code == 1
+    assert "Detect Secrets" in message
+
+
+def test_guilt_covering_ruleset_with_no_required_status_checks_rule_at_all():
+    # Ref-matches, but carries e.g. only `deletion` — same shape as the real
+    # Copilot-review ruleset, just scoped to feature/* instead of main.
+    rs = _covering_ruleset(contexts=None)
+    rulesets = REAL_RULESETS_TODAY + [rs]
+    code, message = mod.evaluate("feature/kb-current", "main", rulesets, MIN_CONTEXTS)
+    assert code == 1
+    assert "carry no required_status_checks" in message
+
+
+def test_innocence_union_across_two_rulesets_satisfies_the_minimum():
+    # Real GitHub semantics: rulesets are cumulative. Split the 5 pinned
+    # contexts across two separate covering rulesets — union must still pass.
+    half_a = _covering_ruleset({"Backend Tests (Python)", "Harness floor recompute"})
+    half_a["id"] = 2
+    half_b = _covering_ruleset(MIN_CONTEXTS - {"Backend Tests (Python)", "Harness floor recompute"})
+    half_b["id"] = 3
+    rulesets = REAL_RULESETS_TODAY + [half_a, half_b]
+    code, _ = mod.evaluate("feature/kb-current", "main", rulesets, MIN_CONTEXTS)
+    assert code == 0
+
+
+# ------------------------------------------------------- load_minimum_contexts (BLIND path)
+
+
+def test_guilt_blind_on_missing_min_contexts_file(tmp_path):
+    assert mod.load_minimum_contexts(tmp_path / "does-not-exist.json") is None
+
+
+def test_guilt_blind_on_empty_min_contexts_list(tmp_path):
+    path = tmp_path / "contexts.json"
+    path.write_text(json.dumps({"minimum_contexts": []}), encoding="utf-8")
+    assert mod.load_minimum_contexts(path) is None
+
+
+def test_innocence_the_real_shipped_min_contexts_file_loads():
+    loaded = mod.load_minimum_contexts(mod.DEFAULT_MIN_CONTEXTS_JSON)
+    assert loaded == MIN_CONTEXTS
+
+
+# --------------------------------------------------------------------------- CLI main()
+
+
+def _write_rulesets(tmp_path: Path, rulesets: list[dict]) -> Path:
+    path = tmp_path / "rulesets.json"
+    path.write_text(json.dumps(rulesets), encoding="utf-8")
+    return path
+
+
+def test_main_cli_exits_zero_for_the_default_branch_with_no_network_call(capsys):
+    # base == default branch short-circuits BEFORE ever calling `gh` — this
+    # is real end-to-end CLI + the REAL shipped minimum-contexts file, and it
+    # must stay deterministic in CI with zero network access.
+    rc = mod.main(["--base-ref", "main", "--repo", "Bali-Zero/Teman2", "--default-branch", "main"])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+
+
+def test_main_cli_guilt_feature_base_with_no_covering_ruleset(tmp_path, capsys):
+    rulesets_path = _write_rulesets(tmp_path, REAL_RULESETS_TODAY)
+    rc = mod.main(
+        [
+            "--base-ref", "feature/kb-current",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+            "--rulesets-json", str(rulesets_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "UNPROTECTED" in captured.out
+
+
+def test_main_cli_innocence_feature_base_with_a_covering_ruleset(tmp_path, capsys):
+    rulesets_path = _write_rulesets(
+        tmp_path, REAL_RULESETS_TODAY + [_covering_ruleset(MIN_CONTEXTS)]
+    )
+    rc = mod.main(
+        [
+            "--base-ref", "feature/kb-current",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+            "--rulesets-json", str(rulesets_path),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out
+    assert "OK" in captured.out
+
+
+def test_main_cli_api_error_is_blind_with_a_distinct_message(monkeypatch, capsys):
+    # Hermetic: force every `gh` invocation to fail rather than depending on
+    # a real network 404 — deterministic, no live-network dependency in CI.
+    monkeypatch.setattr(mod, "_gh", lambda args: (False, ""))
+    rc = mod.main(
+        [
+            "--base-ref", "feature/x",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    # Distinct from the UNPROTECTED guilt message — same exit code, per the
+    # mandate's own spec ("both are fail-closed"), distinguished by prefix.
+    assert "BLIND" in captured.out
+    assert "UNPROTECTED" not in captured.out
+
+
+def test_main_cli_blind_on_unreadable_min_contexts_json(tmp_path, capsys):
+    rc = mod.main(
+        [
+            "--base-ref", "main",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+            "--min-contexts-json", str(tmp_path / "nope.json"),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "BLIND" in captured.out
+
+
+def test_main_cli_blind_on_rulesets_json_not_an_array(tmp_path, capsys):
+    bad = tmp_path / "rulesets.json"
+    bad.write_text(json.dumps({"not": "a list"}), encoding="utf-8")
+    rc = mod.main(
+        [
+            "--base-ref", "feature/x",
+            "--repo", "Bali-Zero/Teman2",
+            "--default-branch", "main",
+            "--rulesets-json", str(bad),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "BLIND" in captured.out


### PR DESCRIPTION
## Summary

S5 check-half (`research/operations/2026-08-26-retro-fleet-sessions-25-26.md` §3 ADOPT table; `docs/factory/ASSEMBLY-LINE.md` "The integration branch must be protected BEFORE the first lane opens a PR"): **an integration branch inherits main's gates or the PR into it goes red.**

Verified live today (2026-08-27), not assumed:

```
$ gh api repos/Bali-Zero/Teman2/rulesets
[{"id":20608865,"name":"Copilot review for default branch", ..., "conditions":{"ref_name":{"include":["~DEFAULT_BRANCH"]}}},
 {"id":19779175,"name":"merge-queue-main", ..., "conditions":{"ref_name":{"include":["refs/heads/main"]}}}]
```

Exactly 2 rulesets. **Nothing covers `refs/heads/feature/*`.** In the 2026-08-25/26 window, 52 PRs merged into `feature/kb-current` (26), `feature/garuda-voa` (23), `feature/due-bot` (2) with **zero required checks**. `ASSEMBLY-LINE.md` already documents the incident this produced: a 15-file customer-facing PR merged unreviewed, and a magic-link PR merged with two backend shards red.

## A corrected premise (found before writing code, not after)

The natural design was "read main's own ruleset's `required_status_checks` rule and pin the minimum from there." That's **wrong**, verified live:

```
$ gh api repos/Bali-Zero/Teman2/rulesets/19779175
{"rules":[{"type":"merge_queue", ...}]}   <- no required_status_checks rule at all
```

Main's real 27 required contexts live in **classic branch protection** (`branches/main/protection/required_status_checks`), a separate mechanism that can't glob-match a branch that doesn't exist yet — which is exactly why it never covered `feature/*` on its own. The pinned minimum is instead hand-picked from those 27 real contexts and lives in `infra/required.d/integration-branch-minimum-contexts.json` (read by both halves, one SSOT):

- `Backend Tests (Python)` — the 08-25 incident: 2 backend shards red, merged anyway
- `Harness floor recompute` — the Gear-3 final on-disk gate; the 08-25 incident: 15-file customer-facing PR merged unreviewed
- `R1 gate — adversarial review present`
- `Detect Secrets`
- `actionlint — workflow schema + expression gate`

All 5 verified byte-for-byte against the live `required_status_checks` contexts list.

## What ships (CHECK-half only — never mutates repo settings/rulesets)

- **`scripts/ci/check_base_protected.py`** — given a PR's base ref: exits 0 if the base is the default branch (main's own classic protection, out of scope — checked *before* any rulesets fetch, so this path makes zero `gh` calls) or if covered by the **union** of active branch rulesets' `required_status_checks` contexts; exits 1 `UNPROTECTED:` (guilt) naming the missing coverage + the exact operator command to fix it; exits 1 `BLIND:` (fail-closed) on any API/resolution error — same exit code, distinct prefix, per spec ("a check that cannot see the rulesets must not certify the base").
- **`.github/workflows/hot-zone-pr-gate.yml`** — new `base-branch-protected` job, runs on every `pull_request`/`merge_group`, no paths filter (this file's own existing C1/C3 contracts). Independent job (own Checks-tab row), so it can later be added to `required_status_checks` on its own.
- **`scripts/ci/setup_merge_queue_ruleset.sh --branch-pattern <pattern>`** (the ARM-half) — **print-only unless `--apply`**, never invoked with `--apply` anywhere in this PR or by CI. Dry-run output (verbatim, `--branch-pattern 'feature/*'`, no `--apply`, captured after the refuter-driven enforcement-default fix below):

```
DRY RUN — nothing executed. Add --apply to actually create/reconcile this ruleset.

Would run (ruleset does not exist yet — created ACTIVE immediately, see below):
  gh api --method POST repos/Bali-Zero/Teman2/rulesets --input - <<'JSON'
{
  "name": "integration-branch-protection",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "include": [
        "refs/heads/feature/*"
      ],
      "exclude": []
    }
  },
  "rules": [
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": false,
        "required_status_checks": [
          {
            "context": "Backend Tests (Python)",
            "integration_id": null
          },
          {
            "context": "Harness floor recompute",
            "integration_id": null
          },
          {
            "context": "R1 gate — adversarial review present",
            "integration_id": null
          },
          {
            "context": "Detect Secrets",
            "integration_id": null
          },
          {
            "context": "actionlint — workflow schema + expression gate",
            "integration_id": null
          }
        ]
      }
    }
  ],
  "bypass_actors": []
}
JSON
```

- **`scripts/tests/test_check_base_protected.py`** — 43 guilt/innocence cases, including the four core fixtures verbatim: base main covered → 0; base feature/x with no ruleset → 1 (guilt); base feature/x with a covering ruleset → 0 (innocence); API error → 1 with a distinct BLIND message. All 43 pass locally (`apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_check_base_protected.py -q` → `43 passed`).

## Adversarial review round (Codex gpt-5.6-sol, read-only, high effort) — complete

Ran against the real PR diff (`gh pr diff 5050`), not a draft. 9 findings; triaged below, most-severe first.

**Confirmed and fixed (3):**

1. **Path-crossing glob bug.** A single `*` in the original `fnmatch.fnmatchcase`-based matcher crossed `/`, so a ruleset scoped to `refs/heads/feature/*` falsely appeared to cover a nested branch `feature/a/b` — a false OK on a branch GitHub itself would not apply that ruleset to. Verified against GitHub's own docs ("`qa/*` ... will not match `qa/foo/bar`", verbatim) before fixing. Replaced with a hand-written `FNM_PATHNAME`-compatible translator; 3 new tests cover both of GitHub's own documented examples plus the originally-reported false positive.
2. **`refs/heads/main`-literal-name bypass.** `normalize_ref` guessed from string content whether to strip a `refs/heads/` prefix — a branch literally *named* `refs/heads/main` (git permits slashes in branch names) would be silently exempted as if it were main itself. Fixed by requiring an explicit `is_full_ref` boolean set by the caller based on which GHA context field supplied the value (`github.event.pull_request.base.ref` vs `github.event.merge_group.base_ref`), never guessed downstream from the string — threaded through `normalize_ref` → `evaluate` → CLI `--base-ref-full` → the workflow's two separate env vars (no `||` merge of the two).
3. **Remediation command left the PR red.** The check's own printed fix command (`setup_merge_queue_ruleset.sh --branch-pattern ... --apply`) created the new ruleset with `enforcement=disabled` — running it exactly as printed would not actually fix anything. Fixed: the create-path now defaults to `enforcement=active` immediately (an existing ruleset being reconciled still keeps its current enforcement unchanged — this asymmetry is deliberate, see the script's own comment).

**Disputed, independently re-verified, and corrected to an honest hedge (1):** whether the ambient `GITHUB_TOKEN` can even authenticate the rulesets `GET` call. My first draft claimed "administration" scope is required and ungrantable (true, but incomplete); Codex countered the real requirement is "Metadata: read". Neither claim could be confirmed — GitHub's REST docs don't publish a permissions table for this endpoint, and "metadata" is *also* absent from actionlint's own valid-scopes list. Corrected the workflow comment and `ASSEMBLY-LINE.md` from a confident (and disputed) claim to "untested, unconfirmed either way — the first real `feature/*` PR after the ARM-half lands will settle it."

**Confirmed but already-declared-by-design, not a defect (1):** the job isn't a required status check yet (doesn't block merge on its own today), a base-branch rename could sidestep a future `feature/*`-scoped ruleset, and a classically-protected branch is reported UNPROTECTED. All three are this PR's explicitly stated CHECK-half scope, not something the refuter discovered — recorded in the evidence pack's `dissent` as CONFIRMED-by-design so the gap reads as open, not closed.

**Declared, not fixed (1):** `gh api repos/.../rulesets` isn't paginated. Real, but inert today (exactly 2 rulesets live) — guessing `gh`'s multi-page JSON shape wrong without real multi-page data risked breaking the working case to guard one that doesn't exist yet. Declared as a residual limit in the module's own docstring.

**Refuted (1):** whether the 5 pinned-context workflows even trigger on a PR into a non-default base. Checked, not assumed: none of their `on.pull_request` blocks carry a `branches:` filter — all 5 fire on `feature/*` exactly as on `main`.

**Self-caught, one more round after the refuter (not a Codex finding):** strengthening a test's own "no network call" claim for the base==main path (via a monkeypatch that raises if `_gh` is ever called) caught a real bug: `main()` called `fetch_live_rulesets()` unconditionally, *before* checking whether the base was the default branch — contradicting this module's own docstring SCOPE section, and meaning a PR into `main` itself paid an avoidable API call and could go BLIND on a transient `gh` failure for the one case that never needed the network. Fixed by hoisting the default-branch short-circuit before the rulesets fetch (reusing `evaluate()` verbatim so the OK message has one source of truth); re-verified against the real `gh` binary — `main` now resolves in 0.049s wall time with no network round-trip.

Full findings + fixes + the two genuinely-disputed items: `evidence/2026-08/agent-nuzantara-infra-base-protected-check-0826-2acb8494/pack.yml` (`dissent:` list, 7 entries).

## Before / After

| | Before | After |
|---|---|---|
| Rulesets covering `refs/heads/feature/*` | 0 | 0 (check-half only; ARM-half is the operator's `--apply` run) |
| PRs merged into an uncovered integration branch, 08-25/26 window | 52 | every future PR into an uncovered base now goes red on its own Checks tab |
| Known bad merges from the incident | 2 | — |

## Test plan

- [x] `scripts/tests/test_check_base_protected.py` — 43/43 pass
- [x] `actionlint .github/workflows/hot-zone-pr-gate.yml` — clean (after removing the invalid `administration` scope)
- [x] `bash -n scripts/ci/setup_merge_queue_ruleset.sh` — clean
- [x] `python3 -m py_compile scripts/ci/check_base_protected.py` — clean
- [x] Manual end-to-end run of `check_base_protected.py` against 5 scenarios (main/covered/uncovered/API-error/merge_group-full-ref-form) — all matched expected exit codes and messages; re-verified post-fix that base=main makes zero network calls (0.049s wall time against the real `gh` binary)
- [x] `--branch-pattern 'feature/*'` dry-run — prints a well-formed ruleset body, 5/5 pinned contexts present, `enforcement: active`
- [x] Cross-family refuter (Codex gpt-5.6-sol, high effort, read-only) — complete, 9 findings triaged above: 3 confirmed+fixed, 1 disputed+hedged, 1 confirmed-by-design, 1 declared-not-fixed, 1 refuted; plus 1 more bug self-caught while extending test coverage post-refuter

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
