### PR TITLE
fix(garuda): the api process now wires the stores its own routers read

### DIFF
--- a/apps/backend-rag/backend/app/setup/service_initializer.py
+++ b/apps/backend-rag/backend/app/setup/service_initializer.py
@@ -1234,101 +1234,32 @@ async def initialize_channel_router(
         app.state.channel_router_init_error = str(e)
 
 
-async def initialize_services(app: FastAPI) -> None:
+async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
+    """Wire every `app.state.garuda_*` adapter. Called by BOTH init paths.
+
+    This function exists because these seven assignments used to live inline
+    in `initialize_services`, which ONLY the `rag` process runs — while all
+    four GARUDA routers are `process_groups=_API`, i.e. mounted ONLY on the
+    `api` process, which runs `initialize_services_light`. The two processes
+    were exactly inverted: `rag` wired the stores and mounted none of the
+    routes; `api` mounted every route and wired none of the stores.
+
+    The visible symptom was a 503 on the first action a real customer takes.
+    `POST /api/visa/voa/eligibility-checks` on balizero.com answered
+    `PERSISTENCE_POLICY_UNAVAILABLE`, which reads as a retention-policy fault
+    and is not one: `get_garuda_check_store` falls back to
+    `UnconfiguredCheckStore`, whose every method raises
+    `PersistencePolicyUnavailable("no garuda check store configured")`.
+    Measured 2026-08-27 against production, after ruling out — each by
+    measurement, not assumption — a missing policy row (exactly one active
+    GARUDA_CHECK/PRODUCTION row), a missing grant (`backend_rag_v2=r/...` in
+    the real `pg_class.relacl`, not the caller-filtered information_schema
+    view), RLS (`relrowsecurity=f`, zero policies) and a wrong database.
+
+    No test could see it: under pytest the app is a single process, so the
+    api/rag split does not exist. `test_api_process_wires_every_state_key_
+    its_routers_read` is the structural guard that now can.
     """
-    Initialize all ZANTARA RAG services with fail-fast for critical services.
-
-    Critical services (SearchService, ZantaraAIClient) must initialize successfully.
-    If any critical service fails, the application will raise RuntimeError to
-    prevent starting in a broken state.
-
-    Non-critical services will log errors and continue with degraded functionality.
-
-    Args:
-        app: FastAPI application instance
-    """
-    if getattr(app.state, "services_initialized", False):
-        return
-
-    logger.info("🚀 Initializing ZANTARA RAG services...")
-
-    # 0. RedisManager (must be first — all Redis consumers depend on it)
-    _initialize_redis_manager(app, "full")
-
-    # 0.1 KG cache proactive invalidation listener (HIGH-13).
-    # Subscribes to `zantara:kg:invalidate` and wipes local KG cache entries
-    # the moment a peer cell increments the KG version. Falls back to the
-    # existing lazy on-read check if Redis is down.
-    try:
-        from backend.services.rag.kg_cache import start_invalidation_listener
-
-        listener = await start_invalidation_listener()
-        app.state.kg_invalidate_listener = listener
-        logger.info("✅ KG cache invalidation listener started")
-    except Exception as e:
-        logger.warning(
-            "KG cache invalidation listener failed to start: %s — "
-            "falling back to lazy version check only",
-            e,
-        )
-
-    # 0.5 VASSAL Phase 3: ConfirmationService + ToolAuthorizer wiring.
-    # Must happen after RedisManager (the service depends on it) and
-    # before anything that calls execute_tool (which reads the module-level
-    # authorizer and confirmation service singletons).
-    try:
-        from backend.services.agents.confirmation_service import ConfirmationService
-        from backend.services.agents.tool_authorizer import ToolAuthorizer
-        from backend.services.rag.agentic.tool_executor import configure_tool_executor
-
-        redis_mgr = getattr(app.state, "redis_manager", None)
-        confirmation_service = ConfirmationService(redis_manager=redis_mgr)
-        await confirmation_service.start()
-        app.state.confirmation_service = confirmation_service
-
-        authorizer = ToolAuthorizer()
-        configure_tool_executor(
-            authorizer=authorizer,
-            confirmation_service=confirmation_service,
-        )
-        logger.info(
-            "✅ VASSAL Phase 3: ConfirmationService + ToolAuthorizer wired (Redis available=%s)",
-            getattr(redis_mgr, "available", False),
-        )
-    except Exception as e:
-        logger.warning(
-            "⚠️ VASSAL Phase 3: ConfirmationService wiring failed: %s — "
-            "confirmation gates will fail-closed (deny)",
-            e,
-        )
-
-    # 1. Critical services (fail-fast)
-    search_service, ai_client = await _init_critical_services(app)
-
-    # 2. Tool stack
-    tool_executor = await _init_tool_stack(app)
-
-    # 2.5 FAQ Cache (non-critical, graceful degradation)
-    await initialize_faq_cache_service(app)
-
-    # 3. RAG components (CulturalRAGService initialized inside _init_rag_components)
-    query_router = await _init_rag_components(app, search_service)
-    cultural_rag_service = app.state.cultural_rag  # Already set by _init_rag_components
-
-    # 4. Specialized agents
-    (
-        autonomous_research_service,
-        cross_oracle_synthesis_service,
-        client_journey_orchestrator,
-    ) = await _init_specialized_agents(app, search_service, ai_client, query_router)
-
-    # Store specialized agents in app.state for router access
-    app.state.cross_oracle_synthesis_service = cross_oracle_synthesis_service
-    app.state.autonomous_research_service = autonomous_research_service
-    app.state.client_journey_orchestrator = client_journey_orchestrator
-
-    # 5. Database services
-    db_pool = await initialize_database_services(app)
 
     # 5.5 GARUDA VOA — magic-link session verifier wiring (L4).
     # Non-critical: on failure the L3/L4 routes keep answering fail-closed
@@ -1524,6 +1455,109 @@ async def initialize_services(app: FastAPI) -> None:
             "(expected until Zero provisions a Xendit sandbox account — L3 fail closed)"
         )
 
+
+
+async def initialize_services(app: FastAPI) -> None:
+    """
+    Initialize all ZANTARA RAG services with fail-fast for critical services.
+
+    Critical services (SearchService, ZantaraAIClient) must initialize successfully.
+    If any critical service fails, the application will raise RuntimeError to
+    prevent starting in a broken state.
+
+    Non-critical services will log errors and continue with degraded functionality.
+
+    Args:
+        app: FastAPI application instance
+    """
+    if getattr(app.state, "services_initialized", False):
+        return
+
+    logger.info("🚀 Initializing ZANTARA RAG services...")
+
+    # 0. RedisManager (must be first — all Redis consumers depend on it)
+    _initialize_redis_manager(app, "full")
+
+    # 0.1 KG cache proactive invalidation listener (HIGH-13).
+    # Subscribes to `zantara:kg:invalidate` and wipes local KG cache entries
+    # the moment a peer cell increments the KG version. Falls back to the
+    # existing lazy on-read check if Redis is down.
+    try:
+        from backend.services.rag.kg_cache import start_invalidation_listener
+
+        listener = await start_invalidation_listener()
+        app.state.kg_invalidate_listener = listener
+        logger.info("✅ KG cache invalidation listener started")
+    except Exception as e:
+        logger.warning(
+            "KG cache invalidation listener failed to start: %s — "
+            "falling back to lazy version check only",
+            e,
+        )
+
+    # 0.5 VASSAL Phase 3: ConfirmationService + ToolAuthorizer wiring.
+    # Must happen after RedisManager (the service depends on it) and
+    # before anything that calls execute_tool (which reads the module-level
+    # authorizer and confirmation service singletons).
+    try:
+        from backend.services.agents.confirmation_service import ConfirmationService
+        from backend.services.agents.tool_authorizer import ToolAuthorizer
+        from backend.services.rag.agentic.tool_executor import configure_tool_executor
+
+        redis_mgr = getattr(app.state, "redis_manager", None)
+        confirmation_service = ConfirmationService(redis_manager=redis_mgr)
+        await confirmation_service.start()
+        app.state.confirmation_service = confirmation_service
+
+        authorizer = ToolAuthorizer()
+        configure_tool_executor(
+            authorizer=authorizer,
+            confirmation_service=confirmation_service,
+        )
+        logger.info(
+            "✅ VASSAL Phase 3: ConfirmationService + ToolAuthorizer wired (Redis available=%s)",
+            getattr(redis_mgr, "available", False),
+        )
+    except Exception as e:
+        logger.warning(
+            "⚠️ VASSAL Phase 3: ConfirmationService wiring failed: %s — "
+            "confirmation gates will fail-closed (deny)",
+            e,
+        )
+
+    # 1. Critical services (fail-fast)
+    search_service, ai_client = await _init_critical_services(app)
+
+    # 2. Tool stack
+    tool_executor = await _init_tool_stack(app)
+
+    # 2.5 FAQ Cache (non-critical, graceful degradation)
+    await initialize_faq_cache_service(app)
+
+    # 3. RAG components (CulturalRAGService initialized inside _init_rag_components)
+    query_router = await _init_rag_components(app, search_service)
+    cultural_rag_service = app.state.cultural_rag  # Already set by _init_rag_components
+
+    # 4. Specialized agents
+    (
+        autonomous_research_service,
+        cross_oracle_synthesis_service,
+        client_journey_orchestrator,
+    ) = await _init_specialized_agents(app, search_service, ai_client, query_router)
+
+    # Store specialized agents in app.state for router access
+    app.state.cross_oracle_synthesis_service = cross_oracle_synthesis_service
+    app.state.autonomous_research_service = autonomous_research_service
+    app.state.client_journey_orchestrator = client_journey_orchestrator
+
+    # 5. Database services
+    db_pool = await initialize_database_services(app)
+
+    # 5.5 GARUDA VOA — every `app.state.garuda_*` adapter, shared by both
+    # init paths. MUST stay a call to the shared function: inlining it here
+    # again is what left the `api` process (the only one that mounts these
+    # routers) with no stores at all.
+    await initialize_garuda_services(app, db_pool)
     # 6. CRM & Memory
     await initialize_crm_and_memory_services(app, ai_client, db_pool)
 
@@ -1991,6 +2025,11 @@ async def initialize_services_light(app: FastAPI) -> None:
                 )
         except Exception as e:
             logger.warning("⚠️ DLQ retry loop failed (light, non-critical): %s", e)
+
+    # 4c. GARUDA VOA — the SAME wiring the rag process does. This process is
+    # the one that actually mounts the GARUDA routers (`process_groups=_API`),
+    # so without this call every one of them fail-closes 503 by construction.
+    await initialize_garuda_services(app, db_pool)
 
     # 5. Mark RAG services as intentionally not-initialized (light mode)
     app.state.search_service = None

--- a/apps/backend-rag/backend/tests/setup/test_api_process_wires_the_state_its_routers_read.py
+++ b/apps/backend-rag/backend/tests/setup/test_api_process_wires_the_state_its_routers_read.py
@@ -1,0 +1,238 @@
+"""The `api` process must wire every `app.state` key its own routers read.
+
+WHY THIS FILE EXISTS. On 2026-08-27 the first action a real customer takes —
+`POST /api/visa/voa/eligibility-checks` on balizero.com — answered HTTP 503
+`PERSISTENCE_POLICY_UNAVAILABLE`. The cause was not the retention policy that
+error names. All four GARUDA routers are `process_groups=_API`, so they are
+mounted ONLY on the `api` process, which runs `initialize_services_light()`.
+Every `app.state.garuda_*` adapter, however, was wired inside
+`initialize_services()` — which ONLY the `rag` process runs, and which mounts
+none of those routers. The two processes were exactly inverted: `rag` wired the
+stores and served none of the routes, `api` served every route and wired none of
+the stores. `get_garuda_check_store` therefore fell back to
+`UnconfiguredCheckStore` on every single request, by construction.
+
+WHY NO EXISTING TEST COULD SEE IT. Under pytest the application is ONE process:
+the api/rag split simply does not exist, `app.dependency_overrides` supplies the
+stores, and every route test passes. The defect lives in the seam between the
+process manifest and the two init functions, which is exactly where no
+behavioural test looks. So this guard is deliberately STATIC — it reads the
+source, not a running app — because the thing it must catch is invisible to a
+running app in a test.
+
+WHAT WOULD MAKE THIS RED (the question a test that cannot fail never answers):
+moving any `app.state.garuda_*` assignment back inside `initialize_services`
+alone, deleting the `initialize_garuda_services` call from the light path, or
+adding a new `_API` router that reads a `garuda_*` state key nothing wires.
+Each is checked below and each fails loudly.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parents[2]
+_INITIALIZER = _BACKEND / "app" / "setup" / "service_initializer.py"
+_MANIFEST = _BACKEND / "app" / "setup" / "router_manifest.py"
+_ROUTERS_DIR = _BACKEND / "app" / "routers"
+
+#: The api process's entry point. `main_api.py` calls exactly this.
+_LIGHT_ENTRY = "initialize_services_light"
+#: The rag process's entry point, via `app_factory.lifespan`.
+_FULL_ENTRY = "initialize_services"
+
+#: State keys a router reads that NOTHING wires, deliberately and on the record.
+#:
+#: This exists because the guard below found one on its very first run, and the
+#: honest answer was neither "delete the assertion" nor "wire it": the staff
+#: late-resolution route fail-closes on purpose until a staff session surface
+#: exists. An exemption that merely lists a name would rot the moment that
+#: changed, so each entry must name a file AND a phrase that file still
+#: contains — the justification is re-read on every run, not trusted once.
+_DELIBERATELY_UNWIRED: dict[str, tuple[str, str]] = {
+    "garuda_staff_session_verifier": (
+        "app/routers/garuda_orders_router.py",
+        "is wired nowhere today",
+    ),
+}
+
+
+def _module() -> ast.Module:
+    return ast.parse(_INITIALIZER.read_text())
+
+
+def _state_assignments(node: ast.AST) -> set[str]:
+    """Every `app.state.NAME = ...` assigned directly in this function body."""
+    found: set[str] = set()
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Assign):
+            continue
+        for target in sub.targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Attribute)
+                and target.value.attr == "state"
+                and isinstance(target.value.value, ast.Name)
+                and target.value.value.id == "app"
+            ):
+                found.add(target.attr)
+    return found
+
+
+def _local_calls(node: ast.AST, known: set[str]) -> set[str]:
+    """Module-level functions from this file that the body calls."""
+    called: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id in known:
+            called.add(sub.func.id)
+    return called
+
+
+def _reachable_state_keys(entry: str) -> set[str]:
+    """State keys assigned by `entry`, following calls to same-file functions.
+
+    Transitive on purpose: the whole point of the cure is that the wiring now
+    lives one call away, in `initialize_garuda_services`. A guard that only
+    looked at the entry function's own body would go green on the BROKEN code
+    and red on the FIXED code — precisely backwards.
+    """
+    tree = _module()
+    fns = {
+        n.name: n
+        for n in tree.body
+        if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef))
+    }
+    assert entry in fns, f"{entry} is not a top-level function in {_INITIALIZER.name}"
+
+    seen: set[str] = set()
+    keys: set[str] = set()
+    stack = [entry]
+    while stack:
+        name = stack.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        body = fns[name]
+        keys |= _state_assignments(body)
+        stack.extend(_local_calls(body, set(fns)) - seen)
+    return keys
+
+
+def _api_router_modules() -> list[str]:
+    """Router module names the manifest puts in the `api` process group.
+
+    Parsed from the manifest source rather than imported: importing the manifest
+    drags in the app's settings and half the service layer, and this guard must
+    stay runnable on a bare checkout.
+    """
+    src = _MANIFEST.read_text()
+    entries = re.findall(
+        r'name="(?P<name>[a-z0-9_]+)"[^)]*?process_groups=(?P<group>_API|_RAG|_BOTH)',
+        src,
+        re.DOTALL,
+    )
+    assert entries, "parsed zero RouterEntry rows — the manifest shape changed"
+    return sorted({name for name, group in entries if group in {"_API", "_BOTH"}})
+
+
+def _garuda_state_keys_read_by(module_name: str) -> set[str]:
+    """`garuda_*` state keys a router module reads off `app.state`."""
+    path = _ROUTERS_DIR / f"{module_name}.py"
+    if not path.exists():
+        return set()
+    src = path.read_text()
+    keys = set(re.findall(r'getattr\(\s*request\.app\.state\s*,\s*"(garuda_[a-z_]+)"', src))
+    keys |= set(re.findall(r"request\.app\.state\.(garuda_[a-z_]+)", src))
+    return keys
+
+
+class TestTheApiProcessWiresWhatItServes:
+    def test_every_garuda_state_key_the_rag_path_wires_is_wired_on_the_api_path_too(
+        self,
+    ) -> None:
+        """The regression, stated as the asymmetry that caused the outage.
+
+        Before the cure this assertion failed with all seven names: the full
+        path wired `garuda_check_store`, `garuda_order_repository`,
+        `garuda_payment_provider`, `garuda_db_pool`, `garuda_magic_link_store`,
+        `garuda_magic_session_verifier` and `garuda_payment_http_client`, and
+        the light path — the only one the api process runs — wired none.
+        """
+        full = {k for k in _reachable_state_keys(_FULL_ENTRY) if k.startswith("garuda_")}
+        light = {k for k in _reachable_state_keys(_LIGHT_ENTRY) if k.startswith("garuda_")}
+
+        assert full, (
+            "found no garuda state keys on the rag init path at all — this guard "
+            "has lost sight of its subject and would pass vacuously"
+        )
+        missing = full - light
+        assert not missing, (
+            "the api process mounts every GARUDA router but its init path does "
+            f"not wire {sorted(missing)}. Each unwired key means a fail-closed "
+            "503 on a live customer-facing route."
+        )
+
+    def test_the_shared_wiring_is_reached_from_both_entry_points(self) -> None:
+        """Names the CURE, so deleting it is a failure and not a silent revert."""
+        tree = _module()
+        fns = {
+            n.name: n
+            for n in tree.body
+            if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef))
+        }
+        assert "initialize_garuda_services" in fns, (
+            "initialize_garuda_services is gone — if the wiring was inlined back "
+            "into one initializer, the api/rag inversion is back with it"
+        )
+        for entry in (_FULL_ENTRY, _LIGHT_ENTRY):
+            assert "initialize_garuda_services" in _local_calls(fns[entry], set(fns)), (
+                f"{entry} no longer calls initialize_garuda_services"
+            )
+
+    @pytest.mark.parametrize("module_name", _api_router_modules())
+    def test_api_router_reads_no_garuda_state_key_the_light_path_leaves_unset(
+        self, module_name: str
+    ) -> None:
+        """The generalisation: catches the NEXT one, not just this one.
+
+        A router added to `_API` tomorrow that reads a `garuda_*` state key
+        nothing wires on the light path fails here at collection time, instead
+        of failing in production as a 503 nobody attributes to wiring.
+        """
+        read = _garuda_state_keys_read_by(module_name)
+        if not read:
+            pytest.skip(f"{module_name} reads no garuda_* state key")
+        light = _reachable_state_keys(_LIGHT_ENTRY)
+        unwired = read - light - set(_DELIBERATELY_UNWIRED)
+        assert not unwired, (
+            f"router {module_name} runs on the api process and reads "
+            f"{sorted(unwired)} off app.state, which "
+            f"{_LIGHT_ENTRY}() never assigns"
+        )
+
+    @pytest.mark.parametrize(
+        ("key", "source_rel", "phrase"),
+        [(k, v[0], v[1]) for k, v in _DELIBERATELY_UNWIRED.items()],
+    )
+    def test_each_deliberately_unwired_key_still_says_why(
+        self, key: str, source_rel: str, phrase: str
+    ) -> None:
+        """An exemption must not outlive the reason it was granted.
+
+        Without this, `_DELIBERATELY_UNWIRED` is just a list of names the guard
+        agrees not to look at — indistinguishable from a defect somebody
+        silenced. Here the justification is re-read every run: if the route is
+        ever wired, or its comment rewritten, this goes red and the exemption
+        gets revisited on purpose instead of persisting by inertia.
+        """
+        source = _BACKEND / source_rel
+        assert source.exists(), f"{source_rel} is gone; the exemption for {key} has no basis"
+        assert phrase in source.read_text(), (
+            f"{source_rel} no longer says {phrase!r}. The exemption for {key} was "
+            "granted on that statement — re-check whether the key is now wired "
+            "(remove the exemption) or the comment simply drifted (update it)."
+        )


### PR DESCRIPTION
## The first action a real customer takes was returning 503 in production

Found by running the live funnel as a user, not by reading code. `POST /api/visa/voa/eligibility-checks` on **balizero.com**, contract-valid body:

```
HTTP 503
{"code":"PERSISTENCE_POLICY_UNAVAILABLE","message_key":"garuda_voa.error.sale_unavailable"}
```

That error names the retention policy and **is not about it**. Ruled out one by one, each by measurement:

| Hypothesis | Verdict | Evidence |
|---|---|---|
| Policy row missing | ❌ | exactly one active `GARUDA_CHECK`/`PRODUCTION` row, `effective_period @> now()` |
| Runtime role can't read it | ❌ | `backend_rag_v2=r/visa_ledger_owner` in the real `pg_class.relacl` — `information_schema.role_table_grants` shows only what the *caller* can see, so trusting it would have been a conclusion drawn from absence |
| RLS hiding the row | ❌ | `relrowsecurity=f`, zero policies |
| Wrong database | ❌ | the probe reaches prod `nuzantara_rag` |

## The actual cause: the two processes are exactly inverted

- All four GARUDA routers are `process_groups=_API` → mounted **only** on the `api` process via `include_light_routers`.
- The `api` process runs `initialize_services_light()`.
- All seven `app.state.garuda_*` assignments lived in `initialize_services()` — run **only** by the `rag` process, whose `include_heavy_routers` mounts **none** of those routers.

So `rag` wired the stores and served none of the routes; `api` served every route and wired none of the stores. `get_garuda_check_store` fell back to `UnconfiguredCheckStore` on every request — **by construction, not by accident**.

GARUDA VOA could never have worked in production, and **no feature flag or Xendit key would have changed it**: the block that reads `GARUDA_XENDIT_SECRET_KEY` sits in the same unreachable function.

## The fix, and the half that matters more

Wiring extracted into `initialize_garuda_services(app, db_pool)`, called from **both** init paths. No behaviour change on `rag`.

The guard is the important half. **No behavioural test could have caught this**: under pytest the app is ONE process, so the api/rag split does not exist and dependency overrides supply the stores. The new test is therefore deliberately **static** — it reads the source, because the defect is invisible to a running app.

It also **generalises**: no `_API` router may read a `garuda_*` state key the light path leaves unset. That earned its place immediately — on its first run it flagged `garuda_staff_session_verifier`, which nothing wires anywhere. That one is deliberate (`garuda_orders_router.py:156` says so), so it is exempted — but a second test asserts the file still carries the phrase the exemption was granted on, so **the exemption cannot outlive its reason**.

## Proof

- **Innocence** — fixed tree: `6 passed`.
- **Guilt** — deleting the light-path call, i.e. recreating the outage: `5 failed`, naming `garuda_voa_public`, `garuda_portal_auth` and `garuda_orders_router` individually.
- **No regressions** — the affected suites show 46 errors, and `origin/main` shows **the same 46** in the same environment: this worktree's test DB has no migrations applied. Measured, not assumed.
- Import chain OK (`from backend.app.dependencies import get_current_user`).
