### PR TITLE
fix(queue-shepherd): force-cancel fallback for the 409 not-queued-yet class

### DIFF
--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -709,13 +709,44 @@ def rearm_pr(repo: str, number: int) -> bool:
 
 
 def cancel_run(repo: str, run_id: int) -> bool:
+    """Cancels a queued Actions run. Post-outage (and on very old runs), GitHub's plain cancel
+    endpoint answers HTTP 409 "Cannot cancel a workflow run that has not been queued yet" for a
+    run whose real state has already moved past QUEUED — the janitor's own discovery-to-cancel
+    gap, or GitHub settling state after an incident. On EXACTLY that 409 class, falls back once
+    to the force-cancel endpoint, which GitHub accepts regardless of the run's current state.
+    Force-cancel is deliberately NOT the default path — only the 409 fallback — because it is a
+    stronger, less-reversible instrument than plain cancel and unconditional use would widen this
+    guard past what the janitor's mandate (cancel stale QUEUED runs) actually needs.
+
+    Any other failure class (a non-409 error, or the force-cancel fallback itself failing — e.g.
+    the HTTP 500s seen on very old 3221xxxx runs) is a single WARNING and this function returns
+    False. No retry loop lives here: superscar #2 (exist != armed) is exactly a "still working"
+    façade that quietly burns a tick's time budget on a run that will never cancel — the janitor's
+    own 10-min tick cadence is the retry, not this call."""
     owner, name = repo.split("/", 1)
     rc, out, err = _run(
         ["gh", "api", "-X", "POST", f"repos/{owner}/{name}/actions/runs/{run_id}/cancel"],
         timeout=30,
     )
-    if rc != 0:
+    if rc == 0:
+        return True
+    if "HTTP 409" not in err:
         logger.warning("cancel_run(%s) failed rc=%s err=%s", run_id, rc, err.strip()[:200])
+        return False
+
+    logger.info(
+        "cancel_run(%s): plain cancel got HTTP 409 (not queued yet) — falling back to force-cancel",
+        run_id,
+    )
+    fc_rc, fc_out, fc_err = _run(
+        ["gh", "api", "-X", "POST", f"repos/{owner}/{name}/actions/runs/{run_id}/force-cancel"],
+        timeout=30,
+    )
+    if fc_rc != 0:
+        logger.warning(
+            "cancel_run(%s): force-cancel fallback also failed rc=%s err=%s",
+            run_id, fc_rc, fc_err.strip()[:200],
+        )
         return False
     return True
 

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -310,6 +310,75 @@ def test_janitor_recheck_still_cancels_a_run_that_stays_stale_on_recheck(monkeyp
     assert calls["cancel"] == [43]
 
 
+# ── cancel_run: 409 "not queued yet" force-cancel fallback ─────────────────
+
+
+def test_cancel_run_409_falls_back_to_force_cancel_and_counts_as_cancelled(monkeypatch):
+    """Guilt: a plain-cancel HTTP 409 ('Cannot cancel a workflow run that has not been queued
+    yet') must trigger exactly one force-cancel attempt, and a SUCCESSFUL force-cancel must be
+    reported as cancelled (cancel_run returns True) — the shape measured live post-outage on Pro
+    (~20 phantom runs retried every tick forever before this fix)."""
+    calls = []
+
+    def fake_run(cmd, timeout=30):
+        calls.append(cmd)
+        if cmd[-1].endswith("/force-cancel"):
+            return 0, "", ""
+        return (
+            1,
+            "",
+            "gh: Cannot cancel a workflow run that has not been queued yet. (HTTP 409)",
+        )
+
+    monkeypatch.setattr(qs, "_run", fake_run)
+    result = qs.cancel_run("Bali-Zero/Teman2", 3221000123)
+
+    assert result is True
+    assert len(calls) == 2
+    assert calls[0][-1].endswith("/actions/runs/3221000123/cancel")
+    assert calls[1][-1].endswith("/actions/runs/3221000123/force-cancel")
+
+
+def test_cancel_run_409_then_force_cancel_also_fails_is_warning_not_crash(monkeypatch, caplog):
+    """Guilt (part 2): when the force-cancel fallback ALSO fails (e.g. the HTTP 500s seen on
+    very old 3221xxxx runs), cancel_run must return False — a single warning, not an exception,
+    and not counted as cancelled — so the caller's per-run loop simply continues to the next run."""
+
+    def fake_run(cmd, timeout=30):
+        if cmd[-1].endswith("/force-cancel"):
+            return 1, "", "gh: Internal Server Error (HTTP 500)"
+        return (
+            1,
+            "",
+            "gh: Cannot cancel a workflow run that has not been queued yet. (HTTP 409)",
+        )
+
+    monkeypatch.setattr(qs, "_run", fake_run)
+    with caplog.at_level("WARNING"):
+        result = qs.cancel_run("Bali-Zero/Teman2", 3221000456)
+
+    assert result is False
+    assert "force-cancel fallback also failed" in caplog.text
+
+
+def test_cancel_run_non_409_failure_never_attempts_force_cancel(monkeypatch):
+    """Innocence: a failure that is NOT the 409 'not queued yet' class (e.g. a plain HTTP 500 on
+    the first cancel attempt, or a network error) must never trigger force-cancel — force-cancel
+    is deliberately not the default path, only the 409 fallback."""
+    calls = []
+
+    def fake_run(cmd, timeout=30):
+        calls.append(cmd)
+        return 1, "", "gh: Internal Server Error (HTTP 500)"
+
+    monkeypatch.setattr(qs, "_run", fake_run)
+    result = qs.cancel_run("Bali-Zero/Teman2", 999)
+
+    assert result is False
+    assert len(calls) == 1  # only the plain cancel — no force-cancel call made
+    assert calls[0][-1].endswith("/actions/runs/999/cancel")
+
+
 def test_janitor_dry_run_never_calls_cancel_run(monkeypatch):
     def fake_fetch_queued_runs(repo=qs.REPO):
         return [{"id": 44, "event": "pull_request", "head_sha": "dead", "head_branch": None, "name": "CI"}]


### PR DESCRIPTION
## Summary
- ~20 phantom post-outage Actions runs (plus a few HTTP 500s on very old 3221xxxx runs) answer the janitor's plain `gh api .../cancel` with `HTTP 409 "Cannot cancel a workflow run that has not been queued yet"`. The janitor retried them every 10-min tick forever — log noise and a superscar #2 (exist != armed) normalization risk.
- `cancel_run()` now falls back, **only** on that specific 409 class, to `gh api .../force-cancel` (GitHub's stronger endpoint, accepts a run in any state). Force-cancel success counts as cancelled; its failure (any error, incl. 500) is a single WARNING and the function returns `False` — no retry loop within the call, no crash, never the default path for a non-409 failure.

## Adversarial review
Small, mechanical, single-concern fix to one function's error-handling branch, with red-first guilt/innocence tests covering exactly the three named cases (409→force-cancel success counted as cancelled; 409→force-cancel also fails→warning not counted; non-409→force-cancel never attempted). Gear 1-2 per the deterministic floor — no evidence pack.

## Test plan
- [x] `python3 -m py_compile scripts/queue_shepherd.py scripts/tests/test_queue_shepherd.py`
- [x] `pytest scripts/tests/test_queue_shepherd.py -q` → 58 passed (55 pre-existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)