### PR TITLE
fix(intel): enforce Qwen batch response cardinality

### DIFF
--- a/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
+++ b/apps/bali-intel-scraper/scripts/run_intel_pipeline.py
@@ -586,19 +586,35 @@ class IntelPipeline:
                 article_lines.append(f"{j}. {title} [{source}] {text}")
 
             articles_text = "\n".join(article_lines)
-            # Pre-build expected output shape
-            example_items = ",".join(
-                f'{{"id":{j + 1},"s":__}}' for j in range(min(2, len(batch)))
-            )
+            expected_ids = ", ".join(str(j) for j in range(1, len(batch) + 1))
 
             prompt = (
                 f"Score each article 0-100: relevance for foreign investors/expats in Bali, Indonesia.\n"
                 f"Criteria: Indonesia/Bali focus(0-30), Expat relevance(0-25), Actionability(0-20), Timeliness(0-15), Quality(0-10).\n"
                 f"IMPORTANT: Articles about OTHER countries (India, Thailand, Malaysia, etc.) that do NOT affect Indonesia MUST score 0-10.\n"
-                f"Reply JSON array only. No explanations.\n"
+                f"Reply with exactly {len(batch)} objects, one per article, using every id once: {expected_ids}.\n"
+                f"Each object must contain only integer fields id and s. No explanations.\n"
                 f"{articles_text}\n"
-                f"[{example_items},...]"
             )
+
+            response_schema = {
+                "type": "array",
+                "minItems": len(batch),
+                "maxItems": len(batch),
+                "items": {
+                    "type": "object",
+                    "required": ["id", "s"],
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": len(batch),
+                        },
+                        "s": {"type": "integer", "minimum": 0, "maximum": 100},
+                    },
+                    "additionalProperties": False,
+                },
+            }
 
             try:
                 resp = _httpx.post(
@@ -608,7 +624,7 @@ class IntelPipeline:
                         "prompt": prompt,
                         "stream": False,
                         "think": False,
-                        "format": "json",
+                        "format": response_schema,
                         "options": {"temperature": 0.0, "num_predict": 40 * len(batch)},
                     },
                     timeout=90

--- a/apps/bali-intel-scraper/tests/unit/test_intel_pipeline_failure_semantics.py
+++ b/apps/bali-intel-scraper/tests/unit/test_intel_pipeline_failure_semantics.py
@@ -180,18 +180,19 @@ def test_unhandled_step_exception_is_fatal_and_preserves_latest(
     assert latest.read_text(encoding="utf-8") == '{"sentinel":"last-known-good"}'
 
 
-def test_qwen_filter_forces_non_thinking_json_and_reports_actual_model(
+def test_qwen_filter_forces_exact_non_thinking_json_schema_and_reports_model(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     pipeline = _pipeline(tmp_path, min_score=30)
     pipeline.state["articles"] = [
         {
-            "title": "Indonesia updates investor rules",
+            "title": f"Indonesia investor update {article_id}",
             "content": "An official Indonesian policy update for foreign investors.",
             "source": "Official source",
             "tier": "T1",
         }
+        for article_id in range(1, 4)
     ]
     observed_payloads: list[dict[str, object]] = []
 
@@ -209,15 +210,31 @@ def test_qwen_filter_forces_non_thinking_json_and_reports_actual_model(
         payload = kwargs["json"]
         assert isinstance(payload, dict)
         observed_payloads.append(payload)
-        return FakeResponse({"response": json.dumps([{"id": 1, "s": 88}])})
+        return FakeResponse(
+            {
+                "response": json.dumps(
+                    [
+                        {"id": 1, "s": 88},
+                        {"id": 2, "s": 77},
+                        {"id": 3, "s": 66},
+                    ]
+                )
+            }
+        )
 
     monkeypatch.setattr(httpx, "get", fake_get)
     monkeypatch.setattr(httpx, "post", fake_post)
 
     assert pipeline.step_qwen_filter() is True
     assert observed_payloads[0]["think"] is False
-    assert observed_payloads[0]["format"] == "json"
+    response_schema = observed_payloads[0]["format"]
+    assert isinstance(response_schema, dict)
+    assert response_schema["type"] == "array"
+    assert response_schema["minItems"] == 3
+    assert response_schema["maxItems"] == 3
+    assert response_schema["items"]["required"] == ["id", "s"]
     step = pipeline.state["steps"]["2.5_qwen_filter"]
     assert step["data"]["errors"] == 0
     assert step["data"]["method"] == "qwen3.5:9b"
     assert pipeline.state["articles"][0]["quality_score"] == 88
+    assert pipeline.state["articles"][2]["quality_score"] == 66


### PR DESCRIPTION
## Outcome

- forces Ollama to return exactly one score for every article in a filter batch
- replaces the loose `format: json` response with a strict JSON array schema
- removes the invalid placeholder example that encouraged partial responses
- preserves non-thinking inference and the existing safe fallback

## Production evidence

Run `20260827_133708` returned only 21 explicit scores for 154 articles (`errors=133`) even though Ollama completed every batch. A direct Pro Ollama probe with the new schema returned the required 3/3 objects.

## Verification

- `ruff check` passed
- focused pytest: 6 passed
- pre-commit and pre-push hooks passed
