### PR TITLE
fix(proprioception): home_fork_scripts false-positive on live-only host content

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -810,7 +810,8 @@
       "live": "~/.config/ghostty/machine.ghostty",
       "repo": "infra/ghostty/machines/mini.ghostty",
       "machines": ["mini"],
-      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. See the pro entry for why this live path appears three times."
+      "live_may_extend_repo": true,
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. See the pro entry for why this live path appears three times. 2026-08-28: this live copy may carry a host-local trailer on top of repo content (e.g. Zero's live-only colour override, marked in the dotfile itself) — proprioception's home_fork_scripts probe verifies repo is a byte-exact prefix of live before treating it as reconciled; a genuine mid-file drift still reports DIVERGED normally."
     },
     {
       "live": "~/scripts/login-healthcheck.sh",

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -469,7 +469,10 @@ def load_declared_fork_pairs(root: Path, machine: str) -> list[dict]:
     for pair in data.get("pairs", []):
         machines = pair.get("machines", ["all"])
         if ("all" in machines or machine in machines) and "live" in pair and "repo" in pair:
-            out.append({"live": pair["live"], "repo": pair["repo"]})
+            entry = {"live": pair["live"], "repo": pair["repo"]}
+            if pair.get("live_may_extend_repo"):
+                entry["live_may_extend_repo"] = True
+            out.append(entry)
     return out
 
 
@@ -494,6 +497,50 @@ def origin_main_sha(root: Path, rel: str) -> str | None:
     except (OSError, subprocess.TimeoutExpired, TypeError, ValueError, AttributeError):
         # A probe that raises takes the whole proprioception run with it.
         return None
+
+
+def _live_extends_repo_verbatim(live: Path, repo: Path) -> bool:
+    """True iff repo's bytes appear whole in live, split into one prefix and
+    one suffix, with exactly one contiguous span of NEW content inserted
+    between them (also covers the degenerate append-only/prepend-only cases,
+    where the other span is empty).
+
+    A pure `live.startswith(repo)` prefix check is too narrow: the real first
+    case (2026-08-28, a live-only Ghostty colour override on Mini, marked in
+    the dotfile itself as "live dotfile only") turned out to be a MID-FILE
+    insertion — the fleet installer places new upstream sections before an
+    existing trailing comment block, so a host-local addition lands in the
+    middle, not appended at the end. A file that merely happens to be longer
+    is not proof of anything; the proof is the longest-common-prefix plus the
+    longest-common-suffix, measured independently from each end, together
+    accounting for the ENTIRE repo file byte-for-byte. Any genuine drift —
+    a changed value, a removed line, a reordering — breaks the prefix match
+    or the suffix match (or both) at the point of the change, so
+    prefix_len + suffix_len falls short of len(repo) and this correctly
+    returns False, reporting DIVERGED normally. This is the structural test
+    for the declared-pairs.json `live_may_extend_repo` flag, distinct from
+    CHECKOUT-STALE (live matches origin/main, the checkout is behind): here
+    repo agrees with what it should say and live legitimately carries MORE,
+    never less, changed, or reordered.
+    """
+    try:
+        repo_bytes = repo.read_bytes()
+        if not repo_bytes:
+            return False  # an empty repo file prefix/suffix-matches anything — refuse to trust it
+        live_bytes = live.read_bytes()
+    except OSError:
+        return False
+    if len(live_bytes) <= len(repo_bytes):
+        return False
+    cap = len(repo_bytes)  # never let prefix+suffix search past repo's own length
+    prefix_len = 0
+    while prefix_len < cap and live_bytes[prefix_len] == repo_bytes[prefix_len]:
+        prefix_len += 1
+    suffix_len = 0
+    max_suffix = cap - prefix_len  # the two spans must not overlap within repo
+    while suffix_len < max_suffix and live_bytes[-1 - suffix_len] == repo_bytes[-1 - suffix_len]:
+        suffix_len += 1
+    return prefix_len + suffix_len == cap
 
 
 def probe_home_fork_scripts(root: Path, args: dict, timeout: int) -> tuple[str, int, list[str]]:
@@ -551,6 +598,8 @@ def probe_home_fork_scripts(root: Path, args: dict, timeout: int) -> tuple[str, 
         live_sha, repo_sha = sha256_file(live), sha256_file(repo)
         if live_sha == repo_sha:
             continue
+        if pair.get("live_may_extend_repo") and _live_extends_repo_verbatim(live, repo):
+            continue  # declared + verified: repo is a verbatim prefix, the rest is a local addition
         upstream = origin_main_sha(root, pair["repo"])
         if upstream is not None and live_sha == upstream:
             ev.append(

--- a/scripts/tests/test_proprioception_home_fork_merge.py
+++ b/scripts/tests/test_proprioception_home_fork_merge.py
@@ -145,3 +145,170 @@ def test_probe_still_unprobeable_when_no_pairs_exist_anywhere(tmp_path: Path) ->
     status, findings, ev = prop.probe_home_fork_scripts(repo, {"pairs": []}, 10)
     assert status == prop.UNPROBEABLE
     assert findings == 0
+
+
+# ---------------------------------------------------------------- live_may_extend_repo
+
+
+def test_load_declared_fork_pairs_passes_through_extend_flag_when_true(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    write_declared_pairs(repo, [{
+        "live": "~/x.ghostty", "repo": "infra/x.ghostty", "machines": ["mini"],
+        "live_may_extend_repo": True,
+    }])
+    assert prop.load_declared_fork_pairs(repo, "mini") == [
+        {"live": "~/x.ghostty", "repo": "infra/x.ghostty", "live_may_extend_repo": True}
+    ]
+
+
+def test_load_declared_fork_pairs_omits_extend_flag_when_absent(tmp_path: Path) -> None:
+    """Guards the opt-in: a pair with no live_may_extend_repo key merges to the
+    plain 2-field dict, exactly as before this feature existed — no accidental
+    exemption for pairs that never declared it."""
+    repo = make_repo(tmp_path)
+    write_declared_pairs(repo, [{"live": "~/x.ghostty", "repo": "infra/x.ghostty", "machines": ["mini"]}])
+    assert prop.load_declared_fork_pairs(repo, "mini") == [{"live": "~/x.ghostty", "repo": "infra/x.ghostty"}]
+
+
+def test_probe_live_may_extend_repo_innocence_trailer_append_reconciled(tmp_path: Path, monkeypatch) -> None:
+    """Repo content is untouched, verbatim, inside a live copy that has grown
+    a host-local trailer at the END of the file. Declared + verified by
+    prefix/suffix split -> not a finding, not even an evidence line (matches
+    the plain live_sha == repo_sha early-continue's silence)."""
+    repo = make_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    live = home / "machine.ghostty"
+    (repo / "infra" / "ghostty").mkdir(parents=True)
+    (repo / "infra" / "ghostty" / "mini.ghostty").write_text("base = 1\nfoo = bar\n", encoding="utf-8")
+    live.write_text("base = 1\nfoo = bar\n# live-only trailer, never in repo\ncolor = red\n", encoding="utf-8")
+    write_declared_pairs(repo, [{
+        "live": str(live), "repo": "infra/ghostty/mini.ghostty", "machines": ["mini"],
+        "live_may_extend_repo": True,
+    }])
+    monkeypatch.setattr(prop, "machine_label", lambda *a, **k: "mini")
+    status, findings, ev = prop.probe_home_fork_scripts(repo, {"pairs": []}, 10)
+    assert status == prop.RECONCILED
+    assert findings == 0
+    assert ev == []
+
+
+def test_probe_live_may_extend_repo_innocence_mid_file_insertion_reconciled(tmp_path: Path, monkeypatch) -> None:
+    """The ACTUAL 2026-08-28 shape: the fleet installer places new upstream
+    sections before an existing trailing comment block, so a host-local
+    addition lands in the MIDDLE of the file, not appended at the end. A pure
+    prefix check would have missed this and kept firing DIVERGED forever."""
+    repo = make_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    live = home / "machine.ghostty"
+    (repo / "infra" / "ghostty").mkdir(parents=True)
+    (repo / "infra" / "ghostty" / "mini.ghostty").write_text(
+        "cursor-color = #a6e3a1\n\n# Measured 2026-08-18: no Nerd Font\nscrollback-limit = 16000000\n",
+        encoding="utf-8",
+    )
+    live.write_text(
+        "cursor-color = #a6e3a1\n\n# live-only colour override\nbackground = #11140F\n\n"
+        "# Measured 2026-08-18: no Nerd Font\nscrollback-limit = 16000000\n",
+        encoding="utf-8",
+    )
+    write_declared_pairs(repo, [{
+        "live": str(live), "repo": "infra/ghostty/mini.ghostty", "machines": ["mini"],
+        "live_may_extend_repo": True,
+    }])
+    monkeypatch.setattr(prop, "machine_label", lambda *a, **k: "mini")
+    status, findings, ev = prop.probe_home_fork_scripts(repo, {"pairs": []}, 10)
+    assert status == prop.RECONCILED
+    assert findings == 0
+    assert ev == []
+
+
+def test_probe_live_may_extend_repo_guilt_mid_file_drift_still_diverged(tmp_path: Path, monkeypatch) -> None:
+    """The flag exempts APPENDED content only. A live copy that differs
+    somewhere INSIDE the shared span (not a pure trailer) is real drift and
+    must still report DIVERGED — the prefix check, not just "flag present",
+    is what decides."""
+    repo = make_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    live = home / "machine.ghostty"
+    (repo / "infra" / "ghostty").mkdir(parents=True)
+    (repo / "infra" / "ghostty" / "mini.ghostty").write_text("base = 1\nfoo = bar\n", encoding="utf-8")
+    live.write_text("base = 2\nfoo = bar\n# live-only trailer\ncolor = red\n", encoding="utf-8")
+    write_declared_pairs(repo, [{
+        "live": str(live), "repo": "infra/ghostty/mini.ghostty", "machines": ["mini"],
+        "live_may_extend_repo": True,
+    }])
+    monkeypatch.setattr(prop, "machine_label", lambda *a, **k: "mini")
+    status, findings, ev = prop.probe_home_fork_scripts(repo, {"pairs": []}, 10)
+    assert status == prop.DIVERGED
+    assert findings == 1
+    assert any("DIVERGED" in e for e in ev)
+
+
+def test_probe_live_may_extend_repo_guilt_flag_absent_still_diverged(tmp_path: Path, monkeypatch) -> None:
+    """The exemption is opt-in per declared pair. The exact same verbatim-prefix
+    live content that is RECONCILED when live_may_extend_repo is declared must
+    still report DIVERGED when the pair never declared it — proves this isn't
+    an automatic prefix-tolerance applied to every pair."""
+    repo = make_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    live = home / "machine.ghostty"
+    (repo / "infra" / "ghostty").mkdir(parents=True)
+    (repo / "infra" / "ghostty" / "mini.ghostty").write_text("base = 1\nfoo = bar\n", encoding="utf-8")
+    live.write_text("base = 1\nfoo = bar\n# live-only trailer\ncolor = red\n", encoding="utf-8")
+    write_declared_pairs(repo, [{"live": str(live), "repo": "infra/ghostty/mini.ghostty", "machines": ["mini"]}])
+    monkeypatch.setattr(prop, "machine_label", lambda *a, **k: "mini")
+    status, findings, ev = prop.probe_home_fork_scripts(repo, {"pairs": []}, 10)
+    assert status == prop.DIVERGED
+    assert findings == 1
+
+
+def test_live_extends_repo_verbatim_refuses_empty_repo(tmp_path: Path) -> None:
+    """An empty repo file prefix-matches ANY live content trivially — refuse to
+    trust that as evidence of a legitimate trailer rather than a real gap."""
+    live = tmp_path / "live.txt"
+    repo = tmp_path / "repo.txt"
+    live.write_text("anything at all\n", encoding="utf-8")
+    repo.write_text("", encoding="utf-8")
+    assert prop._live_extends_repo_verbatim(live, repo) is False
+
+
+def test_live_extends_repo_verbatim_false_when_identical(tmp_path: Path) -> None:
+    """Not a prefix-extension case at all when the two files are byte-identical
+    (the caller's live_sha == repo_sha branch already handles this — the
+    helper itself must not double-count it as "live extends repo")."""
+    live = tmp_path / "live.txt"
+    repo = tmp_path / "repo.txt"
+    live.write_text("same\n", encoding="utf-8")
+    repo.write_text("same\n", encoding="utf-8")
+    assert prop._live_extends_repo_verbatim(live, repo) is False
+
+
+def test_probe_live_may_extend_repo_guilt_two_separate_insertions_still_diverged(tmp_path: Path, monkeypatch) -> None:
+    """The invariant is ONE contiguous inserted span, not 'any extra bytes
+    anywhere'. Two separate insertions break both the single-prefix and
+    single-suffix accounting (repo's middle segment is not reproduced whole
+    at either edge) and must still report DIVERGED — proves the algorithm
+    isn't secretly "live is a superset of repo's characters"."""
+    repo = make_repo(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    live = home / "machine.ghostty"
+    (repo / "infra" / "ghostty").mkdir(parents=True)
+    (repo / "infra" / "ghostty" / "mini.ghostty").write_text(
+        "line-a = 1\nline-b = 2\nline-c = 3\n", encoding="utf-8"
+    )
+    live.write_text(
+        "line-a = 1\n# first local insertion\nline-b = 2\n# second local insertion\nline-c = 3\n",
+        encoding="utf-8",
+    )
+    write_declared_pairs(repo, [{
+        "live": str(live), "repo": "infra/ghostty/mini.ghostty", "machines": ["mini"],
+        "live_may_extend_repo": True,
+    }])
+    monkeypatch.setattr(prop, "machine_label", lambda *a, **k: "mini")
+    status, findings, ev = prop.probe_home_fork_scripts(repo, {"pairs": []}, 10)
+    assert status == prop.DIVERGED
+    assert findings == 1


### PR DESCRIPTION
## Summary
- The `home_fork_scripts` probe compared live-vs-repo bytes with no way to say "live legitimately carries a host-local addition on top of repo content" — real case on Mini 2026-08-28: a live-only Ghostty colour override (marked "live dotfile only" in the dotfile itself) was reported P1 DIVERGED with a fix_hint that would have silently deleted it.
- Fix is opt-in per declared pair (`live_may_extend_repo: true`, mini machine.ghostty entry only) and structural: verifies repo's bytes are covered by a common-prefix + common-suffix split of live's bytes (proves a single inserted span — covers the real shape found, a mid-file insertion, not just a trailing append). Genuine drift still reports DIVERGED.

## Test plan
- [x] 19/19 new + existing tests in `test_proprioception_home_fork_merge.py`
- [x] 159/160 wider `scripts/tests/` suite (1 pre-existing unrelated failure, confirmed by stashing this diff and re-running — identical failure with or without this change)
- [x] Red-before-fix: temporarily removed the exemption check, both new innocence tests failed as expected
- [x] Verified against real files on Mini: probe now reports 0 findings for the ghostty pair; the 4 hard-excluded hook pairs remain untouched and correctly still DIVERGED

🤖 Generated with [Claude Code](https://claude.com/claude-code)