### PR TITLE
feat(mouth): instrument the VOA money funnel with the existing app_* taxonomy

### DIFF
--- a/apps/mouth/src/app/visa/voa/[hash]/page.test.tsx
+++ b/apps/mouth/src/app/visa/voa/[hash]/page.test.tsx
@@ -1,5 +1,36 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import VoaResultPage from "./page";
+
+// The tracker's own emitFunnelAppEvent posts through the SAME global fetch
+// mock the tests below use for the eligibility-check/lead-capture/magic-link
+// calls — mocked here (mirroring visa/match's page.test.tsx) so it never
+// silently consumes a mockResolvedValueOnce meant for a real endpoint, and
+// so tracker calls are assertable.
+const trackerMocks = vi.hoisted(() => ({
+  resultViewed: vi.fn(),
+  ctaClicked: vi.fn(),
+  whatsappHandoff: vi.fn(),
+  shareClicked: vi.fn(),
+  emailSubscribed: vi.fn(),
+  formSubmitFailed: vi.fn(),
+}));
+
+vi.mock("@balizero/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@balizero/core")>();
+  return {
+    ...actual,
+    useFunnelApp: () => ({
+      viewed: vi.fn(),
+      resultViewed: trackerMocks.resultViewed,
+      ctaClicked: trackerMocks.ctaClicked,
+      whatsappHandoff: trackerMocks.whatsappHandoff,
+      shareClicked: trackerMocks.shareClicked,
+      emailSubscribed: trackerMocks.emailSubscribed,
+      formSubmitFailed: trackerMocks.formSubmitFailed,
+    }),
+  };
+});
 
 const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
 
@@ -12,6 +43,43 @@ describe("VoaResultPage — DECLINE (owner decision 5, constraint 5b)", () => {
     vi.clearAllMocks();
     window.localStorage.clear();
     fetchMock.mockReset();
+  });
+
+  it("tracks resultViewed and the DECLINE-path CTAs, never a form value", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        verdict: "DECLINE",
+        reason_codes: ["PURPOSE_NOT_ELIGIBLE"],
+      }),
+    });
+    window.localStorage.setItem(
+      "bz.garuda_voa.wizard",
+      JSON.stringify({
+        values: {
+          case_type: "issuance",
+          purpose: "business-meeting",
+          trip: { nationality: "USA" },
+        },
+      }),
+    );
+    renderWithHash("opaque-decline-hash");
+
+    await waitFor(() =>
+      expect(trackerMocks.resultViewed).toHaveBeenCalledWith(
+        "opaque-decline-hash",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /Try Visa Match/i }));
+    expect(trackerMocks.ctaClicked).toHaveBeenCalledWith(
+      "try_visa_match",
+      "/visa/match",
+    );
+    // Law 2: the CTA event carries a label + destination only.
+    const wire = JSON.stringify(trackerMocks.ctaClicked.mock.calls);
+    expect(wire).not.toContain("USA");
+    expect(wire).not.toContain("business-meeting");
   });
 
   it("shows the empty stamp, never AppStampReveal's ink stamp, on DECLINE", async () => {
@@ -91,6 +159,96 @@ describe("VoaResultPage — ACCEPT", () => {
     expect(screen.getByText(/Ngurah Rai/i)).toBeInTheDocument();
     // Magic-link email capture is present on the accepted path.
     expect(screen.getByLabelText(/continue by email/i)).toBeInTheDocument();
+    expect(trackerMocks.resultViewed).toHaveBeenCalledWith("opaque-test-hash");
+  });
+
+  it("copying the share link fires shareClicked('copy'), never the applicant's data", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        verdict: "ACCEPT",
+        reason_codes: [],
+        price_idr: 790000,
+      }),
+    });
+    renderWithHash();
+    await waitFor(() =>
+      expect(screen.getByTestId("bz-stamp")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy link/i }));
+    await waitFor(() =>
+      expect(trackerMocks.shareClicked).toHaveBeenCalledWith("copy"),
+    );
+  });
+
+  it("magic-link request fires emailSubscribed on 202, never the email address", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        verdict: "ACCEPT",
+        reason_codes: [],
+        price_idr: 790000,
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({ status: 202 });
+    renderWithHash();
+    await waitFor(() =>
+      expect(screen.getByTestId("bz-stamp")).toBeInTheDocument(),
+    );
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/continue by email/i),
+      "customer@example.com",
+    );
+    await user.click(screen.getByRole("button", { name: /email me a link/i }));
+
+    await waitFor(() =>
+      expect(trackerMocks.emailSubscribed).toHaveBeenCalledWith(
+        "voa_magic_link_request",
+      ),
+    );
+    // Positive control: prove the detector below is not vacuously true — it
+    // WOULD catch the email if it were present (it isn't, by construction).
+    expect(JSON.stringify(["customer@example.com"])).toContain(
+      "customer@example.com",
+    );
+    const wire = JSON.stringify(trackerMocks.emailSubscribed.mock.calls);
+    expect(wire).not.toContain("customer@example.com");
+    expect(wire).not.toContain("@example.com");
+  });
+
+  it("magic-link request failure fires formSubmitFailed with endpoint + status, never the email", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        verdict: "ACCEPT",
+        reason_codes: [],
+        price_idr: 790000,
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({ status: 500 });
+    renderWithHash();
+    await waitFor(() =>
+      expect(screen.getByTestId("bz-stamp")).toBeInTheDocument(),
+    );
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/continue by email/i),
+      "customer@example.com",
+    );
+    await user.click(screen.getByRole("button", { name: /email me a link/i }));
+
+    await waitFor(() =>
+      expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+        "/api/visa/voa/auth/magic-links",
+        500,
+      ),
+    );
+    const wire = JSON.stringify(trackerMocks.formSubmitFailed.mock.calls);
+    expect(wire).not.toContain("customer@example.com");
   });
 
   it("never renders a fee/PNBP split — one all-inclusive figure only", async () => {

--- a/apps/mouth/src/app/visa/voa/[hash]/page.tsx
+++ b/apps/mouth/src/app/visa/voa/[hash]/page.tsx
@@ -6,6 +6,7 @@ import {
   AppShareBar,
   AppStampReveal,
   AppWhatsAppCTA,
+  useFunnelApp,
 } from "@balizero/core";
 import { formatIDR } from "@balizero/core/utils";
 import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
@@ -87,6 +88,7 @@ export default function VoaResultPage({
 }: {
   params: Promise<{ hash: string }>;
 }) {
+  const tracker = useFunnelApp("visa_voa", { trackView: false });
   const stampRef = useRef<HTMLDivElement | null>(null);
   const [hash, setHash] = useState<string | null>(null);
   const [data, setData] = useState<VoaResult | null>(null);
@@ -109,11 +111,16 @@ export default function VoaResultPage({
           );
           return;
         }
-        setData((await res.json()) as VoaResult);
+        const result = (await res.json()) as VoaResult;
+        setData(result);
+        // Verdict + price shown together (they render on the same screen) —
+        // one event covers both funnel steps the mandate names.
+        tracker.resultViewed(hash);
       } catch {
         setErr("Network error. Please try again.");
       }
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hash]);
 
   if (err) {
@@ -198,6 +205,9 @@ export default function VoaResultPage({
               {edu.routeKind === "oracle" ? (
                 <a
                   href="/visa/match"
+                  onClick={() =>
+                    tracker.ctaClicked("try_visa_match", "/visa/match")
+                  }
                   style={{
                     display: "inline-block",
                     textAlign: "center",
@@ -219,6 +229,9 @@ export default function VoaResultPage({
                 )}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() =>
+                  tracker.ctaClicked("continue_on_whatsapp_decline", "wa.me")
+                }
                 style={{
                   display: "inline-block",
                   textAlign: "center",
@@ -238,7 +251,7 @@ export default function VoaResultPage({
         <AppShareBar
           url={publicUrl}
           title="Bali Zero — Visa on Arrival check"
-          onShare={() => {}}
+          onShare={(c) => tracker.shareClicked(c)}
         />
       </AppFrame>
     );
@@ -282,11 +295,12 @@ export default function VoaResultPage({
         defaultLabel="Continue on WhatsApp →"
         postScrollLabel="Continue on WhatsApp →"
         stampRef={stampRef}
+        onCaptured={({ leadIntentId }) => tracker.whatsappHandoff(leadIntentId)}
       />
       <AppShareBar
         url={publicUrl}
         title="Bali Zero — Visa on Arrival"
-        onShare={() => {}}
+        onShare={(c) => tracker.shareClicked(c)}
       />
     </AppFrame>
   );
@@ -300,6 +314,7 @@ export default function VoaResultPage({
  * and this form must not create a second oracle on top of that.
  */
 function MagicLinkRequestForm({ resultId }: { resultId: string }) {
+  const tracker = useFunnelApp("visa_voa", { trackView: false });
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">(
     "idle",
@@ -308,6 +323,7 @@ function MagicLinkRequestForm({ resultId }: { resultId: string }) {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setStatus("sending");
+    let httpStatus: number | null = null;
     try {
       const res = await fetch("/api/visa/voa/auth/magic-links", {
         method: "POST",
@@ -320,9 +336,19 @@ function MagicLinkRequestForm({ resultId }: { resultId: string }) {
         body: JSON.stringify({ result_id: resultId, email }),
         credentials: "include",
       });
-      setStatus(res.status === 202 ? "sent" : "error");
+      httpStatus = res.status;
+      if (res.status === 202) {
+        setStatus("sent");
+        // The CTA that continues the money funnel — never the email
+        // address itself, only that a request happened.
+        tracker.emailSubscribed("voa_magic_link_request");
+      } else {
+        setStatus("error");
+        tracker.formSubmitFailed("/api/visa/voa/auth/magic-links", httpStatus);
+      }
     } catch {
       setStatus("error");
+      tracker.formSubmitFailed("/api/visa/voa/auth/magic-links", httpStatus);
     }
   };
 

--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.test.tsx
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.test.tsx
@@ -13,6 +13,27 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.push, replace: mocks.replace }),
 }));
 
+// The tracker's own emitFunnelAppEvent posts through the SAME global fetch
+// mock the tests below use for /api/visa/voa/orders — mocked here (mirroring
+// visa/match's page.test.tsx) so `fetchMock.toHaveBeenCalledTimes(1)` below
+// still counts only the orders call, and tracker calls are assertable.
+const trackerMocks = vi.hoisted(() => ({
+  formSubmitted: vi.fn(),
+  formSubmitFailed: vi.fn(),
+}));
+
+vi.mock("@balizero/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@balizero/core")>();
+  return {
+    ...actual,
+    useFunnelApp: () => ({
+      viewed: vi.fn(),
+      formSubmitted: trackerMocks.formSubmitted,
+      formSubmitFailed: trackerMocks.formSubmitFailed,
+    }),
+  };
+});
+
 const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
 
 function jsonResponse(status: number, body: unknown) {
@@ -37,6 +58,8 @@ describe("CheckoutFlow", () => {
     window.sessionStorage.clear();
     mocks.push.mockReset();
     mocks.replace.mockReset();
+    trackerMocks.formSubmitted.mockReset();
+    trackerMocks.formSubmitFailed.mockReset();
     // jsdom doesn't implement window.location.href assignment navigation; stub it so
     // the redirect-to-provider effect doesn't throw ("Not implemented: navigation").
     // @ts-expect-error -- test-only stub
@@ -104,6 +127,51 @@ describe("CheckoutFlow", () => {
       },
       review_confirmed: true,
     });
+
+    // Checkout attempt telemetry: field NAMES only (Law 2), never the
+    // applicant's own values.
+    expect(trackerMocks.formSubmitted).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        "full_name",
+        "email",
+        "phone",
+        "passport_number",
+      ]),
+    );
+    const wire = JSON.stringify(trackerMocks.formSubmitted.mock.calls);
+    expect(wire).not.toContain("Jane Doe");
+    expect(wire).not.toContain("customer@example.com");
+    expect(wire).not.toContain("X1234567");
+  });
+
+  it("a retryable order failure fires formSubmitFailed with endpoint + status, never the applicant", async () => {
+    writeCheckoutHandoff("result-1", {
+      full_name: "Jane Doe",
+      passport_number: "X1234567",
+    });
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(503, {
+        code: "PAYMENT_PROVIDER_UNAVAILABLE",
+        retryable: true,
+        message_key: "garuda_voa.error.payment_provider_unavailable",
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<CheckoutFlow resultId="result-1" />);
+    await screen.findByText(/Jane Doe/i);
+    await fillAndSubmit(user);
+
+    await waitFor(() =>
+      expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+        "/api/visa/voa/orders",
+        503,
+      ),
+    );
+    const wire = JSON.stringify(trackerMocks.formSubmitFailed.mock.calls);
+    expect(wire).not.toContain("Jane Doe");
+    expect(wire).not.toContain("customer@example.com");
+    expect(wire).not.toContain("X1234567");
   });
 
   it("redirects the browser to checkout_url on a fresh awaiting_payment order — never renders success itself", async () => {

--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.tsx
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { AppFrame } from "@balizero/core";
+import { AppFrame, useFunnelApp } from "@balizero/core";
 import { readCheckoutHandoff } from "../../checkoutHandoff";
 import { useCheckout } from "./useCheckout";
 import type { Applicant } from "../../orders/types";
@@ -20,12 +20,22 @@ import type { Applicant } from "../../orders/types";
  */
 export function CheckoutFlow({ resultId }: { resultId: string }) {
   const router = useRouter();
+  const tracker = useFunnelApp("visa_voa");
   const { state, submit } = useCheckout(resultId);
   const [fullName, setFullName] = useState("");
   const [passportNumber, setPassportNumber] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
   const [missingHandoff, setMissingHandoff] = useState(false);
+
+  // Checkout attempt: the funnel's money step. Never the applicant's own
+  // values — field names only, matching the wizard/visa-match pattern.
+  useEffect(() => {
+    if (state.step === "error") {
+      tracker.formSubmitFailed("/api/visa/voa/orders", state.httpStatus);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state]);
 
   useEffect(() => {
     const handoff = readCheckoutHandoff(resultId);
@@ -96,7 +106,10 @@ export function CheckoutFlow({ resultId }: { resultId: string }) {
         }}
         onSubmit={(e) => {
           e.preventDefault();
-          if (canSubmit) void submit(applicant);
+          if (canSubmit) {
+            tracker.formSubmitted(Object.keys(applicant));
+            void submit(applicant);
+          }
         }}
       >
         <ReadOnlyField label="Full name" value={fullName} />

--- a/apps/mouth/src/app/visa/voa/checkout/[resultId]/useCheckout.ts
+++ b/apps/mouth/src/app/visa/voa/checkout/[resultId]/useCheckout.ts
@@ -13,7 +13,12 @@ export type CheckoutState =
   | { step: "idle" }
   | { step: "submitting" }
   | { step: "created"; order: OrderCheckout }
-  | { step: "error"; message: string; retryable: boolean };
+  | {
+      step: "error";
+      message: string;
+      retryable: boolean;
+      httpStatus: number | null;
+    };
 
 function stableKeyFor(resultId: string, applicant: Applicant): string {
   return JSON.stringify([resultId, applicant]);
@@ -56,6 +61,7 @@ export function useCheckout(resultId: string) {
             step: "error",
             message: messageFor(err.code),
             retryable: err.retryable,
+            httpStatus: err.httpStatus,
           });
           return;
         }
@@ -67,6 +73,7 @@ export function useCheckout(resultId: string) {
                 ? messageFor("SERVICE_UNAVAILABLE")
                 : messageForUnknownCode("__network__"),
             retryable: true,
+            httpStatus: err.httpStatus,
           });
           return;
         }
@@ -74,6 +81,7 @@ export function useCheckout(resultId: string) {
           step: "error",
           message: messageForUnknownCode("__unknown__"),
           retryable: true,
+          httpStatus: null,
         });
       }
     },

--- a/apps/mouth/src/app/visa/voa/page.test.tsx
+++ b/apps/mouth/src/app/visa/voa/page.test.tsx
@@ -8,6 +8,32 @@ import VoaEligibilityPage from "./page";
  * contract's `allOf` forbids on issuance.
  */
 
+// The tracker's own emitFunnelAppEvent posts to /api/analytics/funnel-event
+// through the SAME global fetch mock the tests below use for
+// /api/visa/voa/eligibility-checks — mocked here (mirroring visa/match's
+// page.test.tsx) so `fetchMock.toHaveBeenCalledTimes(1)` below still counts
+// only the eligibility-checks call, and so tracker calls are assertable.
+const trackerMocks = vi.hoisted(() => ({
+  wizardStep: vi.fn(),
+  wizardAbandoned: vi.fn(),
+  formSubmitted: vi.fn(),
+  formSubmitFailed: vi.fn(),
+}));
+
+vi.mock("@balizero/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@balizero/core")>();
+  return {
+    ...actual,
+    useFunnelApp: () => ({
+      viewed: vi.fn(),
+      wizardStep: trackerMocks.wizardStep,
+      wizardAbandoned: trackerMocks.wizardAbandoned,
+      formSubmitted: trackerMocks.formSubmitted,
+      formSubmitFailed: trackerMocks.formSubmitFailed,
+    }),
+  };
+});
+
 const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
 
 function fillIssuanceHappyPath() {
@@ -68,6 +94,21 @@ describe("VoaEligibilityPage — wire contract", () => {
     });
     // Contract allOf: voa_expiry_date is forbidden outside `extension`.
     expect(body).not.toHaveProperty("voa_expiry_date");
+
+    // Telemetry: field NAMES only (Law 2) — the same payload_keys-only
+    // pattern visa/match's W0b fix established, never any answer value.
+    expect(trackerMocks.formSubmitted).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        "case_type",
+        "nationality",
+        "purpose",
+        "entry_date",
+        "passport_expiry_date",
+      ]),
+    );
+    const submittedWire = JSON.stringify(trackerMocks.formSubmitted.mock.calls);
+    expect(submittedWire).not.toContain("ITA");
+    expect(submittedWire).not.toContain("2026-09-01");
   });
 
   it("asks for the current VOA expiry date on the extension path and sends it", async () => {
@@ -123,6 +164,12 @@ describe("VoaEligibilityPage — wire contract", () => {
     expect(
       screen.getByRole("link", { name: /message us on WhatsApp/i }),
     ).toBeInTheDocument();
+    // Network failure (fetch rejects before any response) reports status null
+    // — never a fabricated value — mirroring visa/match's W0b contract.
+    expect(trackerMocks.formSubmitFailed).toHaveBeenCalledWith(
+      "/api/visa/voa/eligibility-checks",
+      null,
+    );
   });
 });
 
@@ -156,5 +203,19 @@ describe("VoaEligibilityPage — customer-facing surface", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+  });
+
+  it("tracks step progression (1-indexed) and abandonment mid-wizard", () => {
+    render(<VoaEligibilityPage />);
+    expect(trackerMocks.wizardStep).toHaveBeenCalledWith(1, 4);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Get a new Visa on Arrival/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(trackerMocks.wizardStep).toHaveBeenCalledWith(2, 4);
+
+    expect(trackerMocks.wizardAbandoned).not.toHaveBeenCalled();
+    window.dispatchEvent(new Event("beforeunload"));
+    expect(trackerMocks.wizardAbandoned).toHaveBeenCalledWith(1);
   });
 });

--- a/apps/mouth/src/app/visa/voa/page.tsx
+++ b/apps/mouth/src/app/visa/voa/page.tsx
@@ -6,6 +6,7 @@ import {
   AppFrame,
   AppTrustStrip,
   AppWizard,
+  useFunnelApp,
   type WizardStep,
 } from "@balizero/core";
 import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
@@ -102,6 +103,7 @@ interface WizardAnswers {
 
 export default function VoaEligibilityPage() {
   const router = useRouter();
+  const tracker = useFunnelApp("visa_voa");
   const [submitError, setSubmitError] = useState<React.ReactNode>(null);
   const [submitting, setSubmitting] = useState(false);
   // AppWizard's per-step render only sees that step's own value, never the
@@ -430,6 +432,11 @@ export default function VoaEligibilityPage() {
         dates.retention_notice_acknowledged ?? false,
     };
 
+    tracker.formSubmitted(Object.keys(body));
+    // Captured OUTSIDE the catch, mirroring visa/match's W0b fix: the
+    // failure event must carry the real HTTP status, never a swallowed
+    // "network error" default — see funnel-app.ts's Law 2 payload note.
+    let status: number | null = null;
     try {
       const res = await fetch("/api/visa/voa/eligibility-checks", {
         method: "POST",
@@ -441,6 +448,7 @@ export default function VoaEligibilityPage() {
         },
         body: JSON.stringify(body),
       });
+      status = res.status;
       if (res.status === 201) {
         const location = res.headers.get("Location");
         const resultId = location?.split("/").pop();
@@ -451,6 +459,7 @@ export default function VoaEligibilityPage() {
       }
       throw new Error(`unexpected status ${res.status}`);
     } catch {
+      tracker.formSubmitFailed("/api/visa/voa/eligibility-checks", status);
       setSubmitError(
         <>
           We couldn&apos;t check eligibility right now. Please try again, or{" "}
@@ -491,6 +500,8 @@ export default function VoaEligibilityPage() {
       <AppWizard
         steps={steps}
         persistKey="bz.garuda_voa.wizard"
+        onStepChange={(step, total) => tracker.wizardStep(step + 1, total)}
+        onAbandon={(step) => tracker.wizardAbandoned(step)}
         onComplete={onComplete}
       />
       {submitting ? (

--- a/apps/mouth/src/lib/funnel-app-events.test.ts
+++ b/apps/mouth/src/lib/funnel-app-events.test.ts
@@ -57,3 +57,65 @@ describe("app_form_submit_failed — Law 2 payload shape (CI guard)", () => {
     expect(body.payload.status).toBeNull();
   });
 });
+
+describe("visa_voa — Law 2 payload shape (money funnel, CI guard)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("gtag", vi.fn());
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true });
+    document.cookie = "bz_session=; Max-Age=0; path=/";
+  });
+
+  it("positive control: the not.toContain check below is NOT vacuous — it detects a real leak", async () => {
+    // Simulates the exact mistake this suite exists to catch: a caller
+    // passing field VALUES instead of field NAMES into formSubmitted.
+    const tracker = createFunnelAppTracker("visa_voa");
+    await tracker.formSubmitted(["A1234567"]); // a passport-number-shaped value
+    const [, init] = fetchMock.mock.calls[0];
+    const wire = (init as RequestInit).body as string;
+    expect(wire).toContain("A1234567");
+  });
+
+  it("eligibility wizard's formSubmitted carries field names only, never an answer value", async () => {
+    const tracker = createFunnelAppTracker("visa_voa");
+    await tracker.formSubmitted([
+      "case_type",
+      "nationality",
+      "purpose",
+      "entry_date",
+      "passport_expiry_date",
+      "retention_notice_acknowledged",
+    ]);
+    const [, init] = fetchMock.mock.calls[0];
+    const wire = (init as RequestInit).body as string;
+    expect(wire).not.toContain("ITA");
+    expect(wire).not.toContain("2026-09-01");
+    expect(wire).not.toContain("A1234567");
+  });
+
+  it("checkout's formSubmitFailed carries endpoint + status only, never the applicant", async () => {
+    const tracker = createFunnelAppTracker("visa_voa");
+    await tracker.formSubmitFailed("/api/visa/voa/orders", 503);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.payload).toEqual({
+      type: "app_form_submit_failed",
+      app: "visa_voa",
+      endpoint: "/api/visa/voa/orders",
+      status: 503,
+    });
+    const wire = (init as RequestInit).body as string;
+    expect(wire).not.toContain("Jane Doe");
+    expect(wire).not.toContain("customer@example.com");
+    expect(wire).not.toContain("X1234567");
+  });
+
+  it("the magic-link CTA's emailSubscribed carries a trigger_type only, never the email address", async () => {
+    const tracker = createFunnelAppTracker("visa_voa");
+    await tracker.emailSubscribed("voa_magic_link_request");
+    const [, init] = fetchMock.mock.calls[0];
+    const wire = (init as RequestInit).body as string;
+    expect(wire).not.toContain("@");
+    expect(wire).not.toContain("customer@example.com");
+  });
+});

--- a/packages/core/analytics/funnel-app.ts
+++ b/packages/core/analytics/funnel-app.ts
@@ -14,7 +14,8 @@ export type FunnelAppName =
   | "kbli_decoder"
   | "kbli_builder"
   | "tax_gap"
-  | "zoning_check";
+  | "zoning_check"
+  | "visa_voa";
 
 /** Finite source-of-truth list of app_* event names (MYTHOS IA-8 app_*
  * reconciliation). The backend allowlist mirrors FUNNEL_EVENTS ∪ APP_EVENTS —

--- a/packages/core/auth/session-bridge.test.ts
+++ b/packages/core/auth/session-bridge.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   attachToServerSession,
   getOrCreateSessionId,
+  readFirstTouchAttribution,
   BZ_SESSION_COOKIE,
 } from "./session-bridge";
 
@@ -43,5 +44,101 @@ describe("session-bridge", () => {
         step_state: { step: 2, answer: "E33G" },
       }),
     });
+  });
+});
+
+describe("readFirstTouchAttribution — inbound UTM/referrer capture (R4)", () => {
+  const originalLocation = window.location;
+  const originalReferrer = document.referrer;
+
+  function stubLocation(href: string) {
+    Object.defineProperty(window, "location", {
+      value: new URL(href),
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  function stubReferrer(value: string) {
+    Object.defineProperty(document, "referrer", { value, configurable: true });
+  }
+
+  beforeEach(() => {
+    document.cookie = `${BZ_SESSION_COOKIE}=; Max-Age=0; path=/`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(document, "referrer", {
+      value: originalReferrer,
+      configurable: true,
+    });
+  });
+
+  it("captures utm_* + the referring hostname only, on a genuine first touch", () => {
+    stubLocation(
+      "https://balizero.com/visa/voa?utm_source=instagram&utm_medium=paid_social&utm_campaign=voa_launch",
+    );
+    stubReferrer("https://www.instagram.com/reel/xyz?igshid=abc123");
+
+    const attribution = readFirstTouchAttribution();
+    expect(attribution).toEqual({
+      utm_source: "instagram",
+      utm_medium: "paid_social",
+      utm_campaign: "voa_launch",
+      referrer_host: "www.instagram.com",
+    });
+    // Law 2 minimization: the referrer's path/query never rides along —
+    // only the hostname that sent the visitor.
+    expect(JSON.stringify(attribution)).not.toContain("igshid");
+    expect(JSON.stringify(attribution)).not.toContain("/reel/xyz");
+  });
+
+  it("returns undefined — never an empty object — with no UTM and no cross-site referrer", () => {
+    stubLocation("https://balizero.com/visa/voa");
+    stubReferrer("");
+    expect(readFirstTouchAttribution()).toBeUndefined();
+  });
+
+  it("returns undefined once bz_session already exists — not a genuine first touch", () => {
+    document.cookie = `${BZ_SESSION_COOKIE}=already-here; path=/`;
+    stubLocation("https://balizero.com/visa/voa?utm_source=instagram");
+    expect(readFirstTouchAttribution()).toBeUndefined();
+  });
+
+  it("attachToServerSession stamps first_touch into step_state on a fresh session", async () => {
+    stubLocation(
+      "https://balizero.com/visa/voa?utm_source=newsletter&utm_medium=email",
+    );
+    stubReferrer("");
+
+    await attachToServerSession({ funnel: "visa" });
+
+    const call = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.step_state.first_touch).toEqual({
+      utm_source: "newsletter",
+      utm_medium: "email",
+    });
+  });
+
+  it("never overwrites an already-persisted first_touch on a later touch in the same session", async () => {
+    document.cookie = `${BZ_SESSION_COOKIE}=already-here; path=/`;
+    stubLocation("https://balizero.com/visa/voa/checkout/abc"); // no UTM on this later page
+
+    await attachToServerSession({
+      funnel: "visa",
+      step_state: { step: "checkout" },
+    });
+
+    const call = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(call[1].body as string);
+    expect(body.step_state).toEqual({ step: "checkout" });
+    expect(body.step_state.first_touch).toBeUndefined();
   });
 });

--- a/packages/core/auth/session-bridge.ts
+++ b/packages/core/auth/session-bridge.ts
@@ -53,15 +53,76 @@ export function getOrCreateSessionId(): string {
   return fresh;
 }
 
+// Same 5 UTM params the outbound builders (whatsapp-utm.ts, social-utm.ts)
+// stamp on every CTA — mirrored here for the inbound read so attribution
+// uses one shared vocabulary in both directions.
+const UTM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+/**
+ * Reads inbound `utm_*` + referring hostname from the CURRENT navigation —
+ * but ONLY on a session's genuine first touch (no `bz_session` cookie yet).
+ * Must be called BEFORE `getOrCreateSessionId()` mints that cookie, or every
+ * call would read as "first touch". Returns `undefined` (never an empty
+ * object) when there's nothing to capture or this is a return visit, so a
+ * caller can omit the key entirely rather than clobbering an already-
+ * persisted first touch with an empty overwrite (funnel_sessions.step_state
+ * merges by top-level key, not deep-merge — see funnel.py `||` comment).
+ *
+ * Only the referring HOSTNAME is kept, never the full referrer URL — a
+ * referrer's path/query can carry a search term or an internal identifier
+ * that isn't ours to log (Law 2 minimization), and "which site sent them"
+ * is all attribution needs.
+ */
+export function readFirstTouchAttribution():
+  Record<string, string> | undefined {
+  if (readCookie(BZ_SESSION_COOKIE)) return undefined;
+  if (typeof window === "undefined") return undefined;
+
+  const attribution: Record<string, string> = {};
+  const params = new URLSearchParams(window.location.search);
+  for (const key of UTM_KEYS) {
+    const value = params.get(key);
+    if (value) attribution[key] = value;
+  }
+
+  try {
+    const referrer = typeof document !== "undefined" ? document.referrer : "";
+    if (referrer) {
+      const referrerHost = new URL(referrer).hostname;
+      if (referrerHost && referrerHost !== window.location.hostname) {
+        attribution.referrer_host = referrerHost;
+      }
+    }
+  } catch {
+    /* malformed/opaque referrer — skip, never throw on attribution */
+  }
+
+  return Object.keys(attribution).length > 0 ? attribution : undefined;
+}
+
 export async function attachToServerSession(payload: {
   funnel: "visa" | "kbli" | "tax" | "property" | "home";
   step_state?: Record<string, unknown>;
 }): Promise<void> {
+  const firstTouch = readFirstTouchAttribution();
   const sessionId = getOrCreateSessionId();
+  const step_state = firstTouch
+    ? { ...payload.step_state, first_touch: firstTouch }
+    : payload.step_state;
   await fetch("/api/funnel/session/touch", {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ session_id: sessionId, ...payload }),
+    body: JSON.stringify({
+      session_id: sessionId,
+      funnel: payload.funnel,
+      step_state,
+    }),
   });
 }


### PR DESCRIPTION
## Summary

The GARUDA VOA funnel (`/visa/voa/**`) emitted **zero** `app_*` analytics
events while the free `/visa/match` funnel is fully instrumented
(`research/operations/2026-08-28-beyond-sota/F2-conversion-funnels.md`
R2/R3) — nobody could measure where paying visitors drop off. This wires the
existing, parity-tested `useFunnelApp` taxonomy into the VOA funnel instead
of inventing a parallel one, and closes the inbound-attribution gap the same
report flagged (outbound UTM was enforced, inbound was never read).

## Events added

New `FunnelAppName`: `"visa_voa"` (`packages/core/analytics/funnel-app.ts`) —
no backend change needed, the backend allowlist mirrors event *names*, not
app values (`test_analytics_funnel_parity.py` unaffected).

| Step (mandate's list) | Page | Event |
|---|---|---|
| view | `/visa/voa` wizard | `app_viewed` (default `useFunnelApp` behavior) |
| question/step progression | wizard | `app_wizard_step_completed`, `app_wizard_abandoned` (on `beforeunload` mid-wizard) |
| — | wizard submit | `app_form_submitted` (field names only), `app_form_submit_failed` (endpoint + real HTTP status) |
| verdict shown + price shown | `/visa/voa/[hash]` | `app_result_viewed(hash)` — both render on the same screen, one event covers both |
| CTA | result page | `app_cta_clicked` (DECLINE's "Try Visa Match" / "Continue on WhatsApp" links), `app_whatsapp_handoff` (ACCEPT's `AppWhatsAppCTA`), `app_share_clicked` (copy/twitter/email) |
| CTA (magic link) | `MagicLinkRequestForm` | `app_email_subscribed("voa_magic_link_request")` on 202, `app_form_submit_failed` on failure |
| checkout attempt | `CheckoutFlow` | `app_viewed` on mount, `app_form_submitted` (field names only) on submit, `app_form_submit_failed` (endpoint + real HTTP status, threaded through `useCheckout`'s new `httpStatus` field) |

**Inbound attribution** (R4-lite): `packages/core/auth/session-bridge.ts`
gained `readFirstTouchAttribution()` — reads `utm_source/medium/campaign/
content/term` (same vocabulary as the outbound `whatsapp-utm.ts`/
`social-utm.ts` builders) + the referring **hostname only** (never the full
referrer URL — path/query can carry a search term that isn't ours to log) on
a session's genuine first touch (no `bz_session` cookie yet), and stamps it
into the existing `/api/funnel/session/touch` call's `step_state.first_touch`
— no new endpoint, no schema change. First-touch-only by construction: a
later touch in the same session never re-reads location and never clobbers
an already-persisted `first_touch` (the backend merges `step_state` by
top-level key, not deep-merge).

## PII exclusion — how it's enforced and tested

Every emitted payload carries **field names or opaque ids only** — never an
answer value, never applicant PII (full name, passport number, email,
phone), matching the existing `app_form_submit_failed` Law 2 contract
(`funnel-app.ts`'s own type comment: "never form values").

- **Wizard submit**: `tracker.formSubmitted(Object.keys(body))` — keys, not
  values (same pattern as `/visa/match`).
- **Checkout submit**: `tracker.formSubmitted(Object.keys(applicant))` — same
  pattern; `useCheckout`'s error state now carries `httpStatus` so the
  failure event reports the real status instead of `null`.
- **Magic-link CTA**: `emailSubscribed("voa_magic_link_request")` — a fixed
  trigger-type string, the email variable never touches the tracker.
- **Referrer**: only `new URL(referrer).hostname` is kept — path/query
  stripped before it ever reaches `step_state`.

### Tests (red-first, extending existing coverage rather than parallel files)

- `apps/mouth/src/app/visa/voa/page.test.tsx` — step progression (1-indexed),
  abandonment, `formSubmitted`/`formSubmitFailed` with a wire-level
  `not.toContain("ITA")`/`not.toContain(date)` check.
- `apps/mouth/src/app/visa/voa/[hash]/page.test.tsx` — `resultViewed` on both
  ACCEPT and DECLINE, DECLINE CTA click, share-copy click, and two magic-link
  tests (success → `emailSubscribed`, failure → `formSubmitFailed`) each
  asserting the email address is absent from the wire.
- `apps/mouth/src/app/visa/voa/checkout/[resultId]/CheckoutFlow.test.tsx` —
  `formSubmitted` field-names-only and `formSubmitFailed(endpoint, 503)`,
  each with a `not.toContain("Jane Doe"/"customer@example.com"/"X1234567")`
  check.
- `apps/mouth/src/lib/funnel-app-events.test.ts` (the existing Law 2 CI
  guard, extended not duplicated) — 4 new tests for `visa_voa`, including a
  **positive control**: `formSubmitted(["A1234567"])` is asserted to `.
  toContain("A1234567")` first, proving the `not.toContain` checks elsewhere
  in the suite are not vacuously true.
- `packages/core/auth/session-bridge.test.ts` — first-touch capture, Law 2
  minimization (referrer path/query never rides along), no-clobber on a
  later touch, and undefined-not-empty-object on a return visit.

Every touched test file mocks `@balizero/core`'s `useFunnelApp` (mirroring
the existing `visa/match/page.test.tsx` pattern) so the tracker's own
`fetch("/api/analytics/funnel-event")` call never pollutes the
`fetchMock.toHaveBeenCalledTimes(1)` assertions already guarding the real
API calls on each page.

## Scope fence honored

Did not touch `apps/mouth/src/lib/api/client.ts` (auth/session plumbing,
another lane's work) or `app/visa/voa/auth/**` / the magic-link consumer
route (another lane's PR #5157, already merged into a disjoint path). If
this instrumentation needs to observe the magic-link *exchange* itself
(not just the *request*, which is covered here), that belongs in a
follow-up PR once that lane's route lands on a stable shape.

## Verification

```
cd apps/mouth
npx tsc --noEmit                                                  # clean
npx eslint <touched files>                                         # 0 errors (pre-existing warnings only)
npx prettier --check <touched files>                                # clean
npx vitest run src/app/visa/voa/page.test.tsx \
  "src/app/visa/voa/[hash]/page.test.tsx" \
  "src/app/visa/voa/checkout/[resultId]/CheckoutFlow.test.tsx" \
  src/lib/funnel-app-events.test.ts \
  src/components/funnel/SessionInit.test.tsx                        # 5 files, 36 passed
# packages/core/auth/session-bridge.test.ts smoke-tested via an ad-hoc
# JSX-free config (packages/core's own vitest.config.ts has a pre-existing,
# documented @vitejs/plugin-react resolution break — funnel-app-events.test.ts
# docstring — unrelated to this change): 8/8 passed.
```

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean (0 errors)
- [x] `prettier --check` clean
- [x] All touched/related vitest files green (44 tests total across
      apps/mouth + packages/core)
- [x] PII-exclusion positive control proves the Law 2 checks are not vacuous

🤖 Generated with [Claude Code](https://claude.com/claude-code)