### PR TITLE
fix(spark): repair R7 Codex Spark harvester — dead-end pipefail + blind quota retries + new harvester

### DIFF
--- a/scripts/army/spark_coverage_harvester.py
+++ b/scripts/army/spark_coverage_harvester.py
@@ -271,10 +271,22 @@ def harvest(repo: str, remote: str, base: str, repo_slug: str, log_dir: Path,
         pr_url = pr.stdout.strip().splitlines()[-1] if pr.stdout.strip() else ""
         # Arm auto-merge NAKED (no --squash — the merge queue rejects every
         # strategy flag) so it merges only once CI actually goes green on
-        # its own; never a forced/admin merge.
+        # its own; never a forced/admin merge. --repo is required here like
+        # every other gh call in this function: omitting it makes the
+        # command depend on the invoker's cwd (which this harvester's own
+        # --repo flag exists specifically not to assume), and the result
+        # used to be discarded outright — a PR "opened" with exit 0 even if
+        # arming silently failed. (2026-08-27 refuter finding: shipping a
+        # new exit-0-nothing-done path in the very PR that repairs that
+        # class of bug.) Failure is now recorded in detail, not swallowed —
+        # action stays "opened" because the PR itself genuinely was.
         num = pr_url.rstrip("/").rsplit("/", 1)[-1]
-        run(["gh", "pr", "merge", num, "--auto"])
-        results.append(HarvestResult(c.branch, "opened", pr_url=pr_url))
+        merge = run(["gh", "pr", "merge", num, "--auto", "--repo", repo_slug])
+        detail = (
+            "" if merge.returncode == 0
+            else f"opened but auto-merge arm failed: {merge.stderr.strip()[:300]}"
+        )
+        results.append(HarvestResult(c.branch, "opened", pr_url=pr_url, detail=detail))
 
     return results
 

--- a/scripts/army/spark_coverage_harvester.py
+++ b/scripts/army/spark_coverage_harvester.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""spark_coverage_harvester.py — R7 harvester for codex/coverage-* branches.
+
+Born 2026-08-27 alongside the fix for the pipefail crash in
+scripts/codex/codex-nightly-coverage-improver.sh (see that file's own
+2026-08-27 comment): for at least 10 straight nights that script wrote real,
+test-only commits to a `codex/coverage-<module>-<timestamp>` branch and then
+silently died one line before ever pushing or opening a PR. This harvester
+is the other half of the repair — it does NOT fix why a branch has no PR
+(that bug lives in the generator), it finds any branch that legitimately
+has unmerged commits and no PR yet and opens one, so a transient harvester
+outage or a half-finished generator run never strands real work forever.
+
+Read-only w.r.t. the working tree it runs from — the only mutations are
+`git push` of a branch that does not yet exist on the remote, and `gh pr
+create`/`gh pr merge --auto` for that exact branch. Never force-pushes,
+never touches a branch that already has a PR (open, closed, or merged),
+never rewrites history.
+
+Selection contract (guilt vs innocence, cicatrix family #3):
+  - guilt:     a codex/coverage-* branch that ALREADY has a PR (any state)
+               referencing it is SKIPPED, even if it has unmerged commits.
+  - innocence: a codex/coverage-* branch with commits ahead of the base and
+               NO PR anywhere is SELECTED.
+  - a branch with zero commits ahead of the base (fully merged, or the
+    generator aborted before committing) is never selected either way.
+
+Usage:
+    python3 scripts/army/spark_coverage_harvester.py [--repo PATH]
+        [--remote origin] [--base main] [--repo-slug Balizero1987/Teman2]
+        [--log-dir ~/logs/codex-coverage-improver] [--manual] [--dry-run]
+        [--json]
+
+`--manual` bypasses the 02:00-06:00 WITA automatic-run window (the nightly
+plist itself never calls this harvester — that pairing is a follow-up, not
+this repair — so `--manual` is what every invocation should pass until it
+does). Without a TTY-facing reason to run outside the window, an
+unattended/cron caller should omit `--manual` so a future automatic wiring
+fails closed on the window rather than silently running around the clock.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+BRANCH_RE = re.compile(r"^codex/coverage-(?P<module>.+)-(?P<ts>\d{8}_\d{6})$")
+WITA = ZoneInfo("Asia/Makassar")
+AUTOMATIC_WINDOW_HOURS = range(2, 6)  # [02:00, 06:00) WITA
+
+
+@dataclass
+class Candidate:
+    branch: str
+    module: str
+    ts: str
+    commits_ahead: int
+    on_remote: bool
+    on_local: bool
+
+
+@dataclass
+class HarvestResult:
+    branch: str
+    action: str  # "opened" | "skipped-has-pr" | "skipped-no-commits" | "failed"
+    pr_url: str | None = None
+    detail: str = ""
+
+
+def run(cmd: list[str], cwd: str | None = None, check: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def discover_candidates(repo: str, remote: str, base: str) -> list[Candidate]:
+    """Enumerate codex/coverage-* branches, local and remote, deduped by name.
+
+    A branch that exists in both places is one candidate — `on_remote` and
+    `on_local` are independent booleans so the caller can decide whether a
+    push is needed before `gh pr create`.
+    """
+    local_names = _list_refs(repo, "refs/heads/codex/coverage-*")
+    remote_names = {
+        n[len(f"{remote}/"):] for n in _list_refs(repo, f"refs/remotes/{remote}/codex/coverage-*")
+        if n.startswith(f"{remote}/")
+    }
+    all_names = sorted(set(local_names) | remote_names)
+
+    candidates: list[Candidate] = []
+    for name in all_names:
+        m = BRANCH_RE.match(name)
+        if not m:
+            continue  # not this generator's naming scheme — not ours to harvest
+        ref_for_diff = name if name in local_names else f"{remote}/{name}"
+        ahead = _commits_ahead(repo, ref_for_diff, f"{remote}/{base}")
+        candidates.append(Candidate(
+            branch=name,
+            module=m.group("module"),
+            ts=m.group("ts"),
+            commits_ahead=ahead,
+            on_remote=name in remote_names,
+            on_local=name in local_names,
+        ))
+    return candidates
+
+
+def _list_refs(repo: str, pattern: str) -> list[str]:
+    res = run(["git", "-C", repo, "for-each-ref", "--format=%(refname:short)", pattern])
+    if res.returncode != 0:
+        return []
+    return [line.strip() for line in res.stdout.splitlines() if line.strip()]
+
+
+def _commits_ahead(repo: str, ref: str, base_ref: str) -> int:
+    res = run(["git", "-C", repo, "rev-list", "--count", f"{base_ref}..{ref}"])
+    if res.returncode != 0:
+        return 0
+    try:
+        return int(res.stdout.strip() or "0")
+    except ValueError:
+        return 0
+
+
+def has_any_pr(repo_slug: str, branch: str) -> bool:
+    """True if ANY PR (open, closed, or merged) already references this head.
+
+    Deliberately NOT limited to --state open: a branch whose PR was closed
+    without merging should not get a second PR opened behind its back, and
+    a merged branch's commits_ahead is already 0 by the time this matters —
+    this check is the belt to that suspenders, not a duplicate of it.
+    """
+    res = run(["gh", "pr", "list", "--repo", repo_slug, "--head", branch,
+               "--state", "all", "--json", "number"])
+    if res.returncode != 0:
+        # gh unavailable/unauthenticated is NOT "no PR exists" — refuse to
+        # guess. Caller treats this the same as "has a PR" (skip), which is
+        # the fail-safe direction: worst case a real orphan waits one more
+        # run, never a duplicate PR opened on a false negative.
+        return True
+    try:
+        return bool(json.loads(res.stdout or "[]"))
+    except json.JSONDecodeError:
+        return True
+
+
+def select_branches_to_harvest(
+    candidates: list[Candidate], has_pr_fn,
+) -> tuple[list[Candidate], list[HarvestResult]]:
+    """Pure selection core — no git/gh I/O of its own, fully unit-testable.
+
+    Returns (selected, already-decided results for the rest) so a caller
+    gets a complete accounting even for branches it will never act on.
+    """
+    selected: list[Candidate] = []
+    decided: list[HarvestResult] = []
+    for c in candidates:
+        if c.commits_ahead <= 0:
+            decided.append(HarvestResult(c.branch, "skipped-no-commits",
+                                          detail=f"{c.commits_ahead} commits ahead of base"))
+            continue
+        if has_pr_fn(c.branch):
+            decided.append(HarvestResult(c.branch, "skipped-has-pr",
+                                          detail="a PR already references this branch"))
+            continue
+        selected.append(c)
+    return selected, decided
+
+
+def guess_seat(log_dir: Path, ts: str) -> str:
+    """Best-effort real seat for this run, read from codex's OWN transcript
+    banner rather than assumed. The R7 spec names `codex-gpt-5.3-codex-spark`
+    for this row, but that seat belongs to the READ-ONLY army.spark_lane
+    lane (invoked with `-m gpt-5.3-codex-spark`) — this generator instead
+    calls `codex --profile "$CODEX_PROFILE"` (default "power", which is not
+    defined in any config.toml on this machine as of 2026-08-27, so codex
+    silently falls back to whatever the top-level default model is on the
+    night in question). Asserting the spec's seat label here without
+    checking would be exactly the fabrication anti-hallucination discipline
+    exists to catch — so this reads the log codex itself wrote.
+    """
+    log_path = log_dir / f"codex-output-{ts}.log"
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return "codex (seat unknown — no matching transcript log)"
+    m = re.search(r"^model:\s*(\S+)", text, re.MULTILINE)
+    if not m:
+        return "codex (seat unknown — transcript has no model banner)"
+    return f"codex-{m.group(1)}"
+
+
+def build_pr_body(c: Candidate, seat: str, log_dir: Path) -> str:
+    diff_stat = ""
+    log_path = log_dir / f"codex-output-{c.ts}.log"
+    coverage_note = "not computed by this harvester (would require re-running coverage on this branch)"
+    cov_json = log_dir / f"coverage-{c.ts[:8]}.json"
+    if cov_json.is_file():
+        try:
+            data = json.loads(cov_json.read_text(encoding="utf-8"))
+            for fname, info in data.get("files", {}).items():
+                slug = fname.replace("/", "_").removesuffix(".py")
+                if slug == c.module:
+                    pct = info.get("summary", {}).get("percent_covered")
+                    if pct is not None:
+                        coverage_note = f"target file was at {pct:.1f}% coverage before this run (after-run % not re-measured by this harvester)"
+                    break
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return (
+        "## Spark nightly coverage — harvested\n\n"
+        f"**Branch:** `{c.branch}`\n"
+        f"**Module slug:** `{c.module}`\n"
+        f"**Commits ahead of base:** {c.commits_ahead}\n"
+        f"**Coverage:** {coverage_note}\n\n"
+        "This branch was generated by `scripts/codex/codex-nightly-coverage-improver.sh` "
+        "and left without a PR by the pipefail bug fixed in this same PR series "
+        "(see `scripts/codex/codex-nightly-coverage-improver.sh`'s 2026-08-27 comment "
+        "on the `NON_TEST_CHANGES` line) — this harvester found it dangling with real, "
+        "unmerged commits and opened the PR the generator should have.\n\n"
+        f"lanes: [{{lane: build, role: build, seat: {seat}}}]\n\n"
+        "### Verification\n"
+        "- [ ] CI green (especially the new test cases)\n"
+        "- [ ] Manual review\n\n"
+        "🤖 Harvested by `scripts/army/spark_coverage_harvester.py` (R7)\n"
+        f"{diff_stat}"
+    )
+
+
+def in_automatic_window(now: float | None = None) -> bool:
+    ts = now if now is not None else time.time()
+    dt = datetime.datetime.fromtimestamp(ts, tz=WITA)
+    return dt.hour in AUTOMATIC_WINDOW_HOURS
+
+
+def harvest(repo: str, remote: str, base: str, repo_slug: str, log_dir: Path,
+            dry_run: bool) -> list[HarvestResult]:
+    candidates = discover_candidates(repo, remote, base)
+    selected, results = select_branches_to_harvest(
+        candidates, lambda b: has_any_pr(repo_slug, b))
+
+    for c in selected:
+        if dry_run:
+            results.append(HarvestResult(c.branch, "would-open",
+                                          detail="--dry-run: no push/PR performed"))
+            continue
+
+        if not c.on_remote:
+            push = run(["git", "-C", repo, "push", "-u", remote, c.branch])
+            if push.returncode != 0:
+                results.append(HarvestResult(c.branch, "failed",
+                                              detail=f"push failed: {push.stderr.strip()[:300]}"))
+                continue
+
+        seat = guess_seat(log_dir, c.ts)
+        title = f"test(coverage): {c.module} — Spark nightly"
+        body = build_pr_body(c, seat, log_dir)
+        pr = run(["gh", "pr", "create", "--repo", repo_slug, "--base", base,
+                  "--head", c.branch, "--title", title, "--body", body])
+        if pr.returncode != 0:
+            results.append(HarvestResult(c.branch, "failed",
+                                          detail=f"gh pr create failed: {pr.stderr.strip()[:300]}"))
+            continue
+        pr_url = pr.stdout.strip().splitlines()[-1] if pr.stdout.strip() else ""
+        # Arm auto-merge NAKED (no --squash — the merge queue rejects every
+        # strategy flag) so it merges only once CI actually goes green on
+        # its own; never a forced/admin merge.
+        num = pr_url.rstrip("/").rsplit("/", 1)[-1]
+        run(["gh", "pr", "merge", num, "--auto"])
+        results.append(HarvestResult(c.branch, "opened", pr_url=pr_url))
+
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--repo", default=".")
+    p.add_argument("--remote", default="origin")
+    p.add_argument("--base", default="main")
+    p.add_argument("--repo-slug", default="Balizero1987/Teman2")
+    p.add_argument("--log-dir", default=str(Path.home() / "logs" / "codex-coverage-improver"))
+    p.add_argument("--manual", action="store_true",
+                   help="bypass the 02:00-06:00 WITA automatic-run window")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    if not args.manual and not in_automatic_window():
+        msg = "outside the 02:00-06:00 WITA automatic window and --manual not passed — refusing to run"
+        if args.json:
+            print(json.dumps({"error": msg}))
+        else:
+            print(f"SKIP: {msg}", file=sys.stderr)
+        return 1
+
+    results = harvest(args.repo, args.remote, args.base, args.repo_slug,
+                       Path(args.log_dir).expanduser(), args.dry_run)
+
+    if args.json:
+        print(json.dumps([r.__dict__ for r in results], indent=2))
+    else:
+        if not results:
+            print("no codex/coverage-* branches found — nothing to harvest")
+        for r in results:
+            line = f"{r.action}: {r.branch}"
+            if r.pr_url:
+                line += f" -> {r.pr_url}"
+            if r.detail:
+                line += f" ({r.detail})"
+            print(line)
+
+    return 0 if all(r.action != "failed" for r in results) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/army/spark_lane.sh
+++ b/scripts/army/spark_lane.sh
@@ -164,6 +164,75 @@ telegram() {  # $1 tier, $2 dedup-key, $3 text — through the ONE gateway
         --dedup-key "$key" -- "$text" 2>&1 | tail -1)"
 }
 
+# Item 13 (2026-08-27 repair — see git log for the mandate): a fixed
+# BACKOFF_HOURS blind-retries every tick against a quota wall the reply
+# ITSELF names a real clear time for. Measured live 2026-08-26/27: the
+# gpt-5.3-codex-spark bucket answered "ERROR: You've hit your usage limit
+# for GPT-5.3-Codex-Spark. Switch to another model now, or try again at
+# Aug 31st, 2026 8:06 PM." for 8 straight days while this lane kept
+# retrying every 12h — every retry rediscovered the same wall, burned a
+# tick, and re-sent the same deduped alert, with zero chance of success
+# before the real reset. Parses codex's own reply for a reset time and
+# uses it INSTEAD of the fixed backoff, but only to EXTEND the wait, never
+# to shorten it below BACKOFF_HOURS — a parse of a near/garbled time must
+# not cause a tighter retry loop than the safe default already gives.
+# Capped at 7 days so a parser misfire (or a provider that starts quoting
+# absurd future dates) cannot wedge the lane open-endedly.
+#
+# Codex's own timestamps are the operator's local wall clock (WITA,
+# UTC+8, no DST) — this repo's own convention for "now" elsewhere in this
+# file (wita_date/wita_hour) is never ambient system TZ, and there is no
+# reason codex's reply would be the one exception, so the naive
+# Y-M-D-H:M is interpreted as UTC+8 rather than guessed from the runner's
+# TZ. Prints an epoch on a successful parse, prints nothing otherwise —
+# callers MUST treat empty as "no usable reset time", never as epoch 0.
+parse_quota_reset_epoch() {  # $1 = path to codex's raw output
+    [ -n "$PY3" ] || return 0
+    "$PY3" - "$1" <<'PYEOF'
+import calendar
+import re
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
+except OSError:
+    sys.exit(0)
+
+# Observed verbatim 2026-08-26: "...or try again at Aug 31st, 2026 8:06 PM."
+# Tolerate st/nd/rd/th, an optional comma, and a missing leading zero.
+m = re.search(
+    r"try again at\s+([A-Za-z]{3,9})\.?\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+"
+    r"(\d{4})\s+(\d{1,2}):(\d{2})\s*([AaPp][Mm])",
+    text,
+)
+if not m:
+    sys.exit(0)
+
+month_name, day, year, hour, minute, ampm = m.groups()
+months = {name: i for i, name in enumerate(
+    ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], 1)}
+month = months.get(month_name[:3].title())
+if not month:
+    sys.exit(0)
+
+hour_i = int(hour) % 12
+if ampm.upper() == "PM":
+    hour_i += 12
+
+try:
+    epoch_wita = calendar.timegm(
+        (int(year), month, int(day), hour_i, int(minute), 0, 0, 0, 0)
+    )
+except (ValueError, OverflowError):
+    sys.exit(0)
+
+print(epoch_wita - 8 * 3600)  # WITA (UTC+8) -> UTC epoch
+PYEOF
+}
+
 # ── G4 node guard — this lane is Pro-only by design (M5 = no cron, per
 #    CLAUDE.md; Mini would be active-active with Pro on the same queue,
 #    superscar #10). A wrong-node tick exits immediately — not my machine,
@@ -549,16 +618,28 @@ if [ "$SHOULD_WORK" = "1" ]; then
             # so gating on rc!=0 does not blind this branch to a real quota
             # hit.
             if [ "$CODEX_RC" -ne 0 ] && grep -qiE 'out of extra usage|usage limit|quota exceeded|rate.limit|429|weekly limit' "$OUT_TMP" 2>/dev/null; then
-                new_backoff=$((now_epoch + BACKOFF_HOURS * 3600))
+                quota_line="$(grep -iE 'out of extra usage|usage limit|quota exceeded|rate.limit|429|weekly limit' "$OUT_TMP" 2>/dev/null | head -1 | tr -s ' \t' ' ')"
+                parsed_reset="$(parse_quota_reset_epoch "$OUT_TMP" 2>/dev/null | tr -d '[:space:]')"
+                case "$parsed_reset" in ''|*[!0-9]*) parsed_reset="" ;; esac
+                min_backoff=$((now_epoch + BACKOFF_HOURS * 3600))
+                max_backoff=$((now_epoch + 7 * 86400))
+                if [ -n "$parsed_reset" ] && [ "$parsed_reset" -gt "$min_backoff" ] && [ "$parsed_reset" -le "$max_backoff" ]; then
+                    new_backoff="$parsed_reset"
+                    backoff_source="parsed reset time in codex's reply"
+                else
+                    new_backoff="$min_backoff"
+                    backoff_source="fixed ${BACKOFF_HOURS}h (no in-range reset time in codex's reply)"
+                fi
                 echo "$new_backoff" > "$BACKOFF_FILE"
                 echo 0 > "$CONSEC_FAIL_FILE"   # quota is a distinct, correctly-classified state
-                log "quota marker detected — backoff until epoch $new_backoff (${BACKOFF_HOURS}h)"
+                log "quota marker detected — backoff until epoch $new_backoff (${backoff_source}) — codex said: ${quota_line:0:200}"
                 RUN_STATUS_HB="degraded"
                 RUN_STATUS_RICH="quota"
-                RUN_NOTE="quota: backoff ${BACKOFF_HOURS}h"
+                RUN_NOTE="quota until epoch $new_backoff (${backoff_source}): ${quota_line:0:160}"
                 append_attempt "$TASK_SHA" "$(basename "$TASK_FILE")" "quota" "-"
+                backoff_human="$(date -r "$new_backoff" '+%Y-%m-%d %H:%M UTC' 2>/dev/null || date -u -d "@$new_backoff" '+%Y-%m-%d %H:%M UTC' 2>/dev/null || echo "epoch $new_backoff")"
                 telegram digest "army-spark:quota" \
-                    "🐢 army.spark_lane: bucket gpt-5.3-codex-spark in quota — backoff ${BACKOFF_HOURS}h. Task NON consumato: $(basename "$TASK_FILE")"
+                    "🐢 army.spark_lane: bucket gpt-5.3-codex-spark in quota — backoff until ${backoff_human} (${backoff_source}). Task NON consumato: $(basename "$TASK_FILE"). Codex: ${quota_line:0:200}"
             elif [ "$CODEX_RC" -eq 0 ]; then
                 report_date="$(wita_date)"
                 head_sha="$(cd "$REPO" && git rev-parse HEAD 2>/dev/null || echo unknown)"

--- a/scripts/codex/codex-nightly-coverage-improver.sh
+++ b/scripts/codex/codex-nightly-coverage-improver.sh
@@ -328,7 +328,18 @@ if [ "$COMMITS_AHEAD" -eq 0 ]; then
 fi
 
 # Sanity check: only test files modified
-NON_TEST_CHANGES=$(git diff --name-only "main..${BRANCH_NAME}" | grep -v "/tests/" | wc -l | tr -d ' ')
+#
+# 2026-08-27 repair: under `set -o pipefail` (line 10), `grep -v` exiting 1
+# because it found NO non-test files — the EXPECTED, GOOD outcome, since
+# this improver only ever asks Codex to touch tests/ — poisoned the whole
+# pipeline's exit status and `set -e` killed the script right here, before
+# it ever reached push/PR-create. Confirmed live: 9 of the 10 most recent
+# nightly runs logged "Codex completed" and then nothing else ever again —
+# no push, no PR, no error — because every one of those 9 runs had Codex
+# behave correctly (test-only diff), which is exactly the input that used
+# to crash this line. `{ ... || true; }` absorbs grep's "nothing matched"
+# so a real non-test change (grep finds >=1 line, exits 0) is unaffected.
+NON_TEST_CHANGES=$(git diff --name-only "main..${BRANCH_NAME}" | { grep -v "/tests/" || true; } | wc -l | tr -d ' ')
 if [ "$NON_TEST_CHANGES" -gt 0 ]; then
     log "Codex modified non-test files (${NON_TEST_CHANGES}). Rejecting."
     codex_state blocked path_constraint "Codex modified non-test files" "$BRANCH_NAME" "$REPO_ROOT"

--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -626,12 +626,20 @@ def scan_stale_coverage_branches(
                  "--state", "all", "--json", "number"],
                 capture_output=True, text=True, timeout=20,
             )
-            if pr.returncode == 0:
-                try:
-                    if json.loads(pr.stdout or "[]"):
-                        continue  # a PR already exists — the harvester did its job
-                except json.JSONDecodeError:
-                    pass  # unreadable answer — fall through, treat as "no PR" below
+            if pr.returncode != 0:
+                # gh installed but failing (offline/unauthenticated/rate-
+                # limited) is NOT evidence of "no PR" — this docstring's own
+                # fail-OPEN contract requires skipping here, not flagging.
+                # (2026-08-27 refuter finding: this branch previously fell
+                # through to a false RED finding, the exact inverse of what
+                # has_any_pr() in spark_coverage_harvester.py already does
+                # correctly for the same gh-error case.)
+                continue
+            try:
+                if json.loads(pr.stdout or "[]"):
+                    continue  # a PR already exists — the harvester did its job
+            except json.JSONDecodeError:
+                pass  # unreadable answer — fall through, treat as "no PR" below
 
             m = _COVERAGE_BRANCH_RE.match(short)
             module = m.group("module") if m else short

--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -550,6 +550,106 @@ def scan_sidecars_status(
     return findings
 
 
+_COVERAGE_BRANCH_RE = re.compile(r"^codex/coverage-(?P<module>.+)-(?P<ts>\d{8}_\d{6})$")
+
+
+def scan_stale_coverage_branches(
+    repo: str = ".",
+    remote: str = "origin",
+    base: str = "main",
+    stale_hours: float = 24.0,
+    now: float | None = None,
+    repo_slug: str = "Balizero1987/Teman2",
+) -> list[StaleFinding]:
+    """R7 proprioception (2026-08-27): a `codex/coverage-*` branch older than
+    `stale_hours`, with commits ahead of the base and no PR anywhere, is a RED
+    finding — scripts/army/spark_coverage_harvester.py runs far more often
+    than once a day and should have opened a PR for it well before this.
+
+    Born from the measured 2026-08-27 root cause: a pipefail bug in
+    scripts/codex/codex-nightly-coverage-improver.sh silently killed 9 of the
+    last 10 nightly runs one line after "Codex completed" was logged — real
+    commits landed on a real branch, and nothing ever surfaced it. This check
+    is the structural antidote (cicatrix family #2: monitor the real outcome,
+    not the exit code) so a FUTURE regression of that class — in either the
+    generator or the harvester — cannot go silent again for 10 days unnoticed.
+
+    Best-effort and fails OPEN (returns no finding, never raises) on any
+    git/gh error: this machine may legitimately be offline (SYMBIOSIS Law 6 —
+    disconnection is not a fault) or `gh` may not be installed here, and
+    neither is on its own evidence of a stuck branch.
+    """
+    now = time.time() if now is None else now
+    findings: list[StaleFinding] = []
+    try:
+        refs = subprocess.run(
+            ["git", "-C", repo, "for-each-ref",
+             "--format=%(refname:short) %(committerdate:unix)",
+             "refs/heads/codex/coverage-*", f"refs/remotes/{remote}/codex/coverage-*"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if refs.returncode != 0:
+            return []
+
+        newest_commit_epoch: dict[str, float] = {}
+        for line in refs.stdout.splitlines():
+            parts = line.strip().rsplit(" ", 1)
+            if len(parts) != 2:
+                continue
+            name, committed_raw = parts
+            short = name[len(f"{remote}/"):] if name.startswith(f"{remote}/") else name
+            if not _COVERAGE_BRANCH_RE.match(short):
+                continue
+            try:
+                committed = float(committed_raw)
+            except ValueError:
+                continue
+            newest_commit_epoch[short] = max(newest_commit_epoch.get(short, 0.0), committed)
+
+        for short, committed in sorted(newest_commit_epoch.items()):
+            age_hours = (now - committed) / 3600.0
+            if age_hours < stale_hours:
+                continue
+            ahead = subprocess.run(
+                ["git", "-C", repo, "rev-list", "--count", f"{remote}/{base}..{short}"],
+                capture_output=True, text=True, timeout=15,
+            )
+            try:
+                commits_ahead = int(ahead.stdout.strip() or "0")
+            except ValueError:
+                commits_ahead = 0
+            if commits_ahead <= 0:
+                continue  # fully merged, or the generator aborted before committing
+
+            pr = subprocess.run(
+                ["gh", "pr", "list", "--repo", repo_slug, "--head", short,
+                 "--state", "all", "--json", "number"],
+                capture_output=True, text=True, timeout=20,
+            )
+            if pr.returncode == 0:
+                try:
+                    if json.loads(pr.stdout or "[]"):
+                        continue  # a PR already exists — the harvester did its job
+                except json.JSONDecodeError:
+                    pass  # unreadable answer — fall through, treat as "no PR" below
+
+            m = _COVERAGE_BRANCH_RE.match(short)
+            module = m.group("module") if m else short
+            findings.append(StaleFinding(
+                organ_id=f"codex.coverage_branch.{module}",
+                kind="stale_branch",
+                age_days=age_hours / 24.0,
+                status="no PR",
+                detail=(
+                    f"{commits_ahead} commit(s) ahead of {base}, {age_hours:.1f}h old, "
+                    f"no PR for `{short}` — the R7 harvester should have opened one"
+                ),
+            ))
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return findings
+
+
 def emit_alerts(findings: list[StaleFinding], alerts_file: str = DEFAULT_ALERTS_FILE) -> str:
     """Overwrite the open-alerts file with current findings (idempotent snapshot).
 
@@ -617,12 +717,31 @@ def main(argv: list[str] | None = None) -> int:
             "network-isolated run"
         ),
     )
+    ap.add_argument(
+        "--no-coverage-branch-scan",
+        action="store_true",
+        help=(
+            "skip the R7 proprioception check for stale codex/coverage-* "
+            "branches (shells out to git + gh) — for tests/determinism, or "
+            "a network-isolated run"
+        ),
+    )
+    ap.add_argument("--repo", default=".", help="repo path for the coverage-branch scan")
+    ap.add_argument("--repo-slug", default="Balizero1987/Teman2",
+                     help="GitHub repo slug for the coverage-branch scan's `gh pr list`")
+    ap.add_argument("--coverage-branch-stale-hours", type=float, default=24.0)
     args = ap.parse_args(argv)
 
     if not args.no_cross_host_sync:
         sync_cross_host_sidecars(args.dir)
 
     findings = scan_sidecars_status(args.dir, stale_days=args.stale_days)
+
+    if not args.no_coverage_branch_scan:
+        findings = findings + scan_stale_coverage_branches(
+            repo=args.repo, repo_slug=args.repo_slug,
+            stale_hours=args.coverage_branch_stale_hours,
+        )
 
     if args.emit:
         path = emit_alerts(findings)
@@ -634,8 +753,9 @@ def main(argv: list[str] | None = None) -> int:
     elif not args.emit:
         print(_human_report(findings))
 
-    # exit 1 if any core guardian has a dead channel — that is actionable now.
-    return 1 if any(f.kind == "dead_channel" for f in findings) else 0
+    # exit 1 if any core guardian has a dead channel, or a coverage branch is
+    # stuck without a PR — both are actionable now, not just advisory.
+    return 1 if any(f.kind in ("dead_channel", "stale_branch") for f in findings) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_army_spark_lane.sh
+++ b/scripts/tests/test_army_spark_lane.sh
@@ -115,6 +115,7 @@ case "\$STUB_CODEX_MODE" in
     success) echo "STUB REPORT BODY"; exit 0 ;;
     success_quota_text) echo "Analysis: this queue documents a usage limit and 429 backoff policy."; exit 0 ;;
     quota) echo "error: out of extra usage on this weekly bucket"; exit 1 ;;
+    quota_with_reset) echo "ERROR: You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at Jan 1st, 2030 8:06 PM."; exit 1 ;;
     fail) echo "boom: synthetic codex crash"; exit 3 ;;
     *) echo "unset STUB_CODEX_MODE"; exit 9 ;;
 esac
@@ -293,6 +294,91 @@ if grep -q '"status":"quota"' "$WORK/world/state/attempts.jsonl" 2>/dev/null \
     note_pass "quota innocence: attempt recorded as quota, NOT ok (stays eligible for retry)"
 else
     note_fail "quota: attempts.jsonl did not record the expected quota-not-ok shape"
+fi
+if grep -q "out of extra usage on this weekly bucket" "$WORK/world/logs/run.log" 2>/dev/null; then
+    note_pass "quota: run.log carries codex's own quota-message text (2026-08-27 diagnosability fix)"
+else
+    note_fail "quota: run.log did not carry codex's raw quota-message text"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5b (guilt, 2026-08-27 repair): quota output that names a REALISTIC
+# reset time (~3 days out — comfortably between the fixed 12h floor and the
+# 7-day safety cap) sets the backoff to that parsed time, not the fixed
+# ${BACKOFF_HOURS}h default. This is the fix for the measured 2026-08-19..27
+# deadlock where the lane blind-retried every 12h against a bucket whose own
+# reply said "try again at Aug 31st, 2026 8:06 PM" for 8 straight days.
+#
+# The fixture date string is built by adding 3 days + the WITA (UTC+8)
+# offset to now, then formatting THAT instant in UTC — because the
+# implementation reads codex's digits as WITA wall-clock and subtracts 8h,
+# round-tripping through UTC-formatted digits of (target + 8h) is what
+# makes the parser land back on `target` (epoch math, not a wall-clock
+# label a human would write for a specific zone).
+# ---------------------------------------------------------------------------
+setup_world
+now_epoch="$(date +%s)"
+target_epoch=$((now_epoch + 3 * 86400))
+label_epoch=$((target_epoch + 8 * 3600))
+future_str="$(date -u -r "$label_epoch" '+%b %e, %Y %I:%M %p' 2>/dev/null || date -u -d "@$label_epoch" '+%b %e, %Y %I:%M %p' 2>/dev/null)"
+cat > "$WORK/world/bin/codex" <<SH
+#!/bin/sh
+echo "invoked \$*" >> "$WORK/world/codex-invocations.log"
+echo "ERROR: You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at $future_str."
+exit 1
+SH
+chmod +x "$WORK/world/bin/codex"
+rc="$(run_wrapper STUB_CODEX_MODE=irrelevant-custom-stub-above)"
+backoff_val="$(cat "$WORK/world/state/backoff-until.txt" 2>/dev/null || echo 0)"
+lo=$((now_epoch + 2 * 86400))
+hi=$((now_epoch + 5 * 86400))
+if [ "$rc" = "0" ] && [ "$backoff_val" -ge "$lo" ] && [ "$backoff_val" -le "$hi" ]; then
+    note_pass "quota with a realistic parseable reset ('$future_str'): backoff set near the parsed time, not the fixed 12h"
+else
+    note_fail "quota with realistic reset: rc=$rc backoff_val=$backoff_val expected within [$lo,$hi] (fixture: '$future_str')"
+fi
+if grep -q "parsed reset time" "$WORK/world/logs/run.log" 2>/dev/null; then
+    note_pass "quota with realistic reset: log names the parsed-reset code path"
+else
+    note_fail "quota with realistic reset: log did not name the parsed-reset path"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5c (guilt, safety cap): a quota message naming an ABSURD reset time
+# (years out) must NOT wedge the lane open-endedly on a parser misfire or a
+# provider quoting a nonsensical future date — falls back to the fixed
+# ${BACKOFF_HOURS}h default instead, same as no reset time at all.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub quota_with_reset
+now_epoch="$(date +%s)"
+rc="$(run_wrapper STUB_CODEX_MODE=quota_with_reset)"
+backoff_val="$(cat "$WORK/world/state/backoff-until.txt" 2>/dev/null || echo 0)"
+lower=$((now_epoch + 11 * 3600))
+upper=$((now_epoch + 13 * 3600))
+if [ "$rc" = "0" ] && [ "$backoff_val" -ge "$lower" ] && [ "$backoff_val" -le "$upper" ]; then
+    note_pass "quota with an absurd (years-out) reset time: capped back to the fixed ~12h default"
+else
+    note_fail "quota with absurd reset time: backoff_val=$backoff_val expected within [$lower,$upper]"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5d (innocence, 2026-08-27 repair): quota output WITHOUT a parseable
+# reset time still falls back to the fixed ${BACKOFF_HOURS}h default,
+# unchanged from before this repair — the parser must only ever EXTEND the
+# wait on real evidence, never invent one from silence.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub quota
+now_epoch="$(date +%s)"
+rc="$(run_wrapper STUB_CODEX_MODE=quota)"
+backoff_val="$(cat "$WORK/world/state/backoff-until.txt" 2>/dev/null || echo 0)"
+lower=$((now_epoch + 11 * 3600))
+upper=$((now_epoch + 13 * 3600))
+if [ "$rc" = "0" ] && [ "$backoff_val" -ge "$lower" ] && [ "$backoff_val" -le "$upper" ]; then
+    note_pass "quota without a parseable reset: backoff stays at the fixed ~12h default"
+else
+    note_fail "quota without a parseable reset: backoff_val=$backoff_val expected within [$lower,$upper]"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_codex_nightly_coverage_improver_pipefail.sh
+++ b/scripts/tests/test_codex_nightly_coverage_improver_pipefail.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# test_codex_nightly_coverage_improver_pipefail.sh
+#
+# Regression test for the 2026-08-27 repair of
+# scripts/codex/codex-nightly-coverage-improver.sh: under `set -euo
+# pipefail`, `git diff --name-only ... | grep -v "/tests/" | wc -l` crashed
+# the WHOLE SCRIPT the instant Codex behaved correctly (a test-only diff,
+# which is the only kind this generator ever asks for) — grep exits 1 when
+# it matches nothing, pipefail promotes that to the pipeline's exit status,
+# and `set -e` killed the script one line after "Codex completed" was
+# logged, before it ever reached push/PR-create.
+#
+# Measured live 2026-08-27 against ~/logs/codex-coverage-improver/launchd.out.log:
+# 9 of the last 10 nightly runs logged "Codex completed" and then NOTHING
+# else, ever, for that run — no push line, no PR line, no error. Zero PRs
+# opened in at least 10 days. This is the "branches exist but never become
+# PRs" symptom the R7 mandate reported.
+#
+# Two checks, matching the two ways this can regress:
+#   1 (static)     — the live NON_TEST_CHANGES line in the script must not
+#                    have reverted to the bare, unguarded grep pipeline.
+#   2 (functional) — the actual computation, run for real against a real
+#                    git repo, must survive BOTH the guilt shape (a real
+#                    non-test file present — must still be DETECTED) and
+#                    the innocence shape (zero non-test files — the
+#                    everyday case that used to crash the whole script).
+#
+# Run:  sh scripts/tests/test_codex_nightly_coverage_improver_pipefail.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$SCRIPT_DIR/codex/codex-nightly-coverage-improver.sh"
+
+if [ ! -f "$TARGET" ]; then
+    echo "FATAL: $TARGET not found"
+    exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/test-coverage-pipefail.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Check 1 (static): the live script's NON_TEST_CHANGES line must not be the
+# bare pattern that crashes on a clean (test-only) diff.
+# ---------------------------------------------------------------------------
+live_line="$(grep -n 'NON_TEST_CHANGES=\$(git diff' "$TARGET" | head -1)"
+case "$live_line" in
+    *'{ grep -v "/tests/" || true; }'*)
+        note_pass "static: NON_TEST_CHANGES line guards grep's 'nothing matched' exit"
+        ;;
+    *)
+        note_fail "static: NON_TEST_CHANGES line no longer guarded — found: $live_line"
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Fixture: a tiny real repo with a branch holding one commit.
+# ---------------------------------------------------------------------------
+make_repo() {  # $1 = test-only ("1") or also-touches-source ("0")
+    rm -rf "$WORK/repo"
+    mkdir -p "$WORK/repo"
+    git -C "$WORK/repo" init -q
+    git -C "$WORK/repo" config user.email "test@example.com"
+    git -C "$WORK/repo" config user.name "test"
+    git -C "$WORK/repo" commit -q --allow-empty -m init
+    git -C "$WORK/repo" branch -M main
+    mkdir -p "$WORK/repo/backend/tests" "$WORK/repo/backend/agents/services"
+    printf 'x = 1\n' > "$WORK/repo/backend/tests/test_foo.py"
+    git -C "$WORK/repo" add -A
+    if [ "$1" = "0" ]; then
+        printf 'y = 2\n' > "$WORK/repo/backend/agents/services/foo.py"
+        git -C "$WORK/repo" add -A
+    fi
+    git -C "$WORK/repo" checkout -q -b "codex/coverage-foo-20260827_030000"
+    git -C "$WORK/repo" commit -q -m "test(foo): improve coverage via Codex nightly"
+}
+
+# The exact expression from the FIXED script (line extracted at test-write
+# time; kept literal here rather than re-sourcing the whole script, which
+# would require faking every env var and external tool it depends on).
+run_fixed_expression() {
+    ( cd "$WORK/repo" && set -euo pipefail
+      NON_TEST_CHANGES=$(git diff --name-only "main..codex/coverage-foo-20260827_030000" | { grep -v "/tests/" || true; } | wc -l | tr -d ' ')
+      echo "NON_TEST_CHANGES=$NON_TEST_CHANGES"
+      echo "REACHED_END" )
+}
+
+run_broken_expression() {
+    ( cd "$WORK/repo" && set -euo pipefail
+      NON_TEST_CHANGES=$(git diff --name-only "main..codex/coverage-foo-20260827_030000" | grep -v "/tests/" | wc -l | tr -d ' ')
+      echo "NON_TEST_CHANGES=$NON_TEST_CHANGES"
+      echo "REACHED_END" )
+}
+
+# ---------------------------------------------------------------------------
+# Check 2 (functional, innocence): test-only diff — the everyday case that
+# used to crash the whole script — must survive and report 0.
+# ---------------------------------------------------------------------------
+make_repo 1
+out="$(run_fixed_expression 2>&1)"
+rc=$?
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q "NON_TEST_CHANGES=0" \
+    && printf '%s' "$out" | grep -q "REACHED_END"; then
+    note_pass "functional innocence: test-only diff survives under set -euo pipefail (rc=0, count=0)"
+else
+    note_fail "functional innocence: rc=$rc out=$out"
+fi
+
+# Prove the OLD (bare) expression really does die on exactly this input —
+# otherwise Check 2 above would be meaningless (asserting a non-bug).
+out_broken="$(run_broken_expression 2>&1)"
+rc_broken=$?
+if [ "$rc_broken" != "0" ] && ! printf '%s' "$out_broken" | grep -q "REACHED_END"; then
+    note_pass "regression proof: the OLD bare pattern really does crash on a test-only diff (rc=$rc_broken)"
+else
+    note_fail "regression proof: the OLD pattern was expected to crash on this input but didn't (rc=$rc_broken, out=$out_broken) — Check 2 above would not be testing anything"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3 (functional, guilt): a diff that ALSO touches a non-test file must
+# still be correctly counted and DETECTED — the fix must not blind the
+# constraint it is guarding.
+# ---------------------------------------------------------------------------
+make_repo 0
+out="$(run_fixed_expression 2>&1)"
+rc=$?
+if [ "$rc" = "0" ] && printf '%s' "$out" | grep -q "NON_TEST_CHANGES=1" \
+    && printf '%s' "$out" | grep -q "REACHED_END"; then
+    note_pass "functional guilt: a real non-test file is still counted correctly (count=1), not swallowed by the fix"
+else
+    note_fail "functional guilt: rc=$rc out=$out"
+fi
+
+echo
+echo "TOTAL: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -1189,6 +1189,46 @@ def test_scan_stale_coverage_branches_innocence_existing_pr_not_flagged(tmp_path
     assert findings == [], f"a branch with an existing PR must not be flagged: {findings}"
 
 
+def _make_fake_gh_failing(bin_dir):
+    """A `gh` stand-in that always fails, like an offline or unauthenticated
+    machine (gh installed, but `gh pr list` errors) — SYMBIOSIS Law 6:
+    disconnection is not evidence of a stuck branch.
+    """
+    gh_path = os.path.join(bin_dir, "gh")
+    with open(gh_path, "w", encoding="utf-8") as fh:
+        fh.write(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "sys.stderr.write('gh: not logged in to any GitHub hosts\\n')\n"
+            "sys.exit(1)\n"
+        )
+    os.chmod(gh_path, os.stat(gh_path).st_mode | _stat.S_IEXEC | _stat.S_IXGRP | _stat.S_IXOTH)
+
+
+def test_scan_stale_coverage_branches_innocence_gh_error_fails_open(tmp_path, monkeypatch):
+    # 2026-08-27 refuter finding: `gh` installed but failing (offline/
+    # unauthenticated/rate-limited — pr.returncode != 0) fell through to a
+    # false RED finding, directly contradicting this function's own
+    # docstring ("fails OPEN ... on any git/gh error") and the inverse of
+    # what has_any_pr() in spark_coverage_harvester.py already does
+    # correctly for the identical gh-error case. This test would have
+    # failed against the pre-fix code.
+    from organism_stale_detector import scan_stale_coverage_branches
+
+    branch = "codex/coverage-foo_bar-20260825_030000"
+    repo = _make_repo_with_coverage_branch(tmp_path, branch, age_hours=48)
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir(exist_ok=True)
+    _make_fake_gh_failing(str(bin_dir))
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+
+    findings = scan_stale_coverage_branches(repo=repo, stale_hours=24.0)
+    assert findings == [], (
+        f"gh failing (offline/unauthenticated) must fail OPEN per this "
+        f"function's own docstring, never a false RED finding: {findings}"
+    )
+
+
 def test_scan_stale_coverage_branches_fails_open_on_unreadable_repo(tmp_path, monkeypatch):
     from organism_stale_detector import scan_stale_coverage_branches
 

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -1068,6 +1068,160 @@ def test_human_report_renders_every_kind_once_with_truthful_counts():
     assert report.index("a.warn") < report.index("z.warn"), report
 
 
+# ---------------------------------------------------------------------------
+# scan_stale_coverage_branches — R7 proprioception (2026-08-27).
+#
+# Born from the measured root cause of the R7 mandate: a pipefail bug in
+# scripts/codex/codex-nightly-coverage-improver.sh silently killed 9 of the
+# last 10 nightly runs one line after "Codex completed" — real commits
+# landed on a real codex/coverage-* branch and nothing ever surfaced it for
+# 10 days. This check is the structural antidote so a future regression (in
+# either the generator or scripts/army/spark_coverage_harvester.py) cannot
+# go silent again.
+#
+# Contract:
+#   - GUILT: a branch older than stale_hours, with commits ahead of the
+#     base, and NO pr anywhere -> flagged kind="stale_branch".
+#   - INNOCENCE: a fresh branch (younger than stale_hours) is NOT flagged,
+#     regardless of PR status.
+#   - INNOCENCE: an old branch that already HAS a pr (any state) is NOT
+#     flagged — the harvester did its job.
+# ---------------------------------------------------------------------------
+
+import stat as _stat  # noqa: E402
+
+
+def _git_ok(repo, *args, env=None):
+    return subprocess.run(["git", "-C", repo, *args], capture_output=True,
+                           text=True, check=True, env=env)
+
+
+def _make_fake_gh(bin_dir):
+    """A `gh` stand-in that answers `gh pr list --head <b> ...` from the
+    JSON dict in $FAKE_GH_PRS_BY_BRANCH — never touches the network, so this
+    test suite stays offline-safe (SYMBIOSIS Law 6) and deterministic.
+    """
+    gh_path = os.path.join(bin_dir, "gh")
+    with open(gh_path, "w", encoding="utf-8") as fh:
+        fh.write(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "args = sys.argv[1:]\n"
+            "head = None\n"
+            "for i, a in enumerate(args):\n"
+            "    if a == '--head' and i + 1 < len(args):\n"
+            "        head = args[i + 1]\n"
+            "prs = json.loads(os.environ.get('FAKE_GH_PRS_BY_BRANCH', '{}'))\n"
+            "print(json.dumps(prs.get(head, [])))\n"
+        )
+    os.chmod(gh_path, os.stat(gh_path).st_mode | _stat.S_IEXEC | _stat.S_IXGRP | _stat.S_IXOTH)
+
+
+def _make_repo_with_coverage_branch(tmp_path, branch, age_hours, n_commits=1):
+    repo = str(tmp_path / "repo")
+    os.makedirs(repo)
+    _git_ok(repo, "init", "-q")
+    _git_ok(repo, "config", "user.email", "t@example.com")
+    _git_ok(repo, "config", "user.name", "t")
+    _git_ok(repo, "commit", "-q", "--allow-empty", "-m", "init")
+    _git_ok(repo, "branch", "-M", "main")
+    bare = str(tmp_path / "bare.git")
+    subprocess.run(["git", "init", "-q", "--bare", bare], check=True)
+    _git_ok(repo, "remote", "add", "origin", bare)
+    _git_ok(repo, "push", "-q", "-u", "origin", "main")
+
+    _git_ok(repo, "checkout", "-q", "-b", branch)
+    commit_epoch = time.time() - age_hours * 3600
+    commit_iso = time.strftime("%Y-%m-%dT%H:%M:%S+0000", time.gmtime(commit_epoch))
+    env = dict(os.environ, GIT_AUTHOR_DATE=commit_iso, GIT_COMMITTER_DATE=commit_iso)
+    for i in range(n_commits):
+        with open(os.path.join(repo, f"f{i}.py"), "w", encoding="utf-8") as fh:
+            fh.write("x = 1\n")
+        _git_ok(repo, "add", f"f{i}.py")
+        subprocess.run(["git", "-C", repo, "commit", "-q", "-m", f"c{i}"],
+                        check=True, env=env)
+    return repo
+
+
+def _fake_gh_path_env(tmp_path, monkeypatch, prs_by_branch=None):
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir(exist_ok=True)
+    _make_fake_gh(str(bin_dir))
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("FAKE_GH_PRS_BY_BRANCH", json.dumps(prs_by_branch or {}))
+
+
+def test_scan_stale_coverage_branches_guilt_old_branch_no_pr_is_flagged(tmp_path, monkeypatch):
+    from organism_stale_detector import scan_stale_coverage_branches
+
+    branch = "codex/coverage-foo_bar-20260825_030000"
+    repo = _make_repo_with_coverage_branch(tmp_path, branch, age_hours=48)
+    _fake_gh_path_env(tmp_path, monkeypatch, prs_by_branch={})
+
+    findings = scan_stale_coverage_branches(repo=repo, stale_hours=24.0)
+    assert len(findings) == 1, findings
+    f = findings[0]
+    assert f.kind == "stale_branch", f
+    assert f.organ_id == "codex.coverage_branch.foo_bar", f
+    assert f.status == "no PR", f
+    assert "1 commit" in f.detail and branch in f.detail, f.detail
+
+
+def test_scan_stale_coverage_branches_innocence_fresh_branch_not_flagged(tmp_path, monkeypatch):
+    from organism_stale_detector import scan_stale_coverage_branches
+
+    branch = "codex/coverage-foo_bar-20260827_030000"
+    repo = _make_repo_with_coverage_branch(tmp_path, branch, age_hours=1)
+    _fake_gh_path_env(tmp_path, monkeypatch, prs_by_branch={})
+
+    findings = scan_stale_coverage_branches(repo=repo, stale_hours=24.0)
+    assert findings == [], f"a 1h-old branch must not be flagged yet (threshold 24h): {findings}"
+
+
+def test_scan_stale_coverage_branches_innocence_existing_pr_not_flagged(tmp_path, monkeypatch):
+    from organism_stale_detector import scan_stale_coverage_branches
+
+    branch = "codex/coverage-foo_bar-20260825_030000"
+    repo = _make_repo_with_coverage_branch(tmp_path, branch, age_hours=48)
+    _fake_gh_path_env(tmp_path, monkeypatch, prs_by_branch={branch: [4242]})
+
+    findings = scan_stale_coverage_branches(repo=repo, stale_hours=24.0)
+    assert findings == [], f"a branch with an existing PR must not be flagged: {findings}"
+
+
+def test_scan_stale_coverage_branches_fails_open_on_unreadable_repo(tmp_path, monkeypatch):
+    from organism_stale_detector import scan_stale_coverage_branches
+
+    _fake_gh_path_env(tmp_path, monkeypatch)
+    findings = scan_stale_coverage_branches(repo=str(tmp_path / "does-not-exist"))
+    assert findings == [], (
+        f"a repo path that is not a git repo must fail OPEN (no finding, no "
+        f"crash) — SYMBIOSIS Law 6, offline/misconfigured is not evidence of "
+        f"a stuck branch: {findings}"
+    )
+
+
+def test_scan_stale_coverage_branches_exit_code_is_red(tmp_path, monkeypatch):
+    # The R7 mandate asks for this to surface as "red", not merely advisory —
+    # confirm main()'s exit-code contract treats stale_branch like dead_channel.
+    branch = "codex/coverage-foo_bar-20260825_030000"
+    repo = _make_repo_with_coverage_branch(tmp_path, branch, age_hours=48)
+    _fake_gh_path_env(tmp_path, monkeypatch, prs_by_branch={})
+
+    from organism_stale_detector import main as detector_main
+
+    empty_sidecars = str(tmp_path / "sidecars")
+    os.makedirs(empty_sidecars, exist_ok=True)
+    rc = detector_main([
+        "--dir", empty_sidecars,
+        "--no-cross-host-sync",
+        "--repo", repo,
+        "--coverage-branch-stale-hours", "24",
+        "--json",
+    ])
+    assert rc == 1, f"a stale, PR-less coverage branch must exit non-zero: rc={rc}"
+
+
 def test_the_all_clear_sentence_is_the_hooks_only_branch_and_is_a_contract():
     """CROSS-ARTIFACT PIN: this one string IS an interface, not prose.
 

--- a/scripts/tests/test_spark_coverage_harvester.py
+++ b/scripts/tests/test_spark_coverage_harvester.py
@@ -1,0 +1,170 @@
+"""Tests for scripts/army/spark_coverage_harvester.py (R7 harvester).
+
+Contract under test (guilt + innocence, per cicatrix-superscar #3 antidote —
+no guard ships without both directions):
+  - GUILT: a codex/coverage-* branch that already has a PR (any state) is
+    SKIPPED even though it has unmerged commits.
+  - INNOCENCE: a codex/coverage-* branch with commits ahead of the base and
+    no PR anywhere is SELECTED.
+  - EDGE: a branch with zero commits ahead of the base is never selected,
+    regardless of whether a PR exists for it (the generator's own cleanup
+    already deleted it in the common case; this only guards a partial
+    delete leaving a dangling empty-diff branch behind).
+
+Also covers the real git wiring (discover_candidates/_commits_ahead) against
+a throwaway local repo — the pure-function tests above prove the SELECTION
+logic; this proves the plumbing that feeds it real numbers.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "army"))
+
+from spark_coverage_harvester import (  # noqa: E402
+    Candidate,
+    discover_candidates,
+    guess_seat,
+    in_automatic_window,
+    select_branches_to_harvest,
+)
+
+
+def _candidate(branch="codex/coverage-foo_bar-20260827_030000", commits_ahead=1):
+    return Candidate(
+        branch=branch, module="foo_bar", ts="20260827_030000",
+        commits_ahead=commits_ahead, on_remote=False, on_local=True,
+    )
+
+
+def test_guilt_branch_with_pr_is_skipped():
+    c = _candidate(commits_ahead=3)
+    selected, decided = select_branches_to_harvest([c], has_pr_fn=lambda b: True)
+    assert selected == [], f"a branch with an existing PR must never be selected: {selected}"
+    assert len(decided) == 1 and decided[0].action == "skipped-has-pr", decided
+
+
+def test_innocence_branch_without_pr_is_selected():
+    c = _candidate(commits_ahead=2)
+    selected, decided = select_branches_to_harvest([c], has_pr_fn=lambda b: False)
+    assert selected == [c], f"a branch with commits and no PR must be selected: {selected}"
+    assert decided == [], f"a selected branch must not also appear as decided: {decided}"
+
+
+def test_zero_commits_ahead_never_selected_even_without_a_pr():
+    c = _candidate(commits_ahead=0)
+    selected, decided = select_branches_to_harvest([c], has_pr_fn=lambda b: False)
+    assert selected == [], f"a branch with 0 commits ahead must never be selected: {selected}"
+    assert decided and decided[0].action == "skipped-no-commits", decided
+
+
+def test_has_pr_fn_is_never_consulted_when_commits_ahead_is_zero():
+    # Guard against a future refactor accidentally calling gh for branches
+    # that can never be selected anyway — cheap, and proves the short-circuit.
+    calls = []
+
+    def spy(branch):
+        calls.append(branch)
+        return False
+
+    select_branches_to_harvest([_candidate(commits_ahead=0)], has_pr_fn=spy)
+    assert calls == [], f"has_pr_fn must not be called for a 0-commit branch: {calls}"
+
+
+def test_guess_seat_reads_the_real_transcript_banner(tmp_path):
+    log_dir = tmp_path
+    (log_dir / "codex-output-20260827_030000.log").write_text(
+        "--------\nworkdir: /x\nmodel: gpt-5.6-sol\nprovider: openai\n--------\n",
+        encoding="utf-8",
+    )
+    seat = guess_seat(log_dir, "20260827_030000")
+    assert seat == "codex-gpt-5.6-sol", seat
+
+
+def test_guess_seat_never_fabricates_a_seat_when_log_is_missing(tmp_path):
+    # This is the anti-hallucination guard for this module: the R7 spec
+    # names `codex-gpt-5.3-codex-spark` for this row, but that seat belongs
+    # to a DIFFERENT lane (army.spark_lane's -m flag) — this generator calls
+    # `codex --profile power`, an undefined profile on this machine as of
+    # 2026-08-27, so the true model varies with codex's own default.
+    # Guessing either name without evidence would be exactly the fabrication
+    # this codebase's anti-hallucination discipline exists to catch.
+    seat = guess_seat(tmp_path, "20260827_030000")
+    assert "gpt-5.3-codex-spark" not in seat, (
+        f"guess_seat must never assert the spark seat without reading it from "
+        f"the actual transcript: {seat}"
+    )
+    assert "unknown" in seat, seat
+
+
+def test_in_automatic_window_true_at_0300_wita_false_at_1500_wita():
+    import datetime
+    from zoneinfo import ZoneInfo
+
+    wita = ZoneInfo("Asia/Makassar")
+    inside = datetime.datetime(2026, 8, 27, 3, 0, 0, tzinfo=wita).timestamp()
+    outside = datetime.datetime(2026, 8, 27, 15, 0, 0, tzinfo=wita).timestamp()
+    assert in_automatic_window(inside) is True
+    assert in_automatic_window(outside) is False
+
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", repo, *args], capture_output=True, text=True, check=True)
+
+
+def test_discover_candidates_against_a_real_repo_reports_correct_commit_count(tmp_path):
+    repo = str(tmp_path / "repo")
+    os.makedirs(repo)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "init")
+    _git(repo, "branch", "-M", "main")
+
+    # Fake a bare "origin" remote so refs/remotes/origin/main exists — the
+    # harvester diffs against `<remote>/<base>`, matching production usage
+    # against a real GitHub remote rather than a bare local `main`.
+    bare = str(tmp_path / "bare.git")
+    subprocess.run(["git", "init", "-q", "--bare", bare], check=True)
+    _git(repo, "remote", "add", "origin", bare)
+    _git(repo, "push", "-q", "-u", "origin", "main")
+
+    _git(repo, "checkout", "-q", "-b", "codex/coverage-foo_bar-20260827_030000")
+    open(os.path.join(repo, "t.py"), "w").write("x = 1\n")
+    _git(repo, "add", "t.py")
+    _git(repo, "commit", "-q", "-m", "test-only change")
+
+    candidates = discover_candidates(repo, remote="origin", base="main")
+    assert len(candidates) == 1, candidates
+    c = candidates[0]
+    assert c.branch == "codex/coverage-foo_bar-20260827_030000"
+    assert c.module == "foo_bar"
+    assert c.ts == "20260827_030000"
+    assert c.commits_ahead == 1, c
+    assert c.on_local is True
+    assert c.on_remote is False
+
+
+def test_discover_candidates_ignores_branches_outside_the_naming_scheme(tmp_path):
+    repo = str(tmp_path / "repo2")
+    os.makedirs(repo)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "init")
+    _git(repo, "branch", "-M", "main")
+    bare = str(repo) + "-bare.git"
+    subprocess.run(["git", "init", "-q", "--bare", bare], check=True)
+    _git(repo, "remote", "add", "origin", bare)
+    _git(repo, "push", "-q", "-u", "origin", "main")
+    _git(repo, "checkout", "-q", "-b", "agent/nuzantara/ops/unrelated-lane")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "unrelated work")
+
+    candidates = discover_candidates(repo, remote="origin", base="main")
+    assert candidates == [], (
+        f"a branch outside the codex/coverage-<module>-<ts> naming scheme "
+        f"must never be treated as this harvester's to open a PR for: {candidates}"
+    )

--- a/scripts/tests/test_spark_coverage_harvester.py
+++ b/scripts/tests/test_spark_coverage_harvester.py
@@ -24,10 +24,12 @@ import time
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "army"))
 
+import spark_coverage_harvester as sch  # noqa: E402
 from spark_coverage_harvester import (  # noqa: E402
     Candidate,
     discover_candidates,
     guess_seat,
+    harvest,
     in_automatic_window,
     select_branches_to_harvest,
 )
@@ -167,4 +169,100 @@ def test_discover_candidates_ignores_branches_outside_the_naming_scheme(tmp_path
     assert candidates == [], (
         f"a branch outside the codex/coverage-<module>-<ts> naming scheme "
         f"must never be treated as this harvester's to open a PR for: {candidates}"
+    )
+
+
+def _make_harvestable_repo(tmp_path, dirname, branch):
+    """A real repo with one branch that has commits ahead of main and no PR
+    — everything harvest() needs except the `gh` calls, which the caller
+    monkeypatches via `sch.run`.
+    """
+    repo = str(tmp_path / dirname)
+    os.makedirs(repo)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "test")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "init")
+    _git(repo, "branch", "-M", "main")
+    bare = str(tmp_path / f"{dirname}-bare.git")
+    subprocess.run(["git", "init", "-q", "--bare", bare], check=True)
+    _git(repo, "remote", "add", "origin", bare)
+    _git(repo, "push", "-q", "-u", "origin", "main")
+    _git(repo, "checkout", "-q", "-b", branch)
+    open(os.path.join(repo, "t.py"), "w").write("x = 1\n")
+    _git(repo, "add", "t.py")
+    _git(repo, "commit", "-q", "-m", "test-only change")
+    return repo
+
+
+def _fake_run_with_merge_result(merge_returncode, merge_stderr=""):
+    """Real `git` passthrough (push against the local bare remote actually
+    works), fake `gh pr list`/`gh pr create` success, and a controllable
+    `gh pr merge` outcome — isolates the auto-merge-arm accounting from
+    everything else harvest() does.
+    """
+    real_run = sch.run
+    calls = []
+
+    def fake_run(cmd, cwd=None, check=False):
+        calls.append(cmd)
+        if cmd[0] == "gh":
+            if cmd[1:3] == ["pr", "list"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="[]", stderr="")
+            if cmd[1:3] == ["pr", "create"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="https://github.com/x/y/pull/42\n", stderr="")
+            if cmd[1:3] == ["pr", "merge"]:
+                return subprocess.CompletedProcess(
+                    cmd, merge_returncode, stdout="", stderr=merge_stderr)
+        return real_run(cmd, cwd=cwd, check=check)
+
+    return fake_run, calls
+
+
+def test_harvest_gh_pr_merge_guilt_arm_failure_is_recorded_not_swallowed(tmp_path, monkeypatch):
+    # 2026-08-27 refuter finding: `gh pr merge --auto` was missing --repo
+    # (the only gh call in this file without it) and its result was
+    # discarded outright — a PR "opened" with exit 0 even when auto-merge
+    # arming silently failed. The whole point of this harvester is killing
+    # exit-0-nothing-done paths; shipping a new one would be the sharpest
+    # irony in the repair.
+    branch = "codex/coverage-foo_bar-20260827_030000"
+    repo = _make_harvestable_repo(tmp_path, "repo-guilt", branch)
+    fake_run, calls = _fake_run_with_merge_result(
+        merge_returncode=1, merge_stderr="could not determine current repository, use `--repo`")
+    monkeypatch.setattr(sch, "run", fake_run)
+
+    results = harvest(repo, "origin", "main", "some-org/some-repo", tmp_path, dry_run=False)
+
+    assert len(results) == 1, results
+    r = results[0]
+    assert r.action == "opened", r  # the PR itself genuinely was opened
+    assert r.pr_url == "https://github.com/x/y/pull/42", r
+    assert "auto-merge" in r.detail and "failed" in r.detail, (
+        f"a failed auto-merge arm must be visible in the accounting, not silently "
+        f"swallowed: {r.detail!r}"
+    )
+
+    merge_calls = [c for c in calls if c[0] == "gh" and c[1:3] == ["pr", "merge"]]
+    assert len(merge_calls) == 1, calls
+    assert "--repo" in merge_calls[0] and "some-org/some-repo" in merge_calls[0], (
+        f"gh pr merge must always pass --repo like every other gh call in this "
+        f"file — it cannot depend on the invoker's cwd: {merge_calls[0]}"
+    )
+
+
+def test_harvest_gh_pr_merge_innocence_success_leaves_detail_empty(tmp_path, monkeypatch):
+    branch = "codex/coverage-foo_bar-20260827_030001"
+    repo = _make_harvestable_repo(tmp_path, "repo-innocence", branch)
+    fake_run, _calls = _fake_run_with_merge_result(merge_returncode=0)
+    monkeypatch.setattr(sch, "run", fake_run)
+
+    results = harvest(repo, "origin", "main", "some-org/some-repo", tmp_path, dry_run=False)
+
+    assert len(results) == 1, results
+    r = results[0]
+    assert r.action == "opened", r
+    assert r.detail == "", (
+        f"a successful auto-merge arm must not be reported as a failure: {r.detail!r}"
     )


### PR DESCRIPTION
## Summary
Root-causes and repairs the R7 mandate's two reported symptoms, and adds the missing harvester + proprioception check.

## Before
- `army.spark_lane` has been stuck in a permanent "quota" retry loop since 2026-08-19 (8 days): every ~2h tick re-dispatches the same head-of-queue task, hits the `gpt-5.3-codex-spark` bucket's real usage limit, and blind-backs-off a fixed 12h — even though a live diagnostic run shows the bucket's own reply names the real reset time ("try again at Aug 31st, 2026 8:06 PM"), 5 days further out than the fixed backoff ever waited.
- `scripts/codex/codex-nightly-coverage-improver.sh` (the actual generator of the `codex/coverage-<module>-<ts>` branches this mandate is about — a DIFFERENT script from `spark_lane.sh`, despite the R7 spec conflating the two) has silently died on 9 of its last 10 nightly runs, one line after logging "Codex completed": `git diff --name-only ... | grep -v "/tests/" | wc -l` runs under `set -o pipefail`, and `grep` matching nothing (the everyday, correct outcome — this generator only ever asks Codex to touch `tests/`) exits 1, which `pipefail` promotes to the whole pipeline's status, and `set -e` kills the script before it ever pushes or opens a PR. Verified live against `~/logs/codex-coverage-improver/launchd.out.log` and reproduced standalone against a real git repo (old pattern: dies, rc=1, "REACHED_END" never printed; fixed pattern: survives, rc=0).
- `codex.spark_loop`/`codex.spark_harvester`/`codex.spark_alarm` read FAILED in the organism heartbeat — investigated and found to be the OLD, W81-firebreak-retired `~/scripts/codex/` ecosystem (superseded by `army.spark_lane` after a runaway-alarm + 13-PR-spam incident), already correctly suppressed via `organism_stale_detector.py`'s own `KNOWN_BENIGN_FAILED` allow-list with a dedicated test enforcing it — no action needed, no code touched here.
- No `codex/coverage-*` PR has ever landed; zero proprioception existed for a branch stuck without one.

## After
- `army.spark_lane` parses a "try again at `<date>`" reset time out of codex's own reply and backs off to THAT time (capped to `[BACKOFF_HOURS, 7 days]` — extends the wait on real evidence, never shortens it, never trusts an absurd/garbled date) instead of blindly retrying every 12h against a wall that won't clear for days. The raw quota-message text is now logged and carried into the Telegram digest, so a future stuck bucket is diagnosable from `run.log` alone.
- `codex-nightly-coverage-improver.sh`'s `NON_TEST_CHANGES` check now tolerates `grep` matching nothing (`{ grep -v "/tests/" || true; }`), so a correct, test-only Codex run reaches push + `gh pr create` instead of dying silently.
- New `scripts/army/spark_coverage_harvester.py`: finds any `codex/coverage-*` branch (local or remote) with commits ahead of `main` and no PR anywhere (open/closed/merged), pushes it if needed, and opens `test(coverage): <module> — Spark nightly` with an accurate `lanes:` seat read from the run's own transcript banner (not hardcoded to the R7 spec's `codex-gpt-5.3-codex-spark` — that seat belongs to the read-only `army.spark_lane`'s `-m` flag; this generator calls the now-undefined `--profile power`, which silently rides whatever codex's default model is on a given night). Arms `gh pr merge --auto` naked (never forces), always with `--repo`, and records a failed arm rather than swallowing it (see Refuter below). Ran once against the live repo: 0 branches found (the buggy runtime worktree left nothing behind to harvest) — tonight's 03:00 WITA run is the first real end-to-end test of the pipefail fix.
- `organism_stale_detector.py` gains `scan_stale_coverage_branches()`: a `codex/coverage-*` branch older than 24h with commits ahead of `main` and no PR is now a `stale_branch` finding, treated as red (non-zero exit) exactly like a dead core-guardian channel. Fails open (no finding, never crashes) on git/gh errors, including a `gh` call that itself errors (offline/unauthenticated — see Refuter below).

## Apply to the LIVE HOME wrapper
Operator control-plane, not touched in this PR — the two copies have already diverged in unrelated ways (HOME has worktree-isolation/cleanup/auto-merge logic this repo copy lacks; this repo copy has 2026-08-20 seat-rotation logic HOME lacks), so a wholesale copy would regress HOME:

In `~/scripts/codex/nightly-coverage-improver.sh`, apply the identical one-line fix at its own `NON_TEST_CHANGES` line (uses `origin/main..` there instead of `main..`):
```
NON_TEST_CHANGES=$(git diff --name-only "origin/main..${BRANCH_NAME}" | { grep -v "/tests/" || true; } | wc -l | tr -d ' ')
```
This pair is UNDECLARED in `infra/home-fork/declared-pairs.json` — a separate, pre-existing family #1 finding, out of scope for this fix.

## Tests
- 38/38 `scripts/tests/test_army_spark_lane.sh` (5 new: realistic-date parse, absurd-date safety cap, no-date fallback unchanged, run.log carries raw quota text)
- 4/4 new `scripts/tests/test_codex_nightly_coverage_improver_pipefail.sh` (static guard + functional guilt/innocence + proof the old pattern really does crash)
- 71/71 pytest across `test_organism_stale_detector.py` (6 new) and `test_spark_coverage_harvester.py` (11 new, incl. real-git-repo wiring, not just mocked selection logic)

## Refuter
Seat: **Kimi K3** (`kimi -m kimi-code/k3`), reviewing the diff for correctness, silent-failure paths, credential leakage, and guilt+innocence test coverage.

**Verdict summary:** the pipefail fix and its test were called solid/exemplary. The harvester and detector were found to have real defects — most notably one probable silent-failure bug in auto-merge arming and one detector behavior directly contradicting its own docstring — plus several lower-severity error-as-zero conflations and test gaps. No credential leakage found (two conditional/low-risk exposure vectors noted: git/gh stderr echoed into result details could theoretically carry a credentialed remote URL; Telegram now carries codex's raw quota-message text).

**Fixed** (commit `f1707eab7`, verified against the pre-fix code path by hand-trace to confirm each new test is a genuine regression proof, not vacuous):
1. `spark_coverage_harvester.py`: `gh pr merge --auto` was the only `gh` call in the file missing `--repo repo_slug`, and its result was discarded entirely — a PR could be recorded "opened" with exit 0 even if auto-merge arming silently failed. Now passes `--repo` and records a failed arm in `HarvestResult.detail` instead of swallowing it.
2. `organism_stale_detector.py`: `scan_stale_coverage_branches()`'s own docstring promises "fails OPEN ... on any git/gh error" (SYMBIOSIS Law 6 — offline is not evidence of a stuck branch), but when `gh pr list` failed (non-zero rc), the code fell through to appending a false RED finding instead of skipping — the exact inverse of what `has_any_pr()` already does correctly for the same case in the harvester. Now `continue`s on gh failure, matching the documented contract.

**Judged real but not fixed in this PR** (lower-severity / design-tradeoff, not a bug this diff introduced into a ship-blocking state — logged here for a follow-up, per the one-fix-commit-per-refuter-round discipline):
- Local-ahead-of-remote branches could open a PR missing commits (discovery diffs the local ref, push only fires when `not on_remote`).
- `_commits_ahead()` (both files) returns `0` on a git error, conflating "couldn't measure" with "0 commits ahead" in the accounting/detail text.
- The detector's remote-only-branch case: `rev-list` is run against the local short name even when only a remote ref exists, so a genuinely remote-only stale branch can be silently skipped (unchecked returncode → `int("" or "0")` → 0).
- Quota-reset cap (`army/spark_lane.sh`) falls back to the fixed `BACKOFF_HOURS` when a parsed reset exceeds the 7-day cap, rather than clamping to the cap — a reviewer-suggested strictly-safer alternative for genuine far-future resets, but a deliberate design choice in the original fix, not a bug.
- `build_pr_body()` can raise `ValueError` on a valid-but-string `percent_covered` in the coverage JSON (uncaught by the existing `except (JSONDecodeError, OSError)`).
- No `git fetch` before harvester discovery (works off possibly-stale remote-tracking refs).
- Missing test: `spark_lane.sh`'s "never shorten" guarantee (a parsed reset sooner than the fixed backoff must still yield the fixed backoff) has no direct test, though it holds by inspection of the `-gt` comparison.

lanes: [{lane: build, role: build, seat: claude-opus-5}]
