### PR TITLE
fix(broker): scope union-merge reap check to the branch's own added lines

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -1167,19 +1167,56 @@ def _is_union_merge_path(path: str, *, cwd: Path) -> bool:
     return proc.stdout.strip().endswith(": merge: union")
 
 
-def _content_subset_ok(head_ref: str, main_ref: str, path: str, *, cwd: Path) -> bool:
-    """For a declared merge=union path: True iff every non-blank line HEAD
-    authored is present in origin/main's current copy of the same path —
-    the append-only-superset half of W88's "diff VUOTO o pura-cancellazione
-    (subset)" rule, since exact blob equality can never hold again once any
-    other lane appends a line after this branch merges."""
-    branch_proc = _run_git(["show", f"{head_ref}:{path}"], cwd=cwd, check=False)
-    main_proc = _run_git(["show", f"{main_ref}:{path}"], cwd=cwd, check=False)
-    if branch_proc.returncode != 0 or main_proc.returncode != 0:
+def _content_subset_ok(
+    base_ref: str, head_ref: str, main_ref: str, path: str, *, cwd: Path
+) -> bool:
+    """For a declared merge=union path: True iff every non-blank line the
+    branch itself ADDED since its own merge-base is present in origin/main's
+    current copy of the same path.
+
+    Deliberately scoped to the branch's OWN added lines (`git diff
+    base_ref..head_ref`), not — as an earlier version of this function did —
+    every line present in HEAD's full snapshot. An append-only ledger is not
+    append-ONLY in practice: a healer tick routinely edits an EXISTING row
+    (correcting it, appending "NEW EVIDENCE", closing it) rather than only
+    adding new ones. Once any such edit lands on origin/main to a row that
+    predates this branch's merge-base, HEAD's frozen copy of that row no
+    longer byte-matches main's copy, and a full-snapshot subset check reads
+    the branch as unmerged even though the branch never touched that row and
+    its own contribution is fully present. Measured live 2026-08-29: a
+    merged, content-on-main ledger-append branch was refused reap for
+    exactly this reason — one line it never wrote (a Sentry-lane row a later
+    lane had edited) no longer matched, and that was read as the branch
+    being unmerged. Scoping to the branch's own additions answers "is what I
+    added still there", never "is the file exactly as I last saw it" — the
+    append-only-superset half of W88's "diff VUOTO o pura-cancellazione
+    (subset)" rule, applied to what the branch actually authored."""
+    diff_proc = _run_git(
+        ["diff", "--unified=0", "--no-color", base_ref, head_ref, "--", path],
+        cwd=cwd,
+        check=False,
+    )
+    if diff_proc.returncode != 0:
         return False
-    branch_lines = {ln for ln in branch_proc.stdout.splitlines() if ln.strip()}
+    added_lines = {
+        ln[1:]
+        for ln in diff_proc.stdout.splitlines()
+        if ln.startswith("+") and not ln.startswith("+++") and ln[1:].strip()
+    }
+    if not added_lines:
+        # The branch touched this union path but added no lines of its own —
+        # a pure deletion/rotation. Fail-safe to False (protect, do not
+        # reap): there is nothing here to verify a subset OF, and a branch
+        # whose only contribution to an append-only ledger is a removal is
+        # consequential enough (something someone else still wants could be
+        # what was removed) to deserve a human/PR path rather than an
+        # automatic pass.
+        return False
+    main_proc = _run_git(["show", f"{main_ref}:{path}"], cwd=cwd, check=False)
+    if main_proc.returncode != 0:
+        return False
     main_lines = {ln for ln in main_proc.stdout.splitlines() if ln.strip()}
-    return branch_lines.issubset(main_lines)
+    return added_lines.issubset(main_lines)
 
 
 def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) -> bool:
@@ -1309,7 +1346,7 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
                 continue
 
             if _is_union_merge_path(f, cwd=worktree):
-                if not _content_subset_ok("HEAD", "origin/main", f, cwd=worktree):
+                if not _content_subset_ok(mb, "HEAD", "origin/main", f, cwd=worktree):
                     return False
                 continue
 

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -1274,6 +1274,71 @@ def test_branch_in_origin_main_union_path_missing_line_refuses_reap(fake_repo):
     assert mod._branch_in_origin_main(wt) is False
 
 
+def test_branch_in_origin_main_union_path_stale_preexisting_row_is_reapable(fake_repo):
+    """Live bug, 2026-08-29: a merged, content-on-main ledger-append branch
+    was refused reap because a DIFFERENT, pre-existing row — one this branch
+    never touched — was edited by a later lane on main. The old subset check
+    compared the branch's FULL frozen snapshot against main, so any edit to
+    a row that predates the branch's merge-base (append-only-in-name only:
+    real healer ticks correct/close existing rows constantly) reads as the
+    branch's own line missing. The fix scopes the subset check to the lines
+    the branch itself ADDED since its own merge-base — that line survives
+    the base-row edit untouched and must still pass."""
+    mod, repo = fake_repo
+    _declare_union_ledger(repo)
+    wt = mod.cmd_create("wr2", "unionstalerow", ttl_minutes=5)
+
+    with (wt / "LEDGER.md").open("a") as f:
+        f.write("- branch's own new row\n")
+    _commit_in_worktree(wt, mod, "LEDGER.md", "append branch's own row")
+
+    # A later lane, on main, EDITS the pre-existing "base line" row (not an
+    # append — a rewrite of a row that predates this branch's merge-base),
+    # then applies the branch's own row on top, exactly as a real merge would.
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True)
+    (repo / "LEDGER.md").write_text("- base line EDITED by another lane\n- branch's own new row\n")
+    subprocess.run(["git", "add", "LEDGER.md"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit",
+         "-m", "edit base row + land branch's row"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=wt, check=True)
+
+    # The branch's own contribution IS on main — reapable, despite the
+    # pre-existing row it never wrote no longer byte-matching its snapshot.
+    assert mod._branch_in_origin_main(wt) is True
+
+
+def test_branch_in_origin_main_union_path_pure_deletion_refuses_reap(fake_repo):
+    """Innocence twin for the added-lines scoping: a branch whose only change
+    to a union path is a DELETION (no added lines to check a subset of) must
+    fail safe to False, never fall back to a full-snapshot comparison that
+    could reintroduce the stale-row false-negative from the test above."""
+    mod, repo = fake_repo
+    _declare_union_ledger(repo)
+    wt = mod.cmd_create("wr2", "uniondelete", ttl_minutes=5)
+
+    (wt / "LEDGER.md").write_text("")
+    _commit_in_worktree(wt, mod, "LEDGER.md", "delete base line, add nothing")
+
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True)
+    with (repo / "LEDGER.md").open("a") as f:
+        f.write("- other lane row\n")
+    subprocess.run(["git", "add", "LEDGER.md"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e", "-c", "user.name=T", "commit", "-m", "other lane append"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "fetch", "origin"], cwd=wt, check=True)
+
+    assert mod._branch_in_origin_main(wt) is False
+
+
 # ---------------------------------------------------------------------------
 # list — orphan detection (W62 ANTIBODY #2)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- \`_content_subset_ok\` compared a branch's FULL frozen ledger snapshot against \`origin/main\` — once ANY other lane edits a pre-existing row on the append-only ledger after this branch's merge-base (the normal shape of a healer tick: correcting/closing an earlier row, not just appending), the branch reads as unmerged even though its own contribution is fully present.
- Measured live 2026-08-29 (Mini healer tick): \`agent_start.py --release healer-tick-0829\` refused a merged, content-on-main worktree (branch squash-merged as PR #5178) — exactly 1 line differed, an unrelated Sentry-lane row a later tick had edited.
- Fix: scope the subset check to the lines the branch itself **added** since its own merge-base (\`git diff base..HEAD\`), not the full file snapshot. A pure-deletion diff fails safe to False.

## Test plan
- [x] New test reproducing the exact live bug — verified red-before-green (fails on unpatched \`agent_start.py\`, passes with the fix)
- [x] Innocence twin: pure-deletion diff still fails safe (never reaps)
- [x] Full suite: \`scripts/tests/test_agent_start.py\` — 83 passed, 1 skipped, no regressions vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)