### PR TITLE
chore(scratch): auto-merge experiment — local-merge resolution control (throwaway, will not merge)

### DIFF
--- a/docs/runbooks/_scratch-automerge-probe-localmerge.md
+++ b/docs/runbooks/_scratch-automerge-probe-localmerge.md
@@ -1,0 +1,11 @@
+# Scratch probe — local-merge resolution arm (throwaway)
+
+Not a real doc. Created for the auto-merge discriminating experiment ordered
+2026-08-29 (team-lead ruling on `cicatrix-superscar.md` §9 PR-1-landing line,
+tracked in `.claude/skills/modus/PENDING-ARMS.md:1188`).
+
+This PR is armed with `gh pr merge --auto`, allowed to go BEHIND/CONFLICTING
+as `origin/main` moves, resolved via a LOCAL `git merge origin/main` + push
+(the arm already known to survive), and CLOSED without merging once the
+field/timeline reads are captured. Safe to delete this file if it is ever
+seen lingering on a branch.


### PR DESCRIPTION
Mirror control for the server-side arm PR. Adds one harmless scratch file. Will be armed with `gh pr merge --auto`, allowed to go BEHIND/CONFLICTING, resolved via a LOCAL `git merge origin/main` + push, field/timeline read before and after, then CLOSED without merging. No functional change.