### PR TITLE
feat(garuda): route the five missing customer-email outbox handlers

### DIFF
--- a/apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py
+++ b/apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py
@@ -83,6 +83,12 @@ class OrderEmailFacts:
     case_type: str
     price_idr: int
     state: str
+    # OP-F04/OP-F05: a late `paid` webhook on a terminal order raises this flag
+    # and leaves `state` UNCHANGED (migration 284, repository.py:487/517). So a
+    # `failed`/`expired` reading alone does NOT mean "no money was taken" — the
+    # two handlers that say so in as many words must read this too. No default:
+    # a `_load` that forgets the column must fail loudly, not send a lie.
+    late_case_open: bool
 
 
 class BrevoEmailSender:
@@ -189,7 +195,7 @@ class PaymentPaidEmailHandler:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT order_id, applicant_email, case_type, price_idr, state
+                SELECT order_id, applicant_email, case_type, price_idr, state, late_case_open
                   FROM garuda_orders
                  WHERE order_id = $1
                 """,
@@ -203,6 +209,7 @@ class PaymentPaidEmailHandler:
             case_type=row["case_type"],
             price_idr=row["price_idr"],
             state=row["state"],
+            late_case_open=row["late_case_open"],
         )
 
     @staticmethod
@@ -285,7 +292,7 @@ class CheckoutReadyEmailHandler:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT order_id, applicant_email, case_type, price_idr, state
+                SELECT order_id, applicant_email, case_type, price_idr, state, late_case_open
                   FROM garuda_orders
                  WHERE order_id = $1
                 """,
@@ -299,6 +306,7 @@ class CheckoutReadyEmailHandler:
             case_type=row["case_type"],
             price_idr=row["price_idr"],
             state=row["state"],
+            late_case_open=row["late_case_open"],
         )
 
     @staticmethod
@@ -325,12 +333,14 @@ class PaymentFailedEmailHandler:
     only from `awaiting_payment`, and nothing in this codebase ever moves an
     order OUT of `failed` again (a late webhook that pays a failed order sets
     `late_case_open` on the SAME `failed`/`expired` state — see OP-F05 — it
-    never flips `state` back). So unlike the checkout-link guard above, this one
-    names a state that, once reached, does not un-become true; it is kept as an
-    explicit guard rather than assumed, because "no code path currently changes
-    it" is not the same invariant as "no code path ever will", and the WARNING
-    log is the same honest trail the payment-paid handler leaves for its own
-    now-false branch.
+    never flips `state` back).
+
+    CORRECTED after a cross-family gate on this same commit: the paragraph above
+    is true and was the WRONG conclusion to draw from it. Precisely BECAUSE a
+    late `paid` leaves `state = 'failed'`, the state alone cannot distinguish
+    "never charged" from "charged late" — and this email's body says "Amount not
+    charged" in as many words. The state guard is therefore not sufficient on
+    its own; `late_case_open` is the second, load-bearing half of it.
 
     CUSTOMER ACTION COPY. The payload carries `customer_action` — one of the
     three values `services/payments/terminal_taxonomy.py::CustomerAction`
@@ -344,7 +354,7 @@ class PaymentFailedEmailHandler:
 
     _CUSTOMER_ACTION_COPY: dict[str, str] = {
         "TRY_A_DIFFERENT_CARD": "Please try again with a different card or payment method.",
-        "TRY_AGAIN_LATER": "Please try again in a few minutes.",
+        "TRY_AGAIN_LATER": "Please try again later.",
         "NONE_ORDER_CLOSED": (
             "This order is now closed. If you still need a Visa on Arrival, "
             "please start a new application."
@@ -371,6 +381,21 @@ class PaymentFailedEmailHandler:
             )
             return
 
+        if facts.late_case_open:
+            # OP-F05: a late `paid` webhook arrived on this terminal order. The
+            # customer WAS charged; `state` stays `failed` by design. Sending
+            # "your payment did not go through / Amount not charged" here tells
+            # a paying customer their money was not taken. Staff already hold
+            # this case (`staff_page_late_paid_after_terminal`) and close it via
+            # resolveLateOrder, which sends its own notice — so this job resolves
+            # silently rather than racing that with a contradiction.
+            logger.warning(
+                "outbox payment_failed_email resolved WITHOUT sending: order %s has an OPEN "
+                "late-payment case — the customer was charged, a failure notice would be false",
+                facts.order_id,
+            )
+            return
+
         customer_action = (job.payload or {}).get("customer_action")
         guidance = self._CUSTOMER_ACTION_COPY.get(customer_action, self._DEFAULT_ACTION_COPY)
 
@@ -385,7 +410,7 @@ class PaymentFailedEmailHandler:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT order_id, applicant_email, case_type, price_idr, state
+                SELECT order_id, applicant_email, case_type, price_idr, state, late_case_open
                   FROM garuda_orders
                  WHERE order_id = $1
                 """,
@@ -399,6 +424,7 @@ class PaymentFailedEmailHandler:
             case_type=row["case_type"],
             price_idr=row["price_idr"],
             state=row["state"],
+            late_case_open=row["late_case_open"],
         )
 
     @staticmethod
@@ -425,8 +451,10 @@ class PaymentExpiredEmailHandler:
     writes `state = 'expired'` only from `awaiting_payment`, and — same as
     `failed` above — nothing in this codebase ever moves an order back out of
     `expired` (a late payment after expiry sets `late_case_open`, never
-    `state`). The guard is still named explicitly rather than assumed, for the
-    same reason `PaymentFailedEmailHandler`'s is.
+    `state`) — which is exactly why the state guard alone is not enough here
+    either: this body says "no payment was taken". `late_case_open` is checked
+    for the same reason, and with the same consequence, as in
+    `PaymentFailedEmailHandler`.
     """
 
     _STATES_WORTH_EXPLAINING = frozenset({"expired"})
@@ -450,6 +478,17 @@ class PaymentExpiredEmailHandler:
             )
             return
 
+        if facts.late_case_open:
+            # OP-F05, same as the failure handler above: the late `paid` webhook
+            # left `state = 'expired'` and raised this flag. The body below says
+            # "no payment was taken" — for this order that is untrue.
+            logger.warning(
+                "outbox payment_expired_email resolved WITHOUT sending: order %s has an OPEN "
+                "late-payment case — the customer was charged, an expiry notice would be false",
+                facts.order_id,
+            )
+            return
+
         await self._sender.send(
             to=facts.email,
             subject="Your Bali Zero Visa on Arrival — payment session expired",
@@ -461,7 +500,7 @@ class PaymentExpiredEmailHandler:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT order_id, applicant_email, case_type, price_idr, state
+                SELECT order_id, applicant_email, case_type, price_idr, state, late_case_open
                   FROM garuda_orders
                  WHERE order_id = $1
                 """,
@@ -475,6 +514,7 @@ class PaymentExpiredEmailHandler:
             case_type=row["case_type"],
             price_idr=row["price_idr"],
             state=row["state"],
+            late_case_open=row["late_case_open"],
         )
 
     @staticmethod
@@ -538,7 +578,7 @@ class RefundEmailHandler:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT order_id, applicant_email, case_type, price_idr, state
+                SELECT order_id, applicant_email, case_type, price_idr, state, late_case_open
                   FROM garuda_orders
                  WHERE order_id = $1
                 """,
@@ -552,20 +592,24 @@ class RefundEmailHandler:
             case_type=row["case_type"],
             price_idr=row["price_idr"],
             state=row["state"],
+            late_case_open=row["late_case_open"],
         )
 
     @staticmethod
     def _body(facts: OrderEmailFacts) -> str:
+        # NO AMOUNT LINE, deliberately. `price_idr` is the ORDER price, not a
+        # refunded amount — nothing in `garuda_orders` records what the provider
+        # actually returned, and OP-05 refunds an order that reached `refunded`
+        # from `awaiting_payment`, i.e. one this flow never marked as charged.
+        # Printing `price_idr` here would assert a figure the code cannot know.
         base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
         tracker = f"{base}/{facts.order_id}"
-        amount = f"IDR {facts.price_idr:,}".replace(",", ".")
         return (
             "Hello,<br><br>"
             "We've refunded your payment for your Bali Zero Visa on Arrival "
             f"({facts.case_type}).<br><br>"
-            f"<b>Amount refunded: {amount}</b><br><br>"
-            "The refund follows your card provider's own timeline to appear on "
-            "your statement.<br><br>"
+            "The refund goes back to the payment method you used, and follows "
+            "your card provider's own timeline to appear on your statement.<br><br>"
             "You can follow this order's status here:<br><br>"
             f'<a href="{tracker}">Track my application</a><br><br>'
             "— Bali Zero"
@@ -927,7 +971,8 @@ class PracticeReceivedEmailHandler:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT o.order_id, o.applicant_email, o.case_type, o.price_idr, o.state
+                SELECT o.order_id, o.applicant_email, o.case_type, o.price_idr, o.state,
+                       o.late_case_open
                   FROM garuda_orders o
                   JOIN garuda_practices p ON p.order_id = o.order_id
                  WHERE o.order_id = $1
@@ -942,6 +987,7 @@ class PracticeReceivedEmailHandler:
             case_type=row["case_type"],
             price_idr=row["price_idr"],
             state=row["state"],
+            late_case_open=row["late_case_open"],
         )
 
     @staticmethod

--- a/apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py
+++ b/apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py
@@ -224,6 +224,354 @@ class PaymentPaidEmailHandler:
         )
 
 
+class CheckoutReadyEmailHandler:
+    """Sends one "your payment link is ready" email per `checkout_ready_email` job.
+
+    ENQUEUED FROM. `repository.py`'s OP-01 transition (`created -> awaiting_payment`)
+    enqueues this in the SAME transaction that writes the `checkout_url` into the
+    outbox `payload` — the URL is a provider capability, never persisted on
+    `garuda_orders` itself (see that call site's own comment), so the payload is
+    the ONLY place this handler can read it from.
+
+    STATE GUARD, AND WHY IT DIFFERS FROM THE PAID HANDLER'S. A checkout link is
+    true only while the order is still, in fact, awaiting payment: the session
+    it points at is provider-side and time-boxed (`checkout_expires_at`), and if
+    the order has already moved on — paid, failed, expired, refunded — the link
+    is either redundant (a `payment_paid_email` job for the same order is on its
+    way) or actively wrong (offering to pay something that can no longer be
+    paid). Unlike `PaymentPaidEmailHandler`, whose guard names the ONE state the
+    email is a durable receipt of, this guard names the ONE state during which
+    the invitation is still live.
+    """
+
+    _STATES_WORTH_LINKING = frozenset({"awaiting_payment"})
+
+    def __init__(self, pool: asyncpg.Pool, sender: BrevoEmailSender) -> None:
+        self._pool = pool
+        self._sender = sender
+
+    async def __call__(self, job: OutboxJob) -> None:
+        facts = await self._load(job.order_id)
+        if facts is None:
+            raise EmailSendFailed(f"order {job.order_id} not found for a queued checkout link")
+
+        if facts.state not in self._STATES_WORTH_LINKING:
+            logger.warning(
+                "outbox checkout_ready_email resolved WITHOUT sending: order %s is in state %r, "
+                "not %s — the checkout link is no longer live",
+                facts.order_id,
+                facts.state,
+                sorted(self._STATES_WORTH_LINKING),
+            )
+            return
+
+        checkout_url = (job.payload or {}).get("checkout_url")
+        if not checkout_url:
+            # The enqueue call always carries this key (repository.py OP-01).
+            # Its absence means the payload was written or read wrong — raise
+            # rather than send a customer an email with no way to pay.
+            raise EmailSendFailed(
+                f"checkout_ready_email job for order {job.order_id} carries no checkout_url"
+            )
+
+        await self._sender.send(
+            to=facts.email,
+            subject="Your Bali Zero Visa on Arrival — complete your payment",
+            html_body=self._body(facts, checkout_url),
+        )
+        logger.info("outbox checkout_ready_email sent for order %s", facts.order_id)
+
+    async def _load(self, order_id: str) -> OrderEmailFacts | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT order_id, applicant_email, case_type, price_idr, state
+                  FROM garuda_orders
+                 WHERE order_id = $1
+                """,
+                order_id,
+            )
+        if row is None:
+            return None
+        return OrderEmailFacts(
+            order_id=row["order_id"],
+            email=row["applicant_email"],
+            case_type=row["case_type"],
+            price_idr=row["price_idr"],
+            state=row["state"],
+        )
+
+    @staticmethod
+    def _body(facts: OrderEmailFacts, checkout_url: str) -> str:
+        base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
+        tracker = f"{base}/{facts.order_id}"
+        amount = f"IDR {facts.price_idr:,}".replace(",", ".")
+        return (
+            "Hello,<br><br>"
+            "Your Bali Zero Visa on Arrival application "
+            f"({facts.case_type}) is ready for payment.<br><br>"
+            f"<b>Amount due: {amount}</b><br><br>"
+            f'<a href="{checkout_url}">Complete my payment</a><br><br>'
+            "You can also follow this order's status here:<br><br>"
+            f'<a href="{tracker}">Track my application</a><br><br>'
+            "— Bali Zero"
+        )
+
+
+class PaymentFailedEmailHandler:
+    """Sends one "your payment did not go through" email per `payment_failed_email` job.
+
+    STATE GUARD. `handle_failure_event` (repository.py) writes `state = 'failed'`
+    only from `awaiting_payment`, and nothing in this codebase ever moves an
+    order OUT of `failed` again (a late webhook that pays a failed order sets
+    `late_case_open` on the SAME `failed`/`expired` state — see OP-F05 — it
+    never flips `state` back). So unlike the checkout-link guard above, this one
+    names a state that, once reached, does not un-become true; it is kept as an
+    explicit guard rather than assumed, because "no code path currently changes
+    it" is not the same invariant as "no code path ever will", and the WARNING
+    log is the same honest trail the payment-paid handler leaves for its own
+    now-false branch.
+
+    CUSTOMER ACTION COPY. The payload carries `customer_action` — one of the
+    three values `services/payments/terminal_taxonomy.py::CustomerAction`
+    classifies every failure into. This handler renders that closed vocabulary
+    into a short next step; an unrecognised value (schema drift, a future enum
+    member) falls back to the same generic guidance rather than raising, since
+    a slightly generic email is better than a lost one.
+    """
+
+    _STATES_WORTH_EXPLAINING = frozenset({"failed"})
+
+    _CUSTOMER_ACTION_COPY: dict[str, str] = {
+        "TRY_A_DIFFERENT_CARD": "Please try again with a different card or payment method.",
+        "TRY_AGAIN_LATER": "Please try again in a few minutes.",
+        "NONE_ORDER_CLOSED": (
+            "This order is now closed. If you still need a Visa on Arrival, "
+            "please start a new application."
+        ),
+    }
+    _DEFAULT_ACTION_COPY = "Please try again, or start a new application if the issue continues."
+
+    def __init__(self, pool: asyncpg.Pool, sender: BrevoEmailSender) -> None:
+        self._pool = pool
+        self._sender = sender
+
+    async def __call__(self, job: OutboxJob) -> None:
+        facts = await self._load(job.order_id)
+        if facts is None:
+            raise EmailSendFailed(f"order {job.order_id} not found for a queued failure email")
+
+        if facts.state not in self._STATES_WORTH_EXPLAINING:
+            logger.warning(
+                "outbox payment_failed_email resolved WITHOUT sending: order %s is in state %r, "
+                "not %s — a failure notice would be stale",
+                facts.order_id,
+                facts.state,
+                sorted(self._STATES_WORTH_EXPLAINING),
+            )
+            return
+
+        customer_action = (job.payload or {}).get("customer_action")
+        guidance = self._CUSTOMER_ACTION_COPY.get(customer_action, self._DEFAULT_ACTION_COPY)
+
+        await self._sender.send(
+            to=facts.email,
+            subject="Your Bali Zero Visa on Arrival — payment did not go through",
+            html_body=self._body(facts, guidance),
+        )
+        logger.info("outbox payment_failed_email sent for order %s", facts.order_id)
+
+    async def _load(self, order_id: str) -> OrderEmailFacts | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT order_id, applicant_email, case_type, price_idr, state
+                  FROM garuda_orders
+                 WHERE order_id = $1
+                """,
+                order_id,
+            )
+        if row is None:
+            return None
+        return OrderEmailFacts(
+            order_id=row["order_id"],
+            email=row["applicant_email"],
+            case_type=row["case_type"],
+            price_idr=row["price_idr"],
+            state=row["state"],
+        )
+
+    @staticmethod
+    def _body(facts: OrderEmailFacts, guidance: str) -> str:
+        base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
+        tracker = f"{base}/{facts.order_id}"
+        amount = f"IDR {facts.price_idr:,}".replace(",", ".")
+        return (
+            "Hello,<br><br>"
+            "We were unable to process your payment for your Bali Zero Visa on "
+            f"Arrival ({facts.case_type}).<br><br>"
+            f"<b>Amount not charged: {amount}</b><br><br>"
+            f"{guidance}<br><br>"
+            "You can follow this order's status here:<br><br>"
+            f'<a href="{tracker}">Track my application</a><br><br>'
+            "— Bali Zero"
+        )
+
+
+class PaymentExpiredEmailHandler:
+    """Sends one "your payment session expired" email per `payment_expired_email` job.
+
+    STATE GUARD. `expire_if_unpaid` (repository.py, reconciliation-driven OP-04)
+    writes `state = 'expired'` only from `awaiting_payment`, and — same as
+    `failed` above — nothing in this codebase ever moves an order back out of
+    `expired` (a late payment after expiry sets `late_case_open`, never
+    `state`). The guard is still named explicitly rather than assumed, for the
+    same reason `PaymentFailedEmailHandler`'s is.
+    """
+
+    _STATES_WORTH_EXPLAINING = frozenset({"expired"})
+
+    def __init__(self, pool: asyncpg.Pool, sender: BrevoEmailSender) -> None:
+        self._pool = pool
+        self._sender = sender
+
+    async def __call__(self, job: OutboxJob) -> None:
+        facts = await self._load(job.order_id)
+        if facts is None:
+            raise EmailSendFailed(f"order {job.order_id} not found for a queued expiry email")
+
+        if facts.state not in self._STATES_WORTH_EXPLAINING:
+            logger.warning(
+                "outbox payment_expired_email resolved WITHOUT sending: order %s is in state %r, "
+                "not %s — an expiry notice would be stale",
+                facts.order_id,
+                facts.state,
+                sorted(self._STATES_WORTH_EXPLAINING),
+            )
+            return
+
+        await self._sender.send(
+            to=facts.email,
+            subject="Your Bali Zero Visa on Arrival — payment session expired",
+            html_body=self._body(facts),
+        )
+        logger.info("outbox payment_expired_email sent for order %s", facts.order_id)
+
+    async def _load(self, order_id: str) -> OrderEmailFacts | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT order_id, applicant_email, case_type, price_idr, state
+                  FROM garuda_orders
+                 WHERE order_id = $1
+                """,
+                order_id,
+            )
+        if row is None:
+            return None
+        return OrderEmailFacts(
+            order_id=row["order_id"],
+            email=row["applicant_email"],
+            case_type=row["case_type"],
+            price_idr=row["price_idr"],
+            state=row["state"],
+        )
+
+    @staticmethod
+    def _body(facts: OrderEmailFacts) -> str:
+        base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
+        tracker = f"{base}/{facts.order_id}"
+        return (
+            "Hello,<br><br>"
+            "The payment session for your Bali Zero Visa on Arrival application "
+            f"({facts.case_type}) expired before it was completed, so no payment "
+            "was taken.<br><br>"
+            "If you still need a Visa on Arrival, please start a new "
+            "application.<br><br>"
+            "You can follow this order's status here:<br><br>"
+            f'<a href="{tracker}">Track my application</a><br><br>'
+            "— Bali Zero"
+        )
+
+
+class RefundEmailHandler:
+    """Sends one "your payment was refunded" email per `refund_email` job.
+
+    STATE GUARD. `handle_refund_event` (repository.py) writes `state =
+    'refunded'` from either `awaiting_payment` (OP-05, refunded out of order)
+    or `paid` (OP-06). Once `refunded`, nothing in this codebase moves the
+    state again — a late paid webhook after a refund (OP-F04) sets
+    `late_case_open`/`late_case_charge_id`, never `state`. So, as with the
+    failed/expired handlers above, `refunded` is a stable terminal reading, and
+    the guard is still named rather than assumed.
+    """
+
+    _STATES_WORTH_CONFIRMING = frozenset({"refunded"})
+
+    def __init__(self, pool: asyncpg.Pool, sender: BrevoEmailSender) -> None:
+        self._pool = pool
+        self._sender = sender
+
+    async def __call__(self, job: OutboxJob) -> None:
+        facts = await self._load(job.order_id)
+        if facts is None:
+            raise EmailSendFailed(f"order {job.order_id} not found for a queued refund email")
+
+        if facts.state not in self._STATES_WORTH_CONFIRMING:
+            logger.warning(
+                "outbox refund_email resolved WITHOUT sending: order %s is in state %r, "
+                "not %s — a refund confirmation would be untrue",
+                facts.order_id,
+                facts.state,
+                sorted(self._STATES_WORTH_CONFIRMING),
+            )
+            return
+
+        await self._sender.send(
+            to=facts.email,
+            subject="Your Bali Zero Visa on Arrival — payment refunded",
+            html_body=self._body(facts),
+        )
+        logger.info("outbox refund_email sent for order %s", facts.order_id)
+
+    async def _load(self, order_id: str) -> OrderEmailFacts | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT order_id, applicant_email, case_type, price_idr, state
+                  FROM garuda_orders
+                 WHERE order_id = $1
+                """,
+                order_id,
+            )
+        if row is None:
+            return None
+        return OrderEmailFacts(
+            order_id=row["order_id"],
+            email=row["applicant_email"],
+            case_type=row["case_type"],
+            price_idr=row["price_idr"],
+            state=row["state"],
+        )
+
+    @staticmethod
+    def _body(facts: OrderEmailFacts) -> str:
+        base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
+        tracker = f"{base}/{facts.order_id}"
+        amount = f"IDR {facts.price_idr:,}".replace(",", ".")
+        return (
+            "Hello,<br><br>"
+            "We've refunded your payment for your Bali Zero Visa on Arrival "
+            f"({facts.case_type}).<br><br>"
+            f"<b>Amount refunded: {amount}</b><br><br>"
+            "The refund follows your card provider's own timeline to appear on "
+            "your statement.<br><br>"
+            "You can follow this order's status here:<br><br>"
+            f'<a href="{tracker}">Track my application</a><br><br>'
+            "— Bali Zero"
+        )
+
+
 class PracticeNotMinted(RuntimeError):
     """No `garuda_practices` row for this payment event. Raised, never swallowed."""
 
@@ -497,14 +845,135 @@ class PortalInviteHandler:
         )
 
 
+class PracticeReceivedEmailHandler:
+    """Sends one "your application is now with the team" email per
+    `practice_received_email` job.
+
+    ENQUEUED FROM A DIFFERENT MODULE THAN THE OTHER FOUR. This job is written
+    by `garuda_portal/practice.py::mint_received_practice`, not
+    `garuda_orders/repository.py` — either from L3's eager path (inside the
+    SAME transaction as `payment.paid`, OP-02) or from the lazy PR-01
+    fallback on a customer's first tracker read. Either way, by the time this
+    handler is claimable the `garuda_practices` row it announces is already
+    committed: the outbox row and the practice row are written in the same
+    transaction (`journal.enqueue_outbox` right after the `INSERT ...
+    RETURNING practice_id`), so "queued but no practice row" is the same
+    "something deleted state out from under a queued job" shape the other
+    handlers in this module raise on, never a race to tolerate.
+
+    NO STATE GUARD ON THE *PRACTICE's* STATE. `garuda_practices.state` only
+    ever moves FORWARD from `Received` (module docstring: no PR-02..PR-11
+    transition code ships yet, and even once it does the enum has no path
+    back to "never happened"). The message here is a receipt of intake, not
+    a claim about current PROCESSING status — "we received your application"
+    stays true whatever the practice's own state becomes later, the same way
+    a shipping "we received your order" notice does not need retracting once
+    the order ships.
+
+    THE GUARD IS ON THE *ORDER's* STATE INSTEAD, AND ONLY ON `refunded`'S
+    NEIGHBOURHOOD. A practice, once created, is never deleted by anything in
+    this codebase — `handle_refund_event` only ever touches `garuda_orders`,
+    never `garuda_practices` — so the row this handler reads about is real
+    and permanent regardless of what happens to the order next. But telling a
+    customer "your application is now open with our team" right after they
+    were refunded is a different kind of false than the practice row itself:
+    it is not a fact about intake, it reads as an active-service promise, and
+    that promise is exactly what a refund closes out. Since a paid order that
+    later refunds moves through `paid -> refunded` and never back (same
+    terminal-once-reached shape the failed/expired/refunded handlers above
+    rely on), the guard names the one state — `paid` — during which the
+    "we're on it" framing is still honest, mirroring
+    `PaymentPaidEmailHandler`'s own `_STATES_WORTH_CONFIRMING` rather than
+    reusing its frozenset object.
+    """
+
+    _STATES_WORTH_NOTIFYING = frozenset({"paid"})
+
+    def __init__(self, pool: asyncpg.Pool, sender: BrevoEmailSender) -> None:
+        self._pool = pool
+        self._sender = sender
+
+    async def __call__(self, job: OutboxJob) -> None:
+        facts = await self._load(job.order_id)
+        if facts is None:
+            # Covers both a missing order and a missing practice row — either
+            # way something the outbox row's own transaction should have
+            # guaranteed is gone. Raise, exhaust visibly, never mark delivered.
+            raise EmailSendFailed(
+                f"order {job.order_id} (or its practice) not found for a queued "
+                "receipt confirmation"
+            )
+
+        if facts.state not in self._STATES_WORTH_NOTIFYING:
+            logger.warning(
+                "outbox practice_received_email resolved WITHOUT sending: order %s is in "
+                "state %r, not %s — the application-is-with-the-team framing is no longer "
+                "honest",
+                facts.order_id,
+                facts.state,
+                sorted(self._STATES_WORTH_NOTIFYING),
+            )
+            return
+
+        await self._sender.send(
+            to=facts.email,
+            subject="Your Bali Zero Visa on Arrival — application received",
+            html_body=self._body(facts),
+        )
+        # order id only — never the address, the name or the passport number.
+        logger.info("outbox practice_received_email sent for order %s", facts.order_id)
+
+    async def _load(self, order_id: str) -> OrderEmailFacts | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT o.order_id, o.applicant_email, o.case_type, o.price_idr, o.state
+                  FROM garuda_orders o
+                  JOIN garuda_practices p ON p.order_id = o.order_id
+                 WHERE o.order_id = $1
+                """,
+                order_id,
+            )
+        if row is None:
+            return None
+        return OrderEmailFacts(
+            order_id=row["order_id"],
+            email=row["applicant_email"],
+            case_type=row["case_type"],
+            price_idr=row["price_idr"],
+            state=row["state"],
+        )
+
+    @staticmethod
+    def _body(facts: OrderEmailFacts) -> str:
+        base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
+        tracker = f"{base}/{facts.order_id}"
+        return (
+            "Hello,<br><br>"
+            "Your Bali Zero Visa on Arrival application "
+            f"({facts.case_type}) has been received and is now open with our "
+            "team.<br><br>"
+            "You can follow its progress at any time here:<br><br>"
+            f'<a href="{tracker}">Track my application</a><br><br>'
+            "We'll email you again when there is news.<br><br>"
+            "— Bali Zero"
+        )
+
+
 def build_handlers(pool: asyncpg.Pool, sender: BrevoEmailSender) -> dict[str, object]:
     """The registry `drain_once` consumes.
 
-    Three job types are routed: `payment_paid_email` (what the customer sees),
-    `practice_release` (what the team sees) and `portal_invite` (how the
-    customer gets IN). All three are enqueued by the SAME transaction in
-    `repository.py` when a payment is confirmed, and routing only the first is
-    what produced a paying customer with a confirmation email and no work item.
+    Eight job types are routed: `checkout_ready_email` and `payment_paid_email`
+    (what the customer sees while paying), `payment_failed_email` and
+    `payment_expired_email` (what the customer sees when paying goes wrong),
+    `refund_email` (what the customer sees when money comes back),
+    `practice_release` (what the team sees), `portal_invite` (how the customer
+    gets IN) and `practice_received_email` (what the customer sees once their
+    application is open with the team). `payment_paid_email`,
+    `practice_release` and `portal_invite` are enqueued by the SAME
+    transaction in `repository.py` when a payment is confirmed; routing only
+    the first of those three is what originally produced a paying customer
+    with a confirmation email and no work item.
 
     THE ROUTER IMPORT IS LAZY ON PURPOSE. `send_portal_invite_email` lives in
     `app/routers/portal_invite.py` — the canonical sender, reused whole rather
@@ -512,13 +981,12 @@ def build_handlers(pool: asyncpg.Pool, sender: BrevoEmailSender) -> dict[str, ob
     invites an import cycle through the router package. Binding it here, inside
     the function, keeps the dependency at call time where it is harmless.
 
-    Every other job_type the repository enqueues — `refund_email`,
-    `payment_failed_email`, `checkout_ready_email`, `payment_expired_email` and
-    the five `staff_page_*` — deliberately has NO entry, so the consumer
-    reports them as `unroutable` and logs them by name rather than pretending
-    they were delivered. That is the intended state, not an oversight: an
-    unrouted job keeps its full attempt budget and is picked up unharmed when
-    its handler is written.
+    Every other job_type the repository enqueues — the five `staff_page_*`
+    jobs — deliberately has NO entry, so the consumer reports them as
+    `unroutable` and logs them by name rather than pretending they were
+    delivered. That is the intended state, not an oversight: an unrouted job
+    keeps its full attempt budget and is picked up unharmed when its handler
+    is written.
     """
 
     from backend.app.core.config import settings
@@ -529,8 +997,13 @@ def build_handlers(pool: asyncpg.Pool, sender: BrevoEmailSender) -> dict[str, ob
         crm_writer=PostgresCrmWriter(pool),
     )
     return {
+        "checkout_ready_email": CheckoutReadyEmailHandler(pool, sender),
         "payment_paid_email": PaymentPaidEmailHandler(pool, sender),
+        "payment_failed_email": PaymentFailedEmailHandler(pool, sender),
+        "payment_expired_email": PaymentExpiredEmailHandler(pool, sender),
+        "refund_email": RefundEmailHandler(pool, sender),
         "practice_release": PracticeReleaseHandler(pool, handoff),
+        "practice_received_email": PracticeReceivedEmailHandler(pool, sender),
         "portal_invite": PortalInviteHandler(
             pool,
             profiles=PortalProfileService(pool),
@@ -544,14 +1017,19 @@ def build_handlers(pool: asyncpg.Pool, sender: BrevoEmailSender) -> dict[str, ob
 __all__ = [
     "INVITE_CREATED_BY",
     "BrevoEmailSender",
+    "CheckoutReadyEmailHandler",
     "CrmPracticeNotWrittenYet",
     "EmailSendFailed",
     "OrderEmailFacts",
+    "PaymentExpiredEmailHandler",
+    "PaymentFailedEmailHandler",
     "PaymentPaidEmailHandler",
     "PortalInviteHandler",
     "PortalInviteUndeliverable",
     "PortalProfileNotCreated",
     "PracticeNotMinted",
+    "PracticeReceivedEmailHandler",
     "PracticeReleaseHandler",
+    "RefundEmailHandler",
     "build_handlers",
 ]

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
@@ -438,3 +438,85 @@ async def test_practice_received_raises_when_the_practice_row_is_missing(pool):
     finally:
         await client.aclose()
     assert rec.requests == []
+
+
+# --------------------------------------------------------------------------
+# PII tripwire — the logs, not the wire
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("handler_cls", "job_type", "state", "needs_practice", "payload"),
+    [
+        # checkout_ready is the one job whose payload is load-bearing: the
+        # handler raises without a `checkout_url` (see
+        # `test_checkout_ready_raises_without_a_checkout_url`), so a payload-less
+        # case here would fail on that instead of testing the logs.
+        (
+            CheckoutReadyEmailHandler,
+            "checkout_ready_email",
+            "awaiting_payment",
+            False,
+            {"checkout_url": "https://checkout.invalid/inv_specimen"},
+        ),
+        (PaymentFailedEmailHandler, "payment_failed_email", "failed", False, None),
+        (PaymentExpiredEmailHandler, "payment_expired_email", "expired", False, None),
+        (RefundEmailHandler, "refund_email", "refunded", False, None),
+        (PracticeReceivedEmailHandler, "practice_received_email", "paid", True, None),
+    ],
+)
+async def test_no_handler_writes_applicant_pii_into_a_log_line(
+    pool, caplog, handler_cls, job_type, state, needs_practice, payload
+):
+    """The bodies necessarily carry the customer's details; the LOGS must not.
+
+    Every handler here logs, and `logger.info("... for order %s")` is the shape
+    they are supposed to use. Nothing structural stops a future edit from
+    widening one of those calls to `%s` the whole `facts` object, or adding the
+    address "to make the log useful" — and by the time that ships, the value is
+    already in Fly's log stream and in Sentry, which is not a place PII can be
+    withdrawn from. Inspection caught this today; this test is what keeps
+    catching it.
+
+    Asserts on the SEEDED values rather than a regex for anything
+    email-shaped: a pattern search would also flag the notifications endpoint
+    URL and would miss the applicant NAME entirely, which is the field a
+    well-meaning "log who we emailed" edit is most likely to reach for.
+    """
+
+    marker_email = f"pii-tripwire-{uuid.uuid4().hex}@example.invalid"
+    order_id = await _seed_order(pool, state=state, email=marker_email)
+    if needs_practice:
+        await _seed_practice(pool, order_id)
+
+    recorder = _Recorder()
+    sender, client = _sender(recorder)
+    try:
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await handler_cls(pool, sender)(_job(order_id, job_type, payload))
+    finally:
+        await client.aclose()
+
+    # Innocence first: if it did not send, the test below proves nothing.
+    assert len(recorder.requests) == 1, (
+        f"{handler_cls.__name__} did not send in state {state!r} — the PII assertion "
+        "below would pass vacuously"
+    )
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert logged.strip(), f"{handler_cls.__name__} logged nothing — nothing to check"
+
+    for label, secret in (
+        ("applicant email", marker_email),
+        ("applicant name", "SPECIMEN TRAVELLER"),
+        ("passport number", "X0000000"),
+        ("phone", "+000000000000"),
+    ):
+        assert secret not in logged, (
+            f"{handler_cls.__name__} wrote the {label} into a log line: {logged!r}"
+        )
+
+    # And the thing that SHOULD be there, so this is not satisfied by silence.
+    assert order_id in logged, (
+        f"{handler_cls.__name__} logged without the order id — the log is unusable"
+    )

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
@@ -1,0 +1,440 @@
+"""Tests for the five customer-email outbox handlers added alongside
+`payment_paid_email`: `checkout_ready_email`, `payment_failed_email`,
+`payment_expired_email`, `refund_email` and `practice_received_email`.
+
+Sibling to `test_outbox_handlers.py`, which already covers the sender's HTTP
+layer and `PaymentPaidEmailHandler` in full — this file exercises only what
+is new: each handler's own state guard (a job whose order has moved on since
+it was enqueued must resolve WITHOUT sending, never raise) and the shared
+"missing order raises" contract. Guilt and innocence for every handler, per
+the module's own `_STATES_WORTH_*` reasoning in `outbox_handlers.py`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+import httpx
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from backend.services.garuda_orders import journal
+from backend.services.garuda_orders.outbox_consumer import KILL_SWITCH_ENV, OutboxJob
+from backend.services.garuda_orders.outbox_handlers import (
+    CheckoutReadyEmailHandler,
+    EmailSendFailed,
+    PaymentExpiredEmailHandler,
+    PaymentFailedEmailHandler,
+    PracticeReceivedEmailHandler,
+    RefundEmailHandler,
+)
+from backend.tests.fixtures.prod_shaped_pool import create_prod_shaped_pool
+
+_DSN = (
+    os.environ.get("GARUDA_L3_TEST_DSN")
+    or os.environ.get("INTAKE_TEST_DSN")
+    or "postgresql://localhost:5432/garuda_outbox_test_0826"
+)
+
+pytestmark = pytest.mark.asyncio
+
+RECIPIENT = "traveller@example.invalid"
+LOGGER_NAME = "garuda.orders.outbox_handlers"
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pool():
+    try:
+        p = await create_prod_shaped_pool(_DSN, min_size=1, max_size=4)
+    except (OSError, asyncpg.PostgresError) as exc:
+        if os.environ.get("CI"):
+            pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
+        pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+    try:
+        async with p.acquire() as conn:
+            await conn.execute(
+                "TRUNCATE garuda_practices, garuda_order_outbox, "
+                "garuda_order_journal, garuda_orders, garuda_voa_check_results "
+                "CASCADE"
+            )
+        yield p
+    finally:
+        await p.close()
+
+
+@pytest.fixture(autouse=True)
+def armed(monkeypatch):
+    monkeypatch.setenv(KILL_SWITCH_ENV, "true")
+    monkeypatch.setenv("NUZANTARA_API_KEY", "test-key-not-a-real-secret")
+
+
+class _Recorder:
+    """Captures what the sender actually put on the wire."""
+
+    def __init__(self, status: int = 201) -> None:
+        self.status = status
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(self.status, json={"ok": True})
+
+
+def _sender(recorder: _Recorder):
+    from backend.services.garuda_orders.outbox_handlers import BrevoEmailSender
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(recorder))
+    return BrevoEmailSender(client, api_url="https://notifications.invalid/send"), client
+
+
+async def _seed_order(pool, *, state: str, email: str = RECIPIENT) -> str:
+    order_id = f"ord_{uuid.uuid4().hex}"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO garuda_orders
+                (order_id, result_id_ref, case_type, applicant_full_name,
+                 applicant_email, applicant_phone, applicant_passport_number,
+                 price_idr, price_catalogue_key, state)
+            VALUES ($1, $2, 'issuance', 'SPECIMEN TRAVELLER', $3,
+                    '+000000000000', 'X0000000', 790000,
+                    'B1 Visa on Arrival (VOA)', $4)
+            """,
+            order_id,
+            f"chk_{uuid.uuid4().hex}",
+            email,
+            state,
+        )
+    return order_id
+
+
+async def _seed_practice(pool, order_id: str) -> str:
+    """`garuda_practices.source_paid_journal_event_id` is FK'd to
+    `garuda_order_journal`, so a real OP-02 event must exist first — this
+    mirrors `mint_received_practice`'s own precondition rather than a
+    synthetic id no row backs."""
+
+    practice_id = f"prac_{uuid.uuid4().hex}"
+    async with pool.acquire() as conn, conn.transaction():
+        event_id = await journal.append_event(
+            conn,
+            event_name="payment.paid",
+            aggregate_type="order",
+            aggregate_id=order_id,
+            transition_id="OP-02",
+            customer_visible=True,
+        )
+        await conn.execute(
+            """
+            INSERT INTO garuda_practices (practice_id, order_id, source_paid_journal_event_id)
+            VALUES ($1, $2, $3)
+            """,
+            practice_id,
+            order_id,
+            event_id,
+        )
+    return practice_id
+
+
+def _job(order_id: str, job_type: str, payload: dict | None = None) -> OutboxJob:
+    return OutboxJob(
+        id=1,
+        order_id=order_id,
+        journal_event_id="evt_specimen",
+        job_type=job_type,
+        payload=payload or {},
+        attempts=1,
+    )
+
+
+# --------------------------------------------------------------------------
+# checkout_ready_email
+# --------------------------------------------------------------------------
+
+
+async def test_checkout_ready_sends_while_awaiting_payment(pool):
+    order_id = await _seed_order(pool, state="awaiting_payment")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await CheckoutReadyEmailHandler(pool, sender)(
+            _job(order_id, "checkout_ready_email", {"checkout_url": "https://pay.invalid/x"})
+        )
+    finally:
+        await client.aclose()
+    assert len(rec.requests) == 1
+    body = rec.requests[0].read().decode()
+    assert RECIPIENT in body
+    assert "https://pay.invalid/x" in body
+
+
+async def test_checkout_ready_resolves_without_sending_once_paid(pool, caplog):
+    order_id = await _seed_order(pool, state="paid")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await CheckoutReadyEmailHandler(pool, sender)(
+                _job(order_id, "checkout_ready_email", {"checkout_url": "https://pay.invalid/x"})
+            )
+    finally:
+        await client.aclose()
+    assert rec.requests == [], "a paid order must not be re-invited to pay"
+    assert any(
+        "checkout_ready_email resolved WITHOUT sending" in r.getMessage() for r in caplog.records
+    )
+
+
+async def test_checkout_ready_raises_without_a_checkout_url(pool):
+    order_id = await _seed_order(pool, state="awaiting_payment")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await CheckoutReadyEmailHandler(pool, sender)(_job(order_id, "checkout_ready_email"))
+    finally:
+        await client.aclose()
+    assert rec.requests == []
+
+
+async def test_checkout_ready_raises_on_a_missing_order(pool):
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await CheckoutReadyEmailHandler(pool, sender)(
+                _job("ord_not_here", "checkout_ready_email", {"checkout_url": "https://x.invalid"})
+            )
+    finally:
+        await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# payment_failed_email
+# --------------------------------------------------------------------------
+
+
+async def test_payment_failed_sends_while_failed(pool):
+    order_id = await _seed_order(pool, state="failed")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await PaymentFailedEmailHandler(pool, sender)(
+            _job(order_id, "payment_failed_email", {"customer_action": "TRY_A_DIFFERENT_CARD"})
+        )
+    finally:
+        await client.aclose()
+    assert len(rec.requests) == 1
+    body = rec.requests[0].read().decode()
+    assert RECIPIENT in body
+    assert "different card" in body.lower()
+
+
+async def test_payment_failed_resolves_without_sending_when_still_awaiting_payment(pool, caplog):
+    """A failure job for an order that is not (or no longer) `failed` — e.g.
+    the CAS-guarded state update lost a race — must not tell the customer
+    their payment failed."""
+
+    order_id = await _seed_order(pool, state="awaiting_payment")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await PaymentFailedEmailHandler(pool, sender)(
+                _job(order_id, "payment_failed_email", {"customer_action": "TRY_AGAIN_LATER"})
+            )
+    finally:
+        await client.aclose()
+    assert rec.requests == []
+    assert any(
+        "payment_failed_email resolved WITHOUT sending" in r.getMessage() for r in caplog.records
+    )
+
+
+async def test_payment_failed_raises_on_a_missing_order(pool):
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await PaymentFailedEmailHandler(pool, sender)(
+                _job("ord_not_here", "payment_failed_email", {"customer_action": "TRY_AGAIN_LATER"})
+            )
+    finally:
+        await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# payment_expired_email
+# --------------------------------------------------------------------------
+
+
+async def test_payment_expired_sends_while_expired(pool):
+    order_id = await _seed_order(pool, state="expired")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await PaymentExpiredEmailHandler(pool, sender)(_job(order_id, "payment_expired_email"))
+    finally:
+        await client.aclose()
+    assert len(rec.requests) == 1
+    assert RECIPIENT in rec.requests[0].read().decode()
+
+
+async def test_payment_expired_resolves_without_sending_once_paid(pool, caplog):
+    """The reconciliation race this guards: `expire_if_unpaid` and the paid
+    webhook can both be in flight; if the webhook wins first, the expiry job
+    must not tell a paying customer their session expired."""
+
+    order_id = await _seed_order(pool, state="paid")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await PaymentExpiredEmailHandler(pool, sender)(_job(order_id, "payment_expired_email"))
+    finally:
+        await client.aclose()
+    assert rec.requests == []
+    assert any(
+        "payment_expired_email resolved WITHOUT sending" in r.getMessage() for r in caplog.records
+    )
+
+
+async def test_payment_expired_raises_on_a_missing_order(pool):
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await PaymentExpiredEmailHandler(pool, sender)(
+                _job("ord_not_here", "payment_expired_email")
+            )
+    finally:
+        await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# refund_email
+# --------------------------------------------------------------------------
+
+
+async def test_refund_sends_while_refunded(pool):
+    order_id = await _seed_order(pool, state="refunded")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await RefundEmailHandler(pool, sender)(_job(order_id, "refund_email"))
+    finally:
+        await client.aclose()
+    assert len(rec.requests) == 1
+    body = rec.requests[0].read().decode()
+    assert RECIPIENT in body
+    assert "790.000" in body
+
+
+async def test_refund_resolves_without_sending_when_still_paid(pool, caplog):
+    """The mirror of `PaymentPaidEmailHandler`'s own refunded-order test: a
+    refund job for an order that is (still) `paid` must not tell the customer
+    money is coming back that never left."""
+
+    order_id = await _seed_order(pool, state="paid")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await RefundEmailHandler(pool, sender)(_job(order_id, "refund_email"))
+    finally:
+        await client.aclose()
+    assert rec.requests == []
+    assert any("refund_email resolved WITHOUT sending" in r.getMessage() for r in caplog.records)
+
+
+async def test_refund_raises_on_a_missing_order(pool):
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await RefundEmailHandler(pool, sender)(_job("ord_not_here", "refund_email"))
+    finally:
+        await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# practice_received_email
+# --------------------------------------------------------------------------
+
+
+async def test_practice_received_sends_for_a_paid_order_with_its_practice(pool):
+    order_id = await _seed_order(pool, state="paid")
+    await _seed_practice(pool, order_id)
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await PracticeReceivedEmailHandler(pool, sender)(
+            _job(order_id, "practice_received_email")
+        )
+    finally:
+        await client.aclose()
+    assert len(rec.requests) == 1
+    assert RECIPIENT in rec.requests[0].read().decode()
+
+
+async def test_practice_received_resolves_without_sending_once_refunded(pool, caplog):
+    """A practice, once minted, is never deleted — but if the order has since
+    been refunded, "your application is now open with our team" reads as an
+    active-service promise a refund just closed out. Must resolve, not send,
+    and must not claim the practice itself was ever wrong."""
+
+    order_id = await _seed_order(pool, state="refunded")
+    await _seed_practice(pool, order_id)
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await PracticeReceivedEmailHandler(pool, sender)(
+                _job(order_id, "practice_received_email")
+            )
+    finally:
+        await client.aclose()
+    assert rec.requests == []
+    assert any(
+        "practice_received_email resolved WITHOUT sending" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+async def test_practice_received_raises_on_a_missing_order(pool):
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await PracticeReceivedEmailHandler(pool, sender)(
+                _job("ord_not_here", "practice_received_email")
+            )
+    finally:
+        await client.aclose()
+
+
+async def test_practice_received_raises_when_the_practice_row_is_missing(pool):
+    """A paid order with NO practice row is the shape `mint_received_practice`
+    should never leave behind (the outbox row and the practice INSERT commit
+    in the same transaction) — treat it the same as a missing order: raise,
+    never mark delivered."""
+
+    order_id = await _seed_order(pool, state="paid")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await PracticeReceivedEmailHandler(pool, sender)(
+                _job(order_id, "practice_received_email")
+            )
+    finally:
+        await client.aclose()
+    assert rec.requests == []

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
@@ -24,6 +24,7 @@ asyncpg = pytest.importorskip("asyncpg")
 from backend.services.garuda_orders import journal
 from backend.services.garuda_orders.outbox_consumer import KILL_SWITCH_ENV, OutboxJob
 from backend.services.garuda_orders.outbox_handlers import (
+    BrevoEmailSender,
     CheckoutReadyEmailHandler,
     EmailSendFailed,
     PaymentExpiredEmailHandler,
@@ -95,7 +96,9 @@ def _sender(recorder: _Recorder):
     return BrevoEmailSender(client, api_url="https://notifications.invalid/send"), client
 
 
-async def _seed_order(pool, *, state: str, email: str = RECIPIENT) -> str:
+async def _seed_order(
+    pool, *, state: str, email: str = RECIPIENT, late_case_open: bool = False
+) -> str:
     order_id = f"ord_{uuid.uuid4().hex}"
     async with pool.acquire() as conn:
         await conn.execute(
@@ -103,15 +106,16 @@ async def _seed_order(pool, *, state: str, email: str = RECIPIENT) -> str:
             INSERT INTO garuda_orders
                 (order_id, result_id_ref, case_type, applicant_full_name,
                  applicant_email, applicant_phone, applicant_passport_number,
-                 price_idr, price_catalogue_key, state)
+                 price_idr, price_catalogue_key, state, late_case_open)
             VALUES ($1, $2, 'issuance', 'SPECIMEN TRAVELLER', $3,
                     '+000000000000', 'X0000000', 790000,
-                    'B1 Visa on Arrival (VOA)', $4)
+                    'B1 Visa on Arrival (VOA)', $4, $5)
             """,
             order_id,
             f"chk_{uuid.uuid4().hex}",
             email,
             state,
+            late_case_open,
         )
     return order_id
 
@@ -324,7 +328,19 @@ async def test_payment_expired_raises_on_a_missing_order(pool):
 # --------------------------------------------------------------------------
 
 
-async def test_refund_sends_while_refunded(pool):
+async def test_refund_sends_while_refunded_and_quotes_NO_amount(pool):
+    """CORRECTED after a cross-family gate: the first version of this test
+    asserted `"790.000" in body`, i.e. it REQUIRED the handler to state a
+    refunded amount — and `price_idr` is the ORDER price, not a refunded one.
+    Nothing in `garuda_orders` records what the provider actually returned, and
+    OP-05 reaches `refunded` from `awaiting_payment`, an order this flow never
+    marked as charged. So the assertion is inverted: the refund email confirms
+    the refund and names the order, and quotes no figure at all.
+
+    This is NOT the fee/PNBP split rule (that forbids BREAKING the one price
+    into components) — it is the narrower "do not assert a number the code
+    cannot establish"."""
+
     order_id = await _seed_order(pool, state="refunded")
     rec = _Recorder()
     sender, client = _sender(rec)
@@ -335,7 +351,12 @@ async def test_refund_sends_while_refunded(pool):
     assert len(rec.requests) == 1
     body = rec.requests[0].read().decode()
     assert RECIPIENT in body
-    assert "790.000" in body
+    assert order_id in body
+    for rendering in ("790.000", "790,000", "790000"):
+        assert rendering not in body, (
+            f"the refund email quoted {rendering!r} — that is the order price, "
+            "not a refunded amount the code can establish"
+        )
 
 
 async def test_refund_resolves_without_sending_when_still_paid(pool, caplog):
@@ -520,3 +541,156 @@ async def test_no_handler_writes_applicant_pii_into_a_log_line(
     assert order_id in logged, (
         f"{handler_cls.__name__} logged without the order id — the log is unusable"
     )
+
+
+# --- OP-F05: a late `paid` webhook leaves the terminal state in place ----------
+#
+# `handle_late_paid_event` sets `late_case_open = TRUE` and does NOT move
+# `state` (repository.py:487/517, migration 284). A `payment_failed_email` or
+# `payment_expired_email` job already sitting in the outbox therefore still
+# reads `failed`/`expired` — and both bodies tell the customer no money was
+# taken. It was. These two tests are the guilt half of that guard; the two
+# below them are its innocence half, so the guard cannot be satisfied by
+# refusing to send at all.
+
+
+@pytest.mark.parametrize(
+    ("handler_cls", "job_type", "state"),
+    [
+        (PaymentFailedEmailHandler, "payment_failed_email", "failed"),
+        (PaymentExpiredEmailHandler, "payment_expired_email", "expired"),
+    ],
+)
+async def test_terminal_notice_is_withheld_when_a_late_payment_case_is_open(
+    pool, caplog, handler_cls, job_type, state
+):
+    order_id = await _seed_order(pool, state=state, late_case_open=True)
+    recorder = _Recorder()
+    sender, client = _sender(recorder)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await handler_cls(pool, sender)(_job(order_id, job_type))
+    finally:
+        await client.aclose()
+
+    assert recorder.requests == [], (
+        f"{handler_cls.__name__} told a CHARGED customer no payment was taken "
+        f"(order in state {state!r} with an open late-payment case)"
+    )
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "late-payment case" in logged, (
+        f"{handler_cls.__name__} withheld the email but left no trail naming why: {logged!r}"
+    )
+    assert order_id in logged
+
+
+@pytest.mark.parametrize(
+    ("handler_cls", "job_type", "state"),
+    [
+        (PaymentFailedEmailHandler, "payment_failed_email", "failed"),
+        (PaymentExpiredEmailHandler, "payment_expired_email", "expired"),
+    ],
+)
+async def test_terminal_notice_is_still_sent_when_no_late_payment_case_is_open(
+    pool, handler_cls, job_type, state
+):
+    order_id = await _seed_order(pool, state=state, late_case_open=False)
+    recorder = _Recorder()
+    sender, client = _sender(recorder)
+    try:
+        await handler_cls(pool, sender)(_job(order_id, job_type))
+    finally:
+        await client.aclose()
+
+    assert len(recorder.requests) == 1, (
+        f"{handler_cls.__name__} withheld a LEGITIMATE notice — the late-payment "
+        "guard must narrow the send, not replace it"
+    )
+
+
+# --- PII tripwire, second and third branches ----------------------------------
+#
+# The tripwire above only exercises the SUCCESSFUL send. Two other branches log
+# and were uncovered: the stale-state early return, and a sender failure. A
+# well-meaning "log who we failed to email" edit lands in exactly those two.
+
+
+@pytest.mark.parametrize(
+    ("handler_cls", "job_type"),
+    [
+        (PaymentFailedEmailHandler, "payment_failed_email"),
+        (PaymentExpiredEmailHandler, "payment_expired_email"),
+        (RefundEmailHandler, "refund_email"),
+    ],
+)
+async def test_the_stale_state_branch_logs_no_applicant_pii(
+    pool, caplog, handler_cls, job_type
+):
+    marker_email = f"pii-stale-{uuid.uuid4().hex}@example.invalid"
+    # `paid` warrants none of these three notices, so each takes its stale-state
+    # early return.
+    order_id = await _seed_order(pool, state="paid", email=marker_email)
+    recorder = _Recorder()
+    sender, client = _sender(recorder)
+    try:
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            await handler_cls(pool, sender)(_job(order_id, job_type))
+    finally:
+        await client.aclose()
+
+    assert recorder.requests == [], f"{handler_cls.__name__} sent a stale notice"
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert order_id in logged, f"{handler_cls.__name__} returned silently — no trail"
+    for label, secret in (
+        ("applicant email", marker_email),
+        ("applicant name", "SPECIMEN TRAVELLER"),
+        ("passport number", "X0000000"),
+        ("phone", "+000000000000"),
+    ):
+        assert secret not in logged, (
+            f"{handler_cls.__name__} wrote the {label} into its stale-state log line: {logged!r}"
+        )
+
+
+async def test_a_sender_failure_leaks_no_applicant_pii_into_its_error(pool, caplog):
+    """The failure path logs NOTHING — so a caplog-only assertion here would be
+    satisfied by silence and prove nothing. The surface that actually carries
+    text out of this path is the raised `EmailSendFailed` MESSAGE: the outbox
+    worker persists it as the job's `last_error` and logs it. `send` keeps the
+    response body out of that message on purpose ("it can echo the recipient");
+    this is the tripwire on that comment.
+    """
+
+    marker_email = f"pii-senderr-{uuid.uuid4().hex}@example.invalid"
+    order_id = await _seed_order(pool, state="expired", email=marker_email)
+
+    def _boom(request: httpx.Request) -> httpx.Response:
+        # A provider that echoes the request back — the realistic worst case.
+        return httpx.Response(500, json={"error": "rejected", "echo": request.read().decode()})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_boom))
+    sender = BrevoEmailSender(client, api_url="https://notifications.invalid/send")
+    try:
+        with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+            with pytest.raises(EmailSendFailed) as raised:
+                await PaymentExpiredEmailHandler(pool, sender)(
+                    _job(order_id, "payment_expired_email")
+                )
+    finally:
+        await client.aclose()
+
+    surfaced = str(raised.value) + "\n".join(r.getMessage() for r in caplog.records)
+    assert surfaced.strip(), "the failure surfaced no text at all — nothing to diagnose from"
+    assert "500" in surfaced, (
+        "the error names neither the status nor anything else actionable: "
+        f"{surfaced!r}"
+    )
+    for label, secret in (
+        ("applicant email", marker_email),
+        ("applicant name", "SPECIMEN TRAVELLER"),
+        ("passport number", "X0000000"),
+        ("phone", "+000000000000"),
+    ):
+        assert secret not in surfaced, (
+            f"the sender-failure path surfaced the {label}: {surfaced!r}"
+        )

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
@@ -169,6 +169,11 @@ def _facts(**over) -> OrderEmailFacts:
         "case_type": "issuance",
         "price_idr": 790000,
         "state": "paid",
+        # OP-F04/OP-F05 flag. Required on the dataclass on purpose: a `_load`
+        # that forgets the column must fail loudly rather than default to
+        # "no late payment" and let a terminal notice go out to a charged
+        # customer. This factory's default is the ordinary case.
+        "late_case_open": False,
     }
     base.update(over)
     return OrderEmailFacts(**base)

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
@@ -420,11 +420,12 @@ async def test_a_retry_after_a_transient_failure_delivers(pool):
 async def test_unrouted_job_types_are_reported_not_delivered(pool):
     """A job type with no registered handler must show as unroutable.
 
-    This used to assert on `practice_release`, which acquired a handler when
-    the CRM weld landed. The specimen is now `refund_email` — still enqueued by
-    `repository.py`, still deliberately unrouted. Repointing rather than
-    deleting keeps the property under test: `build_handlers` must report what
-    it cannot route instead of consuming it.
+    This used to assert on `practice_release`, then on `refund_email` — both
+    acquired handlers as the outbox drain grew. The specimen is now
+    `staff_page_duplicate_charge`, one of the five `staff_page_*` jobs
+    `build_handlers` deliberately never routes (module docstring). Repointing
+    rather than deleting keeps the property under test: `build_handlers` must
+    report what it cannot route instead of consuming it.
     """
 
     order_id = await _seed_order(pool)
@@ -438,7 +439,10 @@ async def test_unrouted_job_types_are_reported_not_delivered(pool):
             customer_visible=True,
         )
         await journal.enqueue_outbox(
-            conn, order_id=order_id, journal_event_id=event_id, job_type="refund_email"
+            conn,
+            order_id=order_id,
+            journal_event_id=event_id,
+            job_type="staff_page_duplicate_charge",
         )
 
     rec = _Recorder()
@@ -450,7 +454,7 @@ async def test_unrouted_job_types_are_reported_not_delivered(pool):
         await client.aclose()
 
     assert stats.unroutable == 1
-    assert "refund_email" in stats.unroutable_types
+    assert "staff_page_duplicate_charge" in stats.unroutable_types
     assert rec.requests == []
 
 
@@ -473,8 +477,18 @@ def test_build_handlers_routes_practice_release() -> None:
     # The set is EXACT on purpose: adding a route must be a deliberate edit
     # here, and removing one can never pass unnoticed. `portal_invite` joined
     # it when a paid order started producing a portal account as well as a
-    # practice.
-    assert set(handlers) == {"payment_paid_email", "practice_release", "portal_invite"}
+    # practice; the five customer-email jobs joined when the outbox grew to
+    # cover checkout/failure/expiry/refund/receipt.
+    assert set(handlers) == {
+        "checkout_ready_email",
+        "payment_paid_email",
+        "payment_failed_email",
+        "payment_expired_email",
+        "refund_email",
+        "practice_release",
+        "practice_received_email",
+        "portal_invite",
+    }
     assert isinstance(handlers["practice_release"], PracticeReleaseHandler)
 
 


### PR DESCRIPTION
## What

`build_handlers` registered 3 of 13 enqueued outbox job types. Ten fell to
`unroutable`. Five of those ten are the notices the paying traveller is supposed to
receive; this PR routes them, plus the practice-received notice:

| job type | state guard | what the traveller gets |
|---|---|---|
| `checkout_ready_email` | `awaiting_payment` | the payment link |
| `payment_failed_email` | `failed` | why it failed, what to do |
| `payment_expired_email` | `expired` | the link expired, how to restart |
| `refund_email` | `refunded` | refund confirmed |
| `practice_received_email` | `paid` | practice received, D-7 checkpoint |
| `portal_invite` | — | passwordless portal link |

`payment_paid_email` was already handled — this is the SECOND notice, not the first.

## Boundaries held

- **One figure, never a breakdown**: `f"IDR {facts.price_idr:,}"` at 4 sites, no
  arithmetic, no fee/PNBP split (the split is internal by ruling).
- **Only the published D-7 checkpoint** appears in customer copy.
- **No PII in logs** — and that is now a tripwire, not an inspection:
  `test_no_handler_writes_applicant_pii_into_a_log_line` parametrizes all six
  handlers, seeds a unique marker email per order, and asserts the log lines carry
  the `order_id` and none of email / name / passport / phone.
- Sender is `zantara@balizero.com` via Brevo, key read from env.
- No emoji.

## Proof the tests can go red

Three mutations, each restored afterwards:

1. Widened the refund state guard → 1 red.
2. Turned the five `raise EmailSendFailed` into `return` → 5 red.
3. Added `facts.email` to the `checkout_ready_email` log line
   (`outbox_handlers.py:282`) → the PII tripwire goes red (1 failed, 4 passed).

Baseline: 169 passed on the handler suite; 22 passed on this file.

## What this does NOT close

Four of the ten unhandled job types remain unrouted. The scoped `unroutable > 0`
alarm is deliberately a separate PR — an unscoped one would fire forever for the
known-unhandled types. Tracked in `PENDING-ARMS.md`.