### PR TITLE
fix(proxy): pass through bodyless 204/205/304 instead of throwing Proxy error

### DIFF
--- a/apps/mouth/src/app/api/[...path]/route.test.ts
+++ b/apps/mouth/src/app/api/[...path]/route.test.ts
@@ -565,3 +565,39 @@ describe("proxy catch-all route — public Visa Oracle boundary", () => {
     );
   });
 });
+
+describe("proxy catch-all route — bodyless upstream statuses (204/205/304)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression: `new Response(buf, { status })` throws a TypeError when `buf`
+  // is passed for a "null body status" (204/205/304) — even an empty
+  // ArrayBuffer counts as a body under the Fetch spec. Before the fix, that
+  // thrown TypeError was caught by the proxy's outer catch block and
+  // surfaced as a fabricated 500 "Proxy error", even though the upstream
+  // mutation (e.g. a DELETE) had already succeeded.
+  it.each([204, 205, 304])(
+    "passes through a bodyless upstream %d instead of throwing Proxy error",
+    async (status) => {
+      process.env.NUZANTARA_API_URL = "https://nuzantara-rag.fly.dev";
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(null, {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const req = new MockNextRequest(
+        "http://localhost/api/portal/documents/5",
+        { method: "DELETE" },
+      );
+
+      const response = await DELETE(req as never);
+
+      expect(response.status).toBe(status);
+      const rawBody = await response.arrayBuffer();
+      expect(rawBody.byteLength).toBe(0);
+    },
+  );
+});

--- a/apps/mouth/src/app/api/[...path]/route.ts
+++ b/apps/mouth/src/app/api/[...path]/route.ts
@@ -11,6 +11,13 @@ export const maxDuration = 300; // 5 minutes max for agentic RAG
 const VISA_ORACLE_EVALUATE_PATH = "/api/visa-oracle/evaluate";
 const VISA_ORACLE_MAX_BODY_BYTES = 32 * 1024;
 
+// The Fetch spec forbids a non-null body on these statuses ("null body status").
+// `new Response(buf, { status })` throws a TypeError even when `buf` is an empty
+// ArrayBuffer — the caught TypeError then surfaced as a fabricated 500 "Proxy
+// error" for upstream responses (e.g. a successful DELETE returning 204) that
+// never actually failed.
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
 class RequestBodyTooLargeError extends Error {
   constructor() {
     super(`Request body exceeds ${VISA_ORACLE_MAX_BODY_BYTES} bytes`);
@@ -507,11 +514,14 @@ async function proxy(req: NextRequest): Promise<Response> {
       }
     }
 
-    return new Response(bodyBuffer, {
-      status: upstream.status,
-      statusText: upstream.statusText,
-      headers: respHeaders,
-    });
+    return new Response(
+      NULL_BODY_STATUSES.has(upstream.status) ? null : bodyBuffer,
+      {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: respHeaders,
+      },
+    );
   } catch (error) {
     logger.error(
       `[Proxy] Fetch error for ${req.method} ${url.pathname}`,


### PR DESCRIPTION
## Defect

Measured 2026-08-28 (memory `discovery_five_measured_defects_on_public_surfaces_2026_08_28`, Zero-authorized out-of-plan fix, 2026-08-30): the Vercel `apps/mouth/src/app/api/[...path]/route.ts` catch-all proxy turns an upstream bodyless `204` (e.g. a successful `DELETE`) into a fabricated **500 `Proxy error`**. The row IS deleted server-side — the client just sees a spurious failure. Trust-breaking: the user retries or reports a bug for something that already worked.

## Root cause

`apps/mouth/src/app/api/[...path]/route.ts:510-514` (pre-fix) read the upstream body into an `ArrayBuffer` unconditionally and passed it to `new Response(bodyBuffer, { status: upstream.status, ... })`. Per the Fetch spec, statuses `204`/`205`/`304` are "null body status" — the `Response` constructor throws a `TypeError` if **any** body is supplied, even an empty `ArrayBuffer(0)`. That thrown error was caught by the proxy's outer `catch` block (line 515), which always responds with a generic 500 `{"error":"Proxy error", ...}` — masking the fact the upstream call had already succeeded.

Verified empirically (Node 26.5.0, this repo's fetch implementation):
```
new Response(new ArrayBuffer(0), { status: 204 })
// TypeError: Response constructor: Invalid response status code 204
```
Same for 205 and 304. `new Response(null, { status: 204 })` does not throw.

## Fix

Added `NULL_BODY_STATUSES = new Set([204, 205, 304])` and, at the final non-streaming response construction, pass `null` instead of `bodyBuffer` when `upstream.status` is one of those three — status/statusText/headers are preserved unchanged. Minimal, single call site (the one exercised by DELETE flows); no scope creep into the (unrelated, never hit by null-body statuses in practice) SSE streaming branch.

## Tests / verification

No existing e2e/integration harness for this route beyond its own unit-test file (`route.test.ts`, vitest), so I extended that file rather than bolting on a new framework:

- Added a parametrized regression test (`204`/`205`/`304`) that mocks the upstream `fetch` to return a bodyless response of each status and asserts the `DELETE` handler returns that same status with an empty body — instead of `500`.
- **Confirmed the test actually catches the regression**: I temporarily reverted only the source fix (kept the new tests) and re-ran — all 3 new tests failed with `expected 500 to be 204/205/304`. Restoring the fix turns them green again.
- Full suite for this file: `22/22 passing` (19 pre-existing + 3 new).
- `npx tsc --noEmit`: clean (exit 0) on the whole `apps/mouth` package.
- `npx eslint` on the two changed files: 0 errors.
- Pre-commit and pre-push hooks passed clean (prettier, lint, typecheck, secrets scan, off-limits check).

## Test plan
- [x] Unit tests added/passing (22/22, incl. 3 new parametrized 204/205/304 cases)
- [x] Regression-catching verified by revert-and-rerun
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] CI required checks (full backend/frontend suites) — pending on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)