### PR TITLE
fix(pending-arms): negated operator disclaimer misread as phantom claim

### DIFF
--- a/scripts/pending_arms_report.py
+++ b/scripts/pending_arms_report.py
@@ -174,6 +174,18 @@ TRUE_OPERATOR_CATEGORIES = frozenset(
 # owner ("operatore" in Italian prose must not slip through as TECH-DEBT — W82 under-match).
 OPERATOR_TAG_RE = re.compile(r"\boperator\s*\[\s*([a-z0-9-]+)\s*\]", re.IGNORECASE)
 
+# Explicit disclaimer of an operator-lane claim ("not operator-gated", "not
+# operator[<cat>]") — found live 2026-08-30 (healer tick, PR #5269 blocked by
+# --strict-phantom): the owner field "next BUILD session (repo-side; not
+# operator-gated — this is a real code fix, just not a healer-tick-safe one)"
+# was classified PHANTOM-OPERATOR because plain substring matching on "operator"
+# cannot see the "not " sitting in front of it. Deliberately narrow: only
+# suppresses the phantom read when there is NO operator[cat] tag anywhere in the
+# owner (checked at the call site below) — an owner mixing a real tag with a
+# disclaiming aside elsewhere must still resolve through the tag logic, never
+# this exception, so a genuine phantom tag can't hide behind a nearby "not".
+NEGATED_OPERATOR_RE = re.compile(r"\bnot\s+operator\b", re.IGNORECASE)
+
 # NATURAL-WAIT: the owner declares a PASSIVE wait on a dated natural trigger
 # (`me (passivo — verifica 07-12)`) — the arming is done, only the proof needs the
 # calendar. NOT overdue debt: strict must not fail on it, and the healer's ledger
@@ -665,6 +677,11 @@ def parse_entry(raw: str, now: date) -> Entry:
         tags = [m.group(1).lower() for m in OPERATOR_TAG_RE.finditer(owner)]
         if tags and all(t in TRUE_OPERATOR_CATEGORIES for t in tags):
             cls = CLASS_OPERATOR_GATED
+        elif not tags and NEGATED_OPERATOR_RE.search(owner):
+            # No bracket tag at all AND the only "operator" mention is inside a
+            # "not operator..." disclaimer — this is prose DENYING an operator-lane
+            # claim, not making one. See NEGATED_OPERATOR_RE comment above.
+            cls = CLASS_TECH_DEBT
         else:
             cls = CLASS_PHANTOM_OPERATOR
     else:

--- a/scripts/tests/test_pending_arms_report.py
+++ b/scripts/tests/test_pending_arms_report.py
@@ -247,6 +247,38 @@ def test_innocence_operator_word_only_in_proof_not_flagged(tmp_path):
     assert e.cls == par.CLASS_TECH_DEBT
 
 
+def test_innocence_negated_operator_disclaimer_is_not_phantom(tmp_path):
+    # Live 2026-08-30 (healer tick): owner text explicitly DENIES claiming an
+    # operator lane ("not operator-gated") — plain substring matching on
+    # "operator" cannot see the negation and misread this as a phantom claim.
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | negated disclaimer artifact | step | "
+        "next BUILD session (repo-side; not operator-gated) | proof",
+    )
+    assert e.cls == par.CLASS_TECH_DEBT
+
+
+def test_guilt_negation_does_not_rescue_a_real_operator_tag(tmp_path):
+    # A negated aside elsewhere in the owner must NOT rescue a genuinely
+    # untagged/mis-tagged operator claim living alongside it.
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | mixed negation artifact | step | "
+        "operator[vibes] (not operator-gated for the other half) | proof",
+    )
+    assert e.cls == par.CLASS_PHANTOM_OPERATOR
+
+
+def test_guilt_bare_operator_word_unaffected_by_negation_regex(tmp_path):
+    # Regression pin: bare "operator" (no "not" nearby) must still phantom.
+    e = _single_entry(
+        tmp_path,
+        "- opened 2026-07-05 | bare operator artifact | step | operator | proof",
+    )
+    assert e.cls == par.CLASS_PHANTOM_OPERATOR
+
+
 def test_firebreak_precedence_over_phantom_documented(tmp_path):
     # Pre-existing precedence: an explicit 'firebreak' in the raw text wins the
     # classification even with an untagged operator owner. Documented, not accidental.


### PR DESCRIPTION
## Summary
- Healer tick on Mini (receptors: ledger-overdue + registry:1-dead-organs) found that PR #5269's CI-blocking `antidotes` failure is a real classifier bug in `scripts/pending_arms_report.py`, not a bad ledger row.
- `elif "operator" in owner.lower():` matches the bare substring `"operator"` anywhere in the owner field — including inside a negation like `"not operator-gated"`. An owner explicitly *disclaiming* an operator-lane claim was misread as *making* one, classifying it PHANTOM-OPERATOR and failing `--strict-phantom` (the CI ledger gate).
- Added `NEGATED_OPERATOR_RE`, fired only when the owner has zero `operator[<cat>]` tags — a mixed owner (real tag + a nearby "not") still resolves through the existing tag logic, so a genuine phantom can't hide behind an unrelated disclaimer elsewhere in the same field.
- Verified the fix against PR #5269's exact ledger content: `phantom_operator: 0`, zero MALFORMED, `--strict-phantom` exit 0 (was exit 1). Mutation-checked: reverting the fix makes the new innocence test fail.

## Test plan
- [x] 3 new tests (innocence: disclaimer not phantom; guilt: negation doesn't rescue a real bad tag; regression pin: bare `operator` still phantoms) — 103/103 pass in the full suite.
- [x] Reproduced PR #5269's exact blocked row against the fix: `phantom_operator=0`, `strict-phantom exit code: 0`.
- [x] Mutation check: reverted the fix, confirmed the new innocence test fails with the exact PHANTOM-OPERATOR misclassification; restored and re-ran green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)