### PR TITLE
fix(wal-probe): remove the unbound-tier hazard and the clock seam that governs nothing

### DIFF
--- a/scripts/tests/test_wal_continuity_probe.py
+++ b/scripts/tests/test_wal_continuity_probe.py
@@ -1254,3 +1254,84 @@ def test_every_send_alert_call_in_this_module_reads_its_verdict():
 
     total = sum(1 for n in ast.walk(tree) if is_send_alert(n))
     assert total >= 6, f"expected every alert path to be present, found {total} call(s)"
+
+
+def test_cannot_verify_tier_escalates_exactly_at_the_streak_threshold():
+    """Innocence and guilt for the helper that replaced a fragile local.
+
+    A blind probe must get LOUDER, never quieter (superscar #2): below the threshold the
+    alert is a digest, at and above it a p0. Both directions are pinned so a mutation
+    that returns a constant dies here whichever constant it picks.
+    """
+    n = probe.CANNOT_VERIFY_P0_STREAK
+    assert probe.cannot_verify_tier(n - 1) == "digest"
+    assert probe.cannot_verify_tier(n) == "p0"
+    assert probe.cannot_verify_tier(n + 5) == "p0"
+
+
+def test_no_local_named_tier_is_bound_inside_run():
+    """STRUCTURAL, and structural for the same reason as the send_alert class assertion.
+
+    CodeQL flagged, at error severity, that `run()` bound `tier` in ONE arm of an
+    if/else and read it from a LATER `elif`. It was safe only because both tested the
+    same `verdict.exit_code` — a correlation nothing in the code stated. Widening that
+    `elif` by one value turns the paging branch into an `UnboundLocalError`: the p0
+    computed and never sent, which is this probe's whole defect class turned inward.
+
+    Asserting "it is initialised before use" would pass again the moment someone adds a
+    plain default, and a default silently picks a tier for a state nobody considered. So
+    the assertion is that the LOCAL does not exist: the tier is derived at the point of
+    use, from `streak`, which both arms bind.
+    """
+    import ast
+    tree = ast.parse(Path(probe.__file__).read_text())
+    run_fn = next(n for n in ast.walk(tree)
+                  if isinstance(n, ast.FunctionDef) and n.name == "run")
+    bound = sorted({
+        t.lineno for node in ast.walk(run_fn)
+        if isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+        for t in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        if isinstance(t, ast.Name) and t.id == "tier"
+    })
+    assert not bound, (
+        f"`run()` binds a local named `tier` at line(s) {bound} — derive it from "
+        "`streak` via cannot_verify_tier() at the point of use instead, so no branch "
+        "can read a tier that another branch was supposed to have set")
+
+
+def test_classify_advertises_no_clock_it_does_not_read():
+    """`classify` had a `now: datetime | None = None` parameter it never read (CodeQL
+    notice: "Variable now is not used"). Every temporal judgment it makes is relative —
+    last-success against last-failure, this run's counters against the previous run's —
+    so the seam governed nothing while looking like it governed everything, and the
+    first test to pin time through it would have been green and proved nothing.
+
+    That is W129 inverted: there a real injected clock was dropped by a caller, here the
+    seam had nothing to govern. W129's cure is to WIRE the clock and prove it with two
+    injected instants; the cure here is to DELETE it, because wiring would have to
+    invent an absolute staleness rule that no RED path defines. This test fails if the
+    parameter comes back without such a rule arriving with it.
+    """
+    import inspect
+    params = inspect.signature(probe.classify).parameters
+    assert "now" not in params, (
+        "classify() takes a `now` parameter again. If an absolute staleness check now "
+        "exists, wire it and pin it the W129 way — the SAME fixture at two injected "
+        "instants yielding different verdicts, so no wall clock satisfies both. If it "
+        "does not, the parameter is a seam that lies about what it controls.")
+    # Over the AST, never over the source text: the first draft of this assertion was a
+    # `"datetime.now" not in inspect.getsource(...)` substring test, and it failed on the
+    # DOCSTRING above that explains why the clock was removed. A guard that a comment can
+    # trip is superscar #3, and one that a comment can SATISFY is the same bug pointed
+    # the other way — so this walks for a real Call node.
+    import ast
+    fn = next(n for n in ast.walk(ast.parse(Path(probe.__file__).read_text()))
+              if isinstance(n, ast.FunctionDef) and n.name == "classify")
+    clock_reads = [
+        n.lineno for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr in ("now", "utcnow", "today")
+    ]
+    assert not clock_reads, (
+        f"classify() reads the wall clock at line(s) {clock_reads} — a pure verdict "
+        "function whose answer depends on when it runs cannot be pinned by any fixture")

--- a/scripts/wal_continuity_probe.py
+++ b/scripts/wal_continuity_probe.py
@@ -455,15 +455,29 @@ def observation_is_blind(obs: dict) -> bool:
     return all(obs.get(k) in (None, "") for k in ARCHIVER_FIELDS)
 
 
-def classify(previous: dict | None, current: dict, now: datetime | None = None,
+def classify(previous: dict | None, current: dict,
              state_status: str = STATE_OK, first_run_count: int = 0,
              carried_pressure: int = 0) -> Verdict:
     """The whole judgment, as a pure function. Every RED path is reachable from here.
 
     Order matters only for which code names the dedup key; ALL findings are collected
     so an alert never hides a second fault behind the first.
+
+    There is deliberately NO `now` parameter. This function reads no wall clock: every
+    temporal judgment it makes is RELATIVE — `last_archived_time` against
+    `last_failed_time`, this run's counters and LSN against the previous run's. It used
+    to take `now: datetime | None = None` and immediately do `now = now or
+    datetime.now(...)` without ever reading the result again (CodeQL: "Variable now is
+    not used"), which advertised an injectable clock that governed nothing: the first
+    test to pin time through it would have been green and proved nothing. That is W129
+    with the polarity reversed — there the injected clock was real and a caller dropped
+    it, here the seam never had anything to govern. W129's cure (a test pinning the SAME
+    fixture at two injected instants, so no wall clock satisfies both) is the right guard
+    when the code SHOULD read the clock; it is not this case, so the seam is removed
+    rather than wired. Adding an ABSOLUTE staleness check ("nothing archived for N
+    hours") would be a new RED path and wants its own adjudication, not a silent
+    resurrection of this parameter.
     """
-    now = now or datetime.now(timezone.utc)
     findings: list[Finding] = []
     notes: list[Finding] = []
     # Starts at what the last run carried; only the stall branch below moves it. Every
@@ -834,6 +848,24 @@ def _as_int(value: Any, default: int) -> int:
         return default
 
 
+def cannot_verify_tier(streak: int) -> str:
+    """digest while the blindness is fresh, p0 once it has persisted.
+
+    This exists so no caller has to hold the tier in a LOCAL that may or may not be
+    bound. The two CANNOT_VERIFY senders used to each compute `tier = "p0" if streak >=
+    ... else "digest"`, and in `run()` that binding lived in only ONE arm of an
+    if/else while the send read it from a LATER `elif` — safe today purely because both
+    branches happen to test the same `verdict.exit_code`, an invisible correlation
+    nothing in the code states (CodeQL, error severity: "Local variable 'tier' may be
+    used before it is initialized"). Widening that `elif` by one value — an entirely
+    ordinary edit — turns the paging branch into an `UnboundLocalError`: the p0 computed
+    and never sent. Deriving the tier at the point of use removes the variable, and with
+    it the possibility; a plain default before the branch would NOT, because it would
+    silently pick a tier for a state nobody considered.
+    """
+    return "p0" if streak >= CANNOT_VERIFY_P0_STREAK else "digest"
+
+
 def state_path() -> Path:
     """Read the env at CALL time, never at import: tests must be able to redirect it.
 
@@ -1120,7 +1152,6 @@ def run(args: argparse.Namespace) -> int:
 
     if cannot_verify_reason:
         streak = _as_int(state.get("cannot_verify_streak"), 0) + 1
-        tier = "p0" if streak >= CANNOT_VERIFY_P0_STREAK else "digest"
         verdict = Verdict(
             verdict=V_CANNOT_VERIFY, exit_code=EXIT_CANNOT_VERIFY,
             findings=[Finding(V_CANNOT_VERIFY,
@@ -1128,7 +1159,8 @@ def run(args: argparse.Namespace) -> int:
         )
         log(f"CANNOT_VERIFY (streak {streak}): {cannot_verify_reason}")
         if not args.dry_run:
-            delivered = send_alert(format_message(verdict, obs), "cannot-verify", tier)
+            delivered = send_alert(format_message(verdict, obs), "cannot-verify",
+                                   cannot_verify_tier(streak))
             if not delivered:
                 log("ALERT NOT DELIVERED: the CANNOT_VERIFY alert did not leave the "
                     "machine.")
@@ -1160,7 +1192,6 @@ def run(args: argparse.Namespace) -> int:
     # re-baseline forever at a polite digest tier.
     if verdict.exit_code == EXIT_CANNOT_VERIFY:
         streak = _as_int(state.get("cannot_verify_streak"), 0) + 1
-        tier = "p0" if streak >= CANNOT_VERIFY_P0_STREAK else "digest"
         condition = "+".join(sorted(n.code for n in verdict.notes
                                     if n.code in EVIDENCE_ERASING_NOTES)).lower()
         verdict.findings.append(Finding(
@@ -1183,8 +1214,11 @@ def run(args: argparse.Namespace) -> int:
             delivered = send_alert(format_message(verdict, obs),
                                    verdict.verdict.lower(), "p0")
         elif verdict.exit_code == EXIT_CANNOT_VERIFY:
+            # `streak` is bound in BOTH arms above; the tier is derived here rather than
+            # carried in a local that only one arm binds. See `cannot_verify_tier`.
             delivered = send_alert(format_message(verdict, obs),
-                                   condition or "cannot-verify", tier)
+                                   condition or "cannot-verify",
+                                   cannot_verify_tier(streak))
         elif voided_codes := [n.code for n in verdict.notes if n.code in VOIDING_NOTES]:
             # A run where a check was SKIPPED is not the same as a run where it passed,
             # and the difference must leave the machine. A timeline switch or a


### PR DESCRIPTION
Two CodeQL findings on #5205's head, both correct, neither blocking. The check-run that carried them is posted by the **GitHub Advanced Security app**, not by an Actions workflow — which is why its `workflowName` is empty and why it looked contextless. It is a different producer from the two required contexts (`CodeQL Analysis (python)` / `(javascript)`, which are the Actions *jobs*), and `branches/main/protection` lists only those two. So an error-severity finding sat visible in the rollup, was read by two agents and a merge queue, and gated nothing.

## 1. `tier` may be used before it is initialized (error)

`run()` bound `tier` in ONE arm of an if/else and read it from a LATER `elif`. It is safe on `origin/main` today only because both branches test the same `verdict.exit_code`, and that is a plain dataclass field (line 406) rather than a computed property, so nothing between the two tests can change it. CodeQL is path-insensitive and cannot see that correlation — but neither can a future editor, because **nothing in the code states it**.

**Measured, not theoretical.** Narrowing the first branch by one plausible conjunct (`and not args.verbose`) on the `origin/main` version makes a real STATS_RESET run, driven through `main()` with a `--from-json` fixture, do this:

```
verdict=CANNOT_VERIFY exit=4
  note STATS_RESET: pg_stat_archiver counters were reset ...
*** UnboundLocalError RAISED: cannot access local variable 'tier' ...
```

The verdict is computed and logged; the crash lands **before any alert leaves the machine**. That is the p0 computed and never sent — this probe's entire defect class turned inward on the probe itself. The identical narrowing applied to this branch's code instead yields `rc=4` with the alert delivered at `digest`.

**Cured by deriving the tier at the point of use** (`cannot_verify_tier(streak)`), not by defaulting it before the branch. A default would silence CodeQL while silently picking a tier for a state nobody considered — which is precisely how a `digest` would come to stand in for a `p0`. `streak` is bound in both arms, so the derivation is total. Both CANNOT_VERIFY senders use the helper, not one of the two (W107).

## 2. `now` is not used (notice)

`classify` took `now: datetime | None = None`, immediately did `now = now or datetime.now(...)`, and never read it again — verified by grepping every `now` in the function's whole range. Every temporal judgment it makes is **relative**: `last_archived_time` against `last_failed_time`, this run's counters and LSN against the previous run's. The only wall-clock reads in the module are the log timestamp and the `observed_at` default.

So this was not dead code — it was an **advertised injectable clock that governed nothing**. No test passes `now=` today (0 occurrences), so nothing is vacuous yet; the hazard is that the seam invites a time-pinning test that would be green and prove nothing.

That is **W129 inverted**: there a real injected clock was dropped by a caller, and the cure was to wire it and prove it with two injected instants on one fixture. Here the seam never had anything to govern, so it is **deleted rather than wired** — wiring would have to invent an absolute staleness rule that no RED path defines. Such a rule would be a new RED path and wants its own adjudication; the test says so, so a future reviver reads the condition rather than rediscovering it.

## Red-first

Three tests, each killed by name by a mutation of a code token:

| mutation | test killed |
|---|---|
| `cannot_verify_tier` returns a constant | `test_cannot_verify_tier_escalates_exactly_at_the_streak_threshold` (+ 2 pre-existing behavioural tests) |
| reintroduce a `tier` local in `run()` | `test_no_local_named_tier_is_bound_inside_run` |
| reintroduce the `now` parameter | `test_classify_advertises_no_clock_it_does_not_read` |

Run under `PYTHONDONTWRITEBYTECODE=1` (W121), restored from a copy and verified byte-identical after each.

One self-correction worth recording: the clock test's first draft asserted `"datetime.now" not in inspect.getsource(classify)` and **failed on the docstring explaining why the clock was removed**. A guard a comment can trip is superscar #3; a guard a comment can *satisfy* is the same bug pointed the other way. It now walks the AST for a real `Call` node.

## State

86 tests pass, `--selftest` passes, `ruff` clean. Gear floor re-derived on the actual changed-file list: **1** — no evidence pack owed, none manufactured.

**I am the author here and cannot gate this.** It wants a non-author adjudicator, as does #5219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtMzhGG16zh4nD6XHG3tSR