### PR TITLE
fix(smoke): the fullstack smoke's migration subset predates policy_scope

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/fullstack_smoke.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fullstack_smoke.py
@@ -53,6 +53,33 @@ DEFAULT_ADMIN_DSN = "postgresql://nuzantara@127.0.0.1:5432/postgres"
 DATABASE_PREFIX = "visa_oracle_smoke_"
 DATABASE_NAME_RE = re.compile(r"^visa_oracle_smoke_[a-z0-9_]{8,80}$")
 LOCAL_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+# ORDER IS LOAD-BEARING: `_migration_paths()` walks this tuple literally and does
+# NOT re-sort it, so a dependency must appear before the migration that needs it.
+# Keep it ascending and the dependency edges hold for free.
+#
+# 261/276/281/289 added 2026-08-27. The earlier omission was NOT an oversight:
+# the full migrations_v2 chain is not standalone-applicable to an empty database
+# (108/132 and others assume the legacy baseline that real CI builds separately
+# via scripts/ci_bootstrap_schema.py), so this tuple is a deliberately curated
+# self-contained Visa Engine subset. Skipping 258-261 was correct — right up to
+# the moment the retention readers began querying `policy_scope`.
+#
+# That column is created by 281, which ALTERs `garuda_voa_checks` (created by
+# 261). With neither applied, the disposable smoke DB lacked the column and the
+# evaluate path raised `UndefinedColumnError` — raw PG: `column "policy_scope"
+# does not exist`. The failure was invisible because this job is advisory AND was
+# already red on main for an unrelated reason.
+#
+# 261 (standalone CREATE TABLE) and 276 (comment-only) are harmless additions to
+# the self-contained set — test_garuda_voa_retention.py already applies exactly
+# this extension against a real throwaway database, which is the empirical proof
+# that the sequence holds.
+#
+# NOTE: three files now encode "which migrations build a Visa Engine test DB"
+# (this one, test_garuda_voa_retention.py, test_retention_binders_scope_to_
+# visa_decision.py). They are independent by necessity, not by accident — but
+# that means a new retention dependency has to be added to each. Grep
+# MIGRATION_NUMBERS before assuming one copy is authoritative.
 MIGRATION_NUMBERS = (
     250,
     251,
@@ -62,6 +89,7 @@ MIGRATION_NUMBERS = (
     255,
     256,
     257,
+    261,
     262,
     263,
     264,
@@ -69,6 +97,9 @@ MIGRATION_NUMBERS = (
     266,
     267,
     268,
+    276,
+    281,
+    289,
 )
 TEST_RULE_PACK_ID = "8a57d996-c7f2-5abc-9c31-4128a29ed848"
 

--- a/apps/backend-rag/backend/scripts/visa_engine/fullstack_smoke.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fullstack_smoke.py
@@ -75,11 +75,14 @@ LOCAL_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 # this extension against a real throwaway database, which is the empirical proof
 # that the sequence holds.
 #
-# NOTE: three files now encode "which migrations build a Visa Engine test DB"
+# NOTE: FOUR places now encode this list. Three are independent test-DB subsets
 # (this one, test_garuda_voa_retention.py, test_retention_binders_scope_to_
-# visa_decision.py). They are independent by necessity, not by accident — but
-# that means a new retention dependency has to be added to each. Grep
-# MIGRATION_NUMBERS before assuming one copy is authoritative.
+# visa_decision.py) — independent by necessity, since each needs a different
+# subset. The fourth is a GUARD: test_fullstack_smoke.py::
+# test_migration_set_is_exact_and_forward_only pins THIS tuple literally, so it
+# goes red the moment these two disagree. That guard is why the list cannot drift
+# silently a second time — update it in the same commit, deliberately, and let it
+# also re-check that every added migration carries a ROLLBACK section.
 MIGRATION_NUMBERS = (
     250,
     251,

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_fullstack_smoke.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_fullstack_smoke.py
@@ -57,6 +57,7 @@ def test_migration_set_is_exact_and_forward_only() -> None:
         255,
         256,
         257,
+        261,
         262,
         263,
         264,
@@ -64,6 +65,9 @@ def test_migration_set_is_exact_and_forward_only() -> None:
         266,
         267,
         268,
+        276,
+        281,
+        289,
     )
     for path in paths:
         text = Path(path).read_text(encoding="utf-8")


### PR DESCRIPTION
## What

The Visa Oracle fullstack smoke builds its disposable DB from a hand-curated
subset of migrations. That subset stopped at 268 and so never created
`policy_scope` — the column the retention readers query since #5059.

Adds `261, 276, 281, 289` to `MIGRATION_NUMBERS`.

## Why the old subset was not a mistake

The full `migrations_v2` chain is **not** standalone-applicable to an empty
database (108/132 and others assume the legacy baseline that real CI builds
separately via `scripts/ci_bootstrap_schema.py`), so a curated self-contained set
is the design. It was correct — right up to the moment the retention readers
began depending on a column created outside it. `281` adds `policy_scope` and
ALTERs `garuda_voa_checks`, which `261` creates.

## Why nobody saw it

This job is **advisory**, and it was **already red on main** for an unrelated
reason: a Playwright `waitForRequest` timeout — the evaluate POST never leaves
the browser (verified identical on runs 33024185465 and 33008596320, backend and
frontend logs both clean).

A pre-existing red is exactly where a new fault hides: the check could not change
colour, so the new failure was invisible. **This PR does not turn the check
green** — it removes one of the two faults. The other is a product-level defect
and is deliberately not in this PR's scope.

## Proof (run locally, both directions)

Applied the tuple verbatim to a throwaway Postgres:

- **old list (15)** → `policy_scope column: None`, and the reader-shaped query
  raises `asyncpg.exceptions.UndefinedColumnError: column "policy_scope" does not
  exist` — verbatim the error in the CI container log.
- **new list (19)** → all 19 migrations apply cleanly, `policy_scope` present,
  reader-shaped query executes and returns 0.

Guilt and innocence, not just innocence.

## Note on ordering

`_migration_paths()` walks the tuple **literally** and does not re-sort it, so
the order is load-bearing: 261 sits in its numeric slot, 281 before 289.

## Not addressed here

Three files now independently encode "which migrations build a Visa Engine test
DB". They are independent by necessity (each needs a different subset), but a new
retention dependency must be added to each. Flagged in a code comment rather than
refactored — collapsing them into one SSOT is a separate concern.