### PR TITLE
fix(visa-oracle): stop telling the visitor they submitted nothing when they did

### DIFF
--- a/apps/mouth/e2e/visa-oracle-v2.spec.ts
+++ b/apps/mouth/e2e/visa-oracle-v2.spec.ts
@@ -209,9 +209,16 @@ test.describe("Visa Oracle v2 integration — page Page", () => {
       fulfillJson(route, curated),
     );
     await page.goto("/visa-oracle");
+    // A pure CURATED response is NON_ENGINE_MODE, not a client-guard
+    // failure — an evaluation genuinely happened and was sealed, just not
+    // rendered as public authority. OracleShell.tsx routes this to the
+    // honest SHADOW headline (fix(visa-oracle): stop telling the visitor
+    // they submitted nothing when they did), matching the unit test in
+    // OracleShell.test.tsx. The malformed-JSON case below is unaffected —
+    // it is MALFORMED_RESPONSE, which stays CLIENT_GUARD.
     await expect(
       page.getByRole("heading", {
-        name: translate("en", "verdict.provenance_headline.CLIENT_GUARD"),
+        name: translate("en", "verdict.provenance_headline.SHADOW"),
       }),
     ).toBeVisible();
     await expect(page.getByText("Visit Visa C1")).toHaveCount(0);

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
@@ -209,16 +209,37 @@ describe("OracleShell authoritative evaluate integration", () => {
     expect(global.fetch).toHaveBeenCalledOnce();
   });
 
-  it("fails closed for a CURATED response in ENGINE mode", async () => {
+  it("fails closed for a CURATED response in ENGINE mode, and says so honestly", async () => {
     global.fetch = engineFetch("SUPPORTED_CANDIDATES", "CURATED");
     render(<OracleShell />);
 
+    // The load-bearing assertion, unchanged: a CURATED decision never
+    // becomes visible authority. This is what "fails closed" means and it
+    // is what the internal-preview test below cites as its innocence case.
+    expect(screen.queryByText("Visit Visa C1")).toBeNull();
+
+    // What DID change: this visitor used to be told "No evaluation was
+    // submitted", which is false -- the server evaluated, sealed and
+    // persisted a real decision, and only declined to render it as
+    // authority because public enforcement is off. That is the identical
+    // situation the SHADOW-mode test directly above covers, so it now
+    // shows the identical, true headline.
     expect(
       await screen.findByRole("heading", {
-        name: translate("en", "verdict.provenance_headline.CLIENT_GUARD"),
+        name: translate("en", "verdict.provenance_headline.SHADOW"),
       }),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Visit Visa C1")).toBeNull();
+
+    // Guard against regressing to the accusatory copy. Asserted on the
+    // literal sentence rather than on the provenance label, so a future
+    // refactor that reroutes this back into the client-guard bucket fails
+    // here even if it renames the label.
+    expect(screen.queryByText(/No evaluation was submitted/i)).toBeNull();
+    expect(
+      screen.queryByRole("heading", {
+        name: translate("en", "verdict.provenance_headline.CLIENT_GUARD"),
+      }),
+    ).toBeNull();
   });
 
   // The PIN-gated internal preview. Its innocence case is the test directly

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
@@ -251,6 +251,35 @@ function fallbackForError(
     if (degradedHumanReview) {
       return buildDegradedHumanReviewOutcome({ assumptions });
     }
+    // NON_ENGINE_MODE is not a guard failure and must not borrow the
+    // guard's copy. It means the server answered normally with
+    // `mode: "CURATED"` -- an evaluation genuinely happened, was sealed
+    // and was persisted -- and `requireEngineResponse` declined to render
+    // it as authority because public enforcement is off. Saying "No
+    // evaluation was submitted" to that visitor states the opposite of
+    // what occurred, and blames their interview for a server-side
+    // configuration they cannot see or influence.
+    //
+    // This is the rule `buildDegradedHumanReviewOutcome`'s own comment in
+    // outcome-fallbacks.ts already states: the "no evaluation was
+    // submitted" claim "must stay reserved for
+    // TEMPORARILY_UNAVAILABLE/network/parse failures" -- cases where the
+    // evaluation really did not happen. NON_ENGINE_MODE is not one of
+    // them; MALFORMED_RESPONSE and RESPONSE_INVARIANT are, because there
+    // the payload could not be trusted at all.
+    //
+    // The public rendering boundary is untouched: buildShadowOutcome
+    // returns TEMPORARILY_UNAVAILABLE with no candidates, exactly as the
+    // guard outcome did. A CURATED decision still never becomes visible
+    // authority. Only the sentence the visitor reads changes, from a
+    // false one to a true one -- and to the same sentence the explicit
+    // SHADOW branch below already shows for this identical situation.
+    if (error.code === "NON_ENGINE_MODE") {
+      return buildShadowOutcome({
+        code: "SHADOW_VERIFICATION_ONLY",
+        assumptions,
+      });
+    }
     return buildClientGuardOutcome({ code: error.code, assumptions });
   }
   return buildClientGuardOutcome({


### PR DESCRIPTION
## The screen the codeowner actually saw

A visitor who completes the interview at `/visa-oracle` is told:

> **This interview contains information the verified API cannot represent safely. No evaluation
> was submitted.**

Both sentences are false. This is the screen that prompted *"ma perché non risponde?"*

## What actually happens

| step | where | what |
|---|---|---|
| production runs SHADOW | `evaluate_path.py:243` | `resolve_response_mode()` returns `"CURATED"` |
| frontend demands ENGINE | `engine-response.ts:499` | `requireEngineResponse()` throws `NON_ENGINE_MODE` |
| every response error → guard | `OracleShell.tsx:253` | all three `VisaOracleResponseError` codes route to `buildClientGuardOutcome` |
| guard copy blames the user | `outcome-fallbacks.ts:39` | *"…No evaluation was submitted."* |

**The evaluation did happen.** The engine evaluated, sealed and persisted a real decision — 6,638
real rows since 2026-07-25. Nothing in the visitor's answers was unrepresentable. The only true
statement is that public enforcement is off, which they can neither see nor influence.

## This is the codebase's own rule, not a new one

`outcome-fallbacks.ts` already states it, in `buildDegradedHumanReviewOutcome`'s own comment:

> This is NOT "no evaluation was submitted": that claim **must stay reserved for
> TEMPORARILY_UNAVAILABLE/network/parse failures** where the [evaluation genuinely did not happen].

`NON_ENGINE_MODE` is not one of those. `MALFORMED_RESPONSE` and `RESPONSE_INVARIANT` are — there
the payload genuinely could not be trusted — and they keep the guard copy.

So `NON_ENGINE_MODE` now routes to `buildShadowOutcome`, which already says the true thing, and
already says it for this identical situation two branches further down the same file:

> Your assessment was submitted for verification. Public engine enforcement is disabled, so no
> visa path is shown.

## The security invariant is untouched

`buildShadowOutcome` returns `TEMPORARILY_UNAVAILABLE` with **no candidates**, exactly as the guard
outcome did. A CURATED decision still never becomes visible authority — the boundary
`engine-adapter.ts` calls *"CURATED can never become visible authority"* holds identically. Only
the sentence changes, from a false one to a true one.

## The test that pinned this, and why updating it is not reward-hacking

`OracleShell.test.tsx`'s *"fails closed for a CURATED response in ENGINE mode"* asserted **two**
things:

1. **no candidate renders** — the actual fail-closed claim, and the innocence case the
   internal-preview test directly below it cites by name. **Untouched, and now asserted first.**
2. the headline is `CLIENT_GUARD` — which pins *which sentence*, not *whether* it fails closed.
   Updated.

The test is now **stricter than before, not laxer**: it additionally asserts the literal sentence
*"No evaluation was submitted"* is absent, matched on the text rather than the provenance label,
so a future refactor that reroutes this back into the guard bucket fails here even if it renames
the label.

**Proven by mutation, not assertion.** Removing the six-line fix fails **exactly one** test — this
one. A test that passed either way would have proven nothing. The mutation ran on a scratch copy
and the tracked file was restored and diffed byte-identical afterwards; the first restore attempt
silently failed on a stale relative path, leaving the mutant on disk while `git diff --stat` still
looked plausible — caught by diffing against the saved original rather than trusting the stat.

**482 frontend tests green.**

## Wording is the codeowner's to override

The sentence shipped here is one the codebase already wrote for this state, not one invented in
this PR. If Zero wants different words for a visitor reaching a Visa Oracle that is deliberately
not yet enforcing, that is a Legge-5 call and this PR is where to make it. **Not armed for
auto-merge** for that reason.

## Related

- **#5059** — the retention-scope P0: the gate abstaining before any decision is persisted.
- **#5062** — the ENFORCE gate that could never pass, so SHADOW could never end.

This PR is the third: while SHADOW is the correct state, the page should say so honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
