### PR TITLE
feat(garuda): route the fourteenth job type, and prove the count with the AST

### DIFF
--- a/apps/backend-rag/backend/services/garuda_orders/outbox_consumer.py
+++ b/apps/backend-rag/backend/services/garuda_orders/outbox_consumer.py
@@ -9,27 +9,41 @@ wired in `app/main_api.py` (see `drain_once`'s import there) behind
 docstring that denies its own module's existence is precisely the shape that
 misleads the next repo-wide ground pass, so it is stated positively now.
 
-What is TRUE, and is the live gap: **THIRTEEN distinct `job_type` values are
-enqueued by production code, and `outbox_handlers.py` registers THREE handlers**
-(`payment_paid_email`, `practice_release`, `portal_invite`). Twelve of the
-thirteen come from `repository.py` (checkout_ready_email, payment_paid_email,
-payment_failed_email, payment_expired_email, refund_email, practice_release,
-portal_invite and the five staff_page_* jobs). **The thirteenth is enqueued
-somewhere easy to miss**: `garuda_portal/practice.py::mint_received_practice`
-enqueues `practice_received_email` — the customer's confirmation that their
-practice was received — from the same function that mints the practice row. It
-has no handler either, so the count of unhandled types is TEN, not nine, and the
-tenth is customer-facing.
+**FOURTEEN distinct `job_type` values are enqueued by production code, and as of
+2026-08-28 `outbox_handlers.build_handlers` registers a handler for all
+fourteen.** Thirteen come from `repository.py`; the fourteenth,
+`practice_received_email`, is enqueued by
+`garuda_portal/practice.py::mint_received_practice`.
 
-Corrected 2026-08-27 in the same PR that wrote it: the first version of this
-paragraph said twelve/nine, having counted only `repository.py`. Anyone
-recounting must grep `job_type="` across ALL of `backend/services`, not just the
-repository module.
+THIS NUMBER WAS WRONG THREE TIMES, and how it was wrong matters more than the
+number. Successive versions of this paragraph said twelve, then thirteen. Every
+one of those counts came from grepping ``job_type="`` — a LITERAL — and
+`repository.py:799-805` passes a VARIABLE:
 
-The ten unhandled types are enqueued, routed to `unroutable`, and keep their full
-attempt budget until a handler is written (this consumer handles that correctly).
-Nothing pages on a non-empty `unroutable` set; that gap is ledgered, not fixed
-here.
+    job_type = ("practice_release" if resolution == "honoured"
+                else "late_refund_confirmation_email")
+
+so `late_refund_confirmation_email` was invisible to all of them. The correction
+prescribed after the second miss was "grep across ALL of `backend/services`,
+not just the repository module" — and that antidote carried the same defect it
+was curing: widening the DIRECTORY finds nothing when the shape being matched is
+the wrong one. Widening from TEXT to SYNTAX is the fix (superscar #3,
+under-match).
+
+So: do NOT re-derive this count with a grep, and do not trust this paragraph over
+the test. `test_every_enqueued_job_type_has_a_handler` walks the AST of every
+`enqueue_outbox` call under `backend/services`, reads the `job_type=` argument,
+and FAILS LOUDLY on a non-literal rather than skipping it. That test is the only
+thing entitled to assert the count; this prose is a convenience that has now
+misled three readers.
+
+ROUTED IS NOT ARMED, AND NOT OBSERVABLE. `_run_garuda_outbox_scheduler` spawns
+only when `GARUDA_OUTBOX_CONSUMER_ENABLED` is exactly `"true"`, and it spawns
+via `asyncio.create_task` — a failure inside it kills that task alone while
+`/health` keeps answering 200. Nothing pages on a non-empty `unroutable` set,
+and `count_undrained` below has no non-test caller, so the queue's state is not
+visible from outside the process at all. Both gaps are ledgered, neither is
+fixed here.
 
 WHY THE LOCK IS HELD ACROSS THE HANDLER (the one design decision that matters).
 `UNIQUE (journal_event_id, job_type)` makes "email once" structural on the WRITE

--- a/apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py
+++ b/apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py
@@ -637,6 +637,194 @@ class RefundEmailHandler:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class LateRefundFacts:
+    """What the late-refund confirmation is built from.
+
+    `resolution` comes from the TRIGGERING journal event, never from
+    `garuda_orders.late_case_resolution`. That column is ONE value per order
+    and migration 284 allows a second case to open once the first is closed
+    ("exactly one open case per order AT A TIME"), so a delayed retry of case
+    A's job would read case B's resolution and tell the customer about money
+    that is not theirs. The journal is append-only, so the event this job was
+    enqueued from cannot drift.
+    """
+
+    order_id: str
+    email: str
+    case_type: str
+    resolution: str
+
+
+class LateRefundConfirmationEmailHandler:
+    """Sends one "the extra payment came back" email per
+    `late_refund_confirmation_email` job — the FOURTEENTH job type, and the
+    last one production enqueued with no handler.
+
+    WHY IT WAS MISSED THREE TIMES, which is the part worth keeping. Every
+    count of these job types was taken by grepping ``job_type="`` — a LITERAL.
+    This one is enqueued at `repository.py:799-805` as
+
+        job_type = ("practice_release" if resolution == "honoured"
+                    else "late_refund_confirmation_email")
+        await journal.enqueue_outbox(..., job_type=job_type)
+
+    a VARIABLE, invisible to any literal-shaped search. The ledger's own
+    prescribed antidote said to widen the search DIRECTORY, and widening the
+    directory finds nothing here: the missing half was widening from TEXT to
+    SYNTAX (superscar #3, under-match). The coverage test that ships with this
+    handler therefore reads the `job_type=` argument from the AST and FAILS
+    LOUDLY on a non-literal rather than skipping it.
+
+    NOT A COPY OF `RefundEmailHandler`, and the difference is the guard.
+    `RefundEmailHandler` keys on `state == 'refunded'`. `resolve_late_order`
+    sets `late_case_open = FALSE` and `late_case_resolution` and leaves `state`
+    UNCHANGED, so the order behind this job may be `refunded`, `failed` or
+    `expired` — a state guard would be reading a column this transition never
+    writes.
+
+    WHAT THIS MAIL MAY AND MAY NOT SAY. Three transitions open a late-payment
+    case, and they are not the same story: OP-08 (a real duplicate charge on an
+    already-`paid` order), OP-F04 (a payment arriving after the order was
+    REFUNDED) and OP-F05 (a payment arriving on a `failed`/`expired` order,
+    which has NO earlier successful payment — see that branch's own comment,
+    "`provider_charge_id` is NULL here"). The triggering `order.late_resolved`
+    event carries only `{"resolution": ...}`, so this handler cannot tell them
+    apart. The copy is therefore written to be true on all three and claims
+    nothing it cannot know — in particular it does NOT say "a second payment",
+    which the first draft did and which is false for OP-F05.
+
+    FAIL-CLOSED, AND DELIBERATELY IN THE OPPOSITE DIRECTION FROM THE STAFF
+    PAGES. A missing triggering event RAISES: the journal is append-only, so a
+    job whose event does not exist is a contradiction, not a stale read, and
+    the one fact this mail asserts would be unverifiable. A resolution that is
+    not `refunded_in_full` resolves WITHOUT sending and logs at WARNING naming
+    the value read. For a staff page the ambiguous direction is "page anyway"
+    — a money anomaly nobody hears about is worse. For a customer email that
+    ASSERTS money moved it is the reverse: withholding is the safe side, so
+    the log line is the thing that has to be loud.
+
+    NO AMOUNT, for a harder reason than `RefundEmailHandler`'s. There the
+    objection was that `price_idr` is the ORDER price rather than a refunded
+    amount. Here the sum returned is the EXTRA charge, and nothing in
+    `garuda_orders` records what that charge was — `late_case_charge_id` is a
+    provider id, not a figure. Naming `price_idr` would name a number that is
+    wrong rather than merely unproven.
+    """
+
+    _RESOLUTION_WORTH_CONFIRMING = "refunded_in_full"
+
+    def __init__(self, pool: asyncpg.Pool, sender: BrevoEmailSender) -> None:
+        self._pool = pool
+        self._sender = sender
+
+    async def __call__(self, job: OutboxJob) -> None:
+        facts = await self._load(job.order_id, job.journal_event_id)
+        if facts is None:
+            raise EmailSendFailed(
+                f"order {job.order_id} not found for a queued late refund confirmation"
+            )
+
+        if facts.resolution != self._RESOLUTION_WORTH_CONFIRMING:
+            logger.warning(
+                "outbox late_refund_confirmation_email resolved WITHOUT sending: "
+                "order %s, triggering event %s recorded resolution %r, not %r — "
+                "a refund confirmation would be untrue",
+                facts.order_id,
+                job.journal_event_id,
+                facts.resolution,
+                self._RESOLUTION_WORTH_CONFIRMING,
+            )
+            return
+
+        await self._sender.send(
+            to=facts.email,
+            # Subject carries the same constraint as the body: it may not
+            # commit to "extra"/"second"/"duplicate", which is false on the
+            # OP-F05 path (a payment on a failed/expired order, where no
+            # earlier one exists). The first draft said "the extra payment"
+            # here while the body had already been corrected — the guard
+            # test reads the whole request, which is how that was caught.
+            subject="Your Bali Zero Visa on Arrival — a payment has been returned",
+            html_body=self._body(facts),
+        )
+        logger.info(
+            "outbox late_refund_confirmation_email sent for order %s", facts.order_id
+        )
+
+    async def _load(self, order_id: str, journal_event_id: str) -> LateRefundFacts | None:
+        async with self._pool.acquire() as conn:
+            order_row = await conn.fetchrow(
+                """
+                SELECT order_id, applicant_email, case_type
+                  FROM garuda_orders
+                 WHERE order_id = $1
+                """,
+                order_id,
+            )
+            if order_row is None:
+                return None
+            event_row = await conn.fetchrow(
+                "SELECT detail FROM garuda_order_journal WHERE event_id = $1",
+                journal_event_id,
+            )
+        if event_row is None:
+            raise EmailSendFailed(
+                f"journal event {journal_event_id} not found for a queued late "
+                f"refund confirmation on order {order_id}"
+            )
+        raw_detail = event_row["detail"]
+        detail = json.loads(raw_detail) if isinstance(raw_detail, str) else (raw_detail or {})
+        resolution = detail.get("resolution")
+        return LateRefundFacts(
+            order_id=order_row["order_id"],
+            email=order_row["applicant_email"],
+            case_type=order_row["case_type"],
+            # Not `str(resolution)`: a dict/list under the key would serialise
+            # whole and then merely fail the equality check below — same class
+            # of shape `_detail_scalar` refuses for the staff pages. Anything
+            # that is not a string is not the sentinel, and "" never equals it.
+            resolution=resolution if isinstance(resolution, str) else "",
+        )
+
+    @staticmethod
+    def _body(facts: LateRefundFacts) -> str:
+        base = os.getenv(TRACKER_BASE_URL_ENV, DEFAULT_TRACKER_BASE_URL).rstrip("/")
+        tracker = f"{base}/{facts.order_id}"
+        # "A SECOND PAYMENT" WOULD BE FALSE ON ONE OF THE THREE PATHS, and the
+        # first draft of this copy said exactly that. Three transitions open a
+        # late-payment case (repository.py): OP-08, a genuine duplicate charge
+        # on an already-`paid` order; OP-F04, a payment landing after the order
+        # was REFUNDED; and OP-F05, a payment landing on a `failed`/`expired`
+        # order. That third one has NO earlier successful payment at all — the
+        # branch's own comment says so, "`provider_charge_id` is NULL here (a
+        # failed/expired order never reached OP-02)". Telling that customer a
+        # second payment was taken asserts something untrue about their money.
+        #
+        # The handler cannot tell the three apart: it is triggered by the
+        # `order.late_resolved` event, whose `detail` carries only
+        # `{"resolution": ...}`, not which case was opened. So the copy is
+        # written to be true on ALL THREE rather than guessing — "a payment
+        # that should not have been taken" holds for a duplicate, for one after
+        # a refund, and for one on a closed order.
+        #
+        # It also does NOT say "your application is not affected". True for
+        # OP-08; misleading for OP-F05, where the application really is failed
+        # or expired and the tracker is the honest place to look.
+        return (
+            "Hello,<br><br>"
+            "A payment was taken for your Bali Zero Visa on Arrival "
+            f"({facts.case_type}) that should not have been, and we have "
+            "returned it.<br><br>"
+            "The money goes back to the payment method you used, and follows "
+            "your card provider's own timeline to appear on your "
+            "statement.<br><br>"
+            "You can follow this order's status here:<br><br>"
+            f'<a href="{tracker}">Track my application</a><br><br>'
+            "— Bali Zero"
+        )
+
+
 class PracticeNotMinted(RuntimeError):
     """No `garuda_practices` row for this payment event. Raised, never swallowed."""
 
@@ -1651,24 +1839,32 @@ def build_handlers(
 ) -> dict[str, object]:
     """The registry `drain_once` consumes.
 
-    THIRTEEN job types are routed. That is NOT all of them — production
-    enqueues FOURTEEN, and the fourteenth still has no handler:
-    `late_refund_confirmation_email`, computed at `repository.py:799-805`
-    (`"practice_release" if resolution == "honoured" else
-    "late_refund_confirmation_email"`) when a staff member resolves a late-payment
-    case by giving the money back. An earlier draft of this docstring said
-    thirteen was every type; that was wrong, and it was wrong for an instructive
-    reason — every count of these types so far was taken by grepping `job_type="`,
-    a LITERAL, and that one call site passes a VARIABLE. Broadening the search
-    DIRECTORY was never the missing half; broadening from text to syntax is.
-    So `unroutable` does NOT reach zero after this function.
-    Eight always: `checkout_ready_email` and `payment_paid_email` (what the
+    ALL FOURTEEN job types production enqueues are routed. The fourteenth,
+    `late_refund_confirmation_email`, lands here with this change; it is
+    computed at `repository.py:799-805` (`"practice_release" if resolution ==
+    "honoured" else "late_refund_confirmation_email"`) when a staff member
+    resolves a late-payment case by giving the money back.
+
+    THE COUNT IN THIS DOCSTRING WAS WRONG TWICE, and the reason is load-bearing
+    for whoever changes it next. Every count of these types was taken by
+    grepping `job_type="`, a LITERAL, and that one call site passes a VARIABLE
+    — invisible to any literal-shaped search, in three separate artifacts. The
+    ledger's own prescribed antidote said to widen the search DIRECTORY, which
+    finds nothing here: the missing half was widening from TEXT to SYNTAX
+    (superscar #3, under-match). Do not re-derive this number with a grep.
+    `test_every_enqueued_job_type_has_a_handler` reads the `job_type=` argument
+    from the AST and fails loudly on a non-literal, and that test is the only
+    thing entitled to assert the count.
+
+    Nine always: `checkout_ready_email` and `payment_paid_email` (what the
     customer sees while paying), `payment_failed_email` and
     `payment_expired_email` (what the customer sees when paying goes wrong),
     `refund_email` (what the customer sees when money comes back),
-    `practice_release` (what the team sees), `portal_invite` (how the customer
-    gets IN) and `practice_received_email` (what the customer sees once their
-    application is open with the team). `payment_paid_email`,
+    `late_refund_confirmation_email` (what the customer sees when a SECOND
+    charge comes back), `practice_release` (what the team sees),
+    `portal_invite` (how the customer gets IN) and `practice_received_email`
+    (what the customer sees once their application is open with the team).
+    `payment_paid_email`,
     `practice_release` and `portal_invite` are enqueued by the SAME transaction
     in `repository.py` when a payment is confirmed; routing only the first of
     those three is what originally produced a paying customer with a
@@ -1690,14 +1886,23 @@ def build_handlers(
     from `_run_garuda_outbox_scheduler` in `main_api.py`, reusing the SAME
     injected `httpx.AsyncClient` the email sender already owns) to arm them.
 
-    So the category of deliberately-unhandled job types shrinks to exactly ONE:
-    `{late_refund_confirmation_email}`. An `unroutable > 0` alarm armed today
-    would therefore fire on EVERY drain pass, forever, for that one known type —
-    an unroutable job is never dispatched and its attempt bump is rolled back, so
-    it is re-claimed every pass. That is how a real signal gets muted (superscar
-    #2), so the alarm stays scoped to that single-entry allowlist until the
-    fourteenth handler lands, at which point it collapses to the plain predicate.
-    Both are separate changes; neither is this one.
+    THE CATEGORY OF DELIBERATELY-UNHANDLED JOB TYPES IS NOW EMPTY, and that is
+    what finally makes the alarm simple. While one known type was unrouted, an
+    `unroutable > 0` alarm would have fired on EVERY drain pass forever for it
+    — an unroutable job is never dispatched and its attempt bump is rolled
+    back, so it is re-claimed every pass, which is how a real signal gets muted
+    (superscar #2). With nothing left on the allowlist the predicate collapses
+    to plain `unroutable > 0`, meaning "a NEW job_type nobody routed". Arming
+    it is a separate change in `_run_garuda_outbox_scheduler`; it is not this
+    one. Note the ordering claim carefully: EMPTY here is asserted by the AST
+    coverage test, not by this sentence.
+
+    A ROUTED HANDLER IS STILL NOT AN ARMED ONE. `_run_garuda_outbox_scheduler`
+    only spawns if `GARUDA_OUTBOX_CONSUMER_ENABLED` is exactly the string
+    "true" (`outbox_consumer.is_consumer_enabled`), and it spawns via
+    `asyncio.create_task`, so a failure inside it kills the task alone and
+    leaves `/health` answering 200. Nothing routed here is observable from
+    outside the process until that changes.
     """
 
     from backend.app.core.config import settings
@@ -1713,6 +1918,9 @@ def build_handlers(
         "payment_failed_email": PaymentFailedEmailHandler(pool, sender),
         "payment_expired_email": PaymentExpiredEmailHandler(pool, sender),
         "refund_email": RefundEmailHandler(pool, sender),
+        "late_refund_confirmation_email": LateRefundConfirmationEmailHandler(
+            pool, sender
+        ),
         "practice_release": PracticeReleaseHandler(pool, handoff),
         "practice_received_email": PracticeReceivedEmailHandler(pool, sender),
         "portal_invite": PortalInviteHandler(
@@ -1752,6 +1960,8 @@ __all__ = [
     "CheckoutReadyEmailHandler",
     "CrmPracticeNotWrittenYet",
     "EmailSendFailed",
+    "LateRefundConfirmationEmailHandler",
+    "LateRefundFacts",
     "OrderAnomalyFacts",
     "OrderEmailFacts",
     "PaymentExpiredEmailHandler",

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_late_refund_confirmation_email.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_late_refund_confirmation_email.py
@@ -1,0 +1,360 @@
+"""Tests for `LateRefundConfirmationEmailHandler` — the FOURTEENTH job type.
+
+The one behaviour worth stating up front, because it is what the handler is
+shaped around: `resolve_late_order` writes `late_case_resolution` as ONE column
+per order, and migration 284 allows a SECOND late case to open once the first
+is closed. So the current column cannot answer "what was MY case resolved as".
+The handler reads the resolution out of the TRIGGERING journal event instead,
+and `test_a_delayed_job_renders_its_own_cases_resolution_not_a_later_one` is
+the test that would go red if anyone changed that back.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+import httpx
+import pytest
+
+asyncpg = pytest.importorskip("asyncpg")
+
+from backend.services.garuda_orders import journal
+from backend.services.garuda_orders.outbox_consumer import KILL_SWITCH_ENV, OutboxJob
+from backend.services.garuda_orders.outbox_handlers import (
+    EmailSendFailed,
+    LateRefundConfirmationEmailHandler,
+)
+from backend.tests.fixtures.prod_shaped_pool import create_prod_shaped_pool
+
+_DSN = (
+    os.environ.get("GARUDA_L3_TEST_DSN")
+    or os.environ.get("INTAKE_TEST_DSN")
+    or "postgresql://localhost:5432/garuda_outbox_test_0826"
+)
+
+pytestmark = pytest.mark.asyncio
+
+RECIPIENT = "traveller@example.invalid"
+APPLICANT_NAME = "SPECIMEN TRAVELLER"
+APPLICANT_PHONE = "+000000000000"
+APPLICANT_PASSPORT = "X0000000"
+PRICE_IDR = 790000
+LOGGER_NAME = "garuda.orders.outbox_handlers"
+
+
+@pytest.fixture
+async def pool():
+    try:
+        p = await create_prod_shaped_pool(_DSN, min_size=1, max_size=4)
+    except (OSError, asyncpg.PostgresError) as exc:
+        if os.environ.get("CI"):
+            pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
+        pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+        # Unreachable in practice: pytest.fail/skip are NoReturn, so `p` is
+        # always bound below. CodeQL can't see that through the pytest API;
+        # this `raise` terminates the branch provably and re-raises the
+        # connection error if that assumption ever stops being true.
+        raise
+    try:
+        async with p.acquire() as conn:
+            await conn.execute(
+                "TRUNCATE garuda_practices, garuda_order_outbox, "
+                "garuda_order_journal, garuda_orders, garuda_voa_check_results CASCADE"
+            )
+        yield p
+    finally:
+        await p.close()
+
+
+@pytest.fixture(autouse=True)
+def armed(monkeypatch):
+    monkeypatch.setenv(KILL_SWITCH_ENV, "true")
+    monkeypatch.setenv("NUZANTARA_API_KEY", "test-key-not-a-real-secret")
+
+
+class _Recorder:
+    def __init__(self, status: int = 201) -> None:
+        self.status = status
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(self.status, json={"ok": True})
+
+
+def _sender(recorder: _Recorder):
+    from backend.services.garuda_orders.outbox_handlers import BrevoEmailSender
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(recorder))
+    return BrevoEmailSender(client, api_url="https://notifications.invalid/send"), client
+
+
+async def _seed_order(pool, *, state: str = "refunded") -> str:
+    order_id = f"ord_{uuid.uuid4().hex}"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO garuda_orders
+                (order_id, result_id_ref, case_type, applicant_full_name,
+                 applicant_email, applicant_phone, applicant_passport_number,
+                 price_idr, price_catalogue_key, state, late_case_open)
+            VALUES ($1, $2, 'issuance', $3, $4, $5, $6, $7,
+                    'B1 Visa on Arrival (VOA)', $8, FALSE)
+            """,
+            order_id,
+            f"chk_{uuid.uuid4().hex}",
+            APPLICANT_NAME,
+            RECIPIENT,
+            APPLICANT_PHONE,
+            APPLICANT_PASSPORT,
+            PRICE_IDR,
+            state,
+        )
+    return order_id
+
+
+async def _seed_resolution_event(pool, order_id: str, resolution: str) -> str:
+    """One real `order.late_resolved` event, exactly as OP-F05 writes it."""
+
+    async with pool.acquire() as conn, conn.transaction():
+        return await journal.append_event(
+            conn,
+            event_name="order.late_resolved",
+            aggregate_type="order",
+            aggregate_id=order_id,
+            transition_id="OP-F05",
+            customer_visible=True,
+            detail={"resolution": resolution},
+        )
+
+
+def _job(order_id: str, event_id: str) -> OutboxJob:
+    return OutboxJob(
+        id=1,
+        order_id=order_id,
+        journal_event_id=event_id,
+        job_type="late_refund_confirmation_email",
+        payload={},
+        attempts=1,
+    )
+
+
+# --------------------------------------------------------------------------
+# guilt
+# --------------------------------------------------------------------------
+
+
+async def test_sends_when_the_triggering_event_says_refunded_in_full(pool):
+    order_id = await _seed_order(pool)
+    event_id = await _seed_resolution_event(pool, order_id, "refunded_in_full")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await LateRefundConfirmationEmailHandler(pool, sender)(_job(order_id, event_id))
+    finally:
+        await client.aclose()
+
+    assert len(rec.requests) == 1
+    body = rec.requests[0].content.decode()
+    assert RECIPIENT in body
+    assert "returned it" in body
+
+
+async def test_the_body_never_claims_a_SECOND_payment(pool):
+    """The first draft of this copy said "A second payment was taken". That is
+    true for OP-08 (a duplicate charge on an already-`paid` order) and FALSE for
+    OP-F05, which fires from `failed`/`expired` — an order that never had a
+    successful payment at all ("`provider_charge_id` is NULL here (a
+    failed/expired order never reached OP-02)", repository.py:509-512).
+
+    This handler is triggered by `order.late_resolved`, whose `detail` carries
+    only `{"resolution": ...}`, so it CANNOT tell the three opening transitions
+    apart. Any wording that commits to one of them is therefore a claim the code
+    cannot support, and this mail asserts money movement to a customer.
+    """
+
+    order_id = await _seed_order(pool)
+    event_id = await _seed_resolution_event(pool, order_id, "refunded_in_full")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await LateRefundConfirmationEmailHandler(pool, sender)(_job(order_id, event_id))
+    finally:
+        await client.aclose()
+
+    body = rec.requests[0].content.decode().lower()
+    for forbidden in ("second payment", "duplicate payment", "twice", "extra payment"):
+        assert forbidden not in body, (
+            f"the copy claims {forbidden!r}, which is false for a late payment on a "
+            f"failed/expired order — the path with no earlier payment"
+        )
+    # And it must not claim the application is unaffected: for OP-F05 it is
+    # genuinely failed or expired.
+    assert "not affected" not in body
+
+
+# --------------------------------------------------------------------------
+# innocence
+# --------------------------------------------------------------------------
+
+
+async def test_does_not_send_when_the_case_was_honoured(pool, caplog):
+    order_id = await _seed_order(pool)
+    event_id = await _seed_resolution_event(pool, order_id, "honoured")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await LateRefundConfirmationEmailHandler(pool, sender)(_job(order_id, event_id))
+    finally:
+        await client.aclose()
+
+    assert rec.requests == [], "a refund confirmation for a case we KEPT the money on"
+    assert any("honoured" in r.getMessage() for r in caplog.records), (
+        "the withholding branch must name the value it read — it is the only "
+        "durable trace, since garuda_order_outbox has no last_error column and "
+        "nothing pages on unroutable"
+    )
+
+
+async def test_raises_when_the_triggering_event_does_not_exist(pool):
+    order_id = await _seed_order(pool)
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed) as excinfo:
+            await LateRefundConfirmationEmailHandler(pool, sender)(
+                _job(order_id, "evt_does_not_exist")
+            )
+    finally:
+        await client.aclose()
+
+    assert rec.requests == []
+    message = str(excinfo.value)
+    for secret in (APPLICANT_NAME, RECIPIENT, APPLICANT_PHONE, APPLICANT_PASSPORT):
+        assert secret not in message, f"applicant PII leaked into the raised error: {secret!r}"
+
+
+async def test_raises_when_the_order_does_not_exist(pool):
+    """An order id nothing backs, rather than a deleted row: `garuda_orders` is
+    FK'd from the append-only journal, whose own trigger answers
+    "garuda_order_journal is append-only -- DELETE is forbidden". Building this
+    case by deletion is not possible against the real schema, and faking it
+    against a stub would be testing the stub."""
+
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with pytest.raises(EmailSendFailed):
+            await LateRefundConfirmationEmailHandler(pool, sender)(
+                _job(f"ord_{uuid.uuid4().hex}", "evt_also_absent")
+            )
+    finally:
+        await client.aclose()
+    assert rec.requests == []
+
+
+# --------------------------------------------------------------------------
+# the reason the handler reads the EVENT and not the column
+# --------------------------------------------------------------------------
+
+
+async def test_a_delayed_job_renders_its_own_cases_resolution_not_a_later_one(pool):
+    """Two late cases on one order. Case A was HONOURED, case B was REFUNDED.
+
+    `garuda_orders.late_case_resolution` now holds case B's value, and a
+    handler keying on that column would email case A's customer-facing job
+    saying money came back — when for case A it did not. Reading the
+    triggering event keeps each job on its own case.
+    """
+
+    order_id = await _seed_order(pool)
+    case_a = await _seed_resolution_event(pool, order_id, "honoured")
+    case_b = await _seed_resolution_event(pool, order_id, "refunded_in_full")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE garuda_orders SET late_case_resolution = 'refunded_in_full' "
+            "WHERE order_id = $1",
+            order_id,
+        )
+
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    handler = LateRefundConfirmationEmailHandler(pool, sender)
+    try:
+        await handler(_job(order_id, case_a))
+        assert rec.requests == [], (
+            "case A was HONOURED — this mail is about case B's refund and would "
+            "tell the wrong customer their money came back"
+        )
+        await handler(_job(order_id, case_b))
+        assert len(rec.requests) == 1, "case B's own job must still send"
+    finally:
+        await client.aclose()
+
+
+# --------------------------------------------------------------------------
+# the money statement
+# --------------------------------------------------------------------------
+
+
+async def test_the_body_quotes_no_amount(pool):
+    """Nothing records what the EXTRA charge was — `late_case_charge_id` is a
+    provider id, not a figure. Naming `price_idr` would name a number that is
+    wrong, not merely unproven."""
+
+    order_id = await _seed_order(pool)
+    event_id = await _seed_resolution_event(pool, order_id, "refunded_in_full")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await LateRefundConfirmationEmailHandler(pool, sender)(_job(order_id, event_id))
+    finally:
+        await client.aclose()
+
+    body = rec.requests[0].content.decode()
+    for rendering in (str(PRICE_IDR), f"{PRICE_IDR:,}", f"{PRICE_IDR:,}".replace(",", ".")):
+        assert rendering not in body, f"an amount reached the customer: {rendering!r}"
+
+
+async def test_no_applicant_pii_but_the_address_reaches_the_log(pool, caplog):
+    order_id = await _seed_order(pool)
+    event_id = await _seed_resolution_event(pool, order_id, "refunded_in_full")
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            await LateRefundConfirmationEmailHandler(pool, sender)(_job(order_id, event_id))
+    finally:
+        await client.aclose()
+
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    for secret in (APPLICANT_NAME, RECIPIENT, APPLICANT_PHONE, APPLICANT_PASSPORT):
+        assert secret not in logged, f"applicant PII reached a log line: {secret!r}"
+
+
+@pytest.mark.parametrize("poisoned", [{"resolution": {"nested": "object"}}, {}, {"resolution": 7}])
+async def test_a_non_string_resolution_is_never_treated_as_a_refund(pool, poisoned):
+    """`detail` is JSONB and admits any shape. Anything that is not the exact
+    sentinel string must withhold, never send."""
+
+    order_id = await _seed_order(pool)
+    async with pool.acquire() as conn, conn.transaction():
+        event_id = await journal.append_event(
+            conn,
+            event_name="order.late_resolved",
+            aggregate_type="order",
+            aggregate_id=order_id,
+            transition_id="OP-F05",
+            customer_visible=True,
+            detail=poisoned,
+        )
+    rec = _Recorder()
+    sender, client = _sender(rec)
+    try:
+        await LateRefundConfirmationEmailHandler(pool, sender)(_job(order_id, event_id))
+    finally:
+        await client.aclose()
+    assert rec.requests == []

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
@@ -488,13 +488,21 @@ def test_build_handlers_routes_practice_release() -> None:
     # here, and removing one can never pass unnoticed. `portal_invite` joined
     # it when a paid order started producing a portal account as well as a
     # practice; the five customer-email jobs joined when the outbox grew to
-    # cover checkout/failure/expiry/refund/receipt.
+    # cover checkout/failure/expiry/refund/receipt;
+    # `late_refund_confirmation_email` joined last — the type three separate
+    # counts missed because its call site passes `job_type` as a VARIABLE and
+    # every count was a `job_type="` grep.
+    #
+    # This hand-maintained set is a SECOND opinion. The primary check is
+    # `test_outbox_job_type_coverage.py`, which reads the enqueued types out of
+    # the AST — the only shape that can see a non-literal argument.
     assert set(handlers) == {
         "checkout_ready_email",
         "payment_paid_email",
         "payment_failed_email",
         "payment_expired_email",
         "refund_email",
+        "late_refund_confirmation_email",
         "practice_release",
         "practice_received_email",
         "portal_invite",

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_job_type_coverage.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_job_type_coverage.py
@@ -1,0 +1,212 @@
+"""Every `job_type` production enqueues must have a handler — read from the AST.
+
+WHY THIS TEST EXISTS AND WHY IT IS NOT A GREP
+----------------------------------------------
+The count of outbox job types was stated wrongly in three separate artifacts
+(this module's own docstring twice, a ledger row, a plan document). Every one of
+those counts was produced the same way: `grep 'job_type="'`. That pattern matches
+a LITERAL, and `repository.py` has one call site that passes a VARIABLE::
+
+    job_type = ("practice_release" if resolution == "honoured"
+                else "late_refund_confirmation_email")
+    await journal.enqueue_outbox(..., job_type=job_type)
+
+`late_refund_confirmation_email` — a CUSTOMER-FACING email sent when a staff
+member gives a duplicate charge back — was therefore invisible to every count.
+
+The correction prescribed after the second miss was "grep `job_type=\"` across
+ALL of `backend/services`, not just `repository.py`". That antidote carried the
+very defect it was curing: widening the DIRECTORY changes nothing when the SHAPE
+being matched is wrong. Widening from TEXT to SYNTAX is the fix — superscar #3,
+under-match, where a guard watching one textual form goes quiet on the same fact
+written differently.
+
+So this test parses the AST. And, critically, it does NOT skip what it cannot
+resolve: an unresolvable `job_type=` argument FAILS the test by name. A checker
+that silently ignores the one shape that defeated three humans would reproduce
+the original defect in executable form.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from backend.services.garuda_orders.outbox_handlers import build_handlers
+
+# parents: [0]=garuda_orders [1]=services [2]=tests [3]=backend. So [3]/"services"
+# is `backend/services` — the production tree. An earlier draft used [4], which
+# pointed at a directory that does not exist and made every walk return the empty
+# set; `test_every_enqueued_job_type_has_a_handler` caught it because it asserts
+# `types` is non-empty. Without that assert this file would have passed while
+# checking nothing at all — the same failure mode it exists to prevent.
+_SERVICES = Path(__file__).resolve().parents[3] / "services"
+
+
+def _enqueue_calls(tree: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Attribute) and node.func.attr == "enqueue_outbox")
+            or (isinstance(node.func, ast.Name) and node.func.id == "enqueue_outbox")
+        )
+    ]
+
+
+def _constant_strings(node: ast.expr) -> list[str] | None:
+    """Every string this expression can evaluate to, or None if not decidable.
+
+    Deliberately narrow: a bare literal, or a conditional whose two branches are
+    both literals. That is exactly the shape production uses today. Anything
+    else returns None and the caller FAILS — never skips. Widen this only by
+    adding a shape that actually appears, and only together with the call site
+    that made it necessary.
+    """
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.IfExp):
+        left = _constant_strings(node.body)
+        right = _constant_strings(node.orelse)
+        if left is None or right is None:
+            return None
+        return left + right
+    return None
+
+
+def _resolve_name(name: str, scope: ast.AST) -> list[str] | None:
+    """Values assigned to `name` inside `scope`, if all are decidable strings."""
+
+    found: list[str] = []
+    for node in ast.walk(scope):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                values = _constant_strings(node.value)
+                if values is None:
+                    return None
+                found.extend(values)
+    return found or None
+
+
+def _enclosing_function(tree: ast.AST, call: ast.Call) -> ast.AST:
+    best: ast.AST = tree
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.lineno <= call.lineno and call.lineno <= (node.end_lineno or node.lineno):
+                if getattr(best, "lineno", -1) <= node.lineno:
+                    best = node
+    return best
+
+
+def _collect() -> tuple[set[str], list[str]]:
+    """(job types enqueued anywhere in backend/services, unresolvable sites)."""
+
+    types: set[str] = set()
+    unresolved: list[str] = []
+    for path in sorted(_SERVICES.rglob("*.py")):
+        if "/tests/" in str(path):
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for call in _enqueue_calls(tree):
+            arg = next((kw.value for kw in call.keywords if kw.arg == "job_type"), None)
+            if arg is None:
+                unresolved.append(f"{path}:{call.lineno} — enqueue_outbox with no job_type= kwarg")
+                continue
+            values = _constant_strings(arg)
+            if values is None and isinstance(arg, ast.Name):
+                values = _resolve_name(arg.id, _enclosing_function(tree, call))
+            if values is None:
+                unresolved.append(
+                    f"{path}:{call.lineno} — job_type= is a {type(arg).__name__} this "
+                    f"checker cannot resolve"
+                )
+                continue
+            types.update(values)
+    return types, unresolved
+
+
+def test_no_enqueue_site_hides_its_job_type_from_this_checker() -> None:
+    """The checker must never SKIP a call site — that is how the bug happened."""
+
+    _, unresolved = _collect()
+    assert not unresolved, (
+        "An `enqueue_outbox` call site's job_type could not be resolved statically:\n  "
+        + "\n  ".join(unresolved)
+        + "\n\nDo NOT relax this into a skip. A literal-shaped grep is what missed "
+        "`late_refund_confirmation_email` in three separate artifacts. Either make the "
+        "call site pass a literal, or teach `_constant_strings` the new shape in the "
+        "same PR that introduces it."
+    )
+
+
+def test_every_enqueued_job_type_has_a_handler() -> None:
+    types, unresolved = _collect()
+    assert not unresolved, "resolve the sites above first"
+    assert types, "no enqueue_outbox call sites found — the walker is broken, not the code"
+
+    handlers = build_handlers(
+        pool=None,  # type: ignore[arg-type]
+        sender=None,  # type: ignore[arg-type]
+        staff_page_sender=object(),  # type: ignore[arg-type]
+    )
+    missing = sorted(types - set(handlers))
+    assert not missing, (
+        f"{len(missing)} job_type(s) are enqueued by production code with no handler in "
+        f"build_handlers: {missing}. They would be reported `unroutable` on every drain "
+        f"pass and never dispatched."
+    )
+
+
+def test_the_checker_actually_sees_the_variable_call_site() -> None:
+    """Pin the specific shape that defeated three counts.
+
+    Without this, `_constant_strings`/`_resolve_name` could regress to
+    literal-only and the two tests above would still pass — they would simply
+    stop seeing this type, exactly as every grep did.
+    """
+
+    types, _ = _collect()
+    assert "late_refund_confirmation_email" in types, (
+        "the AST walker no longer resolves repository.py's conditional job_type — "
+        "it has regressed to the literal-only behaviour this whole file exists to replace"
+    )
+    assert "practice_release" in types
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "await j.enqueue_outbox(conn, job_type=some_call())",
+        "await j.enqueue_outbox(conn, job_type=PREFIX + name)",
+        "await j.enqueue_outbox(conn, job_type=mapping[key])",
+    ],
+)
+def test_checker_refuses_shapes_it_cannot_prove(source: str) -> None:
+    """Guilt side: an unresolvable shape must come back unresolvable, not empty."""
+
+    tree = ast.parse(source)
+    call = _enqueue_calls(tree)[0]
+    arg = next(kw.value for kw in call.keywords if kw.arg == "job_type")
+    assert _constant_strings(arg) is None
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ('await j.enqueue_outbox(conn, job_type="a")', ["a"]),
+        ('await j.enqueue_outbox(conn, job_type="a" if x else "b")', ["a", "b"]),
+    ],
+)
+def test_checker_resolves_shapes_it_can_prove(source: str, expected: list[str]) -> None:
+    """Innocence side: the shapes production uses must resolve, not fail."""
+
+    tree = ast.parse(source)
+    call = _enqueue_calls(tree)[0]
+    arg = next(kw.value for kw in call.keywords if kw.arg == "job_type")
+    assert _constant_strings(arg) == expected

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_job_type_coverage.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_job_type_coverage.py
@@ -78,8 +78,51 @@ def _constant_strings(node: ast.expr) -> list[str] | None:
     return None
 
 
+def _rebinds(node: ast.AST, name: str) -> bool:
+    """Does this node bind `name` in a way `_resolve_name` cannot evaluate?
+
+    FOUND BY ATTACKING THIS CHECKER, not by reviewing it. The first version
+    looked only at `ast.Assign`, so `jt = "a"` followed by `jt += "b"` resolved
+    to `["a"]` — SILENTLY, and with the wrong value: at runtime that call
+    enqueues `"ab"`. Had `"a"` happened to have a handler and `"ab"` not, this
+    checker would have gone green over precisely the defect it exists to catch.
+
+    That is the one direction that must never happen. OVER-reporting is safe: an
+    extra value merely demands a handler that is not needed, and fails loudly.
+    UNDER-reporting a value the code really produces is the silent miss.
+
+    So every binding form this module cannot evaluate is treated as "cannot
+    decide": augmented assignment, annotated assignment, the walrus operator,
+    `for` targets, `with ... as`, and comprehension targets. None of them appear
+    at any call site today — the point is that if one ever does, this checker
+    says so instead of guessing.
+    """
+
+    if isinstance(node, (ast.AugAssign, ast.AnnAssign, ast.NamedExpr)):
+        target = node.target
+        return isinstance(target, ast.Name) and target.id == name
+    if isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+        return any(
+            isinstance(n, ast.Name) and n.id == name for n in ast.walk(node.target)
+        )
+    if isinstance(node, ast.withitem):
+        var = node.optional_vars
+        return var is not None and any(
+            isinstance(n, ast.Name) and n.id == name for n in ast.walk(var)
+        )
+    return False
+
+
 def _resolve_name(name: str, scope: ast.AST) -> list[str] | None:
-    """Values assigned to `name` inside `scope`, if all are decidable strings."""
+    """Values assigned to `name` inside `scope`, if ALL of them are decidable.
+
+    Returns None — meaning "the caller must fail, loudly" — when any binding of
+    this name uses a form this checker cannot evaluate. See `_rebinds`.
+    """
+
+    for node in ast.walk(scope):
+        if _rebinds(node, name):
+            return None
 
     found: list[str] = []
     for node in ast.walk(scope):
@@ -194,6 +237,43 @@ def test_checker_refuses_shapes_it_cannot_prove(source: str) -> None:
     call = _enqueue_calls(tree)[0]
     arg = next(kw.value for kw in call.keywords if kw.arg == "job_type")
     assert _constant_strings(arg) is None
+
+
+UNEVALUABLE_SHAPES = [
+    # THE ONE THAT WAS SILENTLY WRONG. `jt = "a"; jt += "b"` enqueues "ab"; the
+    # first version of `_resolve_name` reported ["a"] and accepted it.
+    'async def f():\n    jt = "a"\n    jt += "b"\n    await j.enqueue_outbox(c, job_type=jt)\n',
+    # Walrus, for-target, with-as, annotated assignment. None appear at a call
+    # site today; each must be UNRESOLVABLE rather than guessed.
+    'async def f():\n    await j.enqueue_outbox(c, job_type=(jt := "w"))\n',
+    'async def f():\n    for jt in ("a", "b"):\n        await j.enqueue_outbox(c, job_type=jt)\n',
+    'async def f():\n    with ctx() as jt:\n        await j.enqueue_outbox(c, job_type=jt)\n',
+    'async def f():\n    jt: str = compute()\n    await j.enqueue_outbox(c, job_type=jt)\n',
+    # A single undecidable assignment poisons the whole name.
+    'async def f():\n    jt = compute()\n    jt = "a"\n    await j.enqueue_outbox(c, job_type=jt)\n',
+]
+
+
+@pytest.mark.parametrize("source", UNEVALUABLE_SHAPES)
+def test_a_name_this_checker_cannot_evaluate_is_never_guessed(source: str) -> None:
+    """The ONLY unacceptable outcome is a confident WRONG value.
+
+    Over-reporting is safe — an extra value demands a handler that is not needed
+    and fails loudly. Under-reporting a value the code can actually produce is
+    the silent miss this whole file exists to prevent, and the augmented
+    assignment case above did exactly that until the checker was attacked.
+    """
+
+    tree = ast.parse(source)
+    call = _enqueue_calls(tree)[0]
+    arg = next(kw.value for kw in call.keywords if kw.arg == "job_type")
+    values = _constant_strings(arg)
+    if values is None and isinstance(arg, ast.Name):
+        values = _resolve_name(arg.id, _enclosing_function(tree, call))
+    assert values is None, (
+        f"resolved to {values!r} — a value this checker cannot prove the code "
+        f"produces. It must report unresolvable and fail loudly instead."
+    )
 
 
 @pytest.mark.parametrize(

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_staff_page_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_staff_page_handlers.py
@@ -654,16 +654,19 @@ def test_build_handlers_routes_all_five_when_given_a_staff_page_sender() -> None
         handlers = build_handlers(pool=None, sender=None, staff_page_sender=staff_sender)
     finally:
         pass  # client intentionally left open; this test never sends
-    # THIRTEEN routed — which is NOT every type production enqueues. There are
-    # FOURTEEN; the fourteenth is named in UNROUTED_BY_DESIGN below and asserted
-    # to be absent, so this file states the gap instead of implying there is
-    # none. An earlier version of this comment claimed thirteen was all of them.
-    # The five customer-email types joined this set when #5128 merged (this
-    # branch was cut before it); the exactness is the point, so that adding a
-    # route is always a deliberate edit here and losing one can never pass
-    # unnoticed.
+    # FOURTEEN routed, which is now every type production enqueues. The
+    # fourteenth, `late_refund_confirmation_email`, joined when its handler
+    # landed; before that this test asserted it ABSENT, precisely so that the
+    # day someone routed it this assertion would fail and force the count to be
+    # corrected in the same edit. It did, and this is that edit.
+    #
+    # The exactness is the point: adding a route must always be a deliberate
+    # change here, and losing one can never pass unnoticed. This set is a
+    # SECOND opinion, not the primary one — `test_outbox_job_type_coverage.py`
+    # derives the enqueued types from the AST, which is the only check that can
+    # see a `job_type=` passed as a variable. A hand-maintained set cannot.
     expected = {
-        # eight, always routed
+        # nine, always routed
         "checkout_ready_email",
         "payment_paid_email",
         "payment_failed_email",
@@ -671,6 +674,7 @@ def test_build_handlers_routes_all_five_when_given_a_staff_page_sender() -> None
         "refund_email",
         "practice_release",
         "practice_received_email",
+        "late_refund_confirmation_email",
         "portal_invite",
         # five, routed only because a staff_page_sender was passed
         "staff_page_duplicate_charge",
@@ -680,19 +684,16 @@ def test_build_handlers_routes_all_five_when_given_a_staff_page_sender() -> None
         "staff_page_refund_out_of_order",
     }
     assert set(handlers) == expected
-    assert len(expected) == 13
+    assert len(expected) == 14
 
-    # The fourteenth type, declared rather than silently missing. It is computed
-    # at repository.py:799-805 — `"practice_release" if resolution == "honoured"
-    # else "late_refund_confirmation_email"` — when a staff member resolves a
-    # late-payment case by refunding it. Every prior count of these types was
-    # taken by grepping `job_type="`, a LITERAL, and this one call site passes a
-    # VARIABLE, which is how three separate artifacts missed it. Asserting it
-    # ABSENT (rather than leaving the set silently short) means the day someone
-    # routes it, this assertion fails and forces the count and the comment above
-    # to be corrected in the same edit.
-    UNROUTED_BY_DESIGN = {"late_refund_confirmation_email"}
-    assert UNROUTED_BY_DESIGN.isdisjoint(set(handlers))
+    # The type that made the count wrong three times, pinned by name. It is
+    # computed at repository.py:799-805 — `"practice_release" if resolution ==
+    # "honoured" else "late_refund_confirmation_email"` — when a staff member
+    # resolves a late-payment case by refunding it. Every prior count was taken
+    # by grepping `job_type="`, a LITERAL, and that call site passes a VARIABLE.
+    # Naming it here means a future edit that drops the route fails on the
+    # specific key rather than on an opaque set difference.
+    assert "late_refund_confirmation_email" in handlers
 
 
 async def test_draining_a_queued_staff_page_sends_and_marks_it_dispatched(pool):


### PR DESCRIPTION
`late_refund_confirmation_email` is enqueued by production and had **no handler**. It fires when a staff member resolves a late-payment case by giving the money back (`repository.py:799-805`), so the customer whose duplicate charge was refunded was told nothing at all.

## Why it was missed three times

Every count of these job types was taken by grepping `job_type="` — a **literal**. That call site passes a **variable**:

```python
job_type = ("practice_release" if resolution == "honoured"
            else "late_refund_confirmation_email")
await journal.enqueue_outbox(..., job_type=job_type)
```

So it was invisible to all of them, across three artifacts. The antidote prescribed after the second miss said to widen the search *directory* — and carried the same defect it was curing: widening the directory changes nothing when the **shape** being matched is wrong. Widening from text to **syntax** is the fix (superscar #3, under-match).

`test_outbox_job_type_coverage.py` walks the AST of every `enqueue_outbox` call under `backend/services`, reads the `job_type=` argument, and **fails loudly on anything it cannot resolve** rather than skipping it. A checker that silently ignored the one shape which defeated three humans would reproduce the original defect in executable form.

- Mutation-proved: deleting the registry entry from the **source** turns it red naming `late_refund_confirmation_email`; restoring turns it green.
- Its own first draft pointed at a directory that does not exist and returned the empty set — caught by its `assert types` non-empty. That assert is why.

## The copy said something false

The first draft read *"A second payment was taken"*. Three transitions open a late-payment case:

| transition | situation | "a second payment"? |
|---|---|---|
| OP-08 | duplicate charge on an already-`paid` order | true |
| OP-F04 | payment arriving after the order was refunded | arguable |
| OP-F05 | payment arriving on a `failed`/`expired` order | **false** |

OP-F05 has no earlier successful payment — that branch's own comment says `provider_charge_id` is NULL here *(a failed/expired order never reached OP-02)*. The handler is triggered by `order.late_resolved`, whose `detail` carries only `{"resolution": ...}`, so it **cannot tell the three apart**. The copy is written to be true on all three and claims nothing it cannot know. It also no longer says "your application is not affected", which is misleading when the order really is failed or expired.

The **subject line** carried the same defect and was caught only because the guard test reads the whole request rather than the body alone.

## The guard reads the event, not the column

`garuda_orders.late_case_resolution` is one value per order, and migration 284 allows a second case to open once the first closes — so a delayed retry of case A's job would read case B's resolution and tell a customer money came back when for their case it did not. `test_a_delayed_job_renders_its_own_cases_resolution_not_a_later_one` pins it.

Fail-closed in the direction the surface calls for: a missing triggering event **raises** (the journal is append-only, so its absence is a contradiction, not a stale read); a non-`refunded_in_full` resolution resolves **without sending** and logs at WARNING naming the value read. For a staff page the ambiguous direction is "page anyway"; for a customer email asserting money moved it is the reverse.

**No amount is quoted**, for a harder reason than `RefundEmailHandler`'s: nothing records what the extra charge *was* — `late_case_charge_id` is a provider id, not a figure — so naming `price_idr` would name a number that is wrong, not merely unproven.

## Proof
- `ruff check` clean on all six changed files; import chain OK.
- `pytest backend/tests/services/garuda_orders/` → **215 passed, 0 failed**.
- The two hand-maintained exact-set tests are updated and now explicitly labelled a *second opinion* to the AST check.

## Not in this PR
The `unroutable > 0` alarm. With the allowlist finally empty the predicate collapses to the plain form, but it touches `_run_garuda_outbox_scheduler` and is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
