### PR TITLE
docs(cicatrix): W123 named the wrong armer — auto-merge-whitelist cannot arm an agent/* branch

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -1253,7 +1253,24 @@ Trenta minuti dopo, `gh pr merge 4658 --auto` ha risposto **«already queued to 
 if: github.event.pull_request.draft == false
 ```
 
-`synchronize` = ogni push al branch della PR. Quindi **ogni push a una PR non-draft la ri-arma**, entro ~6 minuti. Nella stessa lista di run, i branch in draft risultano `skipped`, i non-draft `success` — coerente con la condizione dichiarata, non con un'inferenza.
+`synchronize` = ogni push al branch della PR. Nella stessa lista di run, i branch in draft risultano `skipped`, i non-draft `success`.
+
+**⚠️ CORREZIONE (2026-08-27, Pro — letta su `origin/main`, non dedotta). La conclusione originale di questa cicatrice era «ogni push a una PR non-draft la ri-arma»: è FALSA per i branch che questa flotta usa.** `draft == false` è il cancello del *job*, non l'unica condizione. L'armamento passa da **tre step in cascata**, e il primo è il BRANCH:
+
+```yaml
+# auto-merge-whitelist.yml — step "Check branch whitelist"
+[[ "$BRANCH" =~ ^docs/auto-sync- ]] || [[ "$BRANCH" =~ ^dependabot/(pip|npm_and_yarn)/ ]] || [[ "$BRANCH" =~ ^chore/fmt- ]]
+```
+
+poi l'author allowlist (`dependabot[bot]` | `github-actions[bot]` | `Balizero1987`), poi l'assenza di path CODEOWNERS Tier-1. Solo se tutti e tre passano si arriva allo step `Enable auto-merge`.
+
+`#4658` viveva su `agent/nuzantara/wr3/p03-required-ledger`: **non matcha nessuno dei tre pattern** ⇒ `match=false` allo step 1 ⇒ il workflow non ha mai raggiunto lo step che arma. Lo stesso vale per **ogni** branch `agent/<host>/<lane>/…`, cioè per la totalità delle PR di lane.
+
+**Come l'evidenza è stata mal letta — è la parte riusabile.** La prova citata sopra è `10:12:43Z run auto-merge-whitelist.yml -> success`. Ma un job che esce `match=false` allo step 1 esce **anch'esso `success`**: `success` dice che il job non è fallito, non che ha armato. E «i draft `skipped`, i non-draft `success`» è compatibile con entrambe le tesi, quindi non ne distingue nessuna. **Un run verde non è la prova di un'azione**: la prova è l'effetto (`autoMergeRequest` / `isInMergeQueue`) o il log dello step che la esegue.
+
+**Cosa resta vero, cosa resta ignoto.** Resta vero che alle `10:18:37Z` #4658 è stata armata da qualcuno che non era la lane, e che l'`actor` del timeline non lo distingue (GOTCHA (a), intatto). Resta vero che il DRAFT è il freno più robusto. **Non è noto chi abbia armato:** `auto-merge-whitelist.yml` è l'unico workflow del repo che abilita auto-merge (verificato 2026-08-27, grep su `.github/workflows/`), e per quel branch non può essere stato lui. La causa non è stata determinata e non va inventata.
+
+**Conseguenza operativa, opposta a quella che si leggeva prima.** Su una PR di lane (`agent/*`), **disarmare È un hold che sopravvive ai push**, perché nessun workflow la ri-arma. Chi ha letto questa cicatrice come «tanto si ri-arma da sola» ha rinunciato a un freno che aveva in mano. Il draft resta comunque preferibile — per la ragione di W126, e perché non dipende da questa analisi.
 
 **Perché costa.** «Hold arms» è un protocollo di coordinamento che la flotta usa spesso, e chi lo onora disarmando crede di aver pagato un costo che non ha pagato. Il danno non è la PR accodata — nel mio caso era perfino desiderabile — è che **un impegno preso con altre lane decade in silenzio**, e le lane a valle pianificano sopra un fatto che non è più vero. Peggiora perché il gesto sembra durevole: nessun errore, nessun avviso, e la PR resta apparentemente com'era finché non la si interroga.
 
@@ -1344,7 +1361,7 @@ _Scoperto 2026-08-23 su PR #4681, leggendo la timeline API di GitHub dopo che un
 
 Il draft era reale e il hold era stato applicato; non aveva però rimosso l'entry che la coda aveva già accettato. `gh pr ready --undo` cambia `isDraft` in `true` e non cambia la queued entry.
 
-**MECCANISMO.** `.github/workflows/auto-merge-whitelist.yml` controlla `draft == false` quando decide se armare una PR. La merge queue non riconsulta quel campo per un'entry già accettata. W123 dice quindi la verità solo prima dell'ingresso in coda: il draft impedisce al workflow di ri-armare una PR non ancora accodata, ma non è un eject della coda.
+**MECCANISMO.** `.github/workflows/auto-merge-whitelist.yml` controlla `draft == false` quando decide se armare una PR — ma è solo il primo dei suoi cancelli, e per un branch `agent/*` il workflow si ferma prima di armare comunque (vedi la CORREZIONE 2026-08-27 dentro W123: la whitelist di branch copre solo `docs/auto-sync-*`, `dependabot/{pip,npm_and_yarn}/*`, `chore/fmt-*`). La merge queue non riconsulta quel campo per un'entry già accettata. W123 dice quindi la verità solo prima dell'ingresso in coda: il draft impedisce al workflow di ri-armare una PR non ancora accodata, ma non è un eject della coda.
 
 **IL VERO ERRORE È TEMPORALE.** `isInMergeQueue` era stato letto verso le 13:05 e valeva `false`. Era il campo giusto e la misura era vera in quell'istante. Alle 13:16 è diventato `true`; nessuno l'ha riletto, e il draft delle 13:21 è stato applicato sulla forza di un dato vecchio di sedici minuti. Non il campo sbagliato: **il campo giusto al momento sbagliato** — gemello temporale dell'errore registrato la stessa mattina da wr3/P03, dove il dato giusto era in mano ma veniva letto l'altro campo.
 

--- a/.claude/rules/cicatrix-superscar.md
+++ b/.claude/rules/cicatrix-superscar.md
@@ -64,7 +64,7 @@ access-wall, dev identity su proxy PROD) · W97 (display-cap `[:40]` letto come 
 W101-recidiva-fly-backup (PARTIAL: Fase 2 mai parte) · W104 (`redis-cli` esce 0 con NOAUTH su stdout) ·
 W107 (curato 1 wrapper su 5) · W108 (19/20 cron muti, 2 cause) · W110 (heartbeat sull'organo sbagliato)
 · W116 (allarme su esito giusto, cura codice morto) · W118 (11h fermo, nessun check rosso) · W120
-(sentinella della famiglia stessa disarmata) · W121 (mutation testing su bytecode avvelenato) · W122 (rosso mente: lavoro fatto, SIGINT→130) · W123 (hold disarmato si ri-arma al push)
+(sentinella della famiglia stessa disarmata) · W121 (mutation testing su bytecode avvelenato) · W122 (rosso mente: lavoro fatto, SIGINT→130) · W123 (run `success` ≠ ha armato)
 · W126 (draft non espelle dalla coda)
 · W124
 (PR DIRTY: check-suite `completed` su un sottoinsieme, non su zero corse).


### PR DESCRIPTION
## What

Two scar files, 20 lines. No code. **A correction to a doctrine artifact that is injected into every session and every subagent, fleet-wide.**

## The finding

**W123** concluded *"every push to a non-draft PR re-arms it"*; **W126** repeated the mechanism. Measured on `origin/main` today: **false for the branch class this fleet actually uses.**

`draft == false` is the gate of the *job*, not the only condition. Arming runs **three cascading steps**, and the first is the branch:

```yaml
# auto-merge-whitelist.yml — "Check branch whitelist"
^docs/auto-sync-  |  ^dependabot/(pip|npm_and_yarn)/  |  ^chore/fmt-
```

then the author allowlist, then absence of Tier-1 CODEOWNERS paths. Only then `Enable auto-merge`.

`#4658` lived on `agent/nuzantara/wr3/p03-required-ledger` — matches **none** of the three ⇒ `match=false` at step 1 ⇒ the workflow never reached the arming step. Same for **every** `agent/<host>/<lane>/…` branch, i.e. every lane PR in this repo.

## How the evidence was misread — the reusable part

The proof cited in W123 is `10:12:43Z run auto-merge-whitelist.yml -> success`.

A job that exits `match=false` at step 1 **also exits `success`**. Green says the job did not fail — not that it armed. And *"drafts `skipped`, non-drafts `success`"* is compatible with **both** readings, so it distinguishes neither.

**A green run is not proof of an action.** The proof is the effect (`autoMergeRequest` / `isInMergeQueue`) or the log of the step that performs it.

## What stays true, what stays unknown

- **True:** #4658 *was* armed at `10:18:37Z` by something that was not the lane, and the timeline `actor` cannot tell who (W123 GOTCHA (a), untouched). Draft remains the more robust brake.
- **Unknown:** *who* armed it. `auto-merge-whitelist.yml` is the only workflow in the repo that enables auto-merge (grep over `.github/workflows/`), and for that branch it cannot have been this one. **Cause not determined — deliberately not invented.**

## Why it matters — the lesson inverts

On an `agent/*` PR, **disarming IS a hold that survives pushes**, because no workflow re-arms it. Anyone who read W123 as *"it re-arms itself anyway"* gave up a brake they already had. Draft stays preferable for W126's own reason, which is independent of this analysis.

The compressed line in `cicatrix-superscar.md` carried the same falsehood in 7 words and is corrected too — that file is injected verbatim into every session, so leaving it would keep the error propagating at the widest possible surface. Net **−6 bytes**; budget unaffected.

## Verification

```
scripts/tests/test_superscar_budget.py     10 passed
scripts/lint_scar_number_collision.py      rc=0 — no collisions
pre-commit                                 all checks passed
```

Gear 1: docs-only, 2 files, 20 net lines, no Tier-1 path.
