### PR TITLE
fix(scripts): organ_birth.py header self-reference uses hyphens for underscores too

### DIFF
--- a/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/brief.yml
@@ -30,9 +30,12 @@ objective: |
   Gear 3 by PATH, not by blast radius: `infra/launchagents/*` is a literal
   `HOTZONE_PATTERNS` entry in `scripts/evidence_pack_lint.py` — floor is a
   deterministic lower bound computed from the changed-file set, never the
-  author's choice, regardless of how small or mechanical the diff reads (5
-  files, +137/-8, all header-comment-shaped edits plus one new test file). The
-  PR's own author (a Mini-Pro2 healer tick — autonomous cure session, Claude
+  author's choice, regardless of how small or mechanical the diff reads
+  (three of the changed wrapper files carry only a two-line header-comment
+  edit each, plus one new test file). Diff size in files/lines is
+  deliberately NOT stated as a number here — see `diff.net_lines` in
+  `pack.yml` for why a self-referential count is not a stable claim to make.
+  The PR's own author (a Mini-Pro2 healer tick — autonomous cure session, Claude
   Sonnet 5 per its own commit's co-author line) sized this as routine content;
   it is the PATH, not the content, that trips the floor. This evidence pack is
   supplied after the fact, on the orchestrating session's explicit dispatch, to
@@ -67,10 +70,13 @@ acceptance:
       green) — proving the tests actually exercise the bug, not merely echo the
       fix."
     probe: "pytest scripts/tests/test_organ_birth.py -v"
-  - text:
-      "WHEN every wrapper's own `# Canon:` line in `infra/launchagents/wrappers/*.sh`
-      is scanned against its own actual filename, SHALL find zero mismatches after
-      the fix."
+  - text: "WHEN every `# Canon:` line actually present under
+      `infra/launchagents/wrappers/*.sh` is scanned against its own file's actual
+      filename, SHALL find zero mismatches — measured coverage: 15 of the 50
+      wrapper files carry a `# Canon:` line at all (the other 35 predate
+      organ_birth.py or were hand-authored without one, and are outside this
+      check's scope — silent on them, not passing on them); 0 of those 15 are
+      mismatched after the fix."
     probe: "repo-wide scan of every wrapper's own # Canon: self-reference against its actual filename"
   - text: "WHEN shellcheck runs against the 3 hand-edited wrapper files, SHALL
       introduce zero NEW findings relative to their pre-fix versions (the diff is

--- a/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/brief.yml
@@ -1,0 +1,119 @@
+task_id: organ-birth-underscore-header
+gear: 3
+l_level: L1
+gate_class: opus
+objective: |
+  `scripts/organ_birth.py::wrapper_template()`'s `Canon:`/`Live:` self-reference
+  header f-string only converted `.` to `-` when building the wrapper's own
+  filename, never `_`, while the ACTUAL computed wrapper filename (`main()`'s
+  `dash = args.id.replace(".", "-").replace("_", "-")`, line 331) converts both.
+  Any `organ_id` whose descriptive segment is underscore_case — the house style
+  (`visa_freshness_sentinel`, `git_pull_main`, `llm_burn_alarm`, `tg_digest_flush`)
+  — got a header that lied about its own filename. Trauma: PENDING-ARMS row
+  `ops-visaoracle-wrapper-header-0823`; a 4th instance (`visa_freshness_sentinel`)
+  had already been hand-cured by prior PR #4599, which fixed only that one wrapper
+  and explicitly declined to fix the generator itself.
+
+  PR #5237 (`agent/mini-pro2/infra/organ-birth-underscore-header`) fixes the
+  generator for all future organ births (one new `dash_name =
+  organ_id.replace(".", "-").replace("_", "-")` local, scoped to the header
+  f-string only), hand-corrects the 3 remaining live wrapper headers still
+  mismatched, and adds a 5-test regression suite
+  (`scripts/tests/test_organ_birth.py`) — 2 guilt (the exact underscore trigger,
+  and a multi-underscore stack), 1 innocence (no underscore -> unaffected), 1
+  scope-pin (LOG_DIR/PIDFILE stay dot-only by design — they name runtime
+  artifacts the generator creates itself, not a claim about a pre-existing file,
+  so widening their scope would be an undocumented behavior change), and 1
+  permanent repo-wide regression guard scanning every wrapper's own header
+  against its actual filename.
+
+  Gear 3 by PATH, not by blast radius: `infra/launchagents/*` is a literal
+  `HOTZONE_PATTERNS` entry in `scripts/evidence_pack_lint.py` — floor is a
+  deterministic lower bound computed from the changed-file set, never the
+  author's choice, regardless of how small or mechanical the diff reads (5
+  files, +137/-8, all header-comment-shaped edits plus one new test file). The
+  PR's own author (a Mini-Pro2 healer tick — autonomous cure session, Claude
+  Sonnet 5 per its own commit's co-author line) sized this as routine content;
+  it is the PATH, not the content, that trips the floor. This evidence pack is
+  supplied after the fact, on the orchestrating session's explicit dispatch, to
+  satisfy `Harness floor recompute` — the PR's code+test diff was not
+  independently re-reviewed by this authoring session as part of writing the
+  pack (see `grader:` below for the exact division of responsibility).
+constraints:
+  - 'Fix is scoped to ONE local variable (`dash_name`) inside `wrapper_template()`,
+    consumed only by the `Canon:`/`Live:` comment lines of the generated header —
+    verified by reading the full function body: `LOG_DIR`/`PIDFILE` still use the
+    pre-existing dot-only `organ_id.replace(".", "-")` (unchanged), and the
+    heartbeat sidecar path (`$SIDECAR_DIR/$ORGAN_ID.json`, `ORGAN_ID="{organ_id}"`
+    verbatim) and `registry_entry()`''s declared `path:` field both use the RAW,
+    unconverted `organ_id` — a third, separate naming convention this PR does not
+    touch and does not need to (see dissent below).'
+  - "The 3 hand-fixed wrapper files (`pro-git-pull-main.sh`, `pro-llm-burn-alarm.sh`,
+    `pro-tg-digest-flush.sh`) each change exactly 2 lines — the `# Canon:` and
+    `# Live:` comment lines — nothing else in any of the 3 files is touched
+    (verified: `git diff --stat` on each shows +2/-2, matching exactly the 2
+    replaced comment lines)."
+  - "No runtime behavior change to any of the 3 live wrappers beyond the comment
+    text itself — the lines are `#`-prefixed, never executed by bash."
+acceptance:
+  - text: "WHEN `pytest scripts/tests/test_organ_birth.py -v` is run against the
+      post-fix branch, SHALL report 5/5 tests green (2 guilt, 1 innocence, 1
+      scope-pin, 1 permanent repo-wide regression guard)."
+    probe: "pytest scripts/tests/test_organ_birth.py -v"
+  - text:
+      "WHEN `organ_birth.py` is reverted to its pre-fix form (this PR's parent
+      commit) WHILE the new test file stays at its post-fix form, SHALL exactly the
+      2 guilt tests fail (the innocence, scope-pin, and repo-wide-scan tests stay
+      green) — proving the tests actually exercise the bug, not merely echo the
+      fix."
+    probe: "pytest scripts/tests/test_organ_birth.py -v"
+  - text:
+      "WHEN every wrapper's own `# Canon:` line in `infra/launchagents/wrappers/*.sh`
+      is scanned against its own actual filename, SHALL find zero mismatches after
+      the fix."
+    probe: "repo-wide scan of every wrapper's own # Canon: self-reference against its actual filename"
+  - text: "WHEN shellcheck runs against the 3 hand-edited wrapper files, SHALL
+      introduce zero NEW findings relative to their pre-fix versions (the diff is
+      comment-only)."
+    probe: "shellcheck infra/launchagents/wrappers/pro-git-pull-main.sh"
+consumer_map:
+  - "The `# Canon:`/`# Live:` header is READ-ONLY prose for a human operator
+    debugging a wrapper file — no script in this repo parses it. Verified: `grep
+    -n \"Canon:\\|Live:\" scripts/lint_home_fork.py` returns zero matches — the
+    actual home-fork drift detector (`scripts/lint_home_fork.py`, cicatrix family
+    #1's own antidote) does its own independent sha256 pair-comparison and never
+    reads this comment. This matches the new test suite's own docstring framing
+    (\"reader-misdirection, not a real home-fork DRIFT\") — verified independently
+    here, not merely taken on the test file's word."
+  - "`scripts/organ_birth.py` itself is the only writer of this header (via
+    `wrapper_template()`, called from one site, `main()` line 348) — confirmed by
+    grepping every call site of `wrapper_template(` in the file (exactly one)."
+risks:
+  - "None to running systems: the header is a comment, executed by nothing.
+    The only risk class is a FUTURE reader trusting a wrong self-reference
+    while debugging — the defect class this PR closes."
+  - "Scope creep risk (checked, not found): the fix could have been over-applied
+    to LOG_DIR/PIDFILE or the sidecar path too, silently changing runtime
+    artifact locations for every already-deployed organ. It was not — see
+    constraints above and the scope-pin test."
+grader: |
+  Generator != grader, both for the CODE diff and for this evidence pack. This
+  session authored ONLY the evidence pack (brief.yml + pack.yml), on the
+  orchestrating (team-lead) session's explicit dispatch, after the code+test
+  diff already existed and had already been reviewed/diagnosed as a genuine
+  case-1 (missing Evidence Pack, not a code defect) by a separate PR-status
+  investigation this same session performed earlier in its own session history.
+  The code+test diff itself was authored by a different session entirely (a
+  Mini-Pro2 healer tick, per the PR's own commit co-author line, Claude Sonnet
+  5) — this authoring session did not write scripts/organ_birth.py's fix or its
+  test file, only verified them (receipts below) while building this pack. This
+  session does NOT post the `harness/fable-gate` commit status and does NOT
+  adjudicate its own pack — the orchestrating session dispatches an independent
+  gate separately (CLAUDE.md §Agent PR Contract / §13 Team perimeter rule — the
+  diff's author, and this pack's author, never gates its own diff).
+budget: >-
+  1 evidence-authoring lane (this session), no council, no cross-family dispatch
+  — a small, path-hot-zoned diff whose own verification (pytest run, an
+  independent mutation/revert check, a repo-wide header scan, shellcheck) is
+  fully reproducible locally with no network access and no credential.
+pii: none

--- a/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/pack.yml
@@ -11,8 +11,16 @@ seat_diversity_note: >-
   CI-wiring fix, not a cross-family council dispatch.
 diff:
   net_lines: >-
-    5 files, +137/-8, measured by
-    `git diff --no-renames --numstat origin/main...HEAD`:
+    Not stated as a number, deliberately: this pack's own two files are part of
+    the branch's `git diff --no-renames --numstat origin/main...HEAD` against
+    which any stated count would be checked, so writing the measured value here
+    changes this file's own byte size, which changes the measured value — a
+    fixpoint with no stable answer. See `evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/brief.yml`
+    for the code-only diff's real shape (three wrapper files each carry a
+    two-line header-comment edit; one new local variable in
+    scripts/organ_birth.py; one new test file). Full changed-file list on this
+    branch's diff against origin/main: evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/brief.yml,
+    evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/pack.yml,
     infra/launchagents/wrappers/pro-git-pull-main.sh,
     infra/launchagents/wrappers/pro-llm-burn-alarm.sh,
     infra/launchagents/wrappers/pro-tg-digest-flush.sh,
@@ -44,9 +52,9 @@ receipts:
     exit: 0
     ts: "2026-08-30T01:37:20Z"
     seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
-  - claim: "A repo-wide scan of every wrapper's own # Canon: self-reference against its actual filename, run independently of the PR's own test (not merely trusting that test's PASSED line), finds zero mismatches across every wrapper on this branch"
-    cmd: "python3 -c \"import glob, os, re; mismatches = []\\nfor path in sorted(glob.glob('infra/launchagents/wrappers/*.sh')):\\n    fname = os.path.basename(path)\\n    text = open(path, encoding='utf-8').read()\\n    m = re.search(r'^# Canon: infra/launchagents/wrappers/(\\\\S+)', text, re.M)\\n    if m and m.group(1) != fname:\\n        mismatches.append((fname, m.group(1)))\\nprint('mismatches:', mismatches); print('total wrappers scanned:', len(glob.glob('infra/launchagents/wrappers/*.sh')))\""
-    result: "mismatches: [] ; total wrappers scanned: 50"
+  - claim: "A repo-wide scan of every wrapper's own # Canon: self-reference against its actual filename, run independently of the PR's own test (not merely trusting that test's PASSED line), finds zero mismatches among the wrapper files that actually carry a # Canon: line. CORRECTED after independent gate review (2026-08-30): this pack's first draft said 'zero mismatches across every wrapper on this branch', which is literally true but misleading — the check is vacuously true for any wrapper with no # Canon: line at all, and only a minority of wrapper files carry one"
+    cmd: "python3 -c \"import glob, os, re; total = 0; carry_canon = 0; mismatches = []\\nfor path in sorted(glob.glob('infra/launchagents/wrappers/*.sh')):\\n    total += 1\\n    fname = os.path.basename(path)\\n    text = open(path, encoding='utf-8').read()\\n    m = re.search(r'^# Canon: infra/launchagents/wrappers/(\\\\S+)', text, re.M)\\n    if m:\\n        carry_canon += 1\\n        if m.group(1) != fname:\\n            mismatches.append((fname, m.group(1)))\\nprint('total wrappers:', total); print('carry a # Canon: line:', carry_canon); print('mismatches among those:', mismatches)\""
+    result: "total wrappers: 50 ; carry a # Canon: line: 15 ; mismatches among those: [] — real coverage is 15/50, not 50/50; the other 35 wrapper files predate organ_birth.py or were hand-authored without this comment and are outside this check's scope entirely (it is silent on them, not passing on them)"
     exit: 0
     ts: "2026-08-30T01:33:10Z"
     seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
@@ -74,9 +82,9 @@ dissent:
     objection: >-
       PR #5237 touches infra/launchagents/wrappers/*.sh, which is hot-zone by
       path (infra/launchagents/* is a literal HOTZONE_PATTERNS entry) — floors
-      at Gear 3 regardless of the diff's small, mechanical-looking size (5
-      files, +137/-8, mostly a new test file) or the fact that the change is a
-      header-comment fix with no runtime behaviour change — and the PR shipped
+      at Gear 3 regardless of the diff's small, mechanical-looking size (a
+      handful of files, mostly a new test file, no runtime behaviour change)
+      or the fact that the change is a header-comment fix — and the PR shipped
       with no evidence/brief.yml or evidence/pack.yml in its own diff, so the
       check correctly FAILED with "this diff's deterministic floor is 3
       (source: path) ... but carries no evidence/brief.yml ... it cannot

--- a/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/pack.yml
@@ -1,0 +1,155 @@
+brief_ref: evidence/brief.yml
+plan_ref: "PR #5237 (agent/mini-pro2/infra/organ-birth-underscore-header) — organ_birth.py's Canon:/Live: header f-string converted only '.' to '-', never '_', while the real computed wrapper filename converts both. Evidence pack authored after the code diff, on the orchestrating session's instruction, to satisfy the Harness floor recompute gate the PR's hot-zone path (infra/launchagents/*) requires."
+lanes:
+  - lane: infra-organ-birth-underscore-header
+    role: build
+    seat: "Mini-Pro2 healer tick (autonomous cure session, Claude Sonnet 5 per this PR's own commit co-author line) — authored scripts/organ_birth.py's fix, the 3 hand-corrected wrapper headers, and scripts/tests/test_organ_birth.py. Exact model id/effort not independently queryable via a tool call this turn."
+seat_diversity: not_applicable
+seat_diversity_note: >-
+  Single build lane declared — the D3 seat-diversity floor (>=2 build lanes,
+  at least one non-Anthropic) does not fire. This is a narrow, hot-zone-by-path
+  CI-wiring fix, not a cross-family council dispatch.
+diff:
+  net_lines: >-
+    5 files, +137/-8, measured by
+    `git diff --no-renames --numstat origin/main...HEAD`:
+    infra/launchagents/wrappers/pro-git-pull-main.sh,
+    infra/launchagents/wrappers/pro-llm-burn-alarm.sh,
+    infra/launchagents/wrappers/pro-tg-digest-flush.sh,
+    scripts/organ_birth.py, scripts/tests/test_organ_birth.py.
+  behaviour_change: >-
+    No runtime behaviour change. scripts/organ_birth.py gains one local variable
+    (dash_name) consumed only by the Canon:/Live: comment lines of future
+    generated wrapper headers — LOG_DIR, PIDFILE, and the heartbeat sidecar path
+    are byte-for-byte unchanged. The three hand-edited live wrapper files each
+    change only their two `#`-prefixed Canon:/Live: comment lines, never
+    executed by bash. The new test file adds coverage; it does not change any
+    production code path.
+receipts:
+  - claim: "Deterministic gear floor recomputed from THIS PR's actual diff is 3 — matches the declared gear and the Harness floor recompute check's own FAIL message (infra/launchagents/* is hot-zone by path)"
+    cmd: "git diff --name-only origin/main...HEAD > /tmp/organ-birth-changed-files.txt && python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file /tmp/organ-birth-changed-files.txt"
+    result: "3"
+    exit: 0
+    ts: "2026-08-30T01:34:00Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+  - claim: "The fixed suite (scripts/tests/test_organ_birth.py against the post-fix scripts/organ_birth.py) is fully green: 5 passed, 0 failed"
+    cmd: "python3 -m pytest scripts/tests/test_organ_birth.py -v"
+    result: "test_underscore_organ_id_header_matches_actual_filename PASSED; test_no_underscore_organ_id_unaffected PASSED; test_multi_underscore_segment_all_converted PASSED; test_log_dir_and_pidfile_stay_dot_only_by_design PASSED; test_repo_wide_wrapper_headers_match_their_own_filenames PASSED — 5 passed in 0.08s"
+    exit: 0
+    ts: "2026-08-30T01:35:40Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+  - claim: "Red-before-green, reproduced independently (not taken on the PR body's word): reverting scripts/organ_birth.py alone to its pre-fix (parent commit f4514cd696) content, WHILE keeping the new test file at its post-fix content, fails exactly the two guilt tests and leaves the innocence/scope-pin/repo-wide-scan tests green"
+    cmd: "git show f4514cd696303ac1870be9ad43a636c6e7dedfdc:scripts/organ_birth.py > scripts/organ_birth.py (inside the worktree) && python3 -m pytest scripts/tests/test_organ_birth.py -v ; then restored the post-fix file and reran"
+    result: "2 failed (test_underscore_organ_id_header_matches_actual_filename, test_multi_underscore_segment_all_converted — AssertionError: assert 'pro-visa_freshness_sentinel' == 'pro-visa-freshness-sentinel'), 3 passed; after restore: 5 passed, 0 failed, working tree clean"
+    exit: 0
+    ts: "2026-08-30T01:37:20Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+  - claim: "A repo-wide scan of every wrapper's own # Canon: self-reference against its actual filename, run independently of the PR's own test (not merely trusting that test's PASSED line), finds zero mismatches across every wrapper on this branch"
+    cmd: "python3 -c \"import glob, os, re; mismatches = []\\nfor path in sorted(glob.glob('infra/launchagents/wrappers/*.sh')):\\n    fname = os.path.basename(path)\\n    text = open(path, encoding='utf-8').read()\\n    m = re.search(r'^# Canon: infra/launchagents/wrappers/(\\\\S+)', text, re.M)\\n    if m and m.group(1) != fname:\\n        mismatches.append((fname, m.group(1)))\\nprint('mismatches:', mismatches); print('total wrappers scanned:', len(glob.glob('infra/launchagents/wrappers/*.sh')))\""
+    result: "mismatches: [] ; total wrappers scanned: 50"
+    exit: 0
+    ts: "2026-08-30T01:33:10Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+  - claim: "shellcheck on the 3 hand-edited wrapper files introduces zero new findings versus their pre-fix (base) versions — the one finding present (SC1091, info-level, an unrelated pre-existing sourced-secrets-file note in pro-llm-burn-alarm.sh line 61) is byte-identical on both the pre-fix and post-fix file, well outside the 2-line diff hunk"
+    cmd: "shellcheck infra/launchagents/wrappers/pro-git-pull-main.sh infra/launchagents/wrappers/pro-llm-burn-alarm.sh infra/launchagents/wrappers/pro-tg-digest-flush.sh; then git show f4514cd696303ac1870be9ad43a636c6e7dedfdc:infra/launchagents/wrappers/pro-llm-burn-alarm.sh > /tmp/base.sh && shellcheck /tmp/base.sh"
+    result: "post-fix: 1 finding (SC1091 info, line 61, pro-llm-burn-alarm.sh); pre-fix base copy: the identical SC1091 info finding, same line 61, same text — confirmed pre-existing, not introduced by this diff"
+    exit: 1
+    ts: "2026-08-30T01:38:05Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+  - claim: "scripts/organ_birth.py::wrapper_template() has exactly one call site (main(), line 348) — the fix cannot be bypassed by a second code path that still builds a header some other way"
+    cmd: "grep -n 'wrapper_template(' scripts/organ_birth.py"
+    result: "line 71 (def wrapper_template(...)), line 348 (the one call site inside main())"
+    exit: 0
+    ts: "2026-08-30T01:32:15Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+  - claim: "scripts/lint_home_fork.py (the actual home-fork drift detector, cicatrix family #1's antidote) never reads the Canon:/Live: comment — it does its own independent sha256 pair-comparison, so this header is read-only prose for a human, not a machine-consumed contract"
+    cmd: "grep -n 'Canon:\\|Live:' scripts/lint_home_fork.py"
+    result: "zero matches"
+    exit: 0
+    ts: "2026-08-30T01:39:00Z"
+    seat: "session (this task, worktree .worktrees/infra-evidence-5237)"
+pii_scan: clean
+dissent:
+  - seat: "Harness floor recompute (CI, deterministic)"
+    objection: >-
+      PR #5237 touches infra/launchagents/wrappers/*.sh, which is hot-zone by
+      path (infra/launchagents/* is a literal HOTZONE_PATTERNS entry) — floors
+      at Gear 3 regardless of the diff's small, mechanical-looking size (5
+      files, +137/-8, mostly a new test file) or the fact that the change is a
+      header-comment fix with no runtime behaviour change — and the PR shipped
+      with no evidence/brief.yml or evidence/pack.yml in its own diff, so the
+      check correctly FAILED with "this diff's deterministic floor is 3
+      (source: path) ... but carries no evidence/brief.yml ... it cannot
+      silently pass as 'not a harness task'".
+    status: CONFIRMED
+    note: >-
+      Verified independently rather than accepted on the FAIL message alone:
+      recomputed the floor from this PR's actual changed-file list via
+      evidence_pack_lint.py --print-floor (receipt above) and got 3, matching
+      the check. Answered here by supplying both files at this PR's own
+      per-branch evidence path (scripts/ci/evidence_paths.py --ref/--resolve),
+      never by editing the gate — same shape as the identical prior instance
+      documented in evidence/2026-08/agent-mini-pro2-infra-fly-watcher-detail-145c8438/.
+  - seat: "session, self-check on the diff's own scope"
+    objection: >-
+      scripts/organ_birth.py has THREE distinct self-reference naming schemes
+      for a wrapper's own identity, not one: (1) the Canon:/Live: header —
+      this PR's fix target, now dot+underscore -> hyphen; (2) LOG_DIR/PIDFILE
+      — dot-only -> hyphen, underscore survives, deliberately unchanged; (3)
+      the heartbeat sidecar path ($SIDECAR_DIR/$ORGAN_ID.json, ORGAN_ID set to
+      the raw organ_id verbatim) and registry_entry()'s declared `path:` field
+      — no conversion at all, dots and underscores both survive. Does scoping
+      this fix to ONLY scheme (1) leave scheme (3) — the sidecar/registry path
+      — silently inconsistent the same way scheme (1) was?
+    status: RETRACTED
+    note: >-
+      Investigated, not assumed innocent: read wrapper_template()'s full body
+      (SIDECAR_DIR="$HOME/.organism/last_seen", heartbeat() writes to
+      "$SIDECAR_DIR/$ORGAN_ID.json" with ORGAN_ID="{organ_id}" verbatim — no
+      .replace() at all) and registry_entry() (path: ~/.organism/last_seen/{organ_id}.json
+      — same raw, unconverted organ_id). The two sides agree with each other:
+      both use the raw organ_id, so nothing is inconsistent between what the
+      wrapper writes and what the registry declares it will write. Retracted
+      because scheme (3) was never claiming to match scheme (1)'s
+      hyphen-only file-naming convention in the first place — it names a JSON
+      sidecar path, not a wrapper filename, and this PR's fix (scoped to the
+      Canon:/Live: header only, per its own inline comment) never claimed to
+      touch it. Not a defect; the third scheme is out of scope by design, and
+      is internally consistent on its own terms.
+tests:
+  - "scripts/tests/test_organ_birth.py — 5 tests (2 guilt, 1 innocence, 1
+    scope-pin, 1 permanent repo-wide regression guard) — receipt above."
+  - "Independent red-before-green reproduction (revert organ_birth.py alone,
+    rerun the suite, restore) — receipt above, not merely trusting the PR
+    body's own claim of the same result."
+static:
+  - "shellcheck on the 3 hand-edited wrapper files -> zero new findings versus
+    their pre-fix versions (receipt above; the one SC1091 info-level finding
+    present is pre-existing and unrelated to this diff's 2-line hunks)."
+notes:
+  - >-
+    This evidence pack is deliberately after-the-fact: PR #5237's code+test
+    diff already existed, authored by a different session (a Mini-Pro2 healer
+    tick), before this pack was requested. Its only job is to satisfy Harness
+    floor recompute for a diff whose hot-zone PATH floors it at Gear 3
+    regardless of its small, mechanical size.
+  - >-
+    Written at this PR's own per-branch evidence directory
+    (evidence/2026-08/agent-mini-pro2-infra-organ-birth-underscore-hea-b3b73aaf/),
+    per scripts/ci/evidence_paths.py (S12/C6, 2026-08-23) — never at the fixed
+    evidence/brief.yml / evidence/pack.yml root pair, which a concurrent
+    Gear>=2 PR could be rewriting at the same time. brief_ref: still names the
+    literal evidence/brief.yml (not this pack's own real per-PR path) because
+    harness-floor.yml stages both files under canonical names before linting.
+  - >-
+    council_run: is deliberately omitted. R9 (check_council_run_gear3) NOTICEs
+    rather than FAILs on a Gear-3 pack with no council_run journal until
+    2026-09-02 (today is 2026-08-30) — this pack predates that enforcement
+    date, same known day-0 state as every other existing Gear-3 pack in this
+    repo.
+  - >-
+    This pack does not post a harness/fable-gate commit status — that is the
+    orchestrating session's own next step (an independent gate dispatch), kept
+    separate deliberately: this pack's author (this session) does not gate its
+    own pack, and did not author the code diff it evidences either
+    (generator != grader on both axes — see brief.yml's grader: field).

--- a/infra/launchagents/wrappers/pro-git-pull-main.sh
+++ b/infra/launchagents/wrappers/pro-git-pull-main.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # pro.git_pull_main — Pro auto-sync of ~/nuzantara main checkout (collision-robust; Mini has the 5min sibling)
 # Born via scripts/organ_birth.py (DNA/GENOME 2026-07-06): genes imprinted at birth.
-# Canon: infra/launchagents/wrappers/pro-git_pull_main.sh
-# Live:  ~/scripts/pro-git_pull_main.sh (declared pair, node=pro)
+# Canon: infra/launchagents/wrappers/pro-git-pull-main.sh
+# Live:  ~/scripts/pro-git-pull-main.sh (declared pair, node=pro)
 
 set -u   # G9_fail_visible: unset vars crash, they do not expand empty
 

--- a/infra/launchagents/wrappers/pro-llm-burn-alarm.sh
+++ b/infra/launchagents/wrappers/pro-llm-burn-alarm.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # pro.llm_burn_alarm — burn-rate alarm on llm_cost_events — trailing 24h vs 7-day median, names endpoint+model
 # Born via scripts/organ_birth.py (DNA/GENOME 2026-07-06): genes imprinted at birth.
-# Canon: infra/launchagents/wrappers/pro-llm_burn_alarm.sh
-# Live:  ~/scripts/pro-llm_burn_alarm.sh (declared pair, node=pro)
+# Canon: infra/launchagents/wrappers/pro-llm-burn-alarm.sh
+# Live:  ~/scripts/pro-llm-burn-alarm.sh (declared pair, node=pro)
 
 set -u   # G9_fail_visible: unset vars crash, they do not expand empty
 

--- a/infra/launchagents/wrappers/pro-tg-digest-flush.sh
+++ b/infra/launchagents/wrappers/pro-tg-digest-flush.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # pro.tg_digest_flush — Telegram digest flusher — ONE grouped message per slot for everything tg_notify spooled (notification economy, PR #2067)
 # Born via scripts/organ_birth.py (DNA/GENOME 2026-07-06): genes imprinted at birth.
-# Canon: infra/launchagents/wrappers/pro-tg_digest_flush.sh
-# Live:  ~/scripts/pro-tg_digest_flush.sh (declared pair, node=pro)
+# Canon: infra/launchagents/wrappers/pro-tg-digest-flush.sh
+# Live:  ~/scripts/pro-tg-digest-flush.sh (declared pair, node=pro)
 
 set -u   # G9_fail_visible: unset vars crash, they do not expand empty
 

--- a/scripts/organ_birth.py
+++ b/scripts/organ_birth.py
@@ -74,11 +74,21 @@ def wrapper_template(organ_id: str, node: str, kind: str, description: str) -> s
     llm = kind == "llm-cron"
     daemon = kind == "daemon"
 
+    # W-underscore-header: the actual wrapper filename (computed in main() as
+    # `dash`) replaces BOTH "." and "_" with "-" — repo/live naming is
+    # hyphens-only, no underscores anywhere. This header's self-reference
+    # must match that, or it silently lies about its own filename for any
+    # organ_id whose descriptive segment is underscore_case (the house
+    # style: visa_freshness_sentinel, git_pull_main, ...). Scoped to the
+    # Canon:/Live: comment only — LOG_DIR/PIDFILE below stay dot-only on
+    # purpose, they name runtime artifacts this generator creates itself,
+    # so whatever it produces is correct-by-construction for them.
+    dash_name = organ_id.replace(".", "-").replace("_", "-")
     head = f'''#!/bin/bash
 # {organ_id} — {description}
 # Born via scripts/organ_birth.py (DNA/GENOME 2026-07-06): genes imprinted at birth.
-# Canon: infra/launchagents/wrappers/{organ_id.replace(".", "-")}.sh
-# Live:  ~/scripts/{organ_id.replace(".", "-")}.sh (declared pair, node={node})
+# Canon: infra/launchagents/wrappers/{dash_name}.sh
+# Live:  ~/scripts/{dash_name}.sh (declared pair, node={node})
 
 set -u   # G9_fail_visible: unset vars crash, they do not expand empty
 

--- a/scripts/tests/test_organ_birth.py
+++ b/scripts/tests/test_organ_birth.py
@@ -1,0 +1,119 @@
+"""Tests for organ_birth.py — the wrapper-template self-reference header.
+
+Trauma (PENDING-ARMS 2026-08-23, ops-visaoracle-wrapper-header-0823): the
+`Canon:`/`Live:` header f-string used `organ_id.replace(".", "-")` — dot only.
+The ACTUAL wrapper filename (computed in main() as `dash`) replaces BOTH "."
+and "_" with "-", because repo/live file naming is hyphens-only. Any organ_id
+whose descriptive segment is underscore_case (the house style —
+visa_freshness_sentinel, git_pull_main, llm_burn_alarm, tg_digest_flush) got a
+header that lied about its own filename: reader-misdirection, not a real
+home-fork DRIFT (lint_home_fork.py's sha256 pair-check is comment-blind and
+was never wrong). 3 live wrappers carried the bug on main; a 4th
+(visa_freshness_sentinel) had already been hand-cured by a prior fix.
+
+Contract (guilt + innocence, per cicatrix-superscar #3 antidote):
+  - GUILT: an organ_id with an underscore in its name segment must produce a
+    Canon:/Live: header whose filename matches the ACTUAL computed wrapper
+    filename (dot AND underscore -> hyphen).
+  - INNOCENCE: an organ_id with no underscore is unaffected (dot-only and
+    dot+underscore conversion agree when there's no underscore to convert).
+  - SCOPE PIN: LOG_DIR and PIDFILE stay dot-only on purpose — they name
+    runtime artifacts the generator creates itself (not a claim about a
+    pre-existing file), so whatever it produces is correct-by-construction
+    for them. Widening their scope would be an undocumented behavior change,
+    not a fix.
+"""
+
+import glob
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from organ_birth import wrapper_template  # noqa: E402
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+WRAPPER_DIR = os.path.join(REPO_ROOT, "infra", "launchagents", "wrappers")
+
+
+def _actual_dash_filename(organ_id: str) -> str:
+    """Mirror main()'s `dash` computation — the true wrapper filename."""
+    return organ_id.replace(".", "-").replace("_", "-")
+
+
+def test_underscore_organ_id_header_matches_actual_filename():
+    """GUILT case: the bug's exact trigger — a descriptive segment with '_'."""
+    organ_id = "pro.tg_digest_flush"
+    template = wrapper_template(organ_id, "pro", "cron", "flush the telegram digest queue")
+    actual = _actual_dash_filename(organ_id)
+
+    canon = re.search(r"^# Canon: infra/launchagents/wrappers/(\S+)\.sh$", template, re.M)
+    live = re.search(r"^# Live:  ~/scripts/(\S+)\.sh ", template, re.M)
+    assert canon is not None, "Canon: header line missing"
+    assert live is not None, "Live: header line missing"
+    assert canon.group(1) == actual, (
+        f"Canon: header claims {canon.group(1)!r} but the real wrapper filename "
+        f"is {actual!r} — reader-misdirection (2026-08-23 W-underscore-header)"
+    )
+    assert live.group(1) == actual
+
+
+def test_no_underscore_organ_id_unaffected():
+    """INNOCENCE case: no underscore in the descriptive segment -> unchanged."""
+    organ_id = "pro.freshness"
+    template = wrapper_template(organ_id, "pro", "cron", "no underscore here")
+    actual = _actual_dash_filename(organ_id)
+    assert actual == "pro-freshness"  # sanity: nothing to convert
+
+    canon = re.search(r"^# Canon: infra/launchagents/wrappers/(\S+)\.sh$", template, re.M)
+    assert canon.group(1) == "pro-freshness"
+
+
+def test_multi_underscore_segment_all_converted():
+    """The house style stacks multiple underscores (visa_freshness_sentinel)."""
+    organ_id = "pro.visa_freshness_sentinel"
+    template = wrapper_template(organ_id, "pro", "cron", "watches visa freshness")
+    actual = _actual_dash_filename(organ_id)
+    assert actual == "pro-visa-freshness-sentinel"
+
+    canon = re.search(r"^# Canon: infra/launchagents/wrappers/(\S+)\.sh$", template, re.M)
+    assert canon.group(1) == actual
+
+
+def test_log_dir_and_pidfile_stay_dot_only_by_design():
+    """SCOPE PIN: LOG_DIR/PIDFILE are runtime artifacts the generator creates
+    itself — deliberately NOT widened to the dash conversion, per the
+    2026-08-23 PENDING-ARMS decision (#4599 fixed only the sentinel header
+    instance and explicitly declined to touch LOG_DIR/PIDFILE generation)."""
+    organ_id = "pro.tg_digest_flush"
+    template = wrapper_template(organ_id, "pro", "cron", "flush the telegram digest queue")
+
+    log_dir = re.search(r'^LOG_DIR="\$HOME/logs/([^"]+)"$', template, re.M)
+    pidfile = re.search(r'^PIDFILE="/tmp/nuzantara-([^"]+)\.pid"$', template, re.M)
+    assert log_dir is not None
+    assert pidfile is not None
+    # Dot-only conversion — underscore survives, matching the generator's
+    # documented (and unchanged) runtime-artifact behavior.
+    assert log_dir.group(1) == "pro-tg_digest_flush"
+    assert pidfile.group(1) == "pro-tg_digest_flush"
+
+
+def test_repo_wide_wrapper_headers_match_their_own_filenames():
+    """PERMANENT REGRESSION GUARD (proof-of-armed item 4, PENDING-ARMS row
+    'ops-visaoracle-wrapper-header-0823'): every existing wrapper's own
+    `# Canon:` self-reference must equal its actual filename. Catches a
+    future 5th instance the instant it lands, instead of waiting for another
+    refuter to find it. At the time this test was written, a repo-wide scan
+    found EXACTLY ZERO mismatches (3 were hand-fixed, 1 was already fixed by
+    a prior PR)."""
+    mismatches = []
+    for path in sorted(glob.glob(os.path.join(WRAPPER_DIR, "*.sh"))):
+        fname = os.path.basename(path)
+        text = open(path, encoding="utf-8").read()
+        m = re.search(r"^# Canon: infra/launchagents/wrappers/(\S+)", text, re.M)
+        if m and m.group(1) != fname:
+            mismatches.append((fname, m.group(1)))
+    assert mismatches == [], (
+        f"wrapper header self-reference drift (2026-08-23 class): {mismatches}"
+    )


### PR DESCRIPTION
## Summary
- The Canon:/Live: wrapper-template header f-string only converted `.` to `-`, never `_`, while the actual computed wrapper filename converts both. Any organ_id with an underscore in its descriptive segment got a self-referential header that lied about its own filename.
- Fixes the generator (`scripts/organ_birth.py`) for all future organ births, hand-corrects the 3 remaining live wrapper headers still mismatched (pro-tg-digest-flush, pro-git-pull-main, pro-llm-burn-alarm — a 4th, visa_freshness_sentinel, was already fixed by #4599), and adds a regression suite (`scripts/tests/test_organ_birth.py`, 5 tests: 2 guilt, 1 innocence, 1 scope-pin for LOG_DIR/PIDFILE staying dot-only by design, 1 permanent repo-wide scan).
- Closes PENDING-ARMS row "ops-visaoracle-wrapper-header-0823" — proof-of-armed items 1-4 verified: guilt case, innocence case, repo-wide zero-mismatch grep, and a permanent test that fails on any future drift.

## Test plan
- [x] `pytest scripts/tests/test_organ_birth.py -v` → 5/5 passed
- [x] Verified red-before-green: reverting `organ_birth.py` alone (git stash) fails 2/4 guilt tests, confirming the tests actually exercise the bug
- [x] Repo-wide grep of every `# Canon:` line in `infra/launchagents/wrappers/*.sh` vs its own filename → 0 mismatches after the fix
- [x] Diff on the 3 hand-fixed wrapper files is surgical — only the 2 header comment lines changed, verified via `diff` against pre-fix backups

🤖 Generated with a Mini-Pro2 healer tick (autonomous cure session).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>