### PR TITLE
fix(tests): terminate five pool fixtures' except branch so CodeQL can prove `p` is bound

### DIFF
--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_funnel_end_to_end_http.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_funnel_end_to_end_http.py
@@ -274,6 +274,10 @@ async def pool():
                 f"only end-to-end proof of the funnel and must never skip in CI."
             )
         pytest.skip(f"no local Postgres reachable at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
         raise
 
     async with p.acquire() as conn:

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_customer_emails.py
@@ -59,6 +59,11 @@ async def pool():
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
+        raise
     try:
         async with p.acquire() as conn:
             await conn.execute(

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
@@ -72,6 +72,11 @@ async def pool():
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
+        raise
     try:
         async with p.acquire() as conn:
             await conn.execute(

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_portal_invite_handler.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_portal_invite_handler.py
@@ -54,6 +54,11 @@ async def pool():
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
+        raise
     try:
         async with p.acquire() as conn:
             await conn.execute(

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_staff_page_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_staff_page_handlers.py
@@ -70,6 +70,11 @@ async def pool():
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
+        raise
     try:
         async with p.acquire() as conn:
             await conn.execute(

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_practice_producer_crossing.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_practice_producer_crossing.py
@@ -125,6 +125,11 @@ async def pool():
                 f"silently pass by skipping."
             )
         pytest.skip(f"no local Postgres reachable at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
+        raise
     async with p.acquire() as conn:
         await conn.execute(
             "TRUNCATE garuda_practices, garuda_order_outbox, garuda_order_journal, "


### PR DESCRIPTION
Closes a CodeQL **ERROR**-level alert (`py/uninitialized-local-variable`) as a family rather than one instance at a time.

## The shape
Ten test files under `backend/tests/` use `create_prod_shaped_pool` with this fixture:

```python
    try:
        p = await create_prod_shaped_pool(_DSN, ...)
    except (OSError, asyncpg.PostgresError) as exc:
        if os.environ.get("CI"):
            pytest.fail(...)
        pytest.skip(...)
    async with p.acquire() as conn:      # <-- CodeQL: `p` may be unbound
```

`pytest.fail` and `pytest.skip` are both NoReturn, so `p` is always bound. CodeQL cannot see that through the pytest API.

## The cure
A bare `raise` as the last statement of the except branch — **not** a `# noqa` or a CodeQL suppression, which would hide the class instead of closing it. It terminates the branch provably, and it is the correct behaviour if pytest ever stopped raising: re-raise the connection error rather than proceed with an unbound pool. Four files in the repo already did exactly this; this brings the rest in line.

## Why it surfaced now, and why it is a family fix
CodeQL reports *"new alerts in code changed by this pull request"* — **changed-FILE-scoped, not new-defect-scoped**. It fired on #5129 because that PR touched one of the ten files, not because #5129 introduced anything. Left alone, the alert lands on whoever next touches any of them.

It also did not block #5129: `CodeQL Analysis (python)` and `(javascript)` are the two *required* check runs and both were green; the red one was the non-required aggregate check run named plain `CodeQL`. That is the difference between `UNSTABLE` and `BLOCKED`.

## Scope — measured per file, not pattern-replaced
| files | state |
|---|---|
| `test_outbox_customer_emails`, `test_outbox_handlers`, `test_portal_invite_handler`, `test_staff_page_handlers`, `test_practice_producer_crossing` | genuinely needed the `raise` — added |
| `test_funnel_end_to_end_http` | **already** ended in a bare `raise` — comment only, no behaviour change |
| `test_webhook_router`, `test_repository_integration`, `test_check_to_order_journey`, `test_check_store_purge` | already correct — untouched |

Four of the ten use a **multi-line** `pytest.fail(...)`. A single-string replace tuned to the one-line form would have silently missed them and reported success on a partial fix — the text-vs-syntax under-match (superscar #3) this repo hit three times this week. Each file was read and edited individually.

## Proof
- `ruff check` on all six touched files → `All checks passed!`
- `pytest --collect-only -q` on all six → **exit 0**, 119 tests collected (8 + 30 + 26 + 12 + 40 + 3), every file N>0. (Exit 5 would mean nothing collected, and would not be a pass.)
- The four untouched files were re-read to confirm they really do already terminate their branch, rather than taking that on report.

Generator ≠ grader: the edits were produced by an implementer subagent; this session verified them independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
