### PR TITLE
fix(notifications): the client-alert queue has been dead, not quiet

### DIFF
--- a/apps/backend-rag/backend/app/modules/notifications/service.py
+++ b/apps/backend-rag/backend/app/modules/notifications/service.py
@@ -303,10 +303,20 @@ class NotificationService:
                 AlertType.VISA_CRITICAL,
                 AlertType.VISA_EXPIRED,
             ]:
-                # Get team leader email from database
-                team_leader = await self._get_team_leader_email(alert.client_id)
-                if team_leader:
-                    bcc.append(team_leader)
+                # Get team leader email from database. This address is a BCC:
+                # it is a courtesy copy, never the reason a client goes unwarned.
+                # Until 2026-08-29 this ran unguarded, so a database error here
+                # aborted the whole send and the alert never left the building.
+                try:
+                    team_leader = await self._get_team_leader_email(alert.client_id)
+                except Exception as bcc_error:  # best effort by design: a BCC never blocks the alert
+                    logger.warning(
+                        "Team leader lookup failed; sending alert without BCC",
+                        extra={"client_id": alert.client_id, "error": str(bcc_error)},
+                    )
+                else:
+                    if team_leader:
+                        bcc.append(team_leader)
 
             # Send email
             success = await self.email_provider.send_email(
@@ -390,10 +400,11 @@ class NotificationService:
         async with self.db_pool.acquire() as conn:
             row = await conn.fetchrow(
                 """
-                SELECT u.email
-                FROM users u
-                JOIN clients c ON c.assigned_to = u.email
+                SELECT tm.email
+                FROM team_members tm
+                JOIN clients c ON c.assigned_to = tm.email
                 WHERE c.id = $1
+                  AND tm.active IS NOT FALSE
                 """,
                 client_id,
             )
@@ -412,7 +423,7 @@ class NotificationService:
                     """
                     UPDATE notification_alerts
                     SET status = $1,
-                        sent_at = CASE WHEN $1 = 'sent' THEN NOW() ELSE sent_at END,
+                        sent_at = CASE WHEN $1::text = 'sent' THEN NOW() ELSE sent_at END,
                         error_message = $2
                     WHERE id = $3
                     """,

--- a/apps/backend-rag/backend/app/modules/notifications/service.py
+++ b/apps/backend-rag/backend/app/modules/notifications/service.py
@@ -338,12 +338,44 @@ class NotificationService:
 
         except Exception as e:
             logger.error(f"Failed to process alert {alert.id}", exc_info=e)
-            await self._update_alert_status(alert, AlertStatus.FAILED, str(e))
+            # Recording the failure must never mask the failure itself: until
+            # 2026-08-29 a broken UPDATE here replaced the real cause in Sentry
+            # and left the row 'pending' forever, so it was re-selected as the
+            # head of the queue on every subsequent run.
+            try:
+                await self._update_alert_status(alert, AlertStatus.FAILED, str(e))
+            except Exception as status_error:
+                logger.error(
+                    "Could not record alert failure; the row stays pending",
+                    extra={"alert_id": alert.id, "error": str(status_error)},
+                )
             return NotificationResult(
                 success=False,
                 alert_id=alert.id,
                 error_message=str(e),
             )
+
+    async def _process_one(
+        self,
+        alert: ClientAlert,
+        get_client_email_func,
+    ) -> NotificationResult:
+        """Resolve the recipient and process a single alert."""
+        client_email = await get_client_email_func(alert.client_id)
+        if not client_email:
+            logger.warning(f"No email found for client {alert.client_id}")
+            await self._update_alert_status(
+                alert,
+                AlertStatus.SUPPRESSED,
+                "No email address found",
+            )
+            return NotificationResult(
+                success=False,
+                alert_id=alert.id,
+                error_message="No email address found",
+            )
+
+        return await self.process_alert(alert, client_email)
 
     async def process_alerts_batch(
         self,
@@ -363,26 +395,25 @@ class NotificationService:
         results = []
 
         for alert in alerts:
-            # Get client email
-            client_email = await get_client_email_func(alert.client_id)
-            if not client_email:
-                logger.warning(f"No email found for client {alert.client_id}")
-                await self._update_alert_status(
-                    alert,
-                    AlertStatus.SUPPRESSED,
-                    "No email address found",
+            # One alert's failure must never end the run. The queue is ordered
+            # oldest-first with no LIMIT, so before 2026-08-29 an exception on
+            # the first alert meant every alert behind it was never attempted
+            # at all -- silent non-delivery, with no Sentry event to show for it.
+            try:
+                results.append(await self._process_one(alert, get_client_email_func))
+            except Exception as e:
+                logger.error(
+                    "Alert processing raised; continuing with the rest of the batch",
+                    exc_info=e,
+                    extra={"alert_id": alert.id},
                 )
                 results.append(
                     NotificationResult(
                         success=False,
                         alert_id=alert.id,
-                        error_message="No email address found",
+                        error_message=str(e),
                     ),
                 )
-                continue
-
-            result = await self.process_alert(alert, client_email)
-            results.append(result)
 
         logger.info(
             "Batch processing completed",
@@ -402,7 +433,7 @@ class NotificationService:
                 """
                 SELECT tm.email
                 FROM team_members tm
-                JOIN clients c ON c.assigned_to = tm.email
+                JOIN clients c ON lower(c.assigned_to) = lower(tm.email)
                 WHERE c.id = $1
                   AND tm.active IS NOT FALSE
                 """,

--- a/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_service_db_contracts.py
+++ b/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_service_db_contracts.py
@@ -1,0 +1,138 @@
+"""Database contracts of NotificationService.
+
+These pin three defects measured in production on 2026-08-29 (Sentry org
+``bali-zero-7p``, project ``nuzantara-backend``, 362 events each over 14 days —
+matching the hourly ``_send_pending_alerts`` job, 24 x 14 = 336):
+
+1. ``UndefinedTableError: relation "users" does not exist`` — ``_get_team_leader_email``
+   queried a table that does not exist in this database. The staff directory is
+   ``team_members`` (63 ``FROM team_members`` call sites against 27 ``FROM users``,
+   of which 24 are fake SQL inside debugger tests).
+2. ``AmbiguousParameterError: inconsistent types deduced for parameter $1`` —
+   ``_update_alert_status`` used ``$1`` both as the value of a ``VARCHAR(20)``
+   column and as the left side of a comparison against a text literal, so
+   Postgres could not infer a single type for it.
+3. The consequence of (1) that actually hurt a client: the team leader is only a
+   **BCC**. Because the lookup ran unguarded inside ``process_alert``, a database
+   error while fetching an optional BCC aborted the whole send, so the alert
+   e-mail never reached the client at all — and the ``except`` handler then hit
+   defect (2) while trying to record the failure, leaving the row ``pending``
+   forever.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend.app.modules.notifications.models import (
+    AlertStatus,
+    AlertType,
+    ClientAlert,
+)
+from backend.app.modules.notifications.service import NotificationService
+
+
+class _RecordingConnection:
+    """Captures every SQL string the service sends, and can be told to fail."""
+
+    def __init__(self, *, fetchrow_error: Exception | None = None):
+        self.statements: list[str] = []
+        self.args: list[tuple] = []
+        self._fetchrow_error = fetchrow_error
+
+    async def fetchrow(self, sql, *args):
+        self.statements.append(sql)
+        self.args.append(args)
+        if self._fetchrow_error is not None:
+            raise self._fetchrow_error
+        return {"email": "leader@balizero.com"}
+
+    async def execute(self, sql, *args):
+        self.statements.append(sql)
+        self.args.append(args)
+        return "UPDATE 1"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _pool(conn: _RecordingConnection) -> Mock:
+    pool = Mock()
+    pool.acquire = Mock(return_value=conn)
+    return pool
+
+
+def _service(conn: _RecordingConnection, *, send_ok: bool = True) -> NotificationService:
+    provider = Mock()
+    provider.send_email = AsyncMock(return_value=send_ok)
+    return NotificationService(db_pool=_pool(conn), email_provider=provider)
+
+
+def _alert(alert_type: AlertType) -> ClientAlert:
+    return ClientAlert(
+        id=1,
+        client_id=42,
+        alert_type=alert_type,
+        status=AlertStatus.PENDING,
+        message="m",
+        email_subject="s",
+        email_body="<p>b</p>",
+        created_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+    )
+
+
+class TestTeamLeaderLookupTargetsARealTable:
+    @pytest.mark.asyncio
+    async def test_queries_team_members_and_never_the_absent_users_table(self):
+        conn = _RecordingConnection()
+        service = _service(conn)
+
+        await service._get_team_leader_email(42)
+
+        sql = " ".join(conn.statements).lower()
+        assert "team_members" in sql, "the staff directory is team_members"
+        assert "from users" not in sql, (
+            'relation "users" does not exist in this database — production raised '
+            "UndefinedTableError 362 times in 14 days on this query"
+        )
+
+
+class TestAlertStatusUpdateIsUnambiguous:
+    @pytest.mark.asyncio
+    async def test_status_parameter_is_not_reused_across_two_inferred_types(self):
+        conn = _RecordingConnection()
+        service = _service(conn)
+
+        await service._update_alert_status(_alert(AlertType.BIRTHDAY), AlertStatus.SENT)
+
+        update = next(s for s in conn.statements if "update notification_alerts" in s.lower())
+        normalised = " ".join(update.split())
+        # $1 feeds a VARCHAR(20) column AND a comparison against a text literal.
+        # Without an explicit cast Postgres deduces two different types for one
+        # placeholder and asyncpg raises AmbiguousParameterError.
+        assert "$1 = 'sent'" not in normalised, (
+            "bare $1 compared to a text literal while also assigned to status "
+            "VARCHAR(20) — this is the AmbiguousParameterError seen in production"
+        )
+
+
+class TestAnOptionalBccNeverBlocksTheAlert:
+    @pytest.mark.asyncio
+    async def test_client_is_still_emailed_when_the_team_leader_lookup_fails(self):
+        """A BCC is a nicety; a passport-expiry warning is not."""
+        conn = _RecordingConnection(fetchrow_error=RuntimeError("relation does not exist"))
+        service = _service(conn)
+
+        result = await service.process_alert(
+            _alert(AlertType.PASSPORT_CRITICAL), "client@example.com"
+        )
+
+        service.email_provider.send_email.assert_awaited_once()
+        assert result.success is True
+        sent = service.email_provider.send_email.await_args.kwargs
+        assert sent["to_email"] == "client@example.com"
+        assert not sent.get("bcc"), "the BCC is dropped, the alert still goes out"

--- a/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_service_db_contracts.py
+++ b/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_service_db_contracts.py
@@ -136,3 +136,60 @@ class TestAnOptionalBccNeverBlocksTheAlert:
         sent = service.email_provider.send_email.await_args.kwargs
         assert sent["to_email"] == "client@example.com"
         assert not sent.get("bcc"), "the BCC is dropped, the alert still goes out"
+
+
+class TestOneBadAlertNeverEndsTheRun:
+    """The queue is oldest-first with no LIMIT (``service.py`` ``get_pending_alerts``).
+
+    Before 2026-08-29 ``process_alerts_batch`` had no per-item guard, so the first
+    alert that raised took the whole run down with it — every alert behind it was
+    never attempted, and produced no Sentry event either, because the code that
+    would have raised for them never ran.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_alerts_behind_a_failing_one_are_still_attempted(self):
+        conn = _RecordingConnection()
+        service = _service(conn)
+
+        async def email_for(client_id):
+            if client_id == 1:
+                raise RuntimeError("lookup exploded")
+            return f"c{client_id}@example.com"
+
+        alerts = [_alert(AlertType.BIRTHDAY) for _ in range(3)]
+        for i, alert in enumerate(alerts, start=1):
+            alert.id = i
+            alert.client_id = i
+
+        results = await service.process_alerts_batch(alerts, email_for)
+
+        assert len(results) == 3, "every alert gets a result, none is silently skipped"
+        assert results[0].success is False
+        assert [r.success for r in results[1:]] == [True, True]
+        assert service.email_provider.send_email.await_count == 2
+
+
+class TestRecordingAFailureNeverMasksIt:
+    @pytest.mark.asyncio
+    async def test_a_broken_status_update_does_not_replace_the_real_error(self):
+        """The status UPDATE runs inside the ``except`` that handles the real error.
+
+        When it raised too (the AmbiguousParameterError), it escaped ``process_alert``
+        and became the only thing Sentry ever saw — hiding the cause underneath.
+        """
+        conn = _RecordingConnection()
+        service = _service(conn)
+        service.email_provider.send_email = AsyncMock(side_effect=RuntimeError("smtp down"))
+
+        async def execute_that_fails(sql, *args):
+            raise RuntimeError("ambiguous parameter")
+
+        conn.execute = execute_that_fails
+
+        result = await service.process_alert(_alert(AlertType.BIRTHDAY), "c@example.com")
+
+        assert result.success is False
+        assert "smtp down" in result.error_message, (
+            "the surfaced error must be the real cause, not the bookkeeping failure"
+        )


### PR DESCRIPTION
## What was broken

Two Sentry issues on `bali-zero-7p / nuzantara-backend`, 362 events each over 14 days, both from
`backend/app/modules/notifications/service.py`:

- `UndefinedTableError: relation "users" does not exist` — `_get_team_leader_email` queried a table
  this database has never had. The staff directory is `team_members`; the repo's own identity layer
  says so out loud (`identity/models.py:12-20`, `__tablename__ = "team_members"`), and
  `migration_119_partners.py:27` records the 2026-04-21 cleanup that moved every FK off `users`.
- `AmbiguousParameterError: inconsistent types deduced for parameter $1` — `_update_alert_status`
  used `$1` both as the value of a `VARCHAR(20)` column and as the left side of a comparison against
  a text literal, so Postgres could not infer one type for it.

## What actually hurt the client

The team leader is only a **BCC**. The lookup ran unguarded inside `process_alert`, so a database
error while fetching an optional courtesy copy aborted the whole send: the passport- or visa-expiry
warning never reached the client at all. The `except` handler then hit the second defect while trying
to record the failure, so the row stayed `pending` forever.

The adversarial review then found the larger defect. `process_alerts_batch` had **no per-item guard**,
and `get_pending_alerts` is `ORDER BY created_at ASC` with no `LIMIT` — so the first alert that raised
took the entire run down with it. Every alert behind it was never attempted, and produced **no Sentry
event either**, because the code that would have raised for them never ran. The 362 events are the
visible part; the silent non-delivery behind them is not in Sentry at all.

## The fix

| | |
|---|---|
| `_get_team_leader_email` | joins `team_members`, filters `active IS NOT FALSE`, matches case-insensitively |
| `_update_alert_status` | `$1::text` — one placeholder, one inferred type |
| `process_alert` | the BCC lookup is best-effort; a BCC never blocks an alert |
| `process_alert`'s `except` | the status UPDATE is itself guarded, so bookkeeping cannot mask the real cause |
| `process_alerts_batch` | `_process_one` per alert; a broken alert costs one alert, not the run |

On the case-insensitive join: `admin_team_activity.py:556` does the same join with `ILIKE`. This uses
`lower() = lower()` instead, because `ILIKE` treats `_` as a wildcard and `_` is legal in an email
local part.

## Verification

5 new tests in `test_service_db_contracts.py`, each proven red on the commit before its fix and green
after (the two batch-level tests fail with exactly `RuntimeError: lookup exploded` and
`RuntimeError: ambiguous parameter` escaping, which is the defect itself).

- `118 passed, 1 deselected` on the notifications module
- `ruff check` clean on both files
- import chain OK (`dependencies`, `notifications.service`) — run with the venv, since the pre-commit
  hook uses system python and skips it

The deselected test, `TestSMTPProviderAttachments::test_attachment_payload_decoded_once`, was
reproduced red on a clean detached `origin/main` worktree: it is pre-existing, not from this diff.
Same for the missing `apscheduler` in the local venv (declared in `requirements-prod.txt:127`, not
installed here) — this diff touches no import.

## Not in this PR

`scripts/portal_deadline_watchdog.py:54,65,77` carries three more `JOIN users u` against the same
non-existent relation. Same disease, different organ, its own lane.
