### PR TITLE
test(bot): cover the unknown fall-off reason default

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
@@ -682,6 +682,32 @@ def test_fall_off_reason_map_covers_every_reason_the_module_can_emit() -> None:
     )
 
 
+def test_normalize_fall_off_reason_unrecognized_head_defaults_to_unknown() -> None:
+    """The coverage guard above proves every head the module CAN emit today
+    has a map entry — it says nothing about what happens the day a NEW,
+    not-yet-catalogued head shows up (a genuinely new failure mode, or a
+    caller that got the string wrong). That path is this function's
+    `.get(head, "unknown")` fallback, and nothing else in this file drives
+    it: `_normalize_fall_off_reason` itself is never called directly
+    anywhere in the suite. Left uncovered, a mutation of that literal
+    default (e.g. to some other bounded-looking string) would leave all
+    138 tests in this file's suite green while the DB CHECK constraint on
+    ``generation_fall_off_reason`` (exactly 20 allowed values, see the
+    module docstring) started rejecting every genuinely-new reason instead
+    of gracefully bucketing it under "unknown" — silently reintroducing
+    the blindness this column exists to end.
+    """
+    # A colon-delimited head that is not a key in the map.
+    assert wa_codex_leg._normalize_fall_off_reason("totally_unheard_of_reason:detail") == "unknown"
+    # No colon at all — the whole string is the head, still unrecognized.
+    assert wa_codex_leg._normalize_fall_off_reason("totally_unheard_of_reason") == "unknown"
+    # Falsy input takes the function's earlier explicit `if not raw` branch
+    # rather than reaching the map lookup at all — cover it too so the
+    # function's full return contract (never raises, always "unknown" for
+    # anything it cannot place) is proven, not just the map-lookup tail.
+    assert wa_codex_leg._normalize_fall_off_reason("") == "unknown"
+
+
 # ── the offer boundary is fail-closed (Codex r3) ────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- `_normalize_fall_off_reason`'s `.get(head, "unknown")` fallback in `apps/backend-rag/backend/services/integrations/wa_codex_leg.py` was uncovered — `_normalize_fall_off_reason(` had zero occurrences anywhere in the test suite. The adjacent AST guard test only proves every head the module *can currently emit* has a map entry; it never drives an unrecognized head through the function.
- Adds `test_normalize_fall_off_reason_unrecognized_head_defaults_to_unknown` to `apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py`, asserting the function returns exactly `"unknown"` for (a) a colon-delimited unrecognized head, (b) a headless unrecognized string, and (c) falsy input (the earlier explicit `if not raw` branch).
- No source change — `wa_codex_leg.py` is untouched; only the proof was missing.

## Proof (measured this session, not recalled)

**1. Baseline — full 3-file suite BEFORE the change**
```
backend/tests/unit/services/test_wa_broker.py: 44
backend/tests/unit/services/test_wa_codex_daemon.py: 41
backend/tests/unit/services/test_wa_codex_leg.py: 53
= 138 passed in 5.21s
```

**2. Guilt test — mutate `wa_codex_leg.py:223` `"unknown"` → `"WRONG_DEFAULT_MUTATED"`, run the new test alone:**
```
FAILED backend/tests/unit/services/test_wa_codex_leg.py::test_normalize_fall_off_reason_unrecognized_head_defaults_to_unknown
AssertionError: assert 'WRONG_DEFAULT_MUTATED' == 'unknown'
- unknown
+ WRONG_DEFAULT_MUTATED
```
Source restored immediately after; confirmed via `git diff -- apps/backend-rag/backend/services/integrations/wa_codex_leg.py` → empty output.

**3. Innocence — full 3-file suite AFTER the change (source clean):**
```
backend/tests/unit/services/test_wa_broker.py: 44
backend/tests/unit/services/test_wa_codex_daemon.py: 41
backend/tests/unit/services/test_wa_codex_leg.py: 54
= 139 passed in 5.24s
```

## Test plan
- [x] Baseline suite green (138 passed) before change
- [x] Guilt test goes RED with real diagnostic output when the source literal is mutated
- [x] Source restored, `git diff` on `wa_codex_leg.py` confirmed empty
- [x] Innocence suite green (139 passed) with the new test in place, no source change

🤖 Generated with [Claude Code](https://claude.com/claude-code)