### PR TITLE
feat(ci): Level-5 restore verification — and its own core thesis was armed by nothing

### DIFF
--- a/scripts/ci/restore_drill_verify.py
+++ b/scripts/ci/restore_drill_verify.py
@@ -408,7 +408,11 @@ def _evaluate_one(spec: Invariant, measurement: Optional[dict[str, Any]]) -> dic
             cannot_verify = True
             continue
         count = violations[check]
-        if not isinstance(count, int) or count < 0:
+        # bool is an int subclass in Python (`True < 0` is False either
+        # way) -- excluded so a fixture typo (`"x": true`) reads as
+        # CANNOT-VERIFY, not a genuine-looking FAIL. --dsn can't hit this;
+        # count(*) is always a bigint.
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
             reasons.append(f"check '{check}' has a malformed value: {count!r}")
             cannot_verify = True
             continue

--- a/scripts/ci/restore_drill_verify.py
+++ b/scripts/ci/restore_drill_verify.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""restore_drill_verify.py — Level-5 application verification for the monthly
+Postgres restore drill (`.github/workflows/restore-drill.yml`).
+
+WHY THIS EXISTS: the drill used to declare success from a table CENSUS
+(`TABLES=$(... information_schema.tables ...); test "$TABLES" -ge 50`) — a
+restore producing 60 EMPTY tables passes that check. On 2026-06-06 a
+`PGPASSWORD` env-prefix landed on the wrong side of a pipe, psql got no
+password, the restore produced 0 tables, and the drill reported success
+anyway: the exit code of a restore is not evidence the DATA arrived
+(cicatrix-superscar.md family #2, "esiste != armato", applied to a backup
+instead of a daemon).
+
+WHAT THIS DOES INSTEAD: for five relations this repo has separately
+hardened (file:line cited on each INVARIANTS entry below), it checks a
+non-degenerate RESULT SHAPE — relation exists, every application-required
+column is present, row count is not below a floor where zero is provably
+wrong, JSON/JSONB columns hold the container shape the app promises
+(never a bare scalar or an unparseable string), and each table's own
+CHECK constraints are RE-VERIFIED at the app layer independently of
+whether they survived the restore — a constraint the dump's DDL failed to
+reinstate (possible under `ON_ERROR_STOP=0`, or a role lacking the
+ledger-owner ALTER privilege some of these migrations require, see
+cicatrix-scars.md W130) would otherwise let a broken row sit unnoticed.
+
+A missing relation or a missing required column is a genuinely
+diagnosable finding — scored FAIL, not CANNOT-VERIFY; only an UNTAKEN
+measurement (query error, relation absent from the measurement set,
+relation reported existing with zero columns, or a declared check absent
+from the result) is CANNOT-VERIFY — never a silent PASS, never conflated
+with a genuine FAIL (cicatrix-scars.md W106b / superscar #9: cannot-
+measure is not measured-zero). Every invariant gets exactly one verdict
+per run, reporting every reason found for it together — nothing dropped
+because a worse-class reason also fired.
+
+The violations query for a relation runs only once every column it names
+is confirmed present (see the missing-column gate in `fetch_live`) — found
+empirically: the first cut, run against a deliberately column-dropped
+`conversations` table, reported a raw `column "messages" does not exist`
+Postgres error where it should have reported the missing-column FAIL
+directly. `pg_temp` objects (the `conversations` JSON-array check) are
+SESSION-scoped, so the helper function and the query using it travel in
+ONE `psql` invocation, never two.
+
+REDACTION (SYMBIOSIS Law 2 / UU PDP): a measurement carries relation
+names, column names, and COUNTS — never a row's own values. Fixtures
+under scripts/tests/fixtures/restore_drill/ are synthetic only.
+
+LIVE MODE talks to `psql` over a self-contained DSN in one argv token
+(never a separately-exported `PGPASSWORD` prefixed onto one side of a pipe
+— that construction is the 2026-06-06 bug class above), with
+`-v ON_ERROR_STOP=1` so a broken query surfaces as an error, never a
+truncated result.
+
+Usage:
+    restore_drill_verify.py --dsn postgresql://user:pass@host:port/db [--json]
+    restore_drill_verify.py --fixture scripts/tests/fixtures/restore_drill/healthy.json
+    restore_drill_verify.py --fixture scripts/tests/fixtures/restore_drill/degenerate.json --json
+
+Exit codes:
+    0   PASS — all five golden invariants verified clean
+    1   FAIL — at least one invariant is genuinely violated (named per relation)
+    2   usage error (argparse's own exit code)
+    3   CANNOT-VERIFY — a measurement could not be taken. Never conflated
+        with exit 0 or exit 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class Invariant:
+    """One golden invariant. `checks` names the violation-count keys the
+    measurement for this relation must report (each must be present in the
+    measurement's `violations` dict, and each must be exactly 0)."""
+
+    relation: str
+    required_columns: tuple[str, ...]
+    min_rows: Optional[int]
+    checks: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        assert _IDENT_RE.match(self.relation), f"unsafe relation name: {self.relation!r}"
+
+
+# Column lists and constraints below are taken from the migrations that
+# introduced them, not invented — see the file:line cited on each relation.
+INVARIANTS: tuple[Invariant, ...] = (
+    # migrations_v2/143_legacy_conversations.sql: min_rows=1 (a production
+    # restore to zero rows is degenerate); `messages` is TEXT but defaults
+    # to '[]' — always meant to parse as a JSON array.
+    Invariant(
+        relation="conversations",
+        required_columns=("id", "user_id", "messages", "created_at"),
+        min_rows=1,
+        checks=("messages_not_json_array",),
+    ),
+    # migrations_v2/136 (drive columns) + 223 (lead_metadata JSONB, an
+    # OBJECT payload when present). client_type has only two values
+    # codebase-wide but no DB CHECK constraint — why this re-check matters.
+    Invariant(
+        relation="clients",
+        required_columns=(
+            "id",
+            "full_name",
+            "client_type",
+            "google_drive_folder_id",
+            "created_at",
+            "updated_at",
+        ),
+        min_rows=1,
+        checks=("client_type_unknown", "lead_metadata_not_object"),
+    ),
+    # migrations_v2/252_visa_engine_write_substrate.sql: SHADOW-mode,
+    # legitimately sparse/empty depending on backup timing — no row floor.
+    # `citations` (JSONB array) and the TEMPORARILY_UNAVAILABLE/rule_pack_id
+    # link both restate that migration's own CHECK constraints.
+    Invariant(
+        relation="visa_decisions",
+        required_columns=(
+            "id",
+            "decision_id",
+            "environment",
+            "verdict",
+            "citations",
+            "rule_pack_id",
+            "evaluated_at",
+        ),
+        min_rows=None,
+        checks=(
+            "verdict_unknown",
+            "environment_unknown",
+            "citations_not_array",
+            "temporarily_unavailable_missing_pack",
+        ),
+    ),
+    # migrations_v2/144_events_outbox.sql: pruned daily, legitimately
+    # empty — no row floor. `payload` is JSONB NOT NULL (re-checked since a
+    # partial restore may drop that constraint; a JSON `null` is as
+    # degenerate as a SQL NULL). `consumed_at < created_at` is the ONE
+    # check here with no existing DB constraint to restate — pure app-layer.
+    Invariant(
+        relation="events_outbox",
+        required_columns=("id", "channel", "payload", "created_at", "consumed_at", "consumer_id"),
+        min_rows=None,
+        checks=("channel_blank", "payload_missing", "consumed_before_created"),
+    ),
+    # migrations_v2/264+268_visa_decision_retention_policy*.sql:
+    # "deliberately seeds NO duration and NO policy row" (264's own
+    # comment) — no row floor. The five checks restate that file's own
+    # CHECK/UNIQUE constraints — the exact set an ON_ERROR_STOP=0 restore,
+    # or a role missing ledger-owner ALTER (W130), could silently drop.
+    Invariant(
+        relation="visa_decision_retention_policies",
+        required_columns=(
+            "id",
+            "environment",
+            "policy_version",
+            "retention_interval",
+            "idempotency_retention_interval",
+            "legal_hold_review_interval",
+            "retention_anchor",
+            "effective_period",
+            "approved_by",
+            "approval_reference",
+            "created_at",
+        ),
+        min_rows=None,
+        checks=(
+            "environment_unknown",
+            "retention_anchor_unknown",
+            "idempotency_interval_out_of_bounds",
+            "effective_period_invalid",
+            "duplicate_environment_policy_version",
+        ),
+    ),
+)
+
+_INVARIANT_BY_RELATION: dict[str, Invariant] = {inv.relation: inv for inv in INVARIANTS}
+
+# --- live-mode SQL: three queries per relation, in order ---------------
+# 1) column probe (information_schema; safe even if the relation is absent)
+# 2) row-count probe (names no column beyond the relation itself)
+# 3) violations probe, run ONLY if every column its checks reference is
+#    confirmed present. Every count is a scalar subquery so one bad row
+#    can't fail the whole query — except `conversations`, which uses a
+#    `pg_temp` helper so a malformed JSON row is COUNTED, not thrown.
+
+_COLUMNS_SQL = (
+    "SELECT to_jsonb(array_agg(column_name ORDER BY ordinal_position)) "
+    "FROM information_schema.columns "
+    "WHERE table_schema='public' AND table_name='{relation}';"
+)
+
+_ROW_COUNT_SQL = "SELECT count(*) FROM {relation};"
+
+_CONVERSATIONS_VIOLATIONS_SQL = """
+CREATE OR REPLACE FUNCTION pg_temp.try_jsonb_array(text) RETURNS boolean AS $$
+BEGIN
+  RETURN jsonb_typeof($1::jsonb) = 'array';
+EXCEPTION WHEN OTHERS THEN
+  RETURN false;
+END;
+$$ LANGUAGE plpgsql;
+SELECT jsonb_build_object(
+  'messages_not_json_array',
+  (SELECT count(*) FROM conversations WHERE NOT pg_temp.try_jsonb_array(messages))
+);
+"""
+
+_CLIENTS_VIOLATIONS_SQL = """
+SELECT jsonb_build_object(
+  'client_type_unknown',
+  (SELECT count(*) FROM clients WHERE client_type NOT IN ('individual','company')),
+  'lead_metadata_not_object',
+  (SELECT count(*) FROM clients
+     WHERE lead_metadata IS NOT NULL AND jsonb_typeof(lead_metadata) <> 'object')
+);
+"""
+
+_VISA_DECISIONS_VIOLATIONS_SQL = """
+SELECT jsonb_build_object(
+  'verdict_unknown',
+  (SELECT count(*) FROM visa_decisions WHERE verdict NOT IN (
+     'NEEDS_INPUT','SUPPORTED_CANDIDATES','HUMAN_REVIEW_REQUIRED',
+     'NO_SUPPORTED_PATH','TEMPORARILY_UNAVAILABLE')),
+  'environment_unknown',
+  (SELECT count(*) FROM visa_decisions WHERE environment NOT IN ('TEST','STAGING','PRODUCTION')),
+  'citations_not_array',
+  (SELECT count(*) FROM visa_decisions WHERE jsonb_typeof(citations) <> 'array'),
+  'temporarily_unavailable_missing_pack',
+  (SELECT count(*) FROM visa_decisions
+     WHERE verdict <> 'TEMPORARILY_UNAVAILABLE' AND rule_pack_id IS NULL)
+);
+"""
+
+_EVENTS_OUTBOX_VIOLATIONS_SQL = """
+SELECT jsonb_build_object(
+  'channel_blank',
+  (SELECT count(*) FROM events_outbox WHERE channel IS NULL OR channel = ''),
+  'payload_missing',
+  (SELECT count(*) FROM events_outbox WHERE payload IS NULL OR jsonb_typeof(payload) = 'null'),
+  'consumed_before_created',
+  (SELECT count(*) FROM events_outbox WHERE consumed_at IS NOT NULL AND consumed_at < created_at)
+);
+"""
+
+_VISA_RETENTION_POLICIES_VIOLATIONS_SQL = """
+SELECT jsonb_build_object(
+  'environment_unknown',
+  (SELECT count(*) FROM visa_decision_retention_policies
+     WHERE environment NOT IN ('TEST','STAGING','PRODUCTION')),
+  'retention_anchor_unknown',
+  (SELECT count(*) FROM visa_decision_retention_policies
+     WHERE retention_anchor NOT IN ('EVALUATED_AT','CREATED_AT')),
+  'idempotency_interval_out_of_bounds',
+  (SELECT count(*) FROM visa_decision_retention_policies
+     WHERE idempotency_retention_interval <= interval '0'
+        OR idempotency_retention_interval > retention_interval),
+  'effective_period_invalid',
+  (SELECT count(*) FROM visa_decision_retention_policies
+     WHERE isempty(effective_period) OR lower(effective_period) IS NULL),
+  'duplicate_environment_policy_version',
+  (SELECT COALESCE(SUM(c - 1), 0) FROM (
+     SELECT count(*) AS c FROM visa_decision_retention_policies
+     GROUP BY environment, policy_version HAVING count(*) > 1
+   ) sub)
+);
+"""
+
+_VIOLATIONS_SQL: dict[str, str] = {
+    "conversations": _CONVERSATIONS_VIOLATIONS_SQL,
+    "clients": _CLIENTS_VIOLATIONS_SQL,
+    "visa_decisions": _VISA_DECISIONS_VIOLATIONS_SQL,
+    "events_outbox": _EVENTS_OUTBOX_VIOLATIONS_SQL,
+    "visa_decision_retention_policies": _VISA_RETENTION_POLICIES_VIOLATIONS_SQL,
+}
+assert set(_VIOLATIONS_SQL) == set(_INVARIANT_BY_RELATION), "every invariant needs a violations query"
+
+
+def _run_psql(dsn: str, sql: str, psql_bin: str, timeout: int) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [psql_bin, dsn, "-Atq", "-v", "ON_ERROR_STOP=1"],
+        input=sql,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def fetch_live(dsn: str, psql_bin: str = "psql", timeout: int = 30) -> list[dict[str, Any]]:
+    """One measurement dict per declared invariant, in INVARIANTS order."""
+    measurements: list[dict[str, Any]] = []
+    for inv in INVARIANTS:
+        try:
+            rc, out, err = _run_psql(
+                dsn, _COLUMNS_SQL.format(relation=inv.relation), psql_bin, timeout
+            )
+            if rc != 0:
+                measurements.append({"relation": inv.relation, "error": err.strip() or f"psql exit {rc}"})
+                continue
+            raw = out.strip()
+            columns = json.loads(raw) if raw else None
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as exc:
+            measurements.append({"relation": inv.relation, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+
+        if columns is None:
+            measurements.append({"relation": inv.relation, "exists": False})
+            continue
+
+        measurement: dict[str, Any] = {"relation": inv.relation, "exists": True, "columns": columns}
+
+        # Row count names no column beyond the relation itself — safe either way.
+        try:
+            rc, out, err = _run_psql(
+                dsn, _ROW_COUNT_SQL.format(relation=inv.relation), psql_bin, timeout
+            )
+            if rc != 0:
+                measurements.append({"relation": inv.relation, "error": err.strip() or f"psql exit {rc}"})
+                continue
+            measurement["row_count"] = int(out.strip())
+        except (subprocess.TimeoutExpired, ValueError, OSError) as exc:
+            measurements.append({"relation": inv.relation, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+
+        # Only run this if the schema still has every column it names — a
+        # missing column is already a FAIL via the evaluator's own
+        # required-columns check; querying it anyway would instead surface
+        # as an opaque Postgres parse error (measured, see the docstring).
+        missing = [c for c in inv.required_columns if c not in columns]
+        if not missing:
+            try:
+                rc, out, err = _run_psql(dsn, _VIOLATIONS_SQL[inv.relation], psql_bin, timeout)
+                if rc == 0:
+                    measurement["violations"] = json.loads(out.strip())
+                # A nonzero rc needs no measurement error of its own:
+                # `violations` stays absent and the evaluator already scores
+                # a missing check as CANNOT-VERIFY, without discarding the
+                # row_count/columns already measured successfully.
+            except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+                pass
+
+        measurements.append(measurement)
+    return measurements
+
+
+# --- evaluation (pure, fixture-testable) --------------------------------
+
+
+def _evaluate_one(spec: Invariant, measurement: Optional[dict[str, Any]]) -> dict[str, Any]:
+    if measurement is None:
+        return {
+            "relation": spec.relation,
+            "status": "CANNOT-VERIFY",
+            "reasons": ["no measurement recorded for this relation"],
+        }
+
+    error = measurement.get("error")
+    if error:
+        return {"relation": spec.relation, "status": "CANNOT-VERIFY", "reasons": [f"query error: {error}"]}
+
+    exists = measurement.get("exists")
+    if exists is not True:
+        return {"relation": spec.relation, "status": "FAIL", "reasons": ["relation missing from the restore"]}
+
+    columns = measurement.get("columns")
+    if not columns:
+        # A relation cannot exist in Postgres with zero columns (a PRIMARY
+        # KEY alone guarantees one) — the query is lying about its input.
+        return {
+            "relation": spec.relation,
+            "status": "CANNOT-VERIFY",
+            "reasons": ["relation reported as existing but zero columns were measured"],
+        }
+
+    # One combined reasons list: a FAIL-class finding and a CANNOT-VERIFY-
+    # class one both get reported — nothing dropped for the worse class.
+    reasons: list[str] = []
+    cannot_verify = False
+
+    missing_cols = [c for c in spec.required_columns if c not in columns]
+    if missing_cols:
+        reasons.append(f"missing required column(s): {', '.join(missing_cols)}")
+
+    row_count = measurement.get("row_count")
+    if row_count is None:
+        reasons.append("row_count missing from measurement")
+        cannot_verify = True
+    elif spec.min_rows is not None and row_count < spec.min_rows:
+        reasons.append(f"row_count {row_count} below floor {spec.min_rows}")
+
+    violations = measurement.get("violations") or {}
+    for check in spec.checks:
+        if check not in violations:
+            reasons.append(f"check '{check}' could not be measured (missing from result)")
+            cannot_verify = True
+            continue
+        count = violations[check]
+        if not isinstance(count, int) or count < 0:
+            reasons.append(f"check '{check}' has a malformed value: {count!r}")
+            cannot_verify = True
+            continue
+        if count != 0:
+            reasons.append(f"{check}: {count} row(s) violate")
+
+    if cannot_verify:
+        status = "CANNOT-VERIFY"
+    elif reasons:
+        status = "FAIL"
+    else:
+        status = "PASS"
+    return {"relation": spec.relation, "status": status, "reasons": reasons}
+
+
+def evaluate(measurements: list[dict[str, Any]]) -> dict[str, Any]:
+    """Pure evaluator: exactly one verdict per declared invariant, driven by
+    INVARIANTS — never by whichever relations happen to appear in the input.
+    A relation the input silently drops is CANNOT-VERIFY, not a pass."""
+    by_relation = {m["relation"]: m for m in measurements if isinstance(m, dict) and "relation" in m}
+    per_invariant = [_evaluate_one(spec, by_relation.get(spec.relation)) for spec in INVARIANTS]
+
+    statuses = {v["status"] for v in per_invariant}
+    if "CANNOT-VERIFY" in statuses:
+        aggregate = "CANNOT-VERIFY"
+    elif "FAIL" in statuses:
+        aggregate = "FAIL"
+    else:
+        aggregate = "PASS"
+
+    return {"aggregate": aggregate, "invariants": per_invariant}
+
+
+_EXIT_FOR_AGGREGATE = {"PASS": 0, "FAIL": 1, "CANNOT-VERIFY": 3}
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--dsn", help="Postgres connection URI to probe live (postgresql://user:pass@host:port/db)")
+    src.add_argument("--fixture", help="path to an offline fixture JSON (see scripts/tests/fixtures/restore_drill/)")
+    parser.add_argument("--psql-bin", default="psql", help="psql executable to invoke in --dsn mode (default: psql)")
+    parser.add_argument("--timeout", type=int, default=30, help="per-query timeout in seconds for --dsn mode (default: 30)")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of prose")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+
+    if args.fixture:
+        try:
+            with open(args.fixture) as fh:
+                data = json.load(fh)
+            measurements = data["relations"]
+        except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+            if args.json:
+                print(json.dumps({"aggregate": "CANNOT-VERIFY", "error": str(exc)}))
+            else:
+                print(f"CANNOT-VERIFY: unreadable fixture ({exc})", file=sys.stderr)
+            return 3
+    else:
+        try:
+            measurements = fetch_live(args.dsn, psql_bin=args.psql_bin, timeout=args.timeout)
+        except Exception as exc:  # noqa: BLE001 — any failure here is CANNOT-VERIFY, never a silent pass
+            if args.json:
+                print(json.dumps({"aggregate": "CANNOT-VERIFY", "error": str(exc)}))
+            else:
+                print(f"CANNOT-VERIFY: {exc}", file=sys.stderr)
+            return 3
+
+    result = evaluate(measurements)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"AGGREGATE: {result['aggregate']}")
+        for verdict in result["invariants"]:
+            print(f"  {verdict['relation']}: {verdict['status']}")
+            for reason in verdict["reasons"]:
+                print(f"    - {reason}")
+
+    return _EXIT_FOR_AGGREGATE[result["aggregate"]]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/restore_drill/degenerate.json
+++ b/scripts/tests/fixtures/restore_drill/degenerate.json
@@ -1,0 +1,78 @@
+{
+  "_comment": "Synthetic measurement fixture for restore_drill_verify.py's GUILT case. Only relation/column NAMES and COUNTS appear — no row values (SYMBIOSIS Law 2 / UU PDP). Deliberately MIXED, not uniformly broken: four relations each fail for a DIFFERENT reason, and one (visa_decision_retention_policies) passes clean — so a test against this file can assert the exact named-failing set instead of a blanket 'everything is red'.",
+  "relations": [
+    {
+      "_comment": "messages column dropped mid-restore (simulated schema drift). No violations key: fetch_live() never runs a check that references a missing required column, so this mirrors what a live run would actually measure.",
+      "relation": "conversations",
+      "exists": true,
+      "columns": ["id", "user_id", "created_at"],
+      "row_count": 3
+    },
+    {
+      "_comment": "table restored with correct schema but zero rows -- the 2026-06-06 auth-scope bug class this drill exists to catch.",
+      "relation": "clients",
+      "exists": true,
+      "columns": [
+        "id",
+        "full_name",
+        "client_type",
+        "google_drive_folder_id",
+        "created_at",
+        "updated_at"
+      ],
+      "row_count": 0,
+      "violations": { "client_type_unknown": 0, "lead_metadata_not_object": 0 }
+    },
+    {
+      "_comment": "two independent relational defects on the same table: a verdict outside the engine's enum, and a citations array-shape violation.",
+      "relation": "visa_decisions",
+      "exists": true,
+      "columns": [
+        "id",
+        "decision_id",
+        "environment",
+        "verdict",
+        "citations",
+        "rule_pack_id",
+        "evaluated_at"
+      ],
+      "row_count": 5,
+      "violations": {
+        "verdict_unknown": 2,
+        "environment_unknown": 0,
+        "citations_not_array": 1,
+        "temporarily_unavailable_missing_pack": 0
+      }
+    },
+    {
+      "_comment": "relation absent entirely from the restore.",
+      "relation": "events_outbox",
+      "exists": false
+    },
+    {
+      "relation": "visa_decision_retention_policies",
+      "exists": true,
+      "columns": [
+        "id",
+        "environment",
+        "policy_version",
+        "retention_interval",
+        "idempotency_retention_interval",
+        "legal_hold_review_interval",
+        "retention_anchor",
+        "effective_period",
+        "approved_by",
+        "approval_reference",
+        "created_at"
+      ],
+      "row_count": 1,
+      "violations": {
+        "environment_unknown": 0,
+        "retention_anchor_unknown": 0,
+        "idempotency_interval_out_of_bounds": 0,
+        "effective_period_invalid": 0,
+        "duplicate_environment_policy_version": 0
+      }
+    }
+  ]
+}

--- a/scripts/tests/fixtures/restore_drill/healthy.json
+++ b/scripts/tests/fixtures/restore_drill/healthy.json
@@ -1,0 +1,127 @@
+{
+  "_comment": "Synthetic measurement fixture for restore_drill_verify.py's INNOCENCE case. Every count below is illustrative, not a real production snapshot: no row VALUES appear anywhere in this file (relation/column NAMES and COUNTS only), per SYMBIOSIS Law 2 / UU PDP.",
+  "relations": [
+    {
+      "relation": "conversations",
+      "exists": true,
+      "columns": [
+        "id",
+        "user_id",
+        "messages",
+        "session_id",
+        "rating",
+        "feedback",
+        "created_at",
+        "updated_at"
+      ],
+      "row_count": 842,
+      "violations": { "messages_not_json_array": 0 }
+    },
+    {
+      "relation": "clients",
+      "exists": true,
+      "columns": [
+        "id",
+        "uuid",
+        "full_name",
+        "email",
+        "phone",
+        "whatsapp",
+        "nationality",
+        "passport_number",
+        "tax_id",
+        "status",
+        "client_type",
+        "assigned_to",
+        "address",
+        "notes",
+        "tags",
+        "custom_fields",
+        "google_drive_folder_id",
+        "drive_folder_id",
+        "drive_folder_url",
+        "deleted_at",
+        "date_of_birth",
+        "passport_expiry",
+        "lead_metadata",
+        "created_at",
+        "updated_at"
+      ],
+      "row_count": 512,
+      "violations": { "client_type_unknown": 0, "lead_metadata_not_object": 0 }
+    },
+    {
+      "relation": "visa_decisions",
+      "exists": true,
+      "columns": [
+        "id",
+        "decision_id",
+        "environment",
+        "jurisdiction",
+        "decision_domain",
+        "engine_surface",
+        "engine_mode",
+        "rule_pack_id",
+        "ruleset_activation_id",
+        "rule_pack_sha256",
+        "verdict",
+        "citations",
+        "engine_version",
+        "effective_at",
+        "observed_at",
+        "evaluated_at",
+        "created_at"
+      ],
+      "row_count": 37,
+      "violations": {
+        "verdict_unknown": 0,
+        "environment_unknown": 0,
+        "citations_not_array": 0,
+        "temporarily_unavailable_missing_pack": 0
+      }
+    },
+    {
+      "relation": "events_outbox",
+      "exists": true,
+      "columns": [
+        "id",
+        "channel",
+        "payload",
+        "created_at",
+        "consumed_at",
+        "consumer_id"
+      ],
+      "row_count": 0,
+      "violations": {
+        "channel_blank": 0,
+        "payload_missing": 0,
+        "consumed_before_created": 0
+      }
+    },
+    {
+      "relation": "visa_decision_retention_policies",
+      "exists": true,
+      "columns": [
+        "id",
+        "environment",
+        "policy_version",
+        "retention_interval",
+        "idempotency_retention_interval",
+        "legal_hold_review_interval",
+        "retention_anchor",
+        "effective_period",
+        "approved_by",
+        "approval_reference",
+        "created_at"
+      ],
+      "row_count": 2,
+      "violations": {
+        "environment_unknown": 0,
+        "retention_anchor_unknown": 0,
+        "idempotency_interval_out_of_bounds": 0,
+        "effective_period_invalid": 0,
+        "duplicate_environment_policy_version": 0
+      }
+    }
+  ]
+}

--- a/scripts/tests/test_restore_drill_verify.py
+++ b/scripts/tests/test_restore_drill_verify.py
@@ -214,6 +214,49 @@ def test_a_relation_reported_existing_with_zero_columns_is_cannot_verify():
     assert "zero columns" in verdict["reasons"][0]
 
 
+def test_a_boolean_violation_count_is_cannot_verify_not_a_silent_fail():
+    """Guilt: `isinstance(True, int)` is True in Python, and `True < 0` is
+    False for both True and False -- a fixture typo like
+    `"client_type_unknown": true` (JSON `true` decodes to a Python bool)
+    would otherwise sail past the malformed-value guard entirely and land
+    in the `count != 0` branch as a genuine-looking FAIL
+    ("client_type_unknown: True row(s) violate"), never the
+    CANNOT-VERIFY-with-a-clear-reason the guard exists to give. Not
+    reachable via --dsn (Postgres count(*) is always a bigint), but
+    reachable by an ordinary fixture-authoring mistake -- exactly the input
+    class the guard's own comment claims to catch."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["violations"]["client_type_unknown"] = True
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "CANNOT-VERIFY", verdict
+    assert any("malformed value" in r and "True" in r for r in verdict["reasons"])
+
+
+def test_ordinary_integer_violation_counts_still_evaluate_normally():
+    """Innocence, paired with the guilt test above: the bool exclusion must
+    not disturb ordinary int handling -- a real zero still PASSes and a
+    real nonzero count still FAILs."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["violations"]["client_type_unknown"] = 0
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "PASS", verdict
+
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["violations"]["client_type_unknown"] = 3
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "FAIL", verdict
+    assert any("client_type_unknown: 3 row(s) violate" in r for r in verdict["reasons"])
+
+
 def test_a_missing_column_and_the_checks_it_blocks_are_both_named_not_only_one():
     """A relation can carry BOTH a genuine FAIL-class finding (a missing
     column) and a CANNOT-VERIFY-class one (a check that could not run as a
@@ -272,6 +315,21 @@ def test_row_count_below_floor_fails_a_relation_that_has_one():
     assert "below floor" in verdict["reasons"][0]
 
 
+def test_row_count_exactly_at_the_floor_passes():
+    """The floor is "below which zero is provably wrong" (module docstring)
+    -- AT the floor is not below it. Pinned because the prior round measured
+    this boundary as untested: changing the evaluator's `<` to `<=` left
+    every existing test green, since no fixture set row_count == min_rows
+    exactly. clients carries min_rows=1; row_count == 1 must PASS."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["row_count"] = 1
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "PASS", verdict
+
+
 def test_zero_rows_does_not_fail_a_relation_with_no_floor():
     """visa_decisions/events_outbox/visa_decision_retention_policies carry
     min_rows=None -- zero rows must never fail them on row count alone."""
@@ -283,6 +341,100 @@ def test_zero_rows_does_not_fail_a_relation_with_no_floor():
     for relation in ("visa_decisions", "visa_decision_retention_policies"):
         verdict = next(v for v in result["invariants"] if v["relation"] == relation)
         assert verdict["status"] == "PASS", verdict
+
+
+# ---------------------------------------------------------------------------
+# FAIL vs CANNOT-VERIFY status, pinned directly. The module's own docstring
+# states this discrimination as its core thesis: "A missing relation or a
+# missing required column is a genuinely diagnosable finding -- scored
+# FAIL, not CANNOT-VERIFY". Every existing CANNOT-VERIFY test above asserts
+# `status == "CANNOT-VERIFY"` explicitly, but nothing asserted the FAIL side
+# of the SAME discrimination with an equally explicit status check -- the
+# only guilt coverage for the missing-relation branch (evaluate_one's
+# `exists is not True` case) was a substring check on `reasons`
+# ("relation missing" in ...), which a mutation from FAIL to CANNOT-VERIFY
+# on that branch does not disturb (measured: 16/16 tests stayed green under
+# that exact mutation before these two tests existed).
+# ---------------------------------------------------------------------------
+
+
+def test_relation_missing_from_restore_is_status_fail_not_cannot_verify():
+    """A relation absent from the restore is a diagnosable defect (the
+    restore is provably incomplete), not an untaken measurement -- must be
+    FAIL, never CANNOT-VERIFY, even though both statuses would make
+    `broken = {status != PASS}` assertions pass identically."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "events_outbox":
+            r.clear()
+            r.update({"relation": "events_outbox", "exists": False})
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "events_outbox")
+    assert verdict["status"] == "FAIL", verdict
+    assert "relation missing" in verdict["reasons"][0]
+
+
+def test_missing_required_column_alone_is_status_fail_not_cannot_verify():
+    """A required column dropped from the schema is likewise diagnosable
+    (the app cannot work without it), not a measurement failure -- isolated
+    here from any CANNOT-VERIFY trigger: the removed column (`updated_at`)
+    is not referenced by any of clients' violation checks, so `violations`
+    stays fully measured and row_count stays above its floor. (Contrast
+    `test_a_missing_column_and_the_checks_it_blocks_are_both_named_not_only_one`
+    above, which removes `messages` from conversations AND pops its
+    `violations` dict -- there BOTH a FAIL-class and a CANNOT-VERIFY-class
+    reason fire together, and CANNOT-VERIFY correctly wins per the
+    evaluator's own precedence. This test isolates the FAIL-only case.)"""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["columns"] = [c for c in r["columns"] if c != "updated_at"]
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "FAIL", verdict
+    assert any("missing required column" in r and "updated_at" in r for r in verdict["reasons"])
+
+
+# ---------------------------------------------------------------------------
+# The exit-code mapping the PASS/FAIL/CANNOT-VERIFY status feeds
+# (`_EXIT_FOR_AGGREGATE`) is itself a claim this module makes about a
+# caller-visible contract (docstring "Exit codes" section) -- pinned per
+# value, not just "zero vs nonzero", because the previous round measured
+# that swapping the FAIL (1) and CANNOT-VERIFY (3) exit codes left every
+# existing test green too (nothing asserted an exact nonzero value).
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_for_pass_aggregate_is_exactly_zero():
+    rc = rdv.main(["--fixture", str(_FIXTURES / "healthy.json")])
+    assert rc == 0
+
+
+def test_exit_code_for_a_pure_fail_aggregate_is_exactly_one(tmp_path):
+    """A fixture with exactly one genuine FAIL and no CANNOT-VERIFY anywhere
+    -- confirms `aggregate == "FAIL"` maps to exit 1, distinct from
+    CANNOT-VERIFY's exit 3."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["row_count"] = 0
+    fx = tmp_path / "pure_fail.json"
+    fx.write_text(json.dumps({"relations": relations}))
+    rc = rdv.main(["--fixture", str(fx), "--json"])
+    assert rc == 1
+
+
+def test_exit_code_for_cannot_verify_aggregate_is_exactly_three(capsys):
+    """degenerate.json's `conversations` relation carries both a FAIL-class
+    reason (missing column) and a CANNOT-VERIFY-class one (the check that
+    references that column cannot run) -- CANNOT-VERIFY wins per the
+    evaluator's precedence, so this fixture's aggregate is CANNOT-VERIFY,
+    not FAIL (verified directly here, not assumed)."""
+    fx_path = str(_FIXTURES / "degenerate.json")
+    rc = rdv.main(["--fixture", fx_path, "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["aggregate"] == "CANNOT-VERIFY", out
+    assert rc == 3
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_restore_drill_verify.py
+++ b/scripts/tests/test_restore_drill_verify.py
@@ -1,0 +1,306 @@
+"""restore_drill_verify.py must catch the degenerate shape and must never
+accuse a healthy restore.
+
+TRAUMA this replaces: the drill's OLD success condition was a bare table
+census (`TABLES -ge 50`) — a restore that produces 60 EMPTY tables passed it.
+The workflow's own comment records why that mattered: on 2026-06-06 a
+`PGPASSWORD` env-prefix landed on the wrong side of a pipe, psql got no
+password, the restore silently produced 0 tables, and the drill reported
+success. This corpus proves the replacement (a) genuinely fails on a
+degenerate restore, naming every broken relation individually rather than an
+aggregate "FAILED", and (b) never conflates "could not measure" with
+"measured zero" (cicatrix-scars.md W106b / superscar #9) — the class of bug
+this whole module exists to close off.
+
+Guilt fixture: scripts/tests/fixtures/restore_drill/degenerate.json — four
+relations, each broken for a DIFFERENT reason (schema drift, below-floor row
+count, relational violations, missing relation), and one left clean, so a
+test against this file can assert the exact named-failing set rather than a
+blanket "everything is red" (a test that would pass even if the evaluator
+only ever emitted a single generic failure).
+Innocence fixture: scripts/tests/fixtures/restore_drill/healthy.json — all
+five relations PASS.
+
+Run:  python3 scripts/tests/test_restore_drill_verify.py
+      pytest scripts/tests/test_restore_drill_verify.py -q
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_CI_DIR = Path(__file__).resolve().parents[1] / "ci"
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "restore_drill"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "restore_drill_verify", _CI_DIR / "restore_drill_verify.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec: `Invariant` is a frozen dataclass
+    # under `from __future__ import annotations`, and dataclasses resolves
+    # its string annotations via `sys.modules[cls.__module__]` -- a module
+    # loaded via spec_from_file_location that is never added to sys.modules
+    # crashes there with `AttributeError: 'NoneType' object has no attribute
+    # '__dict__'` (measured, not assumed: this exact failure on the first
+    # run of this file, before this line existed).
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rdv = _load_module()
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    with open(_FIXTURES / name) as f:
+        return json.load(f)
+
+
+def _healthy_relations() -> list[dict[str, Any]]:
+    return copy.deepcopy(_load_fixture("healthy.json")["relations"])
+
+
+# ---------------------------------------------------------------------------
+# Innocence: the healthy fixture.
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_fixture_is_five_explicit_passes():
+    result = rdv.evaluate(_load_fixture("healthy.json")["relations"])
+    assert result["aggregate"] == "PASS"
+    assert len(result["invariants"]) == 5, "must always emit exactly 5 verdicts, one per declared invariant"
+    for verdict in result["invariants"]:
+        assert verdict["status"] == "PASS", verdict
+        assert verdict["reasons"] == [], verdict
+
+
+def test_healthy_fixture_cli_exits_zero():
+    fx_path = str(_FIXTURES / "healthy.json")
+    rc = rdv.main(["--fixture", fx_path])
+    assert rc == 0
+
+
+def test_healthy_fixture_covers_the_legitimately_zero_row_case():
+    """events_outbox is pruned daily (migration 144) -- 0 rows is a healthy
+    state, not a degenerate one. Pinned so nobody "fixes" the fixture into a
+    non-zero count and silently deletes the one case that proves min_rows is
+    NOT applied blindly to every relation."""
+    healthy = _load_fixture("healthy.json")
+    outbox = next(r for r in healthy["relations"] if r["relation"] == "events_outbox")
+    assert outbox["row_count"] == 0
+    result = rdv.evaluate(healthy["relations"])
+    verdict = next(v for v in result["invariants"] if v["relation"] == "events_outbox")
+    assert verdict["status"] == "PASS", verdict
+
+
+# ---------------------------------------------------------------------------
+# Guilt: the degenerate fixture. Mixed on purpose -- 4 broken, 1 clean.
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_fixture_names_every_failed_invariant_not_an_aggregate_only_failure():
+    result = rdv.evaluate(_load_fixture("degenerate.json")["relations"])
+    assert result["aggregate"] != "PASS"
+
+    by_relation = {v["relation"]: v for v in result["invariants"]}
+    assert len(by_relation) == 5
+
+    expected_broken = {"conversations", "clients", "visa_decisions", "events_outbox"}
+    broken = {rel for rel, v in by_relation.items() if v["status"] != "PASS"}
+    assert broken == expected_broken, f"expected exactly {expected_broken} broken, got {broken}"
+
+    # The one relation the fixture leaves clean really is reported clean --
+    # a test that only checked the broken set could pass even if the
+    # evaluator marked EVERYTHING broken (which "names every failed
+    # invariant, not an aggregate failure" explicitly rules out).
+    assert by_relation["visa_decision_retention_policies"]["status"] == "PASS"
+    assert by_relation["visa_decision_retention_policies"]["reasons"] == []
+
+    # Each broken relation names its OWN, distinct cause -- not a shared
+    # generic string that would pass even if every check collapsed to one
+    # "something is wrong" message.
+    assert any("missing required column" in r for r in by_relation["conversations"]["reasons"])
+    assert any("below floor" in r for r in by_relation["clients"]["reasons"])
+    assert any("verdict_unknown" in r for r in by_relation["visa_decisions"]["reasons"])
+    assert any("citations_not_array" in r for r in by_relation["visa_decisions"]["reasons"])
+    assert any("relation missing" in r for r in by_relation["events_outbox"]["reasons"])
+
+
+def test_degenerate_fixture_cli_exits_nonzero(capsys):
+    fx_path = str(_FIXTURES / "degenerate.json")
+    rc = rdv.main(["--fixture", fx_path, "--json"])
+    assert rc != 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["aggregate"] != "PASS"
+    broken = {v["relation"] for v in out["invariants"] if v["status"] != "PASS"}
+    assert broken == {"conversations", "clients", "visa_decisions", "events_outbox"}
+
+
+def test_degenerate_fixture_prose_output_names_relations_not_just_aggregate(capsys):
+    fx_path = str(_FIXTURES / "degenerate.json")
+    rdv.main(["--fixture", fx_path])
+    out = capsys.readouterr().out
+    for relation in ("conversations", "clients", "visa_decisions", "events_outbox"):
+        assert relation in out, f"prose output silently dropped {relation}"
+
+
+# ---------------------------------------------------------------------------
+# "Cannot measure" must never be silently reported as "measured zero"
+# (cicatrix-scars.md W106b / superscar #9). Each of these is exercised
+# directly against `evaluate()`, not via a fixture FILE, because each one
+# is a class of MEASUREMENT failure rather than a schema/data fact — the
+# two fixture files above are reserved for the plan's own file list.
+# ---------------------------------------------------------------------------
+
+
+def test_a_relation_absent_from_the_measurement_list_is_cannot_verify_not_a_pass():
+    """A future bug that silently drops one relation from the measurement
+    set must never read as that relation passing."""
+    relations = _healthy_relations()
+    relations = [r for r in relations if r["relation"] != "events_outbox"]
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "events_outbox")
+    assert verdict["status"] == "CANNOT-VERIFY"
+    assert "no measurement recorded" in verdict["reasons"][0]
+    assert result["aggregate"] == "CANNOT-VERIFY"
+
+
+def test_a_query_error_is_cannot_verify_not_a_pass():
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "visa_decisions":
+            r.clear()
+            r.update({"relation": "visa_decisions", "error": "connection to server was lost"})
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "visa_decisions")
+    assert verdict["status"] == "CANNOT-VERIFY"
+    assert "connection to server was lost" in verdict["reasons"][0]
+
+
+def test_a_declared_check_missing_from_violations_is_cannot_verify_not_zero():
+    """The whole point of this test: `violations` reporting NOTHING for a
+    check must never be read the same as `violations` reporting 0 for it."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            del r["violations"]["client_type_unknown"]
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "CANNOT-VERIFY"
+    assert any("client_type_unknown" in r and "could not be measured" in r for r in verdict["reasons"])
+
+
+def test_a_relation_reported_existing_with_zero_columns_is_cannot_verify():
+    """A relation cannot exist in Postgres with zero columns (a PRIMARY KEY
+    alone guarantees at least one) -- this is the measurement lying about
+    its own input, not a fact about the schema."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["columns"] = []
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "CANNOT-VERIFY"
+    assert "zero columns" in verdict["reasons"][0]
+
+
+def test_a_missing_column_and_the_checks_it_blocks_are_both_named_not_only_one():
+    """A relation can carry BOTH a genuine FAIL-class finding (a missing
+    column) and a CANNOT-VERIFY-class one (a check that could not run as a
+    result) at once. Both must be visible -- an earlier draft of the
+    evaluator discarded the FAIL-class reason whenever a CANNOT-VERIFY one
+    also fired for the same relation."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "conversations":
+            r["columns"] = [c for c in r["columns"] if c != "messages"]
+            r.pop("violations", None)
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "conversations")
+    assert verdict["status"] == "CANNOT-VERIFY"
+    assert any("missing required column" in r and "messages" in r for r in verdict["reasons"])
+    assert any("messages_not_json_array" in r for r in verdict["reasons"])
+
+
+# ---------------------------------------------------------------------------
+# Relational-check math, pinned directly (guilt + innocence on the same
+# invariant, independent of any fixture file).
+# ---------------------------------------------------------------------------
+
+
+def test_visa_decisions_temporarily_unavailable_may_lack_a_rule_pack():
+    """Mirrors migration 252's own CHECK: only a TEMPORARILY_UNAVAILABLE
+    verdict may have a null rule_pack_id."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "visa_decisions":
+            r["violations"]["temporarily_unavailable_missing_pack"] = 0
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "visa_decisions")
+    assert verdict["status"] == "PASS"
+
+
+def test_visa_decisions_non_unavailable_without_a_pack_is_flagged():
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "visa_decisions":
+            r["violations"]["temporarily_unavailable_missing_pack"] = 1
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "visa_decisions")
+    assert verdict["status"] == "FAIL"
+    assert any("temporarily_unavailable_missing_pack" in reason for reason in verdict["reasons"])
+
+
+def test_row_count_below_floor_fails_a_relation_that_has_one():
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] == "clients":
+            r["row_count"] = 0
+    result = rdv.evaluate(relations)
+    verdict = next(v for v in result["invariants"] if v["relation"] == "clients")
+    assert verdict["status"] == "FAIL"
+    assert "below floor" in verdict["reasons"][0]
+
+
+def test_zero_rows_does_not_fail_a_relation_with_no_floor():
+    """visa_decisions/events_outbox/visa_decision_retention_policies carry
+    min_rows=None -- zero rows must never fail them on row count alone."""
+    relations = _healthy_relations()
+    for r in relations:
+        if r["relation"] in ("visa_decisions", "visa_decision_retention_policies"):
+            r["row_count"] = 0
+    result = rdv.evaluate(relations)
+    for relation in ("visa_decisions", "visa_decision_retention_policies"):
+        verdict = next(v for v in result["invariants"] if v["relation"] == relation)
+        assert verdict["status"] == "PASS", verdict
+
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+
+def test_mutually_exclusive_source_flags_are_enforced():
+    try:
+        rdv.main([])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected argparse to reject a call with neither --dsn nor --fixture")
+
+
+if __name__ == "__main__":
+    # Delegate to real pytest (not a hand-rolled loop) so fixture-dependent
+    # tests (capsys) run correctly even outside a `pytest` invocation --
+    # matching test_probe_merge_gate_integrity.py's own convention.
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
The monthly Postgres restore drill declared success from a **table census**:

```
TABLES=$(... information_schema.tables ...)
test "$TABLES" -ge 50 || exit 3
```

A restore producing **60 empty tables** passes that. The workflow's own history records why it
matters: on 2026-06-06 a misplaced `PGPASSWORD` meant psql got no password, the restore produced 0
tables, and the drill reported success. The exit code of a restore is not evidence the DATA arrived —
superscar #2 applied to a backup instead of a daemon.

This adds Level-5 application verification: for five relations this repo has separately hardened, it
checks a non-degenerate **result shape** — the relation exists, every column the application layer
depends on is present, the row count is not below a floor where zero is provably wrong, and declared
violation-checks actually ran.

**This PR is the verifier and its corpus only.** The workflow wiring is stacked in a follow-up so the
two merge classes do not share a PR.

## The core thesis was unarmed, and the gate found it by running the mutation

The module's docstring states its central discrimination: a missing relation is *"a genuinely
diagnosable finding — FAIL, not CANNOT-VERIFY"*. Flipping exactly that on the production file left
**16/16 green**. The only test touching it asserted the reason TEXT:

```python
assert any("relation missing" in r for r in by_relation["events_outbox"]["reasons"])
```

never the STATUS. Same vacuity class as the guilt assertion cured on #5255 today, and here it sat on
the sentence the file exists to defend.

Three more were measured unarmed alongside it.

| mutation | before | after |
|---|---:|---:|
| relation-missing `FAIL` → `CANNOT-VERIFY` (the stated thesis) | **0 red** | **1** |
| `_EXIT_FOR_AGGREGATE` `1`↔`3` swap | **0 red** | **2** |
| row-count floor `<` → `<=` (boundary) | **0 red** | **1** |
| `isinstance(count, int)` bool-exclusion removed | — | **1** |
| `_evaluate_one` FAIL/CANNOT-VERIFY precedence swap | — | **8** |

All re-run by the gate on the production file, `PYTHONDONTWRITEBYTECODE=1` (W121), `cp` restore and
`cmp -s` byte-identical after every one (W125).

## One real bug, not just missing tests

`isinstance(count, int)` does not exclude `bool` — Python's `bool` is an `int` subclass. Reproduced: a
fixture carrying `"client_type_unknown": true` sails past the malformed-value guard (`True < 0` is
`False`) and yields `{'status': 'FAIL', 'reasons': ['client_type_unknown: True row(s) violate']}`
instead of the CANNOT-VERIFY-with-a-clear-reason the guard exists to give. Unreachable via `--dsn`
(Postgres `count(*)` returns a bigint) but reachable by an ordinary fixture typo, and exactly the input
class the guard's own comment claims to catch.

The floor's direction was **not guessed**: the shipped `<` and the docstring's "below which zero is
provably wrong" agree that at-floor passes, so that is what got pinned. Changing it would be a
behaviour change, not a test addition.

## Over contract, declared

**Code-class net 505** against the ~400 target. Condensing already cut the file 574 → 501 (docstring
106 → 65 content lines, comments 77 → 44) with zero logic change; the +4 is the bool fix. The remaining
mass is ~326 lines of code — SQL, the five-invariant declaration, `fetch_live`, `_evaluate_one`,
`evaluate`, argparse — which is not prose to cut.

Split recipes considered and rejected: collapsing the `required_columns` tuples (cosmetic, trades
readability for a number); stripping the per-invariant migration citations (deletes the WHY); splitting
live-fetch from pure evaluation (ships a tool whose docstring describes a `--dsn` mode the file does
not have). A stated overage with a named reason beats a split that manufactures a shipped-but-unarmed
half.

## Phantom-citation re-scan

This file shipped with one: the original docstring cited `_gate_missing_columns`, a function that
exists **nowhere** — the gate is an inline comprehension in `fetch_live`. Gone now. Every remaining
backtick-quoted symbol and `migrations_v2/NNN` reference was grepped against disk: migrations 136, 143,
144, 223, 252, 264, 268 all exist with content matching their claims; W106b and W130 exist, and W106b
was checked for actual membership in family #9 rather than mere existence. Declared imprecision left
as-is: `264+268_visa_decision_retention_policy*.sql` is shorthand, not a literal glob — 268's real
filename differs.

**24 passed** · `py_compile -W error::SyntaxWarning` clean · `ruff check` clean · fixtures
prettier-clean.
