### PR TITLE
fix(codex): distinguish quota exhaustion from generic CLI failure (B2b)

### DIFF
--- a/apps/backend-rag/backend/llm/codex_exec_client.py
+++ b/apps/backend-rag/backend/llm/codex_exec_client.py
@@ -272,9 +272,9 @@ Binding invariants (R24-1, mandate 2026-08-15):
     no auth material (not even a file path's existence bit beyond the
     boolean `available` result) ever reaches an exception message or a log
     line. `CodexExecProcessError` carries only the numeric exit code;
-    `CodexExecAuthError`/`CodexExecOutputShapeError`/`CodexExecTimeoutError`/
-    `CodexExecCommunicationError` carry only fixed local literals. Full type
-    hints throughout; `logger` never `print`.
+    `CodexExecAuthError`/`CodexExecQuotaError`/`CodexExecOutputShapeError`/
+    `CodexExecTimeoutError`/`CodexExecCommunicationError` carry only fixed
+    local literals. Full type hints throughout; `logger` never `print`.
 
 7.  **GROUNDING PROBE.** One designated live call was run from this session
     in the original R24 round (`printf 'Reply with exactly PONG' | codex
@@ -463,6 +463,48 @@ _AUTH_DEATH_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# Quota-exhaustion detection (closes the gap `scripts/wa_codex_seat_probe.py`
+# names as "S1.5 owns sharpening that bucket": until this, a quota-dead seat
+# and a genuine crash both fell into the generic `CodexExecProcessError` /
+# `cli_failure` bucket, indistinguishable from each other). Same
+# word-boundary shape as `_AUTH_DEATH_RE`, DERIVED — never invented — from
+# real `codex exec` output captured elsewhere in this repo:
+#   - "You've hit your usage limit... try again at Aug 19th, 2026" — measured
+#     live, `gpt-5.6-terra` via `codex exec`
+#     (research/operations/2026-07-20-kbli-batch-a-lot8-conductor-gate.md §5b)
+#   - "ERROR: You've hit your usage limit" — measured live, codex CLI
+#     v0.147.0 (research/operations/2026-08-21-world-patterns-import-map.md)
+#   - "ERROR: You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to
+#     another model now, or try again at Aug 31st, 2026 8:06 PM." — measured
+#     live 2026-08-26/27 (scripts/army/spark_lane.sh)
+#   - "ERROR: You've hit your usage limit. Upgrade to Plus to continue using
+#     Codex..." — captured codex transcripts
+#     (docs/design-palettes/funnels/research/tax-codex-brainstorm.md and its
+#     archived twin)
+# Cross-checked against the fleet's own codex-specific cascade grep
+# (`~/scripts/regulatory-watcher-run.sh` tier 3, run against real
+# `codex exec` output in production: `usage.limit|quota|exhausted`) and this
+# repo's own codex-reviewer quota classifier
+# (`scripts/codex_tri_llm_review.py`'s `("hit your weekly limit", "hit your
+# usage limit", "usage limit", "weekly limit", ..., "quota exceeded")`,
+# which scans a `codex` reviewer subprocess's output for exactly this
+# purpose). Deliberately narrower than either: `out of extra usage` is the
+# Claude CLI's own phrasing (`claude_oauth_client.py`'s
+# `_QUOTA_DIAGNOSTIC_PATTERN`) and never appears in a measured `codex`
+# transcript, so it is NOT included here — and a bare `quota`/`429`/`limit`
+# would over-match ordinary Bali Zero domain talk about a client's KITAS
+# "limit of stay" or an investor/worker "quota" (RPTKA), so every
+# alternative below requires the specific multi-word framing actually
+# observed, never a lone word (cicatrix family #3 discipline).
+_QUOTA_RE: re.Pattern[str] = re.compile(
+    r"\b(?:"
+    r"usage\s+limit|"
+    r"weekly\s+limit|"
+    r"quota\s+(?:exceeded|exhausted)"
+    r")(?!\w)",
+    re.IGNORECASE,
+)
+
 
 class CodexExecUnavailableError(RuntimeError):
     """Raised by `generate()` when `available` is `False` (binary missing,
@@ -486,6 +528,19 @@ class CodexExecAuthError(RuntimeError):
     re-login (`codex login`) is needed. Distinct from
     `CodexExecProcessError` so a caller can page a human for THIS class and
     silently retry-later for a generic failure.
+    """
+
+
+class CodexExecQuotaError(RuntimeError):
+    """The subprocess exited non-zero and its STDERR — same scan discipline
+    as `CodexExecAuthError` (stderr-only, known prompt/stdout LINES
+    stripped) — matched a known quota-exhaustion word class (see
+    `_QUOTA_RE`). Distinct from both `CodexExecAuthError` (no re-login can
+    fix this; the seat's usage window must reset) and the generic
+    `CodexExecProcessError` (a caller can page a DEDICATED, time-bound
+    condition for THIS class instead of folding it into an undifferentiated
+    CLI failure — see `wa_codex_daemon.py`'s `error_class="quota_exhausted"`
+    mapping and `scripts/wa_codex_seat_probe.py`'s `VERDICT_QUOTA_DEAD`).
     """
 
 
@@ -749,6 +804,13 @@ def _auth_death_detected(*texts: str) -> bool:
     return any(_AUTH_DEATH_RE.search(t) for t in texts if t)
 
 
+def _quota_exhaustion_detected(*texts: str) -> bool:
+    """Same independent-per-argument scan discipline as
+    `_auth_death_detected` (see its docstring for why concatenation is
+    unsafe), against `_QUOTA_RE` instead."""
+    return any(_QUOTA_RE.search(t) for t in texts if t)
+
+
 class CodexExecClient:
     """Thin async wrapper spawning `codex exec` as a subprocess.
 
@@ -933,6 +995,10 @@ class CodexExecClient:
                 was killed and reaped and the raw exception was suppressed.
             CodexExecAuthError: the subprocess exited non-zero with output
                 matching a known auth-failure word class (point 5).
+            CodexExecQuotaError: the subprocess exited non-zero with output
+                matching a known quota-exhaustion word class (`_QUOTA_RE`),
+                checked after the auth-failure class and before the generic
+                fallback.
             CodexExecProcessError: the subprocess exited non-zero for any
                 other reason.
             CodexExecOutputShapeError: `exit_code == 0` but stdout was
@@ -1114,6 +1180,17 @@ class CodexExecClient:
                     raise CodexExecAuthError(
                         "codex exec reported an authentication failure — operator re-login "
                         "(`codex login`) needed",
+                    )
+                if _quota_exhaustion_detected(stripped_stderr):
+                    logger.warning(
+                        "codex_exec: quota exhaustion detected (exit_code=%d, model=%s) — "
+                        "seat usage window must reset",
+                        exit_code,
+                        resolved_model,
+                    )
+                    raise CodexExecQuotaError(
+                        "codex exec reported quota exhaustion — the seat's usage window "
+                        "must reset before this model can be used again",
                     )
                 logger.warning(
                     "codex_exec: process failed (exit_code=%d, model=%s)",

--- a/apps/backend-rag/backend/llm/codex_exec_client.py
+++ b/apps/backend-rag/backend/llm/codex_exec_client.py
@@ -496,6 +496,44 @@ _AUTH_DEATH_RE: re.Pattern[str] = re.compile(
 # "limit of stay" or an investor/worker "quota" (RPTKA), so every
 # alternative below requires the specific multi-word framing actually
 # observed, never a lone word (cicatrix family #3 discipline).
+#
+# Adversarial review (Kimi K3, fresh context, 2026-08-27) flagged
+# `usage\s+limit` as unanchored to codex/ChatGPT and cited
+# `scripts/army/spark_lane.sh`'s own quota-cicatrix as precedent for
+# over-match. Verified by hand: that cicatrix was about a classifier
+# grepping the MODEL'S OWN OUTPUT even on a SUCCESSFUL run
+# (`exit_code == 0`) — its own fix note states the rule this file already
+# follows: "a successful run whose TEXT happens to mention quota is
+# innocent; only a failed run whose text names the reason is guilty." This
+# scan is already on the guilty side: stderr-only, `exit_code != 0` only,
+# with prompt/stdout lines stripped first (see `generate()` below). The
+# repo's OWN existing codex-quota classifier
+# (`scripts/codex_tri_llm_review.py:258-261`) additionally scans bare
+# `"rate limit"` with no codex-specific anchor at all — this pattern is
+# narrower than that established precedent, not looser. Known residual,
+# declared rather than hidden: a FAILED codex run whose stderr happens to
+# carry the raw error body of a THIRD-PARTY API call the job itself was
+# making (e.g. a 429 response node.js/python fetched and printed
+# verbatim) could still false-positive here if that body's wording
+# happens to say "usage limit"/"weekly limit"/"quota exceeded". No such
+# case has been observed; if it ever is, narrow the match to codex's own
+# `ERROR:`-prefixed framing rather than widening `_AUTH_DEATH_RE`'s
+# sibling discipline further.
+#
+# GAP NOTO (Kimi K3, same review): `quota\s+(?:exceeded|exhausted)` does
+# NOT match the word-order-inverted canonical OpenAI-family forms
+# ("You exceeded your current quota", "insufficient_quota") — searched
+# for a real attestation of either string in this repo
+# (`git grep -iE 'insufficient_quota|exceeded your current quota'`) and in
+# the installed `openai` SDK package under `apps/backend-rag/.venv`
+# (2026-08-27: package version 2.38.0) — NEITHER string appears anywhere
+# in either surface; the SDK does not embed API error-body text at all
+# (it comes from the live HTTP response, never from client source). Per
+# this file's own no-invented-pattern discipline, the inverted form is
+# therefore NOT added: a message using it falls into the generic
+# `CodexExecProcessError` bucket today. If a real `codex exec` transcript
+# ever surfaces this wording, add it with a cited source and its own
+# guilt+innocence tests — do not pattern-match it from memory.
 _QUOTA_RE: re.Pattern[str] = re.compile(
     r"\b(?:"
     r"usage\s+limit|"
@@ -540,7 +578,7 @@ class CodexExecQuotaError(RuntimeError):
     `CodexExecProcessError` (a caller can page a DEDICATED, time-bound
     condition for THIS class instead of folding it into an undifferentiated
     CLI failure — see `wa_codex_daemon.py`'s `error_class="quota_exhausted"`
-    mapping and `scripts/wa_codex_seat_probe.py`'s `VERDICT_QUOTA_DEAD`).
+    mapping and `scripts/wa_codex_seat_probe.py`'s `VERDICT_QUOTA_EXHAUSTED`).
     """
 
 
@@ -1169,6 +1207,21 @@ class CodexExecClient:
                 # own transcript echoes both), and `_auth_death_detected`
                 # scans its argument(s) independently rather than joining
                 # them — see that helper's docstring.
+                #
+                # KNOWN RESIDUAL, documented not fixed (Kimi K3 adversarial
+                # review, 2026-08-27; out of scope for this change):
+                # `_strip_known_lines` matches by WHOLE-LINE EQUALITY. If
+                # `codex exec` ever wraps a long echoed prompt across
+                # multiple stderr lines — plausible for the long, often
+                # Italian, free-text prompts real WA client messages
+                # produce — no single wrapped line equals the whole
+                # original prompt line, the strip silently no-ops on it,
+                # and the client's own words survive into the auth/quota
+                # regex scan below. The "prompt echoes as a single line"
+                # assumption is load-bearing here and is unproven for real
+                # WA traffic specifically (only proven for the short,
+                # inert probe/test prompts this module's own fixtures
+                # use).
                 stripped_stderr = _strip_known_lines(stderr, prompt, stdout)
                 if _auth_death_detected(stripped_stderr):
                     logger.warning(

--- a/apps/backend-rag/backend/services/integrations/wa_broker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_broker.py
@@ -105,6 +105,7 @@ ALLOWED_ERROR_CLASSES = frozenset(
     {
         "exec_timeout",  # codex subprocess exceeded its budget
         "cli_failure",  # codex CLI exited non-zero / unparseable output
+        "quota_exhausted",  # codex seat's usage window is exhausted (B2b)
         "cli_version_mismatch",  # daemon version pin refused to exec (chaos row 8)
         "spawn_failure",  # subprocess could not be started
         "oversized_output",  # result exceeded the transport bound (chaos row 7)

--- a/apps/backend-rag/backend/services/integrations/wa_codex_daemon.py
+++ b/apps/backend-rag/backend/services/integrations/wa_codex_daemon.py
@@ -75,6 +75,7 @@ from backend.llm.codex_exec_client import (
     CodexExecCommunicationError,
     CodexExecOutputShapeError,
     CodexExecProcessError,
+    CodexExecQuotaError,
     CodexExecTimeoutError,
     CodexExecUnavailableError,
 )
@@ -507,6 +508,20 @@ class WaCodexDaemon:
                 claim.job_id,
             )
             error_class = "cli_failure"
+        except CodexExecQuotaError:
+            # B2b: a quota-dead seat is NOT a crash — every subsequent job
+            # will fail the same way until the seat's usage window resets,
+            # but no operator re-login fixes it (unlike auth death above).
+            # Reported as its own wire vocabulary entry so the sentinel can
+            # page a DEDICATED, time-bound condition instead of folding it
+            # into the generic cli_failure bucket, where it was previously
+            # indistinguishable from any other crash.
+            logger.warning(
+                "wa-codex-daemon: codex seat QUOTA EXHAUSTED (job %s reported as "
+                "quota_exhausted) — no operator action; waits for the usage window to reset",
+                claim.job_id,
+            )
+            error_class = "quota_exhausted"
         except (CodexExecProcessError, CodexExecCommunicationError, CodexExecOutputShapeError):
             error_class = "cli_failure"
         except Exception as exc:

--- a/apps/backend-rag/backend/tests/llm/test_codex_exec_client.py
+++ b/apps/backend-rag/backend/tests/llm/test_codex_exec_client.py
@@ -31,6 +31,7 @@ from backend.llm.codex_exec_client import (
     CodexExecModelNotAllowedError,
     CodexExecOutputShapeError,
     CodexExecProcessError,
+    CodexExecQuotaError,
     CodexExecResult,
     CodexExecTimeoutError,
     CodexExecUnavailableError,
@@ -88,6 +89,37 @@ _MEASURED_SUCCESS_STDERR = (
 # ---------------------------------------------------------------------------
 _CONSTRUCTED_AUTH_FAIL_STDERR = b"Error: Not logged in. Run `codex login` to authenticate.\n"
 _CONSTRUCTED_GENERIC_FAIL_STDERR = b"Error: network request failed (connect timeout)\n"
+
+# ---------------------------------------------------------------------------
+# MEASURED quota fixtures — real `codex exec` transcripts captured elsewhere
+# in this repo (never invented; see `_QUOTA_RE`'s own docstring in
+# codex_exec_client.py for the full source list).
+# ---------------------------------------------------------------------------
+_MEASURED_QUOTA_STDERR_1 = (
+    b"ERROR: You've hit your usage limit. Upgrade to Plus to continue using "
+    b"Codex (https://chatgpt.com/explore/plus), or try again at Apr 13th, 2026 1:46 PM.\n"
+)  # docs/design-palettes/funnels/research/tax-codex-brainstorm.md
+_MEASURED_QUOTA_STDERR_2 = (
+    b"ERROR: You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to "
+    b"another model now, or try again at Aug 31st, 2026 8:06 PM.\n"
+)  # scripts/army/spark_lane.sh, measured live 2026-08-26/27
+# CONSTRUCTED quota fixtures — not measured word-for-word from a codex
+# transcript, but each word class is attested elsewhere for codex/CLI quota
+# specifically (see `_QUOTA_RE`'s docstring): "weekly limit" is what this
+# repo's own `scripts/codex_tri_llm_review.py` scans a `codex` reviewer
+# subprocess's output for; "quota exceeded"/"exhausted" is the fleet's own
+# codex-specific cascade grep in `~/scripts/regulatory-watcher-run.sh` tier 3.
+_CONSTRUCTED_WEEKLY_LIMIT_STDERR = b"Error: you've hit your weekly limit, resets Monday 9am\n"
+_CONSTRUCTED_QUOTA_EXCEEDED_STDERR = b"Error: quota exceeded for this account\n"
+# INNOCENT-but-plausible: real Bali Zero domain vocabulary that must NOT
+# false-positive — RPTKA (foreign-worker permit) "quota" and a KITAS "limit
+# of stay" are ordinary immigration/business words, not diagnostics, and
+# neither pairs "quota"/"limit" with the specific framing `_QUOTA_RE`
+# requires (cicatrix family #3: guard must not decide on a bare substring).
+_INNOCENT_QUOTA_WORD_STDERR = (
+    b"boom: could not resolve the client's annual RPTKA quota against the "
+    b"KITAS limit of stay on file\n"
+)
 
 
 class _FakeProcess:
@@ -993,6 +1025,132 @@ class TestAuthDeathDetection:
             await client.generate("hello")
 
 
+class TestQuotaDetection:
+    """B2b — closes the gap `scripts/wa_codex_seat_probe.py` used to name as
+    'S1.5 owns sharpening that bucket': quota exhaustion used to fold into
+    the same generic `CodexExecProcessError` as any other crash."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stderr_text",
+        [
+            _MEASURED_QUOTA_STDERR_1,
+            _MEASURED_QUOTA_STDERR_2,
+            _CONSTRUCTED_WEEKLY_LIMIT_STDERR,
+            _CONSTRUCTED_QUOTA_EXCEEDED_STDERR,
+        ],
+    )
+    async def test_guilt_quota_phrasings_raise_distinct_error(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+        stderr_text: bytes,
+    ) -> None:
+        client = _make_available_client(tmp_path)
+        fake_exec.queue(_FakeProcess(b"", stderr_text, 1))
+
+        with pytest.raises(CodexExecQuotaError):
+            await client.generate("hello")
+
+    @pytest.mark.asyncio
+    async def test_guilt_generic_failure_still_raises_process_error_not_quota(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        client = _make_available_client(tmp_path)
+        fake_exec.queue(_FakeProcess(b"", _CONSTRUCTED_GENERIC_FAIL_STDERR, 1))
+
+        with pytest.raises(CodexExecProcessError) as exc_info:
+            await client.generate("hello")
+        assert exc_info.value.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_guilt_auth_failure_still_raises_auth_not_quota(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        """Auth and quota vocabularies are disjoint, but the scan ORDER
+        (auth checked first in `generate()`) must still resolve an
+        auth-shaped failure to `CodexExecAuthError`, never `CodexExecQuotaError`."""
+        client = _make_available_client(tmp_path)
+        fake_exec.queue(_FakeProcess(b"", _CONSTRUCTED_AUTH_FAIL_STDERR, 1))
+
+        with pytest.raises(CodexExecAuthError):
+            await client.generate("hello")
+
+    @pytest.mark.asyncio
+    async def test_innocence_rptka_and_kitas_quota_talk_does_not_page(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        """Over-match guard (cicatrix family #3): a failure message that
+        happens to mention an RPTKA "quota" or a KITAS "limit of stay" —
+        ordinary Bali Zero domain vocabulary — must not be misclassified as
+        THIS client's own quota exhaustion. Neither word pairs with the
+        specific framing `_QUOTA_RE` requires."""
+        client = _make_available_client(tmp_path)
+        fake_exec.queue(_FakeProcess(b"", _INNOCENT_QUOTA_WORD_STDERR, 1))
+
+        with pytest.raises(CodexExecProcessError):
+            await client.generate("hello")
+
+    @pytest.mark.asyncio
+    async def test_innocence_success_path_never_scanned_for_quota_words(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        """Mirrors `TestAuthDeathDetection`'s equivalent innocence test:
+        `exit_code == 0` never triggers the quota scan at all, so a
+        legitimate answer discussing a client's RPTKA quota/usage limit
+        topic must not misclassify."""
+        client = _make_available_client(tmp_path)
+        answer = (
+            b"Your company's RPTKA usage limit was reached last quarter; "
+            b"the quota exceeded threshold triggers a BKPM review."
+        )
+        fake_exec.queue(_FakeProcess(answer, b"", 0))
+
+        result = await client.generate("what happens when the RPTKA quota is exceeded")
+
+        assert "quota" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_innocence_echoed_prompt_quota_words_do_not_false_positive(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        """A failing run whose stderr echoes a client prompt that itself
+        contains quota-shaped words must not be misclassified as THIS
+        client's own quota exhaustion — only genuine wording OUTSIDE the
+        echoed prompt should trigger `CodexExecQuotaError`."""
+        client = _make_available_client(tmp_path)
+        prompt = "explain what happens when the RPTKA usage limit is exceeded"
+        stderr = b"user\n" + prompt.encode() + b"\nsome unrelated network error\n"
+        fake_exec.queue(_FakeProcess(b"", stderr, 1))
+
+        with pytest.raises(CodexExecProcessError):
+            await client.generate(prompt)
+
+    @pytest.mark.asyncio
+    async def test_guilt_quota_word_outside_echoed_prompt_still_detected(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        client = _make_available_client(tmp_path)
+        prompt = "tell me about visa renewal"
+        stderr = b"user\n" + prompt.encode() + b"\nError: quota exceeded\n"
+        fake_exec.queue(_FakeProcess(b"", stderr, 1))
+
+        with pytest.raises(CodexExecQuotaError):
+            await client.generate(prompt)
+
+
 # ---------------------------------------------------------------------------
 # Timeout — wall-clock kill + reap (F26-6 fix, R26 GLM addendum,
 # 2026-08-15: this is a deadline/output-shape behavior, NOT one of the
@@ -1275,6 +1433,23 @@ class TestSanitizedErrors:
         message = str(exc_info.value)
         assert prompt not in message
         assert "Not logged in" not in message  # raw stderr never echoed into the message
+
+    @pytest.mark.asyncio
+    async def test_innocence_quota_error_message_excludes_prompt_and_raw_output(
+        self,
+        tmp_path,
+        fake_exec: _FakeSubprocessExec,
+    ) -> None:
+        prompt = "my super secret client PII that must never appear in an exception"
+        client = _make_available_client(tmp_path)
+        fake_exec.queue(_FakeProcess(b"", _MEASURED_QUOTA_STDERR_1, 1))
+
+        with pytest.raises(CodexExecQuotaError) as exc_info:
+            await client.generate(prompt)
+
+        message = str(exc_info.value)
+        assert prompt not in message
+        assert "usage limit" not in message  # raw stderr never echoed into the message
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/unit/routers/test_wa_broker_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_wa_broker_router.py
@@ -260,6 +260,20 @@ def test_complete_accepts_error_class_inside_allowed_vocabulary(
     assert resp.status_code == 200
 
 
+def test_complete_accepts_quota_exhausted_error_class(
+    client: TestClient, configured_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """B2b: the daemon now reports `quota_exhausted` as its own wire value
+    (instead of folding it into `cli_failure`) — the router must accept it,
+    not 422 it, or the daemon's typed report never reaches a terminal row."""
+    monkeypatch.setattr(
+        wa_broker_router.wa_broker, "complete_job", AsyncMock(return_value=CompleteStatus.ACCEPTED)
+    )
+    body = _complete_body(result_text=None, error_class="quota_exhausted")
+    resp = client.post("/api/wa-broker/complete", json=body, headers={"X-API-Key": configured_key})
+    assert resp.status_code == 200
+
+
 # ── complete: exec_ms Postgres int ceiling (finding 10) ─────────────────────
 
 

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_daemon.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_daemon.py
@@ -23,6 +23,7 @@ from backend.llm.codex_exec_client import (
     CodexExecCommunicationError,
     CodexExecOutputShapeError,
     CodexExecProcessError,
+    CodexExecQuotaError,
     CodexExecTimeoutError,
     CodexExecUnavailableError,
 )
@@ -463,6 +464,7 @@ class TestErrorMapping:
             (CodexExecCommunicationError("c"), "cli_failure"),
             (CodexExecOutputShapeError("o"), "cli_failure"),
             (CodexExecAuthError("a"), "cli_failure"),
+            (CodexExecQuotaError("q"), "quota_exhausted"),
             (RuntimeError("anything unexpected"), "cli_failure"),
         ],
     )

--- a/scripts/tests/test_wa_codex_seat_probe.py
+++ b/scripts/tests/test_wa_codex_seat_probe.py
@@ -54,6 +54,20 @@ def test_guilt_nonzero_without_auth_signature_is_other_failure() -> None:
     assert verdict == probe.VERDICT_OTHER_FAILURE
 
 
+def test_guilt_exec_usage_limit_on_stderr_is_quota_exhausted() -> None:
+    """B2b: closes the gap this module's docstring used to declare open —
+    quota exhaustion now gets its own verdict, not `other_failure`."""
+    verdict = probe.classify(
+        0, "Logged in using ChatGPT\n", "", 1, "", "ERROR: You've hit your usage limit."
+    )
+    assert verdict == probe.VERDICT_QUOTA_EXHAUSTED
+
+
+def test_guilt_exec_quota_exceeded_on_stderr_is_quota_exhausted() -> None:
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 1, "", "quota exceeded")
+    assert verdict == probe.VERDICT_QUOTA_EXHAUSTED
+
+
 # --------------------------------------------------------------- INNOCENCE
 
 
@@ -80,6 +94,31 @@ def test_innocence_healthy_login_status_output_does_not_match() -> None:
     """Misurato live 2026-08-20: da loggato stampa "Logged in using ChatGPT"
     con rc=0 — e comunque un rc=0 non viene scansionato."""
     assert probe.classify(0, "Logged in using ChatGPT\n", "", 0, "pong", "") == probe.VERDICT_OK
+
+
+def test_innocence_healthy_run_answer_discussing_rptka_quota_is_ok() -> None:
+    """Over-match guard (cicatrix family #3): a SUCCESSFUL exec whose
+    answer discusses a client's real RPTKA quota / KITAS limit of stay is
+    ordinary Bali Zero domain vocabulary — a rc=0 output is never scanned
+    at all, so this must never classify quota_exhausted."""
+    answer = "Your company's RPTKA quota and KITAS limit of stay are both current."
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 0, answer, "")
+    assert verdict == probe.VERDICT_OK
+
+
+def test_innocence_failed_exec_bare_quota_word_is_other_failure_not_quota() -> None:
+    """Over-match guard: a failed exec whose stderr mentions "quota" without
+    the "exceeded"/"exhausted" framing (or "limit" without "usage"/"weekly")
+    must not be misclassified as quota_exhausted."""
+    verdict = probe.classify(
+        0,
+        "Logged in using ChatGPT\n",
+        "",
+        1,
+        "",
+        "boom: could not resolve the RPTKA quota against the KITAS limit of stay",
+    )
+    assert verdict == probe.VERDICT_OTHER_FAILURE
 
 
 def test_fallback_regex_is_byte_identical_to_the_daemon_detector() -> None:
@@ -116,5 +155,34 @@ def test_fallback_regex_is_byte_identical_to_the_daemon_detector() -> None:
     )
     # Flags too (Kimi r1 m9): dropping re.IGNORECASE on either side keeps the
     # bodies identical while the detectors diverge on case.
+    assert "re.IGNORECASE" in match.group(1), "daemon regex lost re.IGNORECASE"
+    assert "re.IGNORECASE" in probe_match.group(1), "probe fallback lost re.IGNORECASE"
+
+
+def test_fallback_quota_regex_is_byte_identical_to_the_daemon_detector() -> None:
+    """Same superscar #1 discipline as the auth-death parity test above,
+    applied to `_QUOTA_RE` / the probe's fallback `QUOTA_RE` copy."""
+    daemon_src = (
+        Path(__file__).parents[2]
+        / "apps"
+        / "backend-rag"
+        / "backend"
+        / "llm"
+        / "codex_exec_client.py"
+    )
+    import re as _re
+
+    text = daemon_src.read_text()
+    match = _re.search(r"_QUOTA_RE[^=]*= re\.compile\((.*?)\n\)", text, _re.DOTALL)
+    assert match is not None, "daemon _QUOTA_RE definition not found"
+    daemon_body = "".join(_re.findall(r'r"([^"]*)"', match.group(1)))
+    probe_text = _MODULE_PATH.read_text()
+    probe_match = _re.search(r"QUOTA_RE = re\.compile\((.*?)\n    \)", probe_text, _re.DOTALL)
+    assert probe_match is not None, "probe fallback QUOTA_RE definition not found"
+    probe_body = "".join(_re.findall(r'r"([^"]*)"', probe_match.group(1)))
+    assert probe_body == daemon_body, (
+        "the probe's fallback regex drifted from the daemon's _QUOTA_RE — "
+        "update the copy in scripts/wa_codex_seat_probe.py"
+    )
     assert "re.IGNORECASE" in match.group(1), "daemon regex lost re.IGNORECASE"
     assert "re.IGNORECASE" in probe_match.group(1), "probe fallback lost re.IGNORECASE"

--- a/scripts/tests/test_wa_codex_seat_sentinel.py
+++ b/scripts/tests/test_wa_codex_seat_sentinel.py
@@ -117,12 +117,28 @@ def test_guilt_other_failure_verdict_is_warn_not_red() -> None:
 
 
 def test_guilt_unrecognized_probe_verdict_falls_visibly_as_warn_never_silent() -> None:
-    """W116: un finale non mappato (un probe futuro che scrive p.es.
-    "quota_exhausted") deve cadere VISIBILE, mai nel secchio sano."""
-    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    """W116: un finale non mappato (un probe futuro che scrive un verdetto
+    ancora sconosciuto a questo lettore) deve cadere VISIBILE, mai nel
+    secchio sano. "quota_exhausted" non e piu questo caso — B2b lo ha reso
+    un verdetto RICONOSCIUTO (vedi test dedicato sotto)."""
+    verdicts = wa.evaluate(_probe("some_future_verdict_not_yet_mapped", 0, 1), 10.0, _gauge(), NOW)
     assert len(verdicts) == 1
     assert verdicts[0].level == wa.WARN
-    assert "quota_exhausted" in verdicts[0].message
+    assert "some_future_verdict_not_yet_mapped" in verdicts[0].message
+
+
+def test_guilt_quota_exhausted_is_red_dedicated_not_warn() -> None:
+    """B2b: closes the gap the test above used to encode — a quota-dead
+    seat is a DEDICATED RED condition now, not the generic WARN
+    "other_failure" bucket (no operator re-login fixes it, but it is real
+    and worth paging on, same severity tier as auth_death)."""
+    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    assert len(verdicts) == 1
+    v = verdicts[0]
+    assert v.level == wa.RED
+    assert v.condition == "quota_exhausted"
+    assert "QUOTA EXHAUSTED" in v.message
+    assert "no operator re-login" in v.message.lower()
 
 
 def test_guilt_never_seen_daemon_null_staleness_parses_to_daemon_silent() -> None:

--- a/scripts/wa_codex_seat_probe.py
+++ b/scripts/wa_codex_seat_probe.py
@@ -21,11 +21,18 @@ This organ manufactures a signal independent of job traffic: `codex login
 status` plus a 1-token synthetic `codex exec`, on the plist's own
 StartInterval, regardless of whether the broker has anything to claim.
 
-CLASSIFICATION — declared limit: quota exhaustion (CodexQuotaError-shaped
-failures in backend/llm/codex_exec_client.py) is NOT distinguished from any
-other non-auth, non-invocation failure here — both land in `other_failure`.
-S1.5 owns sharpening that bucket further. This probe answers exactly one
-question: is the seat's LOGIN dead, yes or no.
+CLASSIFICATION (B2b, closes the S1.5 gap this docstring used to declare
+open): quota exhaustion (`CodexExecQuotaError`-shaped failures in
+backend/llm/codex_exec_client.py, detected via that module's `_QUOTA_RE`)
+is now its own verdict, `quota_exhausted` — the same name
+`wa_codex_seat_sentinel.py` already anticipated in its own
+forward-compatibility comment, and the same wire value the daemon reports
+as `error_class`. Distinct from `auth_death` (a re-login fixes auth death;
+nothing but the usage window resetting fixes quota exhaustion) and from
+`other_failure` (a genuine crash, still undifferentiated). Priority when a
+failure matches BOTH word classes is auth first, same as the daemon's own
+scan order — no measured overlap is known between the two vocabularies, so
+this is a tie-break, not an observed collision.
 
 LEAK SURFACE (Law 2 / scar family #4 — secret/PII in the clear): the status
 file carries ONLY the verdict enum, the two raw exit codes, and a UTC
@@ -76,6 +83,7 @@ logger = logging.getLogger("wa_codex_seat_probe")
 # a degraded fallback, never the source of truth.
 try:
     from backend.llm.codex_exec_client import _AUTH_DEATH_RE as AUTH_DEATH_RE
+    from backend.llm.codex_exec_client import _QUOTA_RE as QUOTA_RE
 
     _AUTH_DEATH_SOURCE: Final[str] = "import"
 except ImportError:  # pragma: no cover — exercised only when the runtime
@@ -97,6 +105,16 @@ except ImportError:  # pragma: no cover — exercised only when the runtime
         r"session\s+invalidated|"
         r"auth(?:entication)?\s+(?:failed|error|required|expired)|"
         r"run\s+`?codex\s+login`?"
+        r")(?!\w)",
+        re.IGNORECASE,
+    )
+    # Byte-identical to `_QUOTA_RE` in `backend/llm/codex_exec_client.py` —
+    # same drift discipline as AUTH_DEATH_RE above (superscar #1).
+    QUOTA_RE = re.compile(
+        r"\b(?:"
+        r"usage\s+limit|"
+        r"weekly\s+limit|"
+        r"quota\s+(?:exceeded|exhausted)"
         r")(?!\w)",
         re.IGNORECASE,
     )
@@ -122,6 +140,7 @@ _UNRUN_RC: Final[int] = -1
 
 VERDICT_OK: Final[str] = "ok"
 VERDICT_AUTH_DEATH: Final[str] = "auth_death"
+VERDICT_QUOTA_EXHAUSTED: Final[str] = "quota_exhausted"
 VERDICT_OTHER_FAILURE: Final[str] = "other_failure"
 VERDICT_PROBE_ERROR: Final[str] = "probe_error"
 
@@ -244,10 +263,16 @@ def classify(
     and exec stdout may carry a partial model answer discussing a CLIENT's
     login/credential).
 
+    Auth outranks quota when a failure text (implausibly) matches both — no
+    measured case is known, but the priority mirrors the daemon's own scan
+    order (auth checked before quota in `codex_exec_client.py::generate`).
+
     Only if NEITHER command produced a real exit code at all is this a
     probe_error (we could not observe anything, auth-dead or otherwise).
-    Any other nonzero combination is other_failure (declared limit: not
-    further distinguished from quota exhaustion — see module docstring)."""
+    Any other nonzero combination that matches neither word class is
+    other_failure — a genuine crash, still undifferentiated (B2b closed the
+    quota half of this gap; a future refinement could still narrow
+    other_failure further)."""
     guilty_texts: list[str] = []
     if login_rc not in (0, _UNRUN_RC):
         guilty_texts.extend((login_out, login_err))
@@ -255,6 +280,8 @@ def classify(
         guilty_texts.append(exec_err)
     if any(AUTH_DEATH_RE.search(t) for t in guilty_texts if t):
         return VERDICT_AUTH_DEATH
+    if any(QUOTA_RE.search(t) for t in guilty_texts if t):
+        return VERDICT_QUOTA_EXHAUSTED
     if login_rc == _UNRUN_RC and exec_rc == _UNRUN_RC:
         return VERDICT_PROBE_ERROR
     if login_rc != 0 or exec_rc != 0:

--- a/scripts/wa_codex_seat_sentinel.py
+++ b/scripts/wa_codex_seat_sentinel.py
@@ -77,6 +77,10 @@ AUTH_DEATH_MSG: Final[str] = (
     "CODEX_HOME=/Users/zantara-codex/.codex HOME=/Users/zantara-codex "
     "/opt/homebrew/bin/codex login"
 )
+QUOTA_EXHAUSTED_MSG: Final[str] = (
+    "codex seat QUOTA EXHAUSTED — no operator re-login fixes this; the seat's "
+    "usage window must reset on its own (B2b, distinct from auth_death)"
+)
 PROBE_SILENT_MSG: Final[str] = "seat probe silent (not armed, or its daemon died)"
 BREAKER_MSG: Final[str] = (
     "codex leg failing — cause is named only in the daemon log: "
@@ -115,12 +119,16 @@ def _probe_side(
         probe_verdict = probe_status.get("verdict")
         if probe_verdict == "auth_death":
             verdicts.append(Verdict(RED, "auth_death", AUTH_DEATH_MSG))
+        elif probe_verdict == "quota_exhausted":
+            # B2b: dedicated RED, not the generic WARN "other_failure" a
+            # quota-dead seat used to fall into — distinct condition string
+            # so it dedups and pages separately from a genuine crash.
+            verdicts.append(Verdict(RED, "quota_exhausted", QUOTA_EXHAUSTED_MSG))
         elif probe_verdict != "ok":
             # other_failure, probe_error, AND any vocabulary this reader does
-            # not know yet (a future probe adding e.g. "quota_exhausted" must
-            # fall somewhere VISIBLE, never into silence — W116: an unmapped
-            # finale that lands in the healthy bucket is how the next real
-            # signal gets lost).
+            # not know yet fall somewhere VISIBLE, never into silence — W116:
+            # an unmapped finale that lands in the healthy bucket is how the
+            # next real signal gets lost.
             verdicts.append(
                 Verdict(
                     WARN,


### PR DESCRIPTION
## Summary

The wa-codex WhatsApp channel is migrating to a ChatGPT/Codex seat (`codex exec`). Until now, when that seat hit its usage-window quota, the failure was indistinguishable from any other CLI crash end to end:

- `codex_exec_client.py`'s `_AUTH_DEATH_RE` only recognizes login/token/401 vocabulary — no quota pattern.
- `wa_codex_daemon.py` classifies every non-auth failure as `error_class="cli_failure"`.
- `scripts/wa_codex_seat_probe.py`'s own docstring named this gap explicitly ("S1.5 owns sharpening that bucket").
- `scripts/wa_codex_seat_sentinel.py` folds any unrecognized/other probe verdict into a generic `WARN` "other_failure" — never a dedicated page.

Consequence: no dedicated alarm today, and once the Gemini fallback is removed, a quota-dead seat would fail silently into the generic bucket.

## Changes

- **`apps/backend-rag/backend/llm/codex_exec_client.py`** — new `_QUOTA_RE` + `CodexExecQuotaError`, checked after the existing auth-death scan and before the generic `CodexExecProcessError` fallback (same stderr-only, line-stripped, independently-scanned-per-argument discipline as the existing auth detector).
- **`apps/backend-rag/backend/services/integrations/wa_codex_daemon.py`** — catches `CodexExecQuotaError` and reports `error_class="quota_exhausted"` (distinct wire value, not folded into `cli_failure`).
- **`apps/backend-rag/backend/services/integrations/wa_broker.py`** — adds `"quota_exhausted"` to the router's closed `ALLOWED_ERROR_CLASSES` vocabulary (otherwise the daemon's new value 422s at the router — found during grounding, not in the original mandate).
- **`scripts/wa_codex_seat_probe.py`** — new `VERDICT_QUOTA_EXHAUSTED`, with a byte-identical fallback regex copy (same superscar-#1 drift discipline as the existing `AUTH_DEATH_RE` copy, enforced by a new parity test).
- **`scripts/wa_codex_seat_sentinel.py`** — pages `quota_exhausted` as a dedicated `RED` condition instead of the generic `WARN` "other_failure" bucket.

### Pattern sourcing (no invented strings)

Every word class in `_QUOTA_RE` (`usage limit`, `weekly limit`, `quota exceeded/exhausted`) is derived from real evidence already in this repo, never invented:

- `"You've hit your usage limit... try again at Aug 19th, 2026"` — measured live, `gpt-5.6-terra` via `codex exec` (`research/operations/2026-07-20-kbli-batch-a-lot8-conductor-gate.md` §5b)
- `"ERROR: You've hit your usage limit"` — measured live, codex CLI v0.147.0 (`research/operations/2026-08-21-world-patterns-import-map.md`)
- `"ERROR: You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at Aug 31st, 2026 8:06 PM."` — measured live 2026-08-26/27 (`scripts/army/spark_lane.sh`)
- `"ERROR: You've hit your usage limit. Upgrade to Plus to continue using Codex..."` — captured codex transcripts (`docs/design-palettes/funnels/research/tax-codex-brainstorm.md` + archived twin)
- Cross-checked against the fleet's own codex-specific cascade grep (`~/scripts/regulatory-watcher-run.sh` tier 3: `usage.limit|quota|exhausted`, run against real `codex exec` output in production) and this repo's own codex-reviewer classifier (`scripts/codex_tri_llm_review.py`)

Deliberately narrower than either source: `out of extra usage` is Claude's own phrasing (`claude_oauth_client.py`'s `_QUOTA_DIAGNOSTIC_PATTERN`) and never appears in a measured `codex` transcript, so it is excluded; no bare `quota`/`limit`/`429` is used, since that would over-match ordinary Bali Zero domain vocabulary (RPTKA foreign-worker "quota", KITAS "limit of stay").

## Adversarial review

**Round 1 (self-review, generator≠grader):**
- Full targeted suite green: `backend/tests/llm/test_codex_exec_client.py` (87 passed), `backend/tests/unit/services/test_wa_codex_daemon.py` + `backend/tests/unit/routers/test_wa_broker_router.py` (72 passed), `scripts/tests/test_wa_codex_seat_probe.py` + `scripts/tests/test_wa_codex_seat_sentinel.py` (36 passed) — 195 total, 0 failed. `ruff check` clean on all touched files.
- Guilt tests: every derived quota phrasing raises `CodexExecQuotaError` at the client, maps to `error_class="quota_exhausted"` at the daemon, classifies `VERDICT_QUOTA_EXHAUSTED` at the probe, and pages `RED` at the sentinel. **Of the 4 guilt fixtures, 2 are MEASURED (captured verbatim from real `codex exec` transcripts elsewhere in this repo) and 2 are CONSTRUCTED — built from word classes attested for codex/CLI quota elsewhere in the repo (`scripts/codex_tri_llm_review.py`'s "weekly limit", `~/scripts/regulatory-watcher-run.sh`'s "quota exceeded/exhausted") but not captured word-for-word from a real `codex exec` stderr.** Labelled as such in the test file, same convention the file already uses for its own `_CONSTRUCTED_*` fixtures.
- Innocence tests: generic CLI failures and auth failures still classify as before; a successful (`exit_code=0`) answer discussing a client's real RPTKA quota / KITAS limit of stay is never scanned at all; a failed run whose stderr mentions "quota"/"limit" WITHOUT the specific multi-word framing does not misclassify; an echoed prompt containing quota-shaped words does not false-positive. **Caveat, stated explicitly rather than left implicit: these three innocence tests would also pass if the whole quota-detection feature were deleted (they assert `CodexExecProcessError`, the pre-existing fallback) — that is expected and correct for an innocence test (it proves no false positive, not that the feature exists), but it means innocence alone is not evidence the feature works; only the guilt tests + the mutation result below are.**
- Mutation test: broke `_QUOTA_RE` to a never-match pattern (`r"(?!)"`) in the source. Before: `87 passed`. After: `6 failed, 81 passed`, all 6 failing with `CodexExecProcessError: codex exec failed (exit_code=1)` — the correct fallback reason, and every innocence test still passing. Restored and re-verified 87/87 green.
- Router closed-vocabulary gap found and closed independently: the daemon's new `error_class="quota_exhausted"` would have 422'd at `wa_broker.py`'s existing validator without the `ALLOWED_ERROR_CLASSES` addition.
- Existing sentinel test `test_guilt_unrecognized_probe_verdict_falls_visibly_as_warn_never_silent` previously hardcoded `"quota_exhausted" -> WARN` (the W116 placeholder example for an unmapped future verdict) — updated to a different placeholder string, added a dedicated `test_guilt_quota_exhausted_is_red_dedicated_not_warn` for the new RED behavior.

**Round 2 (cross-family adversarial refutation, Kimi K3, fresh context, on the full diff) — verdict BLOCK, 2 MAJOR + 2 MINOR. Coordinator independently verified each finding against its cited source before disposing of it:**

1. **MAJOR → downgraded to MINOR/documented, no regex change.** Kimi flagged `usage\s+limit` as unanchored to codex/ChatGPT, citing `scripts/army/spark_lane.sh` as precedent for over-match. Read that cicatrix directly: it concerned a classifier scanning the **model's own output even on successful (`exit_code==0`) runs** — its own fix states "a successful run whose TEXT happens to mention quota is innocent; only a failed run whose text names the reason is guilty." This scan already sits on the guilty side (stderr-only, `exit_code != 0` only, prompt/stdout stripped first), and the repo's own existing codex-quota classifier (`scripts/codex_tri_llm_review.py:258-261`) additionally matches bare `"rate limit"` with no codex-specific anchor at all — this pattern is narrower than that established precedent, not looser. Disposition: no regex change. Documented in the `_QUOTA_RE` comment block: (a) the `exit_code != 0` gate is precisely the cure the cited cicatrix applied, and why a generic multi-word phrase is acceptable here; (b) the one known residual — a failed run whose stderr carries a third-party API's raw 429 error body containing this wording — declared, not hidden.
2. **MAJOR, real, closed.** `quota\s+(?:exceeded|exhausted)` misses the word-order-inverted canonical OpenAI-family forms ("You exceeded your current quota", "insufficient_quota"). Not a regression (that wording is silent today regardless), but exactly the silent-death class this PR exists to prevent. Per the no-invented-pattern constraint: searched for a real attestation before acting — `git grep -iE 'insufficient_quota|exceeded your current quota'` across the repo, and the installed `openai` SDK package (v2.38.0) under `apps/backend-rag/.venv` — **neither string appears in either surface** (the SDK does not embed API error-body text; it comes from the live HTTP response, never from client source). No attestation found, so the pattern was **not added**. Documented as a declared `GAP NOTO` block in the `_QUOTA_RE` comment instead of silently omitting it — if a real `codex exec` transcript ever surfaces this wording, add it with a cited source and its own guilt+innocence tests.
3. **MINOR, real, fixed.** `CodexExecQuotaError`'s docstring cited a dead symbol, `VERDICT_QUOTA_DEAD` — the probe's actual constant is `VERDICT_QUOTA_EXHAUSTED`. Corrected.
4. **MINOR, real, documented not fixed (out of scope).** `_strip_known_lines` matches by whole-line equality; a long client WA prompt that `codex` wraps across multiple stderr lines would not be stripped, letting the client's own words reach the regex scan. Not proven for real WA traffic (only proven for this module's own short, inert test fixtures). Added a comment at the scan site in `generate()` naming this residual explicitly — not changing `_strip_known_lines` itself, which is out of scope for this PR.

Re-ran the full targeted suite (195 passed, 0 failed) and `ruff` (clean) after the round-2 comment-only changes, and repeated the mutation test: identical result to round 1 (before 87 passed / after 6 failed, 81 passed, same failure reason) — confirming round 2 was documentation-only and did not touch runtime behavior.

**NOT verified (declared, not silently assumed):**
- No live `codex exec` call was made against a real quota-exhausted seat during this PR — see the measured-vs-constructed fixture breakdown above.
- Did not verify end-to-end wire behavior against a live `wa_broker` Postgres row (no DB access from this offline check) — only the router's Pydantic validator and the daemon's typed exception mapping, both at the unit level.
- Did not check whether any other consumer of `wa_broker.ALLOWED_ERROR_CLASSES` or the probe's `VERDICT_*` constants exists beyond what `git grep` surfaced.
- The word-order-inverted quota form (finding 2 above) remains genuinely undetected — declared as a known gap, not silently fixed with an unattested pattern.

## Deploy note

**Auto-merge is intentionally NOT armed.** Per repo instruction for this task: a merge on this repo triggers a deploy, and the deploy window is closed until 20:00 WITA. This PR stays open and disarmed; merge/deploy is a follow-up action once the window opens.
