### PR TITLE
fix(consiglio): replace retired DeepSeek member with Kimi K3

### DIFF
--- a/apps/backend-rag/backend/services/research/consiglio_orchestrator.py
+++ b/apps/backend-rag/backend/services/research/consiglio_orchestrator.py
@@ -7,7 +7,12 @@ Current members:
   claude     — Claude Opus 4.7 via OAuth CLI (primary analyst)
   gemini     — Gemini 3.1 Pro (1M ctx) via CLI — gracefully degrades
                on 429 rate limit; result simply omits gemini votes
-  deepseek   — DeepSeek V4 Pro Think Max ($0.01/query, audited exception)
+  kimi       — Kimi K3 via CLI (Moonshot, flat-sub OAuth device-code, no
+               API key). Replaces the retired DeepSeek direct-API member
+               (`deepseek-ask`, called `api.deepseek.com` with
+               `DEEPSEEK_API_KEY` — retired 2026-07-19, pre-auth revoked)
+               — CLAUDE.md §5 names Kimi K3 as the sanctioned replacement
+               refuter/second-opinion seat.
   notebooklm — NotebookLM MCP query — grounded authority validator
 
 If a member fails (network error, rate limit, no binary), the orchestrator
@@ -65,9 +70,9 @@ class ConsiglioResult:
 
 
 class ConsiglioV1:
-    """Runs deliberation across Claude/Gemini/DeepSeek/NotebookLM."""
+    """Runs deliberation across Claude/Gemini/Kimi/NotebookLM."""
 
-    LLMS = ("claude", "gemini", "deepseek", "notebooklm")
+    LLMS = ("claude", "gemini", "kimi", "notebooklm")
 
     def __init__(self, timeout_sec: int = CLAIM_QUERY_TIMEOUT_SEC) -> None:
         self.timeout = timeout_sec
@@ -183,8 +188,8 @@ class ConsiglioV1:
             return ["claude", "-p", full_prompt]
         if llm == "gemini":
             return ["gemini", "-m", "gemini-3.1-pro-preview", "-p", full_prompt]
-        if llm == "deepseek":
-            return ["deepseek-ask", full_prompt]
+        if llm == "kimi":
+            return ["kimi", "-p", full_prompt, "-m", "kimi-code/k3"]
         if llm == "notebooklm":
             return ["nlm-query", full_prompt]
         return None

--- a/apps/backend-rag/backend/tests/unit/services/research/test_consiglio_orchestrator.py
+++ b/apps/backend-rag/backend/tests/unit/services/research/test_consiglio_orchestrator.py
@@ -13,7 +13,7 @@ def test_claim_agreement_count():
     c = ConsiglioClaim(
         key="cadence_instagram_posts_per_day",
         value=1.0,
-        votes={"claude": True, "gemini": True, "deepseek": True, "notebooklm": False},
+        votes={"claude": True, "gemini": True, "kimi": True, "notebooklm": False},
     )
     assert c.agreement_count() == 3
     assert c.is_disputed() is False
@@ -23,7 +23,7 @@ def test_claim_disputed_when_below_3():
     c = ConsiglioClaim(
         key="format_linkedin_authority_tecnico",
         value="long_post",
-        votes={"claude": True, "gemini": True, "deepseek": False, "notebooklm": False},
+        votes={"claude": True, "gemini": True, "kimi": False, "notebooklm": False},
     )
     assert c.agreement_count() == 2
     assert c.is_disputed() is True
@@ -34,7 +34,7 @@ def test_claim_is_disputed_respects_custom_threshold():
     c = ConsiglioClaim(
         key="x",
         value="y",
-        votes={"claude": True, "deepseek": True},  # gemini + notebooklm missing
+        votes={"claude": True, "kimi": True},  # gemini + notebooklm missing
     )
     # With 2 present votes + both True → agreement=2. Default threshold
     # is 3, so this is disputed. But lowered to 2, it's not.
@@ -48,12 +48,12 @@ def test_result_gate_6_passes_when_all_claims_reach_quorum():
         ConsiglioClaim(
             key="k1",
             value="v",
-            votes={"claude": True, "gemini": True, "deepseek": True, "notebooklm": True},
+            votes={"claude": True, "gemini": True, "kimi": True, "notebooklm": True},
         ),
         ConsiglioClaim(
             key="k2",
             value="v",
-            votes={"claude": True, "gemini": True, "deepseek": True, "notebooklm": False},
+            votes={"claude": True, "gemini": True, "kimi": True, "notebooklm": False},
         ),
     ]
     result = ConsiglioResult(claims=claims, meta={})
@@ -65,12 +65,12 @@ def test_result_gate_6_fails_if_any_claim_disputed():
         ConsiglioClaim(
             key="k1",
             value="v",
-            votes={"claude": True, "gemini": True, "deepseek": True, "notebooklm": False},
+            votes={"claude": True, "gemini": True, "kimi": True, "notebooklm": False},
         ),
         ConsiglioClaim(
             key="k2",
             value="v",
-            votes={"claude": True, "gemini": False, "deepseek": False, "notebooklm": False},
+            votes={"claude": True, "gemini": False, "kimi": False, "notebooklm": False},
         ),
     ]
     result = ConsiglioResult(claims=claims, meta={})
@@ -84,12 +84,12 @@ def test_result_gate_6_adapts_to_available_voters():
         ConsiglioClaim(
             key="k1",
             value="v",
-            votes={"claude": True, "deepseek": True},
+            votes={"claude": True, "kimi": True},
         ),
         ConsiglioClaim(
             key="k2",
             value="v",
-            votes={"claude": True, "deepseek": False},
+            votes={"claude": True, "kimi": False},
         ),
     ]
     result = ConsiglioResult(claims=claims, meta={"active_llms": 2})

--- a/apps/backend-rag/backend/tests/unit/services/research/test_no_deepseek_regression.py
+++ b/apps/backend-rag/backend/tests/unit/services/research/test_no_deepseek_regression.py
@@ -1,0 +1,169 @@
+"""Regression lint: no live DeepSeek routing left in ConsiglioV1.
+
+ConsiglioV1's fourth member (`consiglio_orchestrator.py::ConsiglioV1`) used
+to shell out to a local `deepseek-ask` binary — the direct-API path, retired
+2026-07-19 (Zero: pre-authorization revoked, key balance dead — HTTP-402).
+Replaced by ``kimi -p ... -m kimi-code/k3`` (CLAUDE.md §5: "replacement
+refuter seat is Kimi K3"), same shape as the council/oracle voice system's
+swap in `test_no_deepseek_regression.py` under
+`backend/tests/services/council/`.
+
+Same AST-based approach as that sibling guard, deliberately not a bare
+substring match (cicatrix family #3 "guard-over-match", scar W121): a
+docstring correctly recording *why* the retirement happened must not trip
+this guard, only a live class/function name, import, or non-docstring
+string literal referencing the retired binary/URL/env var.
+
+Scope: this one file, not a directory scan — ConsiglioV1 has exactly one
+production file and one test file, both listed explicitly below (unlike the
+council/cognitive guard, there is no risk of a sibling module in this
+directory silently escaping coverage because there are no sibling modules).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_RESEARCH_DIR = Path(__file__).resolve().parents[4] / "services" / "research"
+
+_GUARDED_FILES = [
+    _RESEARCH_DIR / "consiglio_orchestrator.py",
+]
+
+_FORBIDDEN_BINARY = "deepseek-ask"
+_FORBIDDEN_URL = "api.deepseek.com"
+_FORBIDDEN_ENV = "DEEPSEEK_API_KEY"
+_FORBIDDEN_TOKENS = (_FORBIDDEN_BINARY, _FORBIDDEN_URL, _FORBIDDEN_ENV)
+
+_DocstringHolder = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _docstring_node_ids(tree: ast.AST) -> set[int]:
+    """id() of every string-constant AST node in docstring position — the
+    same convention ``ast.get_docstring`` uses. Excluded from the scan."""
+    ids: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, _DocstringHolder):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            ids.add(id(first.value))
+    return ids
+
+
+def _scan_source(source: str, label: str) -> list[str]:
+    """Return a list of human-readable violation strings (empty = clean)."""
+    tree = ast.parse(source, filename=label)
+    docstring_ids = _docstring_node_ids(tree)
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if "deepseek" in node.name.lower():
+                violations.append(
+                    f"{label}: {type(node).__name__} named {node.name!r} "
+                    "reintroduces a DeepSeek code path"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and "deepseek" in node.module.lower():
+                violations.append(
+                    f"{label}: import from module {node.module!r} "
+                    f"(line {getattr(node, 'lineno', '?')}) reintroduces a "
+                    "DeepSeek code path"
+                )
+            for alias in node.names:
+                if "deepseek" in alias.name.lower():
+                    violations.append(
+                        f"{label}: imports {alias.name!r} "
+                        f"(line {getattr(node, 'lineno', '?')})"
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if "deepseek" in alias.name.lower():
+                    violations.append(
+                        f"{label}: imports module {alias.name!r} "
+                        f"(line {getattr(node, 'lineno', '?')})"
+                    )
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if id(node) in docstring_ids:
+                continue  # explanatory prose — allowed
+            for token in _FORBIDDEN_TOKENS:
+                if token in node.value:
+                    violations.append(
+                        f"{label}: live string literal contains {token!r} "
+                        f"(line {getattr(node, 'lineno', '?')})"
+                    )
+
+    return violations
+
+
+# ── Guilt: real reintroduction must be caught ──────────────────────────
+
+
+@pytest.mark.parametrize("path", _GUARDED_FILES, ids=lambda p: p.name)
+def test_no_live_deepseek_token_in_guarded_files(path: Path) -> None:
+    assert path.exists(), f"guarded file moved/renamed: {path}"
+    source = path.read_text(encoding="utf-8")
+    violations = _scan_source(source, str(path))
+    assert violations == [], "\n".join(violations)
+
+
+def test_positive_control_binary_literal_is_caught() -> None:
+    """A live command-list literal invoking the retired `deepseek-ask`
+    binary must be flagged, not silently pass."""
+    source = f'CMD = ["{_FORBIDDEN_BINARY}", prompt]\n'
+    violations = _scan_source(source, "synthetic_cmd.py")
+    assert any(_FORBIDDEN_BINARY in v for v in violations)
+
+
+def test_positive_control_url_literal_is_caught() -> None:
+    source = f'API_URL = "https://{_FORBIDDEN_URL}/v1/chat/completions"\n'
+    violations = _scan_source(source, "synthetic_url.py")
+    assert any(_FORBIDDEN_URL in v for v in violations)
+
+
+def test_positive_control_env_var_literal_is_caught() -> None:
+    source = 'import os\nkey = os.environ.get("DEEPSEEK_API_KEY")\n'
+    violations = _scan_source(source, "synthetic_env.py")
+    assert any(_FORBIDDEN_ENV in v for v in violations)
+
+
+# ── Innocence: correct historical prose must NOT be caught ─────────────
+
+
+def test_module_docstring_mentioning_deepseek_is_allowed() -> None:
+    """A module docstring recording the retirement (exactly what this
+    repo's real file does) must not trip the guard."""
+    source = (
+        '"""DeepSeek V4 Pro was RETIRED 2026-07-19. The deepseek-ask '
+        'binary and api.deepseek.com / DEEPSEEK_API_KEY are the old dead '
+        'path — replaced by Kimi K3."""\n'
+        "\n"
+        "def do_nothing() -> None:\n"
+        "    pass\n"
+    )
+    violations = _scan_source(source, "synthetic_docstring.py")
+    assert violations == []
+
+
+def test_comment_mentioning_deepseek_is_allowed() -> None:
+    """`ast` never sees ``#`` comments at all, so they can never trip this
+    guard — asserted here so the invariant is explicit, not incidental."""
+    source = (
+        "# deepseek-ask used to live here (api.deepseek.com, "
+        "DEEPSEEK_API_KEY) — retired 2026-07-19, replaced by Kimi K3.\n"
+        "def do_nothing() -> None:\n"
+        "    pass\n"
+    )
+    violations = _scan_source(source, "synthetic_comment.py")
+    assert violations == []


### PR DESCRIPTION
## What

Replaces ConsiglioV1's fourth voting member (`apps/backend-rag/backend/services/research/consiglio_orchestrator.py`) from the retired direct DeepSeek door to Kimi K3 — same shape as the council/oracle voice-system swap in #5203.

## Detail

`ConsiglioV1._build_cmd()` shelled out to a local `deepseek-ask` binary for the "deepseek" member, wired (per the module docstring) to the direct DeepSeek API (`api.deepseek.com` + `DEEPSEEK_API_KEY`) — retired 2026-07-19, pre-authorization revoked. No `deepseek-ask` binary exists anywhere in this repo or on this machine's PATH (`which deepseek-ask` → not found; no such script tracked in the repo) — this member was already non-functional before this fix, silently voting nothing every time it ran (the orchestrator's `deliberate()` catches the subprocess `FileNotFoundError` per-member and proceeds with whichever voices responded — Gate 6's `active_llms` count would have already reflected 3/4, not the intended 4/4).

Replaced with `kimi -p <prompt> -m kimi-code/k3` — CLAUDE.md §5 names Kimi K3 as the sanctioned refuter/second-opinion seat, armed on all three fleet machines since 2026-07-19.

## Changes

- `consiglio_orchestrator.py`: `LLMS` tuple `"deepseek"` → `"kimi"`, `_build_cmd`'s deepseek branch → the Kimi CLI invocation, module/class docstrings updated to name the swap and cite the retirement.
- `test_consiglio_orchestrator.py`: renamed all 9 `"deepseek"` vote-dict labels to `"kimi"` — these were always arbitrary proponent-name strings in test fixtures, never exercising the real `_build_cmd` path, so this is a pure consistency rename.
- New `test_no_deepseek_regression.py`: AST-based regression guard, same pattern as the council/oracle sibling guard on #5203 — flags a live class/function name, import, or non-docstring string literal referencing `deepseek-ask`/`api.deepseek.com`/`DEEPSEEK_API_KEY`, exempts docstrings/comments (guilt+innocence tests for both). **Live drill performed**: injected a real `["deepseek-ask", ...]` literal into the actual `consiglio_orchestrator.py`, confirmed the guard goes red, restored the file, confirmed byte-identical to a pre-drill backup and green again.

## No ledger row

Kimi is already armed fleet-wide (CLAUDE.md §5, 2026-07-19) — this PR is inert-to-live with no operator step required, unlike surface (3)'s TP1 re-point (#5207).

## Testing

```
PYTHONPATH=. pytest backend/tests/unit/services/research/ -q
```
58 passed. `ruff check` clean on all three touched files. Import-chain OK.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
