### PR TITLE
fix(mouth): /chat fired two authenticated calls at anonymous visitors, and the fallout reached Sentry

### DIFF
--- a/apps/mouth/src/hooks/useChatPage.test.ts
+++ b/apps/mouth/src/hooks/useChatPage.test.ts
@@ -68,6 +68,11 @@ const mocks = vi.hoisted(() => {
       abortStream: vi.fn(),
     },
     chatSendOptions: null as Record<string, unknown> | null,
+    // Both hooks below call authenticated-only endpoints; these capture what
+    // `useChatPage` allows them to do, so an anonymous visitor firing a 401 is
+    // caught here rather than in production. See the comment at the gate.
+    snapshotOptions: null as Record<string, unknown> | null,
+    conversationsArgs: null as unknown[] | null,
   };
 });
 
@@ -95,7 +100,10 @@ vi.mock("./useChatSidebar", () => ({
   useChatSidebar: () => mocks.sidebar,
 }));
 vi.mock("./useConversations", () => ({
-  useConversations: () => mocks.conversations,
+  useConversations: (...args: unknown[]) => {
+    mocks.conversationsArgs = args;
+    return mocks.conversations;
+  },
 }));
 vi.mock("./useTeamStatus", () => ({
   useTeamStatus: () => mocks.teamStatus,
@@ -104,7 +112,10 @@ vi.mock("./useConversationPersistence", () => ({
   useConversationPersistence: () => mocks.persistence,
 }));
 vi.mock("./useChatSnapshot", () => ({
-  useChatSnapshot: () => mocks.snapshot,
+  useChatSnapshot: (options: Record<string, unknown>) => {
+    mocks.snapshotOptions = options;
+    return mocks.snapshot;
+  },
 }));
 vi.mock("./useChatSend", () => ({
   useChatSend: (options: Record<string, unknown>) => {
@@ -159,6 +170,8 @@ beforeEach(() => {
   mocks.snapshot.isRevalidating = false;
   mocks.chatSend.isStreaming = false;
   mocks.chatSendOptions = null;
+  mocks.snapshotOptions = null;
+  mocks.conversationsArgs = null;
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
     value: 1024,
@@ -180,6 +193,34 @@ describe("useChatPage", () => {
     });
     expect(mocks.conversations.loadConversationList).not.toHaveBeenCalled();
     expect(mocks.teamStatus.loadClockStatus).not.toHaveBeenCalled();
+
+    // The two assertions above only cover the MANUAL refetch inside
+    // `loadInitialData`. The data hooks fetch on their own — a React Query
+    // mount fetch and an effect — and neither consults the auth check that
+    // produced the redirect above. Measured live on 2026-08-27: every
+    // anonymous pageview of the public `/chat` collected a 401 from
+    // `conversations/list` AND `conversations/history`, and the caught history
+    // error went to Sentry (logger.warn forwards unconditionally in prod),
+    // which answered 429 — dropping events. So this test's own promise,
+    // "without loading private chat data", needs these two lines to be true.
+    expect(mocks.snapshotOptions?.enabled).toBe(false);
+    expect(mocks.conversationsArgs?.[0]).toBe(false);
+  });
+
+  it("lets an authenticated visitor load private chat data", async () => {
+    // Innocence half of the pair above: the gate must not cost a logged-in
+    // user their sidebar and history. If this goes red, the fix has broken
+    // the very thing `/chat` exists to do.
+    mocks.api.isAuthenticated.mockReturnValue(true);
+
+    renderHook(() => useChatPage());
+
+    await waitFor(() => {
+      expect(mocks.snapshotOptions).not.toBeNull();
+    });
+    expect(mocks.snapshotOptions?.enabled).toBe(true);
+    expect(mocks.conversationsArgs?.[0]).toBe(true);
+    expect(mocks.router.push).not.toHaveBeenCalledWith("/login");
   });
 
   it("guards empty sends and sends a trimmed message with optimistic state", async () => {

--- a/apps/mouth/src/hooks/useChatPage.ts
+++ b/apps/mouth/src/hooks/useChatPage.ts
@@ -134,10 +134,22 @@ export function useChatPage(): UseChatPageReturn {
   // then revalidates against the DB in the background (DB stays SSOT). See
   // docs in `useChatSnapshot.ts`.
   const userEmail = api.getUserProfile()?.email ?? null;
+  // `/chat` is reachable anonymously (the auth check below redirects, but only
+  // after mount), and BOTH data hooks here call authenticated-only endpoints.
+  // Without this gate every anonymous pageview fired `conversations/list` and
+  // `conversations/history` and collected a 401 from each — measured live on
+  // 2026-08-27. The history 401 is caught by `logger.warn`, and `logger.warn`
+  // forwards to Sentry unconditionally in production (`logger.ts`), so a public
+  // page was posting one Sentry event per anonymous visitor. Sentry answered
+  // 429: it was DROPPING events, which means real errors could be lost behind
+  // this noise. Gating the fetches removes the cause rather than silencing the
+  // symptom. Read during render, like `getUserProfile()` directly above: it
+  // changes no markup, only whether a query is allowed to run.
+  const isAuthenticated = api.isAuthenticated();
   const chatSnapshot = useChatSnapshot({
     sessionId,
     userEmail,
-    enabled: !!sessionId && !isSessionLoading,
+    enabled: !!sessionId && !isSessionLoading && isAuthenticated,
   });
 
   // Seed `messages` from snapshot whenever it changes and we haven't started
@@ -186,7 +198,8 @@ export function useChatPage(): UseChatPageReturn {
   // Custom Hooks
   const chatInput = useChatInput();
   const sidebar = useChatSidebar();
-  const conversations = useConversations();
+  // Same gate as the snapshot above: this hook's list query is authenticated.
+  const conversations = useConversations(isAuthenticated);
   const teamStatus = useTeamStatus();
 
   // Setup toast callbacks

--- a/apps/mouth/src/hooks/useConversations.ts
+++ b/apps/mouth/src/hooks/useConversations.ts
@@ -17,12 +17,21 @@ export const conversationsKeys = {
 /**
  * Hook for listing conversations with React Query
  */
-export function useConversationsList(limit: number = 20, offset: number = 0) {
+export function useConversationsList(
+  limit: number = 20,
+  offset: number = 0,
+  // Defaults to true so every existing caller keeps its current behaviour.
+  // `/chat` passes the visitor's auth state: this endpoint is authenticated,
+  // and firing it while logged out earns a 401 on every anonymous pageview
+  // of a PUBLIC page — see the comment at the call site in `useChatPage.ts`.
+  enabled: boolean = true,
+) {
   return useQuery({
     queryKey: [...conversationsKeys.list(), limit, offset],
     queryFn: () => api.listConversations(limit, offset),
     staleTime: 1000 * 30, // 30 seconds
     select: (data) => data.conversations,
+    enabled,
   });
 }
 
@@ -87,7 +96,7 @@ export function useConversationMutations() {
  * Combined hook with local state for current conversation selection
  * Maintains backward compatibility with the original API
  */
-export function useConversations() {
+export function useConversations(enabled: boolean = true) {
   const [currentConversationId, setCurrentConversationId] = useState<
     number | null
   >(null);
@@ -96,7 +105,7 @@ export function useConversations() {
     data: conversations = [],
     isLoading,
     refetch: loadConversationList,
-  } = useConversationsList();
+  } = useConversationsList(20, 0, enabled);
 
   const {
     deleteConversation: deleteConversationMutation,

--- a/apps/mouth/src/hooks/useConversationsList.enabled.test.tsx
+++ b/apps/mouth/src/hooks/useConversationsList.enabled.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * `useConversationsList` calls an authenticated-only endpoint.
+ *
+ * The hook used to fire on mount unconditionally, which is fine on the private
+ * surfaces it was written for and wrong on `/chat`, which anonymous visitors
+ * can reach: measured live on 2026-08-27, every anonymous pageview collected a
+ * 401 from `conversations/list`. The `enabled` flag added for that gate is only
+ * worth anything if it actually stops the request, so these tests assert
+ * against the REAL React Query machinery — a live QueryClient, the real
+ * `useQuery` — and watch whether the query function is reached at all.
+ *
+ * Both directions are covered on purpose. A gate that never lets anything
+ * through would pass the "does not fetch" half and silently break every
+ * logged-in user, which is the more expensive failure of the two.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  api: { listConversations: vi.fn() },
+}));
+
+vi.mock("@/lib/api", () => ({ api: mocks.api }));
+
+import { useConversationsList } from "./useConversations";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+describe("useConversationsList — the enabled gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.api.listConversations.mockResolvedValue({ conversations: [] });
+  });
+
+  it("does not touch the authenticated endpoint when disabled", async () => {
+    const { result } = renderHook(() => useConversationsList(20, 0, false), {
+      wrapper,
+    });
+
+    // Give React Query every chance to fetch before concluding it did not.
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe("idle");
+    });
+    expect(mocks.api.listConversations).not.toHaveBeenCalled();
+  });
+
+  it("fetches when enabled", async () => {
+    renderHook(() => useConversationsList(20, 0, true), { wrapper });
+
+    await waitFor(() => {
+      expect(mocks.api.listConversations).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.api.listConversations).toHaveBeenCalledWith(20, 0);
+  });
+
+  it("still fetches for callers that pass no flag at all", async () => {
+    // The parameter defaults to true precisely so the private surfaces that
+    // already use this hook keep working untouched. If this goes red, the gate
+    // has leaked out of `/chat` and disabled someone else's data.
+    renderHook(() => useConversationsList(), { wrapper });
+
+    await waitFor(() => {
+      expect(mocks.api.listConversations).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Found by a live sweep of balizero.com on 2026-08-27, not by a report.

## What an anonymous visitor did to production

`/chat` is publicly reachable. Its auth check works — `useChatPage` redirects a
logged-out visitor to `/login` — but it runs *after* mount, and two data hooks
never consult it:

| hook | gate it actually had |
|---|---|
| `useConversationsList` | none — a plain `useQuery`, fetches on mount |
| `useChatSnapshot` | `!!sessionId`, a client-generated UUID **every** visitor has |

Measured live: every anonymous pageview collected a **401** from
`conversations/list` **and** `conversations/history`.

The second one is the expensive half. Its catch calls `logger.warn`, and
`logger.warn` forwards to Sentry **unconditionally** in production
(`logger.ts` — `if (!this.isDevelopment) this.sendToSentry(entry)`). So a public
page was posting one Sentry event per anonymous visitor, and Sentry answered
**429**: it was *dropping* events. Real errors could be lost behind noise
generated by an entirely foreseeable condition.

The visitor saw nothing broken — both failures are caught. That is exactly why
this survived.

## The cure is the cause, not the symptom

Silencing the log would have left the 401s and hidden the next real one.
Instead: don't call an authenticated endpoint while logged out.

- `useConversationsList` takes `enabled`, **defaulting to true** — it has exactly
  one caller and every private surface keeps working untouched.
- `/chat` passes the visitor's auth state to both hooks.
- Auth is read during render, like `getUserProfile()` on the line above: it
  changes no markup, only whether a query may run.

## Evidence, both directions

The existing test `redirects unauthenticated users without loading private chat
data` **already promised this** and only checked the *manual* refetch — the two
automatic fetches walked straight past it. That gap is how the defect lived. It
now asserts both gates.

- **Innocence** — a new sibling test asserts a logged-in visitor still gets
  sidebar and history, and is not redirected. If the gate ever over-fires, this
  goes red instead of the users.
- **Guilt** — mutating the SOURCE (dropping the auth term from the snapshot gate,
  dropping the argument to `useConversations`, dropping `enabled` from the query)
  takes the suite from **0 → 3 red**, and they are the three that must fall.
- A separate test drives the **real** React Query machinery — live `QueryClient`,
  real `useQuery` — to prove `enabled: false` never reaches the query function,
  and that a caller passing no flag still fetches.

17 tests pass on the restored tree.
