### PR TITLE
feat(queue-shepherd): persistent skip-list for GitHub-uncancellable runs

### DIFF
--- a/scripts/queue_shepherd.py
+++ b/scripts/queue_shepherd.py
@@ -106,6 +106,12 @@ ALERTED_FILE = Path(
         os.path.expanduser("~/logs/queue-shepherd/alerted-unknown.json"),
     )
 )
+UNCANCELLABLE_FILE = Path(
+    os.environ.get(
+        "QUEUE_SHEPHERD_UNCANCELLABLE_FILE",
+        os.path.expanduser("~/logs/queue-shepherd/uncancellable.json"),
+    )
+)
 LOG_FILE = Path(
     os.environ.get("QUEUE_SHEPHERD_LOG_FILE", os.path.expanduser("~/logs/queue-shepherd.log"))
 )
@@ -309,6 +315,19 @@ def gc_budget_state(budget_state: dict[str, Any], now: _dt.datetime) -> dict[str
         if parsed and max(parsed) >= cutoff:
             kept[key] = entry
     return kept
+
+
+def gc_uncancellable_state(
+    uncancellable_state: dict[str, Any], candidate_ids: set[str]
+) -> dict[str, Any]:
+    """Pure: drop any recorded run id that is no longer present in THIS TICK's candidate query
+    (the janitor's own stale-run discovery, before skip-list filtering) — the run stopped showing
+    up as a stale-queued candidate (GitHub finally resolved it, it aged past the queued-run query
+    window, or the PR/queue branch it belonged to is simply gone), so remembering it forever would
+    let the file grow unbounded. Presence-based, not time-based (unlike gc_budget_state): there is
+    no useful TTL for "GitHub told us twice it cannot cancel this" — the only trustworthy signal
+    that it is safe to forget an id is that the janitor no longer sees it at all."""
+    return {run_id: entry for run_id, entry in uncancellable_state.items() if run_id in candidate_ids}
 
 
 def decide_rearm(
@@ -708,31 +727,42 @@ def rearm_pr(repo: str, number: int) -> bool:
     return True
 
 
-def cancel_run(repo: str, run_id: int) -> bool:
-    """Cancels a queued Actions run. Post-outage (and on very old runs), GitHub's plain cancel
-    endpoint answers HTTP 409 "Cannot cancel a workflow run that has not been queued yet" for a
-    run whose real state has already moved past QUEUED — the janitor's own discovery-to-cancel
-    gap, or GitHub settling state after an incident. On EXACTLY that 409 class, falls back once
-    to the force-cancel endpoint, which GitHub accepts regardless of the run's current state.
-    Force-cancel is deliberately NOT the default path — only the 409 fallback — because it is a
-    stronger, less-reversible instrument than plain cancel and unconditional use would widen this
-    guard past what the janitor's mandate (cancel stale QUEUED runs) actually needs.
+def cancel_run(repo: str, run_id: int) -> tuple[bool, str]:
+    """Cancels a queued Actions run. Returns (cancelled, outcome), outcome one of:
+      "cancelled"          — cancelled via the plain endpoint, or the force-cancel fallback.
+      "uncancellable_409"  — BOTH the plain cancel AND the force-cancel fallback answered HTTP
+                              409 ("not been queued yet") — a run whose real state GitHub itself
+                              cannot resolve through either endpoint (measured live: post-outage
+                              orphans left `status=queued` for 2-9 days). The caller may persist
+                              this id to a skip-list; the run will never cancel by retrying —
+                              GitHub's own two cancellation endpoints both refuse it.
+      "failed"              — any other failure (non-409 on the first attempt, or the
+                              force-cancel fallback failing with something other than 409, e.g.
+                              the HTTP 500s seen on very old 3221xxxx runs). MUST NEVER enter the
+                              skip-list — a transient error may simply succeed on a later tick.
 
-    Any other failure class (a non-409 error, or the force-cancel fallback itself failing — e.g.
-    the HTTP 500s seen on very old 3221xxxx runs) is a single WARNING and this function returns
-    False. No retry loop lives here: superscar #2 (exist != armed) is exactly a "still working"
-    façade that quietly burns a tick's time budget on a run that will never cancel — the janitor's
-    own 10-min tick cadence is the retry, not this call."""
+    Post-outage (and on very old runs), GitHub's plain cancel endpoint answers HTTP 409 "Cannot
+    cancel a workflow run that has not been queued yet" for a run whose real state has already
+    moved past QUEUED — the janitor's own discovery-to-cancel gap, or GitHub settling state after
+    an incident. On EXACTLY that 409 class, falls back once to the force-cancel endpoint, which
+    GitHub accepts regardless of the run's current state. Force-cancel is deliberately NOT the
+    default path — only the 409 fallback — because it is a stronger, less-reversible instrument
+    than plain cancel and unconditional use would widen this guard past what the janitor's mandate
+    (cancel stale QUEUED runs) actually needs.
+
+    No retry loop lives here: superscar #2 (exist != armed) is exactly a "still working" façade
+    that quietly burns a tick's time budget on a run that will never cancel — the janitor's own
+    10-min tick cadence is the retry, not this call."""
     owner, name = repo.split("/", 1)
     rc, out, err = _run(
         ["gh", "api", "-X", "POST", f"repos/{owner}/{name}/actions/runs/{run_id}/cancel"],
         timeout=30,
     )
     if rc == 0:
-        return True
+        return True, "cancelled"
     if "HTTP 409" not in err:
         logger.warning("cancel_run(%s) failed rc=%s err=%s", run_id, rc, err.strip()[:200])
-        return False
+        return False, "failed"
 
     logger.info(
         "cancel_run(%s): plain cancel got HTTP 409 (not queued yet) — falling back to force-cancel",
@@ -742,13 +772,20 @@ def cancel_run(repo: str, run_id: int) -> bool:
         ["gh", "api", "-X", "POST", f"repos/{owner}/{name}/actions/runs/{run_id}/force-cancel"],
         timeout=30,
     )
-    if fc_rc != 0:
+    if fc_rc == 0:
+        return True, "cancelled"
+    if "HTTP 409" in fc_err:
         logger.warning(
-            "cancel_run(%s): force-cancel fallback also failed rc=%s err=%s",
-            run_id, fc_rc, fc_err.strip()[:200],
+            "cancel_run(%s): force-cancel ALSO got HTTP 409 — GitHub cannot resolve this run's "
+            "state through either endpoint, marking uncancellable",
+            run_id,
         )
-        return False
-    return True
+        return False, "uncancellable_409"
+    logger.warning(
+        "cancel_run(%s): force-cancel fallback also failed rc=%s err=%s",
+        run_id, fc_rc, fc_err.strip()[:200],
+    )
+    return False, "failed"
 
 
 def send_telegram(message: str, dedup_key: str = "") -> bool:
@@ -922,8 +959,27 @@ def run_janitor_pass(dry_run: bool) -> int:
         queued_runs, live_branches
     )
 
+    # Fail-closed on state corruption (same posture as run_rearm_pass's budget-file guard): a
+    # torn/corrupt uncancellable skip-list must never be silently read as "nothing known
+    # uncancellable" — that would burn this whole tick re-hammering ids GitHub has already told us
+    # twice it cannot cancel. `_load_json` raises on a parse failure (vs. a simply-missing file,
+    # which is normal and returns {}); this pass treats that as CANNOT-VERIFY and cancels NOTHING
+    # this tick — placed AFTER the discovery fetches above so a corrupt skip-list never masks a
+    # genuine "CANNOT-VERIFY queued runs" fetch failure as the same zero-action outcome.
+    try:
+        uncancellable_state = {} if dry_run else _load_json(UNCANCELLABLE_FILE)
+    except RuntimeError as exc:
+        logger.error("CANNOT-VERIFY uncancellable skip-list: %s", exc)
+        return 0
+
+    skip_ids = set(uncancellable_state.keys())
+    to_process = [run for run in stale if str(run["id"]) not in skip_ids]
+    skipped_count = len(stale) - len(to_process)
+    if skipped_count:
+        logger.info("skipping %s known-uncancellable runs", skipped_count)
+
     cancelled = 0
-    for run in stale:
+    for run in to_process:
         # Re-verify liveness AT CANCEL TIME with a fresh fetch — never trust the list above,
         # which may already be stale by the time this specific run is reached (mandate: "not
         # from a stale list").
@@ -942,9 +998,17 @@ def run_janitor_pass(dry_run: bool) -> int:
             logger.info("[dry-run] would cancel run %s (%s, event=%s)", run["id"], run.get("name"), run["event"])
             cancelled += 1
             continue
-        if cancel_run(REPO, run["id"]):
+        ok, outcome = cancel_run(REPO, run["id"])
+        if ok:
             logger.info("cancelled stale run %s (%s, event=%s)", run["id"], run.get("name"), run["event"])
             cancelled += 1
+        elif outcome == "uncancellable_409":
+            uncancellable_state[str(run["id"])] = {"recorded_at": _now().strftime("%Y-%m-%dT%H:%M:%SZ")}
+
+    if not dry_run:
+        candidate_ids = {str(run["id"]) for run in stale}
+        uncancellable_state = gc_uncancellable_state(uncancellable_state, candidate_ids)
+        _save_json(UNCANCELLABLE_FILE, uncancellable_state)
     return cancelled
 
 

--- a/scripts/tests/test_queue_shepherd.py
+++ b/scripts/tests/test_queue_shepherd.py
@@ -246,10 +246,11 @@ def test_select_functions_ignore_the_other_events_event_isolation():
     assert qs.select_stale_pull_request_runs(runs, {"dead"}) == []  # innocence: live head
 
 
-def test_janitor_recheck_at_cancel_time_never_cancels_a_run_that_became_live(monkeypatch):
+def test_janitor_recheck_at_cancel_time_never_cancels_a_run_that_became_live(monkeypatch, tmp_path):
     """End-to-end of run_janitor_pass with every gh call monkeypatched: a run discovered stale
     on the FIRST fetch but reported live on the RECHECK fetch (the fresh call immediately
     before cancel) must never be cancelled. This is the literal 'not from a stale list' mandate."""
+    monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", tmp_path / "uncancellable.json")
     calls = {"cancel": []}
 
     discovery_heads = {"other_live_sha"}  # run's head_sha="flaky_sha" is stale here...
@@ -270,7 +271,7 @@ def test_janitor_recheck_at_cancel_time_never_cancels_a_run_that_became_live(mon
 
     def fake_cancel_run(repo, run_id):
         calls["cancel"].append(run_id)
-        return True
+        return True, "cancelled"
 
     monkeypatch.setattr(qs, "fetch_queued_runs", fake_fetch_queued_runs)
     monkeypatch.setattr(qs, "fetch_open_pr_heads", fake_fetch_open_pr_heads)
@@ -283,7 +284,8 @@ def test_janitor_recheck_at_cancel_time_never_cancels_a_run_that_became_live(mon
     assert calls["cancel"] == []
 
 
-def test_janitor_recheck_still_cancels_a_run_that_stays_stale_on_recheck(monkeypatch):
+def test_janitor_recheck_still_cancels_a_run_that_stays_stale_on_recheck(monkeypatch, tmp_path):
+    monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", tmp_path / "uncancellable.json")
     calls = {"cancel": []}
 
     def fake_fetch_queued_runs(repo=qs.REPO):
@@ -297,7 +299,7 @@ def test_janitor_recheck_still_cancels_a_run_that_stays_stale_on_recheck(monkeyp
 
     def fake_cancel_run(repo, run_id):
         calls["cancel"].append(run_id)
-        return True
+        return True, "cancelled"
 
     monkeypatch.setattr(qs, "fetch_queued_runs", fake_fetch_queued_runs)
     monkeypatch.setattr(qs, "fetch_open_pr_heads", fake_fetch_open_pr_heads)
@@ -331,9 +333,10 @@ def test_cancel_run_409_falls_back_to_force_cancel_and_counts_as_cancelled(monke
         )
 
     monkeypatch.setattr(qs, "_run", fake_run)
-    result = qs.cancel_run("Bali-Zero/Teman2", 3221000123)
+    ok, outcome = qs.cancel_run("Bali-Zero/Teman2", 3221000123)
 
-    assert result is True
+    assert ok is True
+    assert outcome == "cancelled"
     assert len(calls) == 2
     assert calls[0][-1].endswith("/actions/runs/3221000123/cancel")
     assert calls[1][-1].endswith("/actions/runs/3221000123/force-cancel")
@@ -355,9 +358,10 @@ def test_cancel_run_409_then_force_cancel_also_fails_is_warning_not_crash(monkey
 
     monkeypatch.setattr(qs, "_run", fake_run)
     with caplog.at_level("WARNING"):
-        result = qs.cancel_run("Bali-Zero/Teman2", 3221000456)
+        ok, outcome = qs.cancel_run("Bali-Zero/Teman2", 3221000456)
 
-    assert result is False
+    assert ok is False
+    assert outcome == "failed"  # a 500, not a 409 -> must NOT classify as uncancellable_409
     assert "force-cancel fallback also failed" in caplog.text
 
 
@@ -372,11 +376,162 @@ def test_cancel_run_non_409_failure_never_attempts_force_cancel(monkeypatch):
         return 1, "", "gh: Internal Server Error (HTTP 500)"
 
     monkeypatch.setattr(qs, "_run", fake_run)
-    result = qs.cancel_run("Bali-Zero/Teman2", 999)
+    ok, outcome = qs.cancel_run("Bali-Zero/Teman2", 999)
 
-    assert result is False
+    assert ok is False
+    assert outcome == "failed"
     assert len(calls) == 1  # only the plain cancel — no force-cancel call made
     assert calls[0][-1].endswith("/actions/runs/999/cancel")
+
+
+def test_cancel_run_409_on_force_cancel_is_uncancellable_409_class(monkeypatch):
+    """Both endpoints answer 409 -> GitHub cannot resolve this run's state through either one.
+    This is the ONLY class run_janitor_pass should ever persist to the skip-list."""
+
+    def fake_run(cmd, timeout=30):
+        return (
+            1,
+            "",
+            "gh: Cannot cancel a workflow run that has not been queued yet. (HTTP 409)",
+        )
+
+    monkeypatch.setattr(qs, "_run", fake_run)
+    ok, outcome = qs.cancel_run("Bali-Zero/Teman2", 32217208723)
+
+    assert ok is False
+    assert outcome == "uncancellable_409"
+
+
+# ── janitor uncancellable skip-list ─────────────────────────────────────────
+
+
+def test_janitor_uncancellable_409_persisted_and_skipped_next_tick(monkeypatch, tmp_path, caplog):
+    """(a) Guilt: 409-on-force-cancel -> id persisted, and the VERY NEXT tick skips it (no
+    cancel_run call at all for that id) with a one-line INFO summary naming the skip count."""
+    uncancellable_path = tmp_path / "uncancellable.json"
+    monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", uncancellable_path)
+
+    def fake_fetch_queued_runs(repo=qs.REPO):
+        return [
+            {"id": 32217208723, "event": "pull_request", "head_sha": "dead", "head_branch": None, "name": "CI"}
+        ]
+
+    def fake_fetch_open_pr_heads(repo=qs.REPO):
+        return set()  # stale on discovery AND on every recheck
+
+    def fake_fetch_live_queue_branches(repo=qs.REPO):
+        return set()
+
+    monkeypatch.setattr(qs, "fetch_queued_runs", fake_fetch_queued_runs)
+    monkeypatch.setattr(qs, "fetch_open_pr_heads", fake_fetch_open_pr_heads)
+    monkeypatch.setattr(qs, "fetch_live_queue_branches", fake_fetch_live_queue_branches)
+
+    # Tick 1: cancel_run reports the both-endpoints-409 class.
+    monkeypatch.setattr(qs, "cancel_run", lambda repo, run_id: (False, "uncancellable_409"))
+    cancelled_1 = qs.run_janitor_pass(dry_run=False)
+    assert cancelled_1 == 0
+    saved = qs._load_json(uncancellable_path)
+    assert "32217208723" in saved
+
+    # Tick 2: cancel_run must NEVER be invoked again for this id.
+    def never_called(repo, run_id):
+        raise AssertionError(f"cancel_run must not be re-invoked for known-uncancellable id {run_id}")
+
+    monkeypatch.setattr(qs, "cancel_run", never_called)
+    with caplog.at_level("INFO"):
+        cancelled_2 = qs.run_janitor_pass(dry_run=False)
+
+    assert cancelled_2 == 0
+    assert "skipping 1 known-uncancellable runs" in caplog.text
+
+
+def test_janitor_transient_failure_not_persisted_retried_next_tick(monkeypatch, tmp_path):
+    """(b) Innocence: a transient failure (e.g. HTTP 500 on force-cancel) must NOT enter the
+    skip-list — the run is re-attempted (cancel_run called again) on the very next tick."""
+    monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", tmp_path / "uncancellable.json")
+
+    def fake_fetch_queued_runs(repo=qs.REPO):
+        return [{"id": 555, "event": "pull_request", "head_sha": "dead", "head_branch": None, "name": "CI"}]
+
+    def fake_fetch_open_pr_heads(repo=qs.REPO):
+        return set()
+
+    def fake_fetch_live_queue_branches(repo=qs.REPO):
+        return set()
+
+    calls = []
+
+    def fake_cancel_run(repo, run_id):
+        calls.append(run_id)
+        return False, "failed"  # a transient 500 — never the 409-on-both-endpoints class
+
+    monkeypatch.setattr(qs, "fetch_queued_runs", fake_fetch_queued_runs)
+    monkeypatch.setattr(qs, "fetch_open_pr_heads", fake_fetch_open_pr_heads)
+    monkeypatch.setattr(qs, "fetch_live_queue_branches", fake_fetch_live_queue_branches)
+    monkeypatch.setattr(qs, "cancel_run", fake_cancel_run)
+
+    qs.run_janitor_pass(dry_run=False)
+    qs.run_janitor_pass(dry_run=False)
+
+    assert calls == [555, 555]  # retried on both ticks — never skip-listed
+
+
+def test_janitor_gc_drops_uncancellable_id_no_longer_a_candidate(monkeypatch, tmp_path):
+    """(c) Self-cleaning: an id sitting in the skip-list from a past tick that no longer appears
+    among THIS tick's stale candidates (its queued run aged out, its PR closed, GitHub finally
+    resolved it, ...) must be dropped — the file cannot grow unbounded."""
+    uncancellable_path = tmp_path / "uncancellable.json"
+    qs._save_json(uncancellable_path, {"999999": {"recorded_at": "2026-08-01T00:00:00Z"}})
+    monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", uncancellable_path)
+
+    def fake_fetch_queued_runs(repo=qs.REPO):
+        return []  # 999999 no longer shows up as a queued run at all
+
+    def fake_fetch_open_pr_heads(repo=qs.REPO):
+        return set()
+
+    def fake_fetch_live_queue_branches(repo=qs.REPO):
+        return set()
+
+    monkeypatch.setattr(qs, "fetch_queued_runs", fake_fetch_queued_runs)
+    monkeypatch.setattr(qs, "fetch_open_pr_heads", fake_fetch_open_pr_heads)
+    monkeypatch.setattr(qs, "fetch_live_queue_branches", fake_fetch_live_queue_branches)
+
+    qs.run_janitor_pass(dry_run=False)
+
+    assert qs._load_json(uncancellable_path) == {}
+
+
+def test_janitor_corrupt_uncancellable_file_fails_closed_no_cancel(monkeypatch, tmp_path):
+    """(d) A torn/corrupt skip-list file must fail closed — same posture as
+    test_rearm_pass_corrupt_budget_file_fails_closed_no_rearm: CANNOT-VERIFY, zero action this
+    tick, and the corrupt file is left exactly as-is (never silently overwritten with a fresh
+    empty state, which would just as silently re-open every known-uncancellable id)."""
+    uncancellable_path = tmp_path / "uncancellable.json"
+    uncancellable_path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(qs, "UNCANCELLABLE_FILE", uncancellable_path)
+
+    def fake_fetch_queued_runs(repo=qs.REPO):
+        return [{"id": 777, "event": "pull_request", "head_sha": "dead", "head_branch": None, "name": "CI"}]
+
+    def fake_fetch_open_pr_heads(repo=qs.REPO):
+        return set()
+
+    def fake_fetch_live_queue_branches(repo=qs.REPO):
+        return set()
+
+    def never_called(repo, run_id):
+        raise AssertionError("cancel_run must never be called when skip-list state is unreadable")
+
+    monkeypatch.setattr(qs, "fetch_queued_runs", fake_fetch_queued_runs)
+    monkeypatch.setattr(qs, "fetch_open_pr_heads", fake_fetch_open_pr_heads)
+    monkeypatch.setattr(qs, "fetch_live_queue_branches", fake_fetch_live_queue_branches)
+    monkeypatch.setattr(qs, "cancel_run", never_called)
+
+    cancelled = qs.run_janitor_pass(dry_run=False)
+
+    assert cancelled == 0
+    assert uncancellable_path.read_text(encoding="utf-8") == "{not json"
 
 
 def test_janitor_dry_run_never_calls_cancel_run(monkeypatch):


### PR DESCRIPTION
## Summary
- Follow-up to #5140 (force-cancel fallback, merged and live on Pro): PROVE-LIVE found the ~20 phantom post-outage runs answer HTTP 409 to force-cancel TOO. Their real state (`status=queued` for 2-9 days, e.g. 32217208723 since 2026-08-19) is a GitHub post-incident orphan neither cancellation endpoint can resolve. Harmless (old heads/closed PRs) but the janitor logged 2 warnings per run per tick, forever — superscar #2 normalization risk.
- `cancel_run()` now returns `(bool, outcome)` with `outcome in {"cancelled", "uncancellable_409", "failed"}`. The janitor persists an id to a new skip-list (`~/logs/queue-shepherd/uncancellable.json`, env override `QUEUE_SHEPHERD_UNCANCELLABLE_FILE`) **only** on `"uncancellable_409"` — both the plain cancel AND the force-cancel fallback answered HTTP 409. A transient failure (500, network) never enters the list.
- `run_janitor_pass` excludes listed ids **before** attempting cancel, logs one INFO line per tick ("skipping N known-uncancellable runs"), and self-cleans every tick: an id no longer present among that tick's stale candidates is dropped (presence-based, not time-based — mirrors `gc_budget_state`'s shape via new `gc_uncancellable_state`).
- Same atomic-write + corrupt-state-fail-closed pattern as the budget file: a torn skip-list is CANNOT-VERIFY, cancels nothing that tick, left untouched.

## Adversarial review
Small, single-concern extension of #5140's already-reviewed `cancel_run` shape. Red-first tests cover exactly the four named cases plus a direct unit test for the new `uncancellable_409` classification; the 3 pre-existing `cancel_run` tests were updated for the tuple return (no behavior change to their scenarios, only the assertion shape). Gear 1-2 — no evidence pack.

## Test plan
- [x] `python3 -m py_compile scripts/queue_shepherd.py scripts/tests/test_queue_shepherd.py`
- [x] `pytest scripts/tests/test_queue_shepherd.py -q` → 63 passed (58 existing + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)