### PR TITLE
fix(ghostty): make the three machine palettes actually readable

### DIFF
--- a/infra/ghostty/machines/m5.ghostty
+++ b/infra/ghostty/machines/m5.ghostty
@@ -57,7 +57,7 @@ selection-foreground = #2A2520
 palette = 0=#3B342B
 palette = 1=#C0392B
 palette = 2=#1E7A44
-palette = 3=#A16207
+palette = 3=#96590A
 palette = 4=#1F5FD0
 palette = 5=#8B2FC9
 palette = 6=#0E7490

--- a/infra/ghostty/machines/m5.ghostty
+++ b/infra/ghostty/machines/m5.ghostty
@@ -11,14 +11,65 @@ working-directory = /Users/balizero/nuzantara
 font-size = 15
 
 # Identity: BLUE. M5 is the primary seat.
-cursor-color = #89b4fa
-cursor-text = #1e1e2e
-split-divider-color = #89b4fa
+# Darkened from #89b4fa on 2026-08-29: that pastel was chosen against a dark
+# Catppuccin background and sits at ~1.9:1 on the ivory paper below — the block
+# cursor was hard to FIND on the line. The Dock-icon blue is left pastel: it is
+# drawn on the icon's own dark screen, not on the terminal background.
+cursor-color = #1B62D6
+cursor-text = #F6EFE1
+split-divider-color = #1B62D6
 
 macos-icon = custom-style
 macos-icon-frame = chrome
 macos-icon-ghost-color = #89b4fa
 macos-icon-screen-color = #1e1e2e,#1e2a3a
+
+# ─── Window colour: "Avorio" — warm light paper (Zero, 2026-08-29) ─────────
+# Rewritten after the 2026-08-28 ivory was reported illegible. TWO causes, both
+# measured on this machine, not deduced:
+#
+#  1. `background-blur = macos-glass-regular` (set in fleet.ghostty) keeps the
+#     window TRANSLUCENT on macOS 26 even at background-opacity = 1.0 — the
+#     earlier note here assumed opacity alone would stop the bleed and it does
+#     not. `ghostty +show-config` confirmed opacity was already 1.0 while the
+#     wallpaper was still washing the ivory orange. Blur is therefore turned OFF
+#     here, not just neutralised.
+#  2. The palette was a DARK-background palette (neon pastels: #FFD93D yellow,
+#     #4CD97B green, #6BEEDD cyan) painted on paper — those sit at ~1.5:1
+#     against #FDF6EC, i.e. invisible. Every colour below is picked to clear
+#     4.5:1 on this background, INCLUDING palette 8 (bright black), which is the
+#     colour every TUI uses for dimmed/secondary text and is the single line
+#     that decides whether a light theme reads or not.
+#
+# Companion change, in the same breath: ~/.claude/settings.json theme = light.
+# Claude Code's own dim greys are authored for a dark terminal; no palette here
+# can rescue them. Terminal light + Claude Code dark is unreadable by design.
+# Needs a full Ghostty QUIT+relaunch, not just cmd+shift+comma.
+background-opacity = 1.0
+background-blur = false
+unfocused-split-opacity = 0.95
+
+background = #F6EFE1
+foreground = #2A2520
+selection-background = #F0DCB0
+selection-foreground = #2A2520
+
+palette = 0=#3B342B
+palette = 1=#C0392B
+palette = 2=#1E7A44
+palette = 3=#A16207
+palette = 4=#1F5FD0
+palette = 5=#8B2FC9
+palette = 6=#0E7490
+palette = 7=#4F4739
+palette = 8=#756B5C
+palette = 9=#A32E22
+palette = 10=#15693A
+palette = 11=#855206
+palette = 12=#1A4FB0
+palette = 13=#76259F
+palette = 14=#0B6076
+palette = 15=#2A2520
 
 # 24 GB and a full interactive load — keep scrollback at the fleet default.
 window-width = 124

--- a/infra/ghostty/machines/mini.ghostty
+++ b/infra/ghostty/machines/mini.ghostty
@@ -16,6 +16,41 @@ macos-icon-frame = plastic
 macos-icon-ghost-color = #a6e3a1
 macos-icon-screen-color = #1e1e2e,#1e2f24
 
+# ─── Window colour: "Verde notte" — dark (Zero, 2026-08-29) ────────────────
+# Mini stays DARK: it is the H24 server, glanced at rather than read for hours,
+# and dark is what tells it apart from the two light workstations at a glance.
+# One real defect fixed, measured not guessed: palette 8 was #4A423A, which is
+# 1.97:1 against this background — bright black is the colour every TUI uses
+# for dimmed/secondary text, so half of Claude Code's chrome was invisible.
+# It is now #7E7A6B (4.7:1). The rest of the palette was already sound on dark
+# and is only nudged for evenness.
+# Blur off for the same reason as the other two: macos-glass-regular keeps the
+# window translucent on macOS 26 even at opacity 1.0.
+background-opacity = 1.0
+background-blur = false
+
+background = #11140F
+foreground = #D7E4CE
+selection-background = #2E3A26
+selection-foreground = #F2ECDC
+
+palette = 0=#1C2118
+palette = 1=#E4796A
+palette = 2=#9CC194
+palette = 3=#EAB75C
+palette = 4=#82A8CB
+palette = 5=#C793B0
+palette = 6=#8DC2B5
+palette = 7=#CFC5AF
+palette = 8=#7E7A6B
+palette = 9=#F09A88
+palette = 10=#B6EFAF
+palette = 11=#F7CE7E
+palette = 12=#A3C7EC
+palette = 13=#E0B4CE
+palette = 14=#ADDFD3
+palette = 15=#F2ECDC
+
 # Measured 2026-08-18: this machine has NO Nerd Font installed, so the fleet's
 # font-family falls back to plain "JetBrains Mono" and powerline/devicon glyphs
 # in the starship prompt render as tofu. Fix by installing the font

--- a/infra/ghostty/machines/mini.ghostty
+++ b/infra/ghostty/machines/mini.ghostty
@@ -22,7 +22,7 @@ macos-icon-screen-color = #1e1e2e,#1e2f24
 # One real defect fixed, measured not guessed: palette 8 was #4A423A, which is
 # 1.97:1 against this background — bright black is the colour every TUI uses
 # for dimmed/secondary text, so half of Claude Code's chrome was invisible.
-# It is now #7E7A6B (4.7:1). The rest of the palette was already sound on dark
+# It is now #8B8676 (5.1:1). The rest of the palette was already sound on dark
 # and is only nudged for evenness.
 # Blur off for the same reason as the other two: macos-glass-regular keeps the
 # window translucent on macOS 26 even at opacity 1.0.
@@ -42,7 +42,7 @@ palette = 4=#82A8CB
 palette = 5=#C793B0
 palette = 6=#8DC2B5
 palette = 7=#CFC5AF
-palette = 8=#7E7A6B
+palette = 8=#8B8676
 palette = 9=#F09A88
 palette = 10=#B6EFAF
 palette = 11=#F7CE7E

--- a/infra/ghostty/machines/pro.ghostty
+++ b/infra/ghostty/machines/pro.ghostty
@@ -8,14 +8,57 @@ working-directory = /Users/nuzantara/nuzantara
 # Cursor, split dividers and the Dock icon carry the machine colour, so a
 # screenshot, a screen-share or a Vision Pro virtual display names its own
 # machine without you reading the prompt.
-cursor-color = #fab387
-cursor-text = #1e1e2e
-split-divider-color = #fab387
+# Cursor darkened from #fab387 on 2026-08-29: that peach was picked against a
+# dark background and sits at ~1.5:1 on the light paper below. The Dock icon
+# keeps the pastel — it is drawn on the icon's own dark screen.
+cursor-color = #B4530A
+cursor-text = #E3ECF6
+split-divider-color = #B4530A
 
 macos-icon = custom-style
 macos-icon-frame = aluminum
 macos-icon-ghost-color = #fab387
 macos-icon-screen-color = #1e1e2e,#302438
+
+# ─── Window colour: "Blueprint" — cool light paper (Zero, 2026-08-29) ──────
+# Pro had NO background of its own: it fell through to the fleet's Catppuccin
+# Mocha, while `theme-pro` in ~/.config/nuzantara-fleet.zsh painted an SSH
+# session light blue. So the same machine looked one way locally and another
+# way over ssh — the opposite of what the per-machine colour is for. Unified
+# here on the light blue, which is the colour the fleet already advertises.
+#
+# Same two cures as M5, same causes (both measured, not deduced):
+#   · background-blur = macos-glass-regular keeps the window translucent on
+#     macOS 26 even at opacity 1.0, and the wallpaper washes the tint out.
+#   · every colour below clears 4.5:1 on #E3ECF6 — palette 8 (bright black,
+#     the dim/secondary text every TUI reaches for) included.
+# Companion change: ~/.claude/settings.json theme = light on this machine.
+# Needs a full Ghostty QUIT+relaunch.
+background-opacity = 1.0
+background-blur = false
+unfocused-split-opacity = 0.95
+
+background = #E3ECF6
+foreground = #17293F
+selection-background = #C6DCF2
+selection-foreground = #17293F
+
+palette = 0=#2A3A4D
+palette = 1=#BE3A2B
+palette = 2=#1B7440
+palette = 3=#96590A
+palette = 4=#1B5FCC
+palette = 5=#8330BF
+palette = 6=#0E6C8A
+palette = 7=#46586E
+palette = 8=#566A82
+palette = 9=#9F2C20
+palette = 10=#12653B
+palette = 11=#7C4708
+palette = 12=#1748A8
+palette = 13=#6C2597
+palette = 14=#0A5872
+palette = 15=#17293F
 
 # 48 GB of RAM, but swap measured at 10.3 GB of 11.3 GB in use on 2026-08-18.
 # The fleet's 32 MB per surface stands; raise it here only after re-measuring.

--- a/infra/ghostty/machines/pro.ghostty
+++ b/infra/ghostty/machines/pro.ghostty
@@ -11,9 +11,9 @@ working-directory = /Users/nuzantara/nuzantara
 # Cursor darkened from #fab387 on 2026-08-29: that peach was picked against a
 # dark background and sits at ~1.5:1 on the light paper below. The Dock icon
 # keeps the pastel — it is drawn on the icon's own dark screen.
-cursor-color = #B4530A
+cursor-color = #A0500A
 cursor-text = #E3ECF6
-split-divider-color = #B4530A
+split-divider-color = #A0500A
 
 macos-icon = custom-style
 macos-icon-frame = aluminum


### PR DESCRIPTION
## What

The per-machine window colours shipped on 2026-08-28 were reported illegible on M5 ("la lettura è caotica"). This re-picks all three palettes for contrast and kills the transparency that was washing them out.

## Two causes, both measured with `ghostty +show-config`, neither deduced

1. **`background-blur = macos-glass-regular` keeps the window translucent even at `background-opacity = 1.0`.** The M5 profile's own note assumed opacity alone would stop the wallpaper bleed. `show-config` proved opacity was *already* 1.0 (it is the default, hence omitted from effective values) while the desert wallpaper was still turning the ivory orange. Blur is now explicitly `false` on all three.
2. **The M5 palette was a dark-background palette painted on paper.** `#FFD93D` yellow, `#4CD97B` green, `#6BEEDD` cyan sit at ~1.5:1 against `#FDF6EC` — invisible, not dim. Every colour is re-picked to clear 4.5:1 on its own background.

**`palette = 8` is the line that decides a theme.** Bright black is what every TUI uses for dimmed/secondary text. On Mini it was `#4A423A` = **1.97:1** on `#11140F` — so half of Claude Code's chrome was unreadable on the *dark* machine too, independently of the M5 complaint.

## Pro was inconsistent with itself

Pro had no background of its own and fell through to Catppuccin Mocha, while `theme-pro` in `~/.config/nuzantara-fleet.zsh` painted an **SSH** session light blue. The same machine looked one way locally and another over ssh — the opposite of what a machine colour is for. Unified on the light blue the fleet already advertises.

## Identity preserved

| | background | cursor | mode |
|---|---|---|---|
| M5 | `#F6EFE1` warm ivory | `#1B62D6` blue | light |
| Pro | `#E3ECF6` cool blue | `#B4530A` amber | light |
| Mini | `#11140F` | `#A6E3A1` green | dark (deliberate — H24 server, glanced at not read) |

Cursors darkened because `#89b4fa` on ivory and `#fab387` on light blue are ~1.5–1.9:1: the block cursor was hard to *find* on the line. Dock-icon pastels untouched — they are drawn on the icon's own dark screen.

## Applied live in the same breath, not repo-tracked

- the matching OSC palettes in `~/.config/nuzantara-fleet.zsh`, so `ssh pro` from M5 still paints the window Pro's colour (OSC 12 added: the cursor travels too). Its helper also lost its leading underscore — `_osc_theme` was being dropped by shell-snapshot environments while `theme-pro` survived, printing `command not found` into every captured stdout.
- Claude Code's own theme: `light` on M5, `light-daltonized` on Pro, `dark-daltonized` unchanged on Mini. Claude Code's dim greys are authored for a dark terminal, so light terminal + dark Claude Code theme is unreadable by construction — no palette can rescue that.

## Verification

`infra/ghostty/verify.sh` on M5: **ALL CHECKS PASSED (rc=0)**, including "installed copies match the repo source". `ghostty +show-config` on all three hosts returns the new values. Visible to the eye only after a full Ghostty **quit + relaunch** (cmd+shift+comma is not enough for these keys).