### PR TITLE
fix(ops): add 7 TP1 seats to organism_digest._SEAT_PROVIDER (roster-drift)

### DIFF
--- a/scripts/organism_digest.py
+++ b/scripts/organism_digest.py
@@ -179,9 +179,26 @@ _SEAT_PROVIDER = {
     "nlm": "Google",
     "qwen-cloud-code": "Alibaba Token Plan (TP1)",
     "jules": "Google",
+    # 7 TP1 seats added 2026-08-29 (W-class: _SEAT_PROVIDER drifted behind
+    # arsenal_probe.py's ALL_SEATS — roster-drift selftest was RED, 27/28,
+    # before this fix). All seven share the SAME MODEL_ROSTER.md provider
+    # section as qwen-cloud-code: "## Alibaba Token Plan (TP1)" documents
+    # deepseek-v4-pro, deepseek-v4-flash-0731, glm-5.2, qwen3.8-max,
+    # qwen3.7-max, qwen3.7-plus and qwen3.6-flash side by side with
+    # qwen-cloud-code's own row (verified 2026-08-29 against the live file).
+    "tp1-deepseek-v4-pro": "Alibaba Token Plan (TP1)",
+    "tp1-deepseek-v4-flash-0731": "Alibaba Token Plan (TP1)",
+    "tp1-glm-5.2": "Alibaba Token Plan (TP1)",
+    "tp1-qwen3.8-max": "Alibaba Token Plan (TP1)",
+    "tp1-qwen3.7-max": "Alibaba Token Plan (TP1)",
+    "tp1-qwen3.7-plus": "Alibaba Token Plan (TP1)",
+    "tp1-qwen3.6-flash": "Alibaba Token Plan (TP1)",
 }
 _FALLBACK_ALL_SEATS = ["claude", "kimi", "agy", "codex", "codex-spark",
-                        "ollama", "nlm", "qwen-cloud-code", "jules"]
+                        "ollama", "nlm", "qwen-cloud-code", "jules",
+                        "tp1-deepseek-v4-pro", "tp1-deepseek-v4-flash-0731",
+                        "tp1-glm-5.2", "tp1-qwen3.8-max", "tp1-qwen3.7-max",
+                        "tp1-qwen3.7-plus", "tp1-qwen3.6-flash"]
 
 
 def _known_seats() -> list[str]:


### PR DESCRIPTION
## Summary
- `arsenal_probe.py`'s `ALL_SEATS` gained 7 TP1 seats (`tp1-deepseek-v4-pro`, `tp1-deepseek-v4-flash-0731`, `tp1-glm-5.2`, `tp1-qwen3.8-max`, `tp1-qwen3.7-max`, `tp1-qwen3.7-plus`, `tp1-qwen3.6-flash`) that `organism_digest.py`'s `_SEAT_PROVIDER` map never learned about, so the boot card rendered `no door: line in roster` for each — verified live in this very session's own injected digest context.
- All seven map to `"Alibaba Token Plan (TP1)"`, the same provider `qwen-cloud-code` already uses — verified against `MODEL_ROSTER.md`'s `## Alibaba Token Plan (TP1)` section, which documents all seven side by side with `qwen-cloud-code`'s own row.
- Also extends `_FALLBACK_ALL_SEATS` to mirror `arsenal_probe.ALL_SEATS` per the existing comment's stated intent.

## Verification
- Rosso-prima: `python3 scripts/organism_digest.py --selftest` was **27/28** on the `roster-drift: _SEAT_PROVIDER covers every known arsenal_probe.py seat` check, confirmed live before the fix.
- Post-fix: **28/28**, re-confirmed under both system python and `python3.11` (pytest venv).
- `scripts/tests/test_organism_digest_pending_arms.py`: 8/8 passed (unrelated suite in the same file, unaffected).
- Live-rendered `arsenal_card()` output confirms the TP1 seats now show `doors: ...=DashScope` instead of `no door: line in roster`.

## Test plan
- [x] `--selftest` 28/28
- [x] `test_organism_digest_pending_arms.py` 8/8
- [x] Live `arsenal_card()` render shows real door for all 7 seats

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>