### PR TITLE
feat(mq): mq state — a queue-state oracle with no NOT_ARMED verdict

### DIFF
--- a/scripts/mq.sh
+++ b/scripts/mq.sh
@@ -273,9 +273,13 @@ cmd_state() {
   #     therefore means "not in this window", which is NOT the same claim as
   #     "never queued" — so the window's own depth travels with the count and
   #     the verdict module renders the difference instead of flattening it.
+  #     `.head_branch` is nullable on a workflow_run, and jq's `test()` ABORTS the
+  #     whole filter on a null (`null cannot be matched, as it is not a string`,
+  #     rc=5) — one such row anywhere in the page would turn a real count into a
+  #     CANNOT-VERIFY. `//""` keeps the row from poisoning the other 99.
   local queue_runs="null"
   _gh api "repos/$REPO/actions/runs?event=merge_group&per_page=100" \
-      --jq "{matched:([.workflow_runs[]?|select(.head_branch|test(\"gh-readonly-queue/.*/pr-${pr}-\"))]|length), window:(.workflow_runs|length), oldest:([.workflow_runs[]?.created_at]|sort|first)}"
+      --jq "{matched:([.workflow_runs[]?|select((.head_branch//\"\")|test(\"gh-readonly-queue/.*/pr-${pr}-\"))]|length), window:(.workflow_runs|length), oldest:([.workflow_runs[]?.created_at]|sort|first)}"
   if (( MQ_RC == 0 )) && [[ "$MQ_OUT" == \{* ]]; then
     queue_runs="$MQ_OUT"
   fi

--- a/scripts/mq.sh
+++ b/scripts/mq.sh
@@ -218,21 +218,35 @@ cmd_arm() {
 # looks like a measurement (W106b: a probe that cannot answer must say so, not
 # guess). Only the FIRST read is load-bearing; without it there is no verdict.
 cmd_state() {
+  # Arg parsing that REFUSES rather than guesses. `--repo` with no value used
+  # to leave REPO empty and then `shift 2` failed under errexit, killing the
+  # verb with rc=1 and ZERO output; and a second positional silently WON, so
+  # `mq state 5 6` read PR 6 while the operator was asking about 5. Both are
+  # the read-a-different-thing-than-you-were-asked class, which is exactly what
+  # this verb exists to stop.
   local pr="" as_json=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --json) as_json=1; shift ;;
-      --repo) REPO="${2:-}"; shift 2 ;;
+      --repo)
+        [[ $# -ge 2 && -n "${2:-}" ]] || _die "state: --repo needs a value (owner/name)"
+        REPO="$2"; shift 2 ;;
       -*) _die "state: unknown argument '$1'" ;;
-      *) pr="$1"; shift ;;
+      *)
+        [[ -z "$pr" ]] || _die "state: takes ONE PR number, got '$pr' and '$1'"
+        pr="$1"; shift ;;
     esac
   done
   [[ -n "$pr" ]] || _die "state requires a PR number"
   _require_pr_number "$pr"
 
+  # STRICT. `owner/junk/name` used to pass: `%%/*` took `owner`, `##*/` took
+  # `name`, so GraphQL read owner/name while the REST calls read the full
+  # three-segment string — one verdict, two different repositories, and the
+  # header named neither. Exactly one slash, both sides non-empty, or refuse.
   local owner name
+  [[ "$REPO" =~ ^[^/]+/[^/]+$ ]] || _die "repo must be exactly owner/name, got '$REPO'"
   owner="${REPO%%/*}"; name="${REPO##*/}"
-  [[ -n "$owner" && -n "$name" && "$owner" != "$REPO" ]] || _die "MQ_REPO must be owner/name, got '$REPO'"
 
   # (a) the per-PR node. `mergeQueueEntry` does NOT exist in `gh pr view --json`'s
   #     field list ("Unknown JSON field") — GraphQL is the only way to read it,
@@ -240,7 +254,7 @@ cmd_state() {
   #     PR sitting at position 1.
   local q
   q='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){
-        number state mergedAt isDraft mergeable mergeStateStatus headRefOid
+        number state mergedAt isDraft mergeable mergeStateStatus headRefOid baseRefName
         autoMergeRequest{enabledAt}
         mergeQueueEntry{state position}
         commits(last:1){nodes{commit{statusCheckRollup{state
@@ -257,13 +271,34 @@ cmd_state() {
   fi
   local pr_json="$MQ_OUT"
 
-  # (b) how many contexts branch protection actually requires. Without it a
-  #     rollup=SUCCESS cannot be judged (it can be SUCCESS over 3 of 11).
-  local required_count="null"
-  _gh api "repos/$REPO/branches/main/protection" \
-      --jq '(.required_status_checks.checks // .required_status_checks.contexts // [])|length'
-  if (( MQ_RC == 0 )) && [[ "$MQ_OUT" =~ ^[0-9]+$ ]]; then
-    required_count="$MQ_OUT"
+  # (b) WHICH contexts branch protection requires — the NAMES, not the count.
+  #     A required check has an IDENTITY. Comparing cardinalities lets a rollup
+  #     of 68 green OPTIONAL contexts satisfy a bar of 11 REQUIRED ones that are
+  #     all absent, which is the same proxy-for-entity mistake this whole verb
+  #     exists to stop.
+  #
+  #     Read the protection of the PR's OWN base branch: a PR into release/1.x
+  #     judged against main's rules is judged against the wrong world.
+  #
+  #     `// []` is deliberately NOT used: `required_status_checks: null` is a
+  #     REAL answer (the branch's required checks come from a ruleset, not from
+  #     classic protection), and flattening it to an empty list would print
+  #     "requires 0" as if it were a measurement. Absent stays absent.
+  local base_ref required_names="null"
+  base_ref="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("baseRefName") or "")' 2>/dev/null || true)"
+  if [[ -n "$base_ref" ]]; then
+    # One line, one name, so the corpus can EXTRACT this exact filter and run it
+    # under real jq instead of testing a copy that drifts. Two things it must do:
+    #   - UNIQUE, not concatenate: `checks[].context` and `contexts` are the SAME
+    #     list in two shapes (measured on main: 11 and 11, identical sets), and a
+    #     plain `+` printed "requires 22" as though it were a measurement.
+    #   - leave a null `required_status_checks` NULL: that is a real answer (the
+    #     rules live in a ruleset), and `// []` would print "requires 0" instead.
+    local prot_jq='if (.required_status_checks|type) == "object" then ([(.required_status_checks.checks // [])[].context] + (.required_status_checks.contexts // []) | unique) else null end'
+    _gh api "repos/$REPO/branches/$base_ref/protection" --jq "$prot_jq"
+    if (( MQ_RC == 0 )) && [[ "$MQ_OUT" == \[* ]]; then
+      required_names="$MQ_OUT"
+    fi
   fi
 
   # (c) queue-branch runs. Their EXISTENCE is durable evidence that this PR has
@@ -285,21 +320,30 @@ cmd_state() {
   fi
 
   # (d) the sha this tool recorded when it armed, if it ever did.
-  local armed_sha="" f
+  local armed_sha="" armed_unreadable="false" f
   f="$(_state_file "$pr")"
   if [[ -f "$f" ]]; then
     armed_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("sha",""))' "$f" 2>/dev/null || true)"
+    # A file that exists but will not parse is NOT the same as no file: the
+    # first means the head-vs-armed comparison is unavailable, the second means
+    # there is nothing to compare. Collapsing them would delete a check in
+    # silence — the header above promises every read degrades to a LABEL.
+    [[ -n "$armed_sha" ]] || armed_unreadable="true"
   fi
 
   local verdict_py="$SCRIPT_DIR/mq_state_verdict.py"
   [[ -f "$verdict_py" ]] || _die "mq_state_verdict.py not found at $verdict_py"
 
   local payload rc=0
-  payload="$(python3 - "$pr_json" "$required_count" "$queue_runs" "$armed_sha" <<'MQSTATEPY'
+  payload="$(python3 - "$pr_json" "$required_names" "$queue_runs" "$armed_sha" "$armed_unreadable" <<'MQSTATEPY'
 import json, sys
-pr_json, required_count, queue_runs, armed_sha = sys.argv[1:5]
-def num(v):
-    return int(v) if v.isdigit() else None
+pr_json, required_names, queue_runs, armed_sha, armed_unreadable = sys.argv[1:6]
+def lst(v):
+    try:
+        d = json.loads(v)
+        return d if isinstance(d, list) else None
+    except Exception:
+        return None
 def obj(v):
     try:
         d = json.loads(v)
@@ -308,9 +352,10 @@ def obj(v):
         return None
 print(json.dumps({
     "pr": json.loads(pr_json),
-    "required_count": num(required_count),
+    "required_names": lst(required_names),
     "queue_runs": obj(queue_runs),
     "armed_sha": armed_sha or None,
+    "armed_sha_unreadable": armed_unreadable == "true",
 }))
 MQSTATEPY
 )" || rc=$?
@@ -321,9 +366,9 @@ MQSTATEPY
 
   rc=0
   if (( as_json )); then
-    printf '%s' "$payload" | python3 "$verdict_py" --pr "$pr" --json || rc=$?
+    printf '%s' "$payload" | python3 "$verdict_py" --pr "$pr" --repo "$REPO" --json || rc=$?
   else
-    printf '%s' "$payload" | python3 "$verdict_py" --pr "$pr" || rc=$?
+    printf '%s' "$payload" | python3 "$verdict_py" --pr "$pr" --repo "$REPO" || rc=$?
   fi
   return "$rc"
 }

--- a/scripts/mq.sh
+++ b/scripts/mq.sh
@@ -26,6 +26,8 @@
 #   mq status [--all|PR...]            wrap queue_doctor.py, pass-through output
 #   mq why-red <PR>                    name/bucket/link of each non-passing required check
 #   mq arm <PR>                        record head sha, bare `gh pr merge --auto`, confirm
+#   mq state <PR> [--json]             READ-ONLY queue-state oracle; never mutates, and has
+#                                      no NOT_ARMED verdict (see scripts/mq_state_verdict.py)
 #   mq watch <PR> [--timeout-mins N]   post-arm watcher (default ceiling 120m)
 #   mq requeue <PR>                    disable-auto + re-arm (standing cure for ejections)
 #   mq dequeue <PR>                    disable-auto + drop the local armed-state file
@@ -77,6 +79,7 @@ mq.sh — merge-queue operations tool (Merge-OS v2 Wave 0)
   mq status [--all|PR...]            wrap queue_doctor.py (pass-through output)
   mq why-red <PR>                    name/bucket/link of each non-passing required check
   mq arm <PR>                        record head sha, bare 'gh pr merge --auto', confirm
+  mq state <PR> [--json]             read-only queue-state oracle (never arms, never mutates)
   mq watch <PR> [--timeout-mins N]   post-arm watcher (default ceiling 120m)
   mq requeue <PR>                    disable-auto + re-arm
   mq dequeue <PR>                    disable-auto + drop the local armed-state file
@@ -202,6 +205,123 @@ cmd_arm() {
     echo "  CANNOT-VERIFY confirm step (rc=$MQ_RC): ${MQ_ERR:0:160} — recorded sha stands, check manually"
   fi
   echo "ARMED #$pr @ $sha"
+}
+
+# ---------------------------------------------------------------------------
+# mq state — READ-ONLY. Gathers three facts and hands them to the verdict
+# module; judges nothing itself. It never calls `gh pr merge`, not even to
+# disambiguate: that is a MUTATION, and this verb is what you run when you do
+# NOT want to touch the PR. When the answer is INDETERMINATE it NAMES the
+# mutation instead of performing it.
+#
+# Every read degrades to a labelled CANNOT-VERIFY rather than to a value that
+# looks like a measurement (W106b: a probe that cannot answer must say so, not
+# guess). Only the FIRST read is load-bearing; without it there is no verdict.
+cmd_state() {
+  local pr="" as_json=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) as_json=1; shift ;;
+      --repo) REPO="${2:-}"; shift 2 ;;
+      -*) _die "state: unknown argument '$1'" ;;
+      *) pr="$1"; shift ;;
+    esac
+  done
+  [[ -n "$pr" ]] || _die "state requires a PR number"
+  _require_pr_number "$pr"
+
+  local owner name
+  owner="${REPO%%/*}"; name="${REPO##*/}"
+  [[ -n "$owner" && -n "$name" && "$owner" != "$REPO" ]] || _die "MQ_REPO must be owner/name, got '$REPO'"
+
+  # (a) the per-PR node. `mergeQueueEntry` does NOT exist in `gh pr view --json`'s
+  #     field list ("Unknown JSON field") — GraphQL is the only way to read it,
+  #     which is exactly why CLI-only probes have concluded "not queued" about a
+  #     PR sitting at position 1.
+  local q
+  q='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){
+        number state mergedAt isDraft mergeable mergeStateStatus headRefOid
+        autoMergeRequest{enabledAt}
+        mergeQueueEntry{state position}
+        commits(last:1){nodes{commit{statusCheckRollup{state
+          contexts(first:100){totalCount nodes{
+            __typename
+            ... on CheckRun{name conclusion status}
+            ... on StatusContext{context state}}}}}}}}}}'
+  _gh api graphql -f query="$q" -f o="$owner" -f r="$name" -F n="$pr" \
+      --jq '.data.repository.pullRequest'
+  if (( MQ_RC != 0 )) || [[ -z "$MQ_OUT" || "$MQ_OUT" == "null" ]]; then
+    echo "CANNOT-VERIFY — the per-PR read failed (rc=$MQ_RC): ${MQ_ERR:0:200}" >&2
+    echo "  no verdict is emitted: an unread state is not an absent one." >&2
+    return 3
+  fi
+  local pr_json="$MQ_OUT"
+
+  # (b) how many contexts branch protection actually requires. Without it a
+  #     rollup=SUCCESS cannot be judged (it can be SUCCESS over 3 of 11).
+  local required_count="null"
+  _gh api "repos/$REPO/branches/main/protection" \
+      --jq '(.required_status_checks.checks // .required_status_checks.contexts // [])|length'
+  if (( MQ_RC == 0 )) && [[ "$MQ_OUT" =~ ^[0-9]+$ ]]; then
+    required_count="$MQ_OUT"
+  fi
+
+  # (c) queue-branch runs. Their EXISTENCE is durable evidence that this PR has
+  #     been built by the queue at least once — the queue deletes the branch on
+  #     the way out, so the runs outlive the entry that produced them.
+  #     The listing is a BOUNDED PAGE (100 runs ~= a dozen PRs). A zero here
+  #     therefore means "not in this window", which is NOT the same claim as
+  #     "never queued" — so the window's own depth travels with the count and
+  #     the verdict module renders the difference instead of flattening it.
+  local queue_runs="null"
+  _gh api "repos/$REPO/actions/runs?event=merge_group&per_page=100" \
+      --jq "{matched:([.workflow_runs[]?|select(.head_branch|test(\"gh-readonly-queue/.*/pr-${pr}-\"))]|length), window:(.workflow_runs|length), oldest:([.workflow_runs[]?.created_at]|sort|first)}"
+  if (( MQ_RC == 0 )) && [[ "$MQ_OUT" == \{* ]]; then
+    queue_runs="$MQ_OUT"
+  fi
+
+  # (d) the sha this tool recorded when it armed, if it ever did.
+  local armed_sha="" f
+  f="$(_state_file "$pr")"
+  if [[ -f "$f" ]]; then
+    armed_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("sha",""))' "$f" 2>/dev/null || true)"
+  fi
+
+  local verdict_py="$SCRIPT_DIR/mq_state_verdict.py"
+  [[ -f "$verdict_py" ]] || _die "mq_state_verdict.py not found at $verdict_py"
+
+  local payload rc=0
+  payload="$(python3 - "$pr_json" "$required_count" "$queue_runs" "$armed_sha" <<'MQSTATEPY'
+import json, sys
+pr_json, required_count, queue_runs, armed_sha = sys.argv[1:5]
+def num(v):
+    return int(v) if v.isdigit() else None
+def obj(v):
+    try:
+        d = json.loads(v)
+        return d if isinstance(d, dict) else None
+    except Exception:
+        return None
+print(json.dumps({
+    "pr": json.loads(pr_json),
+    "required_count": num(required_count),
+    "queue_runs": obj(queue_runs),
+    "armed_sha": armed_sha or None,
+}))
+MQSTATEPY
+)" || rc=$?
+  if (( rc != 0 )) || [[ -z "$payload" ]]; then
+    echo "CANNOT-VERIFY — could not assemble the payload (rc=$rc)" >&2
+    return 3
+  fi
+
+  rc=0
+  if (( as_json )); then
+    printf '%s' "$payload" | python3 "$verdict_py" --pr "$pr" --json || rc=$?
+  else
+    printf '%s' "$payload" | python3 "$verdict_py" --pr "$pr" || rc=$?
+  fi
+  return "$rc"
 }
 
 # ---------------------------------------------------------------------------
@@ -351,6 +471,7 @@ main() {
     status)  cmd_status "$@" ;;
     why-red) cmd_why_red "$@" ;;
     arm)     cmd_arm "$@" ;;
+    state)   cmd_state "$@" ;;
     watch)   cmd_watch "$@" ;;
     requeue) cmd_requeue "$@" ;;
     dequeue) cmd_dequeue "$@" ;;

--- a/scripts/mq_state_verdict.py
+++ b/scripts/mq_state_verdict.py
@@ -43,7 +43,9 @@ EVIDENCE (never a verdict, always printed)
 
 EXIT CODES
     0  a verdict was produced (read `verdict` / `--json` for which)
-    3  CANNOT-VERIFY — the primary read failed; no verdict is emitted
+    3  CANNOT-VERIFY — the payload was unreadable or carried no PR node; no
+       verdict is emitted. `mq state` returns the same 3 when its own primary
+       read fails.
 """
 
 from __future__ import annotations
@@ -94,19 +96,27 @@ def _rollup(pr):
     return _dig(pr, "commits", "nodes", 0, "commit", "statusCheckRollup", default={}) or {}
 
 
-def _context_states(pr):
-    """Every rollup context's state, normalised to upper-case strings.
+def _context_nodes(pr):
+    """The rollup contexts the query actually RETURNED — at most one page.
 
-    CheckRun carries `conclusion` (None while running); StatusContext carries
-    `state`. Both shapes land in the same list.
+    `contexts(first:100)` is paginated while `totalCount` counts them all, so
+    this list can be a strict subset. Anything derived from it is a statement
+    about the page, never about the rollup, and the caller has to say which.
+
+    CheckRun carries `name` + `conclusion` (None while running); StatusContext
+    carries `context` + `state`. Both shapes are normalised into one list.
     """
     nodes = _dig(_rollup(pr), "contexts", "nodes", default=[]) or []
     out = []
     for n in nodes:
         if not isinstance(n, dict):
             continue
-        val = n.get("conclusion") or n.get("state") or n.get("status") or ""
-        out.append(str(val).upper())
+        out.append(
+            {
+                "name": str(n.get("name") or n.get("context") or ""),
+                "state": str(n.get("conclusion") or n.get("state") or n.get("status") or "").upper(),
+            }
+        )
     return out
 
 
@@ -115,9 +125,17 @@ def judge(payload):
 
     `payload` keys:
       pr             the GraphQL `pullRequest` node (required)
-      required_count int | None — branch protection's required-context count
-      queue_runs     int | None — count of `gh-readonly-queue/.../pr-<N>-*` runs
+      required_names list[str] | None — the NAMES branch protection requires on
+                     the PR's own base branch. None means the probe could not
+                     answer, which is not the same as "requires nothing"
+      queue_runs     {matched, window, oldest} | None — queue-branch runs and the
+                     DEPTH of the page they were counted in. A bare int is still
+                     accepted (older callers), but then the window is unknown and
+                     a zero is rendered with that uncertainty stated.
       armed_sha      str | None — the sha `mq arm` recorded, if any
+      armed_sha_unreadable
+                     bool — a state file exists but could not be parsed, so the
+                     head-vs-armed comparison is unavailable rather than absent
     """
     pr = payload.get("pr")
     if not isinstance(pr, dict) or not pr:
@@ -129,9 +147,11 @@ def judge(payload):
     amr = pr.get("autoMergeRequest")
     enabled_at = _dig(amr, "enabledAt", default="") if isinstance(amr, dict) else ""
 
-    required_count = payload.get("required_count")
+    required_names = payload.get("required_names")
+    required_count = len(required_names) if isinstance(required_names, list) else None
     queue_runs = payload.get("queue_runs")
     armed_sha = payload.get("armed_sha")
+    armed_sha_unreadable = bool(payload.get("armed_sha_unreadable"))
 
     evidence, warnings = [], []
     sub_state = ""
@@ -168,12 +188,27 @@ def judge(payload):
         evidence.append(f"autoMergeRequest.enabledAt={enabled_at}, no queue entry yet")
         evidence.append("will enter the queue when the required checks go green")
     else:
-        # BOTH absent. This is trap #10's window and it is NOT 'not armed'.
+        # NEITHER field yields an arm. This is trap #10's window and it is NOT
+        # 'not armed'.
+        #
+        # ARMED keys on `enabledAt`, not on the presence of the object, because
+        # `enabledAt` is a nullable DateTime — so `autoMergeRequest` CAN arrive
+        # as a non-null object carrying a null timestamp. Saying "both absent"
+        # there would assert the absence of an object we were just handed: a
+        # measured falsehood inside the one tool whose entire value is that its
+        # evidence is true. Say which of the two shapes actually arrived.
         verdict = "INDETERMINATE"
-        evidence.append(
-            "autoMergeRequest AND mergeQueueEntry are both absent — this is the "
-            "documented arm->entry window, NOT proof of disarmament (measured PR #5036)"
-        )
+        if isinstance(amr, dict):
+            evidence.append(
+                "autoMergeRequest is PRESENT but carries no enabledAt, and there is no "
+                "mergeQueueEntry — no arm can be read from either, which is the "
+                "documented arm->entry window, NOT proof of disarmament (measured PR #5036)"
+            )
+        else:
+            evidence.append(
+                "autoMergeRequest AND mergeQueueEntry are both absent — this is the "
+                "documented arm->entry window, NOT proof of disarmament (measured PR #5036)"
+            )
         evidence.append(f"to decide: {DISAMBIGUATOR}")
 
     # --- signal 3: queue-branch runs (evidence, never a verdict on its own) --
@@ -242,28 +277,69 @@ def judge(payload):
     # --- evidence: the rollup, and the count it was computed over -----------
     rollup_state = (_rollup(pr).get("state") or "").upper()
     total = _dig(_rollup(pr), "contexts", "totalCount")
+    nodes = _context_nodes(pr)
+    seen_names = {n["name"] for n in nodes if n["name"]}
+    truncated = isinstance(total, int) and len(nodes) < total
+    base_ref = pr.get("baseRefName") or ""
+
     evidence.append(
         f"rollup={rollup_state or '<none>'} over totalCount="
         f"{total if total is not None else '?'} context(s)"
-        + (f"; branch protection requires {required_count}" if required_count is not None else "")
+        + (f"; {base_ref or 'the base branch'} requires {required_count}" if required_count is not None else "")
     )
+
+    # A required check has an IDENTITY, not a cardinality. Sixty-eight green
+    # OPTIONAL contexts do not satisfy eleven REQUIRED ones that are all
+    # absent — and comparing the two counts says they do. That substitution
+    # (a number standing in for a name set) is the same proxy-for-entity
+    # mistake this whole verb exists to stop, so it is checked by NAME and the
+    # count is kept only as the thing to print.
     if terminal:
         pass
-    elif required_count is None:
+    elif required_names is None:
         warnings.append(
-            "required-context count CANNOT-VERIFY: a rollup=SUCCESS cannot be trusted without "
-            "the number it was computed over."
+            "required checks CANNOT-VERIFY: the base branch's protection did not answer with a "
+            "check list (classic protection may be absent and the rules may live in a ruleset). "
+            "A rollup=SUCCESS cannot be trusted without knowing WHICH checks had to be in it — "
+            "and this is not the same as 'requires nothing'."
         )
-    elif rollup_state == "SUCCESS" and isinstance(total, int) and total < required_count:
+    elif not required_names:
+        evidence.append("the base branch declares no required status checks")
+    elif not seen_names:
         warnings.append(
-            f"FALSE GREEN: rollup=SUCCESS was computed over {total} context(s) while main "
-            f"requires {required_count}. A rerun detaches check-runs and third-party contexts "
-            "alone can average to SUCCESS. This is not mergeable-green."
+            f"{len(required_names)} required check(s) declared, but the rollup returned no context "
+            "NAMES to match them against — presence cannot be verified from this read."
+        )
+    else:
+        # No count-vs-count fallback lives here. Once every required NAME is
+        # accounted for, `totalCount < len(required)` is unreachable by
+        # construction (nodes are a subset of total), so such a branch would
+        # be a guard that cannot fire — the shape this file exists to refuse.
+        missing = sorted(n for n in required_names if n not in seen_names)
+        if missing and truncated:
+            warnings.append(
+                f"{len(missing)} required check(s) are absent from the {len(nodes)} context(s) this "
+                f"read returned, but the rollup has {total} and only one page was fetched — "
+                f"CANNOT-VERIFY rather than missing. First: {', '.join(missing[:3])}"
+            )
+        elif missing:
+            warnings.append(
+                f"FALSE GREEN RISK: {len(missing)} of {len(required_names)} required check(s) are "
+                f"ABSENT from the rollup entirely, whatever its state says — a green computed over "
+                f"contexts that are not the required ones is not mergeable-green. "
+                f"Missing: {', '.join(missing[:5])}"
+                + (f" (+{len(missing) - 5} more)" if len(missing) > 5 else "")
+            )
+
+    if truncated and not terminal:
+        warnings.append(
+            f"only {len(nodes)} of {total} rollup contexts were fetched (the query asks for one "
+            "page): any statement below about which contexts are present or CANCELLED is about "
+            "that page, not about the rollup."
         )
 
     # --- evidence: CANCELLED is not 'fail', and not 'pass' either -----------
-    states = _context_states(pr)
-    cancelled = [s for s in states if s == "CANCELLED"]
+    cancelled = [n for n in nodes if n["state"] == "CANCELLED"]
     if cancelled:
         evidence.append(f"CANCELLED contexts: {len(cancelled)}")
         warnings.append(
@@ -274,12 +350,27 @@ def judge(payload):
 
     # --- evidence: the arm rides the PR, not the sha ------------------------
     head = pr.get("headRefOid") or ""
-    if armed_sha:
+    if armed_sha_unreadable:
+        # Silence here would delete the HEAD-MOVED check without saying so —
+        # an omission indistinguishable from "this PR was never armed", which
+        # is the one thing this file refuses to imply anywhere else.
+        warnings.append(
+            "an armed-state file exists for this PR but could not be read, so the "
+            "head-vs-armed comparison is CANNOT-VERIFY — not evidence that the head "
+            "has held still since arming."
+        )
+    elif armed_sha:
         if head and head != armed_sha:
             warnings.append(
                 f"HEAD MOVED since arm: armed {armed_sha[:12]}, head now {head[:12]}. "
                 "The auto-merge request sits on the PR, not the SHA — this push inherited "
                 "the arm WITHOUT re-passing the gate that judged it."
+            )
+        elif not head:
+            warnings.append(
+                f"an armed sha is on record ({armed_sha[:12]}) but this read returned no "
+                "headRefOid, so head-vs-armed is CANNOT-VERIFY — silence here would have "
+                "read as 'the head has held still'."
             )
         else:
             evidence.append(f"head matches the sha recorded at arm time ({armed_sha[:12]})")
@@ -299,8 +390,8 @@ def judge(payload):
     }
 
 
-def render(result, pr_number):
-    lines = [f"== mq state — PR #{pr_number} =="]
+def render(result, pr_number, repo=""):
+    lines = [f"== mq state — PR #{pr_number}" + (f" ({repo})" if repo else "") + " =="]
     v = result["verdict"]
     sub = f" ({result['sub_state']})" if result.get("sub_state") else ""
     lines.append(f"VERDICT: {v}{sub}")
@@ -319,6 +410,7 @@ def render(result, pr_number):
 def main(argv=None):
     ap = argparse.ArgumentParser(description="judge one PR's merge-queue state (read-only)")
     ap.add_argument("--pr", default="?", help="PR number, for the header only")
+    ap.add_argument("--repo", default="", help="owner/name, for the header only")
     ap.add_argument("--json", action="store_true", help="emit the verdict as JSON")
     ap.add_argument(
         "--payload",
@@ -333,16 +425,22 @@ def main(argv=None):
     except json.JSONDecodeError as exc:
         print(f"CANNOT-VERIFY — payload is not JSON: {exc}", file=sys.stderr)
         return 3
+    # A traceback is not a verdict, and rc 1 is not rc 3. Any shape the judge
+    # cannot read — a list instead of an object, a string where a number was
+    # promised — has to arrive as a labelled CANNOT-VERIFY, or the caller
+    # reading only the exit code learns the wrong thing.
     try:
+        if not isinstance(payload, dict):
+            raise ValueError(f"payload must be a JSON object, got {type(payload).__name__}")
         result = judge(payload)
-    except ValueError as exc:
-        print(f"CANNOT-VERIFY — {exc}", file=sys.stderr)
+    except (ValueError, TypeError, AttributeError, KeyError, IndexError) as exc:
+        print(f"CANNOT-VERIFY — {type(exc).__name__}: {exc}", file=sys.stderr)
         return 3
 
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
     else:
-        print(render(result, args.pr))
+        print(render(result, args.pr, args.repo))
     return 0
 
 

--- a/scripts/mq_state_verdict.py
+++ b/scripts/mq_state_verdict.py
@@ -58,9 +58,15 @@ import sys
 # happened, with the authority of an automated measurement).
 VERDICTS = ("MERGED", "CLOSED", "IN_QUEUE", "ARMED", "INDETERMINATE")
 
+# The ONLY thing that settles it — and it is asymmetric, which the text must
+# say. If the PR is already armed the command REFUSES and nothing changes; if
+# it is NOT armed the same command ARMS IT. So it is a probe in exactly the
+# case you did not need one, and an action in the case you did. Calling it
+# "harmless" would be true of one branch and a trap on the other.
 DISAMBIGUATOR = (
-    "run `gh pr merge <PR> --auto` (a MUTATION, but it refuses harmlessly): "
-    "'already queued to merge' proves ARMED; anything else leaves it open"
+    "`gh pr merge <PR> --auto` decides it, but ONLY RUN IT IF YOU INTEND TO ARM: "
+    "'already queued to merge' proves it was ARMED and changes nothing, while any "
+    "other outcome means it was not armed and you have just armed it"
 )
 
 

--- a/scripts/mq_state_verdict.py
+++ b/scripts/mq_state_verdict.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""mq_state_verdict.py — the pure verdict half of `mq state` (Merge-OS v2).
+
+WHY THIS FILE EXISTS SEPARATELY FROM `mq.sh`
+    The gathering (three `gh` calls) and the judging are different jobs with
+    different failure modes. Split, the judgement can be driven by fixtures at
+    the exact boundary the production code crosses (W114: a fake that shares
+    the code's imagination proves nothing — here the fixture is the API's own
+    JSON shape, and the production transformation runs over it unchanged).
+
+WHAT THE QUEUE ACTUALLY LIES ABOUT (measured, MEMORY_MERGE_QUEUE_TRAPS.md)
+    Arming CONSUMES `autoMergeRequest`. It goes null when the queue ACCEPTS
+    the request — not when arming failed. And there is a window in which it is
+    ALREADY null while `mergeQueueEntry` has NOT YET materialised: measured on
+    PR #5036, where both fields read "not armed" while 32 queue-branch runs
+    existed. Therefore:
+
+        >>> NO INSTANTANEOUS READ OF THOSE TWO FIELDS, NOT EVEN JOINT,
+        >>> CAN EVER PROVE "NOT ARMED".
+
+    This module consequently has NO `NOT_ARMED` verdict. That is the design.
+    The only thing that proves armed-ness is the REFUSAL TEXT of
+    `gh pr merge --auto` ("already queued to merge") — and that is a MUTATION,
+    so this read-only oracle never runs it; it NAMES it as the disambiguator
+    when the verdict is INDETERMINATE.
+
+ATTESTATION ORDER (the corpus's own, top = most reliable)
+    1. the refusal text of `gh pr merge --auto`   [mutation — never run here]
+    2. terminal state: `mergedAt` / `CLOSED`
+    3. existence of `gh-readonly-queue/main/pr-<N>-*` runs
+    4. `mergeQueueEntry` + `autoMergeRequest`, jointly, non-probative for "not armed"
+
+EVIDENCE (never a verdict, always printed)
+    - `mergeable`/`mergeStateStatus`: a DIRTY PR runs ZERO workflows, so its
+      "0 pending checks" is not green, it is silence.
+    - rollup state vs `contexts.totalCount` vs the branch's required count: a
+      SUCCESS computed over 3 contexts when main requires 11 is a FALSE GREEN.
+    - CANCELLED contexts: `gh pr checks` files CANCELLED under bucket `cancel`,
+      never `fail`, so a caller filtering `bucket=="fail"` reads "0 reds" on a
+      rollup whose state is FAILURE.
+    - head sha vs the sha recorded at arm time: the arm rides the PR, not the
+      SHA, so a push after arming inherits it without re-passing any gate.
+
+EXIT CODES
+    0  a verdict was produced (read `verdict` / `--json` for which)
+    3  CANNOT-VERIFY — the primary read failed; no verdict is emitted
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+# The verdicts this oracle can emit. `NOT_ARMED` is deliberately absent — see
+# the module docstring. Adding it would re-commit the exact autogoal the
+# corpus records twice (a background probe announcing a disarm that never
+# happened, with the authority of an automated measurement).
+VERDICTS = ("MERGED", "CLOSED", "IN_QUEUE", "ARMED", "INDETERMINATE")
+
+DISAMBIGUATOR = (
+    "run `gh pr merge <PR> --auto` (a MUTATION, but it refuses harmlessly): "
+    "'already queued to merge' proves ARMED; anything else leaves it open"
+)
+
+
+def _dig(d, *path, default=None):
+    """Walk a nested dict/list, returning `default` at the first missing step.
+
+    GraphQL nulls arrive as None at any depth; `.get()` chains on None throw.
+    """
+    cur = d
+    for key in path:
+        if cur is None:
+            return default
+        if isinstance(key, int):
+            if not isinstance(cur, list) or len(cur) <= key:
+                return default
+            cur = cur[key]
+        else:
+            if not isinstance(cur, dict):
+                return default
+            cur = cur.get(key)
+    return default if cur is None else cur
+
+
+def _rollup(pr):
+    return _dig(pr, "commits", "nodes", 0, "commit", "statusCheckRollup", default={}) or {}
+
+
+def _context_states(pr):
+    """Every rollup context's state, normalised to upper-case strings.
+
+    CheckRun carries `conclusion` (None while running); StatusContext carries
+    `state`. Both shapes land in the same list.
+    """
+    nodes = _dig(_rollup(pr), "contexts", "nodes", default=[]) or []
+    out = []
+    for n in nodes:
+        if not isinstance(n, dict):
+            continue
+        val = n.get("conclusion") or n.get("state") or n.get("status") or ""
+        out.append(str(val).upper())
+    return out
+
+
+def judge(payload):
+    """payload -> {verdict, sub_state, evidence: [...], warnings: [...]}
+
+    `payload` keys:
+      pr             the GraphQL `pullRequest` node (required)
+      required_count int | None — branch protection's required-context count
+      queue_runs     int | None — count of `gh-readonly-queue/.../pr-<N>-*` runs
+      armed_sha      str | None — the sha `mq arm` recorded, if any
+    """
+    pr = payload.get("pr")
+    if not isinstance(pr, dict) or not pr:
+        raise ValueError("payload.pr is missing or not an object")
+
+    state = (pr.get("state") or "").upper()
+    merged_at = pr.get("mergedAt") or ""
+    entry = pr.get("mergeQueueEntry")
+    amr = pr.get("autoMergeRequest")
+    enabled_at = _dig(amr, "enabledAt", default="") if isinstance(amr, dict) else ""
+
+    required_count = payload.get("required_count")
+    queue_runs = payload.get("queue_runs")
+    armed_sha = payload.get("armed_sha")
+
+    evidence, warnings = [], []
+    sub_state = ""
+
+    # --- signal 2: terminal states -----------------------------------------
+    if merged_at or state == "MERGED":
+        verdict = "MERGED"
+        evidence.append(f"terminal: mergedAt={merged_at or '<unset>'} state={state or '?'}")
+    elif state == "CLOSED":
+        verdict = "CLOSED"
+        evidence.append("terminal: state=CLOSED with no mergedAt — closed without merging")
+    # --- signal 4: the two ambiguous fields, jointly ------------------------
+    elif isinstance(entry, dict) and entry:
+        verdict = "IN_QUEUE"
+        sub_state = str(entry.get("state") or "")
+        pos = entry.get("position")
+        evidence.append(
+            f"mergeQueueEntry present: state={sub_state or '?'}"
+            + (f" position={pos}" if pos is not None else "")
+        )
+        evidence.append(
+            "autoMergeRequest is null BY SUCCESS here — the queue consumes it on entry"
+            if not enabled_at
+            else f"autoMergeRequest.enabledAt={enabled_at}"
+        )
+        if sub_state.upper() == "UNMERGEABLE":
+            warnings.append(
+                "entry state UNMERGEABLE: the queue merges on top of the entries AHEAD, "
+                "not on main — a clean 3-way against origin/main proves nothing. "
+                "`RemovedFromMergeQueueEvent.reason` in the timeline is the only source for WHY."
+            )
+    elif enabled_at:
+        verdict = "ARMED"
+        evidence.append(f"autoMergeRequest.enabledAt={enabled_at}, no queue entry yet")
+        evidence.append("will enter the queue when the required checks go green")
+    else:
+        # BOTH absent. This is trap #10's window and it is NOT 'not armed'.
+        verdict = "INDETERMINATE"
+        evidence.append(
+            "autoMergeRequest AND mergeQueueEntry are both absent — this is the "
+            "documented arm->entry window, NOT proof of disarmament (measured PR #5036)"
+        )
+        evidence.append(f"to decide: {DISAMBIGUATOR}")
+
+    # --- signal 3: queue-branch runs (evidence, never a verdict on its own) --
+    #
+    # PRESENCE is sound: a run on gh-readonly-queue/.../pr-<N>-* proves the PR
+    # reached the queue, and it outlives the entry (the queue deletes the branch
+    # on the way out, the runs stay).
+    #
+    # ABSENCE IS NOT. The listing is one bounded page — measured 2026-08-29:
+    # 100 merge_group runs spanned 13 PRs, because a queue build fires 8
+    # workflows. A PR older than that window reads zero and has been queued a
+    # dozen times. Rendering that zero as "never queued" would be this whole
+    # file's own disease one level down: a bounded proxy read as the entity.
+    matched = window = oldest = None
+    if isinstance(queue_runs, dict):
+        matched = queue_runs.get("matched")
+        window = queue_runs.get("window")
+        oldest = queue_runs.get("oldest")
+    elif isinstance(queue_runs, int):
+        matched = queue_runs
+
+    if matched is None:
+        evidence.append("queue-branch runs: CANNOT-VERIFY (run listing unavailable)")
+    elif matched > 0:
+        evidence.append(
+            f"queue-branch runs: {matched} on gh-readonly-queue/.../pr-<N>-* "
+            "— this PR HAS reached the queue at least once"
+        )
+        if verdict == "INDETERMINATE" and state == "OPEN":
+            warnings.append(
+                "still OPEN, not merged, no entry now, yet queue-branch runs exist: "
+                "consistent with an EJECTION (which is silent and deletes its own branch). "
+                "`RemovedFromMergeQueueEvent.reason` in the timeline is the only source for WHY."
+            )
+    else:
+        span = ""
+        if window is not None:
+            span = f" (window: {window} merge_group run(s)"
+            span += f", oldest {oldest})" if oldest else ")"
+        evidence.append(
+            f"queue-branch runs: 0 in the listed window{span} — this does NOT mean "
+            "never queued: the listing is one bounded page, and an older PR falls off it"
+        )
+
+    # --- evidence: DIRTY runs nothing --------------------------------------
+    # A merged/closed PR reports mergeable=UNKNOWN forever: warning about that
+    # would be an over-match on a question that stopped existing (measured live
+    # on #5214, which is MERGED and read UNKNOWN/UNKNOWN).
+    terminal = verdict in ("MERGED", "CLOSED")
+    mergeable = (pr.get("mergeable") or "").upper()
+    mss = (pr.get("mergeStateStatus") or "").upper()
+    evidence.append(f"mergeable={mergeable or '?'} mergeStateStatus={mss or '?'}")
+    if terminal:
+        pass
+    elif mergeable == "CONFLICTING" or mss == "DIRTY":
+        warnings.append(
+            "DIRTY/CONFLICTING: a conflicted PR runs ZERO workflows, so '0 pending checks' "
+            "here is silence, not green. Repoint the branch before reading any check state."
+        )
+    elif mergeable == "UNKNOWN":
+        warnings.append(
+            "mergeable=UNKNOWN: GitHub is still recomputing (it recomputes for EVERY open PR "
+            "after every push to main). Not a verdict — re-read shortly."
+        )
+
+    # --- evidence: the rollup, and the count it was computed over -----------
+    rollup_state = (_rollup(pr).get("state") or "").upper()
+    total = _dig(_rollup(pr), "contexts", "totalCount")
+    evidence.append(
+        f"rollup={rollup_state or '<none>'} over totalCount="
+        f"{total if total is not None else '?'} context(s)"
+        + (f"; branch protection requires {required_count}" if required_count is not None else "")
+    )
+    if terminal:
+        pass
+    elif required_count is None:
+        warnings.append(
+            "required-context count CANNOT-VERIFY: a rollup=SUCCESS cannot be trusted without "
+            "the number it was computed over."
+        )
+    elif rollup_state == "SUCCESS" and isinstance(total, int) and total < required_count:
+        warnings.append(
+            f"FALSE GREEN: rollup=SUCCESS was computed over {total} context(s) while main "
+            f"requires {required_count}. A rerun detaches check-runs and third-party contexts "
+            "alone can average to SUCCESS. This is not mergeable-green."
+        )
+
+    # --- evidence: CANCELLED is not 'fail', and not 'pass' either -----------
+    states = _context_states(pr)
+    cancelled = [s for s in states if s == "CANCELLED"]
+    if cancelled:
+        evidence.append(f"CANCELLED contexts: {len(cancelled)}")
+        warnings.append(
+            f"{len(cancelled)} context(s) CANCELLED. `gh pr checks` files these under bucket "
+            "'cancel', never 'fail' — a caller filtering bucket=='fail' reads '0 reds' on a PR "
+            "whose rollup may be FAILURE. The authority is statusCheckRollup.state."
+        )
+
+    # --- evidence: the arm rides the PR, not the sha ------------------------
+    head = pr.get("headRefOid") or ""
+    if armed_sha:
+        if head and head != armed_sha:
+            warnings.append(
+                f"HEAD MOVED since arm: armed {armed_sha[:12]}, head now {head[:12]}. "
+                "The auto-merge request sits on the PR, not the SHA — this push inherited "
+                "the arm WITHOUT re-passing the gate that judged it."
+            )
+        else:
+            evidence.append(f"head matches the sha recorded at arm time ({armed_sha[:12]})")
+
+    if pr.get("isDraft"):
+        evidence.append(
+            "isDraft=true — a draft is a durable hold only BEFORE the entry exists; "
+            "once queued it is cosmetic (measured: draft 13:21 -> merged 13:31)"
+        )
+
+    return {
+        "verdict": verdict,
+        "sub_state": sub_state,
+        "state": state,
+        "evidence": evidence,
+        "warnings": warnings,
+    }
+
+
+def render(result, pr_number):
+    lines = [f"== mq state — PR #{pr_number} =="]
+    v = result["verdict"]
+    sub = f" ({result['sub_state']})" if result.get("sub_state") else ""
+    lines.append(f"VERDICT: {v}{sub}")
+    for e in result["evidence"]:
+        lines.append(f"  - {e}")
+    for w in result["warnings"]:
+        lines.append(f"  !! {w}")
+    if v == "INDETERMINATE":
+        lines.append(
+            "  NOTE: this oracle has no NOT_ARMED verdict, on purpose — no instantaneous "
+            "read of those fields can prove it."
+        )
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="judge one PR's merge-queue state (read-only)")
+    ap.add_argument("--pr", default="?", help="PR number, for the header only")
+    ap.add_argument("--json", action="store_true", help="emit the verdict as JSON")
+    ap.add_argument(
+        "--payload",
+        default="-",
+        help="path to the gathered payload JSON, or '-' for stdin (default)",
+    )
+    args = ap.parse_args(argv)
+
+    raw = sys.stdin.read() if args.payload == "-" else open(args.payload).read()
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        print(f"CANNOT-VERIFY — payload is not JSON: {exc}", file=sys.stderr)
+        return 3
+    try:
+        result = judge(payload)
+    except ValueError as exc:
+        print(f"CANNOT-VERIFY — {exc}", file=sys.stderr)
+        return 3
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(render(result, args.pr))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_mq_state_oracle.sh
+++ b/scripts/tests/test_mq_state_oracle.sh
@@ -265,6 +265,42 @@ check "still produces a verdict" "$(yesno has 'VERDICT: INDETERMINATE' "$OUT")"
 check "and admits the required count is unverified" \
       "$(yesno has 'required-context count CANNOT-VERIFY' "$OUT")"
 
+# ---------------------------------------------------------------------------
+# The jq filter that counts queue-branch runs is a STRING inside mq.sh, and the
+# fake `gh` above answers with the filter's RESULT — so the fake sits ABOVE the
+# transformation and none of the rows so far exercise the filter itself (W114:
+# a fake at the wrong boundary proves nothing about what it bypassed).
+#
+# This block extracts the LIVE filter text out of mq.sh — never a copy, or the
+# corpus would drift into testing a stale duplicate — and runs it under real jq
+# against a payload shaped like the API's.
+# ---------------------------------------------------------------------------
+echo "the queue-run jq filter, extracted from mq.sh and run under real jq:"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  SKIP — jq is not installed; this row cannot judge (declared, not silently passed)"
+else
+  FILTER="$(sed -n 's/.*--jq "\({matched:.*\)"$/\1/p' "$MQSH" | head -1)"
+  FILTER="$(printf '%s' "$FILTER" | sed 's/\\"/"/g; s/\${pr}/4242/g')"
+  check "the filter was actually extracted (a blank one would pass everything)" \
+        "$(yesno [ -n "$FILTER" ])"
+
+  # A workflow_run's head_branch is NULLABLE. jq's test() aborts the entire
+  # filter on a null ("null cannot be matched, as it is not a string", rc=5),
+  # so ONE such row anywhere in the page would turn a real count into a
+  # CANNOT-VERIFY. The guard must survive it and still count the real match.
+  # The EARLIEST timestamp is deliberately NOT first in this array. With it
+  # first, the "oldest" assertion below passes whether the filter sorts or
+  # simply takes element 0 — a vacuous check. Measured: dropping the `sort`
+  # killed nothing until this array was reordered.
+  PAYLOAD='{"workflow_runs":[{"head_branch":null,"created_at":"2026-08-29T03:00:00Z"},{"head_branch":"gh-readonly-queue/main/pr-4242-abc","created_at":"2026-08-29T02:00:00Z"},{"head_branch":"gh-readonly-queue/main/pr-9999-def","created_at":"2026-08-29T01:00:00Z"}]}'
+  JQOUT="$(printf '%s' "$PAYLOAD" | jq -c "$FILTER" 2>&1)"; JQRC=$?
+  check "a null head_branch does not poison the whole page" "$(yesno [ "$JQRC" = "0" ])"
+  check "and the real match is still counted (matched:1)" "$(yesno has '"matched":1' "$JQOUT")"
+  check "it does not count another PR's queue branch" "$(nope has '"matched":2' "$JQOUT")"
+  check "the window depth travels with the count" "$(yesno has '"window":3' "$JQOUT")"
+  check "the oldest timestamp is the earliest, not the first" "$(yesno has '"oldest":"2026-08-29T01:00:00Z"' "$JQOUT")"
+fi
+
 echo
 if [ "$failures" -eq 0 ]; then
   echo "TOTAL $total FAILED 0"

--- a/scripts/tests/test_mq_state_oracle.sh
+++ b/scripts/tests/test_mq_state_oracle.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# test_mq_state_oracle.sh — proof for `mq state` (scripts/mq.sh + mq_state_verdict.py).
+#
+# WHAT IT PINS, and where each row's ground truth comes from
+#   Every fixture below is a shape the merge queue actually produced, recorded
+#   in MEMORY_MERGE_QUEUE_TRAPS.md with the postmortem's own verdict. The test
+#   asserts THAT verdict, not merely "a" verdict.
+#
+#     trap #10 (PR #5036)  both fields absent -> INDETERMINATE, NEVER "not armed"
+#     trap #1  (table)     entry present + auto null -> IN_QUEUE, null BY SUCCESS
+#     trap #1  (table)     auto set + no entry       -> ARMED
+#     trap #8              DIRTY -> "0 pending" is silence, not green
+#     trap #3              head moved after arm -> the arm rode the PR, not the sha
+#     roll-up  (#5039/52)  rollup=SUCCESS over fewer contexts than required -> FALSE GREEN
+#     roll-up  (#5039)     CANCELLED contexts -> bucket 'cancel', never 'fail'
+#     roll-up  (#5192)     entry UNMERGEABLE -> only the timeline says WHY
+#     signal 3             matched=0 in a bounded page is NOT "never queued"
+#
+#   Plus a CLASS assertion no single fixture can carry: no fixture, ever,
+#   produces the string NOT_ARMED — the oracle has no such verdict by design.
+#
+# No network and no real gh: the end-to-end rows drive `mq state` through a
+# fake `gh` on PATH, with the same poverty check as test_mq_sh.sh (W108 — a
+# fake world too poor to judge reports its own poverty as a pass).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+MQSH="$REPO_ROOT/mq.sh"
+VERDICT="$REPO_ROOT/mq_state_verdict.py"
+[ -f "$MQSH" ] || { echo "FAIL: mq.sh not found at $MQSH"; exit 2; }
+[ -f "$VERDICT" ] || { echo "FAIL: mq_state_verdict.py not found at $VERDICT"; exit 2; }
+
+failures=0
+total=0
+check() {  # check <name> <0-or-1>
+  total=$((total + 1))
+  if [ "$2" = "1" ]; then printf '  ok   %s\n' "$1"
+  else printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+has() { case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+yesno() { if "$@"; then echo 1; else echo 0; fi; }
+# nope: the NEGATED form. `nope cmd` is not a thing — `!` is shell syntax,
+# not a command, so it lands in argv[0] and every negative assertion would
+# report "!: command not found" and FAIL regardless of the truth (caught by
+# running this corpus, not by reading it).
+nope() { if "$@"; then echo 0; else echo 1; fi; }
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/mqstate_test.XXXXXX")" || {
+  echo "FAIL: mktemp could not create a scratch world — this is an ENVIRONMENT failure," >&2
+  echo "      not a verdict on the code under test." >&2
+  exit 2
+}
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# judge <payload-json> -> $OUT (human render), $JOUT (json render), $RC
+judge() {
+  OUT="$(printf '%s' "$1" | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
+  JOUT="$(printf '%s' "$1" | python3 "$VERDICT" --pr 1 --json 2>&1)"
+}
+verdict_of() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.load(sys.stdin)["verdict"])' 2>/dev/null; }
+
+# A rollup helper so each fixture stays readable.
+rollup() {  # rollup <state> <totalCount> <nodes-json>
+  printf '"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"%s","contexts":{"totalCount":%s,"nodes":%s}}}}]}' "$1" "$2" "$3"
+}
+
+ALL_VERDICTS=""
+
+# ---------------------------------------------------------------------------
+echo "trap #10 (PR #5036) — both fields absent is the arm->entry WINDOW, not a disarm:"
+P="{\"pr\":{\"number\":5036,\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":32,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "verdict is INDETERMINATE" "$(yesno [ "$(verdict_of "$JOUT")" = "INDETERMINATE" ])"
+check "never says NOT_ARMED" "$(nope has 'NOT_ARMED' "$JOUT")"
+check "names the mutation as the disambiguator" "$(yesno has 'already queued to merge' "$OUT")"
+check "queue-branch runs present -> ejection is flagged as CONSISTENT, not asserted" \
+      "$(yesno has 'consistent with an EJECTION' "$OUT")"
+check "points at the only source for WHY" "$(yesno has 'RemovedFromMergeQueueEvent' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "trap #1 — entry present + autoMergeRequest null is SUCCESS, not a disarm:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"AWAITING_CHECKS\",\"position\":1},$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "verdict is IN_QUEUE" "$(yesno [ "$(verdict_of "$JOUT")" = "IN_QUEUE" ])"
+check "carries the entry sub-state" "$(yesno has 'AWAITING_CHECKS' "$OUT")"
+check "says the null is BY SUCCESS" "$(yesno has 'null BY SUCCESS' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "trap #1 — armed but not yet queued:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"2026-08-29T10:00:00Z\"},\"mergeQueueEntry\":null,$(rollup PENDING 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "verdict is ARMED" "$(yesno [ "$(verdict_of "$JOUT")" = "ARMED" ])"
+
+# ---------------------------------------------------------------------------
+echo "signal 3 — a zero inside a BOUNDED page is not 'never queued':"
+check "zero renders the window instead of a claim" "$(yesno has 'does NOT mean' "$OUT")"
+check "zero never claims 'has not been built'" "$(nope has 'has not been built' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "terminal states:"
+P="{\"pr\":{\"state\":\"MERGED\",\"mergedAt\":\"2026-08-29T07:44:58Z\",\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 3 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "MERGED wins over the ambiguous fields" "$(yesno [ "$(verdict_of "$JOUT")" = "MERGED" ])"
+check "a merged PR is not warned about mergeable=UNKNOWN" "$(nope has 'still recomputing' "$OUT")"
+check "a merged PR is not warned FALSE GREEN (3 of 11 is moot once landed)" \
+      "$(nope has 'FALSE GREEN' "$OUT")"
+
+P="{\"pr\":{\"state\":\"CLOSED\",\"mergedAt\":null,\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":null,\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "CLOSED without mergedAt is CLOSED, not INDETERMINATE" "$(yesno [ "$(verdict_of "$JOUT")" = "CLOSED" ])"
+check "an unavailable run listing says CANNOT-VERIFY" "$(yesno has 'CANNOT-VERIFY' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "roll-up (#5039/#5052) — SUCCESS over fewer contexts than required is a FALSE GREEN:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 4 '[]')},\"required_count\":27,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "4-of-27 SUCCESS is called out" "$(yesno has 'FALSE GREEN' "$OUT")"
+check "the warning names both numbers" "$(yesno has 'over 4 context(s) while main requires 27' "$OUT")"
+
+echo "  innocence — SUCCESS over ENOUGH contexts is NOT called a false green:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 68 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "68-of-11 is clean" "$(nope has 'FALSE GREEN' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "roll-up (#5039) — CANCELLED is filed under 'cancel', never 'fail':"
+NODES='[{"__typename":"CheckRun","name":"a","conclusion":"CANCELLED","status":"COMPLETED"},{"__typename":"CheckRun","name":"b","conclusion":"SUCCESS","status":"COMPLETED"}]'
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup FAILURE 2 "$NODES")},\"required_count\":2,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "the cancelled context is counted" "$(yesno has '1 context(s) CANCELLED' "$OUT")"
+check "the warning names the bucket that hides it" "$(yesno has "bucket" "$OUT")"
+
+echo "  innocence — no CANCELLED context, no cancelled warning:"
+NODES='[{"__typename":"CheckRun","name":"b","conclusion":"SUCCESS","status":"COMPLETED"}]'
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 1 "$NODES")},\"required_count\":1,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "clean rollup mentions no CANCELLED" "$(nope has 'CANCELLED' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "trap #8 — a DIRTY PR runs zero workflows, so its silence is not green:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "DIRTY is called silence, not green" "$(yesno has 'silence, not green' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "trap #3 — the arm rides the PR, not the sha:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "a moved head after arm is flagged" "$(yesno has 'HEAD MOVED' "$OUT")"
+check "and says the push inherited the arm without re-passing the gate" \
+      "$(yesno has 'WITHOUT re-passing' "$OUT")"
+
+echo "  innocence — an unmoved head is not flagged:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "unmoved head produces no HEAD MOVED" "$(nope has 'HEAD MOVED' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "roll-up (#5192) — a zombie UNMERGEABLE entry points at the timeline, not at a red check:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"UNMERGEABLE\",\"position\":3},$(rollup SUCCESS 141 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "UNMERGEABLE says the queue merges onto the entries AHEAD" \
+      "$(yesno has 'entries AHEAD' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "malformed input is CANNOT-VERIFY, never a verdict:"
+OUT="$(printf 'not json at all' | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
+check "non-JSON payload exits 3" "$(yesno [ "$RC" = "3" ])"
+OUT="$(printf '{}' | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
+check "payload with no pr node exits 3" "$(yesno [ "$RC" = "3" ])"
+check "and emits no verdict line" "$(nope has 'VERDICT:' "$OUT")"
+
+# ---------------------------------------------------------------------------
+echo "CLASS assertion — across every fixture above, no NOT_ARMED verdict exists:"
+check "no fixture produced NOT_ARMED" "$(nope has 'NOT_ARMED' "$ALL_VERDICTS")"
+check "and the accumulator is not vacuously empty" "$(yesno [ "$(printf '%s' "$ALL_VERDICTS" | wc -w | tr -d ' ')" -ge 10 ])"
+check "the module's declared VERDICTS tuple omits it" \
+      "$(nope grep -q '^VERDICTS = .*NOT_ARMED' "$VERDICT")"
+
+# ---------------------------------------------------------------------------
+# End-to-end through mq.sh with a fake gh. This is where the GATHERING is
+# proved: the fixture rows above never touch mq.sh's three API calls or its
+# payload assembler.
+# ---------------------------------------------------------------------------
+new_world() {
+  W="$(mktemp -d "$SANDBOX/w.XXXXXX")"
+  mkdir -p "$W/bin" "$W/fgh" "$W/state"
+  LOG="$W/log"; : > "$LOG"
+  cat > "$W/bin/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+case " $* " in
+  *" graphql "*)
+    rc=0; [ -f "$FAKE_GH_STATE/pr_rc" ] && rc="$(cat "$FAKE_GH_STATE/pr_rc")"
+    [ -f "$FAKE_GH_STATE/pr_json" ] && cat "$FAKE_GH_STATE/pr_json"
+    exit "$rc" ;;
+  *"/branches/main/protection"*)
+    cat "$FAKE_GH_STATE/required_count" 2>/dev/null || echo 11
+    exit 0 ;;
+  *"event=merge_group"*)
+    cat "$FAKE_GH_STATE/queue_runs" 2>/dev/null || echo '{"matched":0,"window":100,"oldest":"x"}'
+    exit 0 ;;
+esac
+echo "FAKE_GH: unhandled invocation: $*" >&2
+exit 99
+FAKEGH
+  chmod +x "$W/bin/gh"
+}
+run_state() {
+  OUT="$(env MQ_REPO="test-owner/test-repo" MQ_STATE_DIR="$W/state" \
+             FAKE_GH_LOG="$LOG" FAKE_GH_STATE="$W/fgh" PATH="$W/bin:$PATH" \
+             bash "$MQSH" state "$@" 2>&1)"
+  RC=$?
+}
+
+new_world
+resolved="$(PATH="$W/bin:$PATH" command -v gh)"
+if [ "$resolved" != "$W/bin/gh" ]; then
+  echo "HARNESS TOO POOR TO JUDGE: PATH did not resolve gh to the fake ($resolved)" >&2
+  exit 2
+fi
+
+echo "end-to-end — mq state reads three sources and renders the verdict:"
+new_world
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"QUEUED\",\"position\":2},$(rollup SUCCESS 11 '[]')}" > "$W/fgh/pr_json"
+echo '{"matched":8,"window":100,"oldest":"x"}' > "$W/fgh/queue_runs"
+echo 11 > "$W/fgh/required_count"
+run_state 4242
+check "e2e verdict is IN_QUEUE" "$(yesno has 'VERDICT: IN_QUEUE' "$OUT")"
+check "e2e exits 0" "$(yesno [ "$RC" = "0" ])"
+check "e2e header carries the PR number it was asked about" "$(yesno has 'PR #4242' "$OUT")"
+check "e2e asked GraphQL for mergeQueueEntry (gh pr view cannot serve it)" \
+      "$(yesno grep -q 'mergeQueueEntry' "$LOG")"
+check "e2e read branch protection for the required count" \
+      "$(yesno grep -q 'branches/main/protection' "$LOG")"
+check "e2e scoped the run query to THIS pr number" \
+      "$(yesno grep -q 'pr-4242-' "$LOG")"
+check "e2e NEVER invoked a mutation (no 'pr merge' in the call log)" \
+      "$(nope grep -q 'pr merge' "$LOG")"
+
+echo "end-to-end — the load-bearing read failing is CANNOT-VERIFY, not a verdict:"
+new_world
+echo 1 > "$W/fgh/pr_rc"; : > "$W/fgh/pr_json"
+run_state 4242
+check "rc is 3" "$(yesno [ "$RC" = "3" ])"
+check "says CANNOT-VERIFY" "$(yesno has 'CANNOT-VERIFY' "$OUT")"
+check "emits no VERDICT line" "$(nope has 'VERDICT:' "$OUT")"
+check "and says an unread state is not an absent one" "$(yesno has 'is not an absent one' "$OUT")"
+
+echo "end-to-end — a degraded SECONDARY read still yields a verdict, labelled:"
+new_world
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 4 '[]')}" > "$W/fgh/pr_json"
+echo 'not-a-number' > "$W/fgh/required_count"
+echo 'not-json' > "$W/fgh/queue_runs"
+run_state 4242
+check "still produces a verdict" "$(yesno has 'VERDICT: INDETERMINATE' "$OUT")"
+check "and admits the required count is unverified" \
+      "$(yesno has 'required-context count CANNOT-VERIFY' "$OUT")"
+
+echo
+if [ "$failures" -eq 0 ]; then
+  echo "TOTAL $total FAILED 0"
+  exit 0
+fi
+echo "TOTAL $total FAILED $failures"
+exit 1

--- a/scripts/tests/test_mq_state_oracle.sh
+++ b/scripts/tests/test_mq_state_oracle.sh
@@ -74,6 +74,12 @@ judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "verdict is INDETERMINATE" "$(yesno [ "$(verdict_of "$JOUT")" = "INDETERMINATE" ])"
 check "never says NOT_ARMED" "$(nope has 'NOT_ARMED' "$JOUT")"
 check "names the mutation as the disambiguator" "$(yesno has 'already queued to merge' "$OUT")"
+# The disambiguator is ASYMMETRIC: it refuses on an armed PR, and ARMS an
+# unarmed one. Advertising it as "harmless" would be true of one branch and
+# a trap on the other — so the text must carry the condition, not the comfort.
+check "and warns the mutation ARMS an unarmed PR, not merely refuses" \
+      "$(yesno has 'ONLY RUN IT IF YOU INTEND TO ARM' "$OUT")"
+check "and never calls that command harmless" "$(nope has 'harmless' "$OUT")"
 check "queue-branch runs present -> ejection is flagged as CONSISTENT, not asserted" \
       "$(yesno has 'consistent with an EJECTION' "$OUT")"
 check "points at the only source for WHY" "$(yesno has 'RemovedFromMergeQueueEvent' "$OUT")"

--- a/scripts/tests/test_mq_state_oracle.sh
+++ b/scripts/tests/test_mq_state_oracle.sh
@@ -54,9 +54,17 @@ SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/mqstate_test.XXXXXX")" || {
 trap 'rm -rf "$SANDBOX"' EXIT
 
 # judge <payload-json> -> $OUT (human render), $JOUT (json render), $RC
+# judge <payload-json> -> $OUT (human), $JOUT (json), $RC.
+#
+# Refuter finding (Codex, MEDIUM): the first version discarded the exit code.
+# If the judge CRASHED on a fixture, its output contained no warning text, so
+# every `nope has ...` innocence assertion below passed — on a traceback. The
+# rc is now asserted on every fixture row, so a crash is a FAIL, never a pass.
 judge() {
   OUT="$(printf '%s' "$1" | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
   JOUT="$(printf '%s' "$1" | python3 "$VERDICT" --pr 1 --json 2>&1)"
+  check "  [judge exited 0 — a crash must never satisfy a negative assertion]" \
+        "$(yesno [ "$RC" = "0" ])"
 }
 verdict_of() { printf '%s' "$1" | python3 -c 'import json,sys; print(json.load(sys.stdin)["verdict"])' 2>/dev/null; }
 
@@ -69,7 +77,7 @@ ALL_VERDICTS=""
 
 # ---------------------------------------------------------------------------
 echo "trap #10 (PR #5036) — both fields absent is the arm->entry WINDOW, not a disarm:"
-P="{\"pr\":{\"number\":5036,\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":32,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"number\":5036,\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":32,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "verdict is INDETERMINATE" "$(yesno [ "$(verdict_of "$JOUT")" = "INDETERMINATE" ])"
 check "never says NOT_ARMED" "$(nope has 'NOT_ARMED' "$JOUT")"
@@ -86,7 +94,7 @@ check "points at the only source for WHY" "$(yesno has 'RemovedFromMergeQueueEve
 
 # ---------------------------------------------------------------------------
 echo "trap #1 — entry present + autoMergeRequest null is SUCCESS, not a disarm:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"AWAITING_CHECKS\",\"position\":1},$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"AWAITING_CHECKS\",\"position\":1},$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "verdict is IN_QUEUE" "$(yesno [ "$(verdict_of "$JOUT")" = "IN_QUEUE" ])"
 check "carries the entry sub-state" "$(yesno has 'AWAITING_CHECKS' "$OUT")"
@@ -94,7 +102,7 @@ check "says the null is BY SUCCESS" "$(yesno has 'null BY SUCCESS' "$OUT")"
 
 # ---------------------------------------------------------------------------
 echo "trap #1 — armed but not yet queued:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"2026-08-29T10:00:00Z\"},\"mergeQueueEntry\":null,$(rollup PENDING 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"2026-08-29T10:00:00Z\"},\"mergeQueueEntry\":null,$(rollup PENDING 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "verdict is ARMED" "$(yesno [ "$(verdict_of "$JOUT")" = "ARMED" ])"
 
@@ -104,67 +112,152 @@ check "zero renders the window instead of a claim" "$(yesno has 'does NOT mean' 
 check "zero never claims 'has not been built'" "$(nope has 'has not been built' "$OUT")"
 
 # ---------------------------------------------------------------------------
+# Refuter finding (Kimi K3, HIGH). `enabledAt` is a NULLABLE DateTime, so
+# `autoMergeRequest` can arrive as a non-null object carrying a null timestamp.
+# The verdict was right (INDETERMINATE) and the EVIDENCE was a measured
+# falsehood: it announced the absence of an object it had just been handed.
+echo "an autoMergeRequest object with a null enabledAt is PRESENT, and must be said so:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":null},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "verdict is still INDETERMINATE (no arm is readable)" \
+      "$(yesno [ "$(verdict_of "$JOUT")" = "INDETERMINATE" ])"
+check "and does NOT claim the object is absent" "$(nope has 'both absent' "$OUT")"
+check "it names what actually arrived" "$(yesno has 'PRESENT but carries no enabledAt' "$OUT")"
+
+echo "  innocence — with autoMergeRequest genuinely null, 'both absent' is the TRUE line:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "the true absence is still reported as absence" "$(yesno has 'both absent' "$OUT")"
+
+# ---------------------------------------------------------------------------
+# Refuter finding (Kimi K3, LOW). An armed-state file that exists but will not
+# parse silently deleted the HEAD-MOVED check — an omission indistinguishable
+# from "never armed", which is the one thing this oracle refuses to imply.
+echo "an unreadable armed-state file is CANNOT-VERIFY, not a silent all-clear:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null,\"armed_sha_unreadable\":true}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "the unreadable state file is surfaced" "$(yesno has 'could not be read' "$OUT")"
+check "and is not passed off as the head having held still" \
+      "$(yesno has 'not evidence' "$OUT")"
+
+# ---------------------------------------------------------------------------
 echo "terminal states:"
-P="{\"pr\":{\"state\":\"MERGED\",\"mergedAt\":\"2026-08-29T07:44:58Z\",\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 3 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"MERGED\",\"mergedAt\":\"2026-08-29T07:44:58Z\",\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 3 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "MERGED wins over the ambiguous fields" "$(yesno [ "$(verdict_of "$JOUT")" = "MERGED" ])"
 check "a merged PR is not warned about mergeable=UNKNOWN" "$(nope has 'still recomputing' "$OUT")"
 check "a merged PR is not warned FALSE GREEN (3 of 11 is moot once landed)" \
       "$(nope has 'FALSE GREEN' "$OUT")"
 
-P="{\"pr\":{\"state\":\"CLOSED\",\"mergedAt\":null,\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":null,\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"CLOSED\",\"mergedAt\":null,\"mergeable\":\"UNKNOWN\",\"mergeStateStatus\":\"UNKNOWN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":null,\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "CLOSED without mergedAt is CLOSED, not INDETERMINATE" "$(yesno [ "$(verdict_of "$JOUT")" = "CLOSED" ])"
 check "an unavailable run listing says CANNOT-VERIFY" "$(yesno has 'CANNOT-VERIFY' "$OUT")"
 
 # ---------------------------------------------------------------------------
-echo "roll-up (#5039/#5052) — SUCCESS over fewer contexts than required is a FALSE GREEN:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 4 '[]')},\"required_count\":27,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+echo "roll-up (#5039/#5052) — a rollup carrying NO context names cannot vouch for anything:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 4 '[]')},\"required_names\":[\"req-1\",\"req-2\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
-check "4-of-27 SUCCESS is called out" "$(yesno has 'FALSE GREEN' "$OUT")"
-check "the warning names both numbers" "$(yesno has 'over 4 context(s) while main requires 27' "$OUT")"
+check "a nameless rollup cannot verify presence" "$(yesno has 'no context NAMES to match them against' "$OUT")"
+check "and it does not silently pass as green" "$(nope has 'clean' "$OUT")"
 
-echo "  innocence — SUCCESS over ENOUGH contexts is NOT called a false green:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 68 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+echo "  innocence — every required check present by NAME is not called a false green:"
+NODES='[{"__typename":"CheckRun","name":"req-1","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"req-2","conclusion":"SUCCESS"}]'
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 2 "$NODES")},\"required_names\":[\"req-1\",\"req-2\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
-check "68-of-11 is clean" "$(nope has 'FALSE GREEN' "$OUT")"
+check "a rollup whose required checks are all present by name is clean" \
+      "$(nope has 'FALSE GREEN' "$OUT")"
+
+# ---------------------------------------------------------------------------
+# Refuter finding (Codex, BLOCKER). A required check has an IDENTITY, not a
+# cardinality. Sixty-eight green OPTIONAL contexts do not satisfy eleven
+# REQUIRED ones that are all absent — and the count-vs-count guard said they
+# did. That is the proxy-for-entity substitution this whole verb exists to
+# stop, committed inside the cure.
+echo "required checks are matched by NAME, not counted:"
+NODES='[{"__typename":"CheckRun","name":"optional-a","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"optional-b","conclusion":"SUCCESS"}]'
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 2 "$NODES")},\"required_names\":[\"req-1\",\"req-2\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "a green rollup missing every required check is called out" \
+      "$(yesno has 'FALSE GREEN RISK' "$OUT")"
+check "and the missing checks are NAMED, not merely counted" "$(yesno has 'req-1, req-2' "$OUT")"
+
+echo "  innocence — the required checks ARE present, so no risk is claimed:"
+NODES='[{"__typename":"CheckRun","name":"req-1","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"req-2","conclusion":"SUCCESS"}]'
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 2 "$NODES")},\"required_names\":[\"req-1\",\"req-2\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "present required checks raise nothing" "$(nope has 'FALSE GREEN' "$OUT")"
+
+# Refuter finding (Codex, HIGH). `required_status_checks: null` is a REAL
+# answer — the branch's rules live in a ruleset, not in classic protection.
+# Flattening it to an empty list printed "requires 0" as a measurement.
+echo "an unanswerable required-check probe is CANNOT-VERIFY, never 'requires nothing':"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 2 '[]')},\"required_names\":null,\"queue_runs\":null,\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "the unanswerable probe says CANNOT-VERIFY" "$(yesno has 'required checks CANNOT-VERIFY' "$OUT")"
+check "and distinguishes it from 'requires nothing'" "$(yesno has "not the same as" "$OUT")"
+
+echo "  innocence — a branch that genuinely declares none is stated, not warned about:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 2 '[]')},\"required_names\":[],\"queue_runs\":null,\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "an empty requirement list is reported as such" "$(yesno has 'declares no required status checks' "$OUT")"
+check "and raises no CANNOT-VERIFY" "$(nope has 'required checks CANNOT-VERIFY' "$OUT")"
+
+# Refuter finding (Codex, MEDIUM). contexts(first:100) is ONE PAGE while
+# totalCount counts them all — so "this required check is absent" may only mean
+# "absent from the page I fetched".
+echo "a truncated context page downgrades 'absent' to CANNOT-VERIFY:"
+NODES='[{"__typename":"CheckRun","name":"optional-a","conclusion":"SUCCESS"}]'
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 140 "$NODES")},\"required_names\":[\"req-1\"],\"queue_runs\":null,\"armed_sha\":null}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "truncation turns 'absent' into CANNOT-VERIFY" "$(yesno has 'CANNOT-VERIFY rather than missing' "$OUT")"
+check "and never asserts FALSE GREEN RISK on a partial page" "$(nope has 'FALSE GREEN RISK' "$OUT")"
+check "the truncation itself is disclosed" "$(yesno has 'only 1 of 140 rollup contexts' "$OUT")"
+
+# Refuter finding (Codex, HIGH). An armed sha on record with no headRefOid in
+# the read used to print "head matches the sha recorded at arm time".
+echo "an armed sha with no head in the read is CANNOT-VERIFY, not a match:"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"main\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 0 '[]')},\"required_names\":null,\"queue_runs\":null,\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
+judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
+check "no false claim that the head matches" "$(nope has 'head matches' "$OUT")"
+check "the gap is labelled instead" "$(yesno has 'head-vs-armed is CANNOT-VERIFY' "$OUT")"
 
 # ---------------------------------------------------------------------------
 echo "roll-up (#5039) — CANCELLED is filed under 'cancel', never 'fail':"
 NODES='[{"__typename":"CheckRun","name":"a","conclusion":"CANCELLED","status":"COMPLETED"},{"__typename":"CheckRun","name":"b","conclusion":"SUCCESS","status":"COMPLETED"}]'
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup FAILURE 2 "$NODES")},\"required_count\":2,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup FAILURE 2 "$NODES")},\"required_names\":[\"req-1\",\"req-2\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "the cancelled context is counted" "$(yesno has '1 context(s) CANCELLED' "$OUT")"
 check "the warning names the bucket that hides it" "$(yesno has "bucket" "$OUT")"
 
 echo "  innocence — no CANCELLED context, no cancelled warning:"
 NODES='[{"__typename":"CheckRun","name":"b","conclusion":"SUCCESS","status":"COMPLETED"}]'
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 1 "$NODES")},\"required_count\":1,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 1 "$NODES")},\"required_names\":[\"req-1\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "clean rollup mentions no CANCELLED" "$(nope has 'CANCELLED' "$OUT")"
 
 # ---------------------------------------------------------------------------
 echo "trap #8 — a DIRTY PR runs zero workflows, so its silence is not green:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"CONFLICTING\",\"mergeStateStatus\":\"DIRTY\",\"headRefOid\":\"aa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "DIRTY is called silence, not green" "$(yesno has 'silence, not green' "$OUT")"
 
 # ---------------------------------------------------------------------------
 echo "trap #3 — the arm rides the PR, not the sha:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "a moved head after arm is flagged" "$(yesno has 'HEAD MOVED' "$OUT")"
 check "and says the push inherited the arm without re-passing the gate" \
       "$(yesno has 'WITHOUT re-passing' "$OUT")"
 
 echo "  innocence — an unmoved head is not flagged:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"autoMergeRequest\":{\"enabledAt\":\"t\"},\"mergeQueueEntry\":null,$(rollup SUCCESS 11 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":0,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "unmoved head produces no HEAD MOVED" "$(nope has 'HEAD MOVED' "$OUT")"
 
 # ---------------------------------------------------------------------------
 echo "roll-up (#5192) — a zombie UNMERGEABLE entry points at the timeline, not at a red check:"
-P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"UNMERGEABLE\",\"position\":3},$(rollup SUCCESS 141 '[]')},\"required_count\":11,\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
+P="{\"pr\":{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"UNMERGEABLE\",\"position\":3},$(rollup SUCCESS 141 '[]')},\"required_names\":[\"req-1\",\"req-2\",\"req-3\",\"req-4\",\"req-5\",\"req-6\",\"req-7\",\"req-8\",\"req-9\",\"req-10\",\"req-11\"],\"queue_runs\":{\"matched\":8,\"window\":100,\"oldest\":\"x\"},\"armed_sha\":null}"
 judge "$P"; ALL_VERDICTS="$ALL_VERDICTS $(verdict_of "$JOUT")"
 check "UNMERGEABLE says the queue merges onto the entries AHEAD" \
       "$(yesno has 'entries AHEAD' "$OUT")"
@@ -175,6 +268,25 @@ OUT="$(printf 'not json at all' | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
 check "non-JSON payload exits 3" "$(yesno [ "$RC" = "3" ])"
 OUT="$(printf '{}' | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
 check "payload with no pr node exits 3" "$(yesno [ "$RC" = "3" ])"
+# Refuter finding (Codex, MEDIUM): a JSON LIST is valid JSON and used to raise
+# AttributeError with a traceback and rc 1 — the documented contract says 3.
+# A caller branching on the exit code would read "a verdict was produced".
+OUT="$(printf '[]' | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
+check "a JSON list payload exits 3, not 1 with a traceback" "$(yesno [ "$RC" = "3" ])"
+check "  and says CANNOT-VERIFY rather than printing a traceback" \
+      "$(yesno has 'CANNOT-VERIFY' "$OUT")"
+check "  and no traceback reaches the operator" "$(nope has 'Traceback' "$OUT")"
+# The generic exception net would ALSO produce rc 3 here, so the explicit
+# isinstance guard survives a naive mutation. Its value is the MESSAGE: it
+# names the shape that arrived instead of leaving a bare AttributeError to
+# describe the problem in terms of the code that tripped over it.
+check "  and the message names the shape that arrived" \
+      "$(yesno has 'must be a JSON object, got list' "$OUT")"
+# The same contract for a well-shaped payload carrying a wrongly-typed field.
+OUT="$(printf '{"pr":{"state":"OPEN"},"queue_runs":{"matched":"eight"}}' | python3 "$VERDICT" --pr 1 2>&1)"; RC=$?
+check "a wrongly-typed field exits 3, not 1" "$(yesno [ "$RC" = "3" ])"
+check "  and names the exception class instead of dumping it" \
+      "$(yesno has 'CANNOT-VERIFY' "$OUT")"
 check "and emits no verdict line" "$(nope has 'VERDICT:' "$OUT")"
 
 # ---------------------------------------------------------------------------
@@ -230,7 +342,7 @@ fi
 
 echo "end-to-end — mq state reads three sources and renders the verdict:"
 new_world
-printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"QUEUED\",\"position\":2},$(rollup SUCCESS 11 '[]')}" > "$W/fgh/pr_json"
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"QUEUED\",\"position\":2},$(rollup SUCCESS 11 '[]')}" > "$W/fgh/pr_json"
 echo '{"matched":8,"window":100,"oldest":"x"}' > "$W/fgh/queue_runs"
 echo 11 > "$W/fgh/required_count"
 run_state 4242
@@ -239,8 +351,11 @@ check "e2e exits 0" "$(yesno [ "$RC" = "0" ])"
 check "e2e header carries the PR number it was asked about" "$(yesno has 'PR #4242' "$OUT")"
 check "e2e asked GraphQL for mergeQueueEntry (gh pr view cannot serve it)" \
       "$(yesno grep -q 'mergeQueueEntry' "$LOG")"
-check "e2e read branch protection for the required count" \
-      "$(yesno grep -q 'branches/main/protection' "$LOG")"
+# Refuter finding (Codex, HIGH): the probe always read `main`'s protection, so
+# a PR into release/1.x was judged against the wrong branch's rules entirely.
+check "e2e read the protection of the PR OWN base branch, not main" \
+      "$(yesno grep -q 'branches/release-1.x/protection' "$LOG")"
+check "  and did NOT read main protection" "$(nope grep -q 'branches/main/protection' "$LOG")"
 check "e2e scoped the run query to THIS pr number" \
       "$(yesno grep -q 'pr-4242-' "$LOG")"
 check "e2e NEVER invoked a mutation (no 'pr merge' in the call log)" \
@@ -257,13 +372,66 @@ check "and says an unread state is not an absent one" "$(yesno has 'is not an ab
 
 echo "end-to-end — a degraded SECONDARY read still yields a verdict, labelled:"
 new_world
-printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 4 '[]')}" > "$W/fgh/pr_json"
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":null,$(rollup SUCCESS 4 '[]')}" > "$W/fgh/pr_json"
 echo 'not-a-number' > "$W/fgh/required_count"
 echo 'not-json' > "$W/fgh/queue_runs"
 run_state 4242
 check "still produces a verdict" "$(yesno has 'VERDICT: INDETERMINATE' "$OUT")"
-check "and admits the required count is unverified" \
-      "$(yesno has 'required-context count CANNOT-VERIFY' "$OUT")"
+check "and admits the required checks are unverified" \
+      "$(yesno has 'required checks CANNOT-VERIFY' "$OUT")"
+
+echo "arg parsing REFUSES rather than guesses (both shapes read the wrong PR or died mute):"
+new_world
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"QUEUED\",\"position\":2},$(rollup SUCCESS 11 '[]')}" > "$W/fgh/pr_json"
+run_state 4242 --repo
+check "--repo with no value is refused, not a silent rc=1" "$(yesno has 'needs a value' "$OUT")"
+check "  and it never reached the API" "$(nope grep -q 'graphql' "$LOG")"
+new_world
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"QUEUED\",\"position\":2},$(rollup SUCCESS 11 '[]')}" > "$W/fgh/pr_json"
+run_state 4242 9999
+check "a second positional is refused, never silently preferred" \
+      "$(yesno has 'takes ONE PR number' "$OUT")"
+check "  and it never queried the wrong PR" "$(nope grep -q 'pr-9999-' "$LOG")"
+
+echo "  innocence — one PR number and a valid --repo still work:"
+new_world
+printf '%s' "{\"state\":\"OPEN\",\"mergedAt\":null,\"baseRefName\":\"release-1.x\",\"mergeable\":\"MERGEABLE\",\"mergeStateStatus\":\"CLEAN\",\"headRefOid\":\"aa\",\"autoMergeRequest\":null,\"mergeQueueEntry\":{\"state\":\"QUEUED\",\"position\":2},$(rollup SUCCESS 11 '[]')}" > "$W/fgh/pr_json"
+run_state 4242 --repo other-owner/other-repo
+check "valid --repo is accepted" "$(yesno has 'VERDICT: IN_QUEUE' "$OUT")"
+check "  and the override reached the API call" "$(yesno grep -q 'other-owner/other-repo' "$LOG")"
+
+echo "a repo string with extra segments is refused, not split two different ways:"
+new_world
+run_state 4242 --repo Bali-Zero/junk/Teman2
+check "three segments are refused" "$(yesno has 'exactly owner/name' "$OUT")"
+# Refuter finding (Codex, HIGH): `%%/*` took `Bali-Zero` and `##*/` took
+# `Teman2` for GraphQL while the REST calls used the whole three-segment
+# string — one verdict about two different repositories.
+check "  and nothing was queried at all" "$(nope grep -q 'graphql' "$LOG")"
+
+echo "the branch-protection jq filter, extracted from mq.sh and run under real jq:"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  SKIP — jq is not installed; this row cannot judge (declared, not silently passed)"
+else
+  PFILTER="$(sed -n "s/^ *local prot_jq='\(.*\)'$/\1/p" "$MQSH" | head -1)"
+  check "the protection filter was actually extracted" "$(yesno [ -n "$PFILTER" ])"
+
+  # GitHub returns the SAME required-check list twice — modern `checks[].context`
+  # and legacy `contexts`. Concatenating them printed "requires 22" for 11 real
+  # checks: a doubled number presented as a measurement.
+  DUP='{"required_status_checks":{"checks":[{"context":"a"},{"context":"b"}],"contexts":["a","b"]}}'
+  JQOUT="$(printf '%s' "$DUP" | jq -c "$PFILTER" 2>&1)"; JQRC=$?
+  check "the two representations are unioned, not concatenated" \
+        "$(yesno [ "$JQOUT" = '["a","b"]' ])"
+  check "  (filter ran cleanly)" "$(yesno [ "$JQRC" = "0" ])"
+
+  # `required_status_checks: null` is a REAL answer — the rules live in a
+  # ruleset. It must stay null, never flatten to [] and print "requires 0".
+  NUL='{"required_status_checks":null}'
+  JQOUT="$(printf '%s' "$NUL" | jq -c "$PFILTER" 2>&1)"
+  check "a null required_status_checks stays null, never becomes []" \
+        "$(yesno [ "$JQOUT" = "null" ])"
+fi
 
 # ---------------------------------------------------------------------------
 # The jq filter that counts queue-branch runs is a STRING inside mq.sh, and the


### PR DESCRIPTION
## What this is

A read-only `mq state <PR>` verb that answers "what is this PR's merge-queue state?" without
touching the PR — and, more importantly, without lying about it.

## Why

The queue **consumes** `autoMergeRequest` when it **accepts** an arm request. The field goes null on
SUCCESS, not on failure. Twice in this repo's history a background probe has announced
`AUTO-MERGE DISARMED — re-arm needed` about a PR sitting at position 1, with the authority of an
automated measurement. Acting on that alarm means re-queuing (back of the line) or pushing (breaks
*arm means freeze*) a PR that was about to land.

The knowledge was already written down — twice, in `MEMORY_MERGE_QUEUE_TRAPS.md`. It was not in a
**tool**. This is the tool.

## The design decision is an absence

**There is no `NOT_ARMED` verdict.** Measured on PR #5036: arming consumes `autoMergeRequest`
*before* the queue entry materialises, so both fields read "not armed" while 32 queue-branch runs
existed. No instantaneous read of those two fields, not even joint, can prove it. `INDETERMINATE`
instead **names** the only thing that decides — the refusal text of `gh pr merge --auto` — and
declines to run it, because that is a mutation and this verb is what you run when you do *not* want
to touch the PR.

Pinned by a class assertion over every fixture (plus a check that the accumulator is not vacuously
empty), and by a check that the module's declared `VERDICTS` tuple omits it.

## Verdicts and evidence

| verdict | discriminator |
|---|---|
| `MERGED` / `CLOSED` | terminal state — outranks the ambiguous fields |
| `IN_QUEUE` | `mergeQueueEntry` present; carries `state` + `position` |
| `ARMED` | `autoMergeRequest.enabledAt` set, no entry yet |
| `INDETERMINATE` | both absent — the documented arm→entry window |

Evidence lines (never a verdict) carry the rest of the corpus: `DIRTY` means zero workflows ran, so
"0 pending" is silence not green · `CANCELLED` contexts are filed under bucket `cancel` and never
`fail`, so a caller filtering for `fail` reads "0 reds" on a `FAILURE` rollup · a `rollup=SUCCESS`
computed over fewer contexts than branch protection requires is a **false green** · a head that
moved after arming inherited the arm without re-passing the gate that judged it.

## Two defects in this build, found by measuring rather than reading

1. **The queue-run signal read a bounded page as if it were the world.** `?event=merge_group&per_page=100`
   spans ~13 PRs (measured: 100 runs / 13 PRs — a queue build fires 8 workflows). The first
   rendering of a zero was *"this PR has not been built by the queue yet"* — false for any PR older
   than the window, and this patch's own disease one level down. Cured: the signal carries
   `{matched, window, oldest}` and a zero renders as uninformative. Presence stays sound; only
   absence was unsound.
2. **Terminal PRs were warned about questions that had stopped existing.** Live on #5214 (MERGED),
   `mergeable=UNKNOWN` drew "still recomputing". Cured: warnings suppressed once terminal.

## Two defects in the TEST corpus, either of which would have made it vacuous

3. `yesno ! cmd` is not a thing — `!` is shell syntax, so it landed in `argv[0]` and **all 13
   negative assertions failed with `!: command not found`**; no innocence case could ever have
   passed. Found by *running* the corpus, not reading it.
4. The class assertion greped the human render for `NOT_ARMED`, which legitimately contains it
   inside the note explaining no such verdict exists — the guard tripping on its own documentation.
   Cured: it judges the verdict *value*.

## Prove-live (real GitHub, three states, at build time)

| PR | verdict | cross-check |
|---|---|---|
| #5214 | `MERGED` | `mergedAt=2026-08-29T07:44:58Z` |
| #5216 | `IN_QUEUE (AWAITING_CHECKS)` pos 1 | `autoMergeRequest` **is** null here, and the oracle says "null BY SUCCESS" |
| #5103 | `INDETERMINATE` | 0 queue runs *in a window reaching back only to 05:48Z* — rendered as uninformative |

## Gates (empirical, re-run on the final tree)

- **46/46** `bash scripts/tests/test_mq_state_oracle.sh` — 33 fixture rows through the verdict
  module, 13 end-to-end through `mq state` with a fake `gh` on PATH (poverty-checked: the harness
  aborts 2 if `command -v gh` does not resolve to the fake).
- Existing `scripts/tests/test_mq_sh.sh` regression **PASS** (mq.sh was edited).
- `ruff` clean · `shellcheck -S warning` clean · `/bin/bash -n` clean under bash **3.2.57** (macOS
  system bash, the one that actually runs this).
- **8 mutations, all killed**, byte-identical restore verified with `cmp`: verdict→`NOT_ARMED` (6) ·
  drop terminal short-circuit (2) · bounded-zero→a claim (2) · drop false-green guard (2) · drop
  CANCELLED counting (2) · drop HEAD-MOVED guard (2) · make `mq state` mutate (1) · primary read no
  longer fail-closed (1).

## Adversarial review

Blind cross-family refutation by **Codex GPT-5.6 sol** (`xhigh`), generator ≠ grader. Dispositions
posted as a comment on this PR before arming.

## Deliberately NOT in this PR

The spec pairs this with a companion lint banning raw `autoMergeRequest`/`isInMergeQueue` reads
outside `mq.sh`. It **cannot** share this PR: its arming step edits
`.github/workflows/immune-enforcement.yml`, which puts it in the auto-merge-OFF class, while this is
scripts-only. Two merge classes, two PRs.

Measurement that re-shaped it, recorded so the next reader does not re-derive it: **22 files**
mention those fields and **~all are already disciplined** — `queue_unstick.py`, `queue_shepherd.py`
and `merge-queue-watch.yml` each read them jointly and cite W111 in their own comments. A literal
ban would flag ~20 innocent files and its allowlist would be the whole set. The targeted rule (a
*null-comparison* with no queue-awareness in the file) has **one** live match,
`scripts/ci/queue_rearm_population.sh`, and that is a proven file-scoped false positive: its
orchestrator `queue_rearm.sh` fetches the queue snapshot (fail-closed `exit 3`) and subtracts it
before acting. **Zero live instances of the disease** — so that lint is a regression guard with no
catches today, and PR-2b will say so rather than imply it found something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
