### PR TITLE
fix(lead-capture): the tripwire guarded the wrong enum, and garuda_voa sat in the gap

### DIFF
--- a/apps/backend-rag/backend/services/lead_capture/source.py
+++ b/apps/backend-rag/backend/services/lead_capture/source.py
@@ -98,12 +98,32 @@ class LeadSource(str, Enum):
 class PublicLeadSource(str, Enum):
     """Lead sources accepted by the public capture API.
 
-    ``LeadSource.GARUDA_VOA`` intentionally remains in the persistence enum so
-    historical rows continue to decode. It is absent here because the public
-    GARUDA funnel is retired.
+    This enum — not ``LeadSource`` — is what ``POST /api/lead/capture``
+    validates against (``LeadCaptureRequest.source``). A frontend value absent
+    HERE is rejected with 422, ``AppWhatsAppCTA`` swallows that in its catch,
+    and the visitor is redirected to the bare wa.me link: no prefilled message,
+    no lead row, no error anywhere. Keep it in step with the frontend — the
+    tripwire ``test_frontend_lead_sources_are_accepted_by_the_public_capture_api``
+    is what enforces that.
+
+    ``GARUDA_VOA`` was excluded on 2026-08-21 (#4344) when the then-public
+    GARUDA routes were retired — correct at the time. The funnel was RELAUNCHED
+    four days later (#4960, 2026-08-25, "the public funnel UI, dark by flag")
+    with a result page that captures under ``garuda_voa``, and nobody re-opened
+    this enum. The exclusion therefore described a state that had stopped being
+    true, and the mine was armed for go-live day: the moment
+    ``GARUDA_PUBLIC_ENABLED`` flips, every WhatsApp handoff off the VOA result
+    page 422s — clicks tracked, leads unlogged, exactly the homepage_hero bug
+    (#2495) on the flagship launch. It is re-admitted here.
+
+    ``LeadSource.GARUDA_VOA.result_url_path`` deliberately stays ``None``: the
+    deeplink builder simply omits the "Reference:" back-link for it, the lead is
+    captured either way, and re-pointing that URL is the separate question #4344
+    closed on purpose.
     """
 
     VISA_CLOCK = LeadSource.VISA_CLOCK.value
+    GARUDA_VOA = LeadSource.GARUDA_VOA.value
     VISA_MATCH = LeadSource.VISA_MATCH.value
     KBLI_DECODER = LeadSource.KBLI_DECODER.value
     KBLI_BUILDER = LeadSource.KBLI_BUILDER.value

--- a/apps/backend-rag/backend/tests/services/lead_capture/test_whatsapp_deeplink.py
+++ b/apps/backend-rag/backend/tests/services/lead_capture/test_whatsapp_deeplink.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import logging
 from urllib.parse import parse_qs, urlparse
 
-import pytest
-from pydantic import ValidationError
-
 from backend.app.routers.lead_capture import LeadCaptureRequest
 from backend.services.lead_capture.source import LeadSource, PublicLeadSource
 from backend.services.lead_capture.whatsapp_deeplink import build_whatsapp_url
@@ -178,13 +175,38 @@ class TestSourceEnum:
                 assert s.result_url_path is not None
                 assert s.result_url_path.startswith("/")
 
-    def test_public_capture_rejects_retired_garuda_source(self):
-        with pytest.raises(ValidationError):
-            LeadCaptureRequest.model_validate({"source": "garuda_voa"})
+    def test_public_capture_accepts_garuda_but_never_resurrects_its_url(self):
+        """The RETIRED half of #4344 is the URL, not the capture.
+
+        Until 2026-08-28 this asserted the opposite — that the public capture
+        API REJECTS `garuda_voa` — which was correct when #4344 (2026-08-21)
+        retired the then-public GARUDA routes. Four days later #4960 relaunched
+        the funnel dark-by-flag, and its result page captures under exactly this
+        source (`apps/mouth/src/app/visa/voa/[hash]/page.tsx`, the ACCEPT branch:
+        "prefer a human to walk you through it", offered right after the price
+        stamp). Two encoded intents in direct conflict; the newer one is the
+        ratified product (owner decision 5, "Concept A — The Stamp").
+
+        So the assertion is inverted, NOT deleted, and #4344's other half is
+        pinned here in the same breath: `result_url_path` stays None, so no new
+        public deeplink can resurrect the retired URL. The lead is captured; the
+        WA body simply carries no "Reference:" line.
+
+        Flipping this does NOT make anything public: `/visa/voa/*` is gated
+        server-side in `layout.tsx` on `GARUDA_PUBLIC_ENABLED`, which is off on
+        Vercel (product.yaml: `status: build-dark`, `owner_signed_at: null`,
+        go_live `state: blocked-...`). It only means that WHEN the owner flips
+        that flag, the funnel's highest-intent handoff writes a lead row instead
+        of 422'ing into the bare wa.me link.
+        """
+        req = LeadCaptureRequest.model_validate({"source": "garuda_voa"})
+        assert req.source is PublicLeadSource.GARUDA_VOA
+        assert req.source.to_persisted() is LeadSource.GARUDA_VOA
+        assert LeadSource.GARUDA_VOA.result_url_path is None
 
     def test_historical_garuda_value_still_decodes(self):
         assert LeadSource("garuda_voa") is LeadSource.GARUDA_VOA
-        assert "garuda_voa" not in {source.value for source in PublicLeadSource}
+        assert "garuda_voa" in {source.value for source in PublicLeadSource}
 
     def test_content_funnel_values_are_stable(self):
         # Wire-format values: the mouth frontend sends these literal strings.

--- a/apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
+++ b/apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
@@ -20,7 +20,7 @@ import re
 from pathlib import Path
 
 from backend.core import embeddings
-from backend.services.lead_capture.source import LeadSource
+from backend.services.lead_capture.source import LeadSource, PublicLeadSource
 
 
 def _repo_root() -> Path:
@@ -70,10 +70,40 @@ def _frontend_lead_sources() -> dict[str, str]:
     return found
 
 
-def test_frontend_lead_sources_are_all_valid_enum_values() -> None:
-    """A frontend source the backend enum lacks = 422 on every click, silent.
+def test_public_lead_source_is_a_subset_of_lead_source() -> None:
+    """Every public value must decode to a persisted one, or capture 500s.
+
+    ``PublicLeadSource.to_persisted()`` does ``LeadSource(self.value)``: a public
+    member with no ``LeadSource`` twin raises ValueError at request time, AFTER
+    validation has passed. It is also what makes the tripwire below sufficient —
+    checking the public enum alone covers the persistence enum only while this
+    containment holds.
+    """
+    missing = {s.value for s in PublicLeadSource} - {s.value for s in LeadSource}
+    assert not missing, (
+        f"PublicLeadSource members with no LeadSource twin: {sorted(missing)}. "
+        "to_persisted() raises ValueError on these — a 500 after a valid request."
+    )
+
+
+def test_frontend_lead_sources_are_accepted_by_the_public_capture_api() -> None:
+    """A frontend source the PUBLIC enum lacks = 422 on every click, silent.
 
     This is the exact gap that hid the homepage_hero bug for 10 days (#2495).
+
+    Renamed and re-pointed 2026-08-28. It previously compared against
+    ``LeadSource``, which is NOT the enum the route validates:
+    ``LeadCaptureRequest.source`` is typed ``PublicLeadSource``, and the two
+    differ. So a value present in ``LeadSource`` but absent from
+    ``PublicLeadSource`` passed this tripwire green while still 422'ing in
+    production — and the test's own failure message ("add the value to the
+    enum") walked the reader into exactly that trap: following it literally
+    turned the test green and left the POST broken.
+
+    That was not hypothetical. ``garuda_voa`` sat in precisely that gap between
+    2026-08-25 and this commit, armed to bite on the VOA funnel's go-live day
+    (see PublicLeadSource's docstring). The guard now measures the thing that
+    actually rejects the request.
     """
     found = _frontend_lead_sources()
 
@@ -88,14 +118,20 @@ def test_frontend_lead_sources_are_all_valid_enum_values() -> None:
         "before trusting a green."
     )
 
-    valid = {s.value for s in LeadSource}
-    unknown = {v: f for v, f in found.items() if v not in valid}
+    accepted = {s.value for s in PublicLeadSource}
+    unknown = {v: f for v, f in found.items() if v not in accepted}
     assert not unknown, (
-        "Frontend sends lead source(s) the backend LeadSource enum does not "
-        f"define → POST /api/lead/capture returns 422 and the lead is never "
-        f"written: {unknown}. Add the value to "
-        "apps/backend-rag/backend/services/lead_capture/source.py (with its two "
-        "@property entries) or fix the frontend."
+        "Frontend sends lead source(s) the public capture API does not accept "
+        "→ POST /api/lead/capture returns 422, AppWhatsAppCTA swallows it, and "
+        "the visitor lands on the BARE wa.me link with no prefilled message and "
+        f"no lead row: {unknown}.\n"
+        "Fix in apps/backend-rag/backend/services/lead_capture/source.py — the "
+        "value must be in PublicLeadSource (what the route validates) AND in "
+        "LeadSource with its two @property entries (what persists it). Adding "
+        "it to LeadSource ALONE turns this test green while the POST keeps "
+        "422'ing — that is the bug this message used to cause.\n"
+        "Or fix the frontend: if the CTA is a branch of an existing funnel, "
+        "reuse that funnel's source and carry the distinction in `context`."
     )
 
 


### PR DESCRIPTION
## What was wrong

`test_frontend_lead_sources_are_all_valid_enum_values` exists to stop the frontend
sending a `source=` the backend rejects. It was born from the **homepage_hero** bug
(#2495): the site's primary CTA 422'd for 10 days, clicks tracked, leads unlogged.

**It compared against the wrong enum.** The route validates
`LeadCaptureRequest.source: PublicLeadSource` (`lead_capture.py:43`) — not `LeadSource`.
A value present in the first and absent from the second passed the guard green while
still 422'ing in production. Its failure message then said *"add the value to the enum"*:
follow it literally and the test goes green while the POST stays broken. **The guard
reproduced the exact bug it was written to prevent.**

## What was in the gap

`garuda_voa`, since 2026-08-25.

| date | event |
|---|---|
| 2026-07-27 (#3269) | public VOA funnel ships |
| 2026-08-21 (#4344) | `PublicLeadSource` is born, retires the then-public GARUDA routes, excludes `garuda_voa` — correct at the time |
| 2026-08-25 (#4960) | the funnel is **relaunched** dark-by-flag, its result page capturing under `garuda_voa`; nobody re-opens the enum |

**Not a live outage.** `/visa/voa/*` is gated server-side in `layout.tsx` on
`GARUDA_PUBLIC_ENABLED`, which is off on Vercel — probed today: `200` with a Next 404 body.

**It is a mine armed for go-live**, whose own recorded gesture is *"flip
`GARUDA_PUBLIC_ENABLED=true`"* (`products/garuda-voa/product.yaml`, decision 0). On that
flip, the CTA on the **ACCEPT** branch — *"prefer a human to walk you through it"*,
offered right after the approved price stamp — 422s; the `catch` in `AppWhatsAppCTA`
redirects to the bare `wa.me` link; and the highest-intent lead the funnel produces
arrives as a naked "hi", with no price row and no `lead_intents` record. Nothing goes red.

## What changes

1. The guard compares against `PublicLeadSource` — the enum that actually rejects the
   request — and is renamed to say so. Its message now names both enums, the `wa.me`
   fallback, and the frontend cure (reuse the funnel's source, discriminate in `context`).
2. New `test_public_lead_source_is_a_subset_of_lead_source`. `to_persisted()` does
   `LeadSource(self.value)` and would raise *after* validation passed — a 500 on a valid
   request. It is also what makes checking the public enum alone sufficient.
3. `garuda_voa` is re-admitted to `PublicLeadSource`.

## On reversing a deliberate test

#4344 encoded its retirement in two assertions. **One is inverted, not deleted — and only
one**, because the intent had two halves and only one expired:

- *the retired public URL must never be resurrected* — **still true**. `result_url_path`
  stays `None`, and this PR pins that assertion inside the very test that used to assert
  the rejection, so the protection does not evaporate in the handover.
- *the public API must reject `garuda_voa`* — **expired on 2026-08-25**, when the ratified
  product (owner decision 5, "Concept A — The Stamp") relaunched a funnel that captures
  under it.

## This opens nothing

`product.yaml` keeps `status: build-dark`, `owner_signed_at: null`, go_live
`state: blocked-on-all-above-and-on-the-parent-page`. **Whether to go live stays Zero's
call.** This only ensures the flip does not silently cost us the leads it exists to win.

## Verification

- **Guilt/innocence:** removing `garuda_voa` from the public enum turns the tripwire RED
  naming the exact call-site (`apps/mouth/src/app/visa/voa/[hash]/page.tsx`); restoring it
  turns it green.
- **Scope:** `PublicLeadSource` has exactly one consumer (`lead_capture.py:43`), so the
  blast radius is one field's validation. All 13 frontend sources checked: `garuda_voa`
  was the only one in the gap.
- `ruff` clean · **63 passed** in the lead suite (was 61 passed / 2 failed) · 9 in the
  tripwire file. Exit codes measured individually, not inferred from a pipe.