### PR TITLE
fix(garuda): the read-only tracker 503s when the PAYMENT key is absent

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_orders_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_orders_router.py
@@ -216,7 +216,9 @@ async def create_order_from_check(
         # and it keeps "wrong owner" and "no such result" indistinguishable
         # to the caller, closing the enumeration oracle a distinct status
         # code would open.
-        raise HTTPException(status_code=404, detail={"code": "RESULT_NOT_FOUND", "retryable": False})
+        raise HTTPException(
+            status_code=404, detail={"code": "RESULT_NOT_FOUND", "retryable": False}
+        )
     try:
         applicant = Applicant(
             full_name=applicant_raw["full_name"],
@@ -275,8 +277,29 @@ async def get_order_and_practice(
     order_id: str,
     request: Request,
     response: Response,
-    repository: GarudaOrderRepository = Depends(get_repository),
 ) -> dict:
+    """Read-only tracker. Deliberately NOT `Depends(get_repository)`.
+
+    It used to declare that dependency and never reference it: the handler
+    answers entirely from `PracticeRepository(pool)` below. FastAPI resolves a
+    parameter dependency before the handler body runs, so the declaration was
+    not inert -- `get_repository` 503s whenever
+    `app.state.garuda_order_repository` is unset, and that object is only ever
+    constructed when `GARUDA_XENDIT_SECRET_KEY` is present
+    (`service_initializer.py` §5.7). Net effect: a customer who had ALREADY
+    PAID could not see their own order the moment the payment credential was
+    absent, rotated badly, or the provider wiring raised -- on a route whose
+    real work needs nothing but the database pool.
+
+    Measured in production 2026-08-27, before the Xendit sandbox account
+    exists: `GET /api/visa/voa/orders/{id}` answered `503
+    SERVICE_UNAVAILABLE`, indistinguishable from the checkout routes that
+    genuinely do need the provider. An availability coupling that buys nothing
+    is the whole defect; removing the parameter is the whole fix.
+
+    The `pool is None` guard below still 503s, correctly: that IS this route's
+    only real dependency.
+    """
     _privacy_headers(response)
     actor = await _require_magic_session_actor(request)
     pool = getattr(request.app.state, "garuda_db_pool", None)

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_ownership.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_ownership.py
@@ -194,7 +194,9 @@ def magic_link_store(pool) -> PostgresMagicLinkStore:
 
 
 @pytest.fixture
-def app(repository: GarudaOrderRepository, pool, magic_link_store: PostgresMagicLinkStore) -> FastAPI:
+def app(
+    repository: GarudaOrderRepository, pool, magic_link_store: PostgresMagicLinkStore
+) -> FastAPI:
     application = FastAPI()
     application.include_router(garuda_orders_router.router)
     application.state.garuda_order_repository = repository
@@ -241,9 +243,7 @@ async def _seed_session(
     )
 
 
-async def _seed_order(
-    pool, *, order_id: str, result_id_ref: str, price_idr: int = 790_000
-) -> None:
+async def _seed_order(pool, *, order_id: str, result_id_ref: str, price_idr: int = 790_000) -> None:
     await pool.execute(
         """
         INSERT INTO garuda_orders (order_id, result_id_ref, case_type, applicant_full_name,
@@ -281,9 +281,7 @@ class TestSessionVerification:
         assert resp.status_code == 401
         assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
 
-    async def test_expired_session_is_rejected(
-        self, pool, client: AsyncClient
-    ) -> None:
+    async def test_expired_session_is_rejected(self, pool, client: AsyncClient) -> None:
         raw_secret = "expired-secret-0000000000000000000000000000"
         await _seed_session(
             pool,
@@ -298,9 +296,7 @@ class TestSessionVerification:
         assert resp.status_code == 401
         assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
 
-    async def test_a_valid_session_reaches_past_the_401(
-        self, pool, client: AsyncClient
-    ) -> None:
+    async def test_a_valid_session_reaches_past_the_401(self, pool, client: AsyncClient) -> None:
         """Positive control: a live, unexpired session gets PAST the auth
         gate (a real ORDER_NOT_FOUND, never SESSION_REQUIRED) -- proves the
         401 tests above are testing the auth gate, not an unrelated 404."""
@@ -325,7 +321,9 @@ class TestGetOrderOwnership:
     ) -> None:
         raw_secret_a = "secret-a-get-000000000000000000000000000"
         await _seed_session(pool, raw_secret=raw_secret_a, result_id="result-a-get-000000000")
-        await _seed_order(pool, order_id="ord_get_owned_by_b_0000", result_id_ref="result-b-get-000000000")
+        await _seed_order(
+            pool, order_id="ord_get_owned_by_b_0000", result_id_ref="result-b-get-000000000"
+        )
 
         resp = await client.get(
             "/api/visa/voa/orders/ord_get_owned_by_b_0000",
@@ -357,8 +355,12 @@ class TestGetOrderOwnership:
             "practice": None,
         }
         # No applicant PII in the response shape, today or after this fix.
-        for pii_key in ("applicant_full_name", "applicant_email", "applicant_phone",
-                        "applicant_passport_number"):
+        for pii_key in (
+            "applicant_full_name",
+            "applicant_email",
+            "applicant_phone",
+            "applicant_passport_number",
+        ):
             assert pii_key not in body
 
 
@@ -551,6 +553,121 @@ class TestDbPoolDegradationIsFiveOhThreeNotFiveHundred:
         )
         resp = await client.get(
             "/api/visa/voa/orders/ord_pool_none_0000000",
+            cookies={_SESSION_COOKIE: raw_secret},
+        )
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["detail"]["code"] == "SERVICE_UNAVAILABLE"
+
+
+# ============================================================
+# The tracker must not need the PAYMENT provider (2026-08-27).
+#
+# `get_order_and_practice` declared `repository: GarudaOrderRepository =
+# Depends(get_repository)` and never referenced it -- the handler answers
+# entirely from `PracticeRepository(pool)`. FastAPI resolves parameter
+# dependencies BEFORE the handler body, so the unused declaration was not
+# inert: `get_repository` 503s whenever `app.state.garuda_order_repository`
+# is unset, and that object is only ever constructed when
+# `GARUDA_XENDIT_SECRET_KEY` is present (`service_initializer.py` §5.7).
+#
+# Net effect, measured in production 2026-08-27 before any Xendit account
+# exists: `GET /api/visa/voa/orders/{id}` answered 503, the same as the
+# checkout routes that genuinely need the provider. A customer who had
+# ALREADY PAID would lose sight of their own order the moment that
+# credential were absent or badly rotated -- on a read-only route whose
+# real work needs nothing but the database pool.
+#
+# The class above is this one's mirror: it degrades ONLY the pool and keeps
+# the repository working. This one degrades ONLY the repository and keeps
+# the pool working, and the second test proves the removal was surgical --
+# a route that really does need the repository must still 503.
+# ============================================================
+
+
+class TestTrackerDoesNotDependOnThePaymentProvider:
+    async def _app_without_repository(
+        self,
+        pool,
+        magic_link_store: PostgresMagicLinkStore,
+        *,
+        raw_secret: str,
+        result_id: str,
+        repository_state: str,  # "absent" or "none"
+    ) -> AsyncClient:
+        await _seed_session(pool, raw_secret=raw_secret, result_id=result_id)
+        application = FastAPI()
+        application.include_router(garuda_orders_router.router)
+        # Everything the tracker legitimately needs IS wired: a real pool and
+        # the real session verifier. Only `garuda_order_repository` is missing
+        # -- which is exactly production's state whenever no Xendit key is set.
+        application.state.garuda_db_pool = pool
+        application.state.garuda_magic_session_verifier = magic_link_store.verify_session
+        if repository_state == "none":
+            application.state.garuda_order_repository = None
+        # else "absent": never set, the shape §5.7 actually leaves behind.
+        return AsyncClient(transport=ASGITransport(app=application), base_url="http://t")
+
+    @pytest.mark.parametrize("repository_state", ["absent", "none"])
+    async def test_tracker_answers_without_a_payment_provider_wired(
+        self, pool, magic_link_store: PostgresMagicLinkStore, repository_state: str
+    ) -> None:
+        """GUILT: red before the fix (503), green after (404).
+
+        404 and not 200 only because no order is seeded -- the point is that
+        the answer comes from THIS ROUTE'S OWN LOGIC instead of being
+        short-circuited by an unrelated dependency. Asserting `!= 503` alone
+        would also pass on a 500, so the exact code and body are pinned.
+        """
+        raw_secret = f"secret-tracker-norepo-{repository_state}-000000"
+        client = await self._app_without_repository(
+            pool,
+            magic_link_store,
+            raw_secret=raw_secret,
+            result_id=f"result-tracker-norepo-{repository_state[:4]}",
+            repository_state=repository_state,
+        )
+        resp = await client.get(
+            "/api/visa/voa/orders/ord_tracker_norepo_0000",
+            cookies={_SESSION_COOKIE: raw_secret},
+        )
+        assert resp.status_code == 404, (
+            f"the read-only tracker answered {resp.status_code} with no payment provider "
+            f"wired: {resp.text}. A paid customer cannot see their own order because a "
+            "credential they never touch is absent."
+        )
+        assert resp.json()["detail"]["code"] == "ORDER_NOT_FOUND"
+
+    async def test_creating_an_order_still_503s_without_the_repository(
+        self, pool, magic_link_store: PostgresMagicLinkStore
+    ) -> None:
+        """INNOCENCE: the removal was surgical, not a blanket decoupling.
+
+        `POST /orders` genuinely needs the repository (it creates the checkout
+        session through the provider). If this ever stops being a 503, the
+        dependency was removed from a route that needs it, and the failure
+        would surface as a 500 mid-purchase instead of a retryable 503.
+        """
+        raw_secret = "secret-tracker-create-503-0000000000000"
+        client = await self._app_without_repository(
+            pool,
+            magic_link_store,
+            raw_secret=raw_secret,
+            result_id="result-tracker-create-50",
+            repository_state="absent",
+        )
+        resp = await client.post(
+            "/api/visa/voa/orders",
+            json={
+                "result_id": "result-tracker-create-50",
+                "review_confirmed": True,
+                "applicant": {
+                    "full_name": "Test Traveller",
+                    "email": "tracker-e2e@example.invalid",
+                    "phone": "+390000000000",
+                    "passport_number": "SYNTHETIC000",
+                },
+            },
+            headers={"Idempotency-Key": uuid.uuid4().hex},
             cookies={_SESSION_COOKIE: raw_secret},
         )
         assert resp.status_code == 503, resp.text


### PR DESCRIPTION
## The defect

`get_order_and_practice` — the order tracker, a **read-only** route — declared:

```python
repository: GarudaOrderRepository = Depends(get_repository),
```

…and never referenced it. The handler answers entirely from `PracticeRepository(pool)`.

FastAPI resolves parameter dependencies **before** the handler body runs, so the unused declaration was not inert: `get_repository` 503s whenever `app.state.garuda_order_repository` is unset, and that object is only ever constructed when `GARUDA_XENDIT_SECRET_KEY` is present (`service_initializer.py` §5.7).

**Measured in production 2026-08-27**, before any Xendit sandbox account exists:

```
GET /api/visa/voa/orders/{id} → 503 {"code":"SERVICE_UNAVAILABLE","retryable":true}
```

— indistinguishable from the checkout routes that genuinely *do* need the provider. So a customer who had **already paid** would lose sight of their own order the moment that credential were absent, badly rotated, or its wiring raised — on a route whose real work needs nothing but the database pool.

An availability coupling that buys nothing is the whole defect; removing the parameter is the whole fix. The route's `pool is None` guard still 503s, correctly — that **is** its only real dependency.

**Is this a class or an instance?** An AST pass over every route in the file counted references to the `repository` parameter inside each handler:

| route | uses | verdict |
|---|---|---|
| `POST /orders` | 1 | used |
| `GET /orders/{order_id}` | **0** | **dead** |
| `POST /orders/{id}/browser-return-observations` | 1 | used |
| `POST /webhooks/payment` | 3 | used |
| `POST /staff/orders/{id}/late-resolution` | 1 | used |

Exactly one. This is the whole surface.

## Guilt + innocence

Added to the class that mirrors it — the neighbouring `TestDbPoolDegradation…` degrades only the *pool* and keeps the repository working; this one degrades only the *repository* and keeps the pool working:

- **guilt**, parametrized over `absent` and explicit `None` (the two states §5.7 can leave behind): the tracker must answer **404 `ORDER_NOT_FOUND`** from its own logic. Asserting `!= 503` would also pass on a 500, so the exact code and body are pinned.
- **innocence**: `POST /orders` against the same app must **still 503** — proof the removal was surgical. If that ever goes green, the dependency was dropped from a route that needs it, and a mid-purchase failure would surface as a 500 instead of a retryable 503.

## Measured

| run | result |
|---|---|
| dead parameter restored | **both guilt tests red**, with production's exact response |
| fix in place, whole file | **15/15 pass** |
| surrounding garuda surface (`app/routers/`, `security/`, `garuda_orders/`, `garuda_portal/`) | **371 passed, 1 skipped** (pre-existing: `visa_types` absent locally) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)