### PR TITLE
fix(ci): route the evidence-pack ceremony into the docs-lane classifier

### DIFF
--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -277,6 +277,27 @@ DOC_PREFIXES = (
     ".claude/rules/",
     ".claude/commands/",
     ".claude/agents/",
+    # Zero's order 2026-08-27: docs-only PRs must stop paying the 5 heavy
+    # required checks. Every agent-produced PR writes evidence/brief.yml +
+    # evidence/pack.yml (the modus GROUND/CAPTURE ceremony — see
+    # evidence_pack_lint.py, harness-floor.yml) as fixed root-level paths,
+    # regardless of what the PR's real change is. Before this line,
+    # "evidence/" matched no EXACT_RULES/REGEX_RULES/PREFIX_RULES entry and
+    # fell through to `unknown_paths`, which forces run_all=True (the
+    # fail-open default) — so a purely-documentary PR that still carries its
+    # mandatory evidence pack paid for all six heavy jobs anyway, silently
+    # defeating the domain classifier for the single most common PR shape.
+    # Routing it into docs_content_data (same as this tuple's other
+    # ceremony/metadata prefixes) is correct, not a loophole: this module's
+    # `_suggested_jobs()` never grants docs_content_data any of the six
+    # heavy jobs, and evidence/*.yml is read by nothing under
+    # apps/backend-rag/, apps/mouth/, apps/admin-dashboard*/, apps/wa-mirror/,
+    # apps/nuzantara-mcp*/, apps/evaluator/, or packages/core/ (verified by
+    # grep, 2026-08-27) — so it cannot mask a real regression. A PR that
+    # ALSO changes real code keeps whatever domain that code earns; this
+    # only stops evidence/*.yml from being the one unclassified path that
+    # forces run_all=True on top of a genuinely narrow diff.
+    "evidence/",
 )
 DOC_SUFFIXES = (
     ".md",

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -10,6 +10,7 @@ import unittest
 from pathlib import Path
 
 import change_map as cm
+import security_gate_flags as sgf
 
 
 class ChangeMapTests(unittest.TestCase):
@@ -215,6 +216,84 @@ class ChangeMapTests(unittest.TestCase):
         self.assertTrue(result["domains"]["docs_content_data"])
         self.assertEqual(result["suggested_jobs"], [])
         self.assertEqual(result["would_skip"], list(cm.TEST_JOBS))
+
+    def test_innocence_evidence_pack_alone_skips_product_test_jobs(self) -> None:
+        # Zero's order 2026-08-27: docs-only PRs must stop paying the 5 heavy
+        # required checks. BEFORE the "evidence/" DOC_PREFIXES entry, these
+        # two exact paths matched no rule at all and fell through to
+        # `unknown_paths`, which forces run_all=True — so the mandatory
+        # evidence-pack ceremony (evidence_pack_lint.py / harness-floor.yml,
+        # written by every agent-produced PR) silently defeated L5's own
+        # docs-lane fast path for the single most common PR shape. This is
+        # the guilt case that motivated the fix: revert the "evidence/" line
+        # in change_map.py's DOC_PREFIXES and this test goes red with
+        # unknown_paths == ["evidence/brief.yml", "evidence/pack.yml"].
+        result = cm.classify(["evidence/pack.yml", "evidence/brief.yml"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["unknown_paths"], [])
+        self.assertTrue(result["domains"]["docs_content_data"])
+        self.assertEqual(result["suggested_jobs"], [])
+        self.assertEqual(result["would_skip"], list(cm.TEST_JOBS))
+
+    def test_innocence_nested_evidence_archive_paths_also_route_to_docs(self) -> None:
+        # evidence/<YYYY-MM>/<task-slug>/{pack,brief}.yml is the archived
+        # form (see the repo's own evidence/2026-08/ tree) — a prefix match,
+        # not just the two root-level paths above.
+        result = cm.classify(
+            [
+                "evidence/2026-08/agent-x-ops-docs-fastlane-abc12345/pack.yml",
+                "evidence/2026-08/agent-x-ops-docs-fastlane-abc12345/brief.yml",
+            ]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["unknown_paths"], [])
+        self.assertTrue(result["domains"]["docs_content_data"])
+        self.assertEqual(result["suggested_jobs"], [])
+
+    def test_innocence_docs_pr_with_its_mandatory_evidence_pack_still_fast_paths(
+        self,
+    ) -> None:
+        # The realistic shape: a genuinely docs-only PR that also carries
+        # the evidence pack every agent-produced PR writes. This is the
+        # actual mandate proof — not the synthetic evidence-only case above.
+        result = cm.classify(
+            [
+                "docs/runbooks/ci.md",
+                "research/operations/2026-08-27-note.md",
+                "evidence/pack.yml",
+                "evidence/brief.yml",
+            ]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["unknown_paths"], [])
+        self.assertEqual(result["suggested_jobs"], [])
+        self.assertEqual(result["would_skip"], list(cm.TEST_JOBS))
+        # End-to-end with security.yml's flag math too — this is the full
+        # mandate proof: a docs-only PR with its mandatory evidence pack
+        # pays for none of the 5 heavy required checks (3 in tests.yml via
+        # suggested_jobs above, 2 CodeQL legs in security.yml via these
+        # flags), through the SAME classifier both workflows already share.
+        flags = sgf.compute_flags(result, js_manifest=False)
+        self.assertFalse(flags["run_codeql_python"])
+        self.assertFalse(flags["run_codeql_js"])
+
+    def test_guilt_evidence_pack_never_masks_a_real_code_domain(self) -> None:
+        # The evidence pack routing to docs_content_data must be additive,
+        # never a way to launder a real change past the classifier: a PR
+        # that also touches product code keeps exactly the job set that
+        # code earns, union'd with (never narrowed by) evidence/*.yml.
+        result = cm.classify(
+            [
+                "evidence/pack.yml",
+                "evidence/brief.yml",
+                "apps/backend-rag/backend/app/main.py",
+            ]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["backend_python"])
+        self.assertTrue(result["domains"]["docs_content_data"])
+        self.assertIn("backend-tests", result["suggested_jobs"])
+        self.assertNotEqual(result["suggested_jobs"], [])
 
     def test_guilt_one_code_file_among_fifty_docs_still_forces_its_suite(
         self,


### PR DESCRIPTION
## Summary

Zero's order (2026-08-27): docs-only PRs must stop paying the 5 heavy required
checks (`Backend Tests (Python)`, `E2E Tests (Playwright)`,
`Frontend Tests (Next.js) (mouth, true)` in `tests.yml`; `CodeQL Analysis (python)`,
`CodeQL Analysis (javascript)` in `security.yml`). The 6 cheap required contexts
(harness floor, R1 gate, organ genes, antidotes, actionlint, guard-conformance)
are untouched — they stay always-on for docs too.

## What was actually needed (smaller than the original mandate)

Before writing a new paths-ignore + in-job diff short-circuit, I checked whether
this already exists. It does: **L5 "docs lane"**
(`research/operations/2026-08-21-token-ceremony-ci-system-audit.md` §13.5) is
already **DONE 2026-08-21**. `scripts/ci/change_map.py`'s `changes` job — landed
via #4181 (2026-08-14, wired into `tests.yml`'s six heavy jobs) and #4444
(2026-08-20, wired into `security.yml`'s CodeQL/Bandit/Snyk + diff-scoped Detect
Secrets) — already runs on **both** `pull_request` and `merge_group`, and already
computes `run_backend_tests` / `run_frontend_tests` / `run_e2e_tests` /
`run_codeql_python` / `run_codeql_js` from path→domain classification. A pure
`docs/**`/`research/**` diff already gets `suggested_jobs=[]` and both CodeQL
flags `false` — verified empirically before touching anything.

Building a second, parallel short-circuit (a static `DOCS_ONLY_IGNORE` list, a
merge-group-diff step) would have duplicated this exact mechanism in a
different shape that could disagree with it — precisely the class of mistake
that audit doc calls out about itself ("dispatched as new work and turned out
to be already-shipped").

## The real gap

`evidence/` — the `pack.yml` + `brief.yml` every agent-produced PR writes as
part of the modus GROUND/CAPTURE ceremony (`evidence_pack_lint.py`,
`harness-floor.yml`) — matched **no rule** in `change_map.py`'s classifier.
It fell through to `unknown_paths`, which forces the fail-open
`run_all=True` fallback. So a genuinely docs-only PR that (as every
agent-produced PR does) also carries its evidence pack was silently paying
for the full 6-job heavy suite anyway — the docs-lane fast path was defeated
by the single most common real PR shape.

## Fix

One `DOC_PREFIXES` entry in `scripts/ci/change_map.py`: `"evidence/"`. This
routes `evidence/*.yml` into the `docs_content_data` domain — the same bucket
as its sibling ceremony/doc prefixes (`docs/`, `research/`, `.claude/skills/`,
etc.) — which `_suggested_jobs()` never grants any of the six heavy jobs.

Verified safe, not just convenient: grepped `apps/backend-rag/`, `apps/mouth/`,
`apps/admin-dashboard*/`, `apps/wa-mirror/`, `apps/nuzantara-mcp*/`,
`apps/evaluator/`, `packages/core/` for any read of `evidence/pack.yml` or
`evidence/brief.yml` — zero hits. Nothing under the six heavy jobs' own test
corpora reads these files, so classifying them as docs-lane cannot mask a
regression. And the routing is additive, never a way to launder a real change:
a PR that also touches product code keeps the union of that code's domain,
not a narrowed one (see the guilt test below).

No workflow YAML touched at all — zero `actionlint`/`merge_group`/paths-ignore
surface, and no collision with #5069 (which edits `tests.yml`/`security.yml`'s
`on:` blocks but not this classifier).

## Tests added (`scripts/ci/test_change_map.py`)

- `test_innocence_evidence_pack_alone_skips_product_test_jobs` — the guilt
  case that motivated the fix (revert the one `DOC_PREFIXES` line and this
  goes red with `unknown_paths == ["evidence/brief.yml", "evidence/pack.yml"]`).
- `test_innocence_nested_evidence_archive_paths_also_route_to_docs` — the
  archived form `evidence/<YYYY-MM>/<task-slug>/{pack,brief}.yml`.
- `test_innocence_docs_pr_with_its_mandatory_evidence_pack_still_fast_paths`
  — the realistic mandate proof: docs `.md` + evidence pack →
  `suggested_jobs=[]` **and**, asserted end-to-end through
  `security_gate_flags.compute_flags()`, both CodeQL flags `false`.
- `test_guilt_evidence_pack_never_masks_a_real_code_domain` — evidence pack
  + a real `backend_python` file still runs `backend-tests` (union, not
  narrowed).

## Verification

- `python3 -m unittest test_change_map -v` (from `scripts/ci/`) → **36 passed**
  (32 pre-existing + 4 new)
- `python3 -m unittest test_security_gate_flags -v` → **21 passed**, unchanged
  (no code change in that file — it consumes `change_map.py`'s output, which
  the new tests exercise end-to-end)
- `python3 scripts/ci/check_required_workflow_conformance.py` → `0 violation(s)`
- No workflow files changed → no `actionlint` surface
- `infra/guard-conformance/`: does not census `change_map.py`/`test_change_map.py`
  (grepped, no hit)

## Refuted by

Not yet — flagging honestly rather than claiming a review that didn't happen.