### PR TITLE
fix(intel): make enrichment providers production-safe

### DIFF
--- a/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
+++ b/apps/bali-intel-scraper/scripts/claude_cli_enricher.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from typing import Any
 import logging
 
+import httpx
+
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
@@ -135,6 +137,30 @@ _TIER_TO_SCORE = {"breaking": 90, "developing": 60, "evergreen": 0}
 # truncated mid-thought — but bounded well below the old 200, which let a
 # reason balloon into a near-paragraph.
 _REASON_MAX_CHARS = 120
+
+
+def _claude_provider_ids() -> list[str]:
+    """Return configured OAuth seats once each, without exposing token values."""
+
+    # Seat 3 is assigned to this batch; 4-6 are the immediate quota fallback.
+    candidates = [
+        *(f"CLAUDE_CODE_OAUTH_TOKEN_{seat}" for seat in (3, 4, 5, 6, 1, 2)),
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ]
+    providers: list[str] = []
+    seen_tokens: set[str] = set()
+    for env_name in candidates:
+        token = os.environ.get(env_name, "").strip()
+        if not token or token in seen_tokens:
+            continue
+        seen_tokens.add(token)
+        suffix = env_name.removeprefix("CLAUDE_CODE_OAUTH_TOKEN")
+        providers.append(f"claude{suffix.lower()}")
+    # Interactive sessions may authenticate through Claude's config without
+    # exporting a token, so retain that sanctioned path when no seat is set.
+    return providers or ["claude"]
+
+
 def _provider_attempts(prompt: str) -> list[tuple[str, list[str], str | None, int]]:
     """Return the subscription-first text-generation cascade.
 
@@ -146,36 +172,37 @@ def _provider_attempts(prompt: str) -> list[tuple[str, list[str], str | None, in
 
     claude_bin = shutil.which("claude") or "/Users/nuzantara/.local/bin/claude"
     ollama_bin = shutil.which("ollama") or "/opt/homebrew/bin/ollama"
-    return [
-        (
-            "claude",
-            [
-                claude_bin,
-                "--print",
-                "--model",
-                "claude-sonnet-4-6",
-                "--tools",
-                "",
-                "--disable-slash-commands",
-                "--no-session-persistence",
-            ],
-            prompt,
-            150,
-        ),
+    claude_command = [
+        claude_bin,
+        "--print",
+        "--model",
+        "claude-sonnet-4-6",
+        "--tools",
+        "",
+        "--disable-slash-commands",
+        "--no-session-persistence",
+        "--safe-mode",
+    ]
+    attempts = [
+        (provider, list(claude_command), prompt, 150)
+        for provider in _claude_provider_ids()
+    ]
+    attempts.append(
         (
             "ollama",
             [ollama_bin, "run", "qwen3.5:9b"],
             prompt,
-            240,
-        ),
-    ]
+            120,
+        )
+    )
+    return attempts
 
 
 def _provider_env(provider: str) -> dict[str, str]:
     """Return the smallest environment needed by one subscription/local seat."""
 
     allowed = {"HOME", "LANG", "LC_ALL", "PATH", "TMPDIR"}
-    if provider == "claude":
+    if provider.startswith("claude"):
         allowed.update(
             {
                 "CLAUDE_CONFIG_DIR",
@@ -188,16 +215,49 @@ def _provider_env(provider: str) -> dict[str, str]:
     env = {key: value for key, value in os.environ.items() if key in allowed}
     path_prefix = "/Users/nuzantara/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
     env["PATH"] = f"{path_prefix}:{env.get('PATH', '')}"
-    if provider == "claude" and not env.get("CLAUDE_CODE_OAUTH_TOKEN"):
-        # The nightly LaunchAgent owns the A3/batch seat under the suffixed
-        # variable.  Map that one credential to the canonical child-process
-        # name without forwarding the source name or any neighbouring secret.
-        batch_oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN_3", "").strip()
-        if batch_oauth_token:
-            env["CLAUDE_CODE_OAUTH_TOKEN"] = batch_oauth_token
+    if provider.startswith("claude"):
+        suffix = provider.removeprefix("claude")
+        source_name = f"CLAUDE_CODE_OAUTH_TOKEN{suffix.upper()}"
+        seat_token = os.environ.get(source_name, "").strip()
+        if seat_token:
+            # Forward one selected seat under the canonical child-process name.
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = seat_token
     if provider == "ollama":
         env["OLLAMA_NOHISTORY"] = "1"
     return env
+
+
+def _run_ollama_generation(
+    prompt: str,
+    *,
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    """Generate bounded JSON through local Ollama with reasoning disabled."""
+
+    response = httpx.post(
+        "http://127.0.0.1:11434/api/generate",
+        json={
+            "model": "qwen3.5:9b",
+            "prompt": prompt,
+            "stream": False,
+            "think": False,
+            "format": "json",
+            "keep_alive": "5m",
+            "options": {"temperature": 0, "num_predict": 2300},
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    output = payload.get("response") if isinstance(payload, dict) else None
+    if not isinstance(output, str) or not output.strip():
+        raise ValueError("Ollama returned no JSON response")
+    return subprocess.CompletedProcess(
+        args=["ollama-http", "qwen3.5:9b"],
+        returncode=0,
+        stdout=output,
+        stderr="",
+    )
 
 
 def _run_generation_cascade(
@@ -215,17 +275,26 @@ def _run_generation_cascade(
             continue
         logger.info("Calling %s enrichment provider...", provider)
         try:
-            result = subprocess.run(
-                command,
-                input=stdin_text,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=False,
-                env=_provider_env(provider),
-                cwd="/tmp",
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            if provider == "ollama":
+                result = _run_ollama_generation(prompt, timeout=timeout)
+            else:
+                result = subprocess.run(
+                    command,
+                    input=stdin_text,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                    env=_provider_env(provider),
+                    cwd="/tmp",
+                )
+        except (
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+            httpx.HTTPError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as exc:
             batch_circuit.add(provider)
             errors.append(f"{provider}:{type(exc).__name__}")
             logger.warning(
@@ -453,8 +522,21 @@ def enrich_article_claude_cli(
         category=_escape_for_prompt(
             article.get("qwen_category", article.get("category", "general"))
         ),
-        published_date=_escape_for_prompt(article.get("published_date", "Unknown")),
-        content=_escape_for_prompt(str(article.get("content") or "")[:4000]),
+        published_date=_escape_for_prompt(
+            str(
+                article.get("published_date")
+                or article.get("published")
+                or "Unknown"
+            )
+        ),
+        content=_escape_for_prompt(
+            str(
+                article.get("content")
+                or article.get("text")
+                or article.get("summary")
+                or ""
+            )[:4000]
+        ),
         nlm_legal_basis=nlm_legal,
         nlm_web_findings=nlm_web,
         as_of=as_of,

--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -607,6 +607,8 @@ class IntelPipeline:
                         "model": ollama_model,
                         "prompt": prompt,
                         "stream": False,
+                        "think": False,
+                        "format": "json",
                         "options": {"temperature": 0.0, "num_predict": 40 * len(batch)},
                     },
                     timeout=90
@@ -751,7 +753,7 @@ class IntelPipeline:
                 "filtered": len(filtered),
                 "avg_score": round(avg_score, 1),
                 "errors": errors,
-                "method": "qwen3.5_27b",
+                "method": ollama_model,
             },
         )
         return True

--- a/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_cascade.py
+++ b/apps/bali-intel-scraper/tests/unit/test_claude_cli_enricher_cascade.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -42,8 +43,8 @@ def _json_result(provider: str) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess([], 0, json.dumps(_payload(provider)), "")
 
 
-def _provider(command: list[str]) -> str:
-    return "ollama" if "ollama" in command[0] else "claude"
+def _provider(_command: list[str]) -> str:
+    return "claude"
 
 
 def test_timeout_opens_batch_circuit_and_falls_back_to_local() -> None:
@@ -53,11 +54,17 @@ def test_timeout_opens_batch_circuit_and_falls_back_to_local() -> None:
     def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
         provider = _provider(command)
         calls.append(provider)
-        if provider == "claude":
-            raise subprocess.TimeoutExpired(command, 150)
-        return _json_result(provider)
+        raise subprocess.TimeoutExpired(command, 150)
 
-    with patch.object(enricher.subprocess, "run", side_effect=fake_run):
+    def fake_ollama(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append("ollama")
+        return _json_result("ollama")
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.object(enricher.subprocess, "run", side_effect=fake_run),
+        patch.object(enricher, "_run_ollama_generation", side_effect=fake_ollama),
+    ):
         first = enricher.enrich_article_claude_cli({"title": "One"}, circuit_open=circuit)
         second = enricher.enrich_article_claude_cli({"title": "Two"}, circuit_open=circuit)
 
@@ -74,11 +81,17 @@ def test_invalid_or_error_json_opens_circuit_and_falls_through() -> None:
     def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
         provider = _provider(command)
         calls.append(provider)
-        if provider == "claude":
-            return subprocess.CompletedProcess([], 0, '{"error":"quota"}', "")
-        return _json_result(provider)
+        return subprocess.CompletedProcess([], 0, '{"error":"quota"}', "")
 
-    with patch.object(enricher.subprocess, "run", side_effect=fake_run):
+    def fake_ollama(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append("ollama")
+        return _json_result("ollama")
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.object(enricher.subprocess, "run", side_effect=fake_run),
+        patch.object(enricher, "_run_ollama_generation", side_effect=fake_ollama),
+    ):
         first = enricher.enrich_article_claude_cli({"title": "One"}, circuit_open=circuit)
         second = enricher.enrich_article_claude_cli({"title": "Two"}, circuit_open=circuit)
 
@@ -99,7 +112,11 @@ def test_partial_and_empty_objects_never_count_as_enrichment() -> None:
             enricher.subprocess,
             "run",
             return_value=subprocess.CompletedProcess([], 0, output, ""),
-        ):
+        ), patch.object(
+            enricher,
+            "_run_ollama_generation",
+            return_value=subprocess.CompletedProcess([], 0, output, ""),
+        ), patch.dict(os.environ, {}, clear=True):
             result = enricher.enrich_article_claude_cli({"title": "Invalid"})
         assert result["success"] is False
 
@@ -107,6 +124,8 @@ def test_partial_and_empty_objects_never_count_as_enrichment() -> None:
 def test_provider_contract_is_subscription_local_only_and_secret_minimal(
     monkeypatch,
 ) -> None:
+    for seat in range(1, 7):
+        monkeypatch.delenv(f"CLAUDE_CODE_OAUTH_TOKEN_{seat}", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "must-not-leak")
     monkeypatch.setenv("DATABASE_URL", "must-not-leak")
@@ -127,6 +146,7 @@ def test_provider_contract_is_subscription_local_only_and_secret_minimal(
     assert "Public title" not in command
     assert "--tools" in command and command[command.index("--tools") + 1] == ""
     assert "--no-session-persistence" in command
+    assert "--safe-mode" in command
     assert kwargs["cwd"] == "/tmp"
     assert kwargs["timeout"] == 150
     assert kwargs["input"] and "Public title" in str(kwargs["input"])
@@ -143,11 +163,38 @@ def test_provider_contract_is_subscription_local_only_and_secret_minimal(
         assert secret_name not in child_env
 
 
+def test_local_fallback_disables_thinking_and_forces_bounded_json() -> None:
+    observed: dict[str, object] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"response": json.dumps(_payload("ollama"))}
+
+    def fake_post(*_args: object, **kwargs: object) -> FakeResponse:
+        observed.update(kwargs)
+        return FakeResponse()
+
+    with patch.object(enricher.httpx, "post", side_effect=fake_post):
+        result = enricher._run_ollama_generation("public prompt", timeout=120)
+
+    assert result.returncode == 0
+    request_json = observed["json"]
+    assert isinstance(request_json, dict)
+    assert request_json["think"] is False
+    assert request_json["format"] == "json"
+    assert request_json["keep_alive"] == "5m"
+    assert request_json["options"] == {"temperature": 0, "num_predict": 2300}
+    assert observed["timeout"] == 120
+
+
 def test_batch_seat_token_is_mapped_to_canonical_child_name(monkeypatch) -> None:
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_3", "batch-seat-oauth")
 
-    child_env = enricher._provider_env("claude")
+    child_env = enricher._provider_env("claude_3")
 
     assert child_env["CLAUDE_CODE_OAUTH_TOKEN"] == "batch-seat-oauth"
     assert "CLAUDE_CODE_OAUTH_TOKEN_3" not in child_env
@@ -159,14 +206,83 @@ def test_batch_circuit_resets_between_batches() -> None:
     def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
         provider = _provider(command)
         calls.append(provider)
-        if provider == "claude":
-            raise subprocess.TimeoutExpired(command, 150)
-        return _json_result(provider)
+        raise subprocess.TimeoutExpired(command, 150)
 
-    with patch.object(enricher.subprocess, "run", side_effect=fake_run):
+    def fake_ollama(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append("ollama")
+        return _json_result("ollama")
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.object(enricher.subprocess, "run", side_effect=fake_run),
+        patch.object(enricher, "_run_ollama_generation", side_effect=fake_ollama),
+    ):
         first = enricher.batch_enrich_articles([{"title": "One"}])
         second = enricher.batch_enrich_articles([{"title": "Two"}])
 
     assert first[0]["enrichment_provider"] == "ollama"
     assert second[0]["enrichment_provider"] == "ollama"
     assert calls == ["claude", "ollama", "claude", "ollama"]
+
+
+def test_capped_seat_rotates_to_next_oauth_seat_before_ollama() -> None:
+    used_seats: list[str] = []
+
+    def fake_run(
+        _command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        child_env = kwargs["env"]
+        assert isinstance(child_env, dict)
+        seat = str(child_env["CLAUDE_CODE_OAUTH_TOKEN"])
+        used_seats.append(seat)
+        if seat == "capped-seat":
+            return subprocess.CompletedProcess([], 1, "weekly limit", "")
+        return _json_result("claude_4")
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_CODE_OAUTH_TOKEN_3": "capped-seat",
+                "CLAUDE_CODE_OAUTH_TOKEN_4": "working-seat",
+            },
+            clear=True,
+        ),
+        patch.object(enricher.subprocess, "run", side_effect=fake_run),
+        patch.object(enricher, "_run_ollama_generation") as ollama,
+    ):
+        result = enricher.enrich_article_claude_cli({"title": "Rotation"})
+
+    assert result["provider"] == "claude_4"
+    assert used_seats == ["capped-seat", "working-seat"]
+    ollama.assert_not_called()
+
+
+def test_prompt_uses_scraper_text_summary_and_published_fallbacks() -> None:
+    prompts: list[str] = []
+
+    def fake_cascade(prompt: str, **_kwargs: object) -> tuple[dict[str, object], str, str, list[str]]:
+        prompts.append(prompt)
+        payload = _payload("claude")
+        return payload, json.dumps(payload), "claude", []
+
+    with patch.object(enricher, "_run_generation_cascade", side_effect=fake_cascade):
+        text_result = enricher.enrich_article_claude_cli(
+            {
+                "title": "Text article",
+                "text": "Full scraped text marker",
+                "summary": "Summary marker",
+                "published": "2026-08-27T09:00:00+08:00",
+            }
+        )
+        summary_result = enricher.enrich_article_claude_cli(
+            {"title": "Summary article", "summary": "Only summary marker"}
+        )
+
+    assert text_result["success"] is True
+    assert summary_result["success"] is True
+    assert "Full scraped text marker" in prompts[0]
+    assert "Summary marker" not in prompts[0]
+    assert "Published: 2026-08-27T09:00:00+08:00" in prompts[0]
+    assert "Only summary marker" in prompts[1]

--- a/apps/bali-intel-scraper/tests/unit/test_intel_pipeline_failure_semantics.py
+++ b/apps/bali-intel-scraper/tests/unit/test_intel_pipeline_failure_semantics.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+import json
 import sys
 import urllib.request
 from pathlib import Path
 from types import SimpleNamespace
 
-import asyncio
 import httpx
 
 
@@ -177,3 +178,46 @@ def test_unhandled_step_exception_is_fatal_and_preserves_latest(
     assert pipeline.state["failed_steps"] == ["1_scraping"]
     assert pipeline.state["steps"]["1_scraping"]["data"]["fatal"] is True
     assert latest.read_text(encoding="utf-8") == '{"sentinel":"last-known-good"}'
+
+
+def test_qwen_filter_forces_non_thinking_json_and_reports_actual_model(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    pipeline = _pipeline(tmp_path, min_score=30)
+    pipeline.state["articles"] = [
+        {
+            "title": "Indonesia updates investor rules",
+            "content": "An official Indonesian policy update for foreign investors.",
+            "source": "Official source",
+            "tier": "T1",
+        }
+    ]
+    observed_payloads: list[dict[str, object]] = []
+
+    class FakeResponse:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    def fake_get(*_args: object, **_kwargs: object) -> FakeResponse:
+        return FakeResponse({"models": [{"name": "qwen3.5:9b"}]})
+
+    def fake_post(*_args: object, **kwargs: object) -> FakeResponse:
+        payload = kwargs["json"]
+        assert isinstance(payload, dict)
+        observed_payloads.append(payload)
+        return FakeResponse({"response": json.dumps([{"id": 1, "s": 88}])})
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    assert pipeline.step_qwen_filter() is True
+    assert observed_payloads[0]["think"] is False
+    assert observed_payloads[0]["format"] == "json"
+    step = pipeline.state["steps"]["2.5_qwen_filter"]
+    assert step["data"]["errors"] == 0
+    assert step["data"]["method"] == "qwen3.5:9b"
+    assert pipeline.state["articles"][0]["quality_score"] == 88


### PR DESCRIPTION
## Outcome
- rotate six subscription OAuth seats instead of hard-coding exhausted seat 3
- run Claude with no tools, no persistence, and safe mode
- make Ollama fallback deterministic through the local JSON API with thinking disabled
- preserve scraped text/summary and publication date in enrichment prompts
- force non-thinking JSON for the Qwen quality filter and report the actual model

## Live failure reproduced
Run 20260827_123558 correctly failed closed after Claude seat 3 quota exhaustion and a 240-second Ollama thinking timeout; downstream News Room submission was blocked.

## Verification
- ruff check: passed
- focused pytest: 15 passed
- local Ollama full article probe: strict enrichment contract passed in 51.5s with thinking disabled