### PR TITLE
feat(evidence-pack): cheap-seat floor for mechanical diffs + Gear-3 council_run — NOTICE until 2026-09-02

### DIFF
--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -442,6 +442,45 @@
             "test_is_anthropic_seat_innocence_non_anthropic_token_matches",
             "test_lanes_gear3_opus5_sonnet5_flip_behavior"
           ]
+        },
+        "check_cheap_seat_floor": {
+          "scar": [
+            "#3-substring-trapping",
+            "2026-08-26-piano-spec-receptor-live-8"
+          ],
+          "guilt": [
+            "test_cheap_seat_floor_guilt_no_cheap_lane_rejected_post_flip",
+            "test_cheap_seat_floor_guilt_non_build_lane_does_not_count"
+          ],
+          "innocence": [
+            "test_cheap_seat_floor_innocence_not_100pct_mechanical_skipped",
+            "test_cheap_seat_floor_innocence_cheap_build_lane_passes",
+            "test_cheap_seat_floor_innocence_seat_override_reports_not_fails",
+            "test_cheap_seat_floor_innocence_pre_flip_notice_not_fail",
+            "test_compute_seat_floor_guilt_single_mechanical_file_is_true",
+            "test_compute_seat_floor_innocence_one_non_mechanical_file_flips_to_false",
+            "test_compute_seat_floor_innocence_empty_or_none_is_false",
+            "test_seat_floor_end_to_end_through_lint"
+          ]
+        },
+        "check_council_run_gear3": {
+          "scar": [
+            "#2-esiste-non-armato",
+            "2026-08-26-piano-spec-receptor-live-8"
+          ],
+          "guilt": [
+            "test_council_run_guilt_no_council_run_field_rejected_post_flip",
+            "test_council_run_guilt_dangling_or_escaping_path_rejected",
+            "test_council_run_guilt_single_seat_below_quorum_rejected",
+            "test_council_run_guilt_ok_false_or_wrong_role_does_not_count"
+          ],
+          "innocence": [
+            "test_council_run_innocence_gear_not_3_skipped",
+            "test_council_run_innocence_two_distinct_qualifying_seats_passes",
+            "test_council_run_innocence_seat_override_reports_not_fails",
+            "test_council_run_innocence_pre_flip_notice_not_fail",
+            "test_council_run_end_to_end_through_lint"
+          ]
         }
       }
     },

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -197,6 +197,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import fnmatch
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -726,6 +727,207 @@ def check_lanes_build_seat_diversity(
     return [message], None
 
 
+# --------------------------------------------------------------------------
+# R11/R9 — cheap-seat floor for mechanical diffs + Gear-3 council_run.
+#
+# PR-B of the seat-rules program (spec: 2026-08-26-PIANO-SPEC-receptor-live.md
+# §8; PR-A landed R8 ground-truth-lane + R10 PII-local-seat as #5054). This
+# branch was created from origin/main BEFORE #5054 merged, so it does not
+# have that PR's `SEAT_RULES_ENFORCEMENT_DATE` / `_seat_rule_verdict` shared
+# helper to reuse — self-contained here by design (mandate's own fallback
+# for this ordering), under a distinct name (`R9_R11_ENFORCEMENT_DATE` /
+# `_r9_r11_verdict`) specifically so this file never carries two same-named
+# top-level definitions regardless of which PR's merge lands first. Same
+# enforcement date (2026-09-02) and same `seat_override: <reason>` escape
+# convention as R8/R10 — a human call, always reported, never silently
+# dropped.
+# --------------------------------------------------------------------------
+
+R9_R11_ENFORCEMENT_DATE = datetime.date(2026, 9, 2)
+
+
+def _r9_r11_verdict(
+    rule: str,
+    is_violation: bool,
+    message: str,
+    pack: dict[str, Any],
+    today: datetime.date | None,
+) -> tuple[list[str], str | None]:
+    """Shared phasing+override plumbing for R9/R11 — not a violation ->
+    clean; else an explicit pack-level `seat_override: <non-empty reason>`
+    wins outright (reported, never failed — a human call, not a rollout
+    clock); else NOTICE before R9_R11_ENFORCEMENT_DATE, hard violation
+    on/after. `today` overridable for tests."""
+    if not is_violation:
+        return [], None
+    override = pack.get("seat_override")
+    if isinstance(override, str) and override.strip():
+        return [], f"{rule} (overridden): {message} — {override.strip()}"
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
+    if today < R9_R11_ENFORCEMENT_DATE:
+        return [], f"{rule}: {message}"
+    return [f"{rule}: {message}"], None
+
+
+#: R11 — path classes judged MECHANICAL: translated strings, test fixtures,
+#: the modus PENDING-ARMS ledger (append-only, human-authored prose), and a
+#: mouth catalog data file. `fnmatch`'s `*` crosses `/` so a doubled `**`
+#: here behaves like a single `*` — verified against the real tree
+#: (`apps/mouth/src/i18n/locales/en.json` etc.) 2026-08-26: every real
+#: i18n/locales file on disk sits at least one directory below its
+#: `i18n`/`locales` segment, so the extra `/` the doubled glob demands is
+#: always present; a hypothetical `i18n/foo.json` with no subdirectory
+#: would NOT match — no such file exists in this repo today.
+MECHANICAL_PATH_PATTERNS: tuple[str, ...] = (
+    ".claude/skills/modus/PENDING-ARMS.md",
+    "**/i18n/**/*.json",
+    "**/locales/**/*.json",
+    "**/fixtures/**",
+    "apps/mouth/**/catalog*/**",
+)
+
+#: R11 — a build-lane seat token starting with one of these is "cheap"
+#: (low-cost/high-speed tier), per the mandate's exact roster.
+CHEAP_SEATS: tuple[str, ...] = (
+    "claude-haiku-4-5",
+    "codex-gpt-5.6-luna",
+    "kimi-code/kimi-for-coding-highspeed",
+    "tp1-qwen3.6-flash",
+    "tp1-deepseek-v4-flash-0731",
+)
+
+
+def compute_seat_floor(changed_files: list[str] | None) -> bool:
+    """R11 pure predicate (mirrors compute_floor's shape): True only when
+    changed_files is non-empty AND every single file matches at least one
+    MECHANICAL_PATH_PATTERNS entry. False on None/empty — "zero files are
+    all mechanical" is not evidence of anything, same convention
+    compute_floor uses for its own hotzone check on an empty diff."""
+    if not changed_files:
+        return False
+    return all(
+        any(fnmatch.fnmatchcase(f, pat) for pat in MECHANICAL_PATH_PATTERNS)
+        for f in changed_files
+    )
+
+
+def check_cheap_seat_floor(
+    pack: dict[str, Any],
+    changed_files: list[str] | None,
+    today: datetime.date | None = None,
+) -> tuple[list[str], str | None]:
+    """R11: when compute_seat_floor(changed_files) is True (100% of the
+    diff is mechanical), the pack must declare at least one `role: build`
+    lane whose `seat` starts with a CHEAP_SEATS entry, or carry a non-empty
+    `seat_override: <reason>` naming why a frontier seat was used anyway.
+    GUILT: 100% mechanical, no cheap build lane, no override -> phased
+    violation. INNOCENCE: not 100% mechanical (skipped outright); >=1 cheap
+    build lane present; seat_override present."""
+    if not compute_seat_floor(changed_files):
+        return [], None
+    lanes = pack.get("lanes")
+    has_cheap_build_lane = False
+    if isinstance(lanes, list):
+        for entry in lanes:
+            if not isinstance(entry, dict):
+                continue
+            if str(entry.get("role", "")).strip().lower() != "build":
+                continue
+            seat = entry.get("seat")
+            if isinstance(seat, str) and any(
+                seat.strip().lower().startswith(cheap) for cheap in CHEAP_SEATS
+            ):
+                has_cheap_build_lane = True
+                break
+    message = (
+        "diff is 100% mechanical (i18n/locales strings, test fixtures, "
+        "PENDING-ARMS.md, or a mouth catalog data file) but declares no "
+        f"build lane on a cheap seat ({', '.join(CHEAP_SEATS)})"
+    )
+    return _r9_r11_verdict("seat_floor", not has_cheap_build_lane, message, pack, today)
+
+
+#: R9 — review seats that count toward Gear-3 council quorum.
+COUNCIL_REVIEW_SEATS: tuple[str, ...] = (
+    "codex-gpt-5.6-sol",
+    "kimi-code/k3",
+    "tp1-qwen3.8-max",
+)
+
+
+def _read_council_journal_seats(pack_dir: Path, council_run: Any) -> set[str]:
+    """Resolves `council_run` (declared as a path relative to the pack's
+    OWN directory — mirrors check_brief_ref_exists's repo-confinement
+    shape, scoped to pack_dir instead of repo_root) to a journal.jsonl and
+    returns the set of COUNCIL_REVIEW_SEATS values seen on lines shaped
+    {"seat": str, "role": "review", "ok": true, "ts": str}. A line with
+    extra/missing/wrong-typed keys just doesn't count (skipped, never
+    raises) — same "degrade, don't crash" convention as sum_numstat().
+    Returns the empty set (never raises) on: council_run missing/not a
+    string, an absolute path, a path escaping pack_dir via `..`, a path
+    that doesn't resolve to a file, or unreadable/non-JSON-Lines content —
+    the caller treats that exactly like "found zero qualifying seats"."""
+    if not isinstance(council_run, str) or not council_run.strip():
+        return set()
+    if Path(council_run).is_absolute():
+        return set()
+    pack_dir_resolved = pack_dir.resolve()
+    journal_path = (pack_dir / council_run).resolve()
+    if pack_dir_resolved not in (journal_path, *journal_path.parents):
+        return set()
+    if not journal_path.is_file():
+        return set()
+    try:
+        text = journal_path.read_text(encoding="utf-8")
+    except OSError:
+        return set()
+    seats: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("role") != "review" or entry.get("ok") is not True:
+            continue
+        seat = entry.get("seat")
+        if isinstance(seat, str) and seat.strip() in COUNCIL_REVIEW_SEATS:
+            seats.add(seat.strip())
+    return seats
+
+
+def check_council_run_gear3(
+    pack: dict[str, Any],
+    pack_dir: Path,
+    gear: int | None,
+    today: datetime.date | None = None,
+) -> tuple[list[str], str | None]:
+    """R9: a Gear-3 pack must declare `council_run: <path relative to the
+    pack dir>` resolving to a journal.jsonl (inside the pack dir) carrying
+    >=2 DISTINCT seats from COUNCIL_REVIEW_SEATS, each posting a line
+    shaped {"seat": "...", "role": "review", "ok": true, "ts": "..."}.
+    GUILT: gear==3, <2 distinct qualifying seats, no override -> phased
+    violation. INNOCENCE: gear != 3 (skipped outright — Gear-3-only, same
+    convention as check_dissent_nonempty_on_gear3); >=2 distinct seats
+    found; seat_override present. Known day-0 measure, declared in this
+    PR's body and NOT a bug: every EXISTING Gear-3 pack predates
+    `council_run` entirely and will NOTICE (not FAIL) until 2026-09-02."""
+    if gear != 3:
+        return [], None
+    seats = _read_council_journal_seats(pack_dir, pack.get("council_run"))
+    has_quorum = len(seats) >= 2
+    message = (
+        "gear:3 pack declares no council_run journal with >=2 distinct "
+        f"review seats from {COUNCIL_REVIEW_SEATS} marked ok:true"
+    )
+    return _r9_r11_verdict("council_run", not has_quorum, message, pack, today)
+
+
 # ------------------------------------------------------------------- lint()
 
 
@@ -776,6 +978,16 @@ def lint(
     violations += lane_violations
     if lane_notice:
         print(f"evidence_pack_lint: NOTICE — {lane_notice}", file=sys.stderr)
+
+    seat_floor_violations, seat_floor_notice = check_cheap_seat_floor(pack, changed_files)
+    violations += seat_floor_violations
+    if seat_floor_notice:
+        print(f"evidence_pack_lint: NOTICE — {seat_floor_notice}", file=sys.stderr)
+
+    council_violations, council_notice = check_council_run_gear3(pack, pack_path.parent, gear)
+    violations += council_violations
+    if council_notice:
+        print(f"evidence_pack_lint: NOTICE — {council_notice}", file=sys.stderr)
 
     if changed_files is None:
         print("evidence_pack_lint: NOTICE — no --changed-files-file supplied, "

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -772,17 +772,26 @@ def _r9_r11_verdict(
 
 #: R11 — path classes judged MECHANICAL: translated strings, test fixtures,
 #: the modus PENDING-ARMS ledger (append-only, human-authored prose), and a
-#: mouth catalog data file. `fnmatch`'s `*` crosses `/` so a doubled `**`
-#: here behaves like a single `*` — verified against the real tree
-#: (`apps/mouth/src/i18n/locales/en.json` etc.) 2026-08-26: every real
-#: i18n/locales file on disk sits at least one directory below its
-#: `i18n`/`locales` segment, so the extra `/` the doubled glob demands is
-#: always present; a hypothetical `i18n/foo.json` with no subdirectory
-#: would NOT match — no such file exists in this repo today.
+#: mouth catalog asset (product photo, not source code). CORRECTED
+#: 2026-08-27 by refuter round 1: the original `**/i18n/**/*.json` and
+#: `**/locales/**/*.json` (a DOUBLED `**` with a literal `/` in between)
+#: each demand an EXTRA path segment between the directory name and the
+#: file — verified empirically with `fnmatch.fnmatchcase`, not by regex
+#: reasoning by hand (the reasoning-by-hand version of this comment was
+#: itself wrong and is why this needed correcting): every real on-disk
+#: locale file sits directly at `<i18n-dir>/locales/<lang>.json` with NO
+#: further subdirectory, so `**/locales/**/*.json` matched ZERO real files
+#: (dead code) and `**/i18n/**/*.json` matched only by the incidental luck
+#: of the `locales/` segment supplying that extra required `/` — a locale
+#: file placed directly under `i18n/` with no `locales/` subfolder would
+#: have been missed. Since `fnmatch`'s single `*` already crosses `/`,
+#: the trailing `**` bought nothing: `**/i18n/*.json` and
+#: `**/locales/*.json` (single star before the filename) match every real
+#: file below EITHER nesting depth and are the patterns actually in force.
 MECHANICAL_PATH_PATTERNS: tuple[str, ...] = (
     ".claude/skills/modus/PENDING-ARMS.md",
-    "**/i18n/**/*.json",
-    "**/locales/**/*.json",
+    "**/i18n/*.json",
+    "**/locales/*.json",
     "**/fixtures/**",
     "apps/mouth/**/catalog*/**",
 )
@@ -895,6 +904,9 @@ def _read_council_journal_seats(pack_dir: Path, council_run: Any) -> set[str]:
             continue
         if entry.get("role") != "review" or entry.get("ok") is not True:
             continue
+        ts = entry.get("ts")
+        if not isinstance(ts, str) or not ts.strip():
+            continue  # the declared minimal schema requires "ts" too
         seat = entry.get("seat")
         if isinstance(seat, str) and seat.strip() in COUNCIL_REVIEW_SEATS:
             seats.add(seat.strip())
@@ -979,6 +991,15 @@ def lint(
     if lane_notice:
         print(f"evidence_pack_lint: NOTICE — {lane_notice}", file=sys.stderr)
 
+    if changed_files is None:
+        # Self-contained notice (not folded into the shared "no
+        # --changed-files-file supplied" message a few lines below, which
+        # #5054/PR-A also extends — two PRs editing that one shared string
+        # is a guaranteed merge collision; see this PR's own body for why
+        # it stays self-contained from #5054 throughout).
+        print("evidence_pack_lint: NOTICE — no --changed-files-file "
+              "supplied, seat_floor check (rule 11) skipped for this run",
+              file=sys.stderr)
     seat_floor_violations, seat_floor_notice = check_cheap_seat_floor(pack, changed_files)
     violations += seat_floor_violations
     if seat_floor_notice:

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -1050,14 +1050,18 @@ _R9_R11_POST_FLIP = R9_R11_ENFORCEMENT_DATE
         ".claude/skills/modus/PENDING-ARMS.md",
         "apps/mouth/src/i18n/locales/en.json",
         "apps/admin-dashboard/src/i18n/locales/it.json",
-        "scripts/tests/fixtures/sample.json",
-        "packages/research-os-core/fixtures/p04/valid_01.json",
-        "apps/mouth/public/catalog/services.json",
+        "scripts/tests/fixtures/merge_gate_integrity/guilt_3227.json",
+        "packages/research-os-core/fixtures/object_successor_edge/valid_with_actor.json",
+        "apps/mouth/public/catalog/consultant-services-update-data-coretax-activation.jpg",
     ],
 )
 def test_compute_seat_floor_guilt_single_mechanical_file_is_true(path):
-    """GUILT (for the predicate): each real on-disk MECHANICAL_PATH_PATTERNS
-    class, alone, makes the whole (1-file) diff count as 100% mechanical."""
+    """GUILT (for the predicate): each of these six is a REAL, on-disk file
+    (verified 2026-08-27 by refuter round 1, which found 3 of the original
+    6 example paths here were invented/illustrative rather than real —
+    corrected to actual `find`-verified paths) covering every
+    MECHANICAL_PATH_PATTERNS class; each, alone, makes the whole (1-file)
+    diff count as 100% mechanical."""
     assert compute_seat_floor([path]) is True
 
 
@@ -1214,6 +1218,34 @@ def test_council_run_guilt_ok_false_or_wrong_role_does_not_count(tmp_path):
     assert viol and "council_run" in viol[0]
 
 
+def test_council_run_guilt_missing_ts_does_not_count(tmp_path):
+    """GUILT (regression, refuter round 1 2026-08-27): the declared minimal
+    schema is {"seat", "role": "review", "ok": true, "ts"} — a line missing
+    `ts` (or with it empty/non-string) was silently accepted before this
+    fix; now it does not count toward quorum, same as a missing seat."""
+    _write_journal(tmp_path, "journal.jsonl", [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True},
+        {"seat": "kimi-code/k3", "role": "review", "ok": True, "ts": ""},
+    ])
+    pack = {"council_run": "journal.jsonl"}
+    viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol and "council_run" in viol[0]
+
+
+def test_council_run_guilt_duplicate_only_postings_below_quorum_rejected(tmp_path):
+    """GUILT (regression, refuter round 1 2026-08-27): the SAME seat
+    posting many times must not be mistaken for multiple distinct seats —
+    5 lines, all from one seat, is still only 1 distinct seat, still below
+    the >=2 quorum."""
+    _write_journal(tmp_path, "journal.jsonl", [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True, "ts": f"t{i}"}
+        for i in range(5)
+    ])
+    pack = {"council_run": "journal.jsonl"}
+    viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol and "council_run" in viol[0]
+
+
 def test_council_run_innocence_two_distinct_qualifying_seats_passes(tmp_path):
     """INNOCENCE: >=2 distinct COUNCIL_REVIEW_SEATS members, each ok:true
     role:review, clears the rule — a duplicate posting from the same seat
@@ -1261,6 +1293,21 @@ def test_seat_floor_end_to_end_through_lint(tmp_repo):
     else:
         assert rc == 1
         assert any("seat_floor" in v for v in viol)
+
+
+def test_seat_floor_end_to_end_notice_when_no_changed_files(tmp_repo, capsys):
+    """End-to-end regression (refuter round 1 2026-08-27): with no
+    --changed-files-file, R11 is silently unable to fire (compute_seat_floor
+    is False-by-construction on None) — lint() must SAY so on stderr, the
+    same transparency convention rule 6's own skip-notice already has,
+    rather than silently doing nothing."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    write_pack(lanes=[{"lane": "D1", "role": "build", "seat": "claude-opus-5"}])
+    rc, viol = lint(tmp_path / "evidence" / "pack.yml", tmp_path, None)
+    assert rc == 0 and viol == []
+    err = capsys.readouterr().err
+    assert "seat_floor check (rule 11) skipped" in err
 
 
 def test_council_run_end_to_end_through_lint(tmp_repo):

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import datetime
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -24,8 +23,11 @@ SCRIPTS = REPO / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 from evidence_pack_lint import (  # noqa: E402
     LANES_NON_ANTHROPIC_ENFORCEMENT_DATE,
+    R9_R11_ENFORCEMENT_DATE,
     _is_anthropic_seat,
     check_brief_ref_exists,
+    check_cheap_seat_floor,
+    check_council_run_gear3,
     check_dissent_nonempty_on_gear3,
     check_gear_floor,
     check_lanes_build_seat_diversity,
@@ -34,6 +36,7 @@ from evidence_pack_lint import (  # noqa: E402
     check_size_budget,
     compute_ceiling,
     compute_floor,
+    compute_seat_floor,
     effort_for_gear,
     lint,
     sum_numstat,
@@ -1023,3 +1026,254 @@ def test_lanes_gear3_opus5_sonnet5_flip_behavior():
     )
     assert violations
     assert notice is None
+
+
+# ============================================================================
+# PR-B: R11 cheap-seat floor for mechanical diffs + R9 Gear-3 council_run
+# (2026-08-26-PIANO-SPEC-receptor-live.md §8). Self-contained on this branch
+# (created before #5054/R8-R10 merged) — R9_R11_ENFORCEMENT_DATE is its own
+# constant, not SEAT_RULES_ENFORCEMENT_DATE, precisely so this module never
+# ends up with two same-named top-level definitions regardless of merge
+# order between the two PRs.
+# ============================================================================
+
+_R9_R11_PRE_FLIP = R9_R11_ENFORCEMENT_DATE - datetime.timedelta(days=1)
+_R9_R11_POST_FLIP = R9_R11_ENFORCEMENT_DATE
+
+
+# ---- R11: compute_seat_floor (pure predicate) ------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".claude/skills/modus/PENDING-ARMS.md",
+        "apps/mouth/src/i18n/locales/en.json",
+        "apps/admin-dashboard/src/i18n/locales/it.json",
+        "scripts/tests/fixtures/sample.json",
+        "packages/research-os-core/fixtures/p04/valid_01.json",
+        "apps/mouth/public/catalog/services.json",
+    ],
+)
+def test_compute_seat_floor_guilt_single_mechanical_file_is_true(path):
+    """GUILT (for the predicate): each real on-disk MECHANICAL_PATH_PATTERNS
+    class, alone, makes the whole (1-file) diff count as 100% mechanical."""
+    assert compute_seat_floor([path]) is True
+
+
+def test_compute_seat_floor_innocence_one_non_mechanical_file_flips_to_false():
+    """INNOCENCE: a diff that is mostly mechanical but touches even ONE
+    real code file is NOT 100% mechanical — the rule is all-or-nothing."""
+    assert compute_seat_floor([
+        "apps/mouth/src/i18n/locales/en.json",
+        "apps/backend-rag/backend/app/main.py",
+    ]) is False
+
+
+def test_compute_seat_floor_innocence_empty_or_none_is_false():
+    """INNOCENCE: no changed files is not evidence of "100% mechanical" —
+    same convention as compute_floor's own empty-diff handling."""
+    assert compute_seat_floor([]) is False
+    assert compute_seat_floor(None) is False
+
+
+# ---- R11: check_cheap_seat_floor -------------------------------------------
+
+
+_MECHANICAL_DIFF = ["apps/mouth/src/i18n/locales/en.json", ".claude/skills/modus/PENDING-ARMS.md"]
+
+
+def test_cheap_seat_floor_guilt_no_cheap_lane_rejected_post_flip():
+    """GUILT: a 100%-mechanical diff with only a frontier-tier build seat
+    and no override is a violation on/after the flip."""
+    pack = {"lanes": [{"lane": "D1", "role": "build", "seat": "claude-opus-5"}]}
+    viol, notice = check_cheap_seat_floor(pack, _MECHANICAL_DIFF, today=_R9_R11_POST_FLIP)
+    assert viol and "seat_floor" in viol[0]
+    assert notice is None
+
+
+def test_cheap_seat_floor_innocence_not_100pct_mechanical_skipped():
+    """INNOCENCE: a diff that is not 100% mechanical is not this rule's
+    problem, regardless of seats."""
+    pack = {"lanes": [{"lane": "D1", "role": "build", "seat": "claude-opus-5"}]}
+    viol, notice = check_cheap_seat_floor(
+        pack, ["apps/backend-rag/backend/app/main.py"], today=_R9_R11_POST_FLIP
+    )
+    assert viol == [] and notice is None
+    viol, notice = check_cheap_seat_floor(pack, None, today=_R9_R11_POST_FLIP)
+    assert viol == [] and notice is None
+
+
+@pytest.mark.parametrize(
+    "seat",
+    [
+        "claude-haiku-4-5",
+        "claude-haiku-4-5-20251001",
+        "codex-gpt-5.6-luna",
+        "kimi-code/kimi-for-coding-highspeed",
+        "tp1-qwen3.6-flash",
+        "tp1-deepseek-v4-flash-0731",
+    ],
+)
+def test_cheap_seat_floor_innocence_cheap_build_lane_passes(seat):
+    """INNOCENCE: any CHEAP_SEATS-prefixed build-lane seat clears the rule,
+    even with a trailing version suffix (prefix match, not exact)."""
+    pack = {"lanes": [{"lane": "D1", "role": "build", "seat": seat}]}
+    viol, notice = check_cheap_seat_floor(pack, _MECHANICAL_DIFF, today=_R9_R11_POST_FLIP)
+    assert viol == [] and notice is None
+
+
+def test_cheap_seat_floor_guilt_non_build_lane_does_not_count():
+    """GUILT (for the role filter): a cheap seat on a REVIEW lane does not
+    satisfy R11 — the requirement is specifically a build lane."""
+    pack = {"lanes": [{"lane": "D1", "role": "review", "seat": "claude-haiku-4-5"},
+                       {"lane": "D2", "role": "build", "seat": "claude-opus-5"}]}
+    viol, notice = check_cheap_seat_floor(pack, _MECHANICAL_DIFF, today=_R9_R11_POST_FLIP)
+    assert viol and "seat_floor" in viol[0]
+
+
+def test_cheap_seat_floor_innocence_seat_override_reports_not_fails():
+    """INNOCENCE: `seat_override` clears the violation and is reported."""
+    pack = {
+        "lanes": [{"lane": "D1", "role": "build", "seat": "claude-opus-5"}],
+        "seat_override": "mechanical-looking diff also touched generated code, verified by hand",
+    }
+    viol, notice = check_cheap_seat_floor(pack, _MECHANICAL_DIFF, today=_R9_R11_POST_FLIP)
+    assert viol == []
+    assert notice is not None and "(overridden)" in notice
+
+
+def test_cheap_seat_floor_innocence_pre_flip_notice_not_fail():
+    """INNOCENCE: the same guilty shape only NOTICEs before the flip."""
+    pack = {"lanes": [{"lane": "D1", "role": "build", "seat": "claude-opus-5"}]}
+    viol, notice = check_cheap_seat_floor(pack, _MECHANICAL_DIFF, today=_R9_R11_PRE_FLIP)
+    assert viol == []
+    assert notice is not None and "seat_floor" in notice
+
+
+# ---- R9: check_council_run_gear3 -------------------------------------------
+
+
+def _write_journal(tmp_path: Path, name: str, lines: list[dict]) -> Path:
+    import json as _json
+
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("\n".join(_json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+    return p
+
+
+def test_council_run_innocence_gear_not_3_skipped(tmp_path):
+    """INNOCENCE: this rule is Gear-3-only — Gear 1/2 (or unknown gear)
+    is not its problem, regardless of council_run."""
+    for gear in (None, 1, 2):
+        viol, notice = check_council_run_gear3({}, tmp_path, gear, today=_R9_R11_POST_FLIP)
+        assert viol == [] and notice is None
+
+
+def test_council_run_guilt_no_council_run_field_rejected_post_flip(tmp_path):
+    """GUILT: a Gear-3 pack with no `council_run` field at all is a
+    violation on/after the flip."""
+    viol, notice = check_council_run_gear3({}, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol and "council_run" in viol[0]
+    assert notice is None
+
+
+def test_council_run_guilt_dangling_or_escaping_path_rejected(tmp_path):
+    """GUILT: council_run pointing nowhere, or escaping pack_dir via `..`,
+    or an absolute path, all count as zero qualifying seats — none of them
+    raise."""
+    for bad in ("journal.jsonl", "../../etc/passwd", "/etc/passwd"):
+        pack = {"council_run": bad}
+        viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+        assert viol and "council_run" in viol[0]
+
+
+def test_council_run_guilt_single_seat_below_quorum_rejected(tmp_path):
+    """GUILT: exactly one distinct qualifying review seat is below the
+    >=2 quorum."""
+    _write_journal(tmp_path, "journal.jsonl", [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True, "ts": "2026-08-26T00:00:00Z"},
+    ])
+    pack = {"council_run": "journal.jsonl"}
+    viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol and "council_run" in viol[0]
+    assert notice is None
+
+
+def test_council_run_guilt_ok_false_or_wrong_role_does_not_count(tmp_path):
+    """GUILT (for the line filter): a line with ok:false, or role != review,
+    does not count toward quorum even from a real COUNCIL_REVIEW_SEATS
+    member — 2 such lines still leaves zero qualifying seats."""
+    _write_journal(tmp_path, "journal.jsonl", [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": False, "ts": "x"},
+        {"seat": "kimi-code/k3", "role": "build", "ok": True, "ts": "x"},
+    ])
+    pack = {"council_run": "journal.jsonl"}
+    viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol and "council_run" in viol[0]
+
+
+def test_council_run_innocence_two_distinct_qualifying_seats_passes(tmp_path):
+    """INNOCENCE: >=2 distinct COUNCIL_REVIEW_SEATS members, each ok:true
+    role:review, clears the rule — a duplicate posting from the same seat
+    does not inflate the distinct count (mirrors the guilt case above)."""
+    _write_journal(tmp_path, "council/journal.jsonl", [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True, "ts": "a"},
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True, "ts": "b"},
+        {"seat": "kimi-code/k3", "role": "review", "ok": True, "ts": "c"},
+        {"seat": "not-a-council-seat", "role": "review", "ok": True, "ts": "d"},
+    ])
+    pack = {"council_run": "council/journal.jsonl"}
+    viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol == [] and notice is None
+
+
+def test_council_run_innocence_seat_override_reports_not_fails(tmp_path):
+    """INNOCENCE: `seat_override` clears the violation and is reported."""
+    pack = {"seat_override": "solo emergency hotfix, verified live under active incident"}
+    viol, notice = check_council_run_gear3(pack, tmp_path, gear=3, today=_R9_R11_POST_FLIP)
+    assert viol == []
+    assert notice is not None and "(overridden)" in notice
+
+
+def test_council_run_innocence_pre_flip_notice_not_fail(tmp_path):
+    """INNOCENCE: the same guilty shape only NOTICEs before the flip —
+    and this is the day-0 measure the PR body declares: every EXISTING
+    Gear-3 pack predates council_run entirely."""
+    viol, notice = check_council_run_gear3({}, tmp_path, gear=3, today=_R9_R11_PRE_FLIP)
+    assert viol == []
+    assert notice is not None and "council_run" in notice
+
+
+# ---- end-to-end: lint() wires both R11 and R9 through one call site -------
+
+
+def test_seat_floor_end_to_end_through_lint(tmp_repo):
+    """End-to-end: lint() surfaces an R11 seat_floor violation for a real
+    pack+brief tree via the public entry point."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    write_pack(lanes=[{"lane": "D1", "role": "build", "seat": "claude-opus-5"}])
+    rc, viol = lint(tmp_path / "evidence" / "pack.yml", tmp_path, _MECHANICAL_DIFF)
+    if datetime.datetime.now(datetime.timezone.utc).date() < R9_R11_ENFORCEMENT_DATE:
+        assert rc == 0
+    else:
+        assert rc == 1
+        assert any("seat_floor" in v for v in viol)
+
+
+def test_council_run_end_to_end_through_lint(tmp_repo):
+    """End-to-end: lint() surfaces an R9 council_run violation for a real
+    Gear-3 pack+brief tree via the public entry point (pack_dir resolution
+    comes from pack_path.parent inside lint(), not a parameter the caller
+    threads through)."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=3)
+    write_pack(dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}])
+    rc, viol = lint(tmp_path / "evidence" / "pack.yml", tmp_path, None)
+    if datetime.datetime.now(datetime.timezone.utc).date() < R9_R11_ENFORCEMENT_DATE:
+        assert rc == 0
+    else:
+        assert rc == 1
+        assert any("council_run" in v for v in viol)


### PR DESCRIPTION
feat(evidence-pack): cheap-seat floor for mechanical diffs + Gear-3 council_run — NOTICE until 2026-09-02

Implements enforcers R11 (compute_seat_floor / check_cheap_seat_floor) and R9
(check_council_run_gear3), the two rules spec'd in
2026-08-26-PIANO-SPEC-receptor-live.md §8 alongside R8/R10 (PR-A, #5054).

- R11: when 100% of a diff's changed files fall into MECHANICAL_PATH_PATTERNS
  (i18n/locales strings, test fixtures, the modus PENDING-ARMS.md ledger, a
  mouth catalog data file), the pack must declare a `role: build` lane whose
  seat starts with a CHEAP_SEATS entry (claude-haiku-4-5,
  codex-gpt-5.6-luna, kimi-code/kimi-for-coding-highspeed,
  tp1-qwen3.6-flash, tp1-deepseek-v4-flash-0731) — or carry
  `seat_override: <reason>`.
- R9: a gear:3 pack must declare `council_run: <path relative to the pack
  dir>` resolving to a journal.jsonl with >=2 DISTINCT seats from
  {codex-gpt-5.6-sol, kimi-code/k3, tp1-qwen3.8-max}, each posting a line
  shaped {"seat", "role": "review", "ok": true, "ts"} — or carry
  `seat_override: <reason>`.

Both NOTICE (rc=0) before 2026-09-02, hard FAIL on/after.

## Self-contained by design (not a duplicate-vs-#5054 bug)

This branch was created from origin/main BEFORE #5054 (R8+R10) merged, so it
does not have that PR's `SEAT_RULES_ENFORCEMENT_DATE` / `_seat_rule_verdict`
shared phasing helper to reuse. Per the mandate's own named fallback for this
ordering, this PR is self-contained: its own `R9_R11_ENFORCEMENT_DATE`
constant and `_r9_r11_verdict` helper, deliberately named DIFFERENTLY from
#5054's so the module never carries two same-named top-level definitions
regardless of which PR's merge lands first (a real risk with a shared name:
Python allows silent redefinition, but ruff's F811 would fail CI on it).
Merge order: #5054 should land before this PR; if it lands after, this PR's
own helpers keep working unchanged — the resulting duplication is a small,
inert wart (two near-identical 15-line helpers with different names) that a
follow-up PR can retire by having R9/R11 reuse #5054's `_seat_rule_verdict`
once both are on main together.

Docstring note: the module-level rule-list docstring (~line 138) that #5054
edited to document R8/R10 is NOT touched here, deliberately — #5054 and this
PR both insert content in that same region, and a real PR-A/PR-B collision
there would only ever be resolved by hand at merge time regardless of what
either PR writes. Every new rule here is fully documented in its own
function docstring instead (check_cheap_seat_floor, check_council_run_gear3,
compute_seat_floor, _read_council_journal_seats) — a follow-up can fold a
one-paragraph summary into the module docstring once both PRs are on main.

## Day-0 measurement

Ran the new lint against all 27 existing packs under evidence/**: 26 rc=0,
1 pre-existing unrelated failure (a dissent-rule violation on
evidence/2026-08/.../p04-d3-correc-7cfde7fc/pack.yml — reproduces identically
against the unmodified pack, confirmed not caused by R9/R11).

- R11 (seat_floor): 0 NOTICEs — none of the 27 packs were linted with
  --changed-files-file scoping (day-0 packs predate diff-path awareness),
  and compute_seat_floor(None) is False by construction, same reason R8/R10
  fired zero NOTICEs on the existing tree in #5054.
- R9 (council_run): NOTICE on all 27/27 packs. Verified by direct code
  (not grep on brief.yml text, which undercounted): every single existing
  pack is gear:3 and none declares `council_run` — this is the exact day-0
  measure the mandate names ("every existing Gear-3 pack will NOTICE on R9:
  that is the day-0 measure, not a bug"), not a regression.

**Methodology correction (found during adversarial review, see below):** "27/27
packs are gear:3" is true as measured but the mechanism is not what it first
looks like. Every one of the 27 archived packs declares the literal fixed
path `brief_ref: evidence/brief.yml` — so a day-0 sweep run with
`--repo-root .` resolves every archived pack's gear against the SAME
currently-live top-level `brief.yml`, not each pack's own historical brief at
the time it was produced. The 27/27 figure measures "what the live brief.yml
says today, replayed 27 times," not 27 independently-declared historical
gear values. It does not change the NOTICE-vs-FAIL conclusion (the day-0
NOTICE count is correct either way), but it is a materially different claim
about what was measured, and worth stating precisely rather than implying
27 independent data points.

## Test plan

- [x] scripts/tests/test_evidence_pack_lint.py — 127 passed (guilt+
      innocence per rule, parametrized over real repo paths, pre-flip/
      post-flip date-freeze tests, end-to-end lint() tests; grew from 124
      to 127 after the adversarial-review round below)
- [x] infra/guard-conformance/check_guard_conformance.py — 0 violations
      (registry.json gains check_cheap_seat_floor + check_council_run_gear3)
- [x] scripts/evidence_pack_lint.py --selftest — SELFTEST PASS, no
      regressions on the 6 pre-existing rules
- [x] ruff check on both touched Python files — clean
- [x] Day-0 measurement above, run against the real evidence/ tree

## Adversarial review

Refuter: `codex exec --sandbox read-only -m gpt-5.6-sol -c model_reasoning_effort="high"`
(generator≠grader — Sonnet 5 implemented, Codex/gpt-5.6-sol reviewed).

**Round 1** — found real defects, all fixed in `da2a49fc0`:
1. `MECHANICAL_PATH_PATTERNS` used `**/i18n/**/*.json` / `**/locales/**/*.json` — a literal
   `/` between two `**` groups requires an actual extra path segment on disk. Verified
   empirically with a standalone `fnmatch` probe that `**/locales/**/*.json` matched ZERO
   real on-disk locale files (dead) and `**/i18n/**/*.json` matched only by incidental
   nesting luck. Fixed to single-star `**/i18n/*.json` / `**/locales/*.json`, re-verified to
   still match all real files.
2. 3 of the 6 test example paths for the mechanical-diff guilt fixture were fabricated (not
   actually present on disk: `scripts/tests/fixtures/sample.json`,
   `packages/research-os-core/fixtures/p04/valid_01.json`,
   `apps/mouth/public/catalog/services.json`). Verified via `find`, replaced with real
   `find`-confirmed substitutes in the same directories.
3. `_read_council_journal_seats` never validated the declared `ts` field despite the schema
   requiring it. Added an explicit non-empty-string check; added a guilt test
   (`test_council_run_guilt_missing_ts_does_not_count`) proving a line missing `ts` doesn't
   count toward quorum.
4. Added a regression test proving duplicate postings from the SAME seat never satisfy the
   >=2-DISTINCT-seat quorum on their own
   (`test_council_run_guilt_duplicate_only_postings_below_quorum_rejected`), and a notice-path
   test for the no-`--changed-files-file` case
   (`test_seat_floor_end_to_end_notice_when_no_changed_files`, using pytest's `capsys`).
5. Surfaced the day-0 methodology point above (not a code defect, a measurement-precision
   finding) — folded into the Day-0 measurement section rather than left only here.

No findings were rejected — all were real and fixed. Verified: 127 passed (up from 124),
selftest PASS, guard-conformance 0 violations, ruff clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


