### PR TITLE
fix(llm): pin claude -p children to a sterile config dir + no-session-persistence (W132)

### DIFF
--- a/apps/backend-rag/backend/llm/claude_oauth_client.py
+++ b/apps/backend-rag/backend/llm/claude_oauth_client.py
@@ -149,6 +149,30 @@ CLAUDE_CLI_CANDIDATES: Final[tuple[Path, ...]] = (
     Path.home() / ".npm-global/bin" / "claude",
     Path("/usr/local/bin/claude"),
 )
+# W132 (2026-08-28): pin every child CLI to a STERILE config dir. The default
+# (~/.claude) is the interactive control-plane: its Stop-hook mailbox receptor
+# (mailbox_inject.py) re-opens a "finished" -p session with cross-machine fleet
+# mail, the model answers the mail turn after turn, and `-p` prints the LAST
+# turn — so the caller receives fleet chatter instead of its answer (measured:
+# transcript c68e9228 2026-08-28 — the correct DeckPlan JSON sat at turn 1,
+# discarded; the WR2 draft-generator failed 3/3 on every draft for 8 days on
+# this). A bare config dir has no hooks BY CONSTRUCTION, so for THIS client's
+# consumers the class dies here rather than hook-by-hook (sibling `claude -p`
+# spawners — zantara-gateway, intel enricher — have their own config-dir
+# handling and are tracked separately). The CLI bootstraps a missing dir on its own
+# (verified live, nested paths included) and auth is unaffected for the env
+# seats — the token arrives via CLAUDE_CODE_OAUTH_TOKEN, never from the config
+# dir. DECLARED trade-off: the trailing ("", "keychain") sentinel seat DIES
+# under the sterile dir (keychain credential lookup is config-dir-scoped —
+# measured: "Not logged in"). Accepted: that seat ran in the poisoned default
+# dir too, so its "success" was the same corrupted last-turn output; now it
+# fails fast as `authentication` and cools instead of burning minutes.
+# Escape hatch: point HEADLESS_CONFIG_DIR_ENV at any hook-free profile dir to
+# restore profile-scoped keychain auth for the sentinel seat. Concurrent -p
+# children share the one sterile dir exactly as they shared ~/.claude before
+# (same .claude.json write races, smaller blast radius — the dir is disposable).
+HEADLESS_CONFIG_DIR_ENV: Final[str] = "CLAUDE_OAUTH_HEADLESS_CONFIG_DIR"
+DEFAULT_HEADLESS_CONFIG_DIR: Final[str] = "~/.claude-oauth-headless"
 # Model slug allowlist-by-shape: the value is forwarded to ``--model``, so
 # reject anything that isn't a plain ``claude-*`` slug (blocks argv/flag
 # smuggling via the model field). All current call-site slugs pass:
@@ -225,6 +249,12 @@ def _build_env(token: str) -> dict[str, str]:
     cannot silently escape the Max OAuth path through a direct API key,
     Bedrock, or Vertex. Numbered seat tokens are also removed; the child sees
     only the selected ``CLAUDE_CODE_OAUTH_TOKEN``.
+
+    Also pins ``CLAUDE_CONFIG_DIR`` to a sterile headless dir (W132): the
+    inherited/interactive config dirs carry the control-plane hooks whose
+    Stop-time mailbox delivery extends a one-shot ``-p`` session past its
+    answer. The override is unconditional — an inherited ``CLAUDE_CONFIG_DIR``
+    (e.g. an interactive session spawning this client) must never leak through.
     """
     env = {
         key: value
@@ -237,6 +267,8 @@ def _build_env(token: str) -> dict[str, str]:
         env["CLAUDE_CODE_OAUTH_TOKEN"] = token
     else:
         env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+    headless_dir = os.environ.get(HEADLESS_CONFIG_DIR_ENV, "").strip() or DEFAULT_HEADLESS_CONFIG_DIR
+    env["CLAUDE_CONFIG_DIR"] = os.path.expanduser(headless_dir)
     return env
 
 
@@ -687,6 +719,11 @@ async def complete_async(
         cmd: list[str] = [
             claude_cli,
             "-p",
+            # W132: a one-shot completion must not persist a session — the
+            # transcript trail is what a resumable session leaves behind, and
+            # it also stops unbounded projects/*.jsonl growth in the sterile
+            # config dir (same flag the zantara-gateway sibling already uses).
+            "--no-session-persistence",
             "--disallowedTools",
             *_DISALLOWED_TOOLS,
         ]

--- a/apps/backend-rag/backend/tests/unit/llm/test_claude_oauth_client.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_claude_oauth_client.py
@@ -170,6 +170,55 @@ async def test_build_env_strips_alternate_provider_credentials(
 
 
 @pytest.mark.asyncio
+async def test_build_env_pins_sterile_headless_config_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_oauth_env: None,
+) -> None:
+    """W132 guilt case: an inherited interactive CLAUDE_CONFIG_DIR must never
+    leak into the child. The interactive config dirs carry the control-plane
+    hooks (Stop-time cross-machine mailbox delivery) that extend a one-shot
+    ``-p`` past its answer — the CLI then prints the LAST turn, so the caller
+    receives fleet chatter instead of its completion."""
+    import os
+
+    from backend.llm import claude_oauth_client as mod
+
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/Users/someone/.claude-kaiser")
+    monkeypatch.delenv(mod.HEADLESS_CONFIG_DIR_ENV, raising=False)
+
+    env = mod._build_env("tok_xyz")
+
+    assert env["CLAUDE_CONFIG_DIR"] == os.path.expanduser(mod.DEFAULT_HEADLESS_CONFIG_DIR)
+    assert env["CLAUDE_CONFIG_DIR"] != "/Users/someone/.claude-kaiser"
+    # Innocence: the pin is present even with no inherited value at all.
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    env2 = mod._build_env("tok_xyz")
+    assert env2["CLAUDE_CONFIG_DIR"] == os.path.expanduser(mod.DEFAULT_HEADLESS_CONFIG_DIR)
+
+
+@pytest.mark.asyncio
+async def test_build_env_headless_config_dir_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_oauth_env: None,
+    tmp_path: Any,
+) -> None:
+    """The escape hatch (CLAUDE_OAUTH_HEADLESS_CONFIG_DIR) wins over the
+    default, and a blank value falls back instead of pinning an empty path."""
+    import os
+
+    from backend.llm import claude_oauth_client as mod
+
+    custom = str(tmp_path / "headless-cfg")
+    monkeypatch.setenv(mod.HEADLESS_CONFIG_DIR_ENV, custom)
+    env = mod._build_env("tok_xyz")
+    assert env["CLAUDE_CONFIG_DIR"] == custom
+
+    monkeypatch.setenv(mod.HEADLESS_CONFIG_DIR_ENV, "   ")
+    env2 = mod._build_env("tok_xyz")
+    assert env2["CLAUDE_CONFIG_DIR"] == os.path.expanduser(mod.DEFAULT_HEADLESS_CONFIG_DIR)
+
+
+@pytest.mark.asyncio
 async def test_complete_async_happy_path(
     monkeypatch: pytest.MonkeyPatch,
     clear_oauth_env: None,
@@ -182,7 +231,8 @@ async def test_complete_async_happy_path(
 
     async def fake_create(*args: Any, **kwargs: Any) -> Any:
         calls.append(
-            {"args": args, "env_has_api_key": "ANTHROPIC_API_KEY" in kwargs.get("env", {})}
+            {"args": args, "env_has_api_key": "ANTHROPIC_API_KEY" in kwargs.get("env", {}),
+             "env_config_dir": kwargs.get("env", {}).get("CLAUDE_CONFIG_DIR")}
         )
         return _fake_proc(stdout=b"hello world", returncode=0)
 
@@ -195,6 +245,13 @@ async def test_complete_async_happy_path(
     assert resp.attempts == 1
     assert len(calls) == 1
     assert calls[0]["env_has_api_key"] is False
+    # W132 wiring: the sterile config-dir pin must reach the actual subprocess,
+    # and the one-shot must not persist a session (the transcript-tail is what
+    # let fleet mail extend the session past its answer).
+    import os as _os
+
+    assert calls[0]["env_config_dir"] == _os.path.expanduser(mod.DEFAULT_HEADLESS_CONFIG_DIR)
+    assert "--no-session-persistence" in calls[0]["args"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Every `claude -p` child spawned by `backend/llm/claude_oauth_client.py` inherited the **interactive** `CLAUDE_CONFIG_DIR` (default `~/.claude`). Its Stop-hook mailbox receptor (`mailbox_inject.py`) re-opens a "finished" one-shot session with cross-machine fleet mail; the model answers the mail turn after turn, and `-p` prints the **last** turn — so callers received fleet chatter instead of their completion.

**Measured, not deduced** (transcript `~/.claude/projects/-Users-nuzantara-nuzantara-deploy/c68e9228*.jsonl`): the correct WR2 DeckPlan JSON was emitted at turn 1, then 8 waves of `<cross-machine-message from="mini-pro2:fleet-watch">` extended the session; stdout = «Altri 3 fleet-watch… task DeckPlan chiuso». The WR2 draft generator failed 3/3 on **every draft since 2026-08-20** (12 good topics burned to `rejected`, ~3 multi-minute opus calls wasted per draft per hour).

## Cure

- `_build_env` pins `env["CLAUDE_CONFIG_DIR"]` **unconditionally** to a sterile dir (`~/.claude-oauth-headless`, override `CLAUDE_OAUTH_HEADLESS_CONFIG_DIR`). A bare config dir has no hooks by construction — the class dies for all this client's consumers (WR2 planner/fact lanes, article composer, coreference, surface router), not hook-by-hook.
- `--no-session-persistence` added to argv (the zantara-gateway sibling already uses it): a one-shot must not persist a resumable session; also kills unbounded `projects/*.jsonl` growth + prompt persistence. Probed live: RC=0, clean output, zero new transcripts.

## Declared trade-offs (measured)

- The `("", "keychain")` sentinel seat **dies** under the sterile dir (keychain lookup is config-dir-scoped — probed: `Not logged in`). Accepted: that seat ran in the poisoned dir too, so its "success" was the same corrupted last-turn; now it fails fast as `authentication` and cools.
- Concurrent children share one sterile dir exactly as they shared `~/.claude` before (same `.claude.json` races, smaller blast radius — disposable dir).
- Sibling `claude -p` spawners (zantara-gateway stream-json client, bali-intel enricher) are **not** covered here — one PR one concern; tracked in PENDING-ARMS for a class audit (W107).

## Verification

- 50 tests green in `test_claude_oauth_client.py` (+ langchain wrapper suite), incl. new guilt case (inherited kaiser-style `CLAUDE_CONFIG_DIR` must NOT leak), override + blank-fallback, and a subprocess **wiring** assertion (pin + flag reach the real argv/env).
- Mutation-verified with `PYTHONDONTWRITEBYTECODE=1` (W121): pin disabled → RC=1, restored → RC=0.
- Empirical probes on Pro: sterile-dir `claude -p` returns exact JSON via token_2; CLI bootstraps missing nested dirs; `--no-session-persistence` writes no transcript.
- Cross-family adversarial review: Kimi K3 (findings adopted: the flag, the wiring assert, the scoped class-claim; keychain/concurrency accepted+declared).

Prove-live plan (post-merge): pull Pro dual checkout → `--rebrief` one of today's rejected drafts → kickstart draft-generator → DeckPlan parses, draft advances to `drafts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)