### PR TITLE
fix(ci): required-context guard was blind to paths-ignore, a merge_group-only trigger, and types: narrowing

### DIFF
--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -679,7 +679,7 @@
       }
     },
     "required_workflow_conformance": {
-      "_doc": "Merge-OS v2 Wave 0 trap-disarm (research/operations/2026-08-10-merge-os-v2-submission-system.md §4 Wave 0, Codex F12). scripts/ci/check_required_workflow_conformance.py reads infra/required.d/contexts.json and fails if a required context's defining workflow lacks a merge_group: trigger or carries a top-level pull_request.paths: filter — the exact defect docs-sync.yml and migration-lint.yml shipped (cured same PR): a required check gated by a top-level paths: filter never even starts a run on an innocent PR, so GitHub shows it 'Expected — waiting' forever. Each check_* function IS a guard in the superscar #3 sense, same shape as evidence_pack_lint.py/wr2_editorial_pregate.py.",
+      "_doc": "Merge-OS v2 Wave 0 trap-disarm (research/operations/2026-08-10-merge-os-v2-submission-system.md §4 Wave 0, Codex F12), extended 2026-08-29 (L06-PR1 trigger-symmetry, two cross-family refuter rounds). scripts/ci/check_required_workflow_conformance.py reads infra/required.d/contexts.json and fails if a required context's defining workflow: (2) lacks a merge_group: trigger; (3) lacks a pull_request: trigger entirely; (4) carries a top-level paths:/paths-ignore: filter under on.pull_request (the BRANCH axis is a declared, deliberately-unbuilt scope limit \u2014 flagging branches:/branches-ignore: by key-presence over-matched the innocent branches: [main], so the rule was withdrawn pending a directional test against the protected branch); or (5) narrows on.pull_request.types: without both opened and synchronize — each is a shape where a required check never starts a run for some legitimate PR and hangs 'Expected — waiting' forever (the exact defect docs-sync.yml and migration-lint.yml shipped, cured same PR as rule 4's paths half). No ALLOWLIST escape hatch — removed 2026-08-29: it was empty, unreachable, and silenced rules 2-5 together for any context sharing its workflow_file, wider than its own stated justification. Each check_* function IS a guard in the superscar #3 sense, same shape as evidence_pack_lint.py/wr2_editorial_pregate.py.",
       "source": "scripts/ci/check_required_workflow_conformance.py",
       "census": {
         "method": "ast-def-prefix",
@@ -692,12 +692,40 @@
           "guilt": ["test_guilt_missing_merge_group_flagged"],
           "innocence": ["test_innocence_merge_group_present_passes"]
         },
-        "check_no_pull_request_paths_filter": {
-          "scar": ["Codex-F12"],
-          "guilt": ["test_guilt_toplevel_pr_paths_filter_flagged"],
+        "check_pull_request_trigger_present": {
+          "scar": ["Codex-F12", "L06-PR1"],
+          "guilt": ["test_guilt_missing_pull_request_trigger_flagged"],
+          "innocence": [
+            "test_innocence_bare_pull_request_passes",
+            "test_innocence_pull_request_with_types_passes"
+          ]
+        },
+        "check_no_pull_request_trigger_filters": {
+          "scar": ["Codex-F12", "L06-PR1"],
+          "guilt": [
+            "test_guilt_toplevel_pr_paths_filter_flagged",
+            "test_guilt_toplevel_pr_paths_ignore_filter_flagged",
+            "test_guilt_both_paths_and_paths_ignore_flagged_once_each"
+          ],
           "innocence": [
             "test_innocence_pull_request_without_paths_passes",
+            "test_innocence_pull_request_branches_filter_is_out_of_scope",
             "test_innocence_push_paths_filter_is_out_of_scope"
+          ]
+        },
+        "check_pull_request_types_include_opened_and_synchronize": {
+          "scar": ["L06-PR1"],
+          "guilt": [
+            "test_guilt_types_missing_synchronize_flagged",
+            "test_guilt_types_missing_opened_flagged",
+            "test_guilt_types_missing_both_flagged"
+          ],
+          "innocence": [
+            "test_innocence_types_with_opened_and_synchronize_passes",
+            "test_innocence_types_with_all_three_passes",
+            "test_innocence_bare_pull_request_no_types_key_passes",
+            "test_innocence_pull_request_dict_without_types_key_passes",
+            "test_innocence_malformed_types_not_a_list_out_of_scope"
           ]
         },
         "check_context_workflow_file_exists": {

--- a/scripts/ci/check_required_workflow_conformance.py
+++ b/scripts/ci/check_required_workflow_conformance.py
@@ -29,8 +29,36 @@ snapshot from scripts/ci/snapshot_required_contexts.py):
        merge-queue run at all, which either stalls the queue (nothing to
        report) or silently excludes the check from queue enforcement,
        neither of which is a state a required check should be in;
-    3. its `on.pull_request` sub-block carries NO top-level `paths:` key —
-       the exact Codex F12 trap.
+    3. its `on:` block includes a `pull_request:` trigger at all — a
+       required context that only fires on `merge_group` reports "Expected
+       — waiting for status" on every ordinary PR view forever (same W69
+       shape as rule 4, opposite trigger). Added 2026-08-29 (L06-PR1
+       trigger-symmetry): the live tree had nothing to catch this at the
+       time — all 8 required-context-producing workflows already declare
+       both triggers — but nothing PREVENTED a future one from declaring
+       merge_group-only, and rule 4 alone is silent about that shape (an
+       absent `pull_request` block is not a `paths:` filter);
+    4. its `on.pull_request` sub-block carries NO top-level `paths:` or
+       `paths-ignore:` key — the exact Codex F12 trap. `paths-ignore` was
+       closed 2026-08-29 alongside rule 3; the earlier check matched only
+       the literal token `paths`, so the same "innocent PR never starts a
+       run" defect sailed straight through under the sibling key. The
+       BRANCH axis is deliberately not judged here — see its own DECLARED
+       SCOPE LIMIT below;
+    5. if its `on.pull_request` sub-block declares a `types:` list, that
+       list includes both `opened` AND `synchronize` — added 2026-08-29.
+       Without `synchronize`, a push to an already-open PR never starts a
+       new run on the new head, so this required context can be satisfied
+       on an earlier head SHA and then simply absent on the SHA that
+       actually merges; without `opened`, a PR that is opened and never
+       pushed to again never triggers this workflow at all. A bare
+       `pull_request:` (no `types:` key present at all) declares GitHub's
+       default type set and is unaffected by this rule — deliberately NOT
+       requiring `reopened` too: this repo has been bitten by over-match
+       nine times (superscar #3), and every live `types:` declaration
+       already lists all three, so requiring only the two keys that are
+       load-bearing for the trap this rule exists to catch is the
+       narrower, safer rule.
 
   For every context whose `workflow_file` is null (declared not
   workflow-produced — the allowlist path), the registered
@@ -45,17 +73,76 @@ snapshot from scripts/ci/snapshot_required_contexts.py):
   a human/session who checked, not silently accepted.
 
 DECLARED SCOPE LIMIT (residual risk, not hidden — same style as
-scripts/lint_workflow_timeout_floor.py's own declared limit): rule 3 checks
-`on.pull_request.paths` ONLY, never `on.push.paths`. A `push:`-triggered run
-targets `main` directly, after the PR already merged — it never gates
-whether a PR's required context resolves, so a `paths:` filter there is a
-different, legitimate cost optimization (skip re-running on an irrelevant
-push to main), not the Codex F12 trap. Checked empirically against this
-repo's OWN required-context workflows at authoring time (2026-08-11): 12 of
-them carry a `push.paths` filter and would ALL false-positive under a
-scope that didn't draw this line — none of them carry a `pull_request.paths`
-filter. `merge_group:` itself does not support a `paths:` sub-key in GitHub
-Actions at all, so there is nothing to check there.
+scripts/lint_workflow_timeout_floor.py's own declared limit): rule 4 checks
+`on.pull_request.{paths,paths-ignore}` ONLY, never `on.push.paths`. A `push:`-triggered run targets `main` directly,
+after the PR already merged — it never gates whether a PR's required
+context resolves, so a filter there is a different, legitimate cost
+optimization (skip re-running on an irrelevant push to main), not the Codex
+F12 trap. RE-MEASURED 2026-08-29 (the 2026-08-11 authoring count of "12"
+below was never reproducible at that commit either and is corrected, not
+merely updated — it overstated the live surface by 6x): 2 of the 8
+required-context-producing workflows (`guard-conformance.yml`,
+`organ-conformance.yml`) carry a `push.paths` filter; neither of those two
+also carries `on.pull_request.paths`, so neither would false-positive under
+this scope limit even before this correction. `merge_group:` itself does
+not support a `paths:` sub-key in GitHub Actions at all, so there is
+nothing to check there.
+
+DECLARED SCOPE LIMIT — the BRANCH axis is not judged, deliberately, and
+this is the more instructive of the limits. A `branches:` /
+`branches-ignore:` filter under `on.pull_request` CAN break a required
+context exactly the way `paths:` does: `branches: [develop]` never starts a
+run for a PR to `main`, so the context hangs "Expected — waiting" forever.
+A first cut of rule 4 therefore flagged both keys by PRESENCE, and a second
+cross-family refuter round (2026-08-29) proved that an over-match —
+`branches: [main]` fires on EVERY PR to the protected branch and is
+perfectly innocent, `branches-ignore: [gh-pages]` likewise, yet both were
+reported identically to the genuinely-broken `branches: [develop]`
+(measured: all four shapes returned exactly one violation). Shipping it
+would have been superscar #3's TENTH instance in this repo, inside the very
+guard whose rule 5 cites the previous nine. The rule was WITHDRAWN rather
+than patched twice in one PR (Rule 8: a correction that is itself wrong
+means the surface is under-specified — write the spec, do not stack a third
+fix).
+
+The spec, recorded so the follow-up does not re-derive it: the verdict must
+be DIRECTIONAL against the protected branch, which
+`infra/required.d/contexts.json` already carries as its top-level `branch`
+field ("main" today). `branches:` is guilty only when NO pattern in the list
+can match the protected branch; `branches-ignore:` only when SOME pattern
+CAN. That needs GitHub's branch-pattern glob semantics (`releases/**`, `!`
+negation, `*` not crossing `/`) implemented and tested in their own right —
+a real sub-problem with its own trap surface, not a key-presence check.
+Until it lands, `branches: [develop]` on a required workflow is a live,
+KNOWN, undetected defect class: declared here, not missed.
+
+A third, pre-existing declared scope limit (load_on_block's own contract
+— see its docstring below): `on: [pull_request, merge_group]` (list form)
+and `on: pull_request` (bare scalar form) are both legal GitHub Actions
+syntax, but `load_on_block` only recognizes a MAPPING `on:` block — either
+form collapses to `{}`, which every rule above then reads as "no triggers
+declared at all", over-reporting a workflow that actually declares BOTH
+triggers correctly as failing rules 2 and 3. Not a silent miss (the failure
+direction is loud, not blind) and not live today — none of the 8
+required-context-producing workflows uses either form (verified 2026-08-29)
+— but a false positive waiting for the first workflow author who writes
+`on:` as a list or a bare scalar.
+
+SCAR NOTE (L06-PR1, 2026-08-29 — measured this turn, do NOT "fix" this back
+toward symmetric path filters on both triggers). A broader ask ("assert
+identical path semantics on pull_request and merge_group") is
+UNIMPLEMENTABLE by construction: `merge_group` does not accept `paths:` at
+all, and this repo's own actionlint (a required context) refuses a workflow
+that tries —
+
+    "paths" filter is not available for merge_group event.
+    it is only for push, pull_request, pull_request_target events [events]
+
+— reproduced live against actionlint 1.7.12 at authoring time. Any workflow
+built to satisfy that literal wording would itself fail a required check.
+Rules 2-5 above are the achievable invariant that serves the actual danger
+(trap #9/Codex F12's head-green/queue-red split), not a weakened version of
+the broader ask.
 
 Usage:
     python3 scripts/ci/check_required_workflow_conformance.py
@@ -130,13 +217,75 @@ def check_merge_group_trigger(on_block: dict[str, Any]) -> list[str]:
     return []
 
 
-def check_no_pull_request_paths_filter(on_block: dict[str, Any]) -> list[str]:
-    pr_block = on_block.get("pull_request")
-    if isinstance(pr_block, dict) and "paths" in pr_block:
+def check_pull_request_trigger_present(on_block: dict[str, Any]) -> list[str]:
+    """Added 2026-08-29 (L06-PR1). `"pull_request" not in on_block` means
+    the key is ABSENT entirely — distinct from `on_block["pull_request"]
+    is None`, which is the ordinary bare `pull_request:` (declared, no
+    filters). `on_block["pull_request"]` may ALSO be a dict that narrows
+    via `types:` (3 of the 8 required-context-producing workflows do, all
+    with `[opened, synchronize, reopened]`) — either shape means the
+    trigger is genuinely present and must keep passing this check;
+    check_pull_request_types_include_opened_and_synchronize is the separate
+    rule that judges what's INSIDE a `types:` list, not whether the
+    `pull_request:` key exists at all."""
+    if "pull_request" not in on_block:
         return [
-            "top-level `paths:` filter under `on.pull_request` — an innocent PR "
-            "outside those paths never starts a run, so this required context "
-            "hangs 'Expected — waiting' forever (Codex F12)"
+            "missing `pull_request:` trigger — a merge-queue run can satisfy "
+            "this context while a direct PR view of it stays 'Expected — "
+            "waiting for status' forever (W69, opposite trigger of rule 4)"
+        ]
+    return []
+
+
+def check_no_pull_request_trigger_filters(on_block: dict[str, Any]) -> list[str]:
+    """Renamed 2026-08-29 (was check_no_pull_request_paths_filter) — it
+    judges a KEY SET now, not the single literal token `paths`, and the old
+    name would go stale the moment that set grows again (the branch axis is
+    the declared, still-unbuilt candidate)."""
+    pr_block = on_block.get("pull_request")
+    if not isinstance(pr_block, dict):
+        return []
+    violations: list[str] = []
+    for key in ("paths", "paths-ignore"):
+        if key in pr_block:
+            violations.append(
+                f"top-level `{key}:` filter under `on.pull_request` — an innocent PR "
+                "outside that filter never starts a run, so this required context "
+                "hangs 'Expected — waiting' forever (Codex F12)"
+            )
+    return violations
+
+
+def check_pull_request_types_include_opened_and_synchronize(
+    on_block: dict[str, Any],
+) -> list[str]:
+    """Added 2026-08-29. A `types:` list that narrows the default set is
+    only a defect if it drops `opened` or `synchronize` — those two are the
+    pair a required workflow depends on to ever run at all (`opened`) and
+    to run again on the SHA that actually merges (`synchronize`).
+    Deliberately does NOT require `reopened` too: every live `types:`
+    declaration in this repo already lists all three, so requiring only
+    the two that are load-bearing for the trap this rule exists to catch
+    is the narrower, safer rule (superscar #3: nine prior over-matches in
+    this repo). A `types:` key present but not a list, or absent entirely
+    (bare `pull_request:`), is out of scope for this rule — the former is
+    a different malformed-workflow failure actionlint already catches, the
+    latter means "GitHub's default types", both fine and must keep
+    passing."""
+    pr_block = on_block.get("pull_request")
+    if not isinstance(pr_block, dict):
+        return []
+    types = pr_block.get("types")
+    if not isinstance(types, list):
+        return []
+    missing = [t for t in ("opened", "synchronize") if t not in types]
+    if missing:
+        return [
+            f"`on.pull_request.types` narrows to {types!r} without "
+            f"{' and '.join(missing)} — a push to an open PR whose types list "
+            "omits `synchronize` never starts a new run on the new head, and "
+            "one that omits `opened` never triggers on a PR that is opened "
+            "and never pushed to again"
         ]
     return []
 
@@ -204,9 +353,13 @@ def evaluate(contexts_path: Path, repo_root: Path) -> tuple[list[str], int]:
             violations.append(f"[{name}] workflow {workflow_file} could not be parsed")
             continue
 
-        for v in check_merge_group_trigger(on_block):
-            violations.append(f"[{name}] {workflow_file}: {v}")
-        for v in check_no_pull_request_paths_filter(on_block):
+        rule_violations = (
+            check_merge_group_trigger(on_block)
+            + check_pull_request_trigger_present(on_block)
+            + check_no_pull_request_trigger_filters(on_block)
+            + check_pull_request_types_include_opened_and_synchronize(on_block)
+        )
+        for v in rule_violations:
             violations.append(f"[{name}] {workflow_file}: {v}")
 
     return (violations, len(contexts))
@@ -231,7 +384,11 @@ def main(argv: list[str] | None = None) -> int:
     for v in violations:
         print(f"  ✗ {v}")
     if not violations:
-        print("  ✓ every required context's defining workflow has merge_group + no top-level pull_request paths:")
+        print(
+            "  ✓ every required context's defining workflow has merge_group + pull_request "
+            "(no top-level paths:/paths-ignore:, and types: includes "
+            "opened+synchronize when narrowed)"
+        )
     return 1 if violations else 0
 
 

--- a/scripts/tests/test_check_required_workflow_conformance.py
+++ b/scripts/tests/test_check_required_workflow_conformance.py
@@ -8,6 +8,28 @@ this is the guard's own guilt proof cited in the Merge-OS v2 Wave 0 PR body
 docs-sync.yml / migration-lint.yml FAILED this guard before their cure in
 this same PR, and PASS it after.
 
+EXTENDED 2026-08-29 (L06-PR1 trigger-symmetry, this repo's own re-derivation
+of the same trap): rules 3 (pull_request trigger present at all) and 4's
+`paths-ignore` half were added here rather than in a new, parallel script —
+the module's own docstring already documented this exact invariant (rule 2
+merge_group + rule 4-then-3 pull_request/paths) against this exact
+`infra/required.d/contexts.json` input; a second script asserting the same
+thing against the same file would be superscar #-family hypertrophy, not a
+new antidote. See that module's SCAR NOTE for why the broader "identical
+path filters on both triggers" ask is unimplementable (actionlint rejects
+`paths:` under `merge_group`).
+
+EXTENDED AGAIN 2026-08-29 (same day, second cross-family refuter round on
+this exact guard): two blind non-Anthropic refuters independently found the
+first cut of the trigger-symmetry rules still under-matched. Added here:
+rule 4's `paths-ignore` half (the first cut matched only the literal token
+`paths`) and a new rule 5 (`types:` narrowing that drops `opened` or `synchronize`
+off a required workflow's `on.pull_request`). The same round also found and
+removed the `ALLOWLIST` escape-hatch dict this file used to test: it was
+empty, unreachable, and — per its own comment — silenced BOTH rule 2 and
+rule 3/4/5 violations for any context sharing its `workflow_file`, wider
+than its stated justification and dead code the moment it shipped.
+
 Run:  python3 -m pytest scripts/tests/test_check_required_workflow_conformance.py -q
 """
 from __future__ import annotations
@@ -41,32 +63,159 @@ def test_innocence_merge_group_present_passes():
     assert mod.check_merge_group_trigger(on_block) == []
 
 
-# --------------------------------------------------------- check_no_pull_request_paths_filter
+# ------------------------------------------------------- check_pull_request_trigger_present
+
+
+def test_guilt_missing_pull_request_trigger_flagged():
+    # merge_group-only: a queue entry could satisfy this context while a
+    # direct PR view of it hangs "Expected -- waiting" forever (W69).
+    on_block = {"merge_group": None, "push": {"branches": ["main"]}}
+    violations = mod.check_pull_request_trigger_present(on_block)
+    assert violations
+    assert "pull_request" in violations[0]
+
+
+def test_innocence_bare_pull_request_passes():
+    # {"pull_request": None} is the ordinary `pull_request:` bare-key shape
+    # every real required workflow uses -- key PRESENT, value null. Must
+    # NOT be confused with the key being absent entirely (the guilt case
+    # above).
+    on_block = {"pull_request": None, "merge_group": None}
+    assert mod.check_pull_request_trigger_present(on_block) == []
+
+
+def test_innocence_pull_request_with_types_passes():
+    on_block = {"pull_request": {"types": ["opened", "synchronize", "reopened"]}, "merge_group": None}
+    assert mod.check_pull_request_trigger_present(on_block) == []
+
+
+# --------------------------------------------------------- check_no_pull_request_trigger_filters
 
 
 def test_guilt_toplevel_pr_paths_filter_flagged():
     # The exact shape docs-sync.yml/migration-lint.yml shipped before this PR.
     on_block = {"pull_request": {"paths": ["scripts/docs_sync.py"]}, "merge_group": None}
-    violations = mod.check_no_pull_request_paths_filter(on_block)
+    violations = mod.check_no_pull_request_trigger_filters(on_block)
     assert violations
     assert "paths" in violations[0]
 
 
+def test_guilt_toplevel_pr_paths_ignore_filter_flagged():
+    # Added 2026-08-29 (L06-PR1): the earlier check only matched the literal
+    # token `paths`, so `paths-ignore` sailed through the exact same trap.
+    on_block = {"pull_request": {"paths-ignore": ["docs/**"]}, "merge_group": None}
+    violations = mod.check_no_pull_request_trigger_filters(on_block)
+    assert violations
+    assert "paths-ignore" in violations[0]
+
+
+
+
+
+
+def test_guilt_both_paths_and_paths_ignore_flagged_once_each():
+    on_block = {
+        "pull_request": {"paths": ["a/**"], "paths-ignore": ["b/**"]},
+        "merge_group": None,
+    }
+    violations = mod.check_no_pull_request_trigger_filters(on_block)
+    assert len(violations) == 2
+    joined = " ".join(violations)
+    assert "paths-ignore" in joined and "`paths:`" in joined
+
+
+def test_innocence_pull_request_branches_filter_is_out_of_scope():
+    """DECLARED SCOPE LIMIT, deliberate (see the checker's docstring): a
+    `branches:`/`branches-ignore:` filter under `on.pull_request` is NOT
+    judged here. A first cut of this rule did flag them by key-presence and
+    a second refuter round proved that an over-match: `branches: [main]`
+    fires on every PR to the protected branch and is perfectly innocent,
+    yet was flagged identically to the genuinely-broken `branches:
+    [develop]`. Deciding it needs the DIRECTIONAL test against the
+    protected branch this fixture pins as still-unbuilt."""
+    innocent = {"pull_request": {"branches": ["main"]}, "merge_group": None}
+    guilty_shape = {"pull_request": {"branches": ["develop"]}, "merge_group": None}
+    assert mod.check_no_pull_request_trigger_filters(innocent) == []
+    # and the genuinely-broken shape is ALSO unjudged today — that is the
+    # declared gap, recorded so a future session sees it is known, not missed.
+    assert mod.check_no_pull_request_trigger_filters(guilty_shape) == []
+
+
 def test_innocence_pull_request_without_paths_passes():
     on_block = {"pull_request": None, "merge_group": None}
-    assert mod.check_no_pull_request_paths_filter(on_block) == []
+    assert mod.check_no_pull_request_trigger_filters(on_block) == []
 
 
 def test_innocence_push_paths_filter_is_out_of_scope():
     # Declared scope limit (docstring): on.push.paths is a different,
-    # legitimate optimization, never the Codex F12 trap. 12 real required
-    # workflows in this repo carry exactly this shape.
+    # legitimate optimization, never the Codex F12 trap. RE-MEASURED
+    # 2026-08-29: 2 of 8 real required-context workflows in this repo
+    # carry exactly this shape (guard-conformance.yml, organ-
+    # conformance.yml) -- the 2026-08-11 authoring docstring's "12" was
+    # never reproducible and is corrected in the module docstring too.
     on_block = {
         "pull_request": {},
         "merge_group": None,
         "push": {"branches": ["main"], "paths": ["scripts/**"]},
     }
-    assert mod.check_no_pull_request_paths_filter(on_block) == []
+    assert mod.check_no_pull_request_trigger_filters(on_block) == []
+
+
+# ------------------------------ check_pull_request_types_include_opened_and_synchronize
+
+
+def test_guilt_types_missing_synchronize_flagged():
+    on_block = {"pull_request": {"types": ["opened"]}, "merge_group": None}
+    violations = mod.check_pull_request_types_include_opened_and_synchronize(on_block)
+    assert violations
+    assert "synchronize" in violations[0]
+
+
+def test_guilt_types_missing_opened_flagged():
+    on_block = {"pull_request": {"types": ["synchronize"]}, "merge_group": None}
+    violations = mod.check_pull_request_types_include_opened_and_synchronize(on_block)
+    assert violations
+    assert "opened" in violations[0]
+
+
+def test_guilt_types_missing_both_flagged():
+    on_block = {"pull_request": {"types": ["labeled"]}, "merge_group": None}
+    violations = mod.check_pull_request_types_include_opened_and_synchronize(on_block)
+    assert violations
+    assert "opened" in violations[0] and "synchronize" in violations[0]
+
+
+def test_innocence_types_with_opened_and_synchronize_passes():
+    on_block = {"pull_request": {"types": ["opened", "synchronize"]}, "merge_group": None}
+    assert mod.check_pull_request_types_include_opened_and_synchronize(on_block) == []
+
+
+def test_innocence_types_with_all_three_passes():
+    # Every live `types:` declaration in this repo uses exactly this shape
+    # (tests.yml, security.yml, harness-floor.yml, verified 2026-08-29) --
+    # deliberately NOT requiring `reopened` (superscar #3: over-match).
+    on_block = {
+        "pull_request": {"types": ["opened", "synchronize", "reopened"]},
+        "merge_group": None,
+    }
+    assert mod.check_pull_request_types_include_opened_and_synchronize(on_block) == []
+
+
+def test_innocence_bare_pull_request_no_types_key_passes():
+    on_block = {"pull_request": None, "merge_group": None}
+    assert mod.check_pull_request_types_include_opened_and_synchronize(on_block) == []
+
+
+def test_innocence_pull_request_dict_without_types_key_passes():
+    on_block = {"pull_request": {}, "merge_group": None}
+    assert mod.check_pull_request_types_include_opened_and_synchronize(on_block) == []
+
+
+def test_innocence_malformed_types_not_a_list_out_of_scope():
+    # types: present but not a list is a different, actionlint-shaped
+    # malformed-workflow failure -- out of scope for this rule by design.
+    on_block = {"pull_request": {"types": "opened"}, "merge_group": None}
+    assert mod.check_pull_request_types_include_opened_and_synchronize(on_block) == []
 
 
 # ----------------------------------------------------- check_context_workflow_file_exists
@@ -172,6 +321,93 @@ def test_innocence_evaluate_passes_the_cured_shape(tmp_path):
     assert violations == []
 
 
+def test_guilt_evaluate_flags_merge_group_only_workflow(tmp_path):
+    """A required workflow that declares merge_group but never pull_request
+    at all -- rule 3, added 2026-08-29. Not the docs-sync historical shape
+    (which had pull_request+paths, no merge_group); this is the mirror
+    trigger missing entirely."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "queue-only.yml").write_text(
+        "on:\n  merge_group:\n  push:\n    branches: [main]\njobs:\n"
+        "  check:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    contexts_path = _write_contexts(
+        tmp_path,
+        [{"name": "queue-only-check", "workflow_file": ".github/workflows/queue-only.yml"}],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert len(violations) == 1
+    assert "pull_request" in violations[0]
+
+
+def test_guilt_evaluate_flags_paths_ignore_end_to_end(tmp_path):
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "half-cured.yml").write_text(
+        "on:\n  pull_request:\n    paths-ignore:\n      - docs/**\n  merge_group:\n"
+        "jobs:\n  check:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    contexts_path = _write_contexts(
+        tmp_path,
+        [{"name": "half-cured-check", "workflow_file": ".github/workflows/half-cured.yml"}],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert len(violations) == 1
+    assert "paths-ignore" in violations[0]
+
+
+
+
+def test_guilt_evaluate_flags_types_missing_synchronize_end_to_end(tmp_path):
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "opened-only.yml").write_text(
+        "on:\n  pull_request:\n    types: [opened]\n  merge_group:\n"
+        "jobs:\n  check:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    contexts_path = _write_contexts(
+        tmp_path,
+        [{"name": "opened-only-check", "workflow_file": ".github/workflows/opened-only.yml"}],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert len(violations) == 1
+    assert "synchronize" in violations[0]
+
+
+def test_innocence_non_required_sibling_workflow_never_flagged(tmp_path):
+    """Anti-over-match (superscar #3): a workflow file that exists on disk
+    with a real Codex-F12-shaped defect (paths filter, no merge_group) but
+    is NOT named by any contexts.json entry must never surface a violation
+    -- evaluate() only walks the declared required set, it never scans the
+    workflows directory. Proves the real 43-workflow class (path-filtered,
+    non-required, correct by design) can never be swept in by accident."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "required.yml").write_text(
+        "on:\n  pull_request:\n  merge_group:\njobs:\n  check:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    (wf_dir / "advisory-only.yml").write_text(
+        "on:\n  pull_request:\n    paths:\n      - apps/mouth/**\n"
+        "jobs:\n  lint:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    contexts_path = _write_contexts(
+        tmp_path,
+        [{"name": "required-check", "workflow_file": ".github/workflows/required.yml"}],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert violations == []
+
+
 def test_innocence_allowlisted_context_with_reason_passes(tmp_path):
     contexts_path = _write_contexts(
         tmp_path,
@@ -219,3 +455,30 @@ def test_main_cli_exits_zero_on_the_real_repo_tree(capsys):
     rc = mod.main([])
     captured = capsys.readouterr()
     assert rc == 0, captured.out
+
+
+# --------------------------------------------------------------------- module docstring
+
+
+def test_module_docstring_records_the_actionlint_refusal_fact():
+    """Anti-regression (W102 shape): the module's own docstring must keep
+    the verbatim actionlint refusal message and an explicit "do not fix
+    this back" instruction, so a future session does not re-derive and
+    re-attempt the unimplementable "identical paths on both triggers"
+    version of this guard."""
+    doc = mod.__doc__ or ""
+    assert '"paths" filter is not available for merge_group event' in doc
+    assert "do NOT" in doc and "fix" in doc
+
+
+def test_module_has_no_allowlist_escape_hatch():
+    """Anti-regression for the second refuter round (2026-08-29): the
+    ALLOWLIST dict this module used to carry was empty, pinned empty, and
+    keyed on bare workflow_file -- one entry silenced EVERY rule for EVERY
+    context sharing that file, wider than its own stated "rule 3/4 escape
+    hatch" justification (it also swallowed rule 2's merge_group check).
+    Dead code the moment it shipped; removed rather than fixed. Does NOT
+    assert anything about check_allowlist_entry_has_reason, which is a
+    different, pre-existing mechanism (governs contexts whose
+    workflow_file is null) and stays untouched."""
+    assert not hasattr(mod, "ALLOWLIST")


### PR DESCRIPTION
## What this is

`scripts/ci/check_required_workflow_conformance.py` already guards the Codex-F12 trap: a required
status context whose defining workflow can never report it, so GitHub shows *"Expected — waiting for
status"* forever and the PR is hard-blocked with nothing red to fix. It had **three gaps in that same
failure family**, all closed here:

| gap | shape that slipped through | why it breaks a required check |
| --- | --- | --- |
| matched the literal token `paths` only | `on.pull_request.paths-ignore: [docs/**]` | identical "innocent PR never starts a run" defect, sibling key |
| checked `merge_group:` presence, never `pull_request:` | a `merge_group`-only required workflow | the same W69 shape, opposite trigger: the queue can satisfy it while every PR view hangs |
| never looked inside a `types:` list | `types: [opened]` | a push to an open PR starts no run on the new head, so the context is satisfied on an earlier SHA and simply **absent** on the one that merges |

**No new guard.** This extends the checker that already exists and is already armed
(`immune-enforcement.yml`, whose `antidotes` job is a required context on main) instead of adding a
second overlapping checker that could drift from it. The extension inherits the arming, so **no
workflow file is touched** — this PR is scripts-only.

The lane spec asked for a *new* `lint_trigger_symmetry.py` asserting "identical path semantics on
`pull_request` and `merge_group`". Two measurements re-shaped that before any code was written:

1. **The literal ask is unimplementable.** `merge_group` does not accept `paths:`, and this repo's own
   actionlint — itself a required context — refuses it: `"paths" filter is not available for
   merge_group event. it is only for push, pull_request, pull_request_target events [events]`, rc=1.
   Any workflow built to satisfy that wording would fail a required check. Recorded as a SCAR NOTE in
   the module docstring so nobody "fixes" it back.
2. **Most of it already existed.** Rules 2 and 3 of the existing checker are the same invariant,
   arrived at independently — its docstring even records the same actionlint fact.

## Refutation (generator ≠ grader, two rounds, three seats)

**Round 1** — `kimi-code/k3` and `codex-gpt-5.6-sol`, blind, own file access. **Both returned
DO-NOT-SHIP.** Every finding was re-measured by the orchestrator before disposition (W65: a refuter
hallucinates too).

| # | finding | seat | disposition |
| --- | --- | --- | --- |
| A1 | `branches:`/`branches-ignore:` slip through | both | **accepted → then withdrawn**, see below |
| A2 | `types:` narrowing passes, and a test *pinned* it as innocence | Kimi | **accepted** — now rule 5 |
| A3 | `ALLOWLIST` bypasses rules 2-5, not the "3/4" its own comment claimed | both, independently "remove it" | **accepted — deleted** |
| A4 | docstring asserts "12 workflows carry `push.paths`" | both | **accepted** — measures **2 of 8** |
| A5 | `on:` list/scalar form false-positived | both | **accepted as a declared scope limit** (pre-existing; no live instance) |
| — | `job_id` never validated against the live context→workflow→job map | Codex | **rejected: out of scope**, real and pre-existing |
| — | job-level `if:` can make a required job report success without working | Codex | **rejected: out of scope**, pre-existing |
| — | `workflow_file` not confined to `.github/workflows/` (absolute path escapes `repo_root`) | both | **rejected: out of scope**, pre-existing |

**Round 2**, on the *cured* diff (W105: "a cure births its own defect") — Kimi again, **DO-NOT-SHIP**,
and it was right:

> **A1's fix was an over-match.** `branches:` filters the **base** branch. `branches: [main]` fires on
> *every* PR to the protected branch and is perfectly innocent — yet the key-presence rule flagged it
> identically to the genuinely-broken `branches: [develop]`. Measured: all four shapes returned exactly
> one violation.

Shipping that would have been **superscar #3's tenth instance in this repo, inside the very guard whose
rule 5 cites the previous nine**. Per Rule 8 (*a correction that is itself wrong means the surface is
under-specified — write the spec, do not stack a third fix*), the branch rule was **withdrawn, not
patched twice**. The directional design it needs is written into the module as a DECLARED SCOPE LIMIT so
the follow-up doesn't re-derive it: guilty only when no `branches:` pattern *can* match the protected
branch (`contexts.json` already carries `"branch": "main"`), or when some `branches-ignore:` pattern
can — which needs GitHub's branch-glob semantics implemented and tested in their own right.
`branches: [develop]` on a required workflow therefore remains a **known, declared, undetected** defect
class. Declared, not missed.

## Gate (orchestrator, Opus 5, empirical, re-run after every edit)

W121 discipline throughout — `PYTHONDONTWRITEBYTECODE=1`, `-B`, `-p no:cacheprovider`, `__pycache__`
cleared before every run.

```
pytest scripts/tests/test_check_required_workflow_conformance.py  -> 37 passed
scripts/ci/check_required_workflow_conformance.py                 -> 11 contexts, 0 violations, rc=0
infra/guard-conformance/check_guard_conformance.py                -> 6 checks censused, 0 violations, rc=0
ruff check                                                        -> All checks passed!
```

Mutation-proved, restored byte-identical (`diff -q`) after each:

| mutation | tests killed |
| --- | --- |
| drop `paths-ignore` from the key tuple | 3 |
| neuter the `types` rule | 4 |
| `types` rule requires only `opened` | 2 |
| unwire the `types` rule from `evaluate()` | 1 |
| neuter the `pull_request`-present rule | 2 |
| faithful A3 reversal (reinstate the `ALLOWLIST` constant + bypass) | 1 |

**Zero live false positives**, measured across all 8 required-context workflows: all use mapping `on:`
form, all declare both triggers, none carries `paths`/`paths-ignore`/`branches`/`branches-ignore` under
`pull_request`, and the 3 that use `types:` all declare `[opened, synchronize, reopened]`.

## Declared

- **~448 net lines, over the ~400 guidance, declared rather than split.** The behavioural change is
  ~170 lines in the checker; the bulk is the guilt+innocence corpus for five rules. Splitting would ship
  rules without the proofs that make them stick.
- `ruff` reports a pre-existing `F401 pytest imported but unused` in the test file — verified byte-for-byte
  against `HEAD` before editing, untouched here, out of scope.
- The `types:` rule deliberately does **not** require `reopened`: a reopened PR carries the same head SHA
  it closed with, so the check that already ran still applies. `opened` + `synchronize` is the
  load-bearing pair, and the narrower rule is the safer one in a repo with nine prior over-matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
