### PR TITLE
docs(garuda): the live walk — what production actually answers, leg by leg

### DIFF
--- a/docs/plans/2026-08-24-garuda-voa-live/LIVE-WALK-2026-08-27.md
+++ b/docs/plans/2026-08-24-garuda-voa-live/LIVE-WALK-2026-08-27.md
@@ -1,0 +1,53 @@
+# GARUDA VOA — the live walk, 2026-08-27
+
+What a real visitor gets from production **today**, measured leg by leg with `curl` against
+`https://nuzantara-rag.fly.dev`, with the Xendit half simulated (no payment keys are armed).
+This is a measurement record, not a plan: every row below is an observed HTTP response, and the
+arming steps live in [`WHEN-THE-PAYMENT-KEYS-ARRIVE.md`](WHEN-THE-PAYMENT-KEYS-ARRIVE.md).
+
+**Build measured:** `/health` reported `build_sha 6c47f3beb3` (PR #5102). Main was 3 commits
+ahead at the time — `#5109` (docs), `#5110` (a test file), `#5111` (a test file): **no production
+code**, so the walk describes the true live behaviour and no deploy was owed. Stated explicitly
+because "prod is behind main" is normally a reason to distrust a live measurement; here it is
+checkable that it is not.
+
+## The four layers
+
+| Leg | Request                                                     | Live result                                                                                                  | Reading                                                                                                                                                                                                                                                   |
+| --- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `POST /api/visa/voa/eligibility-checks`                     | **201** `{"verdict":"ACCEPT","reason_codes":[],"published_filing_deadline":"2026-09-26","price_idr":790000}` | **Live.** One all-inclusive price, the published D-7 deadline, no fee/PNBP split.                                                                                                                                                                         |
+| 1a  | same, no `Idempotency-Key`                                  | **400** `IDEMPOTENCY_KEY_REQUIRED`                                                                           | The header is mandatory on the _check_, not only on the order.                                                                                                                                                                                            |
+| 1b  | same key replayed                                           | **201**, _same_ `result_id`                                                                                  | A double-click on Check does not create a second check.                                                                                                                                                                                                   |
+| 2   | `GET …/eligibility-checks/{id}` **with** the session cookie | **200**, byte-identical payload                                                                              | Reloading the result page works.                                                                                                                                                                                                                          |
+| 2b  | same URL, **no** cookie                                     | **404** `RESULT_NOT_FOUND`                                                                                   | A forwarded link reveals nothing — and it is 404, not 403, so it does not even confirm the id exists.                                                                                                                                                     |
+| 2c  | same URL, **forged** cookie                                 | **404** `RESULT_NOT_FOUND`                                                                                   | Same shape as 2b: the guard leaks no signal by error code.                                                                                                                                                                                                |
+| 3   | `POST …/orders`                                             | **503** `SERVICE_UNAVAILABLE` + `correlation_id`                                                             | **Fail-closed, by design** — `GARUDA_XENDIT_SECRET_KEY` is unset, so the lane is never wired. Not a code gap.                                                                                                                                             |
+| 4   | `POST …/auth/magic-links` (malformed body on purpose)       | **422** `INVALID_REQUEST` with the funnel's own `message_key`                                                | **The passwordless-account lane is live and NOT gated on Xendit.** Only its _delivery_ is unverified — see below.                                                                                                                                         |
+| 5   | `GET …/orders/{unknown-uuid}`                               | **503** `SERVICE_UNAVAILABLE`                                                                                | **Should be 404.** The tracker is coupled to the payment credential; PR #5112 decouples it.                                                                                                                                                               |
+| 6   | `POST …/webhooks/payment`, unsigned                         | **503**                                                                                                      | Fail-closed. An attacker cannot forge a paid callback today because the whole lane is dark.                                                                                                                                                               |
+| —   | `GET https://balizero.com/visa/voa`                         | **HTTP 200** whose body is a Next.js 404                                                                     | The public page is **dark on Vercel**. `GARUDA_PUBLIC_ENABLED` is on for Fly and off for Vercel — two platforms, one variable name, independent. A status-code-only probe reads this as healthy; only a body grep for `NEXT_HTTP_ERROR_FALLBACK` sees it. |
+
+## What legs 1-2 also prove, beyond the verdict
+
+The 201 carries `Location: /visa/voa/<id>` and `Set-Cookie: garuda_result_session=…; Domain=.balizero.com;
+HttpOnly; Path=/; SameSite=none; Secure` — **the result id is not in the response body**, so a client
+that reads only the JSON cannot advance. Alongside them: `cache-control: no-store, private`,
+`referrer-policy: no-referrer`, `x-robots-tag: noindex, nofollow, noarchive`, and a visible
+`x-ratelimit-limit: 120`. No applicant field appears in any URL.
+
+## The two things this walk could NOT establish
+
+1. **Magic-link delivery.** The endpoint answers correctly, but completing the account leg needs the
+   token from the email, and no mailbox is readable from a session. Deliberately not worked around:
+   the alternative would have been sending a real magic link to a real address, or minting a token
+   out of band. Its _endpoint_ is proven; its _delivery_ is not.
+2. **The `PRODUCTION` retention-policy row** (`environment='PRODUCTION'`, `policy_scope='GARUDA_ORDER'`).
+   The read-only Postgres MCP is not armed in the session that ran this walk, so this is **NOT
+   VERIFIABLE from here** — it is not "verified absent", and it stays a pre-arm blocker.
+
+## The one live defect this walk found
+
+Leg 5 answering **503 instead of 404** is a real coupling: reading a tracker asked production for a
+payment credential it does not need. PR #5112 removes it, and the leg-5 row is the live evidence for
+that PR — the test suite alone could not have shown it, because the suite wires the repository it is
+testing. Re-run leg 5 after #5112 deploys; the expected answer is `404 ORDER_NOT_FOUND`.


### PR DESCRIPTION
Measured against production with `curl` on 2026-08-27, with the Xendit half simulated. Every row in the file is an observed HTTP response, not a plan.

## What it establishes

- **Legs 1-2 are live.** `201 ACCEPT`, `790000` IDR, published deadline `2026-09-26`; reload with the session cookie returns the byte-identical payload.
- **The ownership guard leaks nothing.** A forwarded link with **no** cookie and a link with a **forged** cookie both answer `404 RESULT_NOT_FOUND` — the same shape, so the error code does not even confirm the id exists.
- **Idempotency holds on the check, not just the order.** Missing header → `400 IDEMPOTENCY_KEY_REQUIRED`; the same key replayed returns the *same* `result_id`.
- **Legs 3-6 fail closed for one named reason** — `GARUDA_XENDIT_SECRET_KEY` unset. By design, not a code gap.
- **The passwordless-account lane is live and NOT gated on Xendit** (`422` with the funnel's own `message_key`). That was not previously established.

## Two things it corrects

1. **The public page is dark on Vercel and answers HTTP 200.** The body is a Next.js 404. A status-code-only probe reads it as healthy — only a body grep for `NEXT_HTTP_ERROR_FALLBACK` sees the truth. `GARUDA_PUBLIC_ENABLED` exists independently on Fly and on Vercel; Fly is on, Vercel is off.
2. **The tracker answers 503 where it should answer 404.** Reading a tracker asked production for a payment credential it does not need. This is the **live evidence for PR #5112**, and the suite alone could not have produced it, because the suite wires the repository under test.

## Two things it deliberately does NOT claim

- **Magic-link delivery is unverified.** The endpoint answers correctly, but completing the account leg needs the token from the email and no mailbox is readable from a session. Not worked around: the alternatives were sending a real magic link to a real address, or minting a token out of band.
- **The `PRODUCTION` retention-policy row is NOT VERIFIABLE** from the session that ran the walk — the read-only Postgres MCP is not armed there. That is not "verified absent"; it stays a pre-arm blocker.

## Build provenance, stated because it would otherwise be a reason to distrust this

`/health` reported `build_sha 6c47f3beb3` while main was 3 commits ahead. Those 3 are `#5109` (docs), `#5110` and `#5111` (one test file each) — **no production code**, so the walk describes true live behaviour and no deploy was owed.

Docs-only diff, one new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)