### PR TITLE
fix(tests): the xdist guilt probe templated off its own parent's live database

### DIFF
--- a/apps/backend-rag/backend/tests/db/test_xdist_worker_isolation.py
+++ b/apps/backend-rag/backend/tests/db/test_xdist_worker_isolation.py
@@ -51,6 +51,19 @@ def _base_db_name(dsn: str) -> str:
     return dsn.rsplit("/", 1)[-1].split("?", 1)[0]
 
 
+def _xdist_swap_db_name(dsn: str, new_db: str) -> str:
+    """Same shape as conftest's `_xdist_swap_db`, kept local on purpose.
+
+    Importing it would drag in conftest's module-level xdist block, which is
+    exactly what `_load_conftest_module` below goes to lengths to neutralize.
+    """
+    base_part, sep, db_and_query = dsn.rpartition("/")
+    if not sep:
+        raise RuntimeError(f"cannot parse a database name out of DSN {dsn!r}")
+    _, _, query = db_and_query.partition("?")
+    return f"{base_part}/{new_db}" + (f"?{query}" if query else "")
+
+
 @pytest_asyncio.fixture
 async def _require_local_postgres() -> None:
     try:
@@ -73,9 +86,7 @@ async def test_serial_run_still_sees_its_own_rows(_require_local_postgres) -> No
     """
     conn = await asyncpg.connect(os.environ["TEST_DATABASE_URL"])
     try:
-        await conn.execute(
-            "CREATE TABLE IF NOT EXISTS _xdist_serial_probe (marker text NOT NULL)"
-        )
+        await conn.execute("CREATE TABLE IF NOT EXISTS _xdist_serial_probe (marker text NOT NULL)")
         await conn.execute("DELETE FROM _xdist_serial_probe")
         await conn.execute(
             "INSERT INTO _xdist_serial_probe (marker) VALUES ($1)", "serial-innocence"
@@ -87,9 +98,59 @@ async def test_serial_run_still_sees_its_own_rows(_require_local_postgres) -> No
     assert count == 1
 
 
-async def test_two_xdist_workers_do_not_share_a_database(
-    _require_local_postgres, tmp_path
-) -> None:
+_PROBE_BASE_DB_RE = re.compile(r"^[A-Za-z0-9_]+_nestedprobe[0-9]+$")
+
+
+def _pristine_dsn() -> str:
+    """The DSN as it was BEFORE conftest repointed it at a worker clone.
+
+    `pytest_configure` stashes it as `"{pid}:{dsn}"` and only trusts the
+    marker when the pid matches, deliberately, so it does not leak into a
+    child process. Inside the worker process itself the pid DOES match, which
+    is exactly the case this helper needs: it wants the base name the whole
+    run started from, not this worker's private clone.
+    """
+    marker = os.environ.get("_XDIST_PRISTINE_TEST_DATABASE_URL", "")
+    pid, _, dsn = marker.partition(":")
+    if pid == str(os.getpid()) and dsn:
+        return dsn
+    return os.environ["TEST_DATABASE_URL"]
+
+
+async def _create_nested_probe_database(admin_dsn: str, probe_db: str) -> None:
+    if not _PROBE_BASE_DB_RE.fullmatch(probe_db):
+        raise RuntimeError(f"refusing to operate on unsafe database name {probe_db!r}")
+    conn = await asyncpg.connect(admin_dsn)
+    try:
+        await conn.execute(f'DROP DATABASE IF EXISTS "{probe_db}" WITH (FORCE)')
+        await conn.execute(f'CREATE DATABASE "{probe_db}"')
+    finally:
+        await conn.close()
+
+
+async def _drop_nested_probe_databases(admin_dsn: str, probe_db: str) -> None:
+    """Drop the probe base and everything the nested run derived from it.
+
+    Each name is re-checked against a regex before the FORCE drop rather than
+    trusted because it came back from a LIKE (cicatrix-superscar #3: a guard
+    that decides on a prefix is not a guard that decides on a name).
+    """
+    conn = await asyncpg.connect(admin_dsn)
+    try:
+        rows = await conn.fetch(
+            r"SELECT datname FROM pg_database WHERE datname = $1 OR datname LIKE $1 || '\_%'",
+            probe_db,
+        )
+        for row in rows:
+            name = row["datname"]
+            if not re.fullmatch(rf"{re.escape(probe_db)}(_gw\d+|_xdist_template)?", name):
+                continue
+            await conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    finally:
+        await conn.close()
+
+
+async def test_two_xdist_workers_do_not_share_a_database(_require_local_postgres, tmp_path) -> None:
     """Guilt: under `-n 2 --dist loadfile`, two workers' writes to a
     same-named table never collide — because they are two different
     Postgres databases, not one shared one (the #4477/c92ed801 bug this
@@ -97,16 +158,46 @@ async def test_two_xdist_workers_do_not_share_a_database(
     """
     out_dir = tmp_path / "xdist-probe-out"
     out_dir.mkdir()
-    base_db = _base_db_name(os.environ["TEST_DATABASE_URL"])
+
+    # CORRECTED 2026-08-27: this used to hand the child the DSN this test
+    # itself is using, with the comment "pass the same base URL". Under CI's
+    # `-n auto` that URL is NOT a base URL — conftest's `pytest_configure`
+    # already repointed it at THIS worker's private clone
+    # (`nuzantara_test_gw0`), and this process holds live sessions on it. The
+    # child then re-derived its own isolation from that name and ran
+    # `CREATE DATABASE ..._xdist_template TEMPLATE "nuzantara_test_gw0"`
+    # against the database its own parent was using: `ObjectInUseError:
+    # source database is being accessed by other users`, gw node down, zero
+    # tests collected, rc=5, and this test reporting "nested xdist probe run
+    # failed". Measured on run 33045801564 (2026-08-27), where it reddened a
+    # docs-only PR while main was green — whether the parent happens to hold
+    # a session at that instant is a race, which is what made it look flaky
+    # rather than broken.
+    #
+    # Handing down the PRISTINE base URL instead does not fix it: the child's
+    # worker clones would then be named `<base>_gw0`/`_gw1`, which ARE the
+    # outer run's own live worker databases. Both failures are the same
+    # mistake — deriving the child's namespace from a name the parent owns.
+    #
+    # So the child gets a base database of its own, named per-pid, created
+    # here and dropped after. Nothing the outer run owns is ever a template,
+    # a drop target, or a collision.
+    admin_dsn = _admin_dsn(_pristine_dsn())
+    probe_db = f"{_base_db_name(_pristine_dsn())}_nestedprobe{os.getpid()}"
+    await _create_nested_probe_database(admin_dsn, probe_db)
+    base_db = probe_db
 
     env = dict(os.environ)
     env["XDIST_PROBE_OUT"] = str(out_dir)
-    # The probe files resolve their own DSN from TEST_DATABASE_URL — pass
-    # the same base URL this test itself is using (the nested pytest_configure
-    # in the CHILD process will repoint it per-worker exactly like it does
-    # for the real suite).
-    env["TEST_DATABASE_URL"] = os.environ["TEST_DATABASE_URL"]
+    # The probe files resolve their own DSN from TEST_DATABASE_URL; the
+    # nested `pytest_configure` will clone per-worker off THIS name.
+    env["TEST_DATABASE_URL"] = _xdist_swap_db_name(_pristine_dsn(), probe_db)
     env.pop("PYTEST_XDIST_WORKER", None)  # this is the OUTER (possibly already-a-worker) run
+    # Do not let the parent's pristine marker reach the child: it is
+    # pid-guarded, so the child would ignore it anyway, but leaving a stale
+    # `pid:dsn` naming the OUTER base database in the child's environment is
+    # exactly the kind of thing a future reader would trust.
+    env.pop("_XDIST_PRISTINE_TEST_DATABASE_URL", None)
 
     result = subprocess.run(
         [
@@ -129,29 +220,35 @@ async def test_two_xdist_workers_do_not_share_a_database(
         text=True,
         timeout=120,
     )
-    assert result.returncode == 0, (
-        f"nested xdist probe run failed (rc={result.returncode}):\n"
-        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
-    )
+    try:
+        assert result.returncode == 0, (
+            f"nested xdist probe run failed (rc={result.returncode}):\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
 
-    a = json.loads((out_dir / "a.json").read_text())
-    b = json.loads((out_dir / "b.json").read_text())
+        a = json.loads((out_dir / "a.json").read_text())
+        b = json.loads((out_dir / "b.json").read_text())
 
-    worker_db_re = re.compile(rf"^{re.escape(base_db)}_gw\d+$")
-    assert worker_db_re.match(a["db"]), a
-    assert worker_db_re.match(b["db"]), b
-    assert a["db"] != b["db"], (
-        f"both xdist workers used the SAME database ({a['db']!r}) — "
-        "per-worker isolation is broken"
-    )
-    assert a["sources_seen"] == ["A"], (
-        f"worker A saw rows from the other worker: {a['sources_seen']!r} — "
-        "shared-Postgres pollution (the #4477 bug)"
-    )
-    assert b["sources_seen"] == ["B"], (
-        f"worker B saw rows from the other worker: {b['sources_seen']!r} — "
-        "shared-Postgres pollution (the #4477 bug)"
-    )
+        worker_db_re = re.compile(rf"^{re.escape(base_db)}_gw\d+$")
+        assert worker_db_re.match(a["db"]), a
+        assert worker_db_re.match(b["db"]), b
+        assert a["db"] != b["db"], (
+            f"both xdist workers used the SAME database ({a['db']!r}) — "
+            "per-worker isolation is broken"
+        )
+        assert a["sources_seen"] == ["A"], (
+            f"worker A saw rows from the other worker: {a['sources_seen']!r} — "
+            "shared-Postgres pollution (the #4477 bug)"
+        )
+        assert b["sources_seen"] == ["B"], (
+            f"worker B saw rows from the other worker: {b['sources_seen']!r} — "
+            "shared-Postgres pollution (the #4477 bug)"
+        )
+    finally:
+        # Always, including on the assertion failures above: a leaked probe
+        # database would make the NEXT run's `DROP ... WITH (FORCE)` the only
+        # thing standing between it and a name collision.
+        await _drop_nested_probe_databases(admin_dsn, probe_db)
 
 
 def _load_conftest_module():


### PR DESCRIPTION
## The random red

`Backend Shard 2` failed on **#5109 — a docs-only PR** — while `main` was green on every recent run:

```
FAILED backend/tests/db/test_xdist_worker_isolation.py::test_two_xdist_workers_do_not_share_a_database
  AssertionError: nested xdist probe run failed (rc=5):
  [gw1] node down: ...
  asyncpg.exceptions.ObjectInUseError: source database "nuzantara_test_gw0" is being accessed by other users
  DETAIL:  There are 2 other sessions using the database.
```

`rc=5` is pytest's "no tests collected" — the nested run's worker died during collection, so the guard reported "the probe failed" rather than *why*.

## Why

The guilt test spawns a nested `pytest -n 2` and passed it `os.environ["TEST_DATABASE_URL"]`, with the comment *"pass the same base URL this test itself is using"*. Under CI's `-n auto` **that variable is not a base URL**: conftest's `pytest_configure` has already repointed it at *this worker's private clone*, and the process holds live sessions on it. The child then re-derived its own isolation from that name and ran

```sql
CREATE DATABASE <clone>_xdist_template TEMPLATE "nuzantara_test_gw0"
```

…against the database its own parent was using.

**The repo already knew.** Three functions below, `test_old_shape_templating_off_a_live_worker_database_fails` (added 2026-08-25 for job 97847958574) reproduces this exact mechanism and asserts Postgres must refuse — and conftest's own scar comment names *"any re-derivation of `base_db` AFTER that overwrite"* as the trigger. A nested subprocess **is** such a re-derivation. That fix cured `_xdist_clone_worker_database`; the probe that drives it was left committing the shape the same file forbids.

Whether the parent holds a session at that instant is a race — which is what made a structural defect read as a flake, and why `main` looked fine.

## The fix

Handing down the **pristine** base URL is *not* the fix: the child's clones would then be named `<base>_gw0`/`_gw1`, which **are** the outer run's own live worker databases. Both failures are one mistake — deriving the child's namespace from a name the parent owns.

So the child gets a **per-pid base database of its own**, created before the run and dropped in a `finally` (including on assertion failure — a leaked probe DB would otherwise make the next run's `DROP ... WITH (FORCE)` the only thing standing between it and a collision). Every drop target is re-checked against a regex rather than trusted for its prefix (superscar #3), and the parent's pid-guarded pristine marker is popped from the child's env so a future reader cannot trust a stale `pid:dsn`.

## Proof — deterministic, not a hoped-for repro

The race does not fire on an idle local machine, so it was made deterministic: hold 2 live sessions on the stand-in parent clone, then run the nested command both ways.

| shape | rc | ObjectInUseError |
|---|---|---|
| old (child templates off the parent's live db) | **5** | **yes** |
| new (child gets its own base db) | **0** | no |

The file then passes **5/5 serially and under `-n 2 --dist loadfile`**, and `psql -l` shows no leftover `nuzantara_test_{gw,nestedprobe,xdist}*` database afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)