### PR TITLE
fix(mouth): stop silencing Sentry source-map upload failures

### DIFF
--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -363,10 +363,21 @@ const nextConfig: NextConfig = {
   // and can cause Mixed Content issues in production.
 };
 
-// Sentry configuration options
-const sentryWebpackPluginOptions = {
-  // Suppresses source map uploading logs during build
-  silent: true,
+// Sentry configuration options.
+//
+// `silent` is deliberately NOT set. Its own type says it "suppresses all build
+// logs (ALL log levels, INCLUDING errors)" — not just the upload chatter the
+// comment here used to claim. That matters because the plugin's default on a
+// failed release/source-map upload is to THROW and stop the build: with
+// `silent: true` the deploy still failed, but with no line saying why. An
+// expired or revoked SENTRY_AUTH_TOKEN is exactly that failure, and it was
+// costing a blind red instead of a named one.
+//
+// `errorHandler` is deliberately NOT set either: providing one makes
+// compilation CONTINUE past an upload failure, which would turn a loud broken
+// deploy into a silent release with no source maps. The default throw is the
+// behaviour we want.
+export const sentryWebpackPluginOptions = {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   // Only upload source maps in production

--- a/apps/mouth/src/lib/sentry-sourcemap-visibility.test.ts
+++ b/apps/mouth/src/lib/sentry-sourcemap-visibility.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { sentryWebpackPluginOptions } from "../../next.config";
+
+/**
+ * A failed source-map upload must never be SILENT.
+ *
+ * The plugin's default on a failed release creation or source-map upload is to
+ * throw and stop the build. Two options can take that away, and both were, or
+ * nearly were, present here:
+ *
+ *   - `silent: true` suppresses ALL build logs including errors, so the deploy
+ *     still fails but says nothing about why. It was set for months under a
+ *     comment claiming it only hid "source map uploading logs".
+ *   - `errorHandler` makes compilation CONTINUE past the failure, which is
+ *     worse: a green deploy whose release has no source maps, so every
+ *     production stack trace stays minified and nobody is told.
+ *
+ * The concrete failure this guards is an expired or revoked
+ * `SENTRY_AUTH_TOKEN` — the credential rotated on 2026-08-28, whose previous
+ * value had been live on Vercel for 205 days.
+ */
+describe("sentry source-map upload failures stay visible", () => {
+  it("does not suppress build logs", () => {
+    expect(sentryWebpackPluginOptions).not.toHaveProperty("silent", true);
+  });
+
+  it("does not swallow upload errors with an errorHandler", () => {
+    expect(
+      (sentryWebpackPluginOptions as Record<string, unknown>).errorHandler,
+    ).toBeUndefined();
+  });
+
+  it("still targets the org and project from the environment", () => {
+    expect(sentryWebpackPluginOptions).toHaveProperty("org");
+    expect(sentryWebpackPluginOptions).toHaveProperty("project");
+  });
+});


### PR DESCRIPTION
## What

`silent: true` sat on the Sentry webpack plugin in `apps/mouth/next.config.ts` under a comment claiming it "suppresses source map uploading logs". The option's own type says otherwise:

> Suppresses all build logs (all log levels, **including errors**).

## Why it matters

The plugin's default on a failed release creation or source-map upload is to **throw and stop the build** — verified against the installed types (`@sentry/bundler-plugin-core/dist/types/types.d.ts:57-72`), not from memory.

Both `SENTRY_DSN` and `NEXT_PUBLIC_SENTRY_DSN` are set in Vercel production, so neither `disableServerWebpackPlugin` nor `disableClientWebpackPlugin` fires and the upload is attempted on every production build. With `silent: true`, a failure therefore produced a **red deploy with no line saying why**. An expired or revoked `SENTRY_AUTH_TOKEN` is exactly that failure.

## What changed

- Removed `silent`. Failures now name themselves.
- Recorded why `errorHandler` must also stay unset: providing one makes compilation **continue** past an upload failure, which is worse than a red build — a green release whose production stack traces are all minified, with nobody told.
- Exported `sentryWebpackPluginOptions` so the invariant is testable.

## Proof

3 tests in `apps/mouth/src/lib/sentry-sourcemap-visibility.test.ts`. Two mutations were each run and proven to turn them red:

| mutation | result |
|---|---|
| re-add `silent: true` | 1 failed |
| add `errorHandler: (e) => console.warn(e)` | 1 failed |
| restored | 3 passed, `tsc --noEmit` clean |

Deterministic gear floor for this changed-file list: **1** (`--print-floor-source` = `none`, no hot zone).

## Context

The org auth token was rotated on 2026-08-28 across `~/.config/nuzantara/sentry.env` (M5/Pro/Mini, 0600) and the M5 Keychain. The value it replaced had been live on Vercel for **205 days** — 46 days past the 2026-07-13 migration that declared the previous credential retired from all shared stores. The Vercel swap and the revocation of the old token are operator actions and are tracked separately; this PR only removes the blindfold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)