### PR TITLE
fix(visa-check): every WhatsApp referral must name the constraint that blocked it

### DIFF
--- a/apps/backend-rag/backend/services/visa_check/match_tree.py
+++ b/apps/backend-rag/backend/services/visa_check/match_tree.py
@@ -297,6 +297,72 @@ _MAX_RESULTS: dict[Purpose, int] = {
 }
 
 
+#: Human-readable purpose names used inside referral explanations.
+#: Every `Purpose` must appear here — `test_every_purpose_has_a_label` enforces
+#: it, so a new purpose cannot ship with an explanation that names it `None`.
+_PURPOSE_LABEL: dict[Purpose, str] = {
+    Purpose.WORK_REMOTE: "remote work",
+    Purpose.INVESTOR: "investment",
+    Purpose.WORK_EMPLOYEE: "local employment",
+    Purpose.FAMILY: "family",
+    Purpose.LONG_TOURISM: "tourism",
+    Purpose.RETIREMENT: "retirement",
+    Purpose.STUDENT: "study",
+    Purpose.OTHER: "the purpose you chose",
+}
+
+
+def _covered_purposes_sentence() -> str:
+    """List the purposes this form can actually rank, as prose.
+
+    Derived from `Purpose` rather than hardcoded, so adding a purpose updates
+    the visitor-facing sentence instead of silently turning it into a lie.
+    """
+    labels = [_PURPOSE_LABEL[p] for p in Purpose if p is not Purpose.OTHER]
+    return f"{', '.join(labels[:-1])} and {labels[-1]}"
+
+
+def _explain_empty_ranking(purpose: Purpose, months: int, band: BudgetBand) -> str:
+    """Name the specific constraint that eliminated every candidate.
+
+    `_rank_for_purpose` can come back empty for two reasons that mean opposite
+    things to the visitor: the catalogue carries no visa for this purpose at
+    all, or it carries several but the budget filter excluded every one. A
+    single "no visa matches cleanly" for both hides the one fact the visitor
+    could act on, so each cause gets its own sentence and its own number.
+    """
+    tagged = [meta for meta in _get_visa_meta().values() if purpose in meta.purposes]
+
+    if not tagged:
+        return (
+            f"Our catalogue carries no visa tagged for {_PURPOSE_LABEL[purpose]}, so "
+            "there is nothing for us to rank — we would rather tell you that than hand "
+            "you a poor match. Indonesia's visa index is wider than this form: tell us "
+            "on WhatsApp what you will actually be doing here and we will name the route."
+        )
+
+    if not any(_budget_fits(meta, band) for meta in tagged):
+        # `_budget_fits` returns True whenever `min_budget_idr is None`, so if
+        # nothing fit then every tagged visa carries a minimum — `min()` below
+        # can never run over an empty sequence.
+        cheapest = min(
+            meta.min_budget_idr for meta in tagged if meta.min_budget_idr is not None
+        )
+        return (
+            f"Every {_PURPOSE_LABEL[purpose]} visa we rank carries a minimum-budget "
+            "requirement above the band you selected — the cheapest one starts at "
+            f"IDR {cheapest:,}. On WhatsApp we can work out whether a staged approach "
+            "gets you there, or whether a different route fits what you have today."
+        )
+
+    return (
+        f"We hold {len(tagged)} {_PURPOSE_LABEL[purpose]} route(s), and none of them "
+        f"came through our ranking for a {months}-month stay at your budget band. That "
+        "combination is unusual enough that it deserves a person rather than a form — "
+        "15 minutes on WhatsApp."
+    )
+
+
 def recommend_visa(
     *,
     nationality: str,
@@ -311,6 +377,13 @@ def recommend_visa(
     2. Under-budget investors refer (E28A, D12, E33G all require budget).
     3. Tourism > 6 months refers (Indonesian tourism visas cap at ~180d).
     4. Everything else: filter VISA_META by purpose tag, score, top-N.
+
+    Invariant on every referral (ruled by Zero, 2026-08-28): the reason must
+    name the specific constraint that blocked us — quoting the stay length,
+    the purpose, or a real IDR figure — and must tell the visitor where to go
+    next. A generic "your case needs a conversation" is not an explanation.
+    Enforced across the whole input space by
+    `tests/services/visa_check/test_match_tree_referral_reasons.py`.
     """
     del nationality  # reserved for future visa-waiver rules
     months = max(1, min(60, int(duration_months)))
@@ -321,9 +394,13 @@ def recommend_visa(
             pre_arrival_steps=[],
             referral_mode=True,
             referral_reason=(
-                "Your case has specifics we don't capture in a 4-step form. "
-                "A 15-minute WhatsApp review with our visa team is faster than "
-                "any guess we could make here."
+                f"This form ranks visas for {_covered_purposes_sentence()} — you told "
+                "us none of those is your reason for coming. The visa follows the "
+                "activity, so we will not reverse-engineer one from a duration and a "
+                f"budget. We do have your {months}-month horizon and your budget band; "
+                "what is missing is what you will actually be doing in Indonesia. "
+                "That is one question on WhatsApp, and the official index names far "
+                "more categories than a four-step form can ask about."
             ),
         )
 
@@ -336,7 +413,8 @@ def recommend_visa(
                 f"Indonesia's tourism visas max out at ~180 days. For a "
                 f"{months}-month stay, we need a non-tourism route (investor, "
                 "digital nomad, retirement) that matches what you actually "
-                "plan to do here."
+                "plan to do here. Tell us on WhatsApp which of those fits and "
+                "we will name the visa."
             ),
         )
 
@@ -348,8 +426,8 @@ def recommend_visa(
             referral_reason=(
                 "Investor routes (E28A, D12, E33G) all have minimum-capital or "
                 "savings requirements that a sub-IDR 50M budget does not meet. "
-                "Let's talk through what kind of business you want to open — "
-                "there may be a staged approach."
+                "Let's talk through what kind of business you want to open on "
+                "WhatsApp — there may be a staged approach."
             ),
         )
 
@@ -365,10 +443,7 @@ def recommend_visa(
             ranking=[],
             pre_arrival_steps=[],
             referral_mode=True,
-            referral_reason=(
-                "No visa in our catalogue matches this combination cleanly. "
-                "Let's review the details on WhatsApp."
-            ),
+            referral_reason=_explain_empty_ranking(purpose, months, budget_band),
         )
 
     return MatchResult(

--- a/apps/backend-rag/backend/tests/services/visa_check/test_match_tree_referral_reasons.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_match_tree_referral_reasons.py
@@ -1,0 +1,246 @@
+"""Every WhatsApp referral must carry a specific, actionable explanation.
+
+Ruled by Zero on 2026-08-28: *«ogni volta che si rimanda a whatsapp deve
+esserci la spiegazione per la quale. una spiegazione precisa.»*
+
+The rule is trivial to satisfy today and trivial to break tomorrow: a referral
+branch added six months from now with a placeholder sentence would ship
+silently and nobody would see it, because the funnel stays green either way.
+So this file does not pin the five sentences that happen to exist right now —
+it sweeps the reachable input space and asserts a *property* of every referral
+it can produce.
+
+The property is **specificity**: the explanation must quote something drawn
+from this request or this catalogue — the stay length the visitor typed, the
+purpose they picked, or a real IDR figure. Generic prose about forms and
+15-minute calls does not qualify, however long it is.
+`test_the_retired_vague_sentences_would_fail_this_gate` is the proof that the
+gate has teeth: it feeds the two sentences this PR deleted through the same
+checker and requires them to FAIL.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+
+import pytest
+
+from backend.services.visa_check import match_tree
+from backend.services.visa_check.catalogue import VisaType
+from backend.services.visa_check.match_tree import (
+    BudgetBand,
+    MatchResult,
+    Purpose,
+    recommend_visa,
+)
+
+# An IDR figure written as "IDR 50M", "IDR 2,000,000,000" or "IDR 50".
+_IDR_AMOUNT = re.compile(r"IDR\s?[\d,]+", re.IGNORECASE)
+
+# The two sentences this PR retired. Kept verbatim so the gate can be shown to
+# reject them — and so neither can quietly return.
+RETIRED_VAGUE_SENTENCES = (
+    "Your case has specifics we don't capture in a 4-step form. "
+    "A 15-minute WhatsApp review with our visa team is faster than "
+    "any guess we could make here.",
+    "No visa in our catalogue matches this combination cleanly. "
+    "Let's review the details on WhatsApp.",
+)
+
+
+def _is_specific(reason: str, *, purpose: Purpose, months: int) -> bool:
+    """True when the explanation quotes a fact from this request or catalogue.
+
+    Three accepted anchors, any one of which is enough:
+      * the stay length the visitor actually entered ("12-month");
+      * the human label of the purpose they picked ("tourism", "investment");
+      * a concrete IDR amount ("IDR 50M", "IDR 2,000,000,000").
+    """
+    haystack = reason.lower()
+    return (
+        f"{months}-month" in haystack
+        or match_tree._PURPOSE_LABEL[purpose].lower() in haystack
+        or bool(_IDR_AMOUNT.search(reason))
+    )
+
+
+def _call(
+    *, purpose: Purpose, duration_months: int, budget_band: BudgetBand
+) -> MatchResult:
+    return recommend_visa(
+        nationality="USA",
+        purpose=purpose,
+        duration_months=duration_months,
+        budget_band=budget_band,
+    )
+
+
+# --------------------------------------------------------------------------
+# The gate itself
+# --------------------------------------------------------------------------
+
+
+def test_the_retired_vague_sentences_would_fail_this_gate() -> None:
+    """Guilt half of the pair: prove the checker rejects what we removed.
+
+    Without this, `_is_specific` could be a rubber stamp and every other test
+    in the file would still pass. Note both retired sentences DO contain
+    digits ("4-step", "15-minute") — a naive "has a number" check would have
+    waved them straight through, which is exactly why the anchors are tied to
+    the request rather than to punctuation.
+    """
+    for sentence in RETIRED_VAGUE_SENTENCES:
+        assert not _is_specific(sentence, purpose=Purpose.OTHER, months=12), (
+            "the specificity checker accepted a sentence this PR deleted for "
+            f"being unspecific — the gate is not discriminating: {sentence!r}"
+        )
+
+
+@pytest.mark.parametrize("purpose", list(Purpose))
+@pytest.mark.parametrize("months", [1, 3, 6, 7, 12, 24, 60])
+@pytest.mark.parametrize("band", list(BudgetBand))
+def test_every_referral_in_the_input_space_explains_itself(
+    purpose: Purpose, months: int, band: BudgetBand
+) -> None:
+    """Innocence half: every referral the tree can reach names its own cause."""
+    result = _call(purpose=purpose, duration_months=months, budget_band=band)
+    if not result.referral_mode:
+        return
+
+    reason = (result.referral_reason or "").strip()
+    assert reason, f"referral with no explanation at all: {purpose}/{months}m/{band}"
+    assert reason not in RETIRED_VAGUE_SENTENCES, (
+        f"a retired vague sentence came back for {purpose}/{months}m/{band}"
+    )
+    assert _is_specific(reason, purpose=purpose, months=months), (
+        f"referral for {purpose.value}/{months}m/{band.value} explains nothing "
+        f"specific — it quotes neither the stay length, nor the purpose, nor an "
+        f"IDR figure: {reason!r}"
+    )
+    # Naming the blocker is only half the job — a diagnosis with no exit leaves
+    # the visitor stuck. Caught live on 2026-08-28: the tourism-over-6-months
+    # referral explained the 180-day cap perfectly and then simply stopped.
+    assert "whatsapp" in reason.lower(), (
+        f"referral for {purpose.value}/{months}m/{band.value} diagnoses the "
+        f"problem but never tells the visitor where to go: {reason!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The two causes behind an empty ranking, which used to share one sentence
+# --------------------------------------------------------------------------
+
+
+def test_catalogue_gap_and_budget_wall_do_not_share_one_sentence() -> None:
+    """They mean opposite things: "we don't cover this" vs "you can't afford it"."""
+    gap = match_tree._explain_empty_ranking(
+        Purpose.STUDENT, 12, BudgetBand.MID_50_500M
+    )
+    wall = match_tree._explain_empty_ranking(
+        Purpose.INVESTOR, 12, BudgetBand.UNDER_50M
+    )
+    assert gap != wall
+
+
+def test_the_empty_ranking_branch_is_actually_wired_to_the_explainer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the CALL SITE, not just the helper.
+
+    Found by an independent verifier on 2026-08-28: with the real `VISA_META`,
+    `recommend_visa`'s `if not ranking:` catch-all is unreachable — an
+    instrumented sweep of 168 input combinations produced 40 referrals and
+    every one came from the three early-return branches. So the parametrised
+    sweep above cannot see this branch, and the two `_explain_empty_ranking`
+    unit tests below call the helper directly: between them, a hardcoded vague
+    string planted at the call site would have shipped green.
+
+    Emptying the catalogue makes the branch reachable, and comparing against
+    the helper's own output pins the wiring rather than the wording.
+    """
+    monkeypatch.setattr(match_tree, "_get_visa_meta", dict)
+
+    result = _call(
+        purpose=Purpose.STUDENT,
+        duration_months=12,
+        budget_band=BudgetBand.MID_50_500M,
+    )
+
+    assert result.referral_mode, "an empty catalogue must refer, not answer"
+    assert result.referral_reason == match_tree._explain_empty_ranking(
+        Purpose.STUDENT, 12, BudgetBand.MID_50_500M
+    ), (
+        "the empty-ranking branch no longer routes through _explain_empty_ranking "
+        f"— it is returning something else: {result.referral_reason!r}"
+    )
+    assert result.referral_reason not in RETIRED_VAGUE_SENTENCES
+
+
+def test_catalogue_gap_names_the_purpose_it_cannot_cover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No visa carries this purpose → say so, and say it about THIS purpose."""
+    monkeypatch.setattr(match_tree, "_get_visa_meta", dict)
+
+    reason = match_tree._explain_empty_ranking(
+        Purpose.RETIREMENT, 24, BudgetBand.OVER_500M
+    )
+
+    assert "retirement" in reason.lower()
+    assert "catalogue" in reason.lower()
+    assert "whatsapp" in reason.lower()
+
+
+def test_budget_wall_quotes_the_cheapest_minimum_the_visitor_missed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every route priced out → name the cheapest threshold, not "no match"."""
+    real = match_tree._get_visa_meta()
+    template = real[VisaType.E33G]
+    stub = {
+        VisaType.E33G: replace(
+            template,
+            purposes=frozenset({Purpose.STUDENT}),
+            min_budget_idr=750_000_000,
+        ),
+    }
+    monkeypatch.setattr(match_tree, "_get_visa_meta", lambda: stub)
+
+    reason = match_tree._explain_empty_ranking(
+        Purpose.STUDENT, 12, BudgetBand.MID_50_500M
+    )
+
+    assert "IDR 750,000,000" in reason, (
+        "the visitor is told they cannot afford anything without being told "
+        f"what the bar actually is: {reason!r}"
+    )
+    assert "study" in reason.lower()
+
+
+# --------------------------------------------------------------------------
+# Drift guards on the machinery the explanations are built from
+# --------------------------------------------------------------------------
+
+
+def test_every_purpose_has_a_label() -> None:
+    """A purpose without a label renders "None" into a visitor-facing string."""
+    missing = [p.value for p in Purpose if p not in match_tree._PURPOSE_LABEL]
+    assert not missing, f"Purpose values with no human label: {missing}"
+
+
+def test_covered_purposes_sentence_lists_every_rankable_purpose() -> None:
+    """The OTHER referral tells the visitor what the form DOES cover.
+
+    Derived from the enum on purpose: hardcoding the list is how that sentence
+    becomes a lie the day a ninth purpose is added.
+    """
+    sentence = match_tree._covered_purposes_sentence()
+    for purpose in Purpose:
+        if purpose is Purpose.OTHER:
+            continue
+        assert match_tree._PURPOSE_LABEL[purpose] in sentence, (
+            f"{purpose.value} is rankable but the OTHER referral does not "
+            f"mention it: {sentence!r}"
+        )
+    assert match_tree._PURPOSE_LABEL[Purpose.OTHER] not in sentence


### PR DESCRIPTION
**Ruled by Zero 2026-08-28**: *«ogni volta che si rimanda a whatsapp deve esserci la spiegazione per la quale. una spiegazione precisa.»*

Measured live on `balizero.com` the same day: of the four referral branches in `recommend_visa`, two explained nothing the visitor could act on.

| before | after |
|---|---|
| `"Your case has specifics we don't capture in a 4-step form."` | lists the purposes the form can rank (derived from the enum, so it cannot drift into a lie), says the visa follows the activity, confirms what we already hold (stay length, budget band), names the one missing fact |
| `"No visa in our catalogue matches this combination cleanly."` | splits into **"our catalogue carries no visa tagged for `<purpose>`"** vs **"the cheapest one starts at IDR 750,000,000"** |

That second sentence covered two situations that mean **opposite** things to a visitor: *we don't cover this* and *you can't afford any of these*.

Two more defects the new sweep caught that reading did not: the `LONG_TOURISM` and `INVESTOR` referrals diagnosed the blocker precisely and then **stopped**, leaving the visitor with no exit. Both now name the handoff.

No behaviour change for the 7 of 10 cases that already answer with a visa, price and timeline.

## The guard is built to be falsifiable — and was falsified

`test_match_tree_referral_reasons.py` asserts the property across the whole reachable input space (8 purposes × 7 durations × 3 bands), not on cases chosen by the author. A referral must quote something from **this** request — the stay length, the purpose, or an IDR amount — and must name the handoff.

- `test_the_retired_vague_sentences_would_fail_this_gate` feeds both deleted sentences through the checker and **requires them to FAIL**. This matters: both contain digits (`"4-step"`, `"15-minute"`), so a naive *has a number* check would have waved them straight through.
- An independent verifier sabotaged the gate three ways. Two went red as intended (12 and 25 failures). **The third stayed GREEN** and exposed a real blind spot: with the production catalogue the `if not ranking:` branch is unreachable — an instrumented sweep of 168 combinations produced 40 referrals, every one from the three early returns — so a hardcoded string planted at that call site would have shipped silently. `test_the_empty_ranking_branch_is_actually_wired_to_the_explainer` empties the catalogue to make the branch reachable and pins the wiring; the same sabotage now fails on exactly that test (verified: `RC=1`, failing test named).

## Verification

- `backend/tests/services/visa_check/` — green, 380 tests collected (175 in the new file)
- pre-commit: anti-reward-hacking lint, Python lint, FastAPI import chain — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)