### PR TITLE
ci(queue): lint_arm_probe.py — bind tonight's autoMergeRequest finding

### DIFF
--- a/scripts/lint_arm_probe.py
+++ b/scripts/lint_arm_probe.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""lint_arm_probe.py — executable antidote for the autoMergeRequest null-ambiguity trap.
+
+THE FINDING (measured 2026-08-29/30, PR #5275): GitHub's `autoMergeRequest` GraphQL
+field reads null in (at least) three different states — a PR the merge queue has
+ACCEPTED and is now processing (the request is CONSUMED, not disarmed), a PR the
+queue EJECTED, and a PR that was genuinely never armed — and non-null in only one.
+`mergeQueueEntry` (the per-PR authoritative field), its sibling boolean
+`isInMergeQueue`, and the branch-level `mergeQueue(branch:...){entries}` snapshot
+are the only POSITIVE probes: a PR is IN the queue *because* the request is live.
+Reading `autoMergeRequest == null` as "disarmed, needs re-arming" therefore fires
+precisely when arming SUCCEEDED — confirmed live on PR #5275 (`autoMergeRequest:
+null` simultaneously with `mergeQueueEntry {state: QUEUED, position: 3}`, and
+`gh pr merge --auto` on it refusing with "already queued to merge") and, per the
+mandate that produced this lint, twice before in production (#4756, #5012: a
+sentinel announced "ARM CONSUMED / re-arm needed" against a PR that was actually
+`mergeQueueEntry.state = AWAITING_CHECKS, position 1`).
+
+THE ANTIDOTE: this lint. A file that TESTS `autoMergeRequest` for truthiness/
+nullness (a "decision position" — a `.get` lookup or bracket subscript keyed
+on the literal field name, or a jq `== null` / `select(...)` filter on it)
+must also reference one of the positive-probe markers — `mergeQueueEntry`,
+`isInMergeQueue`, or `mergeQueue(` — somewhere in the SAME FILE. A file that only
+REQUESTS the field (a `--json ...,autoMergeRequest` field list, or a GraphQL
+mutation's return-selection) without ever testing it is not flagged — nothing
+decides on it, so there is nothing to protect (mq.sh's confirm-step echo,
+github_publisher.py's `_enable_auto_merge` mutation selection).
+
+Detection classes:
+  FAIL   — a decision-position `autoMergeRequest` line with NO positive-probe
+           marker anywhere in the file, and no inline suppression marker on
+           that line.
+  (clean) — decision-position usage WITH a positive-probe marker in the same
+           file, OR no decision-position usage at all.
+
+Suppression marker (CONTENT-based, not a directory exemption — cicatrix #3/
+W109, "an exemption keyed to where a file sits, rather than what it is, is
+itself a scar"): a source line carrying the literal string
+`lint-arm-probe:fixture` is a synthetic guilt/innocence sample embedded in
+this lint's OWN test file, not real decision code, and is excluded entirely
+(from both findings AND positive-probe detection). The marker sits on the
+Python SOURCE line that DEFINES a fixture string constant — as a trailing
+`#` comment, which Python discards at parse time and which therefore never
+becomes part of the fixture TEXT a test hands to `scan_text()`. That is what
+lets the guilt fixture still register as a finding *inside the unit test*
+(the runtime string has no marker) while the static .py file that defines it
+is invisible to this lint's own repo-wide scan (the source line does).
+Nothing else may carry this marker — `scripts/tests/test_lint_arm_probe.py`
+is the only tracked file that does
+(`test_marker_appears_only_in_this_lints_own_test_file`).
+
+Scope notes (deliberate): file-level, not function-level, co-occurrence. A
+file whose own decision logic is safe only because a DIFFERENT file checks
+queue membership before ever acting on its output (a "candidates" filter
+piped into a caller that cross-references `mergeQueue(...)` before acting)
+still reads `autoMergeRequest == null` as part of its own predicate, with
+nothing in ITS file proving that null here means anything narrower than "not
+armed" — so it FAILS this lint even when the full pipeline is safe today.
+That is intentional, not a false positive: the safety property in that shape
+lives in a caller/callee CONTRACT, not in the file itself, and a future
+caller that skips the cross-check reintroduces the exact bug this lint
+exists to catch (see the audit report that shipped alongside this lint for
+the one file this currently affects).
+
+Exit code: 0 = clean · 1 = one or more FAIL findings · 4 = operational error
+(unreadable file — a scan that cannot see is not clean, W84 fail-visible
+discipline).
+
+Tests: scripts/tests/test_lint_arm_probe.py.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _canonical_repo_root() -> Path:
+    """Repo root, worktree-hardened (same discipline as lint_home_fork.py):
+    running from .worktrees/<lane>/ must lint against the MAIN checkout — a
+    worktree is ephemeral, treating it as the source of truth would replay
+    W81."""
+    root = Path(__file__).resolve().parent.parent
+    parts = root.parts
+    if ".worktrees" in parts:
+        idx = parts.index(".worktrees")
+        return Path(*parts[:idx])
+    return root
+
+
+REPO_ROOT = _canonical_repo_root()
+
+_SCAN_EXTS = {".py", ".sh", ".bash", ".yml", ".yaml"}
+_PRUNE_DIRS = {
+    "node_modules", ".venv", "venv", ".git", "__pycache__",
+    ".worktrees", "dist", "build", ".next",
+}
+
+SUPPRESSION_MARKER = "lint-arm-probe:fixture"
+
+_FIELD_TOKEN = "autoMergeRequest"
+
+# The three positive-probe shapes this repo's consumers actually use (audit,
+# 2026-08-29): PullRequest.mergeQueueEntry, PullRequest.isInMergeQueue, and
+# the branch-level repository.mergeQueue(branch:"main"){entries...} snapshot.
+_POSITIVE_PROBE_RE = re.compile(r"mergeQueueEntry|isInMergeQueue|mergeQueue\(")
+
+# Decision-position patterns: autoMergeRequest being TESTED/FILTERED, not
+# merely requested as a field. Anchored on how this repo's own consumers
+# actually read the field (measured across 17 files) — not a generic
+# "field appears" match, which would flag `--json ...,autoMergeRequest`
+# field-selection lines and GraphQL query-declaration lines that are never
+# parsed downstream (guard-over-match, cicatrix #3).
+_DECISION_PATTERNS = [
+    # dict.get("autoMergeRequest") / dict.get('autoMergeRequest')
+    re.compile(r"""\.get\(\s*["']""" + _FIELD_TOKEN + r"""["']"""),
+    # dict["autoMergeRequest"] / dict['autoMergeRequest']
+    re.compile(r"""\[\s*["']""" + _FIELD_TOKEN + r"""["']\s*\]"""),
+    # jq: .autoMergeRequest==null / .autoMergeRequest != null
+    re.compile(r"""\.""" + _FIELD_TOKEN + r"""\s*(==|!=)\s*null"""),
+    # jq: select(...autoMergeRequest...)
+    re.compile(r"""select\([^)]*""" + _FIELD_TOKEN + r"""[^)]*\)"""),
+]
+
+
+# ---------------------------------------------------------------- scanning
+
+
+def _is_full_comment_line(line: str) -> bool:
+    """First non-whitespace char is `#` — a whole-line comment in Python,
+    bash and YAML alike. A trailing inline `code  # comment` is NOT stripped
+    (this lint does not attempt a string-literal-aware tokenizer); a comment
+    mentioning autoMergeRequest AFTER real code on the same line could in
+    principle still match, but no consumer in this repo's audit does that —
+    documented limitation, not a silent gap."""
+    return line.lstrip().startswith("#")
+
+
+def _has_decision_pattern(line: str) -> bool:
+    return any(p.search(line) for p in _DECISION_PATTERNS)
+
+
+def scan_text(text: str, relpath: str) -> dict[str, Any]:
+    """Pure function, no file I/O — the unit-testable core. Returns
+    {"findings": [str], "has_positive_probe": bool, "decision_lines": [(int, str)]}.
+    """
+    lines = text.splitlines()
+    has_positive_probe = False
+    decision_lines: list[tuple[int, str]] = []
+
+    for line_no, line in enumerate(lines, start=1):
+        if SUPPRESSION_MARKER in line:
+            continue
+        if _is_full_comment_line(line):
+            continue
+        if _POSITIVE_PROBE_RE.search(line):
+            has_positive_probe = True
+        if _FIELD_TOKEN in line and _has_decision_pattern(line):
+            decision_lines.append((line_no, line.strip()))
+
+    findings: list[str] = []
+    if decision_lines and not has_positive_probe:
+        for line_no, snippet in decision_lines:
+            findings.append(
+                f"{relpath}:{line_no}: autoMergeRequest tested in a decision "
+                f"position with no mergeQueueEntry/isInMergeQueue/mergeQueue( "
+                f"probe anywhere in this file — null here can mean queued, "
+                f"ejected, or never-armed, and this file cannot tell them "
+                f"apart. {snippet[:160]}"
+            )
+
+    return {
+        "findings": findings,
+        "has_positive_probe": has_positive_probe,
+        "decision_lines": decision_lines,
+    }
+
+
+# ---------------------------------------------------------------- discovery
+
+
+def _walk_files(root: Path, errors: list[str]) -> list[Path]:
+    """os.walk with the standard vendored/ephemeral prune list; unreadable
+    dirs become operational errors (fail-visible), never a silent skip."""
+    found: list[Path] = []
+    if not root.exists():
+        return found
+
+    def _onerror(exc: OSError) -> None:
+        errors.append(f"root unreadable ({type(exc).__name__}): {exc.filename or root}")
+
+    for dirpath, dirnames, filenames in os.walk(root, onerror=_onerror):
+        dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+        for fn in filenames:
+            if Path(fn).suffix.lower() in _SCAN_EXTS:
+                found.append(Path(dirpath) / fn)
+    return found
+
+
+def _rel(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def run(root_paths: list[Path], repo_root: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    findings: list[str] = []
+
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for root in root_paths:
+        for path in _walk_files(root, errors):
+            resolved = path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            files.append(path)
+    files.sort()
+
+    for path in files:
+        relpath = _rel(path, repo_root)
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            errors.append(f"file unreadable ({type(exc).__name__}): {relpath}")
+            continue
+        if _FIELD_TOKEN not in text:
+            continue
+        result = scan_text(text, relpath)
+        findings.extend(result["findings"])
+
+    exit_code = (1 if findings else 0) | (4 if errors else 0)
+    return {
+        "schema": 1,
+        "findings": findings,
+        "errors": errors,
+        "files_scanned": len(files),
+        "exit": exit_code,
+    }
+
+
+# ---------------------------------------------------------------- main
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root", action="append", default=None,
+        help="repeatable; default: repo root (whole tracked tree, standard prunes)",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT, help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    roots = args.root if args.root else ["."]
+    root_paths = [
+        (Path(r) if Path(r).is_absolute() else repo_root / r) for r in roots
+    ]
+
+    result = run(root_paths, repo_root)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return result["exit"]
+
+    print(f"[arm-probe-lint] scanned {result['files_scanned']} file(s) under "
+          f"{', '.join(str(_rel(r, repo_root)) for r in root_paths)}")
+    print(f"[findings] {len(result['findings'])}")
+    for f in result["findings"]:
+        print(f"  - {f}")
+    if result["errors"]:
+        print(f"[errors] {len(result['errors'])} operational error(s) — scan is PARTIAL, not clean:")
+        for e in result["errors"]:
+            print(f"  - {e}")
+    if not result["findings"] and not result["errors"]:
+        print("  clean — every decision-position autoMergeRequest read is co-located "
+              "with a mergeQueueEntry/isInMergeQueue/mergeQueue( probe")
+    if result["exit"]:
+        print(
+            f"ARM-PROBE LINT FAIL (exit {result['exit']}: 1=unsafe-decision 4=scan-error) — "
+            f"autoMergeRequest reads null while QUEUED, EJECTED, and NEVER-ARMED alike; "
+            f"cross-check mergeQueueEntry/isInMergeQueue/mergeQueue( before treating null "
+            f"as disarmed"
+        )
+    return result["exit"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_lint_arm_probe.py
+++ b/scripts/tests/test_lint_arm_probe.py
@@ -1,0 +1,314 @@
+"""Tests for scripts/lint_arm_probe.py (autoMergeRequest null-ambiguity lint).
+
+Every FAIL-class detector gets a GUILT case (the disease IS caught) and an
+INNOCENCE case (the adjacent legitimate state is NOT flagged) — same
+discipline lint_home_fork.py's and lint_plist_keepalive.py's tests apply
+(cicatrix-superscar.md #3, guard-over-match).
+
+SELF-SCAN NOTE: every fixture string below embeds the literal decision
+pattern this lint scans for (a `.get` lookup or bracket subscript keyed on
+the field name, etc.), which means the SOURCE lines that define them, in
+THIS tracked file, would themselves
+trip the lint if it ever walked scripts/tests/. Each such source line
+therefore carries a trailing `# lint-arm-probe:fixture` comment — Python
+discards `#` comments at parse time, so the comment never becomes part of
+the fixture TEXT a test hands to `scan_text()` (the runtime string a guilt
+test asserts a finding against has no marker in it at all, and correctly
+still finds one). The marker only blinds `lint_arm_probe.py`'s own
+repo-walk to ITS SOURCE LINE. `test_marker_appears_only_in_this_lints_own_test_file`
+and `test_this_test_files_own_source_produces_no_findings_when_scanned`
+both verify the mechanism actually holds — see their docstrings.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "lint_arm_probe.py"
+_spec = importlib.util.spec_from_file_location("lint_arm_probe", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+larp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(larp)
+
+
+# ---------------------------------------------------------------- fixtures
+#
+# Each pair below mirrors a SHAPE actually found in the 2026-08-29 audit of
+# this repo's 17 autoMergeRequest consumers.
+
+# GUILT — dict.get("autoMergeRequest") used as an eligibility filter, no
+# positive probe anywhere (mirrors scripts/merge_train.py::order_queue).
+GUILTY_GET_PY = (
+    'def order_queue(prs):\n'
+    '    return [p for p in prs if p.get("autoMergeRequest")]\n'  # lint-arm-probe:fixture
+)
+
+# INNOCENCE — same .get(...) test, but mergeQueueEntry co-occurs in the file
+# (mirrors .github/workflows/merge-queue-watch.yml's Condition 2 / scripts/
+# lane_ship.sh's isInMergeQueue cross-check, generalized to the mergeQueueEntry
+# shape).
+INNOCENT_GET_WITH_PROBE_PY = (
+    'def order_queue(prs):\n'
+    '    eligible = [p for p in prs if p.get("mergeQueueEntry") or p.get("autoMergeRequest")]\n'  # lint-arm-probe:fixture
+    '    return eligible\n'
+)
+
+# GUILT — bracket subscript access, no probe (mirrors scripts/
+# queue_baseline_probe.py::fetch_automerge_enabled_at).
+GUILTY_SUBSCRIPT_PY = (
+    'def fetch_automerge_enabled_at(payload):\n'
+    '    enabled_at = payload["data"]["repository"]["pullRequest"]["autoMergeRequest"]\n'  # lint-arm-probe:fixture
+    '    return enabled_at\n'
+)
+
+# GUILT — jq select()/==null filter, no probe (mirrors scripts/ci/
+# queue_rearm_population.sh's --candidates mode).
+GUILTY_JQ_SH = (
+    'jq -r \'.[]|select(.mergeable=="MERGEABLE" and .autoMergeRequest==null)|.number\'\n'  # lint-arm-probe:fixture
+)
+
+# INNOCENCE — jq decision line, mergeQueue( snapshot probed elsewhere in the
+# same file (mirrors scripts/ci/queue_rearm.sh's `inq=$(... mergeQueue(...) ...)`
+# cross-check before acting on any candidate).
+INNOCENT_JQ_WITH_MERGEQUEUE_PAREN_SH = (
+    'inq=$(gh api graphql -f query="{repository{mergeQueue(branch:\\"main\\"){entries{nodes{pullRequest{number}}}}}}" --jq \'.\')\n'  # lint-arm-probe:fixture
+    'cand=$(echo "$all" | jq -r \'.[]|select(.autoMergeRequest==null)|.number\')\n'  # lint-arm-probe:fixture
+)
+
+# INNOCENCE — isInMergeQueue alone counts as the probe (mirrors
+# merge-queue-watch.yml's ARMED-STUCK condition: `amr` is only tested when
+# truthy, and the alert additionally requires `not isInMergeQueue`).
+INNOCENT_ISINMERGEQUEUE_PY = (
+    'amr = pr.get("autoMergeRequest")\n'  # lint-arm-probe:fixture
+    'if amr and amr.get("enabledAt") and not pr.get("isInMergeQueue"):\n'  # lint-arm-probe:fixture
+    '    alert("armed but stuck")\n'
+)
+
+# INNOCENCE — field requested (--json field list) but never tested: no
+# .get(/subscript/select syntax touches it, so there is nothing to decide on
+# (mirrors scripts/mq.sh's confirm-step, which only echoes the response).
+FIELD_ONLY_NO_DECISION_SH = (
+    'gh pr view "$pr" --json autoMergeRequest,mergeStateStatus,headRefOid\n'  # lint-arm-probe:fixture
+    'echo "confirm: $OUT"\n'
+)
+
+# INNOCENCE — a full-line comment that WOULD match the decision pattern if
+# comment-stripping did not apply (mirrors scripts/pr_watch.sh's own doc
+# comment warning future readers off autoMergeRequest).
+COMMENT_WOULD_MATCH_IF_NOT_STRIPPED_PY = (
+    '# example: `if pr.get("autoMergeRequest"): reroll(pr)` is the anti-pattern this file avoids\n'  # lint-arm-probe:fixture
+)
+
+
+# ---------------------------------------------------------------- scan_text (pure)
+
+
+class TestScanTextGuilt:
+    def test_dict_get_without_probe_is_a_finding(self):
+        result = larp.scan_text(GUILTY_GET_PY, "fake.py")
+        assert len(result["findings"]) == 1
+        assert "fake.py:2" in result["findings"][0]
+        assert result["has_positive_probe"] is False
+
+    def test_bracket_subscript_without_probe_is_a_finding(self):
+        result = larp.scan_text(GUILTY_SUBSCRIPT_PY, "fake.py")
+        assert len(result["findings"]) == 1
+        assert "fake.py:2" in result["findings"][0]
+
+    def test_jq_select_without_probe_is_a_finding(self):
+        result = larp.scan_text(GUILTY_JQ_SH, "fake.sh")
+        assert len(result["findings"]) == 1
+        assert "fake.sh:1" in result["findings"][0]
+
+
+class TestScanTextInnocence:
+    def test_dict_get_with_mergequeueentry_probe_is_clean(self):
+        result = larp.scan_text(INNOCENT_GET_WITH_PROBE_PY, "fake.py")
+        assert result["findings"] == []
+        assert result["has_positive_probe"] is True
+
+    def test_jq_decision_with_mergequeue_paren_probe_is_clean(self):
+        result = larp.scan_text(INNOCENT_JQ_WITH_MERGEQUEUE_PAREN_SH, "fake.sh")
+        assert result["findings"] == []
+        assert result["has_positive_probe"] is True
+
+    def test_isinmergequeue_probe_alone_is_sufficient(self):
+        result = larp.scan_text(INNOCENT_ISINMERGEQUEUE_PY, "fake.py")
+        assert result["findings"] == []
+        assert result["has_positive_probe"] is True
+
+    def test_field_requested_but_never_tested_has_no_decision_lines(self):
+        result = larp.scan_text(FIELD_ONLY_NO_DECISION_SH, "fake.sh")
+        assert result["findings"] == []
+        assert result["decision_lines"] == []
+
+    def test_full_comment_line_is_not_treated_as_a_decision(self):
+        result = larp.scan_text(COMMENT_WOULD_MATCH_IF_NOT_STRIPPED_PY, "fake.py")
+        assert result["findings"] == []
+        assert result["decision_lines"] == []
+        assert result["has_positive_probe"] is False
+
+    def test_suppression_marker_hides_a_line_from_both_directions(self):
+        # A line carrying the marker is invisible even though it would
+        # otherwise match the decision pattern with no probe in scope.
+        text = 'x = pr.get("autoMergeRequest")  # lint-arm-probe:fixture\n'
+        result = larp.scan_text(text, "fake.py")
+        assert result["findings"] == []
+        assert result["decision_lines"] == []
+
+
+# ---------------------------------------------------------------- run() (file I/O)
+
+
+class TestRunDiscovery:
+    def test_finds_guilty_file_under_root(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "scripts" / "bad.py").write_text(GUILTY_GET_PY)
+        result = larp.run([repo], repo)
+        assert result["exit"] & 1
+        assert any("bad.py" in f for f in result["findings"])
+
+    def test_clean_file_with_probe_produces_no_finding(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "scripts" / "good.py").write_text(INNOCENT_GET_WITH_PROBE_PY)
+        result = larp.run([repo], repo)
+        assert result["exit"] == 0
+        assert result["findings"] == []
+
+    def test_prunes_vendored_dirs(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "node_modules" / "pkg").mkdir(parents=True)
+        (repo / "node_modules" / "pkg" / "bad.py").write_text(GUILTY_GET_PY)
+        result = larp.run([repo], repo)
+        assert result["files_scanned"] == 0
+        assert result["findings"] == []
+
+    def test_skips_non_scanned_extensions(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "bad.txt").write_text(GUILTY_GET_PY)
+        result = larp.run([repo], repo)
+        assert result["files_scanned"] == 0
+        assert result["findings"] == []
+
+    def test_dedupes_overlapping_roots(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "scripts" / "bad.py").write_text(GUILTY_GET_PY)
+        result = larp.run([repo, repo / "scripts"], repo)
+        assert result["files_scanned"] == 1
+
+    def test_unreadable_file_is_an_operational_error_not_silent(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        bad = repo / "scripts" / "unreadable.py"
+        bad.write_text(GUILTY_GET_PY)
+        orig_read_text = Path.read_text
+
+        def _boom(self, *a, **k):
+            if self == bad:
+                raise OSError("permission denied")
+            return orig_read_text(self, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        result = larp.run([repo], repo)
+        assert result["exit"] & 4
+        assert any("unreadable.py" in e for e in result["errors"])
+
+    def test_exit_bitmask_combines_findings_and_errors(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "scripts" / "bad.py").write_text(GUILTY_GET_PY)
+        unreadable = repo / "scripts" / "unreadable.py"
+        unreadable.write_text(GUILTY_GET_PY)
+        orig_read_text = Path.read_text
+
+        def _boom(self, *a, **k):
+            if self == unreadable:
+                raise OSError("permission denied")
+            return orig_read_text(self, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        result = larp.run([repo], repo)
+        assert result["exit"] == 5  # 1 (finding) | 4 (error)
+
+
+# ---------------------------------------------------------------- main() / CLI
+
+
+class TestMainCli:
+    def test_json_output_reports_exit_and_findings(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "scripts" / "bad.py").write_text(GUILTY_GET_PY)
+        rc = larp.main(["--json", "--repo-root", str(repo), "--root", "scripts"])
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["exit"] == 1
+        assert len(out["findings"]) == 1
+
+    def test_clean_repo_exits_zero(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        (repo / "scripts").mkdir(parents=True)
+        (repo / "scripts" / "good.py").write_text(INNOCENT_GET_WITH_PROBE_PY)
+        rc = larp.main(["--repo-root", str(repo), "--root", "scripts"])
+        assert rc == 0
+        assert "clean" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------- self-scan governance
+
+
+class TestSelfScanIsClean:
+    """Proves the marker mechanism described in the module docstring actually
+    holds — this is the concrete answer to "make sure the lint does not flag
+    its own test fixtures"."""
+
+    def test_this_test_files_own_source_produces_no_findings_when_scanned(self):
+        this_file = Path(__file__).resolve()
+        text = this_file.read_text(encoding="utf-8")
+        result = larp.scan_text(text, "scripts/tests/test_lint_arm_probe.py")
+        assert result["findings"] == [], (
+            "this lint's own test fixtures are not fully marker-suppressed: "
+            f"{result['findings']}"
+        )
+
+    def test_marker_appears_only_in_this_lints_own_test_file_and_its_definition(self):
+        """The suppression marker is a deliberately narrow escape hatch (see
+        module docstring: content-based, not directory-based — cicatrix #3/
+        W109). Exactly two tracked files may carry it: THIS test file (the
+        only place it functions as a suppression) and lint_arm_probe.py
+        itself (which defines the SUPPRESSION_MARKER constant and documents
+        it — that file's own self-scan passes not via this marker but
+        because its docstring's positive-probe mentions co-occur file-wide,
+        see its module docstring). Nothing else in the tracked tree may
+        carry it; if something does, it is silently exempting real decision
+        code, not a fixture."""
+        this_file = Path(__file__).resolve()
+        top = subprocess.run(
+            ["git", "-C", str(this_file.parent), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=20,
+        )
+        assert top.returncode == 0, f"git rev-parse failed: {top.stderr}"
+        repo_root = Path(top.stdout.strip())
+        this_file_rel = this_file.relative_to(repo_root).as_posix()
+        lint_file_rel = "scripts/lint_arm_probe.py"
+
+        # --untracked: this test must pass BEFORE `git add`, not only after —
+        # a brand-new file (this one, on first run) is untracked by definition.
+        grep = subprocess.run(
+            ["git", "-C", str(repo_root), "grep", "--untracked", "-l", "-F",
+             larp.SUPPRESSION_MARKER],
+            capture_output=True, text=True, timeout=20,
+        )
+        assert grep.returncode in (0, 1), f"git grep failed: {grep.stderr}"
+        hits = sorted(line.strip() for line in grep.stdout.splitlines() if line.strip())
+        assert hits, "expected the suppression marker to appear at least in this test file"
+        assert hits == sorted([this_file_rel, lint_file_rel]), (
+            f"lint-arm-probe:fixture marker leaked outside its own defining/consuming "
+            f"files: {hits}"
+        )


### PR DESCRIPTION
## Summary

Audit + lint for the `autoMergeRequest` null-ambiguity finding (measured tonight on PR #5275: `autoMergeRequest: null` simultaneously with `mergeQueueEntry {state: QUEUED, position: 3}`, `gh pr merge --auto` refusing with "already queued to merge").

- **`scripts/lint_arm_probe.py`** — fails (exit 1) when a file tests `autoMergeRequest` for truthiness/nullness (`.get("autoMergeRequest")`, a bracket subscript, or a jq `==null`/`select(...)`) without also referencing `mergeQueueEntry`, `isInMergeQueue`, or `mergeQueue(` anywhere in the same file. Guilt+innocence tests per cicatrix #3 discipline; a content-based (not directory-based) suppression marker protects the lint's own test fixtures, with a governance test proving the marker isn't smuggled elsewhere.
- **`scripts/tests/test_lint_arm_probe.py`** — 20 tests, all green. Auto-swept by `scripts-tests-sweep.yml` (report-only) with no workflow-file edit needed.

Run against the real repo: 3 findings, 0 false positives on the 14 other known consumers.

## Audit findings (Part 1 of the mandate — not fixed here, Part 3: one PR, one concern)

Re-derived the consumer list independently (grep hit 17 files, not the 14 originally listed — 3 extra: `.github/workflows/merge-queue-watch.yml`, `apps/backend-rag/backend/services/integrations/github_publisher.py`, `apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py`).

**(B) UNSAFE — 3 files, all confirmed live consumers (not test-only):**

1. **`scripts/merge_train.py:161`** (`order_queue()`) — **the one worth triaging first.** Filters the merge-train coordinator's entire eligible-PR set on `p.get("autoMergeRequest")` truthiness, with zero `mergeQueueEntry`/`isInMergeQueue` anywhere in the file. Per tonight's finding, a PR that GitHub's native queue has ACCEPTED (autoMergeRequest now null) is excluded from `eligible` — the coordinator stops managing exactly the PRs deepest in the lifecycle it exists to babysit (red checks, BLOCKED-missing-required, DIRTY). Runs every ~180s via LaunchAgent `com.nuzantara.merge-train`. Config default is DRY-RUN (`~/.agent/merge-train.config` absent on M5 → `{"enabled": true, "dry_run": true}`), so it currently only *logs* the wrong decision rather than acting — **dry_run state on Pro/Mini is unverified from this session** (no `fly`/`launchctl` per constraints), so I can't rule out it's armed for real somewhere in the fleet. Its own test, `test_no_train_label_excluded_and_unarmed_excluded` in `apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py`, **encodes and defends** the wrong semantics (asserts `autoMergeRequest: None` → "unarmed_excluded") — (C) test that entrenches the bug, not a regression guard against it.
2. **`scripts/ci/queue_rearm_population.sh:58,66`** — the pure `--candidates`/`--undecidable` jq filter behind the re-arm tool, keys off `.autoMergeRequest==null` with no queue-membership awareness in this file. **Safe today only because its sole caller** (`scripts/ci/queue_rearm.sh`) fetches `mergeQueue(branch:"main"){entries}` first and explicitly skips any candidate already `" $inq "` before ever acting (queue_rearm.sh itself is SAFE, correctly cross-referenced, same function). The safety property lives in a caller/callee contract, not in this file — a future caller of `--candidates` that skips that cross-check reintroduces the exact bug. Also: no test exercises `queue_rearm.sh`'s own in-queue skip logic (only the two pure sub-functions are unit-tested) — a coverage gap, not this PR's scope.
3. **`scripts/queue_baseline_probe.py:651`** (`fetch_automerge_enabled_at`) — extracts `autoMergeRequest.enabledAt` with no probe anywhere in file. Lower real risk than the other two: only ever queried for PRs already fetched with `--state merged` (terminal, closed) — the queued/ejected/never-armed ambiguity for OPEN PRs doesn't apply the same way — and on null it correctly excludes the PR from the transit-time sample (`transit_unmeasured_prs`) rather than guessing or alarming. Still mechanically flagged because nothing in the file proves that judgment call.

**(A) SAFE — 6 files, already do the right thing:**
`scripts/mq.sh` (only echoes the confirm-step query, never branches on it) · `scripts/lane_ship.sh` (explicit `isInMergeQueue` cross-check, own comment cites W118) · `scripts/pr_watch.sh` (never reads the field in code at all — only a doc comment warning future readers off it, plus a regression test asserting exactly that) · `scripts/queue_doctor.py` (reports "armed but not yet queued" from `mergeQueue(){entries}`, never alarms) · `scripts/ci/queue_rearm.sh` (checks `mergeQueue(){entries}` before acting on any candidate) · `.github/workflows/merge-queue-watch.yml` (ARMED-STUCK condition only evaluates when `autoMergeRequest` is truthy AND `not isInMergeQueue` — the null-because-queued case never reaches the alarm at all) · `apps/backend-rag/backend/services/integrations/github_publisher.py` (`_enable_auto_merge` requests the field back in a mutation's return-selection but never parses/branches on it).

**(C) TEST — correct semantics:** `scripts/tests/test_lane_ship.sh` (explicit W118 regression case), `scripts/tests/test_pr_watch.sh` (asserts the field is NEVER read), `scripts/tests/test_queue_doctor.py`, `scripts/tests/test_mq_sh.sh`, `scripts/ci/test_queue_rearm_population.sh`/`test_queue_rearm_classify.sh`, `scripts/tests/test_queue_baseline_probe.py` — all fixture/mock the field correctly, none encode the wrong semantics. The one exception is `test_merge_train.py`, flagged above under (B).

No client PII, no `fly`/`launchctl`/DB access, no secrets touched.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_lint_arm_probe.py -v` — 20/20 pass
- [x] `python3 scripts/lint_arm_probe.py` against the real repo — 3 findings (the confirmed unsafe files above), 0 errors, 0 false positives on the 14 safe/test files
- [x] `python3 -m py_compile` both new files
- [x] `--json` output validated
- [ ] CI (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtMzhGG16zh4nD6XHG3tSR