### PR TITLE
feat(visa-oracle): per-request CANARY mode override — the rollout lever the evaluate path never had

### DIFF
--- a/apps/backend-rag/backend/app/routers/visa_oracle_evaluate.py
+++ b/apps/backend-rag/backend/app/routers/visa_oracle_evaluate.py
@@ -40,6 +40,18 @@ Abuse controls (Codex red-team, binding per the W1 brief):
   adjudicated HIGH). Missing/mismatched token, unarmed class, or unset
   secret env: 400, with a single generic message that never reveals which
   layer failed.
+- Canary mode override (``X-Visa-Canary-Mode`` + ``X-Visa-Canary-Token``):
+  the per-request rollout lever. Presence of the MODE header is the only
+  thing that opens the branch, so a request without it runs the identical
+  statement it ran before the lever existed. When it is present, the mode
+  must be ``SHADOW``/``ENFORCE`` AND the token must match
+  ``VISA_ENGINE_EVALUATE_CANARY_TOKEN`` (constant-time) — otherwise 400,
+  with one generic message covering every failure layer. On success the
+  request's ``traffic_source`` is FORCED to ``synthetic_driver`` before the
+  canonical request is built, so a canary decision is never counted as real
+  production demand and the idempotency binding records the true label.
+  This is a separate secret from the driver credential on purpose: holding
+  the replay-driver token must not confer the authority to change mode.
 - ``request_category`` (query param, optional): the v2 interview tile
   hint; validated against migration 257's 10-value enum. See
   ``evaluate_path.derive_request_category`` for why the hint exists
@@ -65,6 +77,7 @@ import json
 import re
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import nullcontext
 from enum import Enum
 from typing import Annotated, Any, cast
 
@@ -98,6 +111,12 @@ MAX_CONTENT_LENGTH_DIGITS = 20
 
 #: The W4 gold-corpus replay driver credential header (see module docstring).
 DRIVER_TOKEN_HEADER = "x-visa-driver-token"
+
+#: Per-request canary mode override (see module docstring). BOTH headers are
+#: required: the mode header states the intent, the token header proves the
+#: authority. Neither alone does anything.
+CANARY_MODE_HEADER = "x-visa-canary-mode"
+CANARY_TOKEN_HEADER = "x-visa-canary-token"
 
 #: Opaque caller token accepted for durable replay. A closed ASCII alphabet
 #: avoids normalization ambiguity between proxies and PostgreSQL.
@@ -343,9 +362,37 @@ async def evaluate_applicant(
             detail="request_category is not an accepted value",
         )
 
-    if traffic_source != TrafficSourceParam.REAL.value and (
-        traffic_source not in evaluate_path.resolve_allowed_synthetic_sources()
-        or not evaluate_path.verify_driver_token(request.headers.get(DRIVER_TOKEN_HEADER))
+    # Canary mode override. Presence of the mode header is the ONLY thing
+    # that opens this branch: a request without it takes the exact path it
+    # took before this lever existed, whether or not the secret is
+    # provisioned. Rejection is 400 with a single generic message, for the
+    # same reason as the synthetic gate below — the caller learns nothing
+    # about which layer said no.
+    canary_mode = None
+    if request.headers.get(CANARY_MODE_HEADER) is not None:
+        canary_mode = evaluate_path.parse_canary_mode(request.headers.get(CANARY_MODE_HEADER))
+        if canary_mode is None or not evaluate_path.verify_canary_token(
+            request.headers.get(CANARY_TOKEN_HEADER)
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Canary mode override is not accepted from anonymous callers",
+            )
+        # A canary evaluation is never real traffic. Forced server-side and
+        # unconditionally, so the caller cannot both hold the canary
+        # credential and have its rows counted as production demand — and
+        # cannot self-label `synthetic_gold` either. This overwrite happens
+        # BEFORE the canonical request is built, so the idempotency binding
+        # records the label the row will actually carry.
+        traffic_source = TrafficSourceParam.SYNTHETIC_DRIVER.value
+
+    if (
+        canary_mode is None
+        and traffic_source != TrafficSourceParam.REAL.value
+        and (
+            traffic_source not in evaluate_path.resolve_allowed_synthetic_sources()
+            or not evaluate_path.verify_driver_token(request.headers.get(DRIVER_TOKEN_HEADER))
+        )
     ):
         # One generic message for every failure layer (unarmed class, unset
         # secret env, missing token, mismatched token) — an attacker learns
@@ -372,16 +419,22 @@ async def evaluate_applicant(
     }
     canonical_request_bytes = canonicalize_json(cast(dict[str, JsonValue], canonical_request))
 
+    # `nullcontext` keeps ONE call path: a non-canary request is not merely
+    # equivalent to the pre-canary code, it executes the same statement.
+    authority = (
+        nullcontext() if canary_mode is None else evaluate_path.canary_mode_override(canary_mode)
+    )
     try:
-        return await evaluate_path.run_public_evaluation(
-            db_pool,
-            request=request_body,
-            traffic_source=traffic_source,
-            request_category_hint=request_category,
-            request_trace=request_trace,
-            canonical_request=canonical_request_bytes,
-            idempotency_key=idempotency_key,
-        )
+        with authority:
+            return await evaluate_path.run_public_evaluation(
+                db_pool,
+                request=request_body,
+                traffic_source=traffic_source,
+                request_category_hint=request_category,
+                request_trace=request_trace,
+                canonical_request=canonical_request_bytes,
+                idempotency_key=idempotency_key,
+            )
     except IdempotencyConflictError:
         raise HTTPException(
             status_code=409,

--- a/apps/backend-rag/backend/services/visa_engine/evaluate_path.py
+++ b/apps/backend-rag/backend/services/visa_engine/evaluate_path.py
@@ -50,6 +50,38 @@ Mode discipline (mirrors ``shadow.resolve_match_shadow_enabled``):
   when BOTH the class is allowlisted AND the presented token matches this
   secret (constant-time compare). Unset: synthetic is always rejected
   (fail-closed). This token IS the W4 driver credential.
+- ``VISA_ENGINE_EVALUATE_CANARY_TOKEN`` — the shared secret backing the
+  per-request CANARY mode override (``X-Visa-Canary-Mode`` +
+  ``X-Visa-Canary-Token``, wired by the router). It is the rollout lever
+  the ASSEMBLY-LINE dark -> 5% -> 100% ruling requires and that this
+  surface did not have: before it, the ONLY way to try ENFORCE was to flip
+  the deployment-wide env, taking every live visitor from 0% to 100% in one
+  gesture. Three properties are load-bearing and each has a guilt AND an
+  innocence test:
+
+  1. **Absent by default means byte-identical behaviour.** The override
+     lives in a ``ContextVar`` whose default is ``None``;
+     ``resolve_evaluate_mode`` falls through to the env exactly as before.
+     Provisioning the secret alone changes NOTHING — a request must also
+     carry the header. (Arming a lever and arming a request are different
+     acts: the allowlist bullet above is the scar that taught this.)
+  2. **Not reachable from a guessable public parameter.** It is a header
+     bearing a shared secret compared in constant time, never a query
+     param, cookie, or body field, and it fails closed on an unset env —
+     the same posture as the driver credential, for the same reason.
+  3. **The row says it was a canary.** A canary request is forced to
+     ``traffic_source='synthetic_driver'`` server-side (the router
+     overwrites whatever the caller asked for), so a decision born under
+     the canary can never be counted as real production traffic.
+
+  DECLARED LIMIT of property 3: ``visa_decisions`` has no column that
+  separates a canary row from a W4 replay-driver row, and adding one is a
+  migration this PR deliberately does not carry. Today the pair
+  (``synthetic_driver``, ``engine_mode='ENFORCE'``) is unique to the canary
+  because the deployment is globally SHADOW; the moment ENFORCE is armed
+  deployment-wide, a driver row is also ENFORCE and the pair stops
+  identifying anything. A dedicated column must land BEFORE global ENFORCE
+  — tracked in ``.claude/skills/modus/PENDING-ARMS.md``.
 
 PII boundary (SYMBIOSIS Law 2 / UU PDP): applicant facts are NEVER logged
 and never persisted — the audit row carries only engine identifiers, reason
@@ -70,7 +102,9 @@ import logging
 import os
 import secrets
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import TypeAlias
@@ -181,6 +215,39 @@ ALLOW_SYNTHETIC_SOURCES_ENV = "VISA_ENGINE_EVALUATE_ALLOW_SYNTHETIC_SOURCES"
 #: the W4 gold-corpus replay driver credential (see module docstring).
 DRIVER_TOKEN_ENV = "VISA_ENGINE_DRIVER_TOKEN"
 
+#: The shared secret backing the per-request CANARY mode override (see the
+#: module docstring). Unset: the canary can never engage, for any caller.
+CANARY_TOKEN_ENV = "VISA_ENGINE_EVALUATE_CANARY_TOKEN"
+
+#: The modes a canary request may ask for. ``OFF`` is deliberately absent:
+#: the canary exists to try an authority a deployment has NOT yet armed,
+#: and a request that disables its own surface is indistinguishable from
+#: sending no request at all.
+_CANARY_SELECTABLE_MODES: frozenset[str] = frozenset(
+    {EngineMode.SHADOW.value, EngineMode.ENFORCE.value}
+)
+
+#: Per-request authority override, set by the router ONLY after the canary
+#: credential verifies. Default ``None`` — and that default is the whole
+#: safety argument: with nothing set, ``resolve_evaluate_mode`` reads the
+#: env exactly as it did before this lever existed.
+#:
+#: A ContextVar (rather than threading a parameter through six call sites)
+#: is what makes the override TOTAL: ``resolve_evaluate_mode`` is consulted
+#: independently by ``run_evaluation``, ``run_public_evaluation``,
+#: ``_replay_authority_matches`` and ``resolve_response_mode``, and a lever
+#: that reached only some of them would produce a request whose response
+#: envelope and whose persisted row disagreed about who decided.
+#:
+#: Isolation: asyncio gives every request task its own context, and a task
+#: spawned during the request inherits a COPY taken at creation — so the
+#: override covers the evaluation it belongs to and cannot reach a
+#: concurrent request. ``test_canary_override_does_not_leak_to_a_concurrent_request``
+#: is the guilt test for exactly that claim.
+_CANARY_MODE_OVERRIDE: ContextVar[EngineMode | None] = ContextVar(
+    "visa_engine_evaluate_canary_mode", default=None
+)
+
 #: The engine surface every persisted row and every log line of this module
 #: belongs to (migration 252's ``engine_surface`` CHECK admits it verbatim).
 _SURFACE = EngineSurface.RECOMMEND
@@ -210,13 +277,76 @@ _VISA_PURPOSE_TO_REQUEST_CATEGORY: MappingProxyType[VisaPurpose, str] = MappingP
 
 
 def resolve_evaluate_mode() -> EngineMode:
-    """Resolve the public authority lever; unknown values fail closed to OFF."""
+    """Resolve the public authority lever; unknown values fail closed to OFF.
 
+    A per-request canary override (set only by the router, only after the
+    canary credential verified — see ``canary_mode_override``) wins over the
+    deployment env for the duration of that one request. With no override in
+    context this is byte-for-byte the pre-canary behaviour.
+    """
+
+    override = _CANARY_MODE_OVERRIDE.get()
+    if override is not None:
+        return override
     raw = os.environ.get(EVALUATE_MODE_ENV, EngineMode.OFF.value).strip().upper()
     try:
         return EngineMode(raw)
     except ValueError:
         return EngineMode.OFF
+
+
+def parse_canary_mode(raw: str | None) -> EngineMode | None:
+    """The ``EngineMode`` a canary header asks for, or ``None`` if it asks
+    for nothing this lever may grant.
+
+    Closed vocabulary (``SHADOW``/``ENFORCE``, case-insensitive after
+    strip). ``None``, empty, ``OFF``, and anything unrecognised all return
+    ``None`` — the caller treats that as "not a valid canary request" and
+    rejects, rather than silently evaluating under the deployment default.
+    """
+
+    if raw is None:
+        return None
+    candidate = raw.strip().upper()
+    if candidate not in _CANARY_SELECTABLE_MODES:
+        return None
+    return EngineMode(candidate)
+
+
+def verify_canary_token(presented: str | None) -> bool:
+    """Constant-time check of the canary credential.
+
+    True iff ``CANARY_TOKEN_ENV`` is provisioned (non-empty after strip)
+    AND ``presented`` matches it under ``secrets.compare_digest``. Every
+    other shape — unset/empty env, missing header, mismatched token, a
+    non-ASCII header value — is False. Deliberately a verbatim twin of
+    ``verify_driver_token``: same fail-closed posture, same
+    re-read-never-cache convention, and a separate secret so holding the
+    replay-driver credential does NOT confer the authority to change mode.
+    """
+
+    expected = os.environ.get(CANARY_TOKEN_ENV, "").strip()
+    if not expected or not presented:
+        return False
+    try:
+        return secrets.compare_digest(presented, expected)
+    except TypeError:
+        return False
+
+
+@contextmanager
+def canary_mode_override(mode: EngineMode) -> Iterator[None]:
+    """Bind ``mode`` as this request's authority, restoring on exit.
+
+    Restores via the ``ContextVar`` token rather than resetting to ``None``,
+    so a nested use cannot silently clear an outer binding.
+    """
+
+    token = _CANARY_MODE_OVERRIDE.set(mode)
+    try:
+        yield
+    finally:
+        _CANARY_MODE_OVERRIDE.reset(token)
 
 
 def resolve_evaluate_shadow_enabled() -> bool:
@@ -1849,18 +1979,22 @@ async def run_public_evaluation(
 
 __all__ = [
     "ALLOW_SYNTHETIC_SOURCES_ENV",
+    "CANARY_TOKEN_ENV",
     "DRIVER_TOKEN_ENV",
     "EVALUATE_ENVIRONMENT_ENV",
     "EVALUATE_MODE_ENV",
     "PUBLIC_POLICY_ADAPTER_NAMES",
     "apply_public_policy_adapters",
     "build_temp_unavailable_body",
+    "canary_mode_override",
     "derive_request_category",
+    "parse_canary_mode",
     "resolve_allowed_synthetic_sources",
     "resolve_evaluate_mode",
     "resolve_evaluate_shadow_enabled",
     "resolve_response_mode",
     "run_evaluation",
     "run_public_evaluation",
+    "verify_canary_token",
     "verify_driver_token",
 ]

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_evaluate_canary_lever.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_evaluate_canary_lever.py
@@ -1,0 +1,575 @@
+"""Tests for the per-request CANARY mode override on the evaluate read-path.
+
+The lever under test lets ONE authenticated request run under a different
+``EngineMode`` than the deployment env, so ENFORCE can be tried without
+taking every live visitor from 0% to 100% in a single gesture (the
+ASSEMBLY-LINE dark -> 5% -> 100% ruling). Three properties are
+load-bearing, and each is covered here by a GUILT test (it really does the
+thing) and an INNOCENCE test (it does nothing to anyone else):
+
+1. Absent by default => behaviour identical to before the lever existed.
+   Guilt: ``TestCanaryEngages``. Innocence: ``TestCanaryAbsentChangesNothing``
+   — including the case where the secret IS provisioned but no header is
+   sent, which is the shape the allowlist scar taught us to test.
+2. Not reachable from a guessable public parameter. Guilt: every rejection
+   case in ``TestCanaryCredential``/``TestCanaryRejections``. Innocence:
+   ``test_driver_token_is_not_a_canary_token`` — the two credentials are
+   separate, so holding one does not confer the other's authority.
+3. The row says it was a canary. Guilt:
+   ``test_canary_forces_synthetic_driver_label``. Innocence:
+   ``test_non_canary_request_keeps_its_declared_traffic_source``.
+
+No DB is touched: ``run_public_evaluation`` is replaced by a recorder that
+captures what the router actually handed it AND what
+``resolve_evaluate_mode()`` answered at that moment — which is the only
+honest way to assert that the override reached the evaluator rather than
+merely being stored somewhere.
+
+No test asserts against raw applicant-fact values (SYMBIOSIS Law 2).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from backend.app.routers import visa_oracle_evaluate
+from backend.services.visa_check.match_tree import Purpose
+from backend.services.visa_engine import evaluate_path, shadow
+from backend.services.visa_engine.api_models import VisaOracleEvaluateResponse
+from backend.services.visa_engine.enums import EngineMode
+from backend.services.visa_engine.models import ApplicantFacts
+
+CANARY_MODE_HEADER = "x-visa-canary-mode"
+CANARY_TOKEN_HEADER = "x-visa-canary-token"
+CANARY_SECRET = "canary-secret-value"
+DRIVER_SECRET = "w4-driver-secret"
+
+EVALUATE_URL = "/api/visa-oracle/evaluate"
+
+
+def _facts() -> ApplicantFacts:
+    """A valid ApplicantFacts with a KNOWN single purpose."""
+    facts = shadow.build_shadow_facts(
+        nationality="US", purpose=Purpose.OTHER, duration_months=1, match_hash="canary-hash"
+    )
+    assert facts is not None
+    wire = facts.model_dump(mode="json", by_alias=True)
+    wire["facts"]["intent.purposes"] = {"status": "KNOWN", "value": ["TOURISM"]}
+    return ApplicantFacts.model_validate(wire)
+
+
+def _payload() -> dict:
+    return _facts().model_dump(mode="json", by_alias=True)
+
+
+class _UntouchedPool:
+    """Pool stand-in that fails the test if a connection is ever acquired."""
+
+    def acquire(self) -> None:  # pragma: no cover - failure path only
+        raise AssertionError("db_pool must not be touched on this path")
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(visa_oracle_evaluate.router)
+    app.state.db_pool = _UntouchedPool()
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+class _Recorder:
+    """Stands in for ``run_public_evaluation``.
+
+    Records the ``traffic_source`` the router chose AND the mode
+    ``resolve_evaluate_mode()`` returns *inside* the call — the latter is
+    the actual claim under test, because the override has to be visible to
+    the evaluator, not merely set somewhere the router can see.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, _db_pool: Any, **kwargs: Any) -> Any:
+        self.calls.append(
+            {
+                "traffic_source": kwargs["traffic_source"],
+                "mode_seen_by_evaluator": evaluate_path.resolve_evaluate_mode(),
+                "canonical_request": kwargs["canonical_request"],
+            }
+        )
+        return VisaOracleEvaluateResponse.model_validate(
+            evaluate_path.build_temp_unavailable_body(
+                now=datetime.now(timezone.utc),
+                code="EVALUATE_SURFACE_DISABLED",
+            )
+        )
+
+    @property
+    def only(self) -> dict[str, Any]:
+        assert len(self.calls) == 1, f"expected exactly one evaluation, got {len(self.calls)}"
+        return self.calls[0]
+
+
+@pytest.fixture
+def recorder(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    rec = _Recorder()
+    monkeypatch.setattr(evaluate_path, "run_public_evaluation", rec)
+    return rec
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test states its own arming; nothing inherits a live deployment."""
+    monkeypatch.delenv(evaluate_path.CANARY_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(evaluate_path.DRIVER_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(evaluate_path.ALLOW_SYNTHETIC_SOURCES_ENV, raising=False)
+    monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+
+
+# ---------------------------------------------------------------------------
+# §1 — parse_canary_mode: the closed vocabulary (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestParseCanaryMode:
+    @pytest.mark.parametrize("raw", ["ENFORCE", "enforce", "  Enforce  "])
+    def test_enforce_is_accepted_case_insensitively(self, raw: str) -> None:
+        assert evaluate_path.parse_canary_mode(raw) is EngineMode.ENFORCE
+
+    def test_shadow_is_accepted(self) -> None:
+        assert evaluate_path.parse_canary_mode("SHADOW") is EngineMode.SHADOW
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "OFF", "BOGUS", "ENGINE", "CURATED", "1"])
+    def test_everything_else_is_none(self, raw: str | None) -> None:
+        """``OFF`` is refused on purpose: the canary exists to try an
+        authority the deployment has NOT armed, and a request that disables
+        its own surface is indistinguishable from not sending one."""
+        assert evaluate_path.parse_canary_mode(raw) is None
+
+
+# ---------------------------------------------------------------------------
+# §2 — verify_canary_token: fail-closed credential (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryCredential:
+    def test_unset_env_rejects_everything(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(evaluate_path.CANARY_TOKEN_ENV, raising=False)
+        assert evaluate_path.verify_canary_token("anything") is False
+        assert evaluate_path.verify_canary_token("") is False
+        assert evaluate_path.verify_canary_token(None) is False
+
+    def test_whitespace_only_env_is_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, "   ")
+        assert evaluate_path.verify_canary_token("   ") is False
+
+    def test_matching_token_verifies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        assert evaluate_path.verify_canary_token(CANARY_SECRET) is True
+
+    def test_mismatched_or_missing_token_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        assert evaluate_path.verify_canary_token("canary-secret-valuE") is False
+        assert evaluate_path.verify_canary_token(None) is False
+        assert evaluate_path.verify_canary_token("") is False
+
+    def test_non_ascii_header_value_is_rejected_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``compare_digest`` raises TypeError on non-ASCII str; the guard
+        must answer False rather than turn a header into a 500."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        assert evaluate_path.verify_canary_token("canarì-secret") is False
+
+    def test_driver_token_is_not_a_canary_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """INNOCENCE for property 2: the two credentials are separate
+        secrets, so holding the W4 replay-driver token does not confer the
+        authority to change the engine's mode."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        monkeypatch.setenv(evaluate_path.DRIVER_TOKEN_ENV, DRIVER_SECRET)
+        assert evaluate_path.verify_canary_token(DRIVER_SECRET) is False
+        assert evaluate_path.verify_driver_token(CANARY_SECRET) is False
+
+
+# ---------------------------------------------------------------------------
+# §3 — resolve_evaluate_mode + canary_mode_override (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestModeOverrideMechanics:
+    def test_without_override_the_env_still_decides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        assert evaluate_path.resolve_evaluate_mode() is EngineMode.SHADOW
+
+    def test_override_wins_over_env_and_is_restored_on_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        with evaluate_path.canary_mode_override(EngineMode.ENFORCE):
+            assert evaluate_path.resolve_evaluate_mode() is EngineMode.ENFORCE
+        assert evaluate_path.resolve_evaluate_mode() is EngineMode.SHADOW
+
+    def test_override_is_restored_even_when_the_body_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        with pytest.raises(RuntimeError):
+            with evaluate_path.canary_mode_override(EngineMode.ENFORCE):
+                raise RuntimeError("boom")
+        assert evaluate_path.resolve_evaluate_mode() is EngineMode.SHADOW
+
+    def test_override_reaches_the_derived_resolvers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A lever that reached ``resolve_evaluate_mode`` but not the
+        resolvers built on top of it would produce a response envelope that
+        disagreed with the persisted row about who decided."""
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        assert evaluate_path.resolve_response_mode() == "CURATED"
+        with evaluate_path.canary_mode_override(EngineMode.ENFORCE):
+            assert evaluate_path.resolve_response_mode() == "ENGINE"
+            assert evaluate_path.resolve_evaluate_shadow_enabled() is True
+        assert evaluate_path.resolve_response_mode() == "CURATED"
+
+    def test_nested_override_restores_the_outer_binding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "OFF")
+        with evaluate_path.canary_mode_override(EngineMode.SHADOW):
+            with evaluate_path.canary_mode_override(EngineMode.ENFORCE):
+                assert evaluate_path.resolve_evaluate_mode() is EngineMode.ENFORCE
+            assert evaluate_path.resolve_evaluate_mode() is EngineMode.SHADOW
+        assert evaluate_path.resolve_evaluate_mode() is EngineMode.OFF
+
+    async def test_canary_override_does_not_leak_to_a_concurrent_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The isolation claim, exercised rather than asserted from theory:
+        two tasks run concurrently, one under the override, and the other
+        must never observe ENFORCE."""
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        started = asyncio.Event()
+
+        async def with_canary() -> EngineMode:
+            with evaluate_path.canary_mode_override(EngineMode.ENFORCE):
+                started.set()
+                await asyncio.sleep(0)
+                return evaluate_path.resolve_evaluate_mode()
+
+        async def without_canary() -> EngineMode:
+            await started.wait()
+            await asyncio.sleep(0)
+            return evaluate_path.resolve_evaluate_mode()
+
+        canary_seen, bystander_seen = await asyncio.gather(with_canary(), without_canary())
+        assert canary_seen is EngineMode.ENFORCE
+        assert bystander_seen is EngineMode.SHADOW
+
+
+# ---------------------------------------------------------------------------
+# §4 — HTTP: the canary engages (GUILT)
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryEngages:
+    async def test_valid_canary_makes_the_evaluator_see_enforce(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "ENFORCE",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                },
+            )
+        assert response.status_code == 200
+        assert recorder.only["mode_seen_by_evaluator"] is EngineMode.ENFORCE
+
+    async def test_canary_forces_synthetic_driver_label(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """GUILT for property 3: the caller asked for ``real`` and the row
+        is labelled ``synthetic_driver`` anyway, so a canary decision can
+        never be counted as production demand."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "ENFORCE",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                },
+            )
+        assert response.status_code == 200
+        assert recorder.only["traffic_source"] == "synthetic_driver"
+
+    async def test_canary_cannot_self_label_synthetic_gold(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """The forced label is unconditional: a canary caller cannot use
+        the lever to relabel its rows into the gold-corpus class."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        monkeypatch.setenv(evaluate_path.ALLOW_SYNTHETIC_SOURCES_ENV, "synthetic_gold")
+        monkeypatch.setenv(evaluate_path.DRIVER_TOKEN_ENV, DRIVER_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=synthetic_gold",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "ENFORCE",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                    "x-visa-driver-token": DRIVER_SECRET,
+                },
+            )
+        assert response.status_code == 200
+        assert recorder.only["traffic_source"] == "synthetic_driver"
+
+    async def test_forced_label_is_in_the_canonical_request(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """The overwrite happens BEFORE the canonical request is built, so
+        the idempotency binding records the label the row will carry — not
+        the one the caller asked for."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "ENFORCE",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                },
+            )
+        canonical = recorder.only["canonical_request"]
+        assert b"synthetic_driver" in canonical
+        assert b'"traffic_source":"real"' not in canonical
+
+    async def test_canary_can_also_select_shadow(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "OFF")
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "SHADOW",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                },
+            )
+        assert response.status_code == 200
+        assert recorder.only["mode_seen_by_evaluator"] is EngineMode.SHADOW
+
+    async def test_override_is_released_after_the_response(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "ENFORCE",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                },
+            )
+        assert evaluate_path.resolve_evaluate_mode() is EngineMode.SHADOW
+
+
+# ---------------------------------------------------------------------------
+# §5 — HTTP: every way the canary is refused (GUILT for property 2)
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryRejections:
+    async def _post(self, headers: dict[str, str]) -> httpx.Response:
+        async with _client(_build_app()) as client:
+            return await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers=headers,
+            )
+
+    async def test_mode_header_without_token_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        response = await self._post({CANARY_MODE_HEADER: "ENFORCE"})
+        assert response.status_code == 400
+        assert recorder.calls == []
+
+    async def test_mode_header_with_wrong_token_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        response = await self._post(
+            {CANARY_MODE_HEADER: "ENFORCE", CANARY_TOKEN_HEADER: "not-the-secret"}
+        )
+        assert response.status_code == 400
+        assert recorder.calls == []
+
+    async def test_unprovisioned_secret_rejects_even_a_correct_looking_token(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """Fail-closed: with the env unset there is no value a caller can
+        present that engages the canary."""
+        monkeypatch.delenv(evaluate_path.CANARY_TOKEN_ENV, raising=False)
+        response = await self._post(
+            {CANARY_MODE_HEADER: "ENFORCE", CANARY_TOKEN_HEADER: CANARY_SECRET}
+        )
+        assert response.status_code == 400
+        assert recorder.calls == []
+
+    @pytest.mark.parametrize("bad_mode", ["OFF", "ENGINE", "bogus", "", "   "])
+    async def test_unknown_mode_with_a_valid_token_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder, bad_mode: str
+    ) -> None:
+        """A valid credential never widens the vocabulary — the mirror of
+        the allowlist rule that a valid driver token never arms a class."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        response = await self._post(
+            {CANARY_MODE_HEADER: bad_mode, CANARY_TOKEN_HEADER: CANARY_SECRET}
+        )
+        assert response.status_code == 400
+        assert recorder.calls == []
+
+    async def test_rejection_message_does_not_reveal_the_failing_layer(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """All three failure shapes answer with the same body, so a prober
+        cannot learn whether the secret is provisioned."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        armed_no_token = await self._post({CANARY_MODE_HEADER: "ENFORCE"})
+        armed_bad_token = await self._post(
+            {CANARY_MODE_HEADER: "ENFORCE", CANARY_TOKEN_HEADER: "wrong"}
+        )
+        monkeypatch.delenv(evaluate_path.CANARY_TOKEN_ENV, raising=False)
+        unarmed = await self._post(
+            {CANARY_MODE_HEADER: "ENFORCE", CANARY_TOKEN_HEADER: CANARY_SECRET}
+        )
+        bodies = {armed_no_token.text, armed_bad_token.text, unarmed.text}
+        assert len(bodies) == 1
+        assert recorder.calls == []
+
+    async def test_canary_is_not_reachable_from_a_query_parameter(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """Property 2, stated as a probe: the lever has no public
+        query-parameter surface, so guessing its name changes nothing."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=real"
+                f"&canary=ENFORCE&mode=ENFORCE&engine_mode=ENFORCE"
+                f"&canary_token={CANARY_SECRET}",
+                json=_payload(),
+            )
+        assert response.status_code == 200
+        assert recorder.only["mode_seen_by_evaluator"] is EngineMode.SHADOW
+        assert recorder.only["traffic_source"] == "real"
+
+
+# ---------------------------------------------------------------------------
+# §6 — INNOCENCE: absent canary changes nothing
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryAbsentChangesNothing:
+    async def test_no_headers_keeps_the_deployment_mode(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        async with _client(_build_app()) as client:
+            response = await client.post(f"{EVALUATE_URL}?traffic_source=real", json=_payload())
+        assert response.status_code == 200
+        assert recorder.only["mode_seen_by_evaluator"] is EngineMode.SHADOW
+
+    async def test_provisioned_secret_alone_changes_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """The scar this repeats: arming the allowlist alone once would have
+        let any caller self-label. Arming a LEVER and arming a REQUEST are
+        different acts — with the secret set but no header sent, the
+        request must behave exactly as if the lever did not exist."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+        async with _client(_build_app()) as client:
+            response = await client.post(f"{EVALUATE_URL}?traffic_source=real", json=_payload())
+        assert response.status_code == 200
+        assert recorder.only["mode_seen_by_evaluator"] is EngineMode.SHADOW
+        assert recorder.only["traffic_source"] == "real"
+
+    async def test_token_header_without_mode_header_changes_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """Presence of the MODE header is the only thing that opens the
+        branch; a stray token header is inert."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=real",
+                json=_payload(),
+                headers={CANARY_TOKEN_HEADER: CANARY_SECRET},
+            )
+        assert response.status_code == 200
+        assert recorder.only["mode_seen_by_evaluator"] is EngineMode.SHADOW
+        assert recorder.only["traffic_source"] == "real"
+
+    async def test_non_canary_request_keeps_its_declared_traffic_source(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """INNOCENCE for property 3: the forced label is confined to canary
+        requests; an ordinary armed driver request keeps its own class."""
+        monkeypatch.setenv(evaluate_path.ALLOW_SYNTHETIC_SOURCES_ENV, "synthetic_gold")
+        monkeypatch.setenv(evaluate_path.DRIVER_TOKEN_ENV, DRIVER_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=synthetic_gold",
+                json=_payload(),
+                headers={"x-visa-driver-token": DRIVER_SECRET},
+            )
+        assert response.status_code == 200
+        assert recorder.only["traffic_source"] == "synthetic_gold"
+
+    async def test_synthetic_gate_still_rejects_an_unarmed_caller(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """The pre-existing trust gate is untouched by the new branch: a
+        caller with no credentials still cannot self-label synthetic."""
+        monkeypatch.delenv(evaluate_path.ALLOW_SYNTHETIC_SOURCES_ENV, raising=False)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=synthetic_driver", json=_payload()
+            )
+        assert response.status_code == 400
+        assert recorder.calls == []
+
+    async def test_invalid_traffic_source_is_still_rejected_before_the_canary(
+        self, monkeypatch: pytest.MonkeyPatch, recorder: _Recorder
+    ) -> None:
+        """Query-param validation keeps precedence: a canary credential
+        does not buy a way past the closed vocabulary."""
+        monkeypatch.setenv(evaluate_path.CANARY_TOKEN_ENV, CANARY_SECRET)
+        async with _client(_build_app()) as client:
+            response = await client.post(
+                f"{EVALUATE_URL}?traffic_source=whatever",
+                json=_payload(),
+                headers={
+                    CANARY_MODE_HEADER: "ENFORCE",
+                    CANARY_TOKEN_HEADER: CANARY_SECRET,
+                },
+            )
+        assert response.status_code == 400
+        assert recorder.calls == []


### PR DESCRIPTION
## What this is

`resolve_evaluate_mode()` (`evaluate_path.py`) read **only** the deployment-wide
`VISA_ENGINE_EVALUATE_MODE`. There was no canary, no percentage, no per-request
override — so the only way to try `ENFORCE` was to flip every live visitor from
0% to 100% in a single gesture, which contradicts the ASSEMBLY-LINE
dark → 5% → 100% ruling. This builds the missing lever.

## The three non-negotiable properties, and where each is proven

| Property | Guilt test | Innocence test |
|---|---|---|
| Absent by default ⇒ behaviour **identical** to today | `TestCanaryEngages` | `TestCanaryAbsentChangesNothing` — incl. *secret provisioned, header absent* |
| Not reachable from a guessable public parameter | `TestCanaryRejections` (6 shapes) | `test_driver_token_is_not_a_canary_token` |
| Visible in the decision record | `test_canary_forces_synthetic_driver_label` | `test_non_canary_request_keeps_its_declared_traffic_source` |

## How it works

- `X-Visa-Canary-Mode` (`SHADOW`\|`ENFORCE`) states the intent; `X-Visa-Canary-Token`
  proves the authority against `VISA_ENGINE_EVALUATE_CANARY_TOKEN` — constant-time,
  fail-closed when unset. A **separate secret** from the W4 driver token on purpose:
  holding the replay credential must not confer the authority to change mode.
- Presence of the **mode** header is the only thing that opens the branch, and the
  non-canary path executes the *same statement* it executed before (`nullcontext`),
  so "identical" is structural rather than asserted.
- The override lives in a `ContextVar`, which is what makes it **total**: six call
  sites resolve the mode independently (`run_evaluation`, `run_public_evaluation`,
  `_replay_authority_matches` ×2, `resolve_response_mode`, `resolve_evaluate_shadow_enabled`).
  A lever reaching only some of them would return a response envelope that disagreed
  with the persisted row about who decided.
- A canary request is forced to `traffic_source='synthetic_driver'` server-side,
  **before** the canonical request is built, so the idempotency binding records the
  label the row will actually carry and a canary decision is never counted as real
  production demand.

## No migration — deliberately

`visa_decisions` has no free-form column, and a `ALTER TABLE` there would run as
`backend_rag_v2`, which does not own the table: per the trap documented in migration
289's header, that does not merely fail, it **aborts the deploy**. So the lever uses
the columns that already exist.

**Declared limit** (module docstring + PENDING-ARMS): today the pair
(`synthetic_driver`, `engine_mode='ENFORCE'`) identifies a canary row only because the
deployment is globally SHADOW. Once global ENFORCE is armed, a W4 replay-driver row is
also ENFORCE and the pair stops identifying anything. **A dedicated column must land
before global ENFORCE.**

## Verification

- **46 new tests**, guilt AND innocence per property.
- **5 source mutations, all red** — 6 / 3 / 4 / 2 / 10 failures (ContextVar ignored;
  forced label removed; token fail-open; vocabulary widened to OFF; override never
  released). Baseline back to 46 green. The delta 0→N is the proof, not the count.
- **No regression, measured not assumed**: `test_evaluate_endpoint.py` gives
  198 passed / 31 errors **with and without** this diff (checked on a stashed working
  tree). Those 31 are local Postgres pollution (`TooManyColumnsError: tables can have
  at most 1600 columns`), not this change.
- **Order-independent**: both file orders give 244 passed — no ContextVar cross-test leak.
- Import chain OK; router manifest + registration parity 372 passed; ruff clean.

## What this does NOT do

- Does **not** remove SHADOW globally, and does not arm ENFORCE anywhere.
- Does **not** provision the secret. With `VISA_ENGINE_EVALUATE_CANARY_TOKEN` unset —
  which is its state in production — the lever is inert for every caller.
- Does **not** add a percentage-of-traffic lever; that is a later stage and will need
  its own label (see the declared limit above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
