### PR TITLE
fix(mouth): an invented title on every unknown path, a CORS-blocked prefetch, a dead third-party asset

### DIFF
--- a/apps/mouth/src/app/(blog)/[category]/page.metadata.test.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/page.metadata.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * The 2026-07-30 cure for the root-namespace soft-404 was applied to
+ * `layout.tsx` — both its `generateMetadata` (return "Page not found",
+ * noindex) and its default export (`notFound()` for anything outside the
+ * allow-list). It is correct, and `layout.test.tsx` covers it.
+ *
+ * It did not hold in production, and this file is why: `page.tsx` exports its
+ * OWN `generateMetadata`, and in the Next App Router a page's metadata
+ * OVERRIDES its layout's. So the layout returned "Page not found" and the page
+ * put the invented title straight back.
+ *
+ * Measured live on 2026-08-27, four weeks after that cure landed:
+ *   GET https://balizero.com/nope-single-segment
+ *   -> HTTP 200, <title>Nope-single-segment Insights | Bali Zero</title>
+ * over a body that renders the blog not-found ("Article not found"). Any
+ * single-segment path mints a Bali Zero title from attacker-chosen text.
+ *
+ * Guilt: junk segments get the not-found title and noindex.
+ * Innocence: all six real categories keep their own SEO metadata untouched.
+ */
+import { describe, expect, it } from "vitest";
+
+import { generateMetadata } from "./page";
+import { generateMetadata as layoutMetadata } from "./layout";
+import type { ArticleCategory } from "@/lib/blog/types";
+
+/**
+ * DERIVED from the layout, never transcribed: the whole defect was the two
+ * halves disagreeing, so a hand-copied literal here would reproduce exactly
+ * the blindness this file exists to close. If someone edits the layout's
+ * wording, this suite follows it instead of going green against a stale copy.
+ */
+const NOT_FOUND_TITLE = String(
+  (
+    await layoutMetadata({
+      params: Promise.resolve({ category: "zzz-derive" }),
+    })
+  ).title,
+);
+
+const REAL_CATEGORIES: ArticleCategory[] = [
+  "visas",
+  "business",
+  "taxes",
+  "property",
+  "living",
+  "trends",
+];
+
+// The live probe plus the shapes an SEO-spam crawler actually walks.
+const JUNK = [
+  "nope-single-segment",
+  "zzz-nonsense",
+  "buy-cheap-visas",
+  "id",
+  "it",
+  "cases",
+  "wp-admin",
+];
+
+const meta = (category: string) =>
+  generateMetadata({ params: Promise.resolve({ category }) });
+
+/** Every string VALUE reachable in a metadata object, keys excluded. */
+function collectStrings(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") out.push(value);
+  else if (Array.isArray(value)) value.forEach((v) => collectStrings(v, out));
+  else if (value && typeof value === "object")
+    Object.values(value).forEach((v) => collectStrings(v, out));
+  return out;
+}
+
+describe("(blog)/[category] page metadata — guilt", () => {
+  it.each(JUNK)(
+    "does not mint a title from the URL segment: /%s",
+    async (category) => {
+      const m = await meta(category);
+      expect(m.title).toBe(NOT_FOUND_TITLE);
+      // The root layout sets the title template `%s | Bali Zero`, so this
+      // string must NOT carry the suffix itself — the first draft of this
+      // guard did, which would have rendered "… | Bali Zero | Bali Zero".
+      expect(String(m.title)).not.toContain("Bali Zero");
+      // The segment must appear in no metadata VALUE — that is the whole
+      // defect: arbitrary caller text reaching a Bali Zero <title>.
+      // Deliberately NOT a substring scan of the serialized object: the
+      // key names are part of that string, and `"title"` contains `"it"`,
+      // so a JSON-wide scan fails on the real locale-root probe `/it` for a
+      // reason that has nothing to do with the guard (superscar #3,
+      // over-match — this test tripped on it on first run).
+      for (const value of collectStrings(m)) {
+        expect(value.toLowerCase()).not.toContain(category.toLowerCase());
+      }
+    },
+  );
+
+  it.each(JUNK)("marks junk noindex,nofollow: /%s", async (category) => {
+    const m = await meta(category);
+    expect(m.robots).toMatchObject({ index: false, follow: false });
+  });
+});
+
+describe("(blog)/[category] page metadata — innocence", () => {
+  it.each(REAL_CATEGORIES)(
+    "leaves the real category's own metadata intact: /%s",
+    async (category) => {
+      const m = await meta(category);
+      expect(m.title).not.toBe(NOT_FOUND_TITLE);
+      expect(typeof m.title).toBe("string");
+      expect(String(m.title).length).toBeGreaterThan(0);
+      // A real category must never be marked noindex by this guard.
+      expect(m.robots ?? null).not.toMatchObject({ index: false });
+    },
+  );
+
+  it("keeps the six real categories and the junk set disjoint", () => {
+    // Guards against a future edit that quietly narrows VALID_CATEGORIES and
+    // makes the guilt suite pass for the wrong reason.
+    for (const c of REAL_CATEGORIES) {
+      expect(JUNK).not.toContain(c);
+    }
+  });
+});

--- a/apps/mouth/src/app/(blog)/[category]/page.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/page.tsx
@@ -27,6 +27,25 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { category } = await params;
+  // `[category]` sits at the ROOT of the route tree, so it matches every
+  // unknown single-segment URL on the domain. `generateMetadata` runs before
+  // the component's `notFound()` guard, so without this check the title was
+  // minted from whatever the caller put in the path: measured live on
+  // 2026-08-27, `/nope-single-segment` answered 200 with
+  // `<title>Nope-single-segment Insights | Bali Zero</title>` over a body that
+  // renders "Article not found". Guard the metadata with the SAME list the
+  // component guards with, so an unknown segment can never place
+  // attacker-chosen text in a Bali Zero title.
+  //
+  // The string is deliberately bare: the root layout sets the title template
+  // `%s | Bali Zero`, so it renders as "Page not found | Bali Zero". Writing
+  // the suffix here would produce it twice. It matches `layout.tsx` verbatim.
+  if (!VALID_CATEGORIES.includes(category as ArticleCategory)) {
+    return {
+      title: "Page not found",
+      robots: { index: false, follow: false },
+    };
+  }
   return generateCategoryMetadata(category);
 }
 

--- a/apps/mouth/src/app/kbli-explorer/layout.tsx
+++ b/apps/mouth/src/app/kbli-explorer/layout.tsx
@@ -61,12 +61,16 @@ export default function KBLIExplorerLayout({
   return (
     <div className="h-screen w-full bg-[#050507] text-silver overflow-hidden overflow-x-hidden font-sans selection:bg-accent-sand/30 selection:text-accent-sand">
       <KBLIExplorerJsonLd />
-      {/* Texture Layer: Noise/Grain for tactile feel */}
+      {/* Texture Layer: Noise/Grain for tactile feel.
+          Inlined as a data URI. It used to be fetched from
+          grainy-gradients.vercel.app, which now answers 404 — so the texture
+          had silently stopped rendering while still costing every visitor a
+          failed third-party request (and disclosing their IP to a domain we
+          do not control). Same fractal noise, no network, no third party. */}
       <div
         className="fixed inset-0 z-0 opacity-[0.03] pointer-events-none mix-blend-overlay"
         style={{
-          backgroundImage:
-            'url("https://grainy-gradients.vercel.app/noise.svg")',
+          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)'/%3E%3C/svg%3E")`,
         }}
       />
 

--- a/apps/mouth/src/app/not-found.tsx
+++ b/apps/mouth/src/app/not-found.tsx
@@ -20,7 +20,21 @@ export default function NotFound() {
         <Link href="/" className={buttonVariants({ variant: "default" })}>
           Return Home
         </Link>
-        <Link href="/chat" className={buttonVariants({ variant: "outline" })}>
+        {/* `prefetch={false}` is load-bearing, not a tuning knob: `/chat` is
+            301'd cross-origin to kita.balizero.com by the Vercel Dashboard, and
+            Next's default RSC prefetch (`/chat?_rsc=…`) therefore becomes a
+            cross-origin request that CORS blocks — two console errors and one
+            failed request on every render of this page (measured live
+            2026-08-27). apps/mouth/CLAUDE.md documents the middleware
+            RSC→204 remedy for this class, but this app has no middleware:
+            the redirect lives in the Vercel Dashboard, which cannot detect a
+            prefetch. Not prefetching is the fix that is actually available
+            here; the click-through is unaffected. */}
+        <Link
+          href="/chat"
+          prefetch={false}
+          className={buttonVariants({ variant: "outline" })}
+        >
           Go to Chat
         </Link>
       </div>


### PR DESCRIPTION
Three defects found by a four-channel sweep (HTTP / console / network / rendered text) of 30 public surfaces on balizero.com, 2026-08-27. One batch, one concern: what the live site does wrong to a visitor.

### 1. Every unknown single-segment path minted a Bali Zero title from the URL

Measured live:

```
GET https://balizero.com/nope-single-segment
HTTP/2 200 · x-matched-path: /[category] · x-nextjs-prerender: 1
<title>Nope-single-segment Insights | Bali Zero</title>
```

…over a body that renders "Article not found". `[category]` sits at the ROOT of the route tree, so this is not one page: it is every unknown single-segment path on the domain, an unbounded set of attacker-chosen strings placed inside a Bali Zero `<title>` and served 200.

**This was already cured on 2026-07-30** (ffff82c7d), in `layout.tsx`, correctly — metadata *and* `notFound()`. It did not hold, and that is the interesting part: `page.tsx` exports its own `generateMetadata`, and in the App Router **a page's metadata overrides its layout's**. The layout returned "Page not found"; the page put the invented title straight back. Four weeks in production. The cure now sits on both halves, behind the same allow-list.

### 2. The root `not-found` fired a CORS-blocked prefetch on every render

`/chat` is 301'd cross-origin to kita.balizero.com by the Vercel Dashboard, so Next's default RSC prefetch became a cross-origin request that CORS blocked — two console errors and one failed request, every time. Measured on `/visa/voa` (which renders this not-found because the GARUDA funnel is dark by flag, #4960 — the dark state is intended, the CORS noise is not).

`apps/mouth/CLAUDE.md` documents the middleware RSC→204 remedy for this class, but this app has no middleware and the redirect lives in the Dashboard, which cannot see a prefetch. `prefetch={false}` is the fix that is actually available here; the click-through is unchanged.

### 3. `kbli-explorer` fetched its texture from a domain that answers 404

grainy-gradients.vercel.app is gone. The texture had silently stopped rendering while still costing every visitor a failed third-party request and disclosing their IP to a domain we do not control. Inlined as a data URI.

---

### Verification

- **21 new tests.** Guilt: 7 junk segments get the not-found title, noindex, and no metadata VALUE containing the segment. Innocence: all six real categories keep their own SEO metadata and are never marked noindex.
- The expected title is **derived by calling the layout's own `generateMetadata`**, not transcribed — a hand-copied literal would reproduce exactly the blindness this file exists to close.
- **Mutation:** removing the guard turns 14 of the 21 red; restored, 21 green.
- Existing `layout.test.tsx` (19 tests) still passes — 40 green together.
- Two self-inflicted defects were caught before commit: the guilt assertion first scanned the serialized metadata object and tripped on `/it` (the KEY `"title"` contains `"it"` — superscar #3), and the guard's first draft returned `"Page not found | Bali Zero"` while the root layout already applies the template `%s | Bali Zero`, which would have printed the suffix twice. Both are pinned by tests now.

### Deliberately NOT cured here

- **not-found still answers 200, not 404.** Cause identified (`x-matched-path: /[category]`, prerendered, cache-HIT); cure not established — `dynamicParams = false` would 404 unknown categories but would also break the hourly article-promotion cron for `[category]/[slug]`. Needs a designed fix, not a guess.
- **`/prime` is down** — Google Maps answers `ExpiredKeyMapError`, so the geospatial hub renders no map. Key rotation is `operator[secret]`: **Zero only**.
- **`/news` emits three `_next/image` 400s** — the three referenced JPGs are absent from `public/static/blog/tax/` (the directory holds one file). Inventing client-facing imagery is not a fix a session should make alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)