### PR TITLE
fix(bot): preserve the package-unbuildable sub-reason instead of collapsing it

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql
@@ -1,0 +1,107 @@
+-- 291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql
+--
+-- THE DEFECT (2026-08-27/28, measured live): migration 290 gave every
+-- non-served codex-leg outcome a durable, per-row reason in
+-- wa_outbox.generation_fall_off_reason — but `_normalize_fall_off_reason`
+-- (wa_codex_leg.py) collapses the package-builder leg's THREE genuinely
+-- different failures — `unbuildable:greeting_domain`,
+-- `unbuildable:no_collections`, `unbuildable:dlp_error`
+-- (wa_package_builder.py's PackageUnbuildable call sites) — into the
+-- single stored value "package_unbuildable" by splitting on the first ':'
+-- and mapping the head alone. The sub-reason survived only in an app log
+-- line (wa_package.py's `"wa_package: unbuildable reason=%s"`), and Fly
+-- retains logs for roughly 60 seconds. Cost, measured 2026-08-27:
+-- `wa_outbox` row 348 fell off with "package_unbuildable" at 05:28:34Z; a
+-- real client got an apology instead of an answer, and two separate
+-- investigations had to reason from source structure because the
+-- sub-reason was already gone from the logs both times they looked. This
+-- is the same blindness 290 cured, one level down.
+--
+-- THE CURE: three new category codes, one per known sub-reason, so the
+-- three failures stop colliding on write. "package_unbuildable" itself
+-- stays in the allowed set (widened, not replaced) as the fallback bucket
+-- for a future, not-yet-catalogued PackageUnbuildable reason — same
+-- "unrecognised -> generic bucket, never raise" discipline 290's own
+-- "unknown" catch-all already uses one level up. This migration ONLY
+-- widens the CHECK constraint; the columns it constrains
+-- (generation_fall_off_reason, generation_fall_off_at) already exist
+-- (migration 290) and are untouched here.
+--
+-- CONVERGE, not create: DROP CONSTRAINT IF EXISTS then re-ADD the widened
+-- CHECK, mirroring 290's own shape exactly — a CREATE-IF-NOT-EXISTS here
+-- would be a no-op on a DB that already has the narrower constraint,
+-- which would leave the suite green over a migration that never actually
+-- ran (this repo's own W-class scar for audit-adjacent DDL: see
+-- cicatrix-scars.md, "an audit trigger can veto the transaction it
+-- observes and CREATE TABLE IF NOT EXISTS hides it" and the companion
+-- ledger-owned-DDL scar — both are instances of the same "IF NOT EXISTS
+-- masks a stale constraint" failure mode this migration deliberately does
+-- not repeat).
+--
+-- Ownership check (this repo's own scar: a DDL against an object owned by
+-- a different role can abort the whole deploy, invisibly to CI):
+-- wa_outbox carries no OWNER/GRANT statement anywhere in migrations_v2 —
+-- grep-verified across every migration that touches it (206, 260, 270,
+-- 283, 290, 296) — and migration 290 already ran this exact
+-- DROP CONSTRAINT IF EXISTS / ADD CONSTRAINT pair against the same table,
+-- under the same runtime role, cleanly. No role/grant statement is needed
+-- here.
+
+ALTER TABLE wa_outbox
+    DROP CONSTRAINT IF EXISTS wa_outbox_generation_fall_off_reason_check;
+ALTER TABLE wa_outbox
+    ADD CONSTRAINT wa_outbox_generation_fall_off_reason_check
+    CHECK (generation_fall_off_reason IS NULL OR generation_fall_off_reason IN (
+        'provider_not_codex',
+        'standing_autoreply_disabled',
+        'standing_no_customer_message',
+        'window_margin',
+        'package_build_error',
+        'package_unbuildable',
+        'package_unbuildable_greeting_domain',
+        'package_unbuildable_no_collections',
+        'package_unbuildable_dlp_error',
+        'build_contract_break',
+        'offer_acquire_error',
+        'offer_uncertain',
+        'offer_refused',
+        'offer_contract_break',
+        'wait_error',
+        'wait_failed',
+        'stand_down_drift',
+        'stand_down_fence_lost',
+        'post_completion_error',
+        'consume_lost',
+        'finalize_defect',
+        'internal_error',
+        'unknown'
+    ));
+
+-- === ROLLBACK ===
+
+ALTER TABLE wa_outbox
+    DROP CONSTRAINT IF EXISTS wa_outbox_generation_fall_off_reason_check;
+ALTER TABLE wa_outbox
+    ADD CONSTRAINT wa_outbox_generation_fall_off_reason_check
+    CHECK (generation_fall_off_reason IS NULL OR generation_fall_off_reason IN (
+        'provider_not_codex',
+        'standing_autoreply_disabled',
+        'standing_no_customer_message',
+        'window_margin',
+        'package_build_error',
+        'package_unbuildable',
+        'build_contract_break',
+        'offer_acquire_error',
+        'offer_uncertain',
+        'offer_refused',
+        'offer_contract_break',
+        'wait_error',
+        'wait_failed',
+        'stand_down_drift',
+        'stand_down_fence_lost',
+        'post_completion_error',
+        'consume_lost',
+        'finalize_defect',
+        'internal_error',
+        'unknown'
+    ));

--- a/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
+++ b/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
@@ -141,8 +141,8 @@ logger = logging.getLogger(__name__)
 CUSTOMER_WINDOW_HOURS = 24
 
 # Bounded, non-PII vocabulary for wa_outbox.generation_fall_off_reason
-# (migration 290's CHECK constraint mirrors this set verbatim — keep the
-# two in sync by hand; there is no single source both can import from,
+# (migrations 290+291's CHECK constraint mirrors this set verbatim — keep
+# the two in sync by hand; there is no single source both can import from,
 # since the migration is SQL and this is Python read at a different time).
 _KNOWN_FALL_OFF_REASONS: frozenset[str] = frozenset(
     {
@@ -151,7 +151,16 @@ _KNOWN_FALL_OFF_REASONS: frozenset[str] = frozenset(
         "standing_no_customer_message",
         "window_margin",
         "package_build_error",
+        # "package_unbuildable" stays reachable as the fallback bucket for
+        # a future, not-yet-catalogued PackageUnbuildable reason (migration
+        # 291) — the three KNOWN sub-reasons below get their own distinct
+        # value instead of colliding into this one (2026-08-28: row 348
+        # fell off "package_unbuildable" and the sub-reason was already
+        # gone from the ~60s Fly log retention by the time anyone looked).
         "package_unbuildable",
+        "package_unbuildable_greeting_domain",
+        "package_unbuildable_no_collections",
+        "package_unbuildable_dlp_error",
         "build_contract_break",
         "offer_acquire_error",
         "offer_uncertain",
@@ -198,6 +207,25 @@ _FALL_OFF_REASON_PREFIX_MAP: dict[str, str] = {
     "internal_error": "internal_error",
 }
 
+# Migration 291: the package-builder leg's "unbuildable" head carries a
+# SECOND, genuinely distinct piece of information after its colon — WHICH
+# of `wa_package_builder.PackageUnbuildable`'s call sites refused
+# ("greeting_domain" / "no_collections" / "dlp_error"). Collapsing all
+# three into the single "package_unbuildable" bucket (the pre-291
+# behaviour) is exactly the blindness this map exists to end, one level
+# down from what migration 290 already fixed. Keyed on the EXACT string
+# after the first ':' (never a prefix match — the three known values never
+# collide with each other or with a future one); anything not in this
+# sub-map falls through to `_FALL_OFF_REASON_PREFIX_MAP["unbuildable"]`
+# (the generic "package_unbuildable" bucket) rather than "unknown" — a
+# real PackageUnbuildable outcome should never look indistinguishable from
+# a genuinely uncatalogued reason head.
+_UNBUILDABLE_SUB_REASON_MAP: dict[str, str] = {
+    "greeting_domain": "package_unbuildable_greeting_domain",
+    "no_collections": "package_unbuildable_no_collections",
+    "dlp_error": "package_unbuildable_dlp_error",
+}
+
 
 def _normalize_fall_off_reason(raw: str) -> str:
     """Map an open-ended raw reason string to a bounded DB-safe category.
@@ -216,10 +244,21 @@ def _normalize_fall_off_reason(raw: str) -> str:
     ever fires in prod) maps to "unknown" rather than raising — this
     function backs a best-effort write and must never be the thing that
     turns a fall-off into a second, unrelated failure.
+
+    ONE exception to "the head alone decides the category" (migration
+    291): when the head is "unbuildable", the text AFTER the colon is
+    itself a second, closed-vocabulary signal (which PackageUnbuildable
+    reason fired) and is looked up in ``_UNBUILDABLE_SUB_REASON_MAP``
+    before falling back to the generic "package_unbuildable" bucket — see
+    that map's own docstring.
     """
     if not raw:
         return "unknown"
-    head = raw.split(":", 1)[0]
+    head, _sep, rest = raw.partition(":")
+    if head == "unbuildable":
+        return _UNBUILDABLE_SUB_REASON_MAP.get(
+            rest, _FALL_OFF_REASON_PREFIX_MAP["unbuildable"]
+        )
     return _FALL_OFF_REASON_PREFIX_MAP.get(head, "unknown")
 
 

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
@@ -355,6 +355,71 @@ async def test_unbuildable_falls_off_offer_never_called(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unbuildable_reason", "expected_stored"),
+    [
+        ("greeting_domain", "package_unbuildable_greeting_domain"),
+        ("no_collections", "package_unbuildable_no_collections"),
+        ("dlp_error", "package_unbuildable_dlp_error"),
+    ],
+)
+async def test_unbuildable_sub_reason_recorded_distinctly(
+    monkeypatch: pytest.MonkeyPatch,
+    unbuildable_reason: str,
+    expected_stored: str,
+) -> None:
+    """Migration 291: the codex leg's three PackageUnbuildable sub-reasons
+    must each land in their own DB value, not collapse into the single
+    "package_unbuildable" bucket the way they did before this migration
+    (2026-08-27, measured live: wa_outbox row 348 fell off
+    "package_unbuildable" and the sub-reason — WHICH of greeting_domain /
+    no_collections / dlp_error fired — was already gone from Fly's ~60s
+    log retention by the time anyone looked, twice)."""
+    conn = ScriptedConn()
+    _wire_stubs(
+        monkeypatch,
+        build={
+            "package_wire": None,
+            "package_hash": None,
+            "unbuildable": unbuildable_reason,
+        },
+    )
+    result = await _run(conn=conn)
+    assert result.reason == f"unbuildable:{unbuildable_reason}"
+    [written] = [
+        args for sql, args in conn.executed if "generation_fall_off_reason" in sql
+    ]
+    assert written == (42, expected_stored)
+
+
+@pytest.mark.asyncio
+async def test_unbuildable_unrecognized_sub_reason_falls_back_to_generic_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PackageUnbuildable reason not yet in `_UNBUILDABLE_SUB_REASON_MAP`
+    (a future sub-reason nobody has taught this module yet) must still
+    land somewhere DISTINCTLY LABELED as "an unbuildable package", not in
+    the module-wide "unknown" bucket a genuinely uncatalogued reason HEAD
+    gets — the head here ("unbuildable") is perfectly well known, only the
+    sub-reason is new."""
+    conn = ScriptedConn()
+    _wire_stubs(
+        monkeypatch,
+        build={
+            "package_wire": None,
+            "package_hash": None,
+            "unbuildable": "some_future_reason",
+        },
+    )
+    result = await _run(conn=conn)
+    assert result.reason == "unbuildable:some_future_reason"
+    [written] = [
+        args for sql, args in conn.executed if "generation_fall_off_reason" in sql
+    ]
+    assert written == (42, "package_unbuildable")
+
+
+@pytest.mark.asyncio
 async def test_build_http_error_falls_off(monkeypatch: pytest.MonkeyPatch) -> None:
     stubs = _wire_stubs(monkeypatch, build_exc=RuntimeError("conn refused"))
     result = await _run()

--- a/evidence/2026-08/agent-air-m5-backend-rag-preserve-fall-off-sub-r-eff17443/brief.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-preserve-fall-off-sub-r-eff17443/brief.yml
@@ -1,0 +1,134 @@
+task_id: wa-codex-preserve-fall-off-sub-reason-0828
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Migration 290 (PR #5137, merged 2026-08-28) made every codex-leg
+  fall-off durable, per wa_outbox row, in `generation_fall_off_reason`.
+  But `_normalize_fall_off_reason` (`wa_codex_leg.py`) splits the raw
+  reason string on the first ':' and maps only the HEAD to a DB-safe
+  category — so the package-builder leg's three genuinely different
+  `PackageUnbuildable` outcomes (`greeting_domain` / `no_collections` /
+  `dlp_error`, the three raise sites in `wa_package_builder.py`) all
+  collapse into the single stored value `package_unbuildable`. The
+  sub-reason survived only in an app log line (`wa_package.py`'s
+  `"wa_package: unbuildable reason=%s"`), and Fly retains logs for
+  roughly 60 seconds.
+
+  Case measured that opened the mandate: `wa_outbox` row 348 fell off
+  with `generation_fall_off_reason = "package_unbuildable"` at
+  2026-08-27T05:28:34Z. A real client got an apology instead of an
+  answer, and TWO separate investigations had to reason from source
+  structure instead of data, because the sub-reason was already gone
+  from the ~60s log retention both times anyone looked. Migration 290
+  cured this blindness one level up (row-level: "did codex answer or
+  not"); this mandate cures it one level down (which of the three
+  builder refusals fired).
+
+  Gear 3 for PATH, not for blast radius: the diff touches
+  `apps/backend-rag/backend/db/migrations_v2/` (migration 291),
+  hot-zone for `scripts/evidence_pack_lint.py`. The floor is computed
+  from the diff, never chosen by whoever writes it — verified via
+  `python3 scripts/evidence_pack_lint.py --print-floor
+  --changed-files-file <this PR's changed files>` -> `3`.
+constraints:
+  - "Keep `package_unbuildable` itself reachable in the CHECK's allowed
+    set — it is the fallback bucket for any future, not-yet-catalogued
+    `PackageUnbuildable` reason. Add three DISTINCT values for the three
+    KNOWN sub-reasons instead of replacing the generic bucket."
+  - "The migration must CONVERGE (`DROP CONSTRAINT IF EXISTS` then
+    re-`ADD`), mirroring 290's own shape — a `CREATE ... IF NOT EXISTS`
+    on a DB that already has the narrower constraint would be a no-op,
+    leaving the suite green over a migration that never actually ran
+    (this repo's own audit-trigger / ledger-owned-DDL scar class)."
+  - "Check who OWNS the `wa_outbox` constraint before assuming the
+    ALTER is safe — this repo has a live scar where a DDL against an
+    object owned by a different role aborted the whole deploy invisibly
+    to CI (the migration runner uses the RUNTIME role)."
+  - "Migration numbering: verify 291 free against `origin/main`'s head
+    AND against every currently open PR's diff, not just the two named
+    in the dispatching mandate — re-verify immediately before commit,
+    not only at task start."
+  - 'The AST-based coverage guard
+    (`test_fall_off_reason_map_covers_every_reason_the_module_can_emit`)
+    must keep passing UNMODIFIED — the `"unbuildable"` key must stay
+    in `_FALL_OFF_REASON_PREFIX_MAP` (that guard''s static extraction
+    only sees the HEAD), the sub-reason dispatch is an additional layer
+    on top, never a replacement of that key.'
+acceptance:
+  - "Each of the three sub-reasons (`greeting_domain`, `no_collections`,
+    `dlp_error`) must map to its OWN distinct stored value — a test per
+    sub-reason, not one happy-path case."
+  - 'An unrecognized sub-reason (a future `PackageUnbuildable` reason
+    nobody has taught the module yet) must fall back to the GENERIC
+    `package_unbuildable` bucket, not to the module-wide `unknown`
+    bucket a genuinely uncatalogued reason HEAD gets — the head here
+    (`"unbuildable"`) is well known, only the sub-reason is new.'
+  - "Prove the widened CHECK actually bites: after widening, a value
+    outside the allowed set must still be rejected. A constraint that
+    accepts everything is worse than none."
+  - "Guilt test: mutate the SOURCE (not a test helper) so one
+    sub-reason maps to the WRONG stored value, show the specific test
+    go RED, then restore and show `git diff` clean."
+risks:
+  - "`_KNOWN_FALL_OFF_REASONS` (the Python-side mirror of the CHECK's
+    vocabulary) has no single shared source of truth with the SQL
+    CHECK — verified identical today by hand (23 values on both sides
+    after this PR), but a future change to only one side would not be
+    caught by any test short of running the migration + the full
+    Python suite together."
+  - "Naming choice: the three new values reuse the exact
+    `PackageUnbuildable` reason strings verbatim
+    (`package_unbuildable_greeting_domain` /
+    `_no_collections` / `_dlp_error`) rather than a shorter
+    abbreviation — deliberate, to keep the DB value traceable back to
+    the exact raise site without a second lookup table, at the cost of
+    slightly longer enum values than migration 290's other 19."
+  - "This PR does not change what happens to a fallen-off row
+    operationally (still the worker's retry ladder, per #5097's
+    Gemini-fallback removal) — it only makes the STORED REASON more
+    granular. Whether the new granularity gets used by any dashboard
+    or alert is out of scope here."
+grader: |
+  This dispatch had no independent cross-family refuter invoked —
+  single-implementer task under direct team-lead review. Self-adversarial
+  pass against the mandate's constraints, reported honestly:
+
+  1. Verified via grep that `wa_package_builder.py` has EXACTLY 3
+     `PackageUnbuildable(reason=...)` raise sites (`greeting_domain` at
+     line 515, `no_collections` at 517, `dlp_error` at 582) — no fourth
+     site exists that the sub-map would silently miss.
+  2. Verified the OLD test `test_unbuildable_falls_off_offer_never_called`
+     (which uses the literal sub-reason `"greeting"`, not
+     `"greeting_domain"`) still passes unmodified after the change — it
+     asserts only `result.reason`, never the persisted DB value, so it
+     is unaffected by the new sub-map; confirms the change is additive,
+     not a silent behavior change on an existing test's exact input.
+  3. Verified ownership: grepped every migration touching `wa_outbox`
+     (206, 260, 270, 283, 290, 296) for `OWNER`/`GRANT` — none exists,
+     and migration 290 already ran the identical `DROP CONSTRAINT IF
+     EXISTS` / `ADD CONSTRAINT` pair against the same table under the
+     runtime role, cleanly. No grant needed for 291.
+  4. Verified the widened CHECK on a scratch local Postgres, both
+     directions: forward (290+291) accepts all 3 new values + all
+     pre-existing values, rejects an invalid one; rollback (291 then
+     290) reverts to the exact 290-narrow constraint and then to the
+     bare pre-migration table, byte-identical `\d wa_outbox` diff.
+  5. Guilt-tested the fix itself, not just the acceptance criteria:
+     mutated `_UNBUILDABLE_SUB_REASON_MAP["dlp_error"]`'s VALUE (source,
+     not a test helper) to point at a different sub-reason's stored
+     value. Result: exactly 1 of 3 parametrized cases went RED
+     (`dlp_error`), the other 2 stayed green — proves the test actually
+     discriminates between the three sub-reasons rather than just
+     checking "some string got written". Restored via targeted `Edit`
+     (not a blanket `git checkout` — a first attempt at this discipline
+     accidentally reverted the real fix along with the mutation, caught
+     immediately by re-grepping for the new map and re-applied).
+budget: |
+  Single round. Investigation (confirm PR #5137/migration 290 already
+  merged, read wa_package_builder.py's 3 raise sites, read the AST
+  coverage test) + build (migration 291, wa_codex_leg.py sub-map +
+  normalize-function special case, 4 new tests) + verification (58/89
+  test runs, ruff, squawk, migration round-trip on scratch Postgres,
+  guilt test) + this evidence pack, in one pass.
+pii: none

--- a/evidence/2026-08/agent-air-m5-backend-rag-preserve-fall-off-sub-r-eff17443/pack.yml
+++ b/evidence/2026-08/agent-air-m5-backend-rag-preserve-fall-off-sub-r-eff17443/pack.yml
@@ -1,0 +1,228 @@
+# NOTE: brief_ref is the CANONICAL name, not this pack's own directory — the
+# harness-floor.yml CI workflow copies both discovered per-PR files into
+# /tmp/evidence-check/evidence/{brief,pack}.yml under these exact names
+# before validating, so brief_ref must always read "evidence/brief.yml".
+brief_ref: evidence/brief.yml
+plan_ref: PR #5151 — agent/air-m5/backend-rag/preserve-fall-off-sub-reason
+# Diff stats below are the LITERAL output of the command in the matching
+# receipt (git diff --numstat origin/main...HEAD), summed by hand ONLY as
+# 107+42+65=214 / 0+3+0=3 -- the per-file rows are the transcription of the
+# command's own stdout, not a re-estimate.
+diff:
+  files: 3
+  insertions: 214
+  deletions: 3
+  hotzone_hits:
+    - apps/backend-rag/backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql
+
+lanes:
+  - lane: build
+    role: build
+    seat: sonnet-5
+  - lane: review
+    role: review
+    seat: opus-5 orchestrator (team-lead, direct dispatch review)
+
+receipts:
+  - claim: "Deterministic floor for this diff is 3 (hot-zone migration path: apps/backend-rag/backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql)."
+    cmd: "python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/changed_files_291.txt"
+    exit: 0
+    ts: "2026-08-28T06:15:10Z"
+    seat: sonnet-5
+  - claim: "Migration 291 is squawk-clean under the repo's standard exclusion set."
+    cmd: "squawk --pg-version=15.0 --exclude=require-concurrent-index-creation --exclude=require-timeout-settings --exclude=require-concurrent-index-deletion --exclude=ban-drop-table --exclude=ban-drop-column --exclude=ban-char-field --exclude=prefer-bigint-over-smallint --exclude=prefer-text-field --exclude=prefer-robust-stmts --exclude=constraint-missing-not-valid --exclude=prefer-bigint-over-int --exclude=prefer-identity --exclude=disallowed-unique-constraint apps/backend-rag/backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql"
+    exit: 0
+    ts: "2026-08-28T06:15:40Z"
+    seat: sonnet-5
+  - claim: "The migration carries exactly one ROLLBACK marker."
+    cmd: "grep -c '^-- === ROLLBACK ===$' apps/backend-rag/backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql"
+    exit: 0
+    ts: "2026-08-28T06:15:45Z"
+    seat: sonnet-5
+  - claim: "Queried the full open-PR set (not just origin/main) for migration-number claims, re-checked fresh immediately before commit: no open PR claims 291 or 292. #5072 claims 289_practice_status_log.sql, which COLLIDES with 289_visa_retention_binders_scope_to_visa_decision.sql already merged on origin/main -- a real, pre-existing collision on a different PR, not introduced or touched by this one. #5037 claims 293/294/295 -- no overlap. This PR (#5151) claims 291."
+    cmd: "gh pr list --state open --limit 300 --json number,files -q '.[] | .number as $n | .files[]?.path | select(test(\"migrations_v2/[0-9]+_\")) | \"\\($n): \\(.)\"'"
+    exit: 0
+    ts: "2026-08-28T06:15:55Z"
+    seat: sonnet-5
+  - claim: "wa_package_builder.py has exactly 3 PackageUnbuildable raise sites (greeting_domain line 515, no_collections line 517, dlp_error line 582) -- the sub-map covers all of them, no fourth site is silently missed."
+    cmd: "grep -n 'raise PackageUnbuildable' backend/services/rag/agentic/wa_package_builder.py"
+    exit: 0
+    ts: "2026-08-28T06:17:05Z"
+    seat: sonnet-5
+  - claim: "ruff check is clean on both touched Python files (the migration .sql is not a ruff target)."
+    cmd: "ruff check backend/services/integrations/wa_codex_leg.py backend/tests/unit/services/test_wa_codex_leg.py"
+    exit: 0
+    ts: "2026-08-28T06:16:10Z"
+    seat: sonnet-5
+  - claim: "Literal git diff --numstat origin/main...HEAD over the 3 touched files, transcribed verbatim: migration 291 107/0, wa_codex_leg.py 42/3, test_wa_codex_leg.py 65/0. Totals: 3 files, 214 insertions, 3 deletions."
+    cmd: "git diff --numstat origin/main...HEAD"
+    exit: 0
+    ts: "2026-08-28T06:14:50Z"
+    seat: sonnet-5
+  - claim: "test_wa_codex_leg.py is green: 58 passed, 0 failed (54 pre-existing + 4 new: 3 parametrized sub-reason durability tests + 1 unrecognized-sub-reason-falls-back-to-generic-bucket test)."
+    cmd: "PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py"
+    exit: 0
+    ts: "2026-08-28T06:16:30Z"
+    seat: sonnet-5
+  - claim: "Regression: test_wa_codex_leg.py + test_wa_outbox_worker.py together stay green: 89 passed, 0 failed."
+    cmd: "PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py backend/tests/unit/services/test_wa_outbox_worker.py"
+    exit: 0
+    ts: "2026-08-28T06:16:45Z"
+    seat: sonnet-5
+  - claim: "The AST-based coverage guard test_fall_off_reason_map_covers_every_reason_the_module_can_emit still passes unmodified -- the 'unbuildable' key stays in _FALL_OFF_REASON_PREFIX_MAP (required for its static extraction), the sub-reason dispatch layered on top does not remove or shadow it."
+    cmd: "PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py -k test_fall_off_reason_map_covers_every_reason_the_module_can_emit"
+    exit: 0
+    ts: "2026-08-28T06:16:50Z"
+    seat: sonnet-5
+  - claim: "Guilt test: mutated the SOURCE (_UNBUILDABLE_SUB_REASON_MAP['dlp_error']'s VALUE, not a test helper) to point at the wrong stored value. Result: exactly 1 of 3 parametrized cases went RED (dlp_error), the other 2 (greeting_domain, no_collections) stayed green -- proves the test discriminates per sub-reason, not just 'some string got written'. Restored via targeted Edit; re-ran full suite green (58 passed) and git diff on the touched file empty (matches the committed state exactly)."
+    cmd: "PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py -k test_unbuildable_sub_reason_recorded_distinctly -v"
+    exit: 1
+    ts: "2026-08-28T06:11:30Z"
+    seat: sonnet-5
+  - claim: "_KNOWN_FALL_OFF_REASONS (Python-side mirror) and migration 291's widened CHECK IN-list are set-EQUAL: 23 values on both sides, verified programmatically (set equality), not eyeballed."
+    cmd: "PYTHONPATH=. python3 -c \"import re; from backend.services.integrations.wa_codex_leg import _KNOWN_FALL_OFF_REASONS; sql=open('backend/db/migrations_v2/291_wa_outbox_fall_off_reason_unbuildable_sub_reasons.sql').read(); m=re.search(r'generation_fall_off_reason IN \\((.*?)\\)\\);', sql, re.DOTALL); cv=set(re.findall(r\\\"'([a-z_]+)'\\\", m.group(1))); print('EQUAL:', _KNOWN_FALL_OFF_REASONS==cv)\""
+    exit: 0
+    ts: "2026-08-28T06:16:55Z"
+    seat: sonnet-5
+  - claim: "Migration round-trip against a scratch local Postgres (initdb/pg_ctl on a private throwaway data dir, stopped and dropped after): built a wa_outbox-shaped table, applied 290's forward DDL then 291's forward DDL cleanly. Inserted all pre-existing values and all 3 new sub-reason values -- accepted. Inserted an invalid value ('bogus_value_not_in_check') -- rejected by the widened CHECK with the exact constraint-violation error. Rolled back 291 -- constraint reverts to the exact 290-narrow set (new sub-reason now rejected, old values still accepted). Rolled back 290 -- final \\d wa_outbox schema is byte-identical (diff empty) to the pre-migration baseline."
+    cmd: 'psql -h /tmp -p 55291 -U postgres -d postgres -f forward_290.sql && psql ... -f forward_291.sql && psql ... -c "INSERT ... VALUES (''bogus_value_not_in_check'');" ; psql ... -f rollback_291.sql && psql ... -f rollback_290.sql && diff baseline_schema.txt final_schema.txt'
+    exit: 0
+    ts: "2026-08-28T06:09:40Z"
+    seat: sonnet-5
+
+tests:
+  cmd: "PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py backend/tests/unit/services/test_wa_outbox_worker.py"
+  passed: 89
+  failed: 0
+static:
+  lint: ok
+  typecheck: n/a-python-uses-mypy-elsewhere-not-in-touched-files
+  build: n/a
+
+runtime_proof: []
+
+dissent:
+  - seat: opus-5 orchestrator (team-lead)
+    objection: >
+      Naming risk: reusing the exact PackageUnbuildable reason strings
+      verbatim as the DB value suffix (package_unbuildable_greeting_domain
+      / _no_collections / _dlp_error) makes these three enum values
+      noticeably longer than migration 290's other 19 entries. Is there
+      an existing shorter naming convention in this vocabulary this
+      should have followed instead?
+    status: RETRACTED
+    repro: >
+      Re-read all 20 pre-existing values in migration 290's CHECK: they
+      already mix short (window_margin, consume_lost) and longer,
+      multi-word compound names (standing_autoreply_disabled,
+      stand_down_fence_lost, post_completion_error) -- there is no single
+      short-form convention to violate. Verbatim reuse of the raise
+      site's own reason string is the more traceable choice: a future
+      reader can grep the DB value directly against
+      wa_package_builder.py's raise sites with no intermediate
+      abbreviation table to keep in sync.
+  - seat: opus-5 orchestrator (team-lead)
+    objection: >
+      Does the new _UNBUILDABLE_SUB_REASON_MAP special-case in
+      _normalize_fall_off_reason risk breaking the AST-based coverage
+      guard (test_fall_off_reason_map_covers_every_reason_the_module_can_emit),
+      which extracts heads from CodexLegResult(...) call sites and checks
+      each is a key in _FALL_OFF_REASON_PREFIX_MAP -- does the new
+      two-level dispatch remove or shadow the "unbuildable" key that
+      guard depends on?
+    status: RETRACTED
+    repro: >
+      Ran the guard test in isolation after the change (receipt above):
+      passes unmodified. _FALL_OFF_REASON_PREFIX_MAP["unbuildable"] is
+      untouched ("package_unbuildable", same as before) -- the new
+      _UNBUILDABLE_SUB_REASON_MAP is consulted BEFORE the prefix map only
+      when head == "unbuildable", and falls back to
+      _FALL_OFF_REASON_PREFIX_MAP["unbuildable"] when the sub-reason is
+      unrecognized, so the key the AST guard needs is both present and
+      still semantically meaningful as the generic bucket.
+  - seat: opus-5 orchestrator (team-lead)
+    objection: >
+      The old test test_unbuildable_falls_off_offer_never_called uses the
+      literal sub-reason string "greeting" (not the real "greeting_domain"
+      wa_package_builder.py actually emits) -- did this PR's change alter
+      what that pre-existing test asserts, silently changing its meaning?
+    status: RETRACTED
+    repro: >
+      Re-ran test_unbuildable_falls_off_offer_never_called in isolation
+      after the change: still passes, asserting only
+      result.reason == "unbuildable:greeting" -- it never inspects the
+      persisted DB value (no ScriptedConn / conn.executed assertion in
+      that test), so it is untouched by the new sub-map regardless of
+      whether "greeting" is a real production sub-reason. Confirms the
+      new behavior is additive on top of, not a replacement for, this
+      test's exact input.
+  - seat: opus-5 orchestrator (team-lead)
+    objection: >
+      Ownership/grant risk on the ALTER TABLE ... ADD CONSTRAINT against
+      wa_outbox -- this repo has a live scar (migration runner uses the
+      RUNTIME role, not a migration-specific role) where a DDL against an
+      object owned by a different role aborted a deploy invisibly to CI.
+    status: RETRACTED
+    repro: >
+      Grepped every migration touching wa_outbox (206, 260, 270, 283, 290,
+      296) for OWNER/GRANT statements -- none exists anywhere in this
+      table's migration history. Migration 290 already ran the identical
+      DROP CONSTRAINT IF EXISTS / ADD CONSTRAINT pair against the same
+      table under the runtime role, cleanly (its own PR's verification
+      section confirms this). No role/grant statement needed for 291.
+  - seat: opus-5 orchestrator (team-lead)
+    objection: >
+      Could the widened CHECK constraint accidentally accept a value the
+      Python normalizer could never produce, or vice versa, silently
+      drifting the two vocabularies apart?
+    status: RETRACTED
+    repro: >
+      Verified programmatically (receipt above): _KNOWN_FALL_OFF_REASONS
+      and migration 291's CHECK IN-list are set-EQUAL today, 23 values on
+      both sides. Same residual as migration 290 declared (no single
+      shared source of truth between SQL and Python) -- recorded below as
+      a residual risk, not claimed as structurally impossible to drift.
+  - seat: opus-5 orchestrator (team-lead)
+    objection: >
+      Does the migration's rollback correctly narrow the constraint back
+      to exactly 290's shape, or could it leave a partially-widened or
+      broken constraint behind on rollback?
+    status: RETRACTED
+    repro: >
+      Full round-trip on a scratch local Postgres (receipt above):
+      forward 290+291 -> insert all values (old+new) succeeds, invalid
+      value rejected -> rollback 291 -> new sub-reason value now REJECTED,
+      old values still accepted (constraint is verified byte-for-byte
+      291's rollback CHECK IN-list, which is 290's original 20-value set)
+      -> rollback 290 -> final schema diff-empty against the
+      pre-migration baseline.
+
+residual_risks:
+  - "No independent cross-family review seat was invoked for this
+    dispatch -- a single implementer (sonnet-5) under direct team-lead
+    (opus-5 orchestrator) review, per the mandate's own dispatch shape.
+    The dissent above was performed by the team-lead reviewing this PR's
+    actual diff, not by a second-family seat running independently."
+  - "_KNOWN_FALL_OFF_REASONS and migration 291's CHECK IN-list have no
+    single shared source of truth (SQL vs Python) and must be kept in
+    sync BY HAND -- same residual migration 290 already declared,
+    inherited unchanged by this PR's widening. Verified identical today
+    (receipt above); a future change to only one side would degrade
+    silently to a mismatched 'unknown' write rather than an outright DB
+    error, per 290's own documented failure-mode analysis."
+  - "This PR does not add a mechanism to detect future PackageUnbuildable
+    reasons that are NOT yet in _UNBUILDABLE_SUB_REASON_MAP -- they will
+    correctly fall back to the generic package_unbuildable bucket (not
+    silently misclassified, not 'unknown'), but no test fails to flag
+    that a fourth sub-reason has appeared and could be given its own
+    value. Symmetrical with migration 290's own accepted residual for
+    the module-wide 'unknown' bucket."
+  - "Whether the added granularity actually gets consumed by any
+    dashboard, alert, or investigation tooling is unmeasured this round
+    -- this PR only makes the stored value more specific; it does not
+    change what (if anything) reads generation_fall_off_reason today
+    beyond what migration 290 already wired up."
+
+sources: []
+pii_scan: clean
+size_tokens: 5400


### PR DESCRIPTION
## Problem, measured live

Migration 290 (PR #5137, merged) gave every codex-leg fall-off a durable, per-row reason in `wa_outbox.generation_fall_off_reason`. But `_normalize_fall_off_reason` (`wa_codex_leg.py`) splits the raw reason on the first `:` and maps only the HEAD — so the package-builder leg's three genuinely different failures (`unbuildable:greeting_domain`, `unbuildable:no_collections`, `unbuildable:dlp_error` — the three `PackageUnbuildable` call sites in `wa_package_builder.py`) all collapse into the single stored value `package_unbuildable`. The sub-reason survived only in an app log line (`wa_package.py`'s `"wa_package: unbuildable reason=%s"`), and Fly retains logs for roughly 60 seconds.

Cost, measured 2026-08-27: `wa_outbox` row 348 fell off with `package_unbuildable` at 05:28:34Z; a real client got an apology instead of an answer; and two separate investigations had to reason from source structure because the sub-reason was already gone from the logs both times they looked. Migration 290 gave the row a reason — this makes the reason actionable, one level down.

## What this ships

- **Migration 291** widens `wa_outbox_generation_fall_off_reason_check` (CONVERGE, not create: `DROP CONSTRAINT IF EXISTS` then re-`ADD`, mirroring 290's own shape) to add three new values — `package_unbuildable_greeting_domain`, `package_unbuildable_no_collections`, `package_unbuildable_dlp_error` — while keeping `package_unbuildable` itself in the allowed set as the fallback bucket for any future, not-yet-catalogued `PackageUnbuildable` reason.
- **`wa_codex_leg.py`**: `_normalize_fall_off_reason` now special-cases the `"unbuildable"` head — the text after the colon is looked up in a new `_UNBUILDABLE_SUB_REASON_MAP` before falling back to the generic `package_unbuildable` bucket. `_KNOWN_FALL_OFF_REASONS` (the Python-side mirror of the CHECK's vocabulary) is updated to match.
- Columns (`generation_fall_off_reason` / `generation_fall_off_at`) are untouched — this PR only widens the CHECK's allowed-value set and touches the normalization function.

## Migration numbering

Checked against `origin/main`'s head and every open PR's diff (`gh pr list` + inspected files) both before writing this PR and again immediately before commit: 290 is taken (merged, #5137), 296 is taken. 293/294/295 are claimed by open PR #5037 (visa-oracle). No open PR claims 291, 292. This PR takes **291**.

## Ownership check

`wa_outbox` carries no `OWNER`/`GRANT` statement anywhere in `migrations_v2` — grep-verified across every migration that touches it (206, 260, 270, 283, 290, 296). Migration 290 already ran this exact `DROP CONSTRAINT IF EXISTS` / `ADD CONSTRAINT` pair against the same table under the runtime role, cleanly. No role/grant statement needed here.

## Verification

- `PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py` — **58 passed** (54 pre-existing + 4 new: 3 parametrized sub-reason cases + 1 unrecognized-sub-reason-falls-back-to-generic-bucket case), exit 0.
- `PYTHONPATH=. pytest backend/tests/unit/services/test_wa_codex_leg.py backend/tests/unit/services/test_wa_outbox_worker.py` together — **89 passed**, exit 0 (regression coverage).
- The AST-based coverage guard (`test_fall_off_reason_map_covers_every_reason_the_module_can_emit`) still passes unmodified — the `"unbuildable"` key stays in `_FALL_OFF_REASON_PREFIX_MAP` (required for that guard's static extraction), the sub-reason dispatch is an additional check layered on top, not a replacement.
- **Guilt test**: temporarily mutated the SOURCE (`_UNBUILDABLE_SUB_REASON_MAP["dlp_error"]` value, not a test helper) to point at the wrong stored value. Reran the new parametrized test: `1 failed, 2 passed` — `test_unbuildable_sub_reason_recorded_distinctly[dlp_error-package_unbuildable_dlp_error]` went RED as expected, the other two sub-reasons stayed green. Restored via `git checkout`, reapplied the real fix, reran full suite: **58 passed**. `git diff` on the final commit is exactly the intended 3-file change (verified below).
- **Migration round-trip against a scratch local Postgres** (`initdb`/`pg_ctl`, throwaway, dropped after): built a `wa_outbox`-shaped table, applied 290's forward DDL then 291's forward DDL — both apply cleanly. Inserted all 3 old values (`package_unbuildable`, `unknown`, etc.) and all 3 new sub-reason values — all accepted. Inserted an invalid value (`bogus_value_not_in_check`) — **rejected** by the widened CHECK (`ERROR: new row ... violates check constraint`). Rolled back 291 — constraint reverts to the exact 290-narrow set (new sub-reason value now rejected, old values still accepted). Rolled back 290 — table schema is **byte-identical** (`diff` empty) to the pre-migration baseline.
- `ruff check` on both touched Python files: all pass.
- Pre-commit hooks (migration-number uniqueness — 174 files all unique, migration-rollback-marker — 169 post-cutoff all have the marker, anti-reward-hacking, secrets scan, import-chain smoke) all passed at commit time.

## Scope

Only `wa_codex_leg.py`, `test_wa_codex_leg.py`, and the new migration 291 are touched. No changes to `generation_route`'s CAS-fence semantics, `wa_package.py`, or `wa_package_builder.py` — those are read-only inputs to this PR's logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)