### PR TITLE
fix(second-home): localize fit-check CTA label in it/id

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -274,7 +274,7 @@ export function SecondHomeLanding() {
           data-testid="hero-fit-check-cta"
           style={{ ...fitCheckCtaStyle, justifySelf: "start" }}
         >
-          Start the fit-check
+          {t("secondHome.cta.fitCheck")}
         </Link>
         {price ? (
           <div
@@ -650,7 +650,7 @@ export function SecondHomeLanding() {
           data-testid="footer-fit-check-cta"
           style={fitCheckCtaStyle}
         >
-          Start the fit-check
+          {t("secondHome.cta.fitCheck")}
         </Link>
       </section>
 

--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -394,6 +394,7 @@
       "a6": "{{price}} all-inclusive for the base E33 — one figure, everything included. The fit memo that assesses your route is free."
     },
     "cta": {
+      "fitCheck": "Start the fit-check",
       "title": "Start with a free fit memo",
       "body": "Tell us your situation on WhatsApp. We reply with an honest read: which route fits, what evidence you'll need, and the exact price for your case. No obligation.",
       "button": "Get my free Fit Memo →",

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -394,6 +394,7 @@
       "a6": "{{price}} all-inclusive untuk E33 dasar — satu angka, semua sudah termasuk. Fit memo untuk menilai jalur Anda gratis."
     },
     "cta": {
+      "fitCheck": "Mulai fit-check",
       "title": "Mulai dengan fit memo gratis",
       "body": "Ceritakan situasi Anda di WhatsApp. Kami balas dengan penilaian jujur: jalur mana yang cocok, bukti apa yang Anda perlukan, dan harga pasti untuk kasus Anda. Tanpa kewajiban.",
       "button": "Dapatkan Fit Memo gratis →",

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -394,6 +394,7 @@
       "a6": "{{price}} tutto incluso per l'E33 base — una cifra sola, tutto compreso. Il fit memo che valuta il tuo percorso è gratuito."
     },
     "cta": {
+      "fitCheck": "Inizia il fit-check",
       "title": "Inizia con un fit memo gratuito",
       "body": "Raccontaci la tua situazione su WhatsApp. Ti rispondiamo con una valutazione onesta: quale percorso conviene, quali prove serviranno e il prezzo esatto per il tuo caso. Senza impegno.",
       "button": "Richiedi il Fit Memo gratuito →",


### PR DESCRIPTION
## 1. Insight
Two CTA labels on /visa/second-home were hardcoded English literals and leaked untranslated into the /it and /id locale routes, which are SSG pages that are otherwise fully localized (title, canonical, hreflang, FAQ JSON-LD).

SCOPE — second-home fit-check CTA localization
1. GOAL        : the fit-check CTA label renders in the page's own language on /visa/second-home/it and /visa/second-home/id.
2. NON-GOAL    : does NOT touch the "under 5 hours" reply-time claims (those belong to PR #4779) · does NOT wire analytics on these CTAs (separate work, blocked on reading the visa_cta_click payload shape) · does NOT touch ContentLangSync.tsx or the html lang attribute · does NOT touch packages/core · does NOT add fr/ru keys.
3. FILES       : apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx and apps/mouth/src/i18n/locales/{en,it,id}.json
4. MEASURED BY : git --no-pager grep -c 'Start the fit-check' -- 'apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx' returns 0, with positive control 'secondHome.cta.fitCheck' in the same file returning 2. Layer 3 after merge: curl the /it and /id routes with an explicit UA and grep for the localized label.
5. ROLLBACK    : revert this PR. No DB, no migration.
6. DONE WHEN   : state 6 — localized label present on the served /it and /id pages after /api/health reports this PR's commit.

## 2. Studio
For a visitor on /visa/second-home/it, the hero link and the footer link both read "Start the fit-check" today; after this change they read "Inizia il fit-check". On /visa/second-home/id the same two links change from "Start the fit-check" to "Mulai fit-check". English visitors see no change at all: the EN dictionary value is byte-identical to the literal it replaces. The two links live in apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx at lines 277 and 653, the client component that renders the landing surface, zone VERDE. No layout, spacing or color changes, so CLS is not affected — and CLS has not been measured for this PR because the commit is not served yet.

## 3. Source
Phase 1 read-only audit of /visa/second-home, 27 August 2026, against origin/main at cf5e8c553. The audit covered the SEO, analytics and claims layers; this PR closes one finding from the claims layer.

## 4. Methodology
Read-only inventory first: git grep located the rendering files rather than assuming paths. The two literals were confirmed absent from every locale dictionary before any edit. Every zero in this PR carries a positive control from the same file.

## 5. Raw Observations
Before:
    git --no-pager grep -n 'Start the fit-check' -- 'apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx'
    2 occurrences, lines 277 and 653
    git --no-pager grep -c '"secondHome"' -- 'apps/mouth/src/i18n/locales/fr.json'
    0, positive control '"nav"' returns 1, so the file is real and grep works

After:
    same command on SecondHomeLanding.tsx returns 0 occurrences
    positive control, same file: 'secondHome.cta.fitCheck' returns 2 occurrences

    npm run build      exit 0, /it and /id both SSG
    npm run lint       exit 0, ESLint v9.39.5, 0 errors, 183 pre-existing warnings, 0 warnings in the touched file (positive control: ZantaraWidget returns 1)
    npx vitest --run   exit 0, 15 files, 143 tests passed

Mutation proof that the test actually reads the new key: setting the en.json value to MUTANT-XYZ turned page.test.tsx red (1 failed, 8 passed); restoring it returned 9 passed.

## 6. Reasoning Path
The EN dictionary value was deliberately kept byte-identical to the old literal because apps/mouth/src/app/visa/second-home/page.test.tsx:139 asserts the rendered text. That file is outside this PR's scope, and keeping the value identical is how it stays green without being touched.

The key was placed under secondHome.cta. That subtree is semantically the WhatsApp CTA block, while the fit-check link sits in the hero and in a different section, so secondHome.fitCheckCta would read better. It was left under secondHome.cta to keep the diff minimal against PR #4779, which edits the same object.

fr.json and ru.json carry no secondHome subtree at all, so no new gap is introduced; apps/mouth/src/app/visa/second-home/layout.tsx:11 already documents the fr/ru fallback to English.

## 7. Risk
Overlap with PR #4779, which removes secondHome.cta.note from the same three dictionaries and the same component. Measured rather than assumed: a three-way git merge-file (base origin/main, theirs origin/sancho/retire-under-5-hours, ours this branch) returned rc=0 with 0 conflict markers on all four shared files, and the merged result is correct — cta contains fitCheck, title, body and button, note is gone, and the component has 2 t("secondHome.cta.fitCheck") calls and 0 references to cta.note.

Not measured: whether the localized label appears on the served pages. The commit is not deployed, so that check belongs to prove-live.

## 8. Implication
The /it and /id routes are SSG pages with localized titles, canonicals, hreflang and FAQ JSON-LD. An untranslated CTA label was the one remaining surface where the page contradicted its own declared language.

## 9. Recommendation
Rekomendasi: Tinggi — merge order does not matter; the three-way merge is clean in both directions.

## 10. Next Action
Stopping at ready-for-review per the auto-merge suspension. No arming, no merge, no promote. Two findings from the same audit are filed as separate Todoist rows and are deliberately not attached here: the analytics gap on these two CTAs (blocked on reading the visa_cta_click payload shape) and the html lang attribute on the it/id routes (repo-wide, declared in ContentLangSync.tsx:17-19).
