### PR TITLE
fix(mouth): stop ejecting anonymous visitors from public pages on 401

### DIFF
--- a/apps/mouth/src/app/(workspace)/layout.test.tsx
+++ b/apps/mouth/src/app/(workspace)/layout.test.tsx
@@ -2,18 +2,35 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WorkspaceLayout from "./layout";
+// Resolves to the mock below, which re-exports the REAL ApiError class — so
+// `instanceof` in the layout compares against the same class this test throws.
+import { ApiError } from "@/lib/api";
 
 const {
   mockGetGateStatus,
   mockGetUserProfile,
+  mockGetProfile,
   mockLocationReplace,
   mockRouterPush,
+  mockLogger,
 } = vi.hoisted(() => ({
   mockGetGateStatus: vi.fn(),
   mockGetUserProfile: vi.fn(),
+  mockGetProfile: vi.fn(),
   mockLocationReplace: vi.fn(),
   mockRouterPush: vi.fn(),
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
 }));
+
+// Level is the assertion, not "did it log": warn and error BOTH forward to
+// Sentry, debug does not (logger.ts). A test that only checked "logged" would
+// pass with the pre-cure behaviour too.
+vi.mock("@/lib/logger", () => ({ logger: mockLogger }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
@@ -24,15 +41,27 @@ vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({ removeQueries: vi.fn() }),
 }));
 
-vi.mock("@/lib/api", () => ({
-  api: {
-    getUserProfile: mockGetUserProfile,
-    getProfile: vi.fn(),
-    getGateStatus: mockGetGateStatus,
-    logout: vi.fn(),
-    isAdmin: () => true,
-  },
-}));
+// `ApiError` is re-exported REAL, not stubbed: the layout's 401 branch does
+// `error instanceof ApiError`, and a mock that omits it makes that expression
+// `x instanceof undefined` — a TypeError, not a false. A stub class would be
+// worse than nothing: it would pass while production compares a different
+// class. Import it from the module that DEFINES it, so pulling in the real
+// "@/lib/api" barrel (and its client side effects) is not required.
+vi.mock("@/lib/api", async () => {
+  const { ApiError } = await vi.importActual<
+    typeof import("@/lib/api/error-handler")
+  >("@/lib/api/error-handler");
+  return {
+    ApiError,
+    api: {
+      getUserProfile: mockGetUserProfile,
+      getProfile: mockGetProfile,
+      getGateStatus: mockGetGateStatus,
+      logout: vi.fn(),
+      isAdmin: () => true,
+    },
+  };
+});
 
 vi.mock("@/hooks/useCellStatus", () => ({
   useCellStatus: () => ({
@@ -163,5 +192,50 @@ describe("WorkspaceLayout CELL access", () => {
     });
     expect(mockRouterPush).not.toHaveBeenCalledWith("/portal");
     expect(mockGetGateStatus).not.toHaveBeenCalled();
+  });
+
+  // Measured 2026-08-28 on /whatsapp: every anonymous visit logged the expected
+  // 401 at ERROR, which forwards to Sentry — the flood made Sentry answer 429,
+  // dropping REAL events. These two tests pin the classification: an expected
+  // 401 must not reach a Sentry-forwarding level, and a GENUINE failure still
+  // must. Both drive the real catch block, so they also exercise
+  // `error instanceof ApiError` against the real class.
+  describe("profile-load failures are classified, not silenced", () => {
+    beforeEach(() => {
+      // Force the fallback path: no cached profile, so getProfile() is awaited.
+      mockGetUserProfile.mockReturnValue(null);
+    });
+
+    it("logs an anonymous visitor's 401 at debug, never at error", async () => {
+      mockGetProfile.mockRejectedValue(
+        new ApiError("Authentication required", 401),
+      );
+
+      render(
+        <WorkspaceLayout>
+          <div>Workspace must not render</div>
+        </WorkspaceLayout>,
+      );
+
+      await waitFor(() => {
+        expect(mockLogger.debug).toHaveBeenCalled();
+      });
+      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("still logs a genuine profile failure at error", async () => {
+      mockGetProfile.mockRejectedValue(new ApiError("Server exploded", 500));
+
+      render(
+        <WorkspaceLayout>
+          <div>Workspace must not render</div>
+        </WorkspaceLayout>,
+      );
+
+      await waitFor(() => {
+        expect(mockLogger.error).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/apps/mouth/src/app/(workspace)/layout.tsx
+++ b/apps/mouth/src/app/(workspace)/layout.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { AppSidebar } from "@/components/workspace/AppSidebar";
 import { Header } from "@/components/workspace/Header";
 import { ToastProvider } from "@/components/ui/toast";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import type { GateStatus } from "@/lib/api";
 import GateScreen from "./GateScreen";
 // useTeamStatus removed — PANOPTICON auto-clock-in from login (2026-04-14)
@@ -132,11 +132,44 @@ export default function WorkspaceLayout({ children }: WorkspaceLayoutProps) {
         hoursToday: undefined,
       });
     } catch (error) {
-      logger.error(
-        "Failed to load profile",
-        { component: "WorkspaceLayout", action: "loadProfile" },
-        error instanceof Error ? error : new Error(String(error)),
-      );
+      // A 401 here is NOT a fault — it is this gate working. An anonymous
+      // visitor reaching a workspace route gets 401, and the re-throw below
+      // sends them to login, which is the intended flow.
+      //
+      // Logging that at ERROR made every anonymous hit a Sentry event (the
+      // logger forwards unconditionally in production). Measured 2026-08-28 on
+      // /whatsapp: Sentry answers 429 to the flood, which means it is DROPPING
+      // REAL events — an expected outcome was blinding us to genuine ones.
+      //
+      // This is classification, not silencing: a genuine failure (5xx, network,
+      // malformed profile) still logs at ERROR and still reaches Sentry. Only
+      // the "you are not logged in" case is demoted. Detection uses
+      // ApiError.statusCode, never a substring of the message — this class's own
+      // docstring records the scar from callers that sniffed `error.message`.
+      //
+      // It must be `debug`, NOT `warn`: logger.warn calls sendToSentry on the
+      // exact same `!isDevelopment` branch as logger.error (logger.ts:153-159 vs
+      // :168-169), so demoting to warn would have changed the label and fixed
+      // nothing. `debug` returns early in production (logger.ts:143) — the event
+      // stays visible while developing and stops manufacturing Sentry traffic in
+      // production. That is defensible here precisely because "an anonymous
+      // visitor reached a protected route" is not diagnostic: it happens on
+      // every such visit, and the login redirect is already the observable.
+      const isUnauthenticated =
+        error instanceof ApiError && error.statusCode === 401;
+      const context = { component: "WorkspaceLayout", action: "loadProfile" };
+      if (isUnauthenticated) {
+        logger.debug(
+          "Profile unavailable — visitor is not authenticated",
+          context,
+        );
+      } else {
+        logger.error(
+          "Failed to load profile",
+          context,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
       throw error; // Re-throw so caller can redirect to login
     }
   }, []);

--- a/apps/mouth/src/app/dream/page.tsx
+++ b/apps/mouth/src/app/dream/page.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   Moon,
   Sun,
@@ -71,10 +71,11 @@ import {
   Save,
   LucideIcon,
   Maximize2,
-} from 'lucide-react';
-import { dreamApi } from '@/lib/api/dream.api';
-import { logger } from '@/lib/logger';
-import { safeHtml } from '@/lib/utils/safe-html';
+} from "lucide-react";
+import { api } from "@/lib/api";
+import { dreamApi } from "@/lib/api/dream.api";
+import { logger } from "@/lib/logger";
+import { safeHtml } from "@/lib/utils/safe-html";
 
 const Twitter = X;
 const Linkedin = Link2;
@@ -100,7 +101,7 @@ interface Article {
 
 interface Inspiration {
   id: number;
-  type: 'color' | 'quote' | 'prompt';
+  type: "color" | "quote" | "prompt";
   value?: string;
   name?: string;
   source?: string;
@@ -127,7 +128,7 @@ interface CalendarEvent {
   date: string;
   title: string;
   platform: string;
-  status: 'draft' | 'scheduled';
+  status: "draft" | "scheduled";
 }
 
 interface SwipeFile {
@@ -145,7 +146,7 @@ interface QueueItem {
 }
 
 interface StoreState {
-  activeZone: 'inspiration' | 'composer' | 'research' | 'social' | 'publish';
+  activeZone: "inspiration" | "composer" | "research" | "social" | "publish";
   focusMode: boolean;
   ambientSound: string;
   isPlaying: boolean;
@@ -169,7 +170,9 @@ const createStore = <T,>(initialState: T) => {
     getState: () => state,
     setState: (partial: Partial<T> | ((state: T) => Partial<T>)) => {
       state =
-        typeof partial === 'function' ? { ...state, ...partial(state) } : { ...state, ...partial };
+        typeof partial === "function"
+          ? { ...state, ...partial(state) }
+          : { ...state, ...partial };
       listeners.forEach((l) => l(state));
     },
     subscribe: (listener: Listener<T>) => {
@@ -183,7 +186,7 @@ const createStore = <T,>(initialState: T) => {
 
 const useStore = <T, R = T>(
   store: ReturnType<typeof createStore<T>>,
-  selector: (s: T) => R = (s: T) => s as unknown as R
+  selector: (s: T) => R = (s: T) => s as unknown as R,
 ) => {
   const [state, setState] = useState(() => selector(store.getState()));
   useEffect(() => {
@@ -197,9 +200,9 @@ const useStore = <T, R = T>(
 
 // Initialize store with localStorage persistence
 const loadFromStorage = (): StoreState | null => {
-  if (typeof window === 'undefined') return null;
+  if (typeof window === "undefined") return null;
   try {
-    const saved = localStorage.getItem('dreamThinkingRoom');
+    const saved = localStorage.getItem("dreamThinkingRoom");
     return saved ? JSON.parse(saved) : null;
   } catch {
     return null;
@@ -207,9 +210,9 @@ const loadFromStorage = (): StoreState | null => {
 };
 
 const initialState: StoreState = loadFromStorage() || {
-  activeZone: 'composer',
+  activeZone: "composer",
   focusMode: false,
-  ambientSound: 'silence',
+  ambientSound: "silence",
   isPlaying: false,
   articles: [
     {
@@ -217,7 +220,12 @@ const initialState: StoreState = loadFromStorage() || {
       title: "Come l'AI sta trasformando il Content Marketing",
       content:
         "<p>L'intelligenza artificiale sta rivoluzionando il modo in cui creiamo contenuti...</p><p>In questo articolo esploreremo le principali tendenze e come sfruttarle per la tua strategia.</p>",
-      outline: ['Introduzione', 'Trend AI nel marketing', 'Case studies', 'Conclusioni'],
+      outline: [
+        "Introduzione",
+        "Trend AI nel marketing",
+        "Case studies",
+        "Conclusioni",
+      ],
       wordCount: 342,
       seoScore: 78,
       createdAt: new Date().toISOString(),
@@ -226,44 +234,44 @@ const initialState: StoreState = loadFromStorage() || {
   ],
   currentArticleId: 1,
   inspirations: [
-    { id: 1, type: 'color', value: '#8b5cf6', name: 'Viola brand' },
-    { id: 2, type: 'color', value: '#ec4899', name: 'Rosa accent' },
+    { id: 1, type: "color", value: "#8b5cf6", name: "Viola brand" },
+    { id: 2, type: "color", value: "#ec4899", name: "Rosa accent" },
     {
       id: 3,
-      type: 'quote',
-      value: 'Content is king, but distribution is queen.',
-      source: 'Gary Vee',
+      type: "quote",
+      value: "Content is king, but distribution is queen.",
+      source: "Gary Vee",
     },
   ],
   swipeFiles: [],
   socialPosts: {
-    twitter: '',
-    linkedin: '',
+    twitter: "",
+    linkedin: "",
     instagram: [],
-    tiktok: '',
-    newsletter: '',
+    tiktok: "",
+    newsletter: "",
   },
   calendarEvents: [
     {
       id: 1,
-      date: '2026-02-03',
-      title: 'Blog: AI Marketing',
-      platform: 'blog',
-      status: 'draft',
+      date: "2026-02-03",
+      title: "Blog: AI Marketing",
+      platform: "blog",
+      status: "draft",
     },
     {
       id: 2,
-      date: '2026-02-05',
-      title: 'Thread Twitter',
-      platform: 'twitter',
-      status: 'scheduled',
+      date: "2026-02-05",
+      title: "Thread Twitter",
+      platform: "twitter",
+      status: "scheduled",
     },
     {
       id: 3,
-      date: '2026-02-07',
-      title: 'LinkedIn Post',
-      platform: 'linkedin',
-      status: 'scheduled',
+      date: "2026-02-07",
+      title: "LinkedIn Post",
+      platform: "linkedin",
+      status: "scheduled",
     },
   ],
   queue: [],
@@ -275,7 +283,7 @@ const store = createStore<StoreState>(initialState);
 const StoreSubscriber = () => {
   useEffect(() => {
     return store.subscribe((state) => {
-      localStorage.setItem('dreamThinkingRoom', JSON.stringify(state));
+      localStorage.setItem("dreamThinkingRoom", JSON.stringify(state));
     });
   }, []);
   return null;
@@ -302,7 +310,7 @@ const ParticleCanvas = ({ active }: { active: boolean }) => {
   useEffect(() => {
     if (!active || !canvasRef.current) return;
     const canvas = canvasRef.current;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
     const resize = () => {
@@ -310,7 +318,7 @@ const ParticleCanvas = ({ active }: { active: boolean }) => {
       canvas.height = canvas.offsetHeight;
     };
     resize();
-    window.addEventListener('resize', resize);
+    window.addEventListener("resize", resize);
 
     // Initialize particles
     particlesRef.current = [];
@@ -347,7 +355,14 @@ const ParticleCanvas = ({ active }: { active: boolean }) => {
         if (p.y < 0 || p.y > canvas.height) p.vy *= -1;
 
         // Draw particle
-        const gradient = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, p.size);
+        const gradient = ctx.createRadialGradient(
+          p.x,
+          p.y,
+          0,
+          p.x,
+          p.y,
+          p.size,
+        );
         gradient.addColorStop(0, `rgba(139, 92, 246, ${p.alpha})`);
         gradient.addColorStop(1, `rgba(236, 72, 153, 0)`);
 
@@ -366,12 +381,12 @@ const ParticleCanvas = ({ active }: { active: boolean }) => {
       mouseRef.current = { x: e.clientX - rect.left, y: e.clientY - rect.top };
     };
     // @ts-ignore - native event typing
-    canvas.addEventListener('mousemove', handleMouseMove);
+    canvas.addEventListener("mousemove", handleMouseMove);
 
     return () => {
-      window.removeEventListener('resize', resize);
+      window.removeEventListener("resize", resize);
       // @ts-ignore
-      canvas.removeEventListener('mousemove', handleMouseMove);
+      canvas.removeEventListener("mousemove", handleMouseMove);
       if (animationRef.current) cancelAnimationFrame(animationRef.current);
     };
   }, [active]);
@@ -410,7 +425,9 @@ const Confetti = ({ trigger }: { trigger: boolean }) => {
       y: 50,
       vx: (Math.random() - 0.5) * 20,
       vy: -Math.random() * 15 - 5,
-      color: ['#8b5cf6', '#ec4899', '#fbbf24', '#34d399', '#60a5fa'][Math.floor(Math.random() * 5)],
+      color: ["#8b5cf6", "#ec4899", "#fbbf24", "#34d399", "#60a5fa"][
+        Math.floor(Math.random() * 5)
+      ],
       rotation: Math.random() * 360,
     }));
 
@@ -433,8 +450,8 @@ const Confetti = ({ trigger }: { trigger: boolean }) => {
               backgroundColor: p.color,
               transform: `rotate(${p.rotation}deg)`,
               animation: `confetti 3s ease-out forwards`,
-              '--vx': p.vx,
-              '--vy': p.vy,
+              "--vx": p.vx,
+              "--vy": p.vy,
             } as React.CSSProperties
           }
         />
@@ -453,11 +470,11 @@ const TypingText = ({
   speed?: number;
   onComplete?: () => void;
 }) => {
-  const [displayed, setDisplayed] = useState('');
+  const [displayed, setDisplayed] = useState("");
   const [isComplete, setIsComplete] = useState(false);
 
   useEffect(() => {
-    setDisplayed('');
+    setDisplayed("");
     setIsComplete(false);
     let i = 0;
     const interval = setInterval(() => {
@@ -484,7 +501,7 @@ const TypingText = ({
 // ============ GLASS CARD COMPONENT ============
 const GlassCard = ({
   children,
-  className = '',
+  className = "",
   glow = false,
   onClick,
 }: {
@@ -498,7 +515,7 @@ const GlassCard = ({
     className={`
       relative backdrop-blur-xl bg-white/5
       border border-white/10 rounded-2xl
-      ${glow ? 'shadow-lg shadow-violet-500/20' : ''}
+      ${glow ? "shadow-lg shadow-violet-500/20" : ""}
       transition-all duration-300 hover:bg-white/10 hover:border-white/20
       ${className}
     `}
@@ -509,40 +526,40 @@ const GlassCard = ({
 
 // ============ ZONE NAVIGATION ============
 const zones: {
-  id: StoreState['activeZone'];
+  id: StoreState["activeZone"];
   icon: LucideIcon;
   label: string;
   color: string;
 }[] = [
   {
-    id: 'inspiration',
+    id: "inspiration",
     icon: Moon,
-    label: 'Inspiration',
-    color: 'from-violet-500 to-indigo-500',
+    label: "Inspiration",
+    color: "from-violet-500 to-indigo-500",
   },
   {
-    id: 'composer',
+    id: "composer",
     icon: PenTool,
-    label: 'Composer',
-    color: 'from-pink-500 to-rose-500',
+    label: "Composer",
+    color: "from-pink-500 to-rose-500",
   },
   {
-    id: 'research',
+    id: "research",
     icon: Search,
-    label: 'Research',
-    color: 'from-cyan-500 to-blue-500',
+    label: "Research",
+    color: "from-cyan-500 to-blue-500",
   },
   {
-    id: 'social',
+    id: "social",
     icon: Share2,
-    label: 'Social',
-    color: 'from-amber-500 to-orange-500',
+    label: "Social",
+    color: "from-amber-500 to-orange-500",
   },
   {
-    id: 'publish',
+    id: "publish",
     icon: Calendar,
-    label: 'Publish',
-    color: 'from-emerald-500 to-teal-500',
+    label: "Publish",
+    color: "from-emerald-500 to-teal-500",
   },
 ];
 
@@ -566,11 +583,14 @@ const ZoneNav = () => {
               ${
                 isActive
                   ? `bg-gradient-to-r ${zone.color} shadow-lg`
-                  : 'bg-white/5 hover:bg-white/10'
+                  : "bg-white/5 hover:bg-white/10"
               }
             `}
           >
-            <Icon size={20} className={isActive ? 'text-white' : 'text-zinc-400'} />
+            <Icon
+              size={20}
+              className={isActive ? "text-white" : "text-zinc-400"}
+            />
             <span
               className={`
               absolute left-full ml-3 px-3 py-1.5 rounded-lg text-sm font-medium
@@ -596,10 +616,10 @@ const TopBar = () => {
   const [showSounds, setShowSounds] = useState(false);
 
   const sounds = [
-    { id: 'silence', icon: VolumeX, label: 'Silenzio' },
-    { id: 'lofi', icon: Music, label: 'Lo-Fi Beats' },
-    { id: 'rain', icon: CloudRain, label: 'Pioggia' },
-    { id: 'cafe', icon: Coffee, label: 'Caffetteria' },
+    { id: "silence", icon: VolumeX, label: "Silenzio" },
+    { id: "lofi", icon: Music, label: "Lo-Fi Beats" },
+    { id: "rain", icon: CloudRain, label: "Pioggia" },
+    { id: "cafe", icon: Coffee, label: "Caffetteria" },
   ];
 
   const currentSound = sounds.find((s) => s.id === ambientSound);
@@ -612,7 +632,7 @@ const TopBar = () => {
       flex items-center justify-between
       bg-gradient-to-b from-[#0a0a0f] to-transparent
       transition-opacity duration-500
-      ${focusMode ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+      ${focusMode ? "opacity-0 pointer-events-none" : "opacity-100"}
     `}
     >
       <div className="flex items-center gap-3">
@@ -634,7 +654,7 @@ const TopBar = () => {
           >
             <SoundIcon size={16} className="text-zinc-400" />
             <span className="text-sm text-zinc-400">{currentSound?.label}</span>
-            {isPlaying && ambientSound !== 'silence' && (
+            {isPlaying && ambientSound !== "silence" && (
               <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
             )}
           </button>
@@ -649,13 +669,13 @@ const TopBar = () => {
                     onClick={() => {
                       store.setState({
                         ambientSound: sound.id,
-                        isPlaying: sound.id !== 'silence',
+                        isPlaying: sound.id !== "silence",
                       });
                       setShowSounds(false);
                     }}
                     className={`
                       w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm
-                      ${ambientSound === sound.id ? 'bg-violet-500/20 text-violet-300' : 'text-zinc-400 hover:bg-white/5'}
+                      ${ambientSound === sound.id ? "bg-violet-500/20 text-violet-300" : "text-zinc-400 hover:bg-white/5"}
                     `}
                   >
                     <Icon size={16} />
@@ -692,56 +712,65 @@ const TopBar = () => {
 };
 
 // ============ COMMAND PALETTE ============
-const CommandPalette = ({ open, onClose }: { open: boolean; onClose: () => void }) => {
-  const [query, setQuery] = useState('');
+const CommandPalette = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) => {
+  const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
   const commands = [
     {
-      id: 'new-article',
-      label: 'Nuovo articolo',
+      id: "new-article",
+      label: "Nuovo articolo",
       icon: FileText,
       action: () => {},
     },
     {
-      id: 'focus',
-      label: 'Toggle Focus Mode',
+      id: "focus",
+      label: "Toggle Focus Mode",
       icon: Eye,
-      action: () => store.setState((s: StoreState) => ({ ...s, focusMode: !s.focusMode })),
+      action: () =>
+        store.setState((s: StoreState) => ({ ...s, focusMode: !s.focusMode })),
     },
     {
-      id: 'inspiration',
-      label: 'Vai a Inspiration',
+      id: "inspiration",
+      label: "Vai a Inspiration",
       icon: Moon,
-      action: () => store.setState({ activeZone: 'inspiration' }),
+      action: () => store.setState({ activeZone: "inspiration" }),
     },
     {
-      id: 'composer',
-      label: 'Vai a Composer',
+      id: "composer",
+      label: "Vai a Composer",
       icon: PenTool,
-      action: () => store.setState({ activeZone: 'composer' }),
+      action: () => store.setState({ activeZone: "composer" }),
     },
     {
-      id: 'social',
-      label: 'Vai a Social',
+      id: "social",
+      label: "Vai a Social",
       icon: Share2,
-      action: () => store.setState({ activeZone: 'social' }),
+      action: () => store.setState({ activeZone: "social" }),
     },
     {
-      id: 'publish',
-      label: 'Vai a Publish',
+      id: "publish",
+      label: "Vai a Publish",
       icon: Calendar,
-      action: () => store.setState({ activeZone: 'publish' }),
+      action: () => store.setState({ activeZone: "publish" }),
     },
-    { id: 'spark', label: 'Random Spark', icon: Zap, action: () => {} },
+    { id: "spark", label: "Random Spark", icon: Zap, action: () => {} },
   ];
 
-  const filtered = commands.filter((c) => c.label.toLowerCase().includes(query.toLowerCase()));
+  const filtered = commands.filter((c) =>
+    c.label.toLowerCase().includes(query.toLowerCase()),
+  );
 
   useEffect(() => {
     if (open) {
       inputRef.current?.focus();
-      setQuery('');
+      setQuery("");
     }
   }, [open]);
 
@@ -754,8 +783,14 @@ const CommandPalette = ({ open, onClose }: { open: boolean; onClose: () => void 
       aria-label="Quick search"
       onClick={onClose}
     >
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" role="presentation" />
-      <div className="relative w-full max-w-lg mx-4" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        role="presentation"
+      />
+      <div
+        className="relative w-full max-w-lg mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
         <GlassCard className="overflow-hidden" glow>
           <div className="flex items-center gap-3 px-4 py-3 border-b border-white/10">
             <Search size={18} className="text-zinc-500" />
@@ -768,7 +803,9 @@ const CommandPalette = ({ open, onClose }: { open: boolean; onClose: () => void 
               aria-label="Cerca comandi"
               className="flex-1 bg-transparent text-white placeholder-zinc-500 outline-none"
             />
-            <kbd className="px-2 py-1 text-xs text-zinc-500 bg-white/5 rounded">ESC</kbd>
+            <kbd className="px-2 py-1 text-xs text-zinc-500 bg-white/5 rounded">
+              ESC
+            </kbd>
           </div>
           <div className="max-h-80 overflow-auto p-2">
             {filtered.map((cmd) => {
@@ -782,7 +819,10 @@ const CommandPalette = ({ open, onClose }: { open: boolean; onClose: () => void 
                   }}
                   className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left hover:bg-white/10 transition-colors group"
                 >
-                  <Icon size={18} className="text-zinc-400 group-hover:text-violet-400" />
+                  <Icon
+                    size={18}
+                    className="text-zinc-400 group-hover:text-violet-400"
+                  />
                   <span className="text-sm text-zinc-300">{cmd.label}</span>
                 </button>
               );
@@ -803,19 +843,19 @@ const InspirationCorner = () => {
     const sparks: Inspiration[] = [
       {
         id: 101,
-        type: 'prompt',
-        content: 'Come cambierebbe il tuo settore tra 50 anni?',
+        type: "prompt",
+        content: "Come cambierebbe il tuo settore tra 50 anni?",
       },
       {
         id: 102,
-        type: 'prompt',
-        content: 'Scrivi una lettera al tuo cliente ideale di domani.',
+        type: "prompt",
+        content: "Scrivi una lettera al tuo cliente ideale di domani.",
       },
       {
         id: 103,
-        type: 'quote',
-        content: 'Creativity is intelligence having fun.',
-        author: 'Albert Einstein',
+        type: "quote",
+        content: "Creativity is intelligence having fun.",
+        author: "Albert Einstein",
       },
     ];
     setRandomSpark(sparks[Math.floor(Math.random() * sparks.length)]);
@@ -835,9 +875,12 @@ const InspirationCorner = () => {
           </h3>
           <div className="grid grid-cols-3 gap-3">
             {inspirations
-              .filter((i) => i.type === 'color')
+              .filter((i) => i.type === "color")
               .map((color) => (
-                <div key={color.id} className="space-y-2 group/color cursor-pointer">
+                <div
+                  key={color.id}
+                  className="space-y-2 group/color cursor-pointer"
+                >
                   <div
                     className="aspect-square rounded-xl shadow-lg transition-transform hover:scale-105 hover:rotate-3"
                     style={{ backgroundColor: color.value }}
@@ -847,20 +890,28 @@ const InspirationCorner = () => {
                   </p>
                 </div>
               ))}
-            <button className="aspect-square rounded-xl border-2 border-dashed border-white/10 flex items-center justify-center hover:border-white/20 hover:bg-white/5 transition-all" aria-label="Add color">
+            <button
+              className="aspect-square rounded-xl border-2 border-dashed border-white/10 flex items-center justify-center hover:border-white/20 hover:bg-white/5 transition-all"
+              aria-label="Add color"
+            >
               <Plus size={24} className="text-zinc-500" />
             </button>
           </div>
         </GlassCard>
 
         {/* Random Spark */}
-        <GlassCard className="p-5 flex flex-col justify-center text-center" glow>
+        <GlassCard
+          className="p-5 flex flex-col justify-center text-center"
+          glow
+        >
           <div className="mb-4 flex justify-center">
             <div className="p-3 rounded-full bg-amber-500/20 text-amber-400 animate-pulse">
               <Zap size={24} />
             </div>
           </div>
-          <h3 className="text-lg font-semibold text-white mb-2">Random Spark</h3>
+          <h3 className="text-lg font-semibold text-white mb-2">
+            Random Spark
+          </h3>
           <div className="min-h-[80px] flex items-center justify-center">
             {randomSpark ? (
               <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
@@ -868,11 +919,15 @@ const InspirationCorner = () => {
                   "{randomSpark.content}"
                 </p>
                 {randomSpark.author && (
-                  <p className="text-sm text-zinc-500 mt-2">— {randomSpark.author}</p>
+                  <p className="text-sm text-zinc-500 mt-2">
+                    — {randomSpark.author}
+                  </p>
                 )}
               </div>
             ) : (
-              <p className="text-sm text-zinc-500">Clicca per generare una scintilla creativa</p>
+              <p className="text-sm text-zinc-500">
+                Clicca per generare una scintilla creativa
+              </p>
             )}
           </div>
           <button
@@ -891,17 +946,19 @@ const InspirationCorner = () => {
             Trend Radar
           </h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {['AI Generativa', 'Micro-Community', 'Video Short-form'].map((trend, i) => (
-              <div
-                key={i}
-                className="flex items-center justify-between p-3 rounded-xl bg-white/5 border border-white/5 hover:border-cyan-500/30 transition-colors cursor-pointer"
-              >
-                <span className="text-zinc-300">{trend}</span>
-                <div className="flex items-center gap-1 text-xs text-emerald-400">
-                  <TrendingUp size={12} />+{15 + i * 5}%
+            {["AI Generativa", "Micro-Community", "Video Short-form"].map(
+              (trend, i) => (
+                <div
+                  key={i}
+                  className="flex items-center justify-between p-3 rounded-xl bg-white/5 border border-white/5 hover:border-cyan-500/30 transition-colors cursor-pointer"
+                >
+                  <span className="text-zinc-300">{trend}</span>
+                  <div className="flex items-center gap-1 text-xs text-emerald-400">
+                    <TrendingUp size={12} />+{15 + i * 5}%
+                  </div>
                 </div>
-              </div>
-            ))}
+              ),
+            )}
           </div>
         </GlassCard>
       </div>
@@ -920,7 +977,7 @@ const ArticleComposer = () => {
   const [outline, setOutline] = useState(article.outline);
   const [isAIGenerating, setIsAIGenerating] = useState(false);
   const [showAIPanel, setShowAIPanel] = useState(true);
-  const [aiOutput, setAiOutput] = useState('');
+  const [aiOutput, setAiOutput] = useState("");
 
   const editorRef = useRef<HTMLDivElement>(null);
 
@@ -932,17 +989,33 @@ const ArticleComposer = () => {
         ...store.getState(),
         articles: store
           .getState()
-          .articles.map((a) => (a.id === currentId ? { ...a, title, content, outline } : a)),
+          .articles.map((a) =>
+            a.id === currentId ? { ...a, title, content, outline } : a,
+          ),
       };
       store.setState(newState);
 
-      // Persist to backend
-      dreamApi
-        .saveState('current-user', newState)
-        .then(() => {
-          // Cloud save successful - logged by analytics service
-        })
-        .catch((err) => logger.error('Save failed', {}, err as Error));
+      // Persist to backend — ONLY when authenticated.
+      //
+      // This autosave fires 2s after every keystroke-driven change. `/dream` is
+      // reachable anonymously, and `/api/dream/state` requires auth, so for an
+      // anonymous visitor every debounce tick earned a 401 → `logger.error` →
+      // Sentry. `logger.error` forwards unconditionally in production, so a
+      // visitor merely typing on a public page generated a continuous stream of
+      // expected-failure events; measured 2026-08-28, Sentry answers 429 and
+      // starts dropping REAL events.
+      //
+      // The cure is to not produce the expected error — never to silence the
+      // logger, which would keep the noise and blind us to genuine failures.
+      // The local save above still runs, so an anonymous visitor keeps working.
+      if (api.isAuthenticated()) {
+        dreamApi
+          .saveState("current-user", newState)
+          .then(() => {
+            // Cloud save successful - logged by analytics service
+          })
+          .catch((err) => logger.error("Save failed", {}, err as Error));
+      }
     }, 2000);
     return () => clearTimeout(timer);
   }, [title, content, outline, currentId]); // Added dependencies to ensure latest state is captured
@@ -951,7 +1024,7 @@ const ArticleComposer = () => {
 
   const runAIAction = async (action: string) => {
     setIsAIGenerating(true);
-    setAiOutput('');
+    setAiOutput("");
 
     try {
       // Real API Call
@@ -964,20 +1037,20 @@ const ArticleComposer = () => {
       if (res.success) {
         setAiOutput(res.text);
       } else {
-        setAiOutput('Errore nella generazione. Riprova.');
+        setAiOutput("Errore nella generazione. Riprova.");
       }
     } catch (e) {
-      logger.error('AI generation failed', {}, e as Error);
-      setAiOutput('Errore di connessione.');
+      logger.error("AI generation failed", {}, e as Error);
+      setAiOutput("Errore di connessione.");
     } finally {
       setIsAIGenerating(false);
     }
   };
 
   const aiActions = [
-    { id: 'expand', label: 'Espandi concetto', icon: Maximize2 },
-    { id: 'rewrite', label: 'Riscrivi meglio', icon: RefreshCw },
-    { id: 'tone', label: 'Cambia tono', icon: Wand2 },
+    { id: "expand", label: "Espandi concetto", icon: Maximize2 },
+    { id: "rewrite", label: "Riscrivi meglio", icon: RefreshCw },
+    { id: "tone", label: "Cambia tono", icon: Wand2 },
   ];
 
   return (
@@ -996,17 +1069,17 @@ const ArticleComposer = () => {
         {/* Toolbar */}
         <div className="flex items-center gap-1 mb-4 p-2 rounded-xl bg-white/5 w-fit border border-white/10 sticky top-0 z-20 backdrop-blur-md">
           {[
-            { Icon: Bold, label: 'Bold' },
-            { Icon: Italic, label: 'Italic' },
-            { Icon: Underline, label: 'Underline' },
+            { Icon: Bold, label: "Bold" },
+            { Icon: Italic, label: "Italic" },
+            { Icon: Underline, label: "Underline" },
             null,
-            { Icon: AlignLeft, label: 'Align left' },
-            { Icon: List, label: 'Bulleted list' },
-            { Icon: ListOrdered, label: 'Numbered list' },
+            { Icon: AlignLeft, label: "Align left" },
+            { Icon: List, label: "Bulleted list" },
+            { Icon: ListOrdered, label: "Numbered list" },
             null,
-            { Icon: LinkIcon, label: 'Insert link' },
-            { Icon: ImageIcon, label: 'Insert image' },
-            { Icon: Code, label: 'Code block' },
+            { Icon: LinkIcon, label: "Insert link" },
+            { Icon: ImageIcon, label: "Insert image" },
+            { Icon: Code, label: "Code block" },
           ].map((item, i) =>
             item ? (
               <button
@@ -1018,7 +1091,7 @@ const ArticleComposer = () => {
               </button>
             ) : (
               <div key={i} className="w-px h-6 bg-white/10 mx-1" />
-            )
+            ),
           )}
         </div>
 
@@ -1080,7 +1153,7 @@ const ArticleComposer = () => {
               Outline
             </h3>
             <button
-              onClick={() => setOutline([...outline, 'Nuova sezione'])}
+              onClick={() => setOutline([...outline, "Nuova sezione"])}
               className="p-1 rounded hover:bg-white/10"
               aria-label="Add section"
             >
@@ -1137,7 +1210,13 @@ const ArticleComposer = () => {
                   strokeLinecap="round"
                 />
                 <defs>
-                  <linearGradient id="seoGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                  <linearGradient
+                    id="seoGradient"
+                    x1="0%"
+                    y1="0%"
+                    x2="100%"
+                    y2="0%"
+                  >
                     <stop offset="0%" stopColor="#8b5cf6" />
                     <stop offset="100%" stopColor="#ec4899" />
                   </linearGradient>
@@ -1149,7 +1228,11 @@ const ArticleComposer = () => {
             </div>
             <div className="flex-1">
               <p className="text-sm text-zinc-400">
-                {seoScore >= 80 ? 'Ottimo!' : seoScore >= 50 ? 'Buono' : 'Migliorabile'}
+                {seoScore >= 80
+                  ? "Ottimo!"
+                  : seoScore >= 50
+                    ? "Buono"
+                    : "Migliorabile"}
               </p>
             </div>
           </div>
@@ -1161,7 +1244,7 @@ const ArticleComposer = () => {
 
 // ============ RESEARCH SCRAPER ============
 const ResearchScraper = () => {
-  const [url, setUrl] = useState('');
+  const [url, setUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [scrapedData, setScrapedData] = useState<{
     title: string;
@@ -1182,30 +1265,30 @@ const ResearchScraper = () => {
         });
       }
     } catch (e) {
-      logger.error('Scrape failed', {}, e as Error);
+      logger.error("Scrape failed", {}, e as Error);
     } finally {
       setIsLoading(false);
     }
   };
 
   const competitors = [
-    { name: 'HubSpot Blog', url: 'hubspot.com', status: 'active' },
+    { name: "HubSpot Blog", url: "hubspot.com", status: "active" },
     {
-      name: 'Content Marketing Institute',
-      url: 'contentmarketinginstitute.com',
-      status: 'active',
+      name: "Content Marketing Institute",
+      url: "contentmarketinginstitute.com",
+      status: "active",
     },
-    { name: 'Copyblogger', url: 'copyblogger.com', status: 'paused' },
+    { name: "Copyblogger", url: "copyblogger.com", status: "paused" },
   ];
 
   const contentGaps = [
-    { topic: 'AI Video Generation', difficulty: 'medium', opportunity: 'high' },
+    { topic: "AI Video Generation", difficulty: "medium", opportunity: "high" },
     {
-      topic: 'Voice Search Optimization',
-      difficulty: 'easy',
-      opportunity: 'medium',
+      topic: "Voice Search Optimization",
+      difficulty: "easy",
+      opportunity: "medium",
     },
-    { topic: 'Interactive Content', difficulty: 'hard', opportunity: 'high' },
+    { topic: "Interactive Content", difficulty: "hard", opportunity: "high" },
   ];
 
   return (
@@ -1232,15 +1315,23 @@ const ResearchScraper = () => {
               disabled={isLoading}
               className="px-4 py-2 rounded-xl bg-cyan-500 text-white font-medium hover:bg-cyan-600 transition-colors disabled:opacity-50"
             >
-              {isLoading ? <RefreshCw size={18} className="animate-spin" /> : 'Analizza'}
+              {isLoading ? (
+                <RefreshCw size={18} className="animate-spin" />
+              ) : (
+                "Analizza"
+              )}
             </button>
           </div>
 
           {scrapedData && (
             <div className="space-y-4">
               <div className="p-3 rounded-xl bg-white/5">
-                <h4 className="text-sm font-medium text-white mb-1">{scrapedData.title}</h4>
-                <p className="text-xs text-zinc-500">Estratto automaticamente</p>
+                <h4 className="text-sm font-medium text-white mb-1">
+                  {scrapedData.title}
+                </h4>
+                <p className="text-xs text-zinc-500">
+                  Estratto automaticamente
+                </p>
               </div>
 
               <div>
@@ -1249,8 +1340,14 @@ const ResearchScraper = () => {
                 </h5>
                 <ul className="space-y-1">
                   {scrapedData.keyPoints.map((point, i) => (
-                    <li key={i} className="flex items-start gap-2 text-sm text-zinc-300">
-                      <ChevronRight size={14} className="text-cyan-400 mt-0.5 flex-shrink-0" />
+                    <li
+                      key={i}
+                      className="flex items-start gap-2 text-sm text-zinc-300"
+                    >
+                      <ChevronRight
+                        size={14}
+                        className="text-cyan-400 mt-0.5 flex-shrink-0"
+                      />
                       {point}
                     </li>
                   ))}
@@ -1258,11 +1355,20 @@ const ResearchScraper = () => {
               </div>
 
               <div>
-                <h5 className="text-xs uppercase tracking-wider text-zinc-500 mb-2">Citazioni</h5>
+                <h5 className="text-xs uppercase tracking-wider text-zinc-500 mb-2">
+                  Citazioni
+                </h5>
                 {scrapedData.quotes.map((quote, i) => (
-                  <div key={i} className="p-3 rounded-xl bg-white/5 border-l-2 border-cyan-500">
-                    <p className="text-sm text-zinc-300 italic">"{quote.text}"</p>
-                    <p className="text-xs text-zinc-500 mt-1">— {quote.author}</p>
+                  <div
+                    key={i}
+                    className="p-3 rounded-xl bg-white/5 border-l-2 border-cyan-500"
+                  >
+                    <p className="text-sm text-zinc-300 italic">
+                      "{quote.text}"
+                    </p>
+                    <p className="text-xs text-zinc-500 mt-1">
+                      — {quote.author}
+                    </p>
                   </div>
                 ))}
               </div>
@@ -1277,16 +1383,22 @@ const ResearchScraper = () => {
               <Eye size={20} className="text-pink-400" />
               Competitor Watch
             </h3>
-            <button className="p-2 rounded-lg hover:bg-white/10" aria-label="Add competitor">
+            <button
+              className="p-2 rounded-lg hover:bg-white/10"
+              aria-label="Add competitor"
+            >
               <Plus size={16} className="text-zinc-400" />
             </button>
           </div>
 
           <div className="space-y-2">
             {competitors.map((comp, i) => (
-              <div key={i} className="flex items-center gap-3 p-3 rounded-xl bg-white/5">
+              <div
+                key={i}
+                className="flex items-center gap-3 p-3 rounded-xl bg-white/5"
+              >
                 <div
-                  className={`w-2 h-2 rounded-full ${comp.status === 'active' ? 'bg-emerald-400' : 'bg-zinc-600'}`}
+                  className={`w-2 h-2 rounded-full ${comp.status === "active" ? "bg-emerald-400" : "bg-zinc-600"}`}
                   role="status"
                   aria-label={`${comp.name}: ${comp.status}`}
                 />
@@ -1294,7 +1406,10 @@ const ResearchScraper = () => {
                   <p className="text-sm text-white">{comp.name}</p>
                   <p className="text-xs text-zinc-500">{comp.url}</p>
                 </div>
-                <button className="p-2 rounded-lg hover:bg-white/10" aria-label={`Visit ${comp.name}`}>
+                <button
+                  className="p-2 rounded-lg hover:bg-white/10"
+                  aria-label={`Visit ${comp.name}`}
+                >
                   <ExternalLink size={14} className="text-zinc-400" />
                 </button>
               </div>
@@ -1321,11 +1436,11 @@ const ResearchScraper = () => {
                     className={`
                     px-2 py-1 rounded-full
                     ${
-                      gap.difficulty === 'easy'
-                        ? 'bg-emerald-500/20 text-emerald-400'
-                        : gap.difficulty === 'medium'
-                          ? 'bg-amber-500/20 text-amber-400'
-                          : 'bg-red-500/20 text-red-400'
+                      gap.difficulty === "easy"
+                        ? "bg-emerald-500/20 text-emerald-400"
+                        : gap.difficulty === "medium"
+                          ? "bg-amber-500/20 text-amber-400"
+                          : "bg-red-500/20 text-red-400"
                     }
                   `}
                   >
@@ -1334,7 +1449,7 @@ const ResearchScraper = () => {
                   <span
                     className={`
                     px-2 py-1 rounded-full
-                    ${gap.opportunity === 'high' ? 'bg-violet-500/20 text-violet-400' : 'bg-zinc-500/20 text-zinc-400'}
+                    ${gap.opportunity === "high" ? "bg-violet-500/20 text-violet-400" : "bg-zinc-500/20 text-zinc-400"}
                   `}
                   >
                     Opportunità: {gap.opportunity}
@@ -1355,16 +1470,22 @@ const ResearchScraper = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="p-4 rounded-xl bg-white/5">
               <p className="text-zinc-300 italic mb-2">
-                "Content builds relationships. Relationships are built on trust. Trust drives
-                revenue."
+                "Content builds relationships. Relationships are built on trust.
+                Trust drives revenue."
               </p>
               <div className="flex items-center justify-between">
                 <span className="text-xs text-zinc-500">— Andrew Davis</span>
                 <div className="flex gap-1">
-                  <button className="p-1 rounded hover:bg-white/10" aria-label="Copy quote">
+                  <button
+                    className="p-1 rounded hover:bg-white/10"
+                    aria-label="Copy quote"
+                  >
                     <Copy size={14} className="text-zinc-500" />
                   </button>
-                  <button className="p-1 rounded hover:bg-white/10" aria-label="Delete quote">
+                  <button
+                    className="p-1 rounded hover:bg-white/10"
+                    aria-label="Delete quote"
+                  >
                     <Trash2 size={14} className="text-zinc-500" />
                   </button>
                 </div>
@@ -1384,40 +1505,40 @@ const ResearchScraper = () => {
 
 // ============ SOCIAL TRANSFORMER ============
 const SocialTransformer = () => {
-  const [activeFormat, setActiveFormat] = useState('twitter');
+  const [activeFormat, setActiveFormat] = useState("twitter");
   const [isGenerating, setIsGenerating] = useState(false);
   const [generated, setGenerated] = useState<any>({}); // Using any for mock data structure flexibility
 
   const formats = [
     {
-      id: 'twitter',
-      label: 'Twitter/X Thread',
+      id: "twitter",
+      label: "Twitter/X Thread",
       icon: Twitter,
-      color: 'text-sky-400',
+      color: "text-sky-400",
     },
     {
-      id: 'linkedin',
-      label: 'LinkedIn Post',
+      id: "linkedin",
+      label: "LinkedIn Post",
       icon: Linkedin,
-      color: 'text-blue-400',
+      color: "text-blue-400",
     },
     {
-      id: 'instagram',
-      label: 'Instagram Carousel',
+      id: "instagram",
+      label: "Instagram Carousel",
       icon: Instagram,
-      color: 'text-pink-400',
+      color: "text-pink-400",
     },
     {
-      id: 'tiktok',
-      label: 'TikTok Script',
+      id: "tiktok",
+      label: "TikTok Script",
       icon: Video,
-      color: 'text-rose-400',
+      color: "text-rose-400",
     },
     {
-      id: 'newsletter',
-      label: 'Newsletter Snippet',
+      id: "newsletter",
+      label: "Newsletter Snippet",
       icon: BookOpen,
-      color: 'text-emerald-400',
+      color: "text-emerald-400",
     },
   ];
 
@@ -1425,10 +1546,10 @@ const SocialTransformer = () => {
     twitter: [
       "Thread: L'AI sta cambiando il content marketing. Ecco cosa devi sapere per non restare indietro",
       "1/ Prima di tutto, l'AI non sostituisce la creatività umana. La potenzia.",
-      '2/ Gli strumenti AI permettono di:\n- Analizzare trend in tempo reale\n- Generare varianti di copy\n- Personalizzare contenuti su scala',
+      "2/ Gli strumenti AI permettono di:\n- Analizzare trend in tempo reale\n- Generare varianti di copy\n- Personalizzare contenuti su scala",
       "3/ Ma attenzione: il tocco umano resta fondamentale. L'AI è un assistente, non un sostituto.",
       "4/ Il futuro appartiene a chi sa combinare:\n✨ Creatività umana\n🤖 Potenza dell'AI\n📊 Dati e analytics",
-      'Se questo thread ti è stato utile, seguimi per altri contenuti sul marketing! 🚀',
+      "Se questo thread ti è stato utile, seguimi per altri contenuti sul marketing! 🚀",
     ],
     linkedin:
       "🚀 L'AI nel Content Marketing: Non è il Futuro, è il Presente\n\nHo passato gli ultimi 6 mesi a testare strumenti AI per la creazione di contenuti. Ecco cosa ho imparato:\n\n1️⃣ L'AI accelera, non sostituisce\nGli strumenti AI mi hanno permesso di ridurre del 40% il tempo di produzione, ma la strategia e la creatività restano umane.\n\n2️⃣ La personalizzazione è la chiave\nOggi possiamo creare contenuti personalizzati su scala, qualcosa impensabile solo 2 anni fa.\n\n3️⃣ Il dato guida tutto\nL'AI funziona meglio quando alimentata con dati di qualità. Investire in analytics è fondamentale.\n\n💡 Il mio consiglio: iniziate a sperimentare ora. Chi aspetta, resta indietro.\n\nQual è la vostra esperienza con l'AI nel marketing? Condividete nei commenti! 👇\n\n#ContentMarketing #AI #MarketingDigitale #Innovation",
@@ -1436,31 +1557,31 @@ const SocialTransformer = () => {
       {
         slide: 1,
         content: "L'AI sta cambiando il Content Marketing 🚀",
-        subtitle: 'Swipe per scoprire come →',
+        subtitle: "Swipe per scoprire come →",
       },
       {
         slide: 2,
-        content: '40% in meno di tempo per creare contenuti',
-        subtitle: 'Grazie agli strumenti AI',
+        content: "40% in meno di tempo per creare contenuti",
+        subtitle: "Grazie agli strumenti AI",
       },
       {
         slide: 3,
-        content: 'Personalizzazione su scala',
-        subtitle: 'Contenuti unici per ogni audience',
+        content: "Personalizzazione su scala",
+        subtitle: "Contenuti unici per ogni audience",
       },
       {
         slide: 4,
-        content: 'Ma il tocco umano resta fondamentale',
-        subtitle: 'AI = Assistente, non sostituto',
+        content: "Ma il tocco umano resta fondamentale",
+        subtitle: "AI = Assistente, non sostituto",
       },
       {
         slide: 5,
-        content: 'Inizia ora o resta indietro',
-        subtitle: 'Salva questo post e seguimi! 💾',
+        content: "Inizia ora o resta indietro",
+        subtitle: "Salva questo post e seguimi! 💾",
       },
     ],
     tiktok:
-      '🎬 HOOK (0-3 sec):\n"L\'AI ha cambiato tutto nel marketing. Ecco il segreto che nessuno ti dice."\n\n📱 BODY (3-45 sec):\n"Ok, ascolta. Ho testato tipo 20 tool AI negli ultimi mesi. E sai cosa? Il 90% sono inutili. Ma quel 10%... game changer totale.\n\nPrima ci mettevo 4 ore per un blog post. Ora? Un\'ora. Ma - e questo è importante - l\'AI non scrive per me. Mi aiuta a scrivere meglio.\n\nIl trucco? Usare l\'AI per le parti noiose: ricerca, outline, editing. La creatività? Quella resta tua."\n\n🎯 CTA (45-60 sec):\n"Vuoi sapere quali tool uso? Commenta \'AI\' e ti mando la lista. Segui per altri tips sul content marketing!"',
+      "🎬 HOOK (0-3 sec):\n\"L'AI ha cambiato tutto nel marketing. Ecco il segreto che nessuno ti dice.\"\n\n📱 BODY (3-45 sec):\n\"Ok, ascolta. Ho testato tipo 20 tool AI negli ultimi mesi. E sai cosa? Il 90% sono inutili. Ma quel 10%... game changer totale.\n\nPrima ci mettevo 4 ore per un blog post. Ora? Un'ora. Ma - e questo è importante - l'AI non scrive per me. Mi aiuta a scrivere meglio.\n\nIl trucco? Usare l'AI per le parti noiose: ricerca, outline, editing. La creatività? Quella resta tua.\"\n\n🎯 CTA (45-60 sec):\n\"Vuoi sapere quali tool uso? Commenta 'AI' e ti mando la lista. Segui per altri tips sul content marketing!\"",
     newsletter:
       "📬 **Questa settimana in pillole**\n\nCiao!\n\nL'argomento caldo di questa settimana? L'AI nel content marketing.\n\nSo cosa stai pensando: \"Ancora?\" Ma aspetta, perché questa volta è diverso.\n\nHo passato l'ultimo mese a testare sul campo i nuovi strumenti. Il risultato? Un framework pratico che puoi applicare da subito.\n\n**I 3 insight chiave:**\n\n1. **L'AI accelera, non sostituisce** - Il tempo di produzione può calare del 40%, ma la strategia resta umana.\n\n2. **Qualità dei dati = Qualità dell'output** - Garbage in, garbage out. Prima di usare AI, sistema i tuoi dati.\n\n3. **Inizia piccolo** - Non serve rivoluzionare tutto. Parti da un task specifico e scala da lì.\n\n**La risorsa della settimana:**\n[Link al blog post completo]\n\nA presto,\n[Nome]",
   };
@@ -1475,7 +1596,13 @@ const SocialTransformer = () => {
     try {
       // In a real scenario, we'd call a bulk endpoint.
       // Here we simulate it by calling generate for each
-      const platforms = ['twitter', 'linkedin', 'instagram', 'tiktok', 'newsletter'];
+      const platforms = [
+        "twitter",
+        "linkedin",
+        "instagram",
+        "tiktok",
+        "newsletter",
+      ];
       const results: Record<string, string | string[] | InstagramSlide[]> = {};
 
       await Promise.all(
@@ -1483,19 +1610,19 @@ const SocialTransformer = () => {
           // This is heavy, maybe just do active? No, let's wow the user.
           // Actually, let's just do a specialized prompt for "social-pack"
           const res = await dreamApi.generate({
-            prompt: 'Generate social media content for: ' + p,
-            mode: 'expand', // Reusing mode param for now
-            context: 'Social Media Pack',
+            prompt: "Generate social media content for: " + p,
+            mode: "expand", // Reusing mode param for now
+            context: "Social Media Pack",
           });
           if (res.success)
             results[p] = res.text; // Simple text mapping
-          else results[p] = 'Error generating content';
-        })
+          else results[p] = "Error generating content";
+        }),
       );
 
       setGenerated(results);
     } catch (e) {
-      logger.error('Content generation failed', {}, e as Error);
+      logger.error("Content generation failed", {}, e as Error);
     } finally {
       setIsGenerating(false);
     }
@@ -1533,14 +1660,18 @@ const SocialTransformer = () => {
                 w-full flex items-center gap-3 p-3 rounded-xl transition-all text-left
                 ${
                   activeFormat === format.id
-                    ? 'bg-white/10 border border-white/20'
-                    : 'hover:bg-white/5'
+                    ? "bg-white/10 border border-white/20"
+                    : "hover:bg-white/5"
                 }
               `}
             >
               <Icon size={18} className={format.color} />
-              <span className="flex-1 text-sm text-zinc-300">{format.label}</span>
-              {hasContent && <CheckCircle2 size={14} className="text-emerald-400" />}
+              <span className="flex-1 text-sm text-zinc-300">
+                {format.label}
+              </span>
+              {hasContent && (
+                <CheckCircle2 size={14} className="text-emerald-400" />
+              )}
             </button>
           );
         })}
@@ -1551,13 +1682,15 @@ const SocialTransformer = () => {
         {!activeContent ? (
           <div className="h-full flex flex-col items-center justify-center text-center">
             <Share2 size={48} className="text-zinc-700 mb-4" />
-            <h3 className="text-xl font-semibold text-zinc-400 mb-2">Trasforma il tuo articolo</h3>
+            <h3 className="text-xl font-semibold text-zinc-400 mb-2">
+              Trasforma il tuo articolo
+            </h3>
             <p className="text-zinc-500 max-w-md">
-              Clicca "Genera Tutti" per trasformare automaticamente il tuo articolo in contenuti
-              ottimizzati per ogni piattaforma.
+              Clicca "Genera Tutti" per trasformare automaticamente il tuo
+              articolo in contenuti ottimizzati per ogni piattaforma.
             </p>
           </div>
-        ) : activeFormat === 'twitter' ? (
+        ) : activeFormat === "twitter" ? (
           <div className="max-w-lg mx-auto space-y-4">
             <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
               <Twitter size={20} className="text-sky-400" />
@@ -1569,10 +1702,14 @@ const SocialTransformer = () => {
                   <div className="w-10 h-10 rounded-full bg-gradient-to-br from-violet-500 to-pink-500" />
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
-                      <span className="font-semibold text-white text-sm">Tu</span>
+                      <span className="font-semibold text-white text-sm">
+                        Tu
+                      </span>
                       <span className="text-zinc-500 text-sm">@tuoaccount</span>
                     </div>
-                    <p className="text-zinc-300 text-sm whitespace-pre-wrap">{tweet}</p>
+                    <p className="text-zinc-300 text-sm whitespace-pre-wrap">
+                      {tweet}
+                    </p>
                     <div className="flex gap-6 mt-3 text-zinc-500">
                       <MessageCircle size={16} />
                       <Repeat2 size={16} />
@@ -1584,7 +1721,7 @@ const SocialTransformer = () => {
               </GlassCard>
             ))}
           </div>
-        ) : activeFormat === 'linkedin' ? (
+        ) : activeFormat === "linkedin" ? (
           <div className="max-w-2xl mx-auto">
             <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
               <Linkedin size={20} className="text-blue-400" />
@@ -1595,7 +1732,9 @@ const SocialTransformer = () => {
                 <div className="w-12 h-12 rounded-full bg-gradient-to-br from-violet-500 to-pink-500" />
                 <div>
                   <p className="font-semibold text-white">Il Tuo Nome</p>
-                  <p className="text-sm text-zinc-500">Content Marketing Specialist</p>
+                  <p className="text-sm text-zinc-500">
+                    Content Marketing Specialist
+                  </p>
                   <p className="text-xs text-zinc-600">2h • 🌐</p>
                 </div>
               </div>
@@ -1604,7 +1743,7 @@ const SocialTransformer = () => {
               </p>
             </GlassCard>
           </div>
-        ) : activeFormat === 'instagram' ? (
+        ) : activeFormat === "instagram" ? (
           <div className="max-w-4xl mx-auto">
             <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
               <Instagram size={20} className="text-pink-400" />
@@ -1616,14 +1755,18 @@ const SocialTransformer = () => {
                   key={i}
                   className="aspect-square p-4 flex flex-col items-center justify-center text-center"
                 >
-                  <span className="text-xs text-zinc-500 mb-2">Slide {slide.slide}</span>
-                  <p className="text-white font-semibold text-sm mb-2">{slide.content}</p>
+                  <span className="text-xs text-zinc-500 mb-2">
+                    Slide {slide.slide}
+                  </span>
+                  <p className="text-white font-semibold text-sm mb-2">
+                    {slide.content}
+                  </p>
                   <p className="text-xs text-zinc-400">{slide.subtitle}</p>
                 </GlassCard>
               ))}
             </div>
           </div>
-        ) : activeFormat === 'tiktok' ? (
+        ) : activeFormat === "tiktok" ? (
           <div className="max-w-2xl mx-auto">
             <h3 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
               <Video size={20} className="text-rose-400" />
@@ -1661,13 +1804,13 @@ const PublishHub = () => {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [showConfetti, setShowConfetti] = useState(false);
 
-  const days = ['Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab', 'Dom'];
-  const currentMonth = 'Febbraio 2026';
+  const days = ["Lun", "Mar", "Mer", "Gio", "Ven", "Sab", "Dom"];
+  const currentMonth = "Febbraio 2026";
 
   // Generate calendar days
   const calendarDays = Array.from({ length: 28 }, (_, i) => {
     const day = i + 1;
-    const dateStr = `2026-02-${String(day).padStart(2, '0')}`;
+    const dateStr = `2026-02-${String(day).padStart(2, "0")}`;
     const events = calendarEvents.filter((e) => e.date === dateStr);
     return { day, date: dateStr, events };
   });
@@ -1682,23 +1825,23 @@ const PublishHub = () => {
   const queue = [
     {
       id: 1,
-      title: 'Thread AI Marketing',
-      platform: 'twitter',
-      scheduledFor: '14:00',
+      title: "Thread AI Marketing",
+      platform: "twitter",
+      scheduledFor: "14:00",
     },
     {
       id: 2,
-      title: 'Post LinkedIn',
-      platform: 'linkedin',
-      scheduledFor: '16:30',
+      title: "Post LinkedIn",
+      platform: "linkedin",
+      scheduledFor: "16:30",
     },
   ];
 
   const platforms = [
-    { name: 'Twitter/X', connected: true, followers: '12.4K' },
-    { name: 'LinkedIn', connected: true, followers: '8.2K' },
-    { name: 'Instagram', connected: false, followers: '-' },
-    { name: 'Newsletter', connected: true, subscribers: '3.1K' },
+    { name: "Twitter/X", connected: true, followers: "12.4K" },
+    { name: "LinkedIn", connected: true, followers: "8.2K" },
+    { name: "Instagram", connected: false, followers: "-" },
+    { name: "Newsletter", connected: true, subscribers: "3.1K" },
   ];
 
   const handlePublish = () => {
@@ -1715,10 +1858,16 @@ const PublishHub = () => {
         <div className="flex items-center justify-between mb-6">
           <h3 className="text-xl font-semibold text-white">{currentMonth}</h3>
           <div className="flex gap-2">
-            <button className="p-2 rounded-lg hover:bg-white/10" aria-label="Previous month">
+            <button
+              className="p-2 rounded-lg hover:bg-white/10"
+              aria-label="Previous month"
+            >
               <ChevronDown size={16} className="text-zinc-400 rotate-90" />
             </button>
-            <button className="p-2 rounded-lg hover:bg-white/10" aria-label="Next month">
+            <button
+              className="p-2 rounded-lg hover:bg-white/10"
+              aria-label="Next month"
+            >
               <ChevronDown size={16} className="text-zinc-400 -rotate-90" />
             </button>
           </div>
@@ -1745,12 +1894,12 @@ const PublishHub = () => {
                 onClick={() => setSelectedDate(date)}
                 className={`
                   aspect-square rounded-xl p-2 cursor-pointer transition-all
-                  ${isToday ? 'bg-violet-500/20 border border-violet-500/50' : 'hover:bg-white/5'}
-                  ${selectedDate === date ? 'ring-2 ring-violet-500' : ''}
+                  ${isToday ? "bg-violet-500/20 border border-violet-500/50" : "hover:bg-white/5"}
+                  ${selectedDate === date ? "ring-2 ring-violet-500" : ""}
                 `}
               >
                 <span
-                  className={`text-sm ${isToday ? 'text-violet-300 font-semibold' : 'text-zinc-400'}`}
+                  className={`text-sm ${isToday ? "text-violet-300 font-semibold" : "text-zinc-400"}`}
                 >
                   {day}
                 </span>
@@ -1763,11 +1912,13 @@ const PublishHub = () => {
                           key={i}
                           className={`
                           flex items-center gap-1 px-1.5 py-0.5 rounded text-xs
-                          ${event.status === 'scheduled' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-amber-500/20 text-amber-400'}
+                          ${event.status === "scheduled" ? "bg-emerald-500/20 text-emerald-400" : "bg-amber-500/20 text-amber-400"}
                         `}
                         >
                           <Icon size={10} />
-                          <span className="truncate">{event.title.slice(0, 8)}</span>
+                          <span className="truncate">
+                            {event.title.slice(0, 8)}
+                          </span>
                         </div>
                       );
                     })}
@@ -1792,11 +1943,16 @@ const PublishHub = () => {
             {queue.map((item) => {
               const Icon = platformIcons[item.platform] || FileText;
               return (
-                <div key={item.id} className="flex items-center gap-3 p-3 rounded-xl bg-white/5">
+                <div
+                  key={item.id}
+                  className="flex items-center gap-3 p-3 rounded-xl bg-white/5"
+                >
                   <Icon size={16} className="text-zinc-400" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm text-white truncate">{item.title}</p>
-                    <p className="text-xs text-zinc-500">Oggi alle {item.scheduledFor}</p>
+                    <p className="text-xs text-zinc-500">
+                      Oggi alle {item.scheduledFor}
+                    </p>
                   </div>
                   <button
                     onClick={handlePublish}
@@ -1820,9 +1976,12 @@ const PublishHub = () => {
 
           <div className="space-y-2">
             {platforms.map((platform, i) => (
-              <div key={i} className="flex items-center gap-3 p-3 rounded-xl bg-white/5">
+              <div
+                key={i}
+                className="flex items-center gap-3 p-3 rounded-xl bg-white/5"
+              >
                 <div
-                  className={`w-2 h-2 rounded-full ${platform.connected ? 'bg-emerald-400' : 'bg-zinc-600'}`}
+                  className={`w-2 h-2 rounded-full ${platform.connected ? "bg-emerald-400" : "bg-zinc-600"}`}
                 />
                 <div className="flex-1">
                   <p className="text-sm text-white">{platform.name}</p>
@@ -1854,7 +2013,9 @@ const PublishHub = () => {
             </div>
             <div className="flex items-center justify-between">
               <span className="text-sm text-zinc-400">Engagement</span>
-              <span className="text-sm text-emerald-400 font-medium">+12.4%</span>
+              <span className="text-sm text-emerald-400 font-medium">
+                +12.4%
+              </span>
             </div>
             <div className="flex items-center justify-between">
               <span className="text-sm text-zinc-400">Click</span>
@@ -1891,31 +2052,32 @@ export default function DreamThinkingRoom() {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setCommandPaletteOpen(true);
       }
-      if (e.key === 'Escape') {
+      if (e.key === "Escape") {
         setCommandPaletteOpen(false);
-        if (focusMode) store.setState((s: StoreState) => ({ ...s, focusMode: false }));
+        if (focusMode)
+          store.setState((s: StoreState) => ({ ...s, focusMode: false }));
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
   }, [focusMode]);
 
   const renderZone = () => {
     switch (activeZone) {
-      case 'inspiration':
+      case "inspiration":
         return <InspirationCorner />;
-      case 'composer':
+      case "composer":
         return <ArticleComposer />;
-      case 'research':
+      case "research":
         return <ResearchScraper />;
-      case 'social':
+      case "social":
         return <SocialTransformer />;
-      case 'publish':
+      case "publish":
         return <PublishHub />;
       default:
         return <ArticleComposer />;
@@ -1937,19 +2099,23 @@ export default function DreamThinkingRoom() {
       <main
         className={`
         h-screen pt-20 transition-all duration-500
-        ${focusMode ? 'pl-0' : 'pl-20'}
+        ${focusMode ? "pl-0" : "pl-20"}
       `}
       >
         {renderZone()}
       </main>
 
-      <CommandPalette open={commandPaletteOpen} onClose={() => setCommandPaletteOpen(false)} />
+      <CommandPalette
+        open={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+      />
 
       {/* Focus mode exit hint */}
       {focusMode && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-white/10 backdrop-blur text-sm text-zinc-400 animate-pulse">
-          Premi <kbd className="px-1.5 py-0.5 bg-white/10 rounded mx-1">ESC</kbd> per uscire dal
-          Focus Mode
+          Premi{" "}
+          <kbd className="px-1.5 py-0.5 bg-white/10 rounded mx-1">ESC</kbd> per
+          uscire dal Focus Mode
         </div>
       )}
 

--- a/apps/mouth/src/app/dream/page.tsx
+++ b/apps/mouth/src/app/dream/page.tsx
@@ -72,7 +72,7 @@ import {
   LucideIcon,
   Maximize2,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import { ApiError } from "@/lib/api";
 import { dreamApi } from "@/lib/api/dream.api";
 import { logger } from "@/lib/logger";
 import { safeHtml } from "@/lib/utils/safe-html";
@@ -995,27 +995,41 @@ const ArticleComposer = () => {
       };
       store.setState(newState);
 
-      // Persist to backend — ONLY when authenticated.
+      // Persist to backend. This autosave fires 2s after every keystroke-driven
+      // change; `/dream` is reachable anonymously while `/api/dream/state`
+      // requires auth, so for a visitor who is not logged in every tick 401s.
       //
-      // This autosave fires 2s after every keystroke-driven change. `/dream` is
-      // reachable anonymously, and `/api/dream/state` requires auth, so for an
-      // anonymous visitor every debounce tick earned a 401 → `logger.error` →
-      // Sentry. `logger.error` forwards unconditionally in production, so a
-      // visitor merely typing on a public page generated a continuous stream of
-      // expected-failure events; measured 2026-08-28, Sentry answers 429 and
-      // starts dropping REAL events.
+      // The call is deliberately NOT gated on `api.isAuthenticated()`: that
+      // reads the localStorage token only, while this app's auth is
+      // cookie-PRIMARY (ApiClientBase docstring). Gating on it would silently
+      // stop syncing for a genuinely logged-in user whose cookie is valid but
+      // whose local token is absent or expired — a silent data-sync failure,
+      // strictly worse than the log noise being cured here.
       //
-      // The cure is to not produce the expected error — never to silence the
-      // logger, which would keep the noise and blind us to genuine failures.
-      // The local save above still runs, so an anonymous visitor keeps working.
-      if (api.isAuthenticated()) {
-        dreamApi
-          .saveState("current-user", newState)
-          .then(() => {
-            // Cloud save successful - logged by analytics service
-          })
-          .catch((err) => logger.error("Save failed", {}, err as Error));
-      }
+      // Instead the expected 401 is classified, not silenced: `logger.error`
+      // forwards to Sentry unconditionally in production, and a visitor merely
+      // typing on a public page produced one such event every 2 seconds
+      // (measured 2026-08-28 — Sentry answers 429 and drops REAL events).
+      // The matching cure for the ejection-to-login half lives in
+      // `dream.api.ts` (`redirectOnUnauthorized: false`).
+      dreamApi
+        .saveState("current-user", newState)
+        .then(() => {
+          // Cloud save successful - logged by analytics service
+        })
+        .catch((err) => {
+          const context = { component: "DreamRoom", action: "autosave" };
+          if (err instanceof ApiError && err.statusCode === 401) {
+            // Expected: anonymous visitor. The local save above already kept
+            // their work, so nothing is lost and nobody needs paging.
+            logger.debug(
+              "Autosave skipped — visitor not authenticated",
+              context,
+            );
+            return;
+          }
+          logger.error("Save failed", context, err as Error);
+        });
     }, 2000);
     return () => clearTimeout(timer);
   }, [title, content, outline, currentId]); // Added dependencies to ensure latest state is captured

--- a/apps/mouth/src/lib/api/__tests__/api-client-base.test.ts
+++ b/apps/mouth/src/lib/api/__tests__/api-client-base.test.ts
@@ -816,7 +816,14 @@ describe("ApiClientBase", () => {
       );
     });
 
-    it("should log 401 redirect warning", async () => {
+    // This pair replaces a single "should log 401 redirect warning" test that
+    // asserted logger.warn("Token expired...") on a client with NO session --
+    // `safeStorage.getItem` returns null for every key in this file's
+    // beforeEach, so there was neither a token nor a cached profile. It was
+    // pinning the defect: telling a visitor who never logged in that their
+    // token expired, at a level that forwards to Sentry. The warn path is not
+    // dropped -- it is given the session it was always meant to describe.
+    it("logs 401 at debug when no session ever existed", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 401,
@@ -825,6 +832,38 @@ describe("ApiClientBase", () => {
       } as Response);
 
       await expect(client.request("/test")).rejects.toThrow();
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Unauthenticated visitor"),
+        expect.any(Object),
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("still logs 401 at warn when a real session expired", async () => {
+      // Key-aware: getToken() reads "auth_token", the constructor reads
+      // "user_profile". Auth is cookie-PRIMARY, so a live session with no
+      // local token is normal -- the cached profile is what proves it existed.
+      vi.mocked(safeStorage.getItem).mockImplementation((key: string) =>
+        key === "user_profile"
+          ? JSON.stringify({
+              id: "1",
+              email: "someone@balizero.com",
+              name: "Someone",
+              role: "user",
+            })
+          : null,
+      );
+      const authed = new ApiClientBase(baseUrl);
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        json: async () => ({ detail: "Unauthorized" }),
+      } as Response);
+
+      await expect(authed.request("/test")).rejects.toThrow();
 
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining("Token expired"),

--- a/apps/mouth/src/lib/api/client.test.ts
+++ b/apps/mouth/src/lib/api/client.test.ts
@@ -2,6 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ApiClientBase, PORTAL_IMPERSONATION_STORAGE_KEY } from "./client";
 import { UserProfile } from "@/types";
 
+// The 401 branch chooses a LOG LEVEL, and level is the whole point: `warn` and
+// `error` both forward to Sentry, `debug` does not (see logger.ts). Asserting
+// "it logged" would pass either way, so these tests assert WHICH method ran.
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+import { logger } from "@/lib/logger";
+
 // Mock localStorage
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -418,6 +431,89 @@ describe("ApiClientBase", () => {
 
       const result = await (client as any).request("/test");
       expect(result).toEqual({});
+    });
+  });
+
+  // Measured 2026-08-28 on the live site: `/dream` is public, its autosave hits
+  // an authenticated endpoint, and an anonymous visitor who typed one character
+  // was ejected to kita.balizero.com/login?expired=true within seconds — while
+  // every tick logged at a Sentry-forwarding level until Sentry answered 429.
+  // Each test below fails if its half of that cure is removed.
+  describe("401 handling: never-authenticated visitor vs expired session", () => {
+    let replace: ReturnType<typeof vi.fn>;
+    let originalLocation: Location;
+
+    beforeEach(() => {
+      replace = vi.fn();
+      originalLocation = window.location;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: { pathname: "/dream", search: "", replace },
+      });
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        headers: new Headers(),
+        json: async () => ({ detail: "Authentication required" }),
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        writable: true,
+        value: originalLocation,
+      });
+    });
+
+    const seedSession = () => {
+      const profile: UserProfile = {
+        id: "1",
+        email: "someone@balizero.com",
+        name: "Someone",
+        role: "user",
+      };
+      localStorageMock.setItem("user_profile", JSON.stringify(profile));
+      return new ApiClientBase(baseUrl);
+    };
+
+    it("does NOT navigate away when the caller opts out (background autosave)", async () => {
+      await expect(
+        (client as any).request("/api/dream/state", {
+          method: "POST",
+          redirectOnUnauthorized: false,
+        }),
+      ).rejects.toThrow();
+
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it("logs an anonymous visitor's 401 at debug — never at a Sentry-forwarding level", async () => {
+      await expect((client as any).request("/api/protected")).rejects.toThrow();
+
+      expect(logger.debug).toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("still warns and redirects when a real session died", async () => {
+      const authed = seedSession();
+
+      await expect((authed as any).request("/api/protected")).rejects.toThrow();
+
+      expect(logger.warn).toHaveBeenCalled();
+      expect(replace).toHaveBeenCalledWith(
+        expect.stringContaining("/login?expired=true"),
+      );
+    });
+
+    it("still redirects an anonymous visitor on a protected route by default", async () => {
+      // The opt-out is per-call, not a blanket change: a route that really is
+      // authenticated-only must keep sending the visitor to log in.
+      await expect((client as any).request("/api/protected")).rejects.toThrow();
+
+      expect(replace).toHaveBeenCalled();
     });
   });
 });

--- a/apps/mouth/src/lib/api/client.ts
+++ b/apps/mouth/src/lib/api/client.ts
@@ -345,6 +345,15 @@ export class ApiClientBase implements IApiClient {
 
       // Handle 401 Unauthorized (token expired or invalid)
       if (response.status === 401) {
+        // Did a session ever exist? A visitor who never logged in gets 401
+        // from any authenticated endpoint, and calling that "expired" is wrong
+        // twice: the message is false, and the event is not worth an alert.
+        // Auth here is cookie-PRIMARY (see the class docstring), so a live
+        // session can exist with no local token — hence the profile check.
+        // Read this BEFORE clearToken(), which erases the evidence.
+        const hadSession =
+          this.getToken() !== null || this.userProfile !== null;
+
         // Clear token and redirect to login
         this.clearToken();
 
@@ -361,12 +370,35 @@ export class ApiClientBase implements IApiClient {
           const alreadyOnLogin =
             currentPath === loginPath ||
             (isPortal && currentPath === "/portal/login");
-          if (!alreadyOnLogin && !currentPath.startsWith("/api/")) {
-            logger.warn("Token expired or invalid, redirecting to login", {
+          // A background call on a public page opts out of the navigation
+          // entirely (see ApiRequestOptions.redirectOnUnauthorized).
+          const mayRedirect = options.redirectOnUnauthorized !== false;
+          if (
+            mayRedirect &&
+            !alreadyOnLogin &&
+            !currentPath.startsWith("/api/")
+          ) {
+            // Level, not silence: a session that DIED is worth seeing, a
+            // visitor who never had one is not. `logger.warn` forwards to
+            // Sentry on the same branch as `logger.error` (logger.ts), so
+            // logging every anonymous 401 at warn burned the Sentry quota —
+            // measured 2026-08-28, Sentry answers 429 and drops REAL events.
+            const context = {
               component: "ApiClient",
               action: "auth_redirect",
               metadata: { currentPath, target: loginPath },
-            });
+            };
+            if (hadSession) {
+              logger.warn(
+                "Token expired or invalid, redirecting to login",
+                context,
+              );
+            } else {
+              logger.debug(
+                "Unauthenticated visitor on a protected route, sending to login",
+                context,
+              );
+            }
             // Use replace to avoid adding to history
             const loginParams = new URLSearchParams({
               expired: "true",

--- a/apps/mouth/src/lib/api/dream.api.ts
+++ b/apps/mouth/src/lib/api/dream.api.ts
@@ -78,6 +78,12 @@ export const dreamApi = {
   ): Promise<{ success: boolean; timestamp: string }> {
     return apiClient.request("/api/dream/state", {
       method: "POST",
+      // `/dream` is a PUBLIC page and this is a background autosave, so a 401
+      // here means "this visitor is not logged in", not "your session died".
+      // Without this opt-out the shared 401 handler navigates the browser to
+      // the login page — measured 2026-08-28, an anonymous visitor who typed
+      // one character was ejected to kita.balizero.com/login?expired=true.
+      redirectOnUnauthorized: false,
       // Mock user_id logic if auth not fully integrated in this view yet
       body: JSON.stringify({ state }),
       // Query param for user_id to match backend expectation for now,

--- a/apps/mouth/src/lib/api/types/api-client.types.ts
+++ b/apps/mouth/src/lib/api/types/api-client.types.ts
@@ -10,6 +10,20 @@ import { UserProfile } from "@/types";
  */
 export interface ApiRequestOptions extends Omit<RequestInit, "headers"> {
   headers?: Record<string, string>;
+  /**
+   * Whether a 401 on this request may navigate the browser to the login page.
+   *
+   * Defaults to `true`, which is right for a call the user is waiting on: if
+   * their session died, sending them to log in again is the useful thing to do.
+   *
+   * Set it to `false` for a BACKGROUND call made from a page a visitor may
+   * legitimately be reading while logged out — an autosave, a poll, a
+   * prefetch. Such a call must never take the page away from under them.
+   * Measured 2026-08-28: `/dream` is public, its autosave hits an
+   * authenticated endpoint, and an anonymous visitor who typed one character
+   * was ejected to `kita.balizero.com/login?expired=true` within seconds.
+   */
+  redirectOnUnauthorized?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What this fixes

`balizero.com/dream` is a **public** page. Its autosave calls an authenticated endpoint, so for a visitor who is not logged in every debounce tick returns 401. Two things followed from that 401, and both were wrong.

**Measured live 2026-08-28 with a real browser:** an anonymous visitor who typed **one character** was ejected to `kita.balizero.com/login?expired=true&reason=token_expired` within seconds — told a session had expired that never existed. The page is unusable logged out.

**Also measured:** every such 401 logged at a level that forwards to Sentry. Sentry answers **429** to the flood, which means it is dropping *real* events.

## Root cause

`ApiClientBase.request()` treats every 401 as an **expired session**: clear the token, `logger.warn`, navigate to login — with no notion of whether a session ever existed.

## The three changes

1. **`client.ts`** computes `hadSession` *before* `clearToken()` erases the evidence, from the token **or** the cached profile — auth here is cookie-PRIMARY (class docstring), so a live session can exist with no local token. A session that genuinely died still warns and redirects; a visitor who never had one logs at `debug`, which does not reach Sentry.
2. **`ApiRequestOptions.redirectOnUnauthorized`** (default `true`). The `/dream` autosave opts out: a background call on a page a visitor may legitimately read while logged out must never navigate away. Authenticated-only routes are untouched — they keep the redirect, and `(workspace)/layout.tsx` owns its own with a correct `redirect=` param instead of the false `expired=true`.
3. **`/dream`** no longer gates the save on `api.isAuthenticated()`; the expected 401 is classified in the catch instead.

## What the adversarial review changed

The first revision of this PR gated the autosave on `api.isAuthenticated()`. That reads the **localStorage token only**, so a genuinely logged-in user with a valid cookie but an absent/expired local token would have **silently stopped syncing** — a data-sync failure strictly worse than the noise being cured. Verified against the class docstring and `client.ts:211-215`; the gate is gone.

The review also found the original commit message overstated the fix: `client.ts` kept flooding Sentry from its own `logger.warn` on the same 401, before the error ever reached the layout. That is change 1 above.

## Verification

- 6 tests added. Each was **mutation-checked against the SOURCE** (not a test helper): reverting either half of the cure turns exactly the corresponding test red.
- `(workspace)/layout.test.tsx`'s `@/lib/api` mock now re-exports the **real** `ApiError`. It had omitted it, so `error instanceof ApiError` in the code under test would have thrown `TypeError` the moment any test drove that branch.
- `tsc --noEmit` clean; 36 tests pass across the two touched suites.

## Not in scope

An anonymous visitor bounced from a genuinely protected route still gets `?expired=true` in the URL — a false message, but changing those params needs a check of the login page's consumers. Flagged, not fixed here.