### PR TITLE
docs(garuda): the arming runbook was missing the blocker that fires when you arm

### DIFF
--- a/docs/plans/2026-08-24-garuda-voa-live/WHEN-THE-PAYMENT-KEYS-ARRIVE.md
+++ b/docs/plans/2026-08-24-garuda-voa-live/WHEN-THE-PAYMENT-KEYS-ARRIVE.md
@@ -139,8 +139,27 @@ PERSISTENCE_POLICY_UNAVAILABLE`, indistinguishable from this document's own "key
      `json.dumps`. Double-encoded, the array landed as a JSONB scalar string, and migration 286's
      CHECK calls `jsonb_array_length()` on it: SQLSTATE 22023, escaping as a bare 500 for every
      payload shape. The integration suite passed 10/10 because its pools lacked the codec.
-- ⬜ **Nothing has ever been exercised**: `garuda_voa_check_results` = 0 rows,
-  `garuda_voa_check_idempotency` = 0 rows, `garuda_orders` = 0 rows, `garuda_order_outbox` = 0 rows.
+- ✅ **CORRECTED 2026-08-27 (later the same day): legs 1-2 have now been exercised, and they
+  work.** The "0 rows everywhere" line above this was true when written and is not any more. A live
+  walk as an anonymous visitor produced `201 {"verdict":"ACCEPT","reason_codes":[],
+"published_filing_deadline":"2026-09-26","price_idr":790000}`, a `Location: /visa/voa/<id>` and a
+  `garuda_result_session` cookie (`HttpOnly; Secure; SameSite=none; Domain=.balizero.com`), and a
+  subsequent GET with that cookie returned **200** with the byte-identical payload — so rows really
+  are persisted and readable. `garuda_orders` and `garuda_order_outbox` remain at zero, correctly,
+  because no order can be created without the payment key.
+  **This is the probe the retracted bullet above was missing**, and it can go red: the result id and
+  the session secret come from the response HEADERS (the 201 body carries neither), the same link
+  with **no** cookie and with a **forged** cookie both answer `404 RESULT_NOT_FOUND` — identical
+  shapes, so the error code does not even confirm the id exists — and replaying the same
+  `Idempotency-Key` returns the SAME result id rather than minting a second check. A missing
+  `Idempotency-Key` is rejected `400 IDEMPOTENCY_KEY_REQUIRED`: the header is mandatory on the
+  CHECK, not only on the order.
+- 🟡 **The tracker changed answer on 2026-08-27 and the new answer is the correct one.** It used to
+  return **503** — reading an order's status asked production for a payment credential it does not
+  need. PR #5112 decoupled them, and after the deploy the same request returns
+  **401 `SESSION_REQUIRED`**, measured with no cookie AND with a valid result-session cookie. So the
+  tracker is gated on the **magic-link portal session**, not on the result link — better than
+  assumed, and worth knowing before you read a 401 here as a fault.
 
 **Read this as the lesson it cost.** "Flag on" ≠ "wired" ≠ "works" ≠ "reachable by a visitor" —
 four different claims, and this product satisfied only the first for three days while every gate
@@ -167,6 +186,37 @@ What they cannot prove, and what the sandbox key will test for the first time:
 
 None of these is a reason to delay. They are the reason the first sandbox purchase must be made
 and _watched_, rather than declared once the key is set.
+
+## ⛔ The pre-arm blocker this document was missing — read before setting the keys
+
+**Ten of the thirteen `job_type` values this product enqueues have no handler.** Measured
+2026-08-27: production code enqueues **13** distinct types — twelve from
+`garuda_orders/repository.py`, plus `practice_received_email` from
+`garuda_portal/practice.py::mint_received_practice`, which is the one people miss because it is
+enqueued by the function that mints the practice rather than by the repository. `outbox_handlers.py`
+registers **3**: `payment_paid_email`, `practice_release`, `portal_invite`.
+
+The consumer handles the gap correctly — an unroutable type is counted, logged once per pass, and
+its attempt bump is rolled back so it never marches toward exhaustion. **Nothing pages on it**, and
+that is the exposure. The ten without a handler include:
+
+| Unhandled                                                                               | What it means the moment a real card is used                                                                                                                                                                                  |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payment_failed_email`, `payment_expired_email`, `refund_email`, `checkout_ready_email` | a customer whose card is declined, whose invoice expires, or who is refunded is told nothing                                                                                                                                  |
+| the five `staff_page_*` jobs                                                            | duplicate charge, late-paid-after-refund, late-paid-after-terminal, payment failure, refund-out-of-order — **every money anomaly page reaches nobody**                                                                        |
+| `practice_received_email`                                                               | the practice-received notice. Not silence: `payment_paid_email` IS handled, so a customer who pays successfully does get their payment confirmation — this is a missing second notice, which is why it sits last in this list |
+
+**Why this is latent today and live the instant you arm.** The whole order lane answers 503 while
+`GARUDA_XENDIT_SECRET_KEY` is unset, so none of these jobs is ever produced. Setting the key is
+exactly what starts producing them. The happy path is covered; **every unhappy path is not**, and
+the staff pages for money anomalies are the ones that matter most, because they are the mechanism by
+which a human finds out something went wrong with someone's money.
+
+Full detail, owners and the proof-of-armed criterion are in the `modus` PENDING-ARMS ledger. The
+minimum before a real (not sandbox) purchase: handlers for the four customer emails, a decided
+destination for the five staff pages, and an `unroutable` alarm scoped to types OUTSIDE a
+declared-unbuilt allowlist — an unscoped `unroutable > 0` would fire forever for ten known types,
+which is how a real signal gets muted.
 
 ## The one test purchase that closes all of it
 


### PR DESCRIPTION
Docs-only, one file. Two corrections and one addition, all measured on 2026-08-27.

## The addition, which is the reason this PR exists

`WHEN-THE-PAYMENT-KEYS-ARRIVE.md` is the document someone reads **while setting the keys**. Its "residual risk the keys will expose" section named three real risks — all about whether our payload matches Xendit's contract — and omitted the largest one:

**Ten of the thirteen `job_type` values this product enqueues have no handler, and setting the payment key is precisely what starts producing them.**

| Unhandled | What it means the moment a real card is used |
| --- | --- |
| `payment_failed_email`, `payment_expired_email`, `refund_email`, `checkout_ready_email` | a declined card, an expired invoice, a refund — the customer is told nothing |
| the five `staff_page_*` jobs | duplicate charge, late-paid-after-refund, late-paid-after-terminal, payment failure, refund-out-of-order — **every money-anomaly page reaches nobody** |
| `practice_received_email` | a missing *second* notice, not silence — see below |

The consumer handles the gap correctly (counted, logged, attempt bump rolled back so nothing marches toward exhaustion). **Nothing pages on it** — that is the exposure. The happy path is covered; every unhappy path is not, and the staff pages are the mechanism by which a human finds out something went wrong with someone's money.

The 13th is the one people miss: `practice_received_email` is enqueued by `mint_received_practice`, not by the repository, so counting `job_type="` in `repository.py` alone yields twelve. That undercount reached two artifacts before it was caught.

**Stated without inflation:** `payment_paid_email` **is** handled, so a customer who pays successfully does get their payment confirmation. `practice_received_email` is an additional notice — which is why it sits last in that table rather than first.

## Correction 1 — "nothing has ever been exercised" is no longer true

That bullet claimed 0 rows in all four tables. A live walk as an anonymous visitor returned `201 {"verdict":"ACCEPT","published_filing_deadline":"2026-09-26","price_idr":790000}`, and a GET with the session cookie returned the byte-identical payload — rows persist and are readable. `garuda_orders` / `garuda_order_outbox` remain at zero, correctly: no order can exist without the key.

That walk is also **the probe the document's own retracted bullet admitted it lacked**, and unlike the retracted one it can go red:

- the result id and session secret come from response **headers** — the 201 body carries neither, so a client reading only JSON cannot advance;
- a missing `Idempotency-Key` is rejected `400` (the header is mandatory on the **check**, not just the order), and a replayed one returns the **same** result id;
- the same link answers an identical `404 RESULT_NOT_FOUND` with **no** cookie and with a **forged** cookie — so the error code does not even confirm the id exists.

## Correction 2 — the tracker's answer changed, and the new one is right

It used to return **503**: reading an order's status asked production for a payment credential it does not need. PR #5112 decoupled them, and after that deploy the same request returns **401 `SESSION_REQUIRED`** — measured both with no cookie and with a valid result-session cookie, so the tracker is gated on the **magic-link portal session**, not the result link. Recorded so the next reader does not diagnose that 401 as a fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)