### PR TITLE
fix(email): stop transcribing recipient addresses into logs and the Telegram alert

### DIFF
--- a/apps/backend-rag/backend/app/services/internal_email.py
+++ b/apps/backend-rag/backend/app/services/internal_email.py
@@ -38,6 +38,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
+from backend.security.pii_log_identifier import redact_identifier_for_log
 from backend.services.notifications.email_audit import (
     format_send_error,
     is_critical,
@@ -131,9 +132,9 @@ async def send_internal_email(
         response.raise_for_status()
 
         logger.info(
-            "Internal email sent: to=%s cc=%s context=%s",
-            to,
-            payload.get("cc", ""),
+            "Internal email sent: to=%s cc_count=%d context=%s",
+            redact_identifier_for_log(to),
+            len(cc or []),
             log_context or "",
         )
         if audit_enabled:

--- a/apps/backend-rag/backend/services/notifications/email_audit.py
+++ b/apps/backend-rag/backend/services/notifications/email_audit.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 from backend.core.secret_log_redaction import install_telegram_token_redaction
+from backend.security.pii_log_identifier import redact_identifier_for_log
 
 install_telegram_token_redaction()
 
@@ -201,7 +202,7 @@ def notify_email_failure_critical(
         logger.warning(
             "email_audit: TELEGRAM_BOT_TOKEN not set; skipping alert for %s → %s",
             email_type,
-            to_email,
+            redact_identifier_for_log(to_email),
         )
         return
 
@@ -222,7 +223,7 @@ def notify_email_failure_critical(
     text = (
         "🚨 *Email delivery failure* — critical path\n\n"
         f"*Type:* `{email_type}`{practice_fragment}\n"
-        f"*To:* `{to_email}`\n"
+        f"*To:* `{redact_identifier_for_log(to_email)}`\n"
         f"*Subject:* {short_subj}\n"
         f"*Error:* `{short_err}`\n\n"
         f"{footer}"

--- a/apps/backend-rag/backend/tests/unit/app/services/test_internal_email.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/test_internal_email.py
@@ -1,5 +1,6 @@
 """Tests for the shared internal email client."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -212,3 +213,52 @@ class TestSendInternalEmail:
                     body="<p>x</p>",
                     raise_on_failure=True,
                 )
+
+
+class TestRecipientNeverReachesTheLog:
+    """The success log line is a shared surface, and one nothing scrubs.
+
+    Note what the leak is NOT: Sentry is already covered for this PII class —
+    ``sentry_config._redact_string`` runs ``_EMAIL_RE`` over every free-text
+    string on the way out, so an address in a breadcrumb is masked before it
+    leaves the process. The uncovered surface is the process's own stdout,
+    which on Fly is retained and searchable with no scrubber in between.
+
+    The address stays in the ``email_send_log`` row — the retry worker must
+    read it to resend — and the log gets a stand-in instead.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_log_carries_a_stand_in_not_the_address(self, caplog) -> None:
+        from backend.security.pii_log_identifier import redact_identifier_for_log
+
+        mock_client, _ = _make_mock_client()
+        recipient = "giulia.ferrari@example.net"
+
+        with patch(
+            "backend.app.services.internal_email.get_email_client",
+            new=AsyncMock(return_value=mock_client),
+        ):
+            with caplog.at_level(logging.INFO, logger="backend.app.services.internal_email"):
+                await send_internal_email(
+                    to=recipient,
+                    subject="Hello",
+                    body="<p>body</p>",
+                    cc=["zero@balizero.com", "asya@balizero.com"],
+                    log_context="test req=1",
+                )
+
+        joined = " ".join(record.getMessage() for record in caplog.records)
+        # The send itself is untouched: the payload still carries real addresses.
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["to"] == recipient
+        assert payload["cc"] == "zero@balizero.com, asya@balizero.com"
+        # The log is not.
+        assert "giulia.ferrari" not in joined
+        assert "example.net" not in joined
+        assert "zero@balizero.com" not in joined
+        assert "asya@balizero.com" not in joined
+        # Both halves asserted: dropping the line entirely is not the fix.
+        assert redact_identifier_for_log(recipient) in joined
+        assert "cc_count=2" in joined
+        assert "test req=1" in joined

--- a/apps/backend-rag/backend/tests/unit/services/notifications/test_email_audit.py
+++ b/apps/backend-rag/backend/tests/unit/services/notifications/test_email_audit.py
@@ -9,10 +9,12 @@ Covers:
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from backend.security.pii_log_identifier import redact_identifier_for_log
 from backend.services.notifications.email_audit import (
     CRITICAL_EMAIL_TYPES,
     format_send_error,
@@ -360,3 +362,70 @@ def test_format_send_error_never_returns_empty_string():
         TimeoutError(),
     ]:
         assert format_send_error(exc) != ""
+
+
+# ----------------------------------------------------------------------
+# Recipient address never reaches a shared surface (SYMBIOSIS Law 2)
+# ----------------------------------------------------------------------
+
+
+def test_telegram_alert_never_transcribes_the_recipient_address(monkeypatch):
+    """The alert body carries a stand-in, never the address itself.
+
+    A Telegram alert is a shared surface in the sense CLAUDE.md §14 means:
+    "nessun output, memoria, skill, report, log, alert o artefatto condiviso
+    trascriva PII in chiaro". The operator keeps what triage needs — the
+    email_type, the practice, and a stable token — and resolves the actual
+    address in ``email_send_log``, which is where processing it is legitimate.
+
+    Both halves are asserted on purpose: absence alone would still pass if
+    someone deleted the *To:* line outright, which is not the fix.
+    """
+    from urllib.parse import quote_plus
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    address = "chiara.rossi@studio-legale-milano.it"
+
+    with patch("backend.services.notifications.email_audit.urllib.request.urlopen") as mock_open:
+        notify_email_failure_critical(
+            email_type="welcome",
+            to_email=address,
+            subject="Benvenuta",
+            practice_id=7,
+            error="brevo: 500",
+        )
+
+    body = mock_open.call_args[0][1].decode()
+    # Neither the local part nor the domain, in any encoding urlencode uses.
+    assert "chiara.rossi" not in body
+    assert "studio-legale-milano" not in body
+    assert quote_plus(address) not in body
+    # …and the stand-in is present, so the line still says something.
+    assert quote_plus(redact_identifier_for_log(address)) in body
+    # Triage keys survive.
+    assert "welcome" in body
+    assert "7" in body
+
+
+def test_missing_token_warning_does_not_log_the_recipient_address(monkeypatch, caplog):
+    """The no-token early return logs a warning; it must be address-free too.
+
+    This is the branch that fires in any environment where TELEGRAM_BOT_TOKEN
+    was never provisioned — i.e. exactly where nobody is watching the log.
+    """
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    address = "marco.bianchi@example.org"
+
+    with caplog.at_level(logging.WARNING, logger="backend.services.notifications.email_audit"):
+        notify_email_failure_critical(
+            email_type="hr_bonus",
+            to_email=address,
+            subject="Bonus",
+            practice_id=1,
+            error="anything",
+        )
+
+    joined = " ".join(record.getMessage() for record in caplog.records)
+    assert "marco.bianchi" not in joined
+    assert "example.org" not in joined
+    assert redact_identifier_for_log(address) in joined


### PR DESCRIPTION
## The defect

Three surfaces transcribe a recipient's email address in cleartext:

| Site | What it writes |
|---|---|
| `internal_email.py:133` | `to=<address> cc=<address, address>` on **every successful send** |
| `email_audit.py:225` | `*To:* <address>` in the Telegram alert body for every critical-email failure |
| `email_audit.py:203` | the address again, in the warning logged when `TELEGRAM_BOT_TOKEN` is unset |

Seven production callers reach that alert (`waiting_documents_service`,
`completed_process_service`, `welcome_email_service`, `portal_notification_service`,
`invoice_service`, `internal_email`, and the CRM notifiers), so the second and third
sites cover far more traffic than the file count suggests. Redaction happens at the
point of render, so **no call site changes** and no signature moves.

## What is NOT the reason

The obvious justification — "every `logger.info` is a Sentry breadcrumb" — does not
hold for this PII class, and I checked before writing it down.
`sentry_config._redact_string` applies `_EMAIL_RE` (`sentry_config.py:98,203`) to every
free-text string on the way out, so addresses in breadcrumbs are already masked.

The surfaces actually uncovered are the two Sentry never sees:

- the process's own log stream — stdout, which on Fly is retained and searchable, with
  no scrubber between `logger.info` and the log store;
- the Telegram alert, which is built with `urllib` inside `email_audit` and never passes
  through `before_send` at all.

## The stand-in

`redact_identifier_for_log` already exists (`backend/security/pii_log_identifier.py`):
HMAC-SHA256 keyed by `LOG_PII_HMAC_SALT`, `None`-safe, documented to handle email.
No new helper — the first draft of this change added one and it was a duplicate.

The address stays in `email_send_log`, which is where processing it is legitimate and
necessary: the retry worker reads that column to resend.

**Measured, and it qualifies what the stand-in can do:** `LOG_PII_HMAC_SALT` is not
provisioned on `nuzantara-rag` — `flyctl secrets list` shows `CRM_KG_HASH_SALT` and no
log salt. The helper therefore runs on its random per-process fallback in production.
Privacy is unaffected (an unguessable per-process key is strictly stronger), but the
token is stable only *within* one process: it changes on restart and differs between the
two Fly machines, so an operator cannot follow one recipient across either boundary.
Provisioning the secret is an operator action and is filed as such — it is not a
prerequisite for this change, which is strictly better than the cleartext it replaces.

## Tests

Four assertions, each checking **both halves** — that the address is gone AND that the
stand-in is present. Absence alone would still pass if someone deleted the `*To:*` line
outright, which is not the fix.

## Scope: what this does NOT fix

An AST census over the backend found **88** further `logger.*` calls passing an
identifier named `to`/`to_email`/`email`/`recipient` without redaction — auth, HR,
analytics, CRM, Zoho, invoicing, migrations, seed scripts. That census is coarse in both
directions: it certainly holds false positives (some of those names carry counts or
already-redacted values), and it under-counts, because it cannot see an address rendered
into an f-string rather than passed as a logging argument — which is exactly how the
Telegram alert leaked.

Those sites are reported, not swept: a blind 88-site edit is not reviewable, and calling
the family cured because three members were fixed is the failure mode this repo already
has a scar for.

## Adversarial review

Generator ≠ grader is honoured on the part that matters most here — whether the tests
prove anything — by mutating the source and requiring the suite to go red. Four
mutations, run in a throwaway worktree at this commit (never in the branch's own tree,
because the pre-push hook runs pytest there and a mutation would have failed the push
for an invented reason):

| Mutation | rc | Caught by |
|---|---|---|
| `redact_identifier_for_log(to)` → `to` | 1 | `test_success_log_carries_a_stand_in_not_the_address` |
| alert body f-string un-redacted | 1 | `test_telegram_alert_never_transcribes_the_recipient_address` |
| the whole `*To:*` line deleted | 1 | same test — this is the "presence" half doing its job |
| no-token warning un-redacted | 1 | `test_missing_token_warning_does_not_log_the_recipient_address` |

One mutation, one test, each caught by the intended one. Baseline 31 passed, no residual
diff in the throwaway tree.

### Claims retracted while writing this

Three things I asserted earlier and then measured to be false. They are listed because
each would have shipped a plausible, wrong justification into the repo:

1. **"The post-send audit write can make a delivered email read as failed, expiring a
   token the customer already holds."** Not reachable: `record_email_result` swallows
   every exception internally (`email_audit.py:159-160`, `:181-182`), so it cannot
   propagate into the caller's `except`.
2. **"Sentry breadcrumbs leak the address because redaction works by key."** False for
   this PII class — see the body above.
3. **My own first mutation harness reported `rc=1` with zero `FAILED` lines.** The
   pytest output carried ANSI colour codes, so `^FAILED` never matched; reporting that
   `rc=1` without opening the raw output would have been exactly the empty proof this
   battery exists to rule out. Re-run with `--color=no`, the attribution above is what
   came back.

### Verification gaps, stated

- The local pre-push hook **skips the backend suite by default**
  (`PREPUSH_RUN_BACKEND=0`); locally I ran the two changed test files (31 passed) plus
  every test file that imports either module (242 passed). The full suite is CI's
  `Backend Tests (Python)`, not something this branch has proven locally.
- The 88-site census is unverified per-site. It is a lead, not a finding.
