### PR TITLE
fix(bot): stop a follow-up message from silently killing the answer to the previous one

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
@@ -576,7 +576,7 @@ async def _apply_pending_status(conn: asyncpg.Connection, wamid: str) -> None:
 async def _coalesce_thread_bursts(
     conn: asyncpg.Connection, thread_id: int, outbox_id: int
 ) -> int:
-    """Supersede other pending bot-reply rows of the same thread (P2).
+    """Supersede other NOT-YET-STARTED pending bot-reply rows of the same thread (P2).
 
     The generator always answers the *latest* thread message (see
     ``wa_inbox_bot._load_thread_context``), so whichever row of a same-thread
@@ -584,6 +584,25 @@ async def _coalesce_thread_bursts(
     burst — the other pending bot-reply rows would just be redundant sends.
     Only ``needs_generation`` rows are touched: a pending HUMAN send must
     never be silently dropped.
+
+    ``attempts = 0`` is what makes "redundant" TRUE, and it is not decorative
+    (2026-08-28, measured in production, thread 394 / row 363). Without it
+    this sweep also killed rows that had already generated real text. That
+    row's answer was produced by ChatGPT three times — every broker job
+    ``consumed_ok``, 9711/10137/8521 ms — and rejected three times by the
+    finalize safety pipeline; it sat at attempts 3 of MAX_ATTEMPTS waiting
+    for its 4th try when a follow-up message arrived 3m27s later and this
+    UPDATE marked it ``failed``. Silently: the sweep writes only ``status``,
+    never a fall-off reason, and never reaches ``_maybe_send_apology`` (which
+    is called ONLY from the two ladder-exhaustion branches). The client got
+    no answer and no apology, and nothing alerted.
+
+    A row with ``attempts > 0`` is not a burst duplicate — it is a question
+    somebody is still owed an answer to. Left alone, its ladder ends one of
+    only two ways: the answer is delivered, or the apology is sent. Never
+    silence. It may then reply after the newer row does; a second, later
+    message is a far smaller harm than a question answered by nothing, and
+    its own context load already includes the follow-up.
     """
     async with conn.transaction():
         superseded = await conn.fetch(
@@ -593,6 +612,7 @@ async def _coalesce_thread_bursts(
             WHERE thread_id = $1
               AND status = 'pending'
               AND needs_generation = true
+              AND attempts = 0
               AND id <> $2
             RETURNING id, message_id
             """,

--- a/apps/backend-rag/backend/tests/db/test_wa_outbox_coalescing_spares_started_rows.py
+++ b/apps/backend-rag/backend/tests/db/test_wa_outbox_coalescing_spares_started_rows.py
@@ -1,0 +1,116 @@
+"""Coalescing must not silently kill a row that already generated an answer.
+
+Measured in production 2026-08-28 (thread 394, `wa_outbox` row 363): ChatGPT
+produced an answer THREE times — every broker job `consumed_ok`, 9711/10137/
+8521 ms — the finalize pipeline rejected all three, and the row sat at
+attempts 3 of MAX_ATTEMPTS waiting for its 4th try. A follow-up message
+arrived 3m27s later and `_coalesce_thread_bursts` marked the row `failed`.
+No answer, no apology (that sweep never reaches `_maybe_send_apology`), no
+alert.
+
+This runs the REAL sweep against a REAL Postgres rather than asserting on SQL
+text: a predicate is only worth what the database does with it, and a text
+assertion would keep passing if someone rewrote the query.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from backend.services.integrations.wa_outbox_worker import _coalesce_thread_bursts
+
+
+async def _seed(db_tx: asyncpg.Connection) -> tuple[int, dict[str, int]]:
+    """A thread with three pending bot-reply rows, one per shape under test."""
+    thread_id = await db_tx.fetchval(
+        "INSERT INTO meta_inbox_threads (counterpart_phone) VALUES ($1) "
+        "RETURNING thread_id",
+        "+000000000000",  # synthetic, never a real number
+    )
+    ids: dict[str, int] = {}
+    for label, attempts, needs_generation in (
+        ("winner", 0, True),
+        ("fresh_burst", 0, True),
+        ("already_generated", 3, True),
+        ("human_send", 0, False),
+    ):
+        message_id = await db_tx.fetchval(
+            "INSERT INTO meta_inbox_messages (thread_id, direction, sender_role) "
+            "VALUES ($1, 'inbound', 'customer') RETURNING id",
+            thread_id,
+        )
+        ids[label] = await db_tx.fetchval(
+            "INSERT INTO wa_outbox (thread_id, message_id, needs_generation, "
+            "status, attempts) VALUES ($1, $2, $3, 'pending', $4) RETURNING id",
+            thread_id,
+            message_id,
+            needs_generation,
+            attempts,
+        )
+    return thread_id, ids
+
+
+@pytest.mark.asyncio
+async def test_coalescing_spares_a_row_that_already_generated(
+    db_tx: asyncpg.Connection,
+) -> None:
+    thread_id, ids = await _seed(db_tx)
+
+    superseded = await _coalesce_thread_bursts(db_tx, thread_id, ids["winner"])
+
+    status = {
+        label: await db_tx.fetchval(
+            "SELECT status FROM wa_outbox WHERE id = $1", outbox_id
+        )
+        for label, outbox_id in ids.items()
+    }
+
+    # The one this test exists for: attempts > 0 means real work already
+    # happened, so the row keeps its ladder and will end in an answer or an
+    # apology — never in silence.
+    assert status["already_generated"] == "pending"
+
+    # Unchanged behaviour, asserted so this guard cannot be "satisfied" by
+    # disabling coalescing altogether.
+    assert status["fresh_burst"] == "failed"
+    assert status["winner"] == "pending"
+    assert status["human_send"] == "pending"
+    assert superseded == 1
+
+
+@pytest.mark.asyncio
+async def test_coalescing_still_supersedes_a_true_burst(
+    db_tx: asyncpg.Connection,
+) -> None:
+    """Innocence: the normal case — several messages seconds apart, none of
+    them started — must still collapse to a single reply."""
+    thread_id = await db_tx.fetchval(
+        "INSERT INTO meta_inbox_threads (counterpart_phone) VALUES ($1) "
+        "RETURNING thread_id",
+        "+000000000001",
+    )
+    outbox_ids: list[int] = []
+    for _ in range(3):
+        message_id = await db_tx.fetchval(
+            "INSERT INTO meta_inbox_messages (thread_id, direction, sender_role) "
+            "VALUES ($1, 'inbound', 'customer') RETURNING id",
+            thread_id,
+        )
+        outbox_ids.append(
+            await db_tx.fetchval(
+                "INSERT INTO wa_outbox (thread_id, message_id, needs_generation, "
+                "status, attempts) VALUES ($1, $2, true, 'pending', 0) RETURNING id",
+                thread_id,
+                message_id,
+            )
+        )
+
+    superseded = await _coalesce_thread_bursts(db_tx, thread_id, outbox_ids[0])
+
+    assert superseded == 2
+    remaining = await db_tx.fetchval(
+        "SELECT count(*) FROM wa_outbox WHERE thread_id = $1 AND status = 'pending'",
+        thread_id,
+    )
+    assert remaining == 1


### PR DESCRIPTION
## The defect, measured live

Thread 394 / `wa_outbox` row **363**, 2026-08-28.

A client asked a question. ChatGPT generated the answer **three times** — every `broker_jobs` row `outcome = consumed_ok`, null `error_class`, 9711 / 10137 / 8521 ms of real execution — and the finalize safety pipeline rejected all three. The row sat at **attempts 3 of MAX_ATTEMPTS(5)**, waiting for its 4th try. 3m27s later the client, having received nothing, sent a short follow-up. Claiming that new row runs `_coalesce_thread_bursts` as its **first** action, and the sweep marked row 363 `failed`.

Silently, in the strict sense: the sweep writes only `status` — never a fall-off reason, which is why the row still carries the **stale** `finalize_defect` of its 3rd attempt — and never reaches `_maybe_send_apology`, which is called ONLY from the two ladder-exhaustion branches. **The client got no answer and no apology, and nothing alerted.**

Row 363's own evidence names the mechanism, and is the sonda for next time: `attempts = 3 < MAX_ATTEMPTS` **and** `apology_sent_at IS NULL`. Exhaustion always attempts an apology; suppression never does.

## The premise was in the docstring

> "the other pending bot-reply rows would just be **redundant** sends"

True when the superseded row has produced nothing. **False** when three real generations are already behind it.

## The cure

The predicate that makes that premise true: `AND attempts = 0`.

A row that has started is not a burst duplicate — it is a question somebody is still owed an answer to, and its ladder ends one of only two ways: the answer is delivered, or the apology is sent. Never silence.

Accepted trade-off, stated rather than hidden: the spared row may reply **after** the newer one does. A second, later message is a far smaller harm than a question answered by nothing, and the spared row's own context load already includes the follow-up.

## Proof

Against a **real Postgres**, not against SQL text — a predicate is worth only what the database does with it, and a text assertion keeps passing when someone rewrites the query.

- a pending row with `attempts = 3` **survives** the sweep — this is the cure;
- a pending row with `attempts = 0` is **still superseded**, and a pending **human** send is still untouched — so the guard cannot be "satisfied" by disabling coalescing altogether;
- a true burst (three not-yet-started rows) still collapses to exactly one reply.

**Guilt verified**: removing the predicate with the tests in place fails the first assertion, `assert 'failed' == 'pending'`.

**56 passed** — the new db test plus both `wa_outbox_worker` unit suites.

## Companion

PR #5187 cures the diagnostic half of the same incident: `finalize_defect` was a single bucket for eleven distinct rejection branches, so *why* three good answers were discarded is still unknown. This PR makes sure that, whatever the reason, the client is never left with nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhakhSmQUDzdUUFJHn3gyo