### PR TITLE
fix(backend-rag): make magic-link deny-path timing test direction-aware

### DIFF
--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_magic_link_store_integration.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_magic_link_store_integration.py
@@ -537,13 +537,27 @@ async def test_deny_path_timing_does_not_separate_under_repetition(pool, store):
     tight bound here would be exactly the kind of noisy, non-reproducible
     check this repo's verification discipline warns against. What IS
     reliably true, and what this test actually checks: averaged over many
-    repetitions, no deny path's MEAN latency should separate from the
-    others by an order of magnitude — a real "return immediately on no
-    row" shortcut would show up as a large, not a marginal, gap even
-    through CI noise. The tolerance below (5x) is deliberately generous;
-    it exists to catch a gross regression, not to certify constant-time
-    behaviour (the class docstring explains why true constant-time against
-    the underlying Postgres index is not attempted here at all).
+    repetitions, the unknown-token deny path's MEAN latency should never
+    come out an order of magnitude FASTER than the already-consumed deny
+    path's — a real "return immediately on no row" shortcut would show up
+    as exactly that gap, large not marginal, even through CI noise. The
+    tolerance below (5x) is deliberately generous; it exists to catch a
+    gross regression, not to certify constant-time behaviour (the class
+    docstring explains why true constant-time against the underlying
+    Postgres index is not attempted here at all).
+
+    Direction matters and is asserted deliberately, not incidentally: the
+    threat this test guards against only ever makes the unknown path
+    FASTER (it returns before doing the consumed-row comparison work), so
+    only that direction is evidence of it. A SLOWER unknown path is not
+    that vulnerability — 2026-08-27 CI run 33038395493 (Backend Shard 3)
+    failed on exactly this: unknown mean=8.935ms vs consumed mean=1.293ms
+    (unknown 6.9x SLOWER), which the previous direction-blind `max/min`
+    ratio treated as a violation. That gap was the sampling below, not the
+    adapter: all 30 unknown samples (fresh random token per call, always
+    an index miss) ran first, then all 30 consumed samples (one repeated
+    token, page hot after its first hit) ran second — a cold path
+    compared to a warm one by construction.
     """
     import time
 
@@ -565,15 +579,38 @@ async def test_deny_path_timing_does_not_separate_under_repetition(pool, store):
     consumed_raw_token = await _issue_and_capture_token(store, idempotency_key="issue-key-timing-consumed")
     await store.exchange(idempotency_key="exchange-key-timing-consumed-prime", token=consumed_raw_token)
 
-    unknown_samples = [await _time_unknown() for _ in range(trials)]
-    consumed_samples = [await _time_consumed(consumed_raw_token) for _ in range(trials)]
+    # Discarded warmup over BOTH paths before any sample is kept: the
+    # first query on a fresh asyncpg pool connection pays one-time
+    # statement-prepare/plan-cache cost that has nothing to do with
+    # either code path. Paying it here, uncounted, keeps it from landing
+    # entirely on whichever series happens to run first.
+    await _time_unknown()
+    await _time_consumed(consumed_raw_token)
+
+    # Interleaved sampling, not two consecutive blocks — see the
+    # docstring: running all of one series before the other compares a
+    # cold path to a warm one by construction. Interleaving spreads any
+    # residual warm-up or scheduler drift evenly across both series
+    # instead of concentrating it in whichever one goes first.
+    unknown_samples: list[float] = []
+    consumed_samples: list[float] = []
+    for _ in range(trials):
+        unknown_samples.append(await _time_unknown())
+        consumed_samples.append(await _time_consumed(consumed_raw_token))
 
     unknown_mean = sum(unknown_samples) / len(unknown_samples)
     consumed_mean = sum(consumed_samples) / len(consumed_samples)
-    ratio = max(unknown_mean, consumed_mean) / max(min(unknown_mean, consumed_mean), 1e-9)
 
-    assert ratio < 5.0, (
-        f"unknown-vs-consumed deny latency separated by {ratio:.1f}x "
+    if unknown_mean >= consumed_mean:
+        # Not the threat this test guards against (that shortcut only
+        # ever makes the unknown path FASTER) — nothing to assert in this
+        # direction; a slower unknown path is the ordinary shape of the
+        # comparison (see docstring), not a regression.
+        return
+
+    unknown_faster_ratio = consumed_mean / max(unknown_mean, 1e-9)
+    assert unknown_faster_ratio < 5.0, (
+        f"unknown-deny path is {unknown_faster_ratio:.1f}x FASTER than the consumed-deny path "
         f"(unknown mean={unknown_mean * 1000:.3f}ms, consumed mean={consumed_mean * 1000:.3f}ms) "
         f"— investigate for a short-circuit branch, not just CI noise"
     )


### PR DESCRIPTION
## Summary
- `test_deny_path_timing_does_not_separate_under_repetition` (garuda_portal magic-link store integration) failed CI 2026-08-27 (run 33038395493, Backend Shard 3): `unknown mean=8.935ms` vs `consumed mean=1.293ms`, a direction-blind `max/min` ratio of 6.9x.
- Fix is scoped to that ONE test, no production code touched:
  1. **Direction-aware assertion.** The threat this test guards against ("return immediately on no row" short-circuit) only ever makes the unknown-token deny path *faster*. The old `max(...)/min(...)` ratio fired on either direction; it now only asserts when `unknown_mean < consumed_mean`.
  2. **Removed the cold/warm confound.** All 30 unknown samples (fresh random token per call — always an index miss) previously ran first, then all 30 consumed samples (one repeated token — hot after the first hit) ran second, comparing a cold path to a warm one by construction. Added a discarded warmup over both paths and interleaved the two sample series instead of two consecutive blocks.
- Stays advisory (5x tolerance kept, not tightened into a flaky constant-time assertion); not skipped/xfailed.

## Adversarial review
- **Threat modeled**: a regression that makes the unknown-token deny path return early (skip the constant-shape comparison work) — the actual security property this test protects.
- **False-negative risk after the fix**: could the direction-aware assertion now miss a real short-circuit? No — it still fires whenever `unknown_mean` is materially (5x+) faster than `consumed_mean`, which is exactly the shape a short-circuit produces. It only stops firing on the direction that was never the threat (unknown slower), so no coverage is lost, only a source of false positives.
- **False-positive risk removed**: cold/warm sampling asymmetry could make the unknown path spuriously appear slower on shared CI vCPUs; the interleaved sampling + discarded warmup addresses the mechanism, and the direction gate is a second independent line of defense even if some residual cold-start noise remains.
- **Proved on real fixtures, not just synthetic numbers**: two throwaway monkeypatch tests (not committed) reused the file's real `pool`/`store` fixtures against a live local Postgres:
  - Simulated short-circuit (unknown path returns early) → new assertion fired RED: `unknown-deny path is 64.0x FASTER than the consumed-deny path (unknown mean=0.133ms, consumed mean=8.489ms)`.
  - Injected the CI failure's exact shape (artificial delay added only to the unknown path) → stayed GREEN: `unknown_mean=11.5379ms consumed_mean=1.0416ms` (unknown slower, no assertion fires).

## Test plan
- [x] Ran the full `test_magic_link_store_integration.py` file (12 tests) against a real local Postgres (`nuzantara_test`, migrations 285/286 applied manually since the checkout used was stale on those migration numbers) — all green.
- [x] Proved the new assertion goes RED against a real simulated short-circuit on the real fixtures.
- [x] Proved the new assertion stays GREEN under an injected cold/warm gap shaped like the actual CI failure numbers.
- [ ] CI (Backend Tests / Shard 3) — will confirm once the PR's checks run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>