### PR TITLE
fix(ci): merge-train stops dropping queue-accepted PRs on null autoMergeRequest

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py
@@ -32,20 +32,51 @@ def _pr(number: int, labels: list[str] | None = None, automerge: bool = True) ->
 
 
 class TestOrderQueue:
+    """`in_queue_numbers` is a required kwarg (2026-08-30 fix): every call
+    below passes it explicitly, never relies on a default — the whole point
+    of the fix is that there IS no default a caller could silently fall
+    back to (see `order_queue`'s own docstring)."""
+
     def test_fifo_by_number(self):
-        q = train.order_queue([_pr(30), _pr(10), _pr(20)])
+        q = train.order_queue([_pr(30), _pr(10), _pr(20)], in_queue_numbers=set())
         assert [p["number"] for p in q] == [10, 20, 30]
 
     def test_auto_revert_priority_lane(self):
         # Spec §10.1: the revert-PR (highest number) jumps to the head.
-        q = train.order_queue([_pr(10), _pr(20), _pr(99, labels=["auto-revert"])])
+        q = train.order_queue(
+            [_pr(10), _pr(20), _pr(99, labels=["auto-revert"])], in_queue_numbers=set()
+        )
         assert [p["number"] for p in q] == [99, 10, 20]
 
-    def test_no_train_label_excluded_and_unarmed_excluded(self):
+    def test_no_train_label_excluded_and_never_armed_excluded(self):
+        """A PR opted out (no-train label) and a PR genuinely never armed
+        (autoMergeRequest null AND not in the queue snapshot) are both
+        excluded — the correct, narrower half of the old test's name.
+        `test_queue_accepted_pr_with_null_automerge_is_still_eligible` below
+        is the half the old test got backwards: null alone is NOT "unarmed",
+        it is also what a queue-accepted PR reads."""
         q = train.order_queue(
-            [_pr(10, labels=["no-train"]), _pr(20, automerge=False), _pr(30)]
+            [_pr(10, labels=["no-train"]), _pr(20, automerge=False), _pr(30)],
+            in_queue_numbers=set(),
         )
         assert [p["number"] for p in q] == [30]
+
+    def test_queue_accepted_pr_with_null_automerge_is_still_eligible(self):
+        """2026-08-30 fix — the PR #5275 shape: GitHub's queue has ACCEPTED
+        this PR (autoMergeRequest reads null because the request was
+        CONSUMED on entry, not because it was disarmed), and the queue
+        snapshot (`in_queue_numbers`, GraphQL `mergeQueueEntry`'s positive
+        probe) proves it. Pre-fix, `order_queue` read the null field alone
+        and silently dropped this PR from `eligible` — exactly the bug this
+        test exists to catch (verified against the pre-fix source: this
+        assertion fails there, asserting `[30]` instead of `[20, 30]` —
+        the corrected test does not merely pass, it discriminates). The
+        test above proves this fix does not also flip a genuinely
+        never-armed PR (null AND absent from the snapshot) to eligible."""
+        q = train.order_queue(
+            [_pr(20, automerge=False), _pr(30)], in_queue_numbers={20},
+        )
+        assert [p["number"] for p in q] == [20, 30]
 
 
 class TestSkiplist:

--- a/scripts/merge_train.py
+++ b/scripts/merge_train.py
@@ -152,13 +152,37 @@ class Decision:
     details: dict[str, Any] = field(default_factory=dict)
 
 
-def order_queue(prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def order_queue(
+    prs: list[dict[str, Any]], *, in_queue_numbers: set[int]
+) -> list[dict[str, Any]]:
     """FIFO by PR number, with the auto-revert priority lane at the head
-    (spec §10.1). Opt-out label excluded entirely."""
+    (spec §10.1). Opt-out label excluded entirely.
+
+    Eligibility answers "is this PR under active management?" —
+    `autoMergeRequest` non-null OR the PR's number is in `in_queue_numbers`
+    (GitHub's own merge-queue entries, the positive probe). `in_queue_numbers`
+    is required, not optional with an empty-set default: `autoMergeRequest`
+    ALONE used to gate this (pre-2026-08-30) and that was the bug — the field
+    reads null in (at least) three different states: a PR the queue has
+    ACCEPTED (the request is CONSUMED, not disarmed), a PR the queue EJECTED,
+    and a PR genuinely never armed. The old code treated all three as "not
+    eligible", silently dropping exactly the PRs deepest in the lifecycle
+    this coordinator exists to babysit — measured live on PR #5275
+    (`autoMergeRequest: null` simultaneously with `mergeQueueEntry
+    {state: QUEUED, position: 3}`) and the false re-arm alarms on #4756/
+    #5012. A required parameter with no default means a caller that forgets
+    to pass a real snapshot gets a loud TypeError, not a silent reversion to
+    the old, wrong, autoMergeRequest-only reading. `mergeQueueEntry` and
+    `isInMergeQueue` are GraphQL-only — not in `gh pr list`/`gh pr view
+    --json`'s field list (verified live against the gh CLI) — so
+    `in_queue_numbers` comes from a raw GraphQL `mergeQueue(branch:"main")
+    {entries}` snapshot (`fetch_queue_membership()` below), the same shape
+    scripts/queue_doctor.py and scripts/ci/queue_rearm.sh already use for
+    the identical cross-check."""
     eligible = [
         p
         for p in prs
-        if p.get("autoMergeRequest")
+        if (p.get("autoMergeRequest") or p["number"] in in_queue_numbers)
         and OPTOUT_LABEL not in {lbl["name"] for lbl in p.get("labels", [])}
     ]
     reverts = sorted(
@@ -285,6 +309,38 @@ def fetch_queue() -> list[dict[str, Any]]:
         "pr", "list", "--repo", REPO, "--state", "open", "--limit", "100",
         "--json", "number,labels,autoMergeRequest",
     ])
+
+
+_MERGE_QUEUE_QUERY = (
+    "query($owner:String!,$name:String!){repository(owner:$owner,name:$name){"
+    'mergeQueue(branch:"main"){entries(first:100){nodes{pullRequest{number}}}}}}'
+)
+
+
+def fetch_queue_membership() -> set[int]:
+    """PR numbers GitHub's native merge queue currently holds — the positive
+    probe `order_queue()` needs (2026-08-30 fix). `mergeQueueEntry` and
+    `isInMergeQueue` are GraphQL-only, absent from `gh pr list`/`gh pr view
+    --json`'s field list, so this is a raw `gh api graphql` call on the
+    branch-level snapshot — the same shape scripts/queue_doctor.py and
+    scripts/ci/queue_rearm.sh already use for the identical cross-check.
+    Raises like every other fetch_* here (RuntimeError/TimeoutExpired) —
+    the caller must fail closed, never treat a failed probe as an empty
+    queue (W104: never fabricate a zero)."""
+    owner, name = REPO.split("/", 1)
+    data = gh_json([
+        "api", "graphql",
+        "-f", f"query={_MERGE_QUEUE_QUERY}",
+        "-f", f"owner={owner}",
+        "-f", f"name={name}",
+    ])
+    repo = ((data or {}).get("data") or {}).get("repository") or {}
+    entries = ((repo.get("mergeQueue") or {}).get("entries") or {}).get("nodes") or []
+    return {
+        e["pullRequest"]["number"]
+        for e in entries
+        if e and e.get("pullRequest") and isinstance(e["pullRequest"].get("number"), int)
+    }
 
 
 def fetch_head_detail(number: int) -> dict[str, Any]:
@@ -537,7 +593,24 @@ def run_tick() -> dict[str, Any]:
         state["last_decision"] = {"action": "abort", "reason": "auth_failed"}
         return state
 
-    queue = order_queue(fetch_queue())
+    # Positive-probe preflight (2026-08-30 fix): order_queue()'s eligibility
+    # test needs to know who GitHub's queue currently holds, because
+    # autoMergeRequest alone cannot tell "accepted" apart from "ejected"/
+    # "never armed". A failed probe here must fail closed, exactly like the
+    # auth preflight above — silently falling back to an empty set would
+    # readmit the exact bug this fetch exists to close (W104: never
+    # fabricate a zero).
+    try:
+        in_queue_numbers = fetch_queue_membership()
+    except (RuntimeError, subprocess.TimeoutExpired) as exc:
+        state["last_decision"] = {
+            "action": "abort",
+            "reason": "queue_membership_probe_failed",
+            "details": {"error": str(exc)[:200]},
+        }
+        return state
+
+    queue = order_queue(fetch_queue(), in_queue_numbers=in_queue_numbers)
     state["queue_depth"] = len(queue)
     if not queue:
         state["head_pr"] = None


### PR DESCRIPTION
## Summary

Fixes the live-but-latent defect flagged by `scripts/lint_arm_probe.py` (PR #5284): `scripts/merge_train.py::order_queue()` gated eligibility on `autoMergeRequest` truthiness alone. That field reads null in at least three states — a PR the queue has ACCEPTED (request CONSUMED on entry, not disarmed), a PR the queue EJECTED, and a PR genuinely never armed — and `order_queue` treated all three as "not eligible", silently excluding queue-accepted PRs from every tick's eligible set. Measured live shape: PR #5275 (`autoMergeRequest: null` simultaneous with `mergeQueueEntry {state: QUEUED, position: 3}`).

Confirmed by team-lead: `com.nuzantara.merge-train` is loaded and running every ~180s on Pro, currently `dry_run: true` — latent, not active, but one boolean flip away from acting on the wrong decision.

## Fix

- `order_queue()` now takes a **required** `in_queue_numbers: set[int]` kwarg — no default, so a caller that forgets it gets a loud `TypeError`, not a silent reversion to the old (wrong) `autoMergeRequest`-only reading. Eligibility is now "is this PR under active management?" = `autoMergeRequest` non-null **OR** its number is in `in_queue_numbers`.
- New `fetch_queue_membership()` — a raw `gh api graphql` call on `mergeQueue(branch:"main"){entries}`, the same shape `scripts/queue_doctor.py` and `scripts/ci/queue_rearm.sh` already use. Verified live against the `gh` CLI: `mergeQueueEntry`/`isInMergeQueue` are **not** in `gh pr list`/`gh pr view --json`'s field list — GraphQL is the only path.
- `run_tick()` calls this before `order_queue()`; a failed probe **aborts the tick** (fail closed), matching the existing auth-preflight pattern in the same function — never silently degrades to an empty set, which would readmit the exact bug being fixed.

## Test fix

The old test, `test_no_train_label_excluded_and_unarmed_excluded`, asserted the wrong semantics (`autoMergeRequest: None` → excluded, full stop) — it would go green on the bug and red on a correct fix. Per team-lead direction, mutated the source, not the test:

- Kept the correct half as `test_no_train_label_excluded_and_never_armed_excluded` (a PR null AND absent from the queue snapshot stays excluded).
- Added `test_queue_accepted_pr_with_null_automerge_is_still_eligible` — the PR #5275 shape: null but present in `in_queue_numbers` → must be eligible.

**Empirically verified the new guilt test discriminates** (not just documents): ran it against a copy of the pre-fix source (condition reverted to `if p.get("autoMergeRequest")`, ignoring `in_queue_numbers`) — it asserts `[20, 30]`, the old logic returns `[30]`, assertion fails as expected. Against the fixed source it passes. 44/44 tests green (`pytest apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py`).

Also ran `scripts/lint_arm_probe.py` (from PR #5284, not yet merged — copied in for a manual check, not committed here) against this branch: `merge_train.py` no longer flags.

## Scope (per team-lead direction — leave the other two alone)

- **`queue_baseline_probe.py`**: left untouched. Merged-only PRs, excludes rather than guesses, correct in practice.
- **`scripts/ci/queue_rearm_population.sh`**: left untouched. Its safety today lives entirely in its sole caller's (`queue_rearm.sh`) cross-check against the queue snapshot before acting on any candidate — not in the file itself. Making it self-sufficient means extending its pure-function input contract (a new field/CLI arg carrying the in-queue set, a caller rewire in `queue_rearm.sh`, new guilt/innocence fixtures in `test_queue_rearm_population.sh`) — not a small change, so it stays a separate concern per one-PR-one-concern.

No client PII, no `fly`/`launchctl`/DB access, no secrets touched, no external endpoints.

## Test plan

- [x] `python3 -m py_compile scripts/merge_train.py apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py`
- [x] `python3 -m pytest apps/backend-rag/backend/tests/unit/scripts/test_merge_train.py -v` — 44/44 pass
- [x] Empirical old-vs-new discrimination check on the new guilt test (see above)
- [x] `lint_arm_probe.py` (PR #5284) re-run against this branch — `merge_train.py` clean
- [ ] CI (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtMzhGG16zh4nD6XHG3tSR