### PR TITLE
docs(garuda): decision 3 data_retention_days ratified — 90 days executed live

### DIFF
--- a/products/garuda-voa/product.yaml
+++ b/products/garuda-voa/product.yaml
@@ -198,7 +198,18 @@ owner_decisions: # §3 switchboard — filled with prepared proposals, signed at
     gesture: "read and approve — 7(b) is answered and changed no row"
   - id: 3
     decision: data_retention_days
-    state: proposal-ready
+    state: ratified
+    # RATIFIED 2026-08-28 (Zero, verbatim "2 ok 90"): retention eligibility = 90 days.
+    # EXECUTED LIVE the same day, two acts, both verified via the readonly proxy afterwards:
+    #   (1) 2026-08-26: v1 seeded (garuda-check-privacy-v1, 30d, mirror of visa-oracle values)
+    #       — this already dissolved the fail-closed persistence blocker measured 2026-08-25
+    #       below; 13 rows in garuda_voa_check_results are bound to it, proof it binds.
+    #   (2) 2026-08-28 11:15:41Z: rotated by the append-only ceremony (superuser, Zero's own
+    #       terminal — the ledger-owner SET ROLE variant fails: the guard's strand-check
+    #       SELECTs consumer tables the role cannot read): v1 period closed [2026-08-26
+    #       04:40:27Z, 2026-08-28 11:15:41Z), garuda-check-privacy-v2 opened 90d/1d/30d,
+    #       CREATED_AT anchor, approved_by zero. Exactly one open GARUDA_CHECK policy.
+    ratified_value_days: 90
     # ── blocks_go_live MOVED HERE 2026-08-25 (orchestrator session). ──
     # Until today this flag lived ONLY on decision 7, on a claim that turned out to be
     # stale (see that block). Clearing it there left the switchboard asserting that NOTHING
@@ -218,10 +229,11 @@ owner_decisions: # §3 switchboard — filled with prepared proposals, signed at
     #
     # This is a STRONGER blocker than 7 ever was: 7 was about whether a price could be
     # quoted; this is about whether any customer record can be persisted at all.
-    blocks_go_live: true
-    proposed_value_days: 90
+    # (2026-08-28: the three MEASURED facts above are history now — the seed + rotation
+    # dissolved them; kept for provenance of why the flag lived here.)
+    blocks_go_live: false
     packet: products/garuda-voa/ops/decision-packets/03-data-retention.md
-    gesture: "approve or change the number"
+    gesture: "done — ratified and executed live, see state block"
   - id: 4
     decision: legacy_garuda_voa_checks_rows
     state: measured-proposal-ready


### PR DESCRIPTION
## Summary
- Decision 3 (`data_retention_days`) moves `proposal-ready` → `ratified`: Zero ruled **90 days** on 2026-08-28 (verbatim «2 ok 90») and the rotation ceremony ran live the same day from his terminal (superuser path; the SET ROLE variant fails on the guard's strand-check permissions).
- Live state, independently verified via the readonly proxy: `garuda-check-privacy-v1` (30d, seeded 2026-08-26) closed `[2026-08-26T04:40:27Z, 2026-08-28T11:15:41Z)`; `garuda-check-privacy-v2` (90d/1d/30d, CREATED_AT anchor) open from the same instant. Exactly one open GARUDA_CHECK policy.
- `blocks_go_live` flips to **false** on this decision: the 2026-08-25 fail-closed persistence blocker is dissolved (policy row exists; 13 rows in `garuda_voa_check_results` are bound to it).
- Decision 4 (25 legacy pilot rows) is NOT touched here — its purge runs through the sanctioned bind→purge primitives in a follow-up.

## Verification
- Readonly-proxy query output quoted in the state block; config/docs only, no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)