### PR TITLE
fix(visa-oracle): R3 heuristic-autopsy ENG hand-off — 5 independent UX fixes

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/QuestionScreen.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/QuestionScreen.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { QUESTIONS } from "../_lib/tree";
@@ -94,5 +94,64 @@ describe("QuestionScreen country picker", () => {
     expect(
       screen.getByRole("button", { name: "Remove Italy" }),
     ).toBeInTheDocument();
+  });
+
+  it("filters the country <select> by name/code via the predictive search input, without blocking a normal selection (R3 D-V5)", async () => {
+    const user = userEvent.setup();
+    const { onAnswer } = renderNationalities();
+    const picker = screen.getByLabelText("Passport countries");
+    const search = screen.getByLabelText("Search countries");
+
+    const unfilteredCount = within(picker).getAllByRole("option").length;
+
+    await user.type(search, "Ital");
+    const filtered = within(picker).getAllByRole(
+      "option",
+    ) as HTMLOptionElement[];
+    expect(filtered.length).toBeLessThan(unfilteredCount);
+    expect(
+      filtered.some((option) => option.textContent?.includes("Italy (IT)")),
+    ).toBe(true);
+    // The "not listed" escape hatch must survive every filter — a typo
+    // should never trap the applicant with zero usable options.
+    expect(filtered.some((option) => option.value === "not-listed")).toBe(true);
+
+    await user.selectOptions(picker, "IT");
+    await user.click(screen.getByRole("button", { name: "Add country" }));
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(onAnswer).toHaveBeenCalledWith("IT");
+  });
+
+  it("clears the search filter when the question changes, so a stale query never hides options on the next country field", () => {
+    const { rerender } = render(
+      <QuestionScreen
+        language="en"
+        question={QUESTIONS.nationalities}
+        onAnswer={vi.fn()}
+        onSkip={vi.fn()}
+        onBack={vi.fn()}
+        canGoBack
+      />,
+    );
+    const search = screen.getByLabelText(
+      "Search countries",
+    ) as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "Ital" } });
+    expect(search.value).toBe("Ital");
+
+    rerender(
+      <QuestionScreen
+        language="en"
+        question={QUESTIONS.family_sponsor_nationalities}
+        onAnswer={vi.fn()}
+        onSkip={vi.fn()}
+        onBack={vi.fn()}
+        canGoBack
+      />,
+    );
+    expect(
+      (screen.getByLabelText("Search countries") as HTMLInputElement).value,
+    ).toBe("");
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/QuestionScreen.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/QuestionScreen.tsx
@@ -408,17 +408,32 @@ function CountryPicker({
   onNotListed: () => void;
 }) {
   const [pendingCode, setPendingCode] = useState("");
+  const [countryQuery, setCountryQuery] = useState("");
   const options = useMemo(() => getCountryOptions(language), [language]);
   const nameByCode = useMemo(
     () =>
       new Map<string, string>(options.map(({ code, name }) => [code, name])),
     [options],
   );
+  // Predictive filter (D-V5): 190+ countries in a plain <select> forces
+  // scroll-and-scan. This narrows the <option> list client-side by name or
+  // code — no new dependency, no change to how a selection is committed.
+  const filteredOptions = useMemo(() => {
+    const query = countryQuery.trim().toLowerCase();
+    if (!query) return options;
+    return options.filter(
+      ({ code, name }) =>
+        name.toLowerCase().includes(query) ||
+        code.toLowerCase().includes(query),
+    );
+  }, [options, countryQuery]);
   const selectId = `${questionId}-country`;
+  const searchId = `${questionId}-country-search`;
   const maxReached = selectedCodes.length >= maxSelections;
 
   useEffect(() => {
     setPendingCode("");
+    setCountryQuery("");
   }, [language, questionId]);
 
   const addPendingCountry = () => {
@@ -447,6 +462,23 @@ function CountryPicker({
           {translate(language, labelI18nKey)}
         </span>
       </label>
+      <label className="oracle-input-label" htmlFor={searchId}>
+        <span className="oracle-sr-only">
+          {translate(language, "question.country_picker.search")}
+        </span>
+        <input
+          id={searchId}
+          type="text"
+          className="oracle-form-control"
+          value={countryQuery}
+          onChange={(event) => setCountryQuery(event.target.value)}
+          placeholder={translate(
+            language,
+            "question.country_picker.search_placeholder",
+          )}
+          autoComplete="off"
+        />
+      </label>
       <div className="oracle-country-picker__control">
         <select
           id={selectId}
@@ -468,7 +500,7 @@ function CountryPicker({
           <option value="">
             {translate(language, "question.country_picker.placeholder")}
           </option>
-          {options.map(({ code, name }) => (
+          {filteredOptions.map(({ code, name }) => (
             <option
               key={code}
               value={code}

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.test.ts
@@ -39,4 +39,37 @@ describe("i18n.ts — translate()", () => {
     expect(translate("en", "back.button")).toBe("Back");
     expect(translate("id", "back.button")).toBe("Kembali");
   });
+
+  it("resolves {{plural:singular|plural}} to the singular form for count === 1, never '1 interview branches' (R3 D-V7)", () => {
+    expect(translate("en", "paths.counter.label", { count: 1 })).toBe(
+      "1 interview branch",
+    );
+    expect(translate("en", "paths.counter.aria", { count: 1 })).toBe(
+      "1 interview branch remaining",
+    );
+    expect(translate("en", "confirmation.paths_remaining", { count: 1 })).toBe(
+      "1 interview branch remaining",
+    );
+  });
+
+  it("resolves {{plural:singular|plural}} to the plural form for any count !== 1", () => {
+    expect(translate("en", "paths.counter.label", { count: 3 })).toBe(
+      "3 interview branches",
+    );
+    expect(translate("en", "paths.counter.label", { count: 0 })).toBe(
+      "0 interview branches",
+    );
+    expect(translate("en", "confirmation.paths_remaining", { count: 5 })).toBe(
+      "5 interview branches remaining",
+    );
+  });
+
+  it("Bahasa Indonesia does not inflect for number, so ID copy is identical at count 1 and count 3", () => {
+    expect(translate("id", "paths.counter.label", { count: 1 })).toBe(
+      "1 cabang wawancara",
+    );
+    expect(translate("id", "paths.counter.label", { count: 3 })).toBe(
+      "3 cabang wawancara",
+    );
+  });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts
@@ -565,6 +565,8 @@ const en = {
   "question.invalid_country_codes":
     "Choose a country from the verified list, or select Not listed.",
   "question.country_picker.placeholder": "Choose a country",
+  "question.country_picker.search": "Search countries",
+  "question.country_picker.search_placeholder": "Type a country name…",
   "question.country_picker.not_listed": "Other / not listed",
   "question.country_picker.add": "Add country",
   "question.country_picker.selected": "Selected countries",
@@ -591,7 +593,7 @@ const en = {
   "tree.nationalities": "Passports",
   "tree.birth_date": "Age check",
   "tree.category": "Category",
-  "tree.trip_scope": "Purpose overlap",
+  "tree.trip_scope": "Trip purpose",
   "tree.entry_pattern": "Entry pattern",
   "tree.sponsor_category": "Sponsor category",
   "tree.business_activity": "Business activity",
@@ -641,8 +643,9 @@ const en = {
   "tree.sr_status.pending": "not yet reached",
   "tree.sr_status.pruned": "different interview branch",
 
-  "paths.counter.label": "{{count}} interview branches",
-  "paths.counter.aria": "{{count}} interview branches remaining",
+  "paths.counter.label": "{{count}} interview {{plural:branch|branches}}",
+  "paths.counter.aria":
+    "{{count}} interview {{plural:branch|branches}} remaining",
 
   "confirmation.title": "Here’s what you told us",
   "confirmation.your_answers": "Your answers",
@@ -653,7 +656,8 @@ const en = {
   "confirmation.group.review": "Review signals",
   "confirmation.assumptions_title": "Assumptions we made",
   "confirmation.edit": "Edit",
-  "confirmation.paths_remaining": "{{count}} interview branches remain",
+  "confirmation.paths_remaining":
+    "{{count}} interview {{plural:branch|branches}} remaining",
   "confirmation.price_preview":
     "If a supported Bali Zero service has verified pricing, it will appear as one all-inclusive amount.",
   "confirmation.cta": "See my options",
@@ -1375,6 +1379,8 @@ const id: Record<Keys, string> = {
   "question.invalid_country_codes":
     "Pilih negara dari daftar terverifikasi, atau pilih Tidak tercantum.",
   "question.country_picker.placeholder": "Pilih negara",
+  "question.country_picker.search": "Cari negara",
+  "question.country_picker.search_placeholder": "Ketik nama negara…",
   "question.country_picker.not_listed": "Lainnya / tidak tercantum",
   "question.country_picker.add": "Tambah negara",
   "question.country_picker.selected": "Negara terpilih",
@@ -1401,7 +1407,7 @@ const id: Record<Keys, string> = {
   "tree.nationalities": "Paspor",
   "tree.birth_date": "Pemeriksaan usia",
   "tree.category": "Kategori",
-  "tree.trip_scope": "Tujuan tumpang tindih",
+  "tree.trip_scope": "Tujuan perjalanan",
   "tree.entry_pattern": "Pola masuk",
   "tree.sponsor_category": "Kategori sponsor",
   "tree.business_activity": "Kegiatan bisnis",
@@ -1643,8 +1649,19 @@ export const dict = { en, id };
  * hardcoding the EN ordering everywhere. */
 export const BODY_FIRST: Record<Language, boolean> = { en: false, id: true };
 
-/** Simple `{{var}}` interpolation — no ICU pluralization needed at this
- * scale. Missing keys return the raw key (visibly broken, never silent). */
+/** Matches `{{plural:singular|plural}}` markers — see `translate()` below.
+ * Kept as a plain literal-string marker (not a `{{count}}`-style var) so an
+ * English string can carry the ONE irregular plural it needs ("branch" →
+ * "branches") without a second interpolation pass at every call site. */
+const PLURAL_MARKER_RE = /\{\{plural:([^|{}]*)\|([^{}]*)\}\}/g;
+
+/** Simple `{{var}}` interpolation, plus one narrow pluralization escape
+ * hatch: `{{plural:singular|plural}}` resolves to `singular` when
+ * `vars.count === 1`, else `plural` — still not full ICU pluralization
+ * (this file does not need that at its current scale), just enough to stop
+ * "1 interview branches" reading as a typo. Bahasa Indonesia does not
+ * inflect nouns for number, so ID strings simply never use the marker.
+ * Missing keys return the raw key (visibly broken, never silent). */
 export function translate(
   language: Language,
   key: Keys,
@@ -1655,6 +1672,14 @@ export function translate(
   if (vars) {
     for (const [name, v] of Object.entries(vars)) {
       value = value.replaceAll(`{{${name}}}`, String(v));
+    }
+    if (typeof vars.count === "number") {
+      const count = vars.count;
+      value = value.replace(
+        PLURAL_MARKER_RE,
+        (_match, singular: string, plural: string) =>
+          count === 1 ? singular : plural,
+      );
     }
   }
   return value;

--- a/apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.test.tsx
+++ b/apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.test.tsx
@@ -88,6 +88,31 @@ describe("OrderReturnPage — browser return is an observation, not a truth", ()
     });
   });
 
+  it("shows a visible waiting state — never a blank screen — while the browser-return observation is in flight (R3 D-G4/ENG hand-off: minimal transition state)", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams({ return_nonce: "a".repeat(20) }),
+    );
+    let resolveFetch: (value: unknown) => void = () => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    render(<OrderReturnPage />);
+
+    expect(screen.getByText("Confirming your payment…")).toBeInTheDocument();
+    expect(
+      screen.getByText("One moment while we check your order status."),
+    ).toBeInTheDocument();
+
+    resolveFetch({ ok: true, status: 204, json: async () => ({}) });
+    await waitFor(() =>
+      expect(mocks.replace).toHaveBeenCalledWith("/visa/voa/orders/order-1"),
+    );
+  });
+
   it("forwards straight to the tracker without calling the API when no return_nonce is present", async () => {
     mocks.useSearchParams.mockReturnValue(new URLSearchParams());
 


### PR DESCRIPTION
## What / why

Design Study Loop R3 (`research/design/2026-08-27-r3-heuristic-autopsy-defect-inventory-axis-gap.md` §7, ruling Q-R3.3=a) named five UX fixes that are cure-ready **independently of the R4/R5 redesign**. This PR ships them. No product code outside the five items below; no pricing/abstain-threshold/migration/CI-workflow surface touched.

## Item 1+2 — D-V7: plural counter bug + jargon label (commit `c2538ca75`)

- **`apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/i18n.ts:656`** — `"confirmation.paths_remaining"` interpolated a raw `{{count}}` into an invariant plural noun ("interview branches"), so the review-gate screen (`ConfirmationCard.tsx:231`) literally rendered **"1 interview branches remain"**. Same bug in the progress counter's aria-label (`i18n.ts:645`, consumed by `PathsCounter.tsx:52`) and its visible label (`i18n.ts:644`, `PathsCounter.tsx:46`).
  - Fix: added a narrow `{{plural:singular|plural}}` marker to `translate()` (i18n.ts:1652-1687) — resolves to the singular form when `vars.count === 1`, plural otherwise. Deliberately **not** full ICU pluralization; the file's own pre-existing comment says that's unneeded at this scale, and this is smaller than ICU. Bahasa Indonesia does not inflect nouns for number (`"cabang wawancara"` is invariant), so ID copy is untouched — verified by a new test.
- **`i18n.ts:594`** (EN) / **`:1407`** (ID) — `"tree.trip_scope": "Purpose overlap"` is the breadcrumb-trail label for the trip-scope question (wired via `flow.ts:1088`, rendered in `LivingTree.tsx`). "Purpose overlap" reads like internal engine jargon next to sibling labels that are plain 1-3-word phrases ("Passports", "Current status", "Category"). Renamed to **"Trip purpose"** (ID: **"Tujuan perjalanan"**) — matches sibling tone, and the underlying question text itself ("Is this your only purpose for the trip?") was already fine and untouched.

No test previously asserted the count=1 case or the literal breadcrumb string — both were free to regress silently. Added coverage in `i18n.test.ts` (count 0/1/3/5 across all three interpolated keys + an ID-invariance check).

## Item 3 — D-V5: predictive search on the nationality selector (commit `d68f7f636`)

`CountryPicker` (`QuestionScreen.tsx`, backs both `nationalities` and `family_sponsor_nationalities` — both `kind: "country-codes"`) rendered a bare `<select>` over 190+ ISO countries with zero filtering — forced scroll-and-scan (H7 flexibility & efficiency).

Added a plain text `<input>` above the existing `<select>` that filters the rendered `<option>` list client-side by name-or-code substring match (case-insensitive) — **no new dependency**, no change to the wire format, multi-select/chip logic, or the "Other / not listed" escape hatch (which always survives the filter, so a typo can never zero-out the applicant's options). Query resets on question/language change (new `useEffect` dependency), so a stale filter from a prior country field can't hide options on the next one. New i18n keys `question.country_picker.search` / `.search_placeholder` (EN+ID).

Tests: filter narrows the `<select>`'s option count and a normal selection still commits through Add→Continue; the query clears across a question change (verified via `rerender`).

## Item 4 — ENG hand-off "GARUDA silent return-route transition state" (commit `c953f21a1`)

Investigated `apps/mouth/src/app/visa/voa/orders/[orderId]/return/page.tsx` before writing any code. **It already renders a visible waiting state** — title "Confirming your payment…", body "One moment while we check your order status.", `aria-live="polite"` — for the entire window between the browser landing on the return route and the `router.replace()` to the order tracker. This shipped in `f95d7bd73` ("train 4/4 — the public funnel UI, dark by flag"), which predates this PR.

**No behavior change made** — the ask in §7 is already met. What was genuinely missing was test coverage: the existing `page.test.tsx` only asserted the API/redirect behavior (never shows success, posts `return_nonce` correctly, forwards on error/no-nonce) and never asserted the transition copy itself renders. Added one test that holds the observation `fetch` open and asserts both strings are visible before it resolves, so a future refactor can't silently regress back to a blank screen mid-redirect.

## Item 5 — `holds_stay_permit` (D-V4, "inert question") — **HIGH-RISK item, no code change**

Per instructions, did the census before touching anything:

**Who asks it (frontend):** `tree.ts:194-207` defines the question (`kind: "branch"`, `decisionMapping: { kind: "HUMAN_CONTEXT" }` — it is *not itself* mapped to an engine fact). `flow.ts` gates it into the offshore path (funnel-cost optimization from PR #4727: ask this ONE gate question before the full onshore chain) and its answer determines:
  - whether `stay_permit_code` (→ `immigration.current_status_code`) is asked at all (`holds_stay_permit === "yes"` → ask it), or
  - `fact-mapper.ts:480`: `holds_stay_permit === "no"` (offshore) → `immigration.current_status_code` is synthesized directly as the `NO_STAY_PERMIT` sentinel, *without* asking the granular question.

**Who consumes it (engine):** `immigration.current_status_code` — the fact `holds_stay_permit` gates the value of, one way or another — is read directly by **5 live production rules** (`hf.bridging.*` / `el.bridging.*`), per the explicit, team-lead-reviewed docstring in `backend/services/visa_engine/fact_registry.py::_derive_has_active_stay_permit` (2026-08-24): *"the live signed pack has zero rule consumers of `derived.has_active_stay_permit` at all today — the 5 live `hf.bridging.*`/`el.bridging.*` rules that read stay-permit facts read `immigration.current_status_code`/`current_status_expiry` directly."* No rule pack file references `holds_stay_permit` or `derived.has_active_stay_permit` — but 5 live rules DO reference the fact this question ultimately controls.

**Conclusion: `holds_stay_permit` is not inert.** Removing it would either (a) force the granular `current_status_code` question on every offshore applicant, defeating the exact funnel-cost fix PR #4727 shipped, or (b) leave `immigration.current_status_code` unset for offshore "no" applicants, silently breaking the 5 live bridging rules for that population. Per the project's engine-safety invariant ("a rule on a fact never asked is not inert — it cancels the product"), this fails the "zero consuming rules" bar the mandate required before any removal — so per instructions, the engine and the question set are untouched.

**"Why we ask" — already present, no gap to fill.** `tree.ts:205`: `whyWeAsk: { i18nKey: "why.holds_stay_permit" }` → i18n.ts: *"The E-code catalogue only applies to KITAS/KITAP holders; everyone else answers the shorter code list below."* (ID equivalent present too.) This already explains concretely what the answer changes. The mandate's fallback instruction for this item ("limit the code change to adding a Why-we-ask") requires zero action since it was already shipped.

Flagging for R4/R5: the autopsy's D-V4 classification ("inert question... nothing downstream changes") does not hold against the current engine code — plausibly diagnosed from a captured-screen read rather than a rule-pack audit, since the re-routing this question drives is invisible on screen. Please don't relitigate a removal of this question without re-reading this analysis or re-running the same census.

## Deferred (none)

All five items were resolved — none needed to be parked as "too large" or "not found." Item 4 needed zero product-code change (already shipped); item 5 needed zero product-code change (safety-gated by a live rule dependency).

## Test plan

- `npx vitest run` on the three directly-touched suites: `i18n.test.ts` (8), `QuestionScreen.test.tsx` (7, incl. 2 new), `orders/[orderId]/return/page.test.tsx` (5, incl. 1 new) → **3 files passed, 19/19 tests passed**, verified twice (once directly, once via an independent subagent re-run) after ruling out machine-saturation flakiness (this Pro box had ~90+ concurrent node processes from unrelated parallel agent lanes at the time — a broader-suite run showed non-reproducible environment-shaped failures, e.g. `next/font` mock errors and missing vitest globals, that vanished on isolated re-runs; none touched the files this PR changes).
- `tsc --noEmit -p tsconfig.json` (apps/mouth): exit 0, zero errors.
- Pre-commit/pre-push hooks (prettier, typecheck, secrets scan, off-limits-file check): all green on all three commits.

Net diff: 3 commits, 5 files, ~183 insertions / 9 deletions — under the ~400-net-line contract line.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>