### PR TITLE
fix(bot): codex-leg retry budget — replace the ever-scoped ALREADY_SPENT with a live/terminal/reattach protocol

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql
@@ -57,6 +57,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_broker_jobs_serve_outbox_live
       AND state IN ('offered', 'leased', 'completed_pending_consume');
 
 -- === ROLLBACK ===
+--
+-- NOT ALWAYS REVERSIBLE (documented, not fixed — Kimi K3 cross-family
+-- review round 2): once this migration has been live long enough for a
+-- single outbox_id to accumulate MORE THAN ONE broker_jobs row (mode=
+-- 'serve') — the entire point of this change — the CREATE UNIQUE INDEX
+-- below fails outright with a duplicate-key error, because a row set
+-- unique on bare outbox_id can no longer be built over data that already
+-- violates it. There is no forward-compatible down-migration for that
+-- state: reverting the SCHEMA requires first reverting the DATA (deleting
+-- every non-latest broker_jobs row per outbox_id, which throws away the
+-- audit trail the multi-row design exists to keep) or accepting the
+-- rollback cannot run until the offending rows have aged out via the
+-- normal 7-day retention sweep. A rollback that fails loudly here is the
+-- INTENDED behavior — silently succeeding on an index that doesn't
+-- actually hold the caller's assumed invariant would be worse.
 
 DROP INDEX IF EXISTS uq_broker_jobs_serve_outbox_live;
 

--- a/apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql
@@ -1,0 +1,65 @@
+-- 296_wa_broker_jobs_live_only_unique.sql
+-- BOT-V4 S2 — retry budget for the codex leg (gradino 2/5 of the Gemini
+-- retirement plan). research/operations/2026-08-19-bot-chatgpt-provider-
+-- broker-spec.md still describes "ONE codex leg per outbox row, ever"
+-- (migration 270's header, uq_broker_jobs_serve_outbox). That invariant is
+-- what turned every RECOVERABLE codex failure into a silent Gemini
+-- fall-off (offer_job's second offer read generation_route IS NOT NULL and
+-- returned ALREADY_SPENT with no job_id — not even a way to reattach a
+-- still-running job). With Gemini scheduled for permanent removal from
+-- this channel, that same fall-off would become a mute customer instead.
+--
+-- New invariant, same spirit, narrower scope: ONE codex leg IN FLIGHT per
+-- outbox row at a time, up to wa_outbox's own MAX_ATTEMPTS (5) legs total
+-- over the row's life — wa_codex_leg.py's offer_job now offers a NEW leg
+-- once the PRIOR one for the same outbox_id is terminal (consumed/expired/
+-- failed), and reattaches (rather than re-offering) to one still alive.
+--
+-- Why a new broker_jobs ROW per leg, not an in-place reset of the one row
+-- (the no-migration option): the wider option was reusing an existing
+-- row column, e.g. wa_outbox.attempts, as the budget counter — but that
+-- counter is written by the OUTER retry ladder only when a claim's
+-- generation genuinely raises, and a worker crash between a durable offer
+-- and that raise (stale-claim reclaim, see wa_outbox_worker.py's
+-- claim_expires_at sweep) resets wa_outbox.status to 'pending' WITHOUT
+-- ever touching attempts — so attempts cannot durably bound how many
+-- codex legs a row has actually spent across a crash/reclaim cycle. A new
+-- broker_jobs row is written durably by the SAME INSERT that creates the
+-- leg, so counting rows for an outbox_id survives that crash by
+-- construction. It also keeps each attempt's own error_class/outcome/
+-- exec_ms — an in-place reset would have to null and overwrite that
+-- history on every retry, destroying the audit trail this table exists to
+-- carry (migration 270's header, "PII surface with a lifecycle").
+--
+-- The DDL: uq_broker_jobs_serve_outbox was NEVER scoped to "one live job"
+-- — it was outbox_id-unique across ALL states, forever (migration 270's
+-- own header: "the durable wa_outbox.generation_route marker ... is what
+-- makes the invariant HISTORICAL"). That is exactly the invariant this
+-- migration retires. Replaced with a partial index scoped to the LIVE
+-- states only (offered/leased/completed_pending_consume) — still exactly
+-- one in-flight serve job per outbox row (the property offer_job's
+-- MAX_DEPTH=1 global admission cap and the advisory xact lock already
+-- assume), but a second, third, ... row is now permitted once the prior
+-- one is terminal. The application-level cap on TOTAL rows per outbox_id
+-- (mirroring wa_outbox_worker.MAX_ATTEMPTS) lives in offer_job, not here —
+-- the DB only ever enforced "one live", never "N total".
+--
+-- The table ships (still) near-empty: WA_GENERATION_PROVIDER stays unset
+-- in every environment until gradino 5 flips it, so this DROP+CREATE INDEX
+-- takes its ACCESS EXCLUSIVE lock on a table with no meaningful traffic
+-- (same premise migrations 272/274 documented for this table).
+
+DROP INDEX IF EXISTS uq_broker_jobs_serve_outbox;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_broker_jobs_serve_outbox_live
+    ON broker_jobs (outbox_id)
+    WHERE mode = 'serve'
+      AND state IN ('offered', 'leased', 'completed_pending_consume');
+
+-- === ROLLBACK ===
+
+DROP INDEX IF EXISTS uq_broker_jobs_serve_outbox_live;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_broker_jobs_serve_outbox
+    ON broker_jobs (outbox_id)
+    WHERE mode = 'serve';

--- a/apps/backend-rag/backend/services/integrations/wa_broker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_broker.py
@@ -457,9 +457,14 @@ async def offer_job(
     async with conn.transaction():
         await conn.execute(_ADMISSION_LOCK_SQL)
 
+        # broker_last_seen_at travels alongside the liveness boolean —
+        # reused below (no extra query) to resolve the daemon-still-busy
+        # ambiguity on a retry whose prior leg expired by deadline (S2
+        # cross-family review round 2, "budget-drain" finding).
         gauge = await conn.fetchrow(
             """
-            SELECT broker_last_seen_at >= now() - ($1 * INTERVAL '1 second')
+            SELECT broker_last_seen_at,
+                   broker_last_seen_at >= now() - ($1 * INTERVAL '1 second')
                        AS broker_alive
             FROM wa_broker_gauge WHERE id = 1
             """,
@@ -536,26 +541,74 @@ async def offer_job(
             # Gemini fall-off; with Gemini's removal that becomes a mute
             # customer instead. New rule: reattach to a still-alive leg,
             # or admit a fresh one while the row has budget left.
+            # deadline_open is DB-computed (never a Python/DB clock
+            # comparison) — same discipline as the gauge's broker_alive
+            # boolean and wait_for_job's deadline_passed. thread_epoch is
+            # NOT NULL at the schema (migration 270) — no broker_jobs row
+            # can ever exist without it, so no defensive cast guard here.
             prior = await conn.fetchrow(
                 """
-                SELECT job_id, state, thread_epoch FROM broker_jobs
+                SELECT job_id, state, thread_epoch, deadline_at,
+                       deadline_at > now() AS deadline_open
+                FROM broker_jobs
                 WHERE outbox_id = $1 AND mode = 'serve'
                 ORDER BY created_at DESC
                 LIMIT 1
                 """,
                 outbox_id,
             )
-            if prior is not None and prior["state"] not in _TERMINAL_STATES:
-                # Still alive (offered/leased/completed_pending_consume) —
-                # hand its job_id back instead of losing it. No new job is
-                # created, so the canary CAS (if this call won one) is
-                # reverted, same as every other non-creating exit.
+            if (
+                prior is not None
+                and prior["state"] not in _TERMINAL_STATES
+                and prior["deadline_open"]
+            ):
+                # Still alive (offered/leased/completed_pending_consume)
+                # AND its own deadline has not yet elapsed — hand its
+                # job_id back instead of losing it. A live-state row PAST
+                # its own deadline (not yet reaped) is deliberately NOT
+                # reattached here (S2 cross-family review round 2, minor
+                # 2): the caller would just wait_for_job it straight into
+                # an immediate deadline-CAS — a wasted round trip for a
+                # leg that is, for every practical purpose, already done.
+                # It falls through to the terminal-budget path below
+                # exactly like a formally 'expired' row would.
                 await _revert_canary_cas(conn)
                 return OfferResult(
                     OfferOutcome.REATTACHED,
                     job_id=prior["job_id"],
                     thread_epoch=int(prior["thread_epoch"]),
                 )
+
+            if prior is not None and prior["state"] not in ("consumed", "failed"):
+                # AMBIGUOUS: the prior leg is not reattachable (terminal,
+                # or live but past its own deadline) AND the daemon never
+                # explicitly told us it is done with it — 'consumed' and
+                # 'failed' are the only two states that follow an actual
+                # /complete report; 'expired' (and "live but deadline_open
+                # false") both mean nobody has confirmed the daemon has
+                # moved on. The daemon is single-flight and strictly
+                # sequential (claim -> exec -> complete -> claim again,
+                # never polling mid-exec — verified against
+                # wa_codex_daemon.py's run_forever, not its docstring), so
+                # broker_last_seen_at moving to AFTER this leg's own
+                # deadline_at is proof positive it has cycled back to idle
+                # since. Without that proof, admitting a new leg risks the
+                # "budget drain" race (S2 cross-family review round 2,
+                # MAJOR): the daemon is still busy on the leg that just
+                # expired under it, so a second (third, fourth...) leg
+                # would sit unclaimed until IT ALSO expires, burning the
+                # whole retry budget and multiple breaker-failure folds on
+                # one slow-but-healthy exec instead of one. QUEUE_FULL is
+                # deliberately reused here, not a new outcome: the shape
+                # is identical (same-claim Gemini fall-off, zero
+                # retry-ladder involvement) and semantically apt — there
+                # genuinely is no CONFIRMED capacity right now.
+                if (
+                    gauge["broker_last_seen_at"] is None
+                    or gauge["broker_last_seen_at"] <= prior["deadline_at"]
+                ):
+                    await _revert_canary_cas(conn)
+                    return OfferResult(OfferOutcome.QUEUE_FULL)
 
             leg_count = await conn.fetchval(
                 "SELECT count(*) FROM broker_jobs WHERE outbox_id = $1 AND mode = 'serve'",
@@ -567,8 +620,9 @@ async def offer_job(
                 # 3 — no silent fall-off for this case either).
                 await _revert_canary_cas(conn)
                 return OfferResult(OfferOutcome.LEGS_EXHAUSTED)
-            # else: the prior leg is terminal and the budget has room —
-            # fall through to the SAME savepoint-protected INSERT a fresh
+            # else: the prior leg is terminal (or confirmed/proven not to
+            # be occupying the daemon) and the budget has room — fall
+            # through to the SAME savepoint-protected INSERT a fresh
             # (first-ever) offer uses below. uq_broker_jobs_serve_outbox_live
             # (migration 296) only forbids a SECOND live row, so this INSERT
             # is expected to succeed; the advisory xact lock already

--- a/apps/backend-rag/backend/services/integrations/wa_broker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_broker.py
@@ -27,9 +27,19 @@ Hard rules carried from the spec:
   - ``completed_pending_consume`` is NON-terminal (Codex r3-NEW-1): it holds
     ``result_text`` under the fence until the single consumer (the worker's
     finalization) CASes it to ``consumed``. The reaper covers a dead consumer.
-  - One serve-mode job per outbox row, ever — enforced by the DB
-    (``uq_broker_jobs_serve_outbox``, migration 270); ``offer_job`` treats the
-    unique violation as "already spent" and reports it, never retries.
+  - One serve-mode job IN FLIGHT per outbox row at a time — enforced by the
+    DB (``uq_broker_jobs_serve_outbox_live``, migration 296, superseding
+    migration 270's ever-scoped ``uq_broker_jobs_serve_outbox``). A row may
+    spend more than one leg over its life: once the prior leg is terminal
+    (consumed/expired/failed), ``offer_job`` admits a new one, up to
+    ``MAX_CODEX_LEGS`` legs total — the same retry budget
+    ``wa_outbox_worker.MAX_ATTEMPTS`` already gives the row overall. A
+    caller offering into a still-LIVE prior leg gets it back
+    (``OfferOutcome.REATTACHED``) instead of losing it. This retired the
+    original "ever" invariant, whose only effect was turning every
+    RECOVERABLE codex failure into a silent fall-off to Gemini — safe while
+    Gemini stood behind it, a mute customer once Gemini is gone (spec
+    gradino 2/5).
   - Client text never in logs: this module logs job ids, states and typed
     outcomes only — never ``package`` or ``result_text`` content.
 """
@@ -62,6 +72,25 @@ LEASE_TTL_S = 20
 # more than one outstanding (offered|leased) job means the second cannot start
 # within budget by construction. DB-atomic via advisory xact lock below.
 MAX_DEPTH = 1
+
+# Retry budget for the codex leg (spec gradino 2/5, migration 296): the most
+# broker_jobs rows a single outbox_id may ever accumulate (mode='serve').
+# Deliberately mirrors wa_outbox_worker.MAX_ATTEMPTS by VALUE, not by
+# import — wa_outbox_worker already imports wa_codex_leg which imports
+# this module, so importing back would cycle. The two constants are
+# cross-checked by
+# test_max_codex_legs_matches_outbox_worker_max_attempts (test_wa_broker.py)
+# so a change to one without the other fails CI instead of drifting quietly
+# (same closed-vocabulary discipline as ALLOWED_ERROR_CLASSES / W114).
+# Counted as durable broker_jobs ROWS, not a read of wa_outbox.attempts:
+# attempts is only written by the outer retry ladder when a claim's
+# generation actually raises, and a worker crash between a durable offer
+# and that raise (stale-claim reclaim — wa_outbox_worker.py's
+# claim_expires_at sweep resets status to 'pending' WITHOUT touching
+# attempts) would leave it under-counting how many codex legs a row has
+# really spent. A row-count anchored on the INSERT that creates each leg
+# survives that crash by construction.
+MAX_CODEX_LEGS = 5
 
 # "Broker absent" threshold (spec 2.1). Deliberately NOT 2x the poll interval:
 # the broker is single-flight and does not poll while an exec is in flight, so
@@ -135,13 +164,30 @@ def absent_after_seconds() -> int:
 
 class OfferOutcome(str, enum.Enum):
     """Why an offer did or did not happen. The caller (worker broker leg)
-    routes to the Gemini leg on anything but OFFERED."""
+    routes to the Gemini leg on anything but OFFERED or REATTACHED — those
+    two carry a job_id worth waiting on; every other member is a certain
+    non-durable outcome."""
 
-    OFFERED = "offered"
+    OFFERED = "offered"  # a NEW job was created (first leg, or a retry
+    # leg once the prior one went terminal — both share this member; the
+    # caller's handling is identical either way).
+    REATTACHED = "reattached"  # a PRIOR leg for this outbox_id is still
+    # alive (offered/leased/completed_pending_consume) — its job_id comes
+    # back so the caller waits/consumes it instead of losing it. This is
+    # the fix for the historical bug: a retry used to see ALREADY_SPENT
+    # with no job_id and fall off, even when the original leg was still
+    # running to completion unobserved.
     BROKER_ABSENT = "broker_absent"
     BREAKER_OPEN = "breaker_open"
     QUEUE_FULL = "queue_full"
-    ALREADY_SPENT = "already_spent"  # unique violation: row's codex leg used
+    ALREADY_SPENT = "already_spent"  # defensive fallback only: the DB's own
+    # unique-violation verdict on the live-scoped index (a race the
+    # advisory xact lock should already make unreachable in practice).
+    LEGS_EXHAUSTED = "legs_exhausted"  # the prior leg is terminal, but this
+    # outbox_id has already spent MAX_CODEX_LEGS rows — a NAMED terminal
+    # outcome, never conflated with the generic ALREADY_SPENT above: a
+    # caller needs to tell "the DB raced me" apart from "this row is truly
+    # done with codex" (spec gradino 2/5, point 3 — no silent fall-off).
     FENCE_LOST = "fence_lost"  # wa_outbox claim no longer ours
 
 
@@ -149,6 +195,16 @@ class OfferOutcome(str, enum.Enum):
 class OfferResult:
     outcome: OfferOutcome
     job_id: uuid.UUID | None = None
+    # Set alongside job_id on OFFERED/REATTACHED only: the epoch the
+    # SERVING job actually runs under. For OFFERED this equals the caller's
+    # own thread_epoch argument; for REATTACHED it is the PRIOR leg's own
+    # frozen value, which can predate this call's local epoch read (the
+    # prior leg may have been offered by an earlier, since-failed claim).
+    # wa_codex_leg.py's post-completion drift check must fence against
+    # THIS value, not its own freshly-read thread_epoch — using the wrong
+    # one would silently defeat the thread-epoch-drift protocol on a
+    # reattach (spec 2.3).
+    thread_epoch: int | None = None
 
 
 class WaitOutcome(str, enum.Enum):
@@ -376,7 +432,8 @@ async def offer_job(
     package_hash: str,
     thread_epoch: int,
 ) -> OfferResult:
-    """Offer one serve-mode job — the row's ONE codex leg (spec 2).
+    """Offer one serve-mode job for this outbox row (spec 2, retry budget
+    gradino 2/5).
 
     ONE TRANSACTION, fenced on the outbox claim (Codex NEW-2): the
     ``generation_route`` marker and the job INSERT commit or vanish together;
@@ -384,6 +441,13 @@ async def offer_job(
     breaker, depth) is checked INSIDE the same transaction under an advisory
     xact lock, so two workers reading the same stale gauge cannot double-offer
     past the cap (Codex H12).
+
+    A row may call this more than once over its life (worker retries).
+    The first call always creates a fresh job. Every later call re-reads
+    this SAME row's leg history and answers one of: REATTACHED (a prior
+    leg is still alive — take its job_id back, do not create a second
+    one), a fresh OFFERED (the prior leg is terminal and the row has not
+    exhausted MAX_CODEX_LEGS), or LEGS_EXHAUSTED (terminal, budget spent).
 
     ``package``/``evidence_inputs`` arrive as already-serialized JSON strings
     (the caller owns the allowlist schema, spec 2.2) — this module never
@@ -404,8 +468,20 @@ async def offer_job(
         if gauge is None or not gauge["broker_alive"]:
             return OfferResult(OfferOutcome.BROKER_ABSENT)
 
+        # Excludes THIS outbox_id's own live job(s) — a retry reattaching
+        # to a leg it already holds asks for no NEW capacity, so it must
+        # never be refused by the very cap that admitted that leg in the
+        # first place (retry budget, spec gradino 2/5). Safe globally: the
+        # advisory xact lock above serializes every offer, so depth
+        # (unscoped) never exceeds MAX_DEPTH=1 at any committed state —
+        # if THIS row already holds the one live slot, no OTHER row can
+        # hold one too, so excluding self can never hide a real conflict.
         depth = await conn.fetchval(
-            "SELECT count(*) FROM broker_jobs WHERE state IN ('offered', 'leased')",
+            """
+            SELECT count(*) FROM broker_jobs
+            WHERE state IN ('offered', 'leased') AND outbox_id != $1
+            """,
+            outbox_id,
         )
         if int(depth or 0) >= MAX_DEPTH:
             return OfferResult(OfferOutcome.QUEUE_FULL)
@@ -420,27 +496,84 @@ async def offer_job(
         if not await breaker_admits(conn):
             return OfferResult(OfferOutcome.BREAKER_OPEN)
 
-        # Route marker, fenced on the outbox claim.
+        # Route marker, fenced on the outbox claim. Idempotent re-write
+        # (SET generation_route = 'codex' unconditionally, no longer
+        # ``AND generation_route IS NULL``): this ONE statement now serves
+        # BOTH the ownership check (claim_token + status must still match —
+        # a caller whose lease was reclaimed must never learn about, let
+        # alone extend, another owner's leg) AND the read of the row's
+        # PRE-update route via the FROM-old self-join (same pattern
+        # consume_result uses to read a value before its own UPDATE nulls
+        # it). route_before is NULL only on this row's very first-ever
+        # offer; any other value means a prior leg exists and this is a
+        # retry. A fenced-is-None result is now UNAMBIGUOUSLY fence loss —
+        # the historical version conflated "fence lost" with "marker
+        # already set" and reported ALREADY_SPENT for both, which was safe
+        # only because that branch never wrote anything; it is not safe
+        # once a retry can create or reattach to a job (see the FENCE_LOST
+        # branch below, and its test's updated expectation).
         fenced = await conn.fetchrow(
             """
-            UPDATE wa_outbox SET generation_route = 'codex'
-            WHERE id = $1 AND claim_token = $2 AND status = $3
-              AND generation_route IS NULL
-            RETURNING id
+            UPDATE wa_outbox AS w
+            SET generation_route = 'codex'
+            FROM wa_outbox AS old
+            WHERE w.id = old.id
+              AND w.id = $1 AND w.claim_token = $2 AND w.status = $3
+            RETURNING w.id, old.generation_route AS route_before
             """,
             outbox_id,
             claim_token,
             outbox_expected_status,
         )
         if fenced is None:
-            # Either the lease was lost, or the marker is already set (a
-            # previous attempt spent the leg). Disambiguate for the ledger.
-            already = await conn.fetchval(
-                "SELECT generation_route IS NOT NULL FROM wa_outbox WHERE id = $1",
+            await _revert_canary_cas(conn)
+            return OfferResult(OfferOutcome.FENCE_LOST)
+
+        if fenced["route_before"] is not None:
+            # RETRY: this outbox row already spent at least one codex leg.
+            # The historical "ever" invariant (migration 270) is exactly
+            # what turned every recoverable codex failure into a silent
+            # Gemini fall-off; with Gemini's removal that becomes a mute
+            # customer instead. New rule: reattach to a still-alive leg,
+            # or admit a fresh one while the row has budget left.
+            prior = await conn.fetchrow(
+                """
+                SELECT job_id, state, thread_epoch FROM broker_jobs
+                WHERE outbox_id = $1 AND mode = 'serve'
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
                 outbox_id,
             )
-            await _revert_canary_cas(conn)
-            return OfferResult(OfferOutcome.ALREADY_SPENT if already else OfferOutcome.FENCE_LOST)
+            if prior is not None and prior["state"] not in _TERMINAL_STATES:
+                # Still alive (offered/leased/completed_pending_consume) —
+                # hand its job_id back instead of losing it. No new job is
+                # created, so the canary CAS (if this call won one) is
+                # reverted, same as every other non-creating exit.
+                await _revert_canary_cas(conn)
+                return OfferResult(
+                    OfferOutcome.REATTACHED,
+                    job_id=prior["job_id"],
+                    thread_epoch=int(prior["thread_epoch"]),
+                )
+
+            leg_count = await conn.fetchval(
+                "SELECT count(*) FROM broker_jobs WHERE outbox_id = $1 AND mode = 'serve'",
+                outbox_id,
+            )
+            if int(leg_count or 0) >= MAX_CODEX_LEGS:
+                # Terminal + budget exhausted: NAMED, never conflated with
+                # the generic ALREADY_SPENT below (spec gradino 2/5, point
+                # 3 — no silent fall-off for this case either).
+                await _revert_canary_cas(conn)
+                return OfferResult(OfferOutcome.LEGS_EXHAUSTED)
+            # else: the prior leg is terminal and the budget has room —
+            # fall through to the SAME savepoint-protected INSERT a fresh
+            # (first-ever) offer uses below. uq_broker_jobs_serve_outbox_live
+            # (migration 296) only forbids a SECOND live row, so this INSERT
+            # is expected to succeed; the advisory xact lock already
+            # serializes the whole broker system-wide, so no other offer
+            # can be racing this one for the same or any other outbox_id.
 
         # SAVEPOINT around the INSERT (S2 cross-family review, finding 2):
         # a UniqueViolationError aborts the enclosing PostgreSQL transaction,
@@ -480,12 +613,13 @@ async def offer_job(
                     t_exec,
                 )
         except asyncpg.UniqueViolationError:
-            # uq_broker_jobs_serve_outbox: the leg was already spent by a
-            # path that did not set the marker (should not happen — the two
-            # writes are one transaction — but the DB is the invariant's
-            # owner, so honor its verdict rather than assume). The marker
-            # written above survives the savepoint rollback and commits,
-            # repairing the missing historical fence.
+            # uq_broker_jobs_serve_outbox_live: a live row already exists
+            # for this outbox_id via a path this transaction did not see
+            # (should not happen — the advisory xact lock serializes the
+            # whole broker, and the REATTACHED branch above already checks
+            # for a live prior leg — but the DB is the invariant's owner,
+            # so honor its verdict rather than assume). The marker written
+            # above survives the savepoint rollback and commits.
             await _revert_canary_cas(conn)
             return OfferResult(OfferOutcome.ALREADY_SPENT)
 
@@ -496,7 +630,7 @@ async def offer_job(
         thread_id,
         t_exec,
     )
-    return OfferResult(OfferOutcome.OFFERED, job_id=job_id)
+    return OfferResult(OfferOutcome.OFFERED, job_id=job_id, thread_epoch=thread_epoch)
 
 
 async def wait_for_job(

--- a/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
+++ b/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
@@ -35,9 +35,12 @@ The codex leg runs IFF all of (spec 2.1 route decision):
      about to lose its send window never waits on a broker round-trip.
   4. The context package builds (``POST /api/wa-package/build``, the RAG
      process owns the retriever); unbuildable -> Gemini.
-  5. ``offer_job`` returns OFFERED — admission lock, gauge liveness,
+  5. ``offer_job`` returns OFFERED (a fresh job) or REATTACHED (a prior
+     leg for this row is still alive) — admission lock, gauge liveness,
      breaker, depth and the wa_outbox fence are all checked inside the
-     offer transaction; every other outcome -> Gemini.
+     offer transaction; every other outcome -> Gemini, including the
+     NAMED ``legs_exhausted`` (this row already spent its whole codex
+     retry budget — spec gradino 2/5).
 
 A consumed completion is NEVER returned raw: it runs through
 ``finalize_wa_answer(provider="codex")`` — the SHARED post-generation
@@ -366,7 +369,16 @@ async def _attempt(
             exc_name,
         )
         return CodexLegResult(fail=f"offer_uncertain:{exc_name}")
-    if offer.outcome is not wa_broker.OfferOutcome.OFFERED:
+    # OFFERED (a job was just created — first leg or a fresh retry leg) and
+    # REATTACHED (a prior leg for this outbox_id is still alive) both carry
+    # a job_id worth waiting on and are handled identically from here.
+    # Every other outcome is a certain non-durable fall-off (retry budget
+    # gradino 2/5) — including the now-NAMED LEGS_EXHAUSTED, distinct in
+    # the log/reason from the generic ALREADY_SPENT race fallback.
+    if offer.outcome not in (
+        wa_broker.OfferOutcome.OFFERED,
+        wa_broker.OfferOutcome.REATTACHED,
+    ):
         logger.info(
             "wa_codex_leg: offer fell off (outbox=%s outcome=%s)",
             outbox_id,
@@ -382,13 +394,42 @@ async def _attempt(
         )
         return CodexLegResult(fail=f"offer_uncertain:{type(release_exc).__name__}")
     if offer.job_id is None:
-        # OFFERED without an id is a broken transport contract over a
-        # possibly-durable job — falling off would run Gemini beside it
-        # with no way to ever wait/consume/discard (Codex r4 finding 1).
+        # OFFERED/REATTACHED without an id is a broken transport contract
+        # over a possibly-durable job — falling off would run Gemini
+        # beside it with no way to ever wait/consume/discard (Codex r4
+        # finding 1).
         logger.error(
-            "wa_codex_leg: OFFERED without job_id (outbox=%s)", outbox_id
+            "wa_codex_leg: %s without job_id (outbox=%s)",
+            offer.outcome.value,
+            outbox_id,
         )
         return CodexLegResult(fail="offer_contract_break:missing_job_id")
+    if offer.thread_epoch is None:
+        # Same contract-break class as a missing job_id — the post-
+        # completion drift check below has nothing safe to fence against.
+        logger.error(
+            "wa_codex_leg: %s without thread_epoch (outbox=%s job=%s)",
+            offer.outcome.value,
+            outbox_id,
+            offer.job_id,
+        )
+        return CodexLegResult(fail="offer_contract_break:missing_thread_epoch")
+    if offer.outcome is wa_broker.OfferOutcome.REATTACHED:
+        logger.info(
+            "wa_codex_leg: reattached to a still-alive prior leg "
+            "(outbox=%s job=%s)",
+            outbox_id,
+            offer.job_id,
+        )
+    # The epoch the SERVING job actually runs under — for a fresh OFFERED
+    # this equals the local `epoch` read above, but for REATTACHED it is
+    # the PRIOR leg's own frozen thread_epoch, which can predate this
+    # claim's own thread read (the prior leg may have been offered by an
+    # earlier, since-failed claim). The post-completion drift check below
+    # MUST fence against this value, not the local `epoch` — using the
+    # wrong one would silently defeat the thread-epoch-drift protocol on
+    # a reattach (spec 2.3).
+    serving_epoch = offer.thread_epoch
 
     # From here on an OFFERED job is DURABLE: an untyped failure can no
     # longer be an in-claim fall-off — the daemon may complete the job and
@@ -435,7 +476,10 @@ async def _attempt(
         # Drift check (spec 2.3), BEFORE consuming: a takeover — or a
         # takeover+release, which moves handling_version without leaving
         # human_handling true — during exec means this completion must
-        # never be sent AND must never trigger a fresh generation.
+        # never be sent AND must never trigger a fresh generation. Fenced
+        # against serving_epoch (the epoch the JOB actually ran under),
+        # not the local `epoch` — on a REATTACHED leg those two can
+        # differ (see serving_epoch's definition above).
         async with pool.acquire() as check_conn:
             fresh = await check_conn.fetchrow(
                 """
@@ -448,7 +492,7 @@ async def _attempt(
         if (
             fresh is None
             or bool(fresh["human_handling"])
-            or int(fresh["handling_version"]) != epoch
+            or int(fresh["handling_version"]) != serving_epoch
         ):
             # Stand-down is ATOMIC (Codex r2 finding 3): the drift verdict
             # terminalizes the outbox row, discards the completion and

--- a/apps/backend-rag/backend/tests/integration/test_wa_broker_pg.py
+++ b/apps/backend-rag/backend/tests/integration/test_wa_broker_pg.py
@@ -225,12 +225,21 @@ async def test_retry_after_terminal_prior_leg_admits_a_new_job(
     outbox_id, thread_id, claim = await _outbox_row(conn)
     first = await _offer(conn, outbox_id, thread_id, claim)
     assert first.outcome is OfferOutcome.OFFERED
+    # deadline_at moves to the PAST alongside the state, simulating an
+    # actually-elapsed budget window (not just a manually-forced state) —
+    # required for the daemon-occupancy ambiguity gate (S2 cross-family
+    # review round 2, "budget drain" fix) to resolve in this retry's
+    # favor: it needs proof the daemon polled AFTER this leg's own
+    # deadline, which _seed_alive_gauge below supplies by re-stamping
+    # broker_last_seen_at to now() (after the past deadline_at).
     await conn.execute(
         "UPDATE broker_jobs SET state = 'expired', package = NULL, "
-        "evidence_inputs = NULL, result_text = NULL, outcome = 'expired_leased' "
+        "evidence_inputs = NULL, result_text = NULL, outcome = 'expired_leased', "
+        "deadline_at = now() - interval '1 second' "
         "WHERE job_id = $1",
         first.job_id,
     )
+    await _seed_alive_gauge(conn)
 
     second = await _offer(conn, outbox_id, thread_id, claim)
 
@@ -252,6 +261,50 @@ async def test_retry_after_terminal_prior_leg_admits_a_new_job(
         await conn.fetchval("SELECT generation_route FROM wa_outbox WHERE id = $1", outbox_id)
         == "codex"
     )
+
+
+async def test_retry_blocked_while_daemon_not_proven_free_after_expiry(
+    conn: asyncpg.Connection,
+) -> None:
+    """MAJOR fix, real-DB proof (S2 cross-family review round 2, "budget
+    drain"): an expired-by-deadline prior leg must NOT admit a new one
+    while the gauge cannot prove the single-flight daemon has cycled back
+    to /claim since that leg's own deadline_at — otherwise a genuinely
+    slow-but-healthy exec (documented, pre-existing, wa_codex_daemon.py's
+    compute_budget_s docstring) would let every subsequent retry sit
+    unclaimed until it ALSO expires, burning the whole MAX_CODEX_LEGS
+    budget on one slow exec. Here broker_last_seen_at is stamped BEFORE
+    the expired leg's own deadline_at — unproven — QUEUE_FULL, and (the
+    real-DB guarantee a mock cannot give) no second row is created."""
+    outbox_id, thread_id, claim = await _outbox_row(conn)
+    await conn.execute(
+        """
+        INSERT INTO wa_broker_gauge (id, broker_last_seen_at, updated_at)
+        VALUES (1, now() - interval '20 seconds', now())
+        ON CONFLICT (id) DO UPDATE
+        SET broker_last_seen_at = now() - interval '20 seconds', updated_at = now()
+        """
+    )
+    first = await _offer(conn, outbox_id, thread_id, claim)
+    assert first.outcome is OfferOutcome.OFFERED
+    await conn.execute(
+        "UPDATE broker_jobs SET state = 'expired', package = NULL, "
+        "evidence_inputs = NULL, result_text = NULL, outcome = 'expired_leased', "
+        "deadline_at = now() - interval '5 seconds' "
+        "WHERE job_id = $1",
+        first.job_id,
+    )
+    # broker_last_seen_at (20s in the past) still predates the expired
+    # leg's own deadline_at (5s in the past) — never re-seeded since.
+
+    second = await _offer(conn, outbox_id, thread_id, claim)
+
+    assert second.outcome is OfferOutcome.QUEUE_FULL
+    assert second.job_id is None
+    count = await conn.fetchval(
+        "SELECT count(*) FROM broker_jobs WHERE outbox_id = $1", outbox_id
+    )
+    assert count == 1  # no second row was created
 
 
 async def test_retry_while_prior_leg_still_alive_reattaches(

--- a/apps/backend-rag/backend/tests/integration/test_wa_broker_pg.py
+++ b/apps/backend-rag/backend/tests/integration/test_wa_broker_pg.py
@@ -20,6 +20,7 @@ family #2).
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import os
 import uuid
@@ -56,6 +57,7 @@ _BROKER_MIGRATIONS = (
     _MIGRATIONS_DIR / "272_wa_broker_package_text.sql",
     _MIGRATIONS_DIR / "273_wa_broker_completion_digest.sql",
     _MIGRATIONS_DIR / "274_wa_broker_completed_at_check.sql",
+    _MIGRATIONS_DIR / "296_wa_broker_jobs_live_only_unique.sql",
 )
 
 _SCHEMA = "wa_broker_it"
@@ -207,24 +209,146 @@ async def test_full_lifecycle_offer_claim_complete_consume(
     assert await wa_broker.consume_result(conn, offered.job_id) is None
 
 
-async def test_second_offer_on_same_row_is_already_spent(
+async def test_retry_after_terminal_prior_leg_admits_a_new_job(
     conn: asyncpg.Connection,
 ) -> None:
+    """THE FIX (spec gradino 2/5, migration 296): the historical version of
+    this test proved the OLD 'ever' invariant — a durable generation_route
+    marker permanently refusing any second leg, even a recoverable one.
+    That is exactly what made every recoverable codex failure a silent
+    Gemini fall-off. Now: terminalize the first leg WITHOUT deleting it
+    (a real reaper/complete_job transition never deletes — only the 7-day
+    sweep does), re-offer on the SAME claim, and require a FRESH OFFERED
+    with a NEW job_id — both rows persist, proving the live-only unique
+    index (not row deletion) is what makes the second INSERT succeed."""
     await _seed_alive_gauge(conn)
     outbox_id, thread_id, claim = await _outbox_row(conn)
     first = await _offer(conn, outbox_id, thread_id, claim)
     assert first.outcome is OfferOutcome.OFFERED
-    # Terminalize the live job so depth admits, then re-offer: the DURABLE
-    # marker (generation_route) must refuse the second leg.
     await conn.execute(
         "UPDATE broker_jobs SET state = 'expired', package = NULL, "
         "evidence_inputs = NULL, result_text = NULL, outcome = 'expired_leased' "
         "WHERE job_id = $1",
         first.job_id,
     )
-    await conn.execute("DELETE FROM broker_jobs WHERE job_id = $1", first.job_id)
+
     second = await _offer(conn, outbox_id, thread_id, claim)
-    assert second.outcome is OfferOutcome.ALREADY_SPENT
+
+    assert second.outcome is OfferOutcome.OFFERED
+    assert second.job_id is not None
+    assert second.job_id != first.job_id
+    # BOTH rows persist — the first terminal leg is history, not deleted.
+    rows = await conn.fetch(
+        "SELECT job_id, state FROM broker_jobs WHERE outbox_id = $1 ORDER BY created_at",
+        outbox_id,
+    )
+    assert [r["job_id"] for r in rows] == [first.job_id, second.job_id]
+    assert rows[0]["state"] == "expired"
+    assert rows[1]["state"] == "offered"
+    # The durable marker stays 'codex' throughout (it now means "this row
+    # has ever touched codex", not "spent" — the per-row leg count is what
+    # actually gates a retry).
+    assert (
+        await conn.fetchval("SELECT generation_route FROM wa_outbox WHERE id = $1", outbox_id)
+        == "codex"
+    )
+
+
+async def test_retry_while_prior_leg_still_alive_reattaches(
+    conn: asyncpg.Connection,
+) -> None:
+    """A retry offered while the row's OWN prior leg is still 'leased'
+    (mid-exec) must REATTACH to it, not fall behind the depth cap — the
+    depth query excludes THIS outbox_id's own live job precisely so a
+    reattach never competes with itself for the one global admission
+    slot (a live DB proof that the exclusion in offer_job's depth query
+    actually works, not just the unit-mocked shape)."""
+    await _seed_alive_gauge(conn)
+    outbox_id, thread_id, claim = await _outbox_row(conn)
+    first = await _offer(conn, outbox_id, thread_id, claim)
+    assert first.outcome is OfferOutcome.OFFERED
+    # Simulate the broker having claimed it (still non-terminal).
+    await conn.execute(
+        "UPDATE broker_jobs SET state = 'leased', fence_token = gen_random_uuid(), "
+        "leased_at = now() WHERE job_id = $1",
+        first.job_id,
+    )
+
+    second = await _offer(conn, outbox_id, thread_id, claim)
+
+    assert second.outcome is OfferOutcome.REATTACHED
+    assert second.job_id == first.job_id
+    # No second row was created.
+    count = await conn.fetchval(
+        "SELECT count(*) FROM broker_jobs WHERE outbox_id = $1", outbox_id
+    )
+    assert count == 1
+
+
+async def test_retry_budget_exhausts_after_max_codex_legs(
+    conn: asyncpg.Connection,
+) -> None:
+    """INNOCENCE for the budget cap: MAX_CODEX_LEGS terminal legs are all
+    admitted (proving the cap is >=, not off-by-one), and the very NEXT
+    retry gets the NAMED LEGS_EXHAUSTED — never a silent fall-off
+    conflated with a different cause."""
+    await _seed_alive_gauge(conn)
+    outbox_id, thread_id, claim = await _outbox_row(conn)
+
+    job_ids: list[uuid.UUID] = []
+    for _ in range(wa_broker.MAX_CODEX_LEGS):
+        offered = await _offer(conn, outbox_id, thread_id, claim)
+        assert offered.outcome is OfferOutcome.OFFERED
+        job_ids.append(offered.job_id)
+        await conn.execute(
+            "UPDATE broker_jobs SET state = 'failed', package = NULL, "
+            "evidence_inputs = NULL, result_text = NULL, outcome = 'broker_failed' "
+            "WHERE job_id = $1",
+            offered.job_id,
+        )
+
+    assert len(set(job_ids)) == wa_broker.MAX_CODEX_LEGS  # every leg was distinct
+
+    exhausted = await _offer(conn, outbox_id, thread_id, claim)
+    assert exhausted.outcome is OfferOutcome.LEGS_EXHAUSTED
+    assert exhausted.job_id is None
+    total_rows = await conn.fetchval(
+        "SELECT count(*) FROM broker_jobs WHERE outbox_id = $1", outbox_id
+    )
+    assert total_rows == wa_broker.MAX_CODEX_LEGS  # the exhausted call created nothing
+
+
+async def test_two_concurrent_offers_on_the_same_row_never_create_two_live_jobs(
+    conn: asyncpg.Connection, pool: asyncpg.Pool
+) -> None:
+    """INNOCENCE, real concurrency: two workers racing an offer for the
+    SAME outbox row (same claim_token+status — the realistic shape of a
+    worker retry racing a slow-to-reclaim sibling) must never both create
+    a live job. The advisory xact lock serializes them; whichever runs
+    second must see the first's job (REATTACHED if still live) rather
+    than a second INSERT — this is exactly what uq_broker_jobs_serve_outbox_live
+    plus the advisory lock are for, and only a real DB proves it (a mock
+    cannot manufacture a genuine UniqueViolation race)."""
+    await _seed_alive_gauge(conn)
+    outbox_id, thread_id, claim = await _outbox_row(conn)
+
+    async def _one_offer() -> wa_broker.OfferResult:
+        async with pool.acquire() as c:
+            return await _offer(c, outbox_id, thread_id, claim)
+
+    results = await asyncio.gather(_one_offer(), _one_offer())
+    outcomes = sorted(r.outcome.value for r in results)
+    # Exactly one OFFERED (the winner) and one REATTACHED (the loser
+    # catching the winner's still-live job) — never two OFFERED.
+    assert outcomes == ["offered", "reattached"]
+    job_ids = {r.job_id for r in results}
+    assert len(job_ids) == 1  # both results point at the SAME job
+    live_count = await conn.fetchval(
+        "SELECT count(*) FROM broker_jobs WHERE outbox_id = $1 "
+        "AND state IN ('offered', 'leased', 'completed_pending_consume')",
+        outbox_id,
+    )
+    assert live_count == 1
 
 
 async def test_offer_depth_cap_and_fence_lost(conn: asyncpg.Connection) -> None:
@@ -257,18 +381,25 @@ async def test_unique_violation_savepoint_repairs_the_marker(
     conn: asyncpg.Connection,
 ) -> None:
     """Finding 2: UniqueViolationError must NOT roll back the historical
-    'spent' fence. Pre-insert a serve job WITHOUT the marker (the
-    compatibility scenario), offer, and require BOTH the ALREADY_SPENT
+    'spent' fence. Pre-insert a LIVE serve job WITHOUT the marker (the
+    compatibility/defensive scenario — a write inconsistency the code
+    never expects but the DB, as the invariant's owner, must still be
+    honored against) and offer: the retry-lookup branch never runs
+    (route_before is NULL, since the marker was bypassed), so this drives
+    the INSERT straight into uq_broker_jobs_serve_outbox_live's REAL
+    UniqueViolationError — not merely a terminal row, which migration 296
+    deliberately no longer blocks (see test_retry_after_terminal_prior_
+    leg_admits_a_new_job for that case). Requires BOTH the ALREADY_SPENT
     verdict AND a persisted generation_route."""
     await _seed_alive_gauge(conn)
     outbox_id, thread_id, claim = await _outbox_row(conn)
-    # A terminal serve job that spent the leg but never set the marker.
+    # A LIVE serve job that already holds the leg but never set the marker.
     await conn.execute(
         """
         INSERT INTO broker_jobs
             (outbox_id, thread_id, mode, state, package_hash, thread_epoch,
-             deadline_at, outcome)
-        VALUES ($1, $2, 'serve', 'expired', 'h', 1, now(), 'expired_leased')
+             deadline_at)
+        VALUES ($1, $2, 'serve', 'offered', 'h', 1, now() + interval '1 minute')
         """,
         outbox_id,
         thread_id,

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_broker.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_broker.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import logging
 import uuid
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import asyncpg
@@ -210,7 +211,7 @@ async def test_offer_job_happy_path_offers_fences_and_inserts() -> None:
     assert update_args == (OUTBOX_ID, CLAIM_TOKEN, EXPECTED_STATUS)
 
     # no broker_jobs history lookup on a first-ever offer.
-    assert not conn.sql_contains("SELECT job_id, state, thread_epoch FROM broker_jobs")
+    assert not conn.sql_contains("SELECT job_id, state, thread_epoch, deadline_at")
     assert not conn.sql_contains("SELECT count(*) FROM broker_jobs WHERE outbox_id")
 
     insert_calls = conn.sql_with_args("INSERT INTO broker_jobs")
@@ -362,7 +363,7 @@ async def test_offer_job_fence_lost_when_update_matches_no_row() -> None:
     # SAFETY: a lost fence must never trigger a broker_jobs lookup — a
     # caller that no longer owns the row must learn NOTHING about another
     # owner's leg, let alone reattach to or extend it.
-    assert not conn.sql_contains("SELECT job_id, state, thread_epoch FROM broker_jobs")
+    assert not conn.sql_contains("SELECT job_id, state, thread_epoch, deadline_at")
     assert not conn.sql_contains("SELECT count(*) FROM broker_jobs WHERE outbox_id")
     assert conn.sql_with_args(_REVERT_CANARY_WHERE)
 
@@ -418,7 +419,12 @@ async def test_offer_job_retry_reattaches_to_still_alive_prior_leg() -> None:
             {"broker_alive": True},
             {"breaker_state": "closed"},
             {"id": OUTBOX_ID, "route_before": "codex"},  # retry
-            {"job_id": prior_job_id, "state": "leased", "thread_epoch": THREAD_EPOCH - 1},
+            {
+                "job_id": prior_job_id,
+                "state": "leased",
+                "thread_epoch": THREAD_EPOCH - 1,
+                "deadline_open": True,  # still inside its own budget
+            },
         ],
         fetchval_results=[0],  # depth only — no INSERT, no leg_count query
     )
@@ -474,12 +480,20 @@ async def test_offer_job_retry_legs_exhausted_when_prior_terminal_and_budget_spe
     — spec gradino 2/5, point 3: never a silent fall-off conflated with
     another cause."""
     prior_job_id = uuid.uuid4()
+    prior_deadline = datetime.now(timezone.utc) - timedelta(seconds=5)
+    daemon_polled_after = prior_deadline + timedelta(seconds=1)
     conn = ScriptedConn(
         fetchrow_results=[
-            {"broker_alive": True},
+            {"broker_alive": True, "broker_last_seen_at": daemon_polled_after},
             {"breaker_state": "closed"},
             {"id": OUTBOX_ID, "route_before": "codex"},
-            {"job_id": prior_job_id, "state": "expired", "thread_epoch": THREAD_EPOCH},
+            {
+                "job_id": prior_job_id,
+                "state": "expired",
+                "thread_epoch": THREAD_EPOCH,
+                "deadline_at": prior_deadline,
+                "deadline_open": False,
+            },
         ],
         fetchval_results=[
             0,  # depth
@@ -493,6 +507,186 @@ async def test_offer_job_retry_legs_exhausted_when_prior_terminal_and_budget_spe
     assert result.job_id is None
     assert not conn.sql_contains("INSERT INTO broker_jobs")
     assert conn.sql_with_args(_REVERT_CANARY_WHERE)
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_blocked_when_daemon_not_proven_free_after_expiry() -> None:
+    """MAJOR fix (S2 cross-family review round 2, "budget drain"): a
+    healthy-but-slow exec can outlive its own deadline_at (documented in
+    wa_codex_daemon.py's compute_budget_s — a slow claim leg means "the
+    exec can outlive the lease... just wasted work", pre-existing and
+    accepted for a SINGLE leg under the old ever-scoped invariant). With
+    retries now possible, admitting a fresh leg while the single-flight
+    daemon MIGHT still be grinding on the one that just expired would let
+    every subsequent leg sit unclaimed until it also expires — burning
+    the whole MAX_CODEX_LEGS budget and multiple breaker folds on one slow
+    exec. Proof required: broker_last_seen_at must be AFTER the expired
+    leg's own deadline_at (daemon proven to have cycled back to /claim
+    since). Here it is NOT (still <= deadline_at) — QUEUE_FULL, no
+    leg_count query, no INSERT, canary reverted (same shape as every
+    other non-creating exit — this is a same-claim Gemini fall-off, zero
+    retry-ladder involvement)."""
+    prior_job_id = uuid.uuid4()
+    prior_deadline = datetime.now(timezone.utc) - timedelta(seconds=5)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            # daemon's last known poll predates the expired leg's own
+            # deadline — cannot prove it is no longer busy on it.
+            {"broker_alive": True, "broker_last_seen_at": prior_deadline - timedelta(seconds=1)},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {
+                "job_id": prior_job_id,
+                "state": "expired",
+                "thread_epoch": THREAD_EPOCH,
+                "deadline_at": prior_deadline,
+                "deadline_open": False,
+            },
+        ],
+        fetchval_results=[0],  # depth only — leg_count/INSERT never reached
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.QUEUE_FULL
+    assert result.job_id is None
+    assert not conn.sql_contains("SELECT count(*) FROM broker_jobs WHERE outbox_id")
+    assert not conn.sql_contains("INSERT INTO broker_jobs")
+    assert conn.sql_with_args(_REVERT_CANARY_WHERE)
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_blocked_when_gauge_has_no_broker_last_seen_at() -> None:
+    """INNOCENCE-adjacent: a NULL broker_last_seen_at (gauge row seeded
+    but never actually polled — should not coexist with broker_alive=True
+    in practice, but the code must fail closed, not raise, if it does)
+    must also block admission, same as a too-early one."""
+    prior_job_id = uuid.uuid4()
+    prior_deadline = datetime.now(timezone.utc) - timedelta(seconds=5)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True, "broker_last_seen_at": None},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {
+                "job_id": prior_job_id,
+                "state": "expired",
+                "thread_epoch": THREAD_EPOCH,
+                "deadline_at": prior_deadline,
+                "deadline_open": False,
+            },
+        ],
+        fetchval_results=[0],
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.QUEUE_FULL
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_admits_when_daemon_proven_free_after_expiry() -> None:
+    """INNOCENCE for the budget-drain fix: once broker_last_seen_at is
+    genuinely AFTER the expired leg's own deadline_at (the daemon proved
+    it cycled back to /claim since), a fresh leg is admitted normally —
+    the fix narrows WHEN a retry is admitted, it does not disable
+    retries."""
+    prior_job_id = uuid.uuid4()
+    new_job_id = uuid.uuid4()
+    prior_deadline = datetime.now(timezone.utc) - timedelta(seconds=5)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True, "broker_last_seen_at": prior_deadline + timedelta(seconds=1)},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {
+                "job_id": prior_job_id,
+                "state": "expired",
+                "thread_epoch": THREAD_EPOCH,
+                "deadline_at": prior_deadline,
+                "deadline_open": False,
+            },
+        ],
+        fetchval_results=[
+            0,  # depth
+            wa_broker.MAX_CODEX_LEGS - 1,  # leg_count: room for one more
+            new_job_id,  # INSERT ... RETURNING job_id
+        ],
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.OFFERED
+    assert result.job_id == new_job_id
+    assert conn.sql_contains("INSERT INTO broker_jobs")
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_live_but_deadline_passed_does_not_reattach() -> None:
+    """Minor fix (S2 cross-family review round 2, minor 2): a row that is
+    still formally 'leased'/'offered' (the reaper has not run yet) but
+    whose OWN deadline_at has already elapsed must NOT be reattached —
+    reattaching would send the caller straight into wait_for_job's own
+    immediate deadline-CAS, a wasted round trip for a leg that is, for
+    every practical purpose, already done. It falls through to the same
+    ambiguity gate a formally 'expired' row would, and — once the daemon
+    is proven free — a fresh leg is admitted instead."""
+    prior_job_id = uuid.uuid4()
+    new_job_id = uuid.uuid4()
+    prior_deadline = datetime.now(timezone.utc) - timedelta(seconds=5)
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True, "broker_last_seen_at": prior_deadline + timedelta(seconds=1)},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {
+                "job_id": prior_job_id,
+                "state": "leased",  # still formally live...
+                "thread_epoch": THREAD_EPOCH,
+                "deadline_at": prior_deadline,
+                "deadline_open": False,  # ...but its own budget is spent
+            },
+        ],
+        fetchval_results=[0, wa_broker.MAX_CODEX_LEGS - 1, new_job_id],
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.OFFERED
+    assert result.job_id == new_job_id
+    assert result.job_id != prior_job_id
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_consumed_prior_skips_ambiguity_check() -> None:
+    """'consumed' is a CONFIRMED-done state (the worker's own consume_result
+    CAS, following a real completion) — no daemon-occupancy ambiguity is
+    possible, so the ambiguity gate must never even read
+    gauge['broker_last_seen_at']. Deliberately OMITTED from the gauge dict
+    here: if the code touched it, this test would raise KeyError instead
+    of asserting — the crash IS the proof of "never touched"."""
+    prior_job_id = uuid.uuid4()
+    new_job_id = uuid.uuid4()
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True},  # no broker_last_seen_at key at all
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {
+                "job_id": prior_job_id,
+                "state": "consumed",
+                "thread_epoch": THREAD_EPOCH,
+                "deadline_at": datetime.now(timezone.utc) - timedelta(seconds=5),
+                "deadline_open": False,
+            },
+        ],
+        fetchval_results=[0, wa_broker.MAX_CODEX_LEGS - 1, new_job_id],
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.OFFERED
+    assert result.job_id == new_job_id
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_broker.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_broker.py
@@ -174,12 +174,16 @@ def _offer_kwargs(**overrides: Any) -> dict[str, Any]:
 
 @pytest.mark.asyncio
 async def test_offer_job_happy_path_offers_fences_and_inserts() -> None:
+    """INNOCENCE: a row's very first offer must behave EXACTLY as before
+    the retry-budget change — one fenced UPDATE, one INSERT, OFFERED with
+    the caller's own thread_epoch, no broker_jobs history lookup at all
+    (route_before is NULL, so the retry branch never runs)."""
     job_id = uuid.uuid4()
     conn = ScriptedConn(
         fetchrow_results=[
             {"broker_alive": True},  # gauge liveness
             {"breaker_state": "closed"},  # breaker_admits -> True, no CAS
-            {"id": OUTBOX_ID},  # fenced UPDATE RETURNING id
+            {"id": OUTBOX_ID, "route_before": None},  # fenced UPDATE, first-ever offer
         ],
         fetchval_results=[
             0,  # admission depth
@@ -191,17 +195,23 @@ async def test_offer_job_happy_path_offers_fences_and_inserts() -> None:
 
     assert result.outcome is wa_broker.OfferOutcome.OFFERED
     assert result.job_id == job_id
+    assert result.thread_epoch == THREAD_EPOCH
 
     # advisory-lock statement ran, first thing in the transaction
     assert conn.executed[0][0] == wa_broker._ADMISSION_LOCK_SQL
 
-    update_calls = conn.sql_with_args("UPDATE wa_outbox SET generation_route")
+    update_calls = conn.sql_with_args("UPDATE wa_outbox")
     assert update_calls, "expected the fenced wa_outbox UPDATE to run"
     update_sql, update_args = update_calls[0]
-    assert "claim_token = $2" in update_sql
-    assert "status = $3" in update_sql
-    assert "generation_route IS NULL" in update_sql
+    assert "SET generation_route = 'codex'" in update_sql
+    assert "w.claim_token = $2" in update_sql
+    assert "w.status = $3" in update_sql
+    assert "route_before" in update_sql
     assert update_args == (OUTBOX_ID, CLAIM_TOKEN, EXPECTED_STATUS)
+
+    # no broker_jobs history lookup on a first-ever offer.
+    assert not conn.sql_contains("SELECT job_id, state, thread_epoch FROM broker_jobs")
+    assert not conn.sql_contains("SELECT count(*) FROM broker_jobs WHERE outbox_id")
 
     insert_calls = conn.sql_with_args("INSERT INTO broker_jobs")
     assert insert_calls, "expected the job INSERT to run"
@@ -233,7 +243,7 @@ async def test_offer_job_broker_absent_when_gauge_missing() -> None:
 
     assert result.outcome is wa_broker.OfferOutcome.BROKER_ABSENT
     assert result.job_id is None
-    assert not conn.sql_contains("UPDATE wa_outbox SET generation_route")
+    assert not conn.sql_contains("UPDATE wa_outbox AS w")
 
 
 @pytest.mark.asyncio
@@ -243,7 +253,7 @@ async def test_offer_job_broker_absent_when_gauge_stale() -> None:
     result = await wa_broker.offer_job(conn, **_offer_kwargs())
 
     assert result.outcome is wa_broker.OfferOutcome.BROKER_ABSENT
-    assert not conn.sql_contains("UPDATE wa_outbox SET generation_route")
+    assert not conn.sql_contains("UPDATE wa_outbox AS w")
 
 
 @pytest.mark.asyncio
@@ -258,7 +268,7 @@ async def test_offer_job_queue_full_when_depth_at_cap() -> None:
     result = await wa_broker.offer_job(conn, **_offer_kwargs())
 
     assert result.outcome is wa_broker.OfferOutcome.QUEUE_FULL
-    assert not conn.sql_contains("UPDATE wa_outbox SET generation_route")
+    assert not conn.sql_contains("UPDATE wa_outbox AS w")
     # lock + gauge fetchrow + depth fetchval only — the breaker was never touched
     assert len(conn.executed) == 3
 
@@ -272,7 +282,7 @@ async def test_offer_job_admits_when_depth_below_cap() -> None:
         fetchrow_results=[
             {"broker_alive": True},
             {"breaker_state": "closed"},
-            {"id": OUTBOX_ID},
+            {"id": OUTBOX_ID, "route_before": None},
         ],
         fetchval_results=[wa_broker.MAX_DEPTH - 1, job_id],
     )
@@ -280,6 +290,28 @@ async def test_offer_job_admits_when_depth_below_cap() -> None:
     result = await wa_broker.offer_job(conn, **_offer_kwargs())
 
     assert result.outcome is wa_broker.OfferOutcome.OFFERED
+
+
+@pytest.mark.asyncio
+async def test_offer_job_depth_check_excludes_this_outbox_ids_own_live_job() -> None:
+    """The depth cap's SQL must exclude the CALLER's own outbox_id — a
+    retry reattaching to a leg it already holds (its own job still
+    'offered'/'leased') asks for no NEW capacity, so it must never be
+    refused by the very cap that admitted that leg in the first place.
+    Without this exclusion a retry on a row whose prior leg is still
+    mid-exec would hit QUEUE_FULL and fall off to Gemini — the exact bug
+    class this PR fixes, just reached through a different admission gate."""
+    conn = ScriptedConn(
+        fetchrow_results=[{"broker_alive": True}],
+        fetchval_results=[0],
+    )
+    await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    depth_calls = conn.sql_with_args("outbox_id != $1")
+    assert depth_calls, "expected the depth-cap query to run with the exclusion"
+    depth_sql, depth_args = depth_calls[0]
+    assert "state IN ('offered', 'leased')" in depth_sql
+    assert depth_args == (OUTBOX_ID,)
 
 
 @pytest.mark.asyncio
@@ -296,50 +328,42 @@ async def test_offer_job_breaker_open_blocks_offer() -> None:
     result = await wa_broker.offer_job(conn, **_offer_kwargs())
 
     assert result.outcome is wa_broker.OfferOutcome.BREAKER_OPEN
-    assert not conn.sql_contains("UPDATE wa_outbox SET generation_route")
+    assert not conn.sql_contains("UPDATE wa_outbox AS w")
     # breaker_admits itself refused — no canary was ever consumed, so
     # offer_job's own revert call site is never reached.
     assert not conn.sql_with_args(_REVERT_CANARY_WHERE)
 
 
 @pytest.mark.asyncio
-async def test_offer_job_already_spent_when_fence_lost_but_marker_set() -> None:
-    conn = ScriptedConn(
-        fetchrow_results=[
-            {"broker_alive": True},
-            {"breaker_state": "closed"},  # breaker admits
-            None,  # fenced UPDATE RETURNING id -> 0 rows
-        ],
-        fetchval_results=[
-            0,  # depth
-            True,  # generation_route IS NOT NULL -> marker already set
-        ],
-    )
-
-    result = await wa_broker.offer_job(conn, **_offer_kwargs())
-
-    assert result.outcome is wa_broker.OfferOutcome.ALREADY_SPENT
-    assert result.job_id is None
-    assert not conn.sql_contains("INSERT INTO broker_jobs")
-    # post-admission failure exit -> the won canary CAS must be reverted.
-    assert conn.sql_with_args(_REVERT_CANARY_WHERE)
-
-
-@pytest.mark.asyncio
-async def test_offer_job_fence_lost_when_marker_not_set() -> None:
+async def test_offer_job_fence_lost_when_update_matches_no_row() -> None:
+    """The fenced UPDATE now carries BOTH the ownership check and the
+    route_before read in one statement (FROM-old self-join) — a caller
+    whose claim_token/status no longer matches gets FENCE_LOST unconditionally,
+    with NO further lookup. This supersedes the historical behavior (a
+    separate ``SELECT generation_route IS NOT NULL`` query) that reported
+    ALREADY_SPENT whenever the marker happened to be set even if THIS
+    caller's own fence was lost — safe only while that branch never wrote
+    anything; unsafe now that a retry can reattach to or extend another
+    owner's leg, so it is deliberately gone."""
     conn = ScriptedConn(
         fetchrow_results=[
             {"broker_alive": True},
             {"breaker_state": "closed"},
-            None,
+            None,  # fenced UPDATE matches no row -> fence lost, full stop
         ],
-        fetchval_results=[0, False],  # depth, generation_route IS NOT NULL -> False
+        fetchval_results=[0],  # depth only — leg_count/prior lookups never run
     )
 
     result = await wa_broker.offer_job(conn, **_offer_kwargs())
 
     assert result.outcome is wa_broker.OfferOutcome.FENCE_LOST
+    assert result.job_id is None
     assert not conn.sql_contains("INSERT INTO broker_jobs")
+    # SAFETY: a lost fence must never trigger a broker_jobs lookup — a
+    # caller that no longer owns the row must learn NOTHING about another
+    # owner's leg, let alone reattach to or extend it.
+    assert not conn.sql_contains("SELECT job_id, state, thread_epoch FROM broker_jobs")
+    assert not conn.sql_contains("SELECT count(*) FROM broker_jobs WHERE outbox_id")
     assert conn.sql_with_args(_REVERT_CANARY_WHERE)
 
 
@@ -350,17 +374,19 @@ async def test_offer_job_already_spent_on_insert_unique_violation() -> None:
     marker written just before it — so the marker UPDATE must still be
     present in the audit trail even though the statement after it raised.
     The canary CAS must also be reverted, same as the other post-admission
-    failure exits."""
+    failure exits. First-ever offer (route_before None) hitting the DB's
+    live-scoped unique index defensively — the code never expects this
+    under the advisory xact lock, but must still honor the DB's verdict."""
     conn = ScriptedConn(
         fetchrow_results=[
             {"broker_alive": True},
             {"breaker_state": "closed"},
-            {"id": OUTBOX_ID},  # fenced UPDATE succeeds this time
+            {"id": OUTBOX_ID, "route_before": None},  # fenced UPDATE succeeds
         ],
         fetchval_results=[
             0,  # depth
             asyncpg.UniqueViolationError(
-                'duplicate key value violates unique constraint "uq_broker_jobs_serve_outbox"'
+                'duplicate key value violates unique constraint "uq_broker_jobs_serve_outbox_live"'
             ),
         ],
     )
@@ -370,12 +396,139 @@ async def test_offer_job_already_spent_on_insert_unique_violation() -> None:
     assert result.outcome is wa_broker.OfferOutcome.ALREADY_SPENT
     assert result.job_id is None
 
-    update_calls = conn.sql_with_args("UPDATE wa_outbox SET generation_route")
+    update_calls = conn.sql_with_args("UPDATE wa_outbox")
     assert update_calls, (
         "the generation_route marker UPDATE must survive the savepoint "
         "rollback of the failing INSERT"
     )
     assert conn.sql_with_args(_REVERT_CANARY_WHERE)
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_reattaches_to_still_alive_prior_leg() -> None:
+    """COLPA (bug this PR fixes): a retry offer on a row whose prior codex
+    leg is STILL ALIVE must hand back that job's id (REATTACHED) — not
+    lose it behind a bare ALREADY_SPENT the way the historical code did.
+    thread_epoch travels back from the PRIOR job's own frozen value, not
+    this call's fresh THREAD_EPOCH argument (they may legitimately differ:
+    the prior leg could have been offered under an earlier claim)."""
+    prior_job_id = uuid.uuid4()
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},  # retry
+            {"job_id": prior_job_id, "state": "leased", "thread_epoch": THREAD_EPOCH - 1},
+        ],
+        fetchval_results=[0],  # depth only — no INSERT, no leg_count query
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.REATTACHED
+    assert result.job_id == prior_job_id
+    assert result.thread_epoch == THREAD_EPOCH - 1
+    assert not conn.sql_contains("INSERT INTO broker_jobs")
+    assert not conn.sql_contains("SELECT count(*) FROM broker_jobs WHERE outbox_id")
+    # no new job was created — the canary CAS (if won) must be reverted,
+    # same as every other non-creating exit.
+    assert conn.sql_with_args(_REVERT_CANARY_WHERE)
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_admits_new_leg_when_prior_terminal_and_budget_available() -> None:
+    """A retry offer whose prior leg is TERMINAL and the row has not yet
+    spent MAX_CODEX_LEGS admits a fresh leg — OFFERED, a NEW job_id, and
+    (unlike REATTACHED) the caller's OWN fresh thread_epoch, since this
+    leg is offered under the CURRENT claim."""
+    prior_job_id = uuid.uuid4()
+    new_job_id = uuid.uuid4()
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {"job_id": prior_job_id, "state": "failed", "thread_epoch": THREAD_EPOCH},
+        ],
+        fetchval_results=[
+            0,  # depth
+            wa_broker.MAX_CODEX_LEGS - 1,  # leg_count: room for one more
+            new_job_id,  # INSERT ... RETURNING job_id
+        ],
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.OFFERED
+    assert result.job_id == new_job_id
+    assert result.thread_epoch == THREAD_EPOCH
+    insert_calls = conn.sql_with_args("INSERT INTO broker_jobs")
+    assert insert_calls, "a terminal prior leg with budget left must admit a new one"
+    assert not conn.sql_with_args(_REVERT_CANARY_WHERE)
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_legs_exhausted_when_prior_terminal_and_budget_spent() -> None:
+    """The 'terminal + limit reached' case must be a NAMED terminal outcome
+    (LEGS_EXHAUSTED) distinct from the generic ALREADY_SPENT race fallback
+    — spec gradino 2/5, point 3: never a silent fall-off conflated with
+    another cause."""
+    prior_job_id = uuid.uuid4()
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            {"job_id": prior_job_id, "state": "expired", "thread_epoch": THREAD_EPOCH},
+        ],
+        fetchval_results=[
+            0,  # depth
+            wa_broker.MAX_CODEX_LEGS,  # leg_count: budget fully spent
+        ],
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.LEGS_EXHAUSTED
+    assert result.job_id is None
+    assert not conn.sql_contains("INSERT INTO broker_jobs")
+    assert conn.sql_with_args(_REVERT_CANARY_WHERE)
+
+
+@pytest.mark.asyncio
+async def test_offer_job_retry_no_prior_row_falls_through_to_insert() -> None:
+    """Defensive edge case: route_before is 'codex' (marker set) but no
+    broker_jobs row is found for this outbox_id (should not happen — the
+    marker and the INSERT are written in the same original transaction —
+    but the DB is the invariant's owner, so treat 'no history' the same as
+    'terminal with room': admit a fresh leg rather than refuse silently)."""
+    new_job_id = uuid.uuid4()
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"broker_alive": True},
+            {"breaker_state": "closed"},
+            {"id": OUTBOX_ID, "route_before": "codex"},
+            None,  # no broker_jobs row found for this outbox_id
+        ],
+        fetchval_results=[0, 0, new_job_id],  # depth, leg_count=0, INSERT
+    )
+
+    result = await wa_broker.offer_job(conn, **_offer_kwargs())
+
+    assert result.outcome is wa_broker.OfferOutcome.OFFERED
+    assert result.job_id == new_job_id
+
+
+@pytest.mark.asyncio
+async def test_max_codex_legs_matches_outbox_worker_max_attempts() -> None:
+    """Closed-vocabulary cross-check (W114 discipline): MAX_CODEX_LEGS
+    cannot import wa_outbox_worker.MAX_ATTEMPTS (wa_outbox_worker already
+    imports wa_codex_leg which imports this module — importing back would
+    cycle), so the two constants are independent by construction and must
+    be pinned equal here instead, or they silently drift."""
+    from backend.services.integrations import wa_outbox_worker
+
+    assert wa_broker.MAX_CODEX_LEGS == wa_outbox_worker.MAX_ATTEMPTS
 
 
 # ── wait_for_job ─────────────────────────────────────────────────────────

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
@@ -3,7 +3,15 @@
 Chaos-table ownership (design s2-pr5 §7): rows 2 (ALREADY_SPENT -> Gemini),
 3-adjacent (fall-off semantics), 7 (typed failure -> fall-off), 9 (broker
 dark -> Gemini-only) live here; rows 1/4 are pinned by PR-2's broker suite,
-rows 5/6/8 by PR-6's daemon tests.
+rows 5/6/8 by PR-6's daemon tests. Retry-budget update (spec gradino 2/5,
+migration 296): row 2's ALREADY_SPENT still falls off (now a defensive
+race fallback, not the normal retry path), but a retry offer on a row
+with a STILL-ALIVE prior leg now returns REATTACHED — this leg proceeds
+to wait/consume the SAME job rather than falling off, and a terminal
+prior leg with budget left gets a fresh OFFERED leg instead of falling
+off at all. See test_offer_job_retry_* in test_wa_broker.py for the
+offer_job-side coverage; this file covers only wa_codex_leg.py's
+consumption of the new outcomes.
 
 Fake discipline: the real ``wa_broker`` enums travel through a stub
 namespace, so every ``is not OfferOutcome.OFFERED`` identity check in the
@@ -209,7 +217,15 @@ def _wire_stubs(
         offer_job=AsyncMock(
             return_value=offer
             if offer is not None
-            else OfferResult(OfferOutcome.OFFERED, job_id=uuid.uuid4())
+            else OfferResult(
+                OfferOutcome.OFFERED,
+                job_id=uuid.uuid4(),
+                # matches _thread()'s default handling_version=3 — most
+                # tests never touch the epoch and just need the drift
+                # check's `serving_epoch` to equal what `_thread()` hands
+                # back as `fresh["handling_version"]`.
+                thread_epoch=3,
+            )
         ),
         wait_for_job=AsyncMock(
             return_value=wait if wait is not None else WaitResult(WaitOutcome.COMPLETED)
@@ -348,13 +364,17 @@ async def test_build_contract_break_missing_wire_falls_off(
         OfferOutcome.QUEUE_FULL,
         OfferOutcome.ALREADY_SPENT,
         OfferOutcome.FENCE_LOST,
+        OfferOutcome.LEGS_EXHAUSTED,
     ],
 )
 async def test_every_non_offered_outcome_falls_off_without_waiting(
     monkeypatch: pytest.MonkeyPatch, outcome: OfferOutcome
 ) -> None:
     """Chaos rows 2/9: every admission refusal is a route decision, not an
-    error — straight to Gemini, no wait, no consume, no fold."""
+    error — straight to Gemini, no wait, no consume, no fold. LEGS_EXHAUSTED
+    (spec gradino 2/5) joins this set: named distinctly from ALREADY_SPENT
+    in the reason string, but the same fall-off shape until Gemini itself
+    is retired from this channel."""
     stubs = _wire_stubs(monkeypatch, offer=OfferResult(outcome))
     result = await _run()
     assert result.text is None and not result.stand_down
@@ -621,6 +641,100 @@ async def test_offered_without_job_id_is_a_contract_break_fail(
     assert result.fail == "offer_contract_break:missing_job_id"
     assert result.text is None and not result.stand_down
     stubs.wait_for_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_offered_without_thread_epoch_is_a_contract_break_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract-break class as a missing job_id (Codex r4 finding 1):
+    without thread_epoch the post-completion drift check has nothing safe
+    to fence against, so this must fail closed before ever waiting."""
+    stubs = _wire_stubs(
+        monkeypatch,
+        offer=OfferResult(OfferOutcome.OFFERED, job_id=uuid.uuid4(), thread_epoch=None),
+    )
+    result = await _run()
+    assert result.fail == "offer_contract_break:missing_thread_epoch"
+    assert result.text is None and not result.stand_down
+    stubs.wait_for_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reattached_proceeds_to_wait_like_offered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REATTACHED is the fix for the historical bug: a retry offer on a
+    row whose prior codex leg is still alive gets that job's id back and
+    must wait/consume/finalize it exactly like a fresh OFFERED — never
+    fall off and lose it to Gemini."""
+    job_id = uuid.uuid4()
+    stubs = _wire_stubs(
+        monkeypatch,
+        offer=OfferResult(OfferOutcome.REATTACHED, job_id=job_id, thread_epoch=3),
+    )
+    conn = ScriptedConn(
+        fetchrow_results=[{"human_handling": False, "handling_version": 3}]
+    )
+    result = await _run(conn=conn)
+    assert result.text == "the broker reply"
+    assert result.stand_down is False
+    stubs.wait_for_job.assert_awaited_once()
+    assert stubs.wait_for_job.await_args.args[1] == job_id
+    stubs.consume_result.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reattach_drift_check_fences_on_the_jobs_own_epoch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The critical correctness case: a REATTACHED job's post-completion
+    drift check must compare against the PRIOR leg's own frozen
+    thread_epoch (offer.thread_epoch), never this claim's freshly-read
+    local epoch. Here the CURRENT claim's thread reads handling_version=5
+    (it started later than the original leg), the reattached job was
+    actually offered under epoch=3, and the thread's live handling_version
+    is STILL 3 (nothing moved since the original offer) — using the local
+    epoch (5) would wrongly declare drift and discard a perfectly valid
+    completion; using the job's own epoch (3) correctly finds none."""
+    job_id = uuid.uuid4()
+    stubs = _wire_stubs(
+        monkeypatch,
+        offer=OfferResult(OfferOutcome.REATTACHED, job_id=job_id, thread_epoch=3),
+    )
+    conn = ScriptedConn(
+        fetchrow_results=[{"human_handling": False, "handling_version": 3}]
+    )
+    result = await _run(conn=conn, thread=_thread(handling_version=5))
+    assert result.text == "the broker reply"
+    assert result.stand_down is False
+    stubs.discard_completion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reattach_drift_check_still_catches_real_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INNOCENCE for the above: if the thread's live handling_version has
+    actually moved PAST the reattached job's own frozen epoch, the drift
+    check must still fire — the fix narrows WHICH epoch is authoritative,
+    it does not disable the protocol."""
+    job_id = uuid.uuid4()
+    stubs = _wire_stubs(
+        monkeypatch,
+        offer=OfferResult(OfferOutcome.REATTACHED, job_id=job_id, thread_epoch=3),
+    )
+    conn = ScriptedConn(
+        fetchrow_results=[
+            {"human_handling": False, "handling_version": 4},  # moved past 3
+            {"id": 42},  # atomic stand-down abort: fenced RETURNING
+        ]
+    )
+    result = await _run(conn=conn, thread=_thread(handling_version=5))
+    assert result.stand_down is True
+    assert result.text is None
+    stubs.discard_completion.assert_awaited_once()
+    stubs.consume_result.assert_not_awaited()
 
 
 def test_stub_namespace_mirrors_the_real_module() -> None:

--- a/evidence/2026-08/agent-air-m5-backend-rag-codex-leg-retry-budget-e69f8464/brief.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-codex-leg-retry-budget-e69f8464/brief.yml
@@ -1,0 +1,86 @@
+task_id: codex-leg-retry-budget-0827
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Sciogliere l'invariante che, tolto il ripiego su Gemini, trasforma ogni
+  fallimento recuperabile della rotta ChatGPT in silenzio verso un cliente.
+
+  Stato di partenza, misurato: `offer_job` marcava `wa_outbox.generation_route
+  = 'codex'` al primo offer, e ogni offer successivo per la stessa riga — a
+  qualunque claim_token futuro — tornava `ALREADY_SPENT` SENZA `job_id`. Il
+  chiamante non poteva nemmeno riagganciare il job già offerto. Non era un
+  difetto: era voluto, e la chaos-table del test lo dice ("row 2:
+  ALREADY_SPENT -> Gemini"). L'invariante "UNA gamba codex per riga, per
+  sempre" aveva senso finché Gemini raccoglieva ogni caduta.
+
+  Il proprietario ha stabilito il 2026-08-27 che Gemini esce dal canale
+  WhatsApp in modo permanente. Da quel momento quell'invariante È la causa
+  del silenzio, non una protezione. Questa PR la riformula in: "una gamba
+  IN VOLO per riga, fino a un budget di gambe" — lo stesso limite che il
+  contatore dei tentativi già imponeva.
+
+  Gear 3 per PATH, non per raggio d'azione: il diff tocca
+  `apps/backend-rag/backend/db/migrations_v2/` (migrazione 296), che è
+  hot-zone in `scripts/evidence_pack_lint.py`. Il pavimento è un limite
+  inferiore deterministico calcolato dal diff, mai una scelta di chi scrive.
+constraints:
+  - "Il CAS di `complete_job` non si tocca. È la protezione contro la doppia
+    risposta al cliente, ed è l'unica che la review avversariale ha attaccato
+    senza riuscire a romperla. Non si baratta per comodità."
+  - "La transazione fenced su claim_token+status e la protezione contro il
+    doppio-job restano intatte: l'unique index passa da mai-scoped a
+    scoped-agli-stati-vivi, non sparisce."
+  - "Il vocabolario chiuso degli stati non si allarga senza aggiornare ogni
+    validatore che lo legge."
+  - "Nessuna cifra, nessun prezzo, nessun riferimento normativo: questo
+    codice non produce testo rivolto al cliente."
+acceptance:
+  - "Un secondo offer con la gamba precedente VIVA restituisce il job_id
+    esistente (REATTACHED) e la gamba si riaggancia invece di cadere."
+  - "Un secondo offer con la gamba precedente TERMINALE e budget disponibile
+    ammette una nuova gamba."
+  - "Oltre il budget l'esito è NOMINATO (LEGS_EXHAUSTED), mai un fall-off
+    silenzioso."
+  - "Due worker concorrenti sulla stessa riga non producono due gambe vive —
+    dimostrato su Postgres reale, non su mock."
+  - "Una gamba scaduta per deadline NON libera budget finché il demone non ha
+    completato almeno un giro di polling dopo quella scadenza."
+risks:
+  - "Il rollback della migrazione non è reversibile una volta che una riga ha
+    due gambe: il CREATE UNIQUE INDEX originale fallirebbe sui duplicati.
+    Dichiarato nel file SQL e nel corpo PR — un rollback che fallisce
+    rumorosamente è preferibile a uno che sembra riuscito."
+  - "Il DROP+CREATE dell'indice non è concorrente: prende ACCESS EXCLUSIVE.
+    Accettabile perché `broker_jobs` è quasi vuota (una riga in tutta la sua
+    storia, misurata il 2026-08-27); se quella premessa decade, la build
+    dell'indice blocca le scritture del broker."
+  - "Il budget è contato sulle righe reali di `broker_jobs`, che lo sweep a 7
+    giorni cancella: su una riga molto vecchia il budget si riazzera. La
+    direzione dell'errore è 'qualche gamba in più', mai una risposta doppia,
+    e la scala esterna dei tentativi la limita comunque."
+grader: |
+  Verifica indipendente della sessione conduttrice (generator != grader: chi
+  ha scritto il diff non lo giudica). Review avversariale cross-family con
+  Kimi K3 su contesto fresco, prompt di refutazione su sette assi
+  (concorrenza/doppio-job, migrazione, correttezza del riaggancio, budget,
+  esito terminale, controllo di profondità, qualità dei test). Verdetto
+  grezzo BLOCK con due MAJOR.
+
+  La conduttrice ha pesato i rilievi invece di eseguirli: il MAJOR sull'esito
+  terminale che lascia il cliente muto è stato RESPINTO con motivazione —
+  giudica contro un mondo in cui Gemini è già stato tolto, che è il quinto
+  gradino di questa scala, non il secondo; oggi quel ramo cade correttamente
+  su Gemini. Il MAJOR sul prosciugamento del budget è stato ACCETTATO come
+  regressione vera introdotta da questa PR: prima una scadenza bruciava una
+  gamba, dopo ne bruciava cinque.
+
+  La cura preferita dalla conduttrice (leggere `in_flight` dal gauge) si è
+  rivelata SBAGLIATA — quel campo è codice morto, il demone lo manda
+  hardcodato a zero — e il costruttore l'ha corretta usando un timestamp che
+  il database scrive di suo. Registrato qui perché una cura basata su un
+  campo morto sarebbe stata verde per sempre.
+budget: |
+  Due round. Round 1: costruzione + review avversariale. Round 2: cura del
+  prosciugamento del budget, due minori, e questo pacchetto di evidenze.
+pii: none

--- a/evidence/2026-08/agent-air-m5-backend-rag-codex-leg-retry-budget-e69f8464/pack.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-codex-leg-retry-budget-e69f8464/pack.yml
@@ -1,0 +1,235 @@
+# NOTE: brief_ref is the CANONICAL name, not this pack's own directory — the
+# harness-floor.yml CI workflow copies both discovered per-PR files into
+# /tmp/evidence-check/evidence/{brief,pack}.yml under these exact names
+# before validating, so brief_ref must always read "evidence/brief.yml".
+brief_ref: evidence/brief.yml
+plan_ref: PR #5093 — agent/air-m5/backend-rag/codex-leg-retry-budget
+# Diff stats below are the LITERAL output of the command in the matching
+# receipt (git diff --numstat origin/main...HEAD), summed by hand ONLY as
+# 80+216+53+195+383+117=1044 / 0+28+9+11+36+3=87 -- the per-file rows are the
+# transcription of the command's own stdout, not a re-estimate.
+diff:
+  files: 6
+  insertions: 1044
+  deletions: 87
+  hotzone_hits:
+    - apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql
+
+lanes:
+  - lane: build
+    role: build
+    seat: sonnet-5
+  - lane: review
+    role: review
+    seat: kimi-code/k3
+
+receipts:
+  - claim: "Deterministic floor for this diff is 3 (hot-zone migration path: apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql)."
+    cmd: "python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/changed_files_296.txt"
+    exit: 0
+    ts: "2026-08-27T03:51:32Z"
+    seat: sonnet-5
+  - claim: "Migration 296 is squawk-clean under the repo's standard exclusion set."
+    cmd: "squawk --pg-version=15.0 --exclude=require-concurrent-index-creation --exclude=require-timeout-settings --exclude=require-concurrent-index-deletion --exclude=ban-drop-table --exclude=ban-drop-column --exclude=ban-char-field --exclude=prefer-bigint-over-smallint --exclude=prefer-text-field --exclude=prefer-robust-stmts --exclude=constraint-missing-not-valid --exclude=prefer-bigint-over-int --exclude=prefer-identity --exclude=disallowed-unique-constraint apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql"
+    exit: 0
+    ts: "2026-08-27T03:51:37Z"
+    seat: sonnet-5
+  - claim: "The migration carries exactly one ROLLBACK marker."
+    cmd: "grep -c '^-- === ROLLBACK ===$' apps/backend-rag/backend/db/migrations_v2/296_wa_broker_jobs_live_only_unique.sql"
+    exit: 0
+    ts: "2026-08-27T03:51:40Z"
+    seat: sonnet-5
+  - claim: "Queried the FULL open-PR set (not just main + one named PR) for migration-number claims: no open PR claims 296. #5072 claims 289_practice_status_log.sql and #5059 independently claims 289_visa_retention_binders_scope_to_visa_decision.sql — a real collision between those two PRs, not introduced or touched by this one. #5037 claims 293/294/295, one below this PR's 296 — no overlap."
+    cmd: "gh pr list --state open --limit 300 --json number,files -q '.[] | .number as $n | .files[]?.path | select(test(\"migrations_v2/[0-9]+_\")) | \"\\($n): \\(.)\"'"
+    exit: 0
+    ts: "2026-08-27T03:51:56Z"
+    seat: sonnet-5
+  - claim: "origin/main's real migration tip is 288_practices_source_idempotency_key.sql (171 files under migrations_v2/) -- NOT 278 as a refuter transcript claimed; that claim was not propagated into this PR's cure."
+    cmd: "git ls-tree origin/main -- apps/backend-rag/backend/db/migrations_v2/ | grep -oE '[0-9]{3}_[a-z_0-9]+\\.sql' | sort -t_ -k1 -n | tail -5"
+    exit: 0
+    ts: "2026-08-27T03:52:01Z"
+    seat: sonnet-5
+  - claim: "ruff is clean on all 5 touched Python files."
+    cmd: "ruff check backend/services/integrations/wa_broker.py backend/services/integrations/wa_codex_leg.py backend/tests/unit/services/test_wa_broker.py backend/tests/unit/services/test_wa_codex_leg.py backend/tests/integration/test_wa_broker_pg.py"
+    exit: 0
+    ts: "2026-08-27T03:52:05Z"
+    seat: sonnet-5
+  - claim: "Literal git diff --numstat origin/main...HEAD, transcribed verbatim: 296_wa_broker_jobs_live_only_unique.sql 80/0, wa_broker.py 216/28, wa_codex_leg.py 53/9, test_wa_broker_pg.py 195/11, test_wa_broker.py 383/36, test_wa_codex_leg.py 117/3. Totals: 6 files, 1044 insertions, 87 deletions."
+    cmd: "git diff --numstat origin/main...HEAD"
+    exit: 0
+    ts: "2026-08-27T04:03:58Z"
+    seat: sonnet-5
+  - claim: "Full test_wa_broker.py + test_wa_codex_leg.py unit suite is green: 93 passed, 0 failed."
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_broker.py backend/tests/unit/services/test_wa_codex_leg.py"
+    exit: 0
+    ts: "2026-08-27T04:03:34Z"
+    seat: sonnet-5
+  - claim: "Full test_wa_broker_pg.py integration suite against a real local PostgreSQL is green: 34 passed, 0 failed."
+    cmd: "TEST_DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_test PYTHONPATH=. python -m pytest backend/tests/integration/test_wa_broker_pg.py"
+    exit: 0
+    ts: "2026-08-27T04:03:45Z"
+    seat: sonnet-5
+  - claim: "Unaffected sibling suite test_wa_outbox_worker.py stays green after this change: 27 passed, 0 failed."
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_outbox_worker.py"
+    exit: 0
+    ts: "2026-08-27T04:03:54Z"
+    seat: sonnet-5
+  - claim: "Mutation M1 (disable the REATTACHED branch, `if False and (...)`) turns exactly test_offer_job_retry_reattaches_to_still_alive_prior_leg red (KeyError: 'broker_last_seen_at' -- falls through into the ambiguity-gate block whose mock gauge this test does not populate, which is itself evidence the branch was skipped): 92 passed, 1 failed. File cleanly reverted afterward, re-confirmed green."
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_broker.py backend/tests/unit/services/test_wa_codex_leg.py"
+    exit: 1
+    ts: "2026-08-27T03:54:07Z"
+    seat: sonnet-5
+  - claim: "Mutation M2 (drop the depth query's `outbox_id != $1` exclusion) turns exactly test_offer_job_depth_check_excludes_this_outbox_ids_own_live_job red: 43 passed, 1 failed. File cleanly reverted afterward."
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_broker.py -v"
+    exit: 1
+    ts: "2026-08-27T03:54:54Z"
+    seat: sonnet-5
+  - claim: "Mutation M3 (off-by-one on the legs cap, `>` instead of `>=`) turns exactly test_offer_job_retry_legs_exhausted_when_prior_terminal_and_budget_spent red on BOTH suites: unit 43 passed/1 failed, integration 0 passed/1 failed (single targeted test run). File cleanly reverted afterward."
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_broker.py -v ; TEST_DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_test PYTHONPATH=. python -m pytest backend/tests/integration/test_wa_broker_pg.py::test_retry_budget_exhausts_after_max_codex_legs -v"
+    exit: 1
+    ts: "2026-08-27T03:56:00Z"
+    seat: sonnet-5
+  - claim: "Mutation M4 (round-2 budget-drain fix: force the broker_last_seen_at ambiguity-gate condition to `False and ... and False`, disabling it) turns exactly test_offer_job_retry_blocked_when_daemon_not_proven_free_after_expiry and test_offer_job_retry_blocked_when_gauge_has_no_broker_last_seen_at red on unit (42 passed, 2 failed), and exactly test_retry_blocked_while_daemon_not_proven_free_after_expiry red on the real-Postgres integration suite (33 passed, 1 failed) -- confirmed on BOTH unit and a real DB. File cleanly reverted afterward, re-confirmed green on unit."
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_broker.py -v ; TEST_DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_test PYTHONPATH=. python -m pytest backend/tests/integration/test_wa_broker_pg.py -v"
+    exit: 1
+    ts: "2026-08-27T03:57:08Z"
+    seat: sonnet-5
+  - claim: 'Mutation M5 (round-2 reattach-deadline fix: drop `and prior["deadline_open"]` from the REATTACHED condition) turns exactly test_offer_job_retry_live_but_deadline_passed_does_not_reattach red on unit (43 passed, 1 failed). NOT independently caught by the real-Postgres integration suite (34 passed, 0 failed under the same mutation) -- the integration fixtures do not happen to isolate this specific edge; recorded honestly in residual_risks, not hidden. File cleanly reverted afterward, re-confirmed green on both suites plus the sibling suite and ruff.'
+    cmd: "PYTHONPATH=. python -m pytest backend/tests/unit/services/test_wa_broker.py -v ; TEST_DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_test PYTHONPATH=. python -m pytest backend/tests/integration/test_wa_broker_pg.py -v"
+    exit: 0
+    ts: "2026-08-27T04:01:32Z"
+    seat: sonnet-5
+  - claim: "After reverting every mutant, the full unit + integration + sibling suites and ruff are all green again, and git status shows only the four intended files carrying diffs (no stray .bak)."
+    cmd: "git status --porcelain"
+    exit: 0
+    ts: "2026-08-27T04:02:02Z"
+    seat: sonnet-5
+
+tests:
+  cmd: "PYTHONPATH=. pytest backend/tests/unit/services/test_wa_broker.py backend/tests/unit/services/test_wa_codex_leg.py"
+  passed: 93
+  failed: 0
+static:
+  lint: ok
+  typecheck: n/a-python-uses-mypy-elsewhere-not-in-touched-files
+  build: n/a
+
+runtime_proof: []
+
+dissent:
+  - seat: kimi-code/k3
+    objection: >
+      "Budget drain" MAJOR: a slow-but-healthy codex exec can legitimately
+      outlive wait_for_job's deadline_at for a single leg (pre-existing,
+      documented behavior). The round-1 retry mechanism could let a caller
+      whose reattach fails admit a SECOND leg while the single-flight daemon
+      is still stuck finishing the first -- and a third, fourth, fifth,
+      burning the entire 5-leg budget on one slow exec instead of one
+      genuine retry, with a breaker-failure fold on each.
+    status: CONFIRMED
+    repro: >
+      Both premises verified by reading code, not docstrings: (a)
+      wa_codex_daemon.py's run_forever is genuinely single-flight sequential
+      (claim -> exec -> complete -> claim again, never concurrent polling
+      mid-exec); (b) compute_budget_s derives the exec budget from
+      deadline_at - now() - net_margin_s with nothing bounding real exec
+      latency below that, so the wait deadline really can be shorter than a
+      slow-but-healthy exec. Cured: a leg past its own deadline no longer
+      frees retry budget until wa_broker_gauge.broker_last_seen_at (updated
+      on every /claim poll, including idle ones) is provably AFTER that
+      leg's deadline_at -- proof the daemon completed a full idle cycle
+      since. Otherwise QUEUE_FULL (reused outcome). The coordinator's
+      stated-preferred fix (reuse the gauge's in_flight field) was tried
+      first and found NOT viable: in_flight is dead code, hardcoded to 0 on
+      every /claim, never set to 1 anywhere in the codebase. Mutation M4
+      (receipts above) proves the cure: 2/2 unit tests + 1/1 integration
+      test targeting exactly this gate turn red when it is disabled, and
+      nothing else does.
+  - seat: kimi-code/k3
+    objection: >
+      Once Gemini is removed from the WA channel, LEGS_EXHAUSTED has no
+      safety net of its own -- no leg is offered, no message is sent,
+      silence toward the customer.
+    status: CONFIRMED
+    repro: >
+      The finding is real, but the coordinator explicitly weighted it as
+      OUT OF SCOPE for this PR and no code change was made for it: this
+      PR's job (gradino 2/5 of the Gemini-retirement plan) is only to make
+      the retry budget real and countable, not to build what happens after
+      the budget is spent -- that is gradino 4/5's job (Gemini removal +
+      final-fallback design) by construction, and it must land before
+      gradino 5 removes Gemini or this branch goes silent for real
+      customers. Recorded here and in the PR body as an explicit
+      dependency, not a bug in the current diff.
+  - seat: kimi-code/k3
+    objection: >
+      Possible TypeError on int(prior["thread_epoch"]) if the column is
+      NULL on a pre-existing row.
+    status: RETRACTED
+    repro: >
+      Checked the schema directly: thread_epoch is NOT NULL since migration
+      270's original DDL. No broker_jobs row, pre- or post-296, can ever
+      exist without it -- the finding does not hold. No guard added; a
+      one-line inline comment documents the NOT NULL fact instead of adding
+      unreachable defensive code.
+  - seat: kimi-code/k3
+    objection: >
+      A reattach can hand back a leg whose deadline_at has already passed
+      but was not yet reaped -- wasting a round trip on a wait_for_job call
+      that resolves into an immediate deadline-CAS, plus a false
+      breaker-failure fold.
+    status: CONFIRMED
+    repro: >
+      Cured by adding a DB-computed `deadline_at > now() AS deadline_open`
+      to the prior-leg query and requiring it on the REATTACHED branch; a
+      live-but-past-deadline row now falls through to the ambiguity/budget
+      path exactly like a formally 'expired' row would. Mutation M5
+      (receipts above) proves the cure on unit (1/1 target test turns red
+      when the guard is dropped) but NOT on the integration suite (0/34
+      turn red under the same mutation) -- the integration fixtures did not
+      happen to construct a live-but-expired prior-leg scenario isolating
+      just this guard. Recorded honestly as a residual risk, not hidden.
+  - seat: kimi-code/k3
+    objection: >
+      The migration head is 278, so migration 296 may collide with an
+      in-flight number.
+    status: RETRACTED
+    repro: >
+      Verified false and NOT propagated into this PR: origin/main's real
+      migration tip is 288 (git ls-tree, receipt above), and no open PR
+      claims 296 (full gh pr list scan, receipt above). Separately, and
+      unrelated to this claim: #5072 and #5059 independently both claim
+      migration 289 -- a real collision, between two other PRs, not
+      introduced or touched here.
+
+residual_risks:
+  - "Real-world timing/frequency of the budget-drain race in production was
+    not empirically measured this round -- the fix is logically sound and
+    mutation-tested (M4), but its actual trigger rate was reasoned from code
+    (daemon single-flight + budget-derivation formula), not observed against
+    live traffic. WA_GENERATION_PROVIDER is unset in every environment
+    today, so there is no live traffic to measure against yet."
+  - "Mutation M5 (the deadline_open guard on REATTACHED) is caught by the
+    unit suite but NOT independently by the integration suite against a
+    real Postgres -- the integration fixtures did not happen to construct a
+    live-but-expired prior-leg scenario that isolates just this guard. The
+    same code path is exercised end-to-end by the surrounding integration
+    tests, but no single integration test pins this specific edge the way
+    the unit test does."
+  - "Behavior under the live Fly Postgres role/permission set was not
+    checked -- only a local Postgres was available this session. Same role
+    that owns wa_outbox/broker_jobs per the mandate, so a DDL-abort on
+    deploy is not expected, but this is reasoned, not observed."
+  - "Interaction with #5088 (still open, unmerged) was checked only as a
+    non-overlapping-diff review (it touches the same file,
+    ALLOWED_ERROR_CLASSES gains quota_exhausted, a small addition with no
+    apparent overlap) -- not tested together."
+  - "Migration 296's rollback is irreversible once any outbox_id has
+    accumulated 2+ broker_jobs rows (mode=serve) -- the entire point of this
+    migration. Declared explicitly in the migration file's own ROLLBACK
+    section and in the PR body: a rollback that fails loudly there is
+    intended behavior, not a bug to fix."
+
+sources: []
+pii_scan: clean
+size_tokens: 5400


### PR DESCRIPTION
## Summary

Second of five gradini toward retiring the Gemini leg on the WA channel (first: #5088, quota-vs-crash classification). Before Gemini can be removed for good, the codex leg needs a real retry budget — today it has none.

`wa_broker.offer_job`'s historical invariant was **"one codex leg per outbox row, ever"** (migration 270's `uq_broker_jobs_serve_outbox`): the first offer sets `wa_outbox.generation_route = 'codex'` permanently, and every subsequent offer for that row sees `generation_route IS NOT NULL` and returns `ALREADY_SPENT` — **with no `job_id`**, so the caller can't even reattach to a job that might still be running. In the worker's retry ladder this is a fall-off, and today it falls off to Gemini, which is why nobody has noticed. Once Gemini is gone, that fall-off is silence toward the customer.

## What changed

- **Migration 296**: relaxes `uq_broker_jobs_serve_outbox` (unique on `outbox_id`, *forever*) to `uq_broker_jobs_serve_outbox_live` (unique on `outbox_id`, scoped to `state IN ('offered','leased','completed_pending_consume')`). A terminal prior leg no longer blocks a new row for the same `outbox_id`.
- **`offer_job`**: the fenced `UPDATE wa_outbox` now reads the row's **pre-update** `generation_route` via a `FROM old` self-join in the same statement that re-verifies `claim_token`/`status` ownership. A retry (`route_before IS NOT NULL`) branches:
  - prior leg still alive (`offered`/`leased`/`completed_pending_consume`) **and its own `deadline_at` has not yet elapsed** → **`REATTACHED`**, carries the existing `job_id` back;
  - prior leg terminal or ambiguous, **and the daemon is proven idle since** → fresh **`OFFERED`**, new row (subject to budget below);
  - prior leg terminal or ambiguous, and the daemon's idleness since that leg is NOT proven → **`QUEUE_FULL`** (round-2 addition, see Adversarial review);
  - budget exhausted (`>= MAX_CODEX_LEGS`, mirrors `wa_outbox_worker.MAX_ATTEMPTS` = 5) → **`LEGS_EXHAUSTED`**, a *named* terminal outcome — never silently conflated with the generic `ALREADY_SPENT` (kept only as the DB-race defensive fallback on `UniqueViolationError`).
  - A truly lost fence (`claim_token`/`status` mismatch) is now unambiguously `FENCE_LOST` — the historical code reported `ALREADY_SPENT` for that case too whenever the marker happened to be set, which was harmless only because that branch never wrote anything. It is not harmless once a retry can reattach to or extend another owner's leg, so the ambiguity is gone.
- **Depth-cap fix**: the global admission-depth query (`MAX_DEPTH = 1`, the whole broker is single-flight) now excludes the **caller's own `outbox_id`**. Without this, a retry reattaching to its own still-`leased` prior leg would be refused by the very cap that admitted that leg in the first place — same bug class, different gate. Proven safe: the advisory xact lock serializes every offer, so global depth never exceeds 1 at any committed state — if this row already holds the one live slot, no other row can, so excluding self can't hide a real conflict.
- **`wa_codex_leg.py`**: treats `REATTACHED` exactly like `OFFERED` (wait → consume → finalize), and — this is the subtle one — fences the post-completion **drift check** against `OfferResult.thread_epoch` (the job's own frozen epoch) instead of the claim's freshly-read local `epoch`. On a reattach those two can differ (the prior leg may have been offered by an earlier, since-failed claim); using the wrong one would silently defeat the thread-epoch-drift protocol (spec 2.3). Covered by two new tests, one proving no-false-drift and one proving real drift still fires.

## Why a migration + counting rows, not a no-migration option

Two no-migration alternatives were considered and rejected:
1. **Read `wa_outbox.attempts`** as the leg counter. Rejected: `attempts` is written only by the *outer* retry ladder when a claim's generation actually raises. A worker crash between a durable offer and that raise (stale-claim reclaim resets `status` to `'pending'` without touching `attempts`) means `attempts` can under-count how many codex legs a row has really spent — not crash-safe.
2. **Reset the same `broker_jobs` row in place** on each retry. Rejected: destroys the per-attempt `error_class`/`outcome`/`exec_ms` audit trail this table exists to carry, and needs careful resets of `fence_token`/`completion_key`/timestamps on every retry — more surface for bugs than a partial-index change.

A new row per leg, counted by `SELECT count(*) FROM broker_jobs WHERE outbox_id = $1 AND mode = 'serve'`, is durable at the exact moment the leg is created and survives the crash window by construction.

## Tests (round 2, real numbers)

- `test_wa_broker.py`: **44 unit tests** (round 1: 39; +5 round 2: the ambiguity-gate blocked/gauge-missing/admits-when-proven-free set, the reattach-with-stale-deadline-does-not-reattach test, and the consumed-prior-skips-ambiguity-check test).
- `test_wa_codex_leg.py`: 49 unit tests (unchanged from round 1 — round 2 touched no contract this file depends on).
- `test_wa_broker_pg.py`: **34 integration tests against a real local PostgreSQL** (round 1: 33; +1 round 2: `test_retry_blocked_while_daemon_not_proven_free_after_expiry`; one existing test, `test_retry_after_terminal_prior_leg_admits_a_new_job`, was corrected to also force `deadline_at` into the past and re-seed the gauge afterward — its original setup left `deadline_at` in the future, which the new ambiguity gate correctly started rejecting once the gate existed; that failure was the gate working as designed, not a regression).
- `test_wa_outbox_worker.py` (unaffected sibling suite): 27 passed, unchanged.
- **93 unit + 34 integration = 127 tests, all green.**
- `ruff check` clean on all 4 touched Python files (the 5th touched file, the migration SQL, is not a ruff target).

### Mutation testing — round 1 (3 mutations, all still valid, re-run this round)

| Mutation | Before | After | Caught by |
|---|---|---|---|
| Disable the REATTACHED branch (`if False:`) | 88 passed | 87 passed, 1 failed | `test_offer_job_retry_reattaches_to_still_alive_prior_leg` (only) |
| Drop the depth query's `outbox_id != $1` exclusion | 39 passed | 38 passed, 1 failed | `test_offer_job_depth_check_excludes_this_outbox_ids_own_live_job` (only) |
| Off-by-one on the legs cap (`>` instead of `>=`) | 39/33 passed | 1 failed in each suite | `test_offer_job_retry_legs_exhausted_when_prior_terminal_and_budget_spent` (unit + integration) |

### Mutation testing — round 2 (2 new mutations, one per round-2 fix)

| Mutation | Command | Before | After | Caught by |
|---|---|---|---|---|
| Disable the budget-drain ambiguity gate (force the `broker_last_seen_at` condition to `False ... and False`) | unit `test_wa_broker.py` | 44 passed | 42 passed, 2 failed | `test_offer_job_retry_blocked_when_daemon_not_proven_free_after_expiry` + `test_offer_job_retry_blocked_when_gauge_has_no_broker_last_seen_at` (only) |
| (same mutation) | integration `test_wa_broker_pg.py` (real Postgres) | 34 passed | 33 passed, 1 failed | `test_retry_blocked_while_daemon_not_proven_free_after_expiry` (only) — **confirmed on both unit AND a real DB** |
| Drop `and prior["deadline_open"]` from the REATTACHED condition | unit `test_wa_broker.py` | 44 passed | 43 passed, 1 failed | `test_offer_job_retry_live_but_deadline_passed_does_not_reattach` (only) |
| (same mutation) | integration `test_wa_broker_pg.py` (real Postgres) | 34 passed | **34 passed, 0 failed — NOT caught** | none (see "Not verified" below) |

Every mutation restored to green and re-verified after measurement. `git status` confirms only the 4 intended files carry diffs — no stray `.bak`.

## Adversarial review (round 2 — Kimi K3 cross-family review, coordinator-weighted)

Five findings were surfaced by a fresh-context Kimi K3 pass over the round-1 diff. The coordinator weighted each before any code was touched; dispositions below.

- **MAJOR — "budget drain" race (accepted, cured).** A slow-but-healthy codex exec can legitimately outlive `wait_for_job`'s `deadline_at` for a single leg — this is pre-existing, documented behavior. The new retry mechanism could let a caller reattach-fail into admitting a *second* leg while the daemon (single-flight, sequential: claim → exec → complete → claim again, verified against `wa_codex_daemon.py`'s `run_forever` code, not its docstring) is still stuck finishing the first — and a third, fourth, fifth, burning the whole 5-leg budget on one slow exec instead of one genuine retry, with a breaker-failure fold on each. Both premises the coordinator asked to verify before curing held: (a) the daemon really is single-flight, no concurrent claim while an exec is in flight; (b) the worker's wait deadline really can be shorter than a real slow exec (`compute_budget_s` in `wa_codex_daemon.py` derives the exec budget from `deadline_at - now() - net_margin_s`, and nothing bounds real exec latency below that). **Chosen cure, and why it's not the coordinator's preferred one:** the coordinator's stated-preferred direction was reusing the gauge's `in_flight` field. That field turned out to be dead code — `/claim` hardcodes it to `0` on every poll and nothing in the codebase ever sets it to `1`, so it cannot distinguish "daemon busy" from "daemon idle" today; building the fix on it would have looked correct and always resolved to "not busy". Implemented the coordinator's own stated fallback instead: **a leg past its deadline does not free budget until the daemon is *provably* idle since that leg expired**, using a field that is genuinely live — `wa_broker_gauge.broker_last_seen_at`, which the daemon updates on every `/claim` poll including idle ones. If `broker_last_seen_at > prior.deadline_at`, the daemon has completed at least one full poll cycle after the ambiguous leg's deadline and is provably not still working on it — safe to admit a new leg. Otherwise: `QUEUE_FULL` (deliberately reused, not a new outcome — same shape as the existing same-claim Gemini fall-off, zero retry-ladder involvement, semantically apt: there is no *confirmed* capacity right now). No change to the daemon or the router; entirely contained in `wa_broker.py`, per the "don't touch `complete_job`'s CAS" constraint (unchanged) and general minimal-invasiveness.
- **Rejected finding, and why (per coordinator instruction, verbatim record):** the refuter separately argued that once Gemini is removed, `LEGS_EXHAUSTED` "falls off" into nothing — no leg is offered, no message is sent, silence. **This is real but is explicitly NOT a defect of this PR**: `LEGS_EXHAUSTED` does not have a safety net of its own, and none was promised — this PR's job (gradino 2/5) is only to make the retry budget *real and countable*, not to build what happens after the budget is spent. That is gradino 4/5's job (Gemini removal + final-fallback design) by construction — gradino 4 must exist and land *before* gradino 5 removes Gemini, or this branch goes silent for real customers. No code change made for this finding; it is recorded here as an explicit dependency, not a bug in the current PR.
- **Minor 1 (verified false, no code change).** Possible `TypeError` on `int(prior["thread_epoch"])` if the column is `NULL`. Checked the schema directly (migration 270 DDL): `thread_epoch` is `NOT NULL`. No `broker_jobs` row — pre- or post-296 — can exist without it. No guard added; documented inline in `wa_broker.py` instead of adding dead defensive code.
- **Minor 2 (accepted, cured).** A reattach could hand back a leg whose `deadline_at` had already passed but wasn't yet reaped by the reaper sweep — wasting a round trip on a `wait_for_job` call that resolves into an immediate deadline-CAS, plus a false breaker-failure fold. Fixed by adding a DB-computed `deadline_at > now() AS deadline_open` to the prior-leg query and requiring it on the REATTACHED branch; a live-but-past-deadline row now falls through to the ambiguity/terminal-budget path exactly like a formally `'expired'` row would. Covered by `test_offer_job_retry_live_but_deadline_passed_does_not_reattach` (unit) — mutation-tested (see table above); **not independently caught by the integration suite** (see "Not verified").
- **Document, not cure (migration rollback irreversibility).** The rollback in `296_wa_broker_jobs_live_only_unique.sql` is not always reversible: once any `outbox_id` has accumulated 2+ `broker_jobs` rows (mode=`serve`) — the entire point of this migration — `CREATE UNIQUE INDEX uq_broker_jobs_serve_outbox` in the rollback section fails with a duplicate-key error, because a bare-`outbox_id`-unique index cannot be rebuilt over data that already violates it. This is now an explicit comment in the migration file's `-- === ROLLBACK ===` section (not fixed — a rollback that fails loudly here is the intended behavior; silently "succeeding" on an index that doesn't hold the invariant would be worse).
- **Migration-head correction (not propagated).** The refuter's transcript claimed the migration head was `278`; verified false — the real head is `288`, and `296` does not collide with it or with any currently open PR's migration number. Separately (noted in passing, not this PR's problem): #5072 and #5059 both independently claim migration `289` — a real collision, between two other PRs, not introduced or touched here.
- **Not verified this round**: real-world timing/frequency of the budget-drain race in production (the fix is logically sound and mutation-tested, but its actual trigger rate was reasoned from code, not measured against live traffic — `WA_GENERATION_PROVIDER` is unset everywhere today, so there is no live traffic to measure against yet). Mutation B (deadline_open guard) is caught by the unit suite but not independently by the integration suite — the integration fixtures didn't happen to construct a live-but-expired prior leg scenario that isolates just this guard; the unit test's isolation (mocked connection, exact row state) is the only proof for that specific edge, though the same code path is exercised end-to-end by the surrounding integration tests. Behavior under the live Fly Postgres role/permission set (only local Postgres available this session). Interaction with #5088 (still open, unmerged) beyond the non-overlapping-diff check already noted in round 1.

## Migration

Touches `db/migrations_v2/` (296) — flagged per repo convention, Squawk-lintable (no `squawk-ignore` needed; matches `uq_broker_jobs_serve_outbox`'s own precedent in migration 270, and `require-concurrent-index-*` is already excluded repo-wide in `migration-lint.yml`). `broker_jobs` ships flag-OFF in every environment (`WA_GENERATION_PROVIDER` unset) — no live traffic, ACCESS EXCLUSIVE lock is on an empty-or-tiny table, same premise as migrations 272/274 for this same table. Rollback irreversibility documented above and in the migration file itself.

## NOT armed for auto-merge

Per the mandate: this PR has a migration and the coordinator merges it personally, after the gate, inside the evening deploy window. Left open, unarmed.
