### PR TITLE
fix(garuda): the Xendit key and its callback token are ONE credential — arming half took money and delivered nothing

### DIFF
--- a/apps/backend-rag/backend/app/setup/service_initializer.py
+++ b/apps/backend-rag/backend/app/setup/service_initializer.py
@@ -1274,8 +1274,12 @@ async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
             # (TEST/STAGING/PRODUCTION, migration 285's CHECK constraint),
             # distinct from `settings.environment` ("production"/"staging"/
             # "development"), never derived from it by string-casing alone.
-            garuda_environment = os.environ.get("GARUDA_ENVIRONMENT", "PRODUCTION").strip() or "PRODUCTION"
-            garuda_magic_link_store = PostgresMagicLinkStore(db_pool, environment=garuda_environment)
+            garuda_environment = (
+                os.environ.get("GARUDA_ENVIRONMENT", "PRODUCTION").strip() or "PRODUCTION"
+            )
+            garuda_magic_link_store = PostgresMagicLinkStore(
+                db_pool, environment=garuda_environment
+            )
 
             # `garuda_orders_router._require_magic_session_actor` reads this
             # directly off app.state (L3's file, LANES.md file-ownership —
@@ -1331,9 +1335,7 @@ async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
                 "⚠️ GARUDA VOA magic-link wiring failed (non-critical, L3/L4 fail closed): %s", e
             )
     else:
-        logger.warning(
-            "⚠️ GARUDA VOA magic-link wiring skipped: no db_pool (L3/L4 fail closed)"
-        )
+        logger.warning("⚠️ GARUDA VOA magic-link wiring skipped: no db_pool (L3/L4 fail closed)")
 
     # 5.6 GARUDA VOA — CheckStore wiring (L2). Unconditional, unlike the
     # order/payment wiring below: `PostgresCheckStore.create()` runs its
@@ -1420,7 +1422,24 @@ async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
     # success/failure split anyway (browser return is an OBSERVATION, not a
     # truth).
     garuda_xendit_secret_key = os.environ.get("GARUDA_XENDIT_SECRET_KEY", "").strip()
-    if db_pool is not None and garuda_xendit_secret_key:
+    garuda_xendit_callback_token = os.environ.get("GARUDA_XENDIT_CALLBACK_TOKEN", "").strip()
+    if garuda_xendit_secret_key and not garuda_xendit_callback_token:
+        # Named out loud, because this pair used to be armable by halves. The
+        # gate below required only the secret key while the callback token
+        # defaulted to `""` — which opens checkout and then makes EVERY Xendit
+        # callback answer 401 (`xendit.py::verify_signature`; measured
+        # 2026-08-27). The customer is really charged and the order never
+        # leaves `awaiting_payment`. `XenditPaymentProvider.__init__` now
+        # refuses that construction outright, so without this branch the whole
+        # order lane would fail closed with a ValueError swallowed by the
+        # `except Exception` below and one generic "wiring failed" line. This
+        # says WHICH half is missing instead.
+        logger.error(
+            "⛔ GARUDA VOA order lane NOT wired: GARUDA_XENDIT_SECRET_KEY is set but "
+            "GARUDA_XENDIT_CALLBACK_TOKEN is empty. Arming the key alone would open "
+            "checkout while rejecting every payment callback — set both or neither."
+        )
+    if db_pool is not None and garuda_xendit_secret_key and garuda_xendit_callback_token:
         try:
             import httpx as _garuda_httpx
 
@@ -1433,9 +1452,7 @@ async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
             garuda_payment_http_client = _garuda_httpx.AsyncClient(timeout=30.0)
             garuda_payment_provider = XenditPaymentProvider(
                 secret_key=garuda_xendit_secret_key,
-                callback_verification_token=os.environ.get(
-                    "GARUDA_XENDIT_CALLBACK_TOKEN", ""
-                ).strip(),
+                callback_verification_token=garuda_xendit_callback_token,
                 public_base_url=os.environ.get(
                     "GARUDA_PUBLIC_BASE_URL", "https://balizero.com"
                 ).strip(),
@@ -1470,7 +1487,6 @@ async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
             db_pool is not None,
             bool(garuda_xendit_secret_key),
         )
-
 
 
 async def initialize_services(app: FastAPI) -> None:
@@ -1695,9 +1711,7 @@ async def initialize_services(app: FastAPI) -> None:
             app.state.self_healing_task = asyncio.create_task(
                 healing_agent.monitoring_loop(), name="self_healing"
             )
-            service_registry.register(
-                "self_healing", ServiceStatus.HEALTHY, critical=False
-            )
+            service_registry.register("self_healing", ServiceStatus.HEALTHY, critical=False)
             logger.info("✅ Reduced self-healing agent: Active (GC-only, 5min, per-machine)")
         except Exception as e:
             service_registry.register(

--- a/apps/backend-rag/backend/services/payments/xendit.py
+++ b/apps/backend-rag/backend/services/payments/xendit.py
@@ -98,6 +98,31 @@ class XenditPaymentProvider:
             raise ValueError(
                 "XenditPaymentProvider requires a sandbox (xnd_development_) secret key"
             )
+        if not callback_verification_token.strip():
+            # The SECOND half of the credential, and the one that fails
+            # SILENTLY when forgotten. `verify_signature` below rejects on
+            # `not received or not hmac.compare_digest(received, token)`: with
+            # an empty configured token, EVERY input is rejected — measured
+            # 2026-08-27 against this class, including a header carrying an
+            # arbitrary value, because `compare_digest(x, "")` is False for
+            # any non-empty x. That is not a security hole (nothing gets in),
+            # it is a money hole: `service_initializer.py` §5.7 arms the whole
+            # order lane on `GARUDA_XENDIT_SECRET_KEY` alone and reads THIS
+            # token with a `""` default, so setting one env var and forgetting
+            # the other opens checkout while making every legitimate Xendit
+            # callback answer 401. The customer is really charged, the order
+            # never leaves `awaiting_payment`, and nothing surfaces to them.
+            #
+            # Refusing construction here rather than only in §5.7 is
+            # deliberate: this is the one place every caller must pass, so a
+            # future second call site cannot reintroduce the hole. A provider
+            # that can never verify a callback is not a degraded provider, it
+            # is a provider that must not exist.
+            raise ValueError(
+                "XenditPaymentProvider requires a non-empty callback_verification_token: "
+                "with an empty one, every Xendit callback is rejected and paid orders "
+                "never advance (set GARUDA_XENDIT_CALLBACK_TOKEN)"
+            )
         self._secret_key = secret_key
         self._callback_verification_token = callback_verification_token
         # `public_base_url` is the ONE thing this adapter needs to reach the

--- a/apps/backend-rag/backend/tests/services/payments/test_xendit_callback_token_guard.py
+++ b/apps/backend-rag/backend/tests/services/payments/test_xendit_callback_token_guard.py
@@ -1,0 +1,124 @@
+"""A provider that can never verify a callback must not be constructible.
+
+WHY. `verify_signature` rejects on
+`not received or not hmac.compare_digest(received, self._callback_verification_token)`.
+With an empty configured token that is EVERY input — measured 2026-08-27
+against this class, including a header carrying an arbitrary value, because
+`compare_digest(x, "")` is False for any non-empty x.
+
+Nothing gets in, so this is not a security hole. It is a money hole:
+`service_initializer.py` §5.7 armed the whole order lane on
+`GARUDA_XENDIT_SECRET_KEY` alone while reading the callback token with a `""`
+default. Setting one env var and forgetting the other opened checkout and made
+every legitimate Xendit callback answer 401 — the customer really charged, the
+order never leaving `awaiting_payment`, and nothing surfacing to them.
+
+Guilt and innocence for both halves of that pair.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from backend.services.payments.port import WebhookSignatureInvalid
+from backend.services.payments.xendit import XenditFeeConfig, XenditPaymentProvider
+
+_FEE = XenditFeeConfig(percentage_bps=350, fixed_idr=6000)
+
+
+def _client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(lambda _r: httpx.Response(200, json={})))
+
+
+def _build(*, secret_key: str = "xnd_development_fake", token: str) -> XenditPaymentProvider:
+    return XenditPaymentProvider(
+        secret_key=secret_key,
+        callback_verification_token=token,
+        public_base_url="https://example.invalid",
+        fee_config=_FEE,
+        client=_client(),
+    )
+
+
+class TestTheConstructorRefusesAnUnverifiableProvider:
+    @pytest.mark.parametrize("token", ["", " ", "\t", "\n  "])
+    def test_an_empty_or_blank_callback_token_is_refused(self, token: str) -> None:
+        """Blank, not just empty: `os.environ.get(...).strip()` yields `""` for
+        a var set to whitespace, but a direct caller can still pass `" "`."""
+        with pytest.raises(ValueError, match="callback_verification_token"):
+            _build(token=token)
+
+    def test_the_error_names_the_env_var_an_operator_must_set(self) -> None:
+        """The message is the whole value of failing here rather than later.
+
+        A bare `ValueError` would be swallowed by §5.7's `except Exception` and
+        surface as one generic "wiring failed" line, leaving whoever armed the
+        key to guess which half is missing.
+        """
+        with pytest.raises(ValueError) as exc:
+            _build(token="")
+        message = str(exc.value)
+        assert "GARUDA_XENDIT_CALLBACK_TOKEN" in message
+        assert "never advance" in message or "rejected" in message
+
+    def test_a_real_token_still_constructs(self) -> None:
+        """Innocence: the guard rejects the unusable case, not the usable one."""
+        provider = _build(token="a-real-callback-token")
+        assert provider is not None
+
+    def test_the_sandbox_key_guard_is_unchanged(self) -> None:
+        """The pre-existing half of the pair, pinned so this PR cannot have
+        loosened it while adding the second."""
+        with pytest.raises(ValueError, match="sandbox"):
+            _build(secret_key="xnd_production_looks_real", token="a-real-callback-token")
+
+
+class TestWhatTheEmptyTokenWouldHaveDone:
+    """The behaviour the constructor guard now makes unreachable.
+
+    Kept as a live test rather than a comment: it drives the REAL
+    `verify_signature` against a provider whose token is emptied AFTER
+    construction, so if someone ever relaxes the constructor guard, these
+    assertions still describe exactly what they would be re-enabling.
+    """
+
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {},
+            {"x-callback-token": ""},
+            {"x-callback-token": "anything"},
+            {"X-Callback-Token": "anything"},
+        ],
+    )
+    def test_every_callback_is_rejected_when_the_token_is_empty(
+        self, headers: dict[str, str]
+    ) -> None:
+        provider = _build(token="placeholder-to-pass-the-guard")
+        provider._callback_verification_token = ""  # the state §5.7 used to allow
+        with pytest.raises(WebhookSignatureInvalid):
+            provider.verify_signature(raw_body=b"{}", headers=headers)
+
+    def test_a_correct_token_is_accepted_case_insensitively(self) -> None:
+        """Innocence for the verifier itself: with a real token, the header is
+        matched regardless of case.
+
+        Collects what was accepted and asserts the exact set rather than
+        relying on "no exception was raised" — a test whose only claim is the
+        absence of a throw states nothing a reader (or a linter) can check, and
+        would keep passing if `verify_signature` became a no-op.
+        """
+        provider = _build(token="real-token")
+        casings = ("x-callback-token", "X-Callback-Token", "X-CALLBACK-TOKEN")
+        accepted = []
+        for header in casings:
+            try:
+                provider.verify_signature(raw_body=b"{}", headers={header: "real-token"})
+            except WebhookSignatureInvalid:
+                continue
+            accepted.append(header)
+        assert accepted == list(casings), (
+            f"only {accepted} accepted out of {list(casings)} — HTTP header names are "
+            "case-insensitive and Xendit's exact casing is not something to depend on"
+        )

--- a/docs/plans/2026-08-24-garuda-voa-live/WHEN-THE-PAYMENT-KEYS-ARRIVE.md
+++ b/docs/plans/2026-08-24-garuda-voa-live/WHEN-THE-PAYMENT-KEYS-ARRIVE.md
@@ -53,18 +53,42 @@ route and `get_repository()` already answer with a fail-closed **503**. That is 
 
 Set these four on `nuzantara-rag`:
 
-| Variable                       | Read at                    | Note                                                                       |
-| ------------------------------ | -------------------------- | -------------------------------------------------------------------------- |
-| `GARUDA_XENDIT_SECRET_KEY`     | `service_initializer:1478` | **The gate.** Must start `xnd_development_` or startup raises ValueError.  |
-| `GARUDA_XENDIT_CALLBACK_TOKEN` | `service_initializer:1492` | Verifies the `x-callback-token` header on every webhook (`xendit.py:175`). |
-| `GARUDA_XENDIT_FEE_BPS`        | `service_initializer:1499` | **Defaults to `"0"`.**                                                     |
-| `GARUDA_XENDIT_FEE_FIXED_IDR`  | `service_initializer:1500` | **Defaults to `"0"`.**                                                     |
+| Variable                       | Read at                    | Note                                                                                                                     |
+| ------------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `GARUDA_XENDIT_SECRET_KEY`     | `service_initializer:1478` | **The gate.** Must start `xnd_development_` or startup raises ValueError.                                                |
+| `GARUDA_XENDIT_CALLBACK_TOKEN` | `service_initializer` §5.7 | **Also a gate, as of 2026-08-27.** Verifies `x-callback-token` on every webhook. Empty is no longer armable — see below. |
+| `GARUDA_XENDIT_FEE_BPS`        | `service_initializer:1499` | **Defaults to `"0"`.**                                                                                                   |
+| `GARUDA_XENDIT_FEE_FIXED_IDR`  | `service_initializer:1500` | **Defaults to `"0"`.**                                                                                                   |
 
 Two more are already correct and need no action:
 
 - `GARUDA_PUBLIC_BASE_URL` — defaults to `https://balizero.com` (`service_initializer:1496`), the
   canonical apex. `www.` 308-redirects to it.
 - `GARUDA_ENVIRONMENT` — defaults to `"PRODUCTION"` (`service_initializer:1432`, `:1506`).
+
+⚠️ **The key and the token are ONE credential — arming half of it takes real money and delivers
+nothing.** Corrected 2026-08-27, after measuring it. `verify_signature` rejects on
+`not received or not hmac.compare_digest(received, token)`, so with an **empty configured token
+EVERY input is rejected** — including a header carrying an arbitrary value, because
+`compare_digest(x, "")` is False for any non-empty `x`. Nothing gets in, so this was never a
+security hole. It was a money hole: the arming gate required only `GARUDA_XENDIT_SECRET_KEY` while
+this token defaulted to `""`, so setting one variable and forgetting the other **opened checkout
+while making every legitimate Xendit callback answer 401**. The customer is really charged, the
+order never leaves `awaiting_payment`, and nothing surfaces to them — the only trace is a 401 in
+the Fly logs that nothing alerts on.
+
+That shape is now unreachable rather than merely documented:
+
+- `XenditPaymentProvider.__init__` refuses a blank `callback_verification_token` outright, next to
+  the existing sandbox-key guard — one place every caller must pass, so a future second call site
+  cannot reintroduce it.
+- §5.7 requires BOTH variables before it arms anything, and logs which half is missing by name
+  instead of letting a `ValueError` become one generic "wiring failed" line.
+- Guilt + innocence: `backend/tests/services/payments/test_xendit_callback_token_guard.py`. Removing
+  the constructor guard turns 5 of them red.
+
+So: **set both, or neither.** Setting only the key now fails closed with a named error, which is the
+correct outcome — but it is still a wasted deploy, so set them in the same `fly secrets set` call.
 
 ⚠️ **The two fee variables default to zero, silently.** Those figures must come from the actual
 Xendit contract — they are not in this repo and must not be guessed here. Leaving them at `0` does


### PR DESCRIPTION
## Measured, not reasoned

`verify_signature` rejects on `not received or not hmac.compare_digest(received, token)`. Probed against the real class:

```
Configured token EMPTY (the default if the var is forgotten):
  no x-callback-token header at all       -> rejected
  header present but empty                -> rejected
  header with an arbitrary value          -> rejected
```

All three rejected — `compare_digest(x, "")` is False for any non-empty `x`. **Nothing gets in, so this was never a security hole.**

## It was a money hole

`service_initializer.py` §5.7 armed the **entire order lane** on `GARUDA_XENDIT_SECRET_KEY` alone, while reading `GARUDA_XENDIT_CALLBACK_TOKEN` with a `""` default.

So setting one variable and forgetting the other **opened checkout** and made every legitimate Xendit callback answer **401**:

- the customer is really charged,
- the order never leaves `awaiting_payment`,
- nothing surfaces to them,
- and the only trace is a 401 in the Fly logs that nothing alerts on.

The keys arrive in days. This was a trap laid directly in front of the next person to touch it.

## The fix makes the shape unreachable, not merely documented

- **`XenditPaymentProvider.__init__` refuses a blank `callback_verification_token`**, beside the existing sandbox-key guard. Placed there and not only in §5.7 deliberately: it is the one place every caller must pass, so a future second call site cannot reintroduce the hole. *A provider that can never verify a callback is not a degraded provider — it is one that must not exist.*
- **§5.7 requires both variables** before it arms anything, and logs **which half is missing, by name**. Without that branch the new `ValueError` would be swallowed by the surrounding `except Exception` and surface as one generic "wiring failed" line — the same guessing game, one layer down.

No caller was constructing the provider with an empty token (every call site checked: §5.7 is the only production one, all tests pass real strings), so the guard breaks nothing.

## Guilt + innocence

`backend/tests/services/payments/test_xendit_callback_token_guard.py`:

- blank **and whitespace** tokens refused (a direct caller can pass `" "` where `os.environ.get(...).strip()` would have yielded `""`);
- the error **names the env var** — a bare `ValueError` is useless to whoever just armed the key;
- a real token still constructs (innocence);
- the pre-existing **sandbox-key guard pinned**, so this change cannot have loosened one half while adding the other;
- a second class drives the **real** `verify_signature` against a post-construction-emptied token, so the behaviour the guard makes unreachable stays described in executable form if anyone ever relaxes it.

**The pre-commit anti-reward-hacking lint caught my own test and was right**: the case-insensitivity test originally asserted nothing — "no exception was raised" states nothing a reader can check and would survive `verify_signature` becoming a no-op. It now collects the accepted casings and asserts the exact set.

| run | result |
|---|---|
| constructor guard removed | **5 red** |
| restored — payments + garuda_orders + app/routers + setup | **763 passed**, 1 xfailed (pre-existing, ledgered) |

## Runbook

`WHEN-THE-PAYMENT-KEYS-ARRIVE.md`'s row for this variable said only what it *does*, never what happens if you forget it. It now says both, and **"set both, or neither"** — in the same `fly secrets set` call, since setting only the key now fails closed with a named error but still wastes a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)