### PR TITLE
fix(wa): the pricing veto was blind to English magnitude words — in both directions

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -272,18 +272,62 @@ def _starts_with_internal_monologue_leak(answer: str) -> bool:
 # * source numbers are extracted per TOKEN, never from a concatenation of the
 #   whole source ("Rp 12.345" followed by "67 days" can never authorize an
 #   invented "Rp 34.567").
+#
+# ENGLISH MAGNITUDE WORDS (added 2026-08-30): the Indonesian-only list below was
+# not merely incomplete — it was a TOTAL VETO BYPASS in both directions, measured
+# on origin/main before this change:
+#   price_tokens_outside_sources("...IDR 2.5 billion.", [])          -> []
+#   price_tokens_outside_sources("...IDR 999 billion.", [])          -> []   <- INVENTED
+#   price_tokens_outside_sources("Rp 2.500.000.000", [<curated_qa>]) -> ["IDR:2500000000"]
+# Mechanism: with "billion" unknown, the regex captures only the bare "2.5",
+# _canonical_value returns 25, and 25 < _VETO_FLOORS["IDR"] discards it BEFORE the
+# source-membership check ever runs. So an English-worded amount was never
+# validated as grounded AND never caught as hallucinated — the 999-billion control
+# proves that is the rule, not an accident of one value. Symmetrically, a source
+# stating the right figure in English prose (the live curated_qa entry for PT PMA
+# paid-up capital says "IDR 2.5 billion") could not be canonicalized either, so a
+# CORRECT digit-grouped answer was rejected against evidence that actually
+# supported it — the mechanism behind the finalize_pricing_outside_package
+# rejections measured on the live bot 2026-08-30.
+#
+# The pattern is DERIVED from the dict below, longest-alternative-first, so the two
+# can never drift apart. That coupling was live-ammunition: _canonical_value does
+# _AMOUNT_MULTIPLIERS[multiplier.lower()] with no .get(), so a token the pattern
+# matches and the dict lacks is a KeyError inside the finalize path, not a miss.
+# test_wa_finalize_price_veto.py asserts the derivation holds.
+#
+# NOT widened here, deliberately, and named so it is not mistaken for coverage: a
+# bare currency WORD ("2,5 miliar rupiah", with no Rp/IDR/USD marker) is still
+# invisible to this veto. Adding "rupiah" as a currency marker only ever ADDS
+# rejections, and the live bot is already over-rejecting (4 of 5 battery questions
+# blocked on 2026-08-30); widening the marker vocabulary is a separate change that
+# needs its own false-positive measurement, not a rider on this one.
 _AMOUNT_MULTIPLIERS: dict[str, float] = {
     "k": 1e3,
     "rb": 1e3,
     "ribu": 1e3,
+    "thousand": 1e3,
+    "thousands": 1e3,
     "jt": 1e6,
     "juta": 1e6,
+    "mn": 1e6,
+    "million": 1e6,
+    "millions": 1e6,
     "miliar": 1e9,
     "milyar": 1e9,
     "bn": 1e9,
+    "billion": 1e9,
+    "billions": 1e9,
     "triliun": 1e12,
+    "trillion": 1e12,
+    "trillions": 1e12,
 }
-_MULT_PATTERN = r"(?:jt|juta|rb|ribu|k|miliar|milyar|bn|triliun)"
+# Longest first so a longer token is never pre-empted by a prefix of itself
+# ("juta" by "jt" is safe only by luck of ordering; "millions" by "million" is not).
+_MULT_ALTERNATION = "|".join(
+    sorted((re.escape(k) for k in _AMOUNT_MULTIPLIERS), key=len, reverse=True)
+)
+_MULT_PATTERN = f"(?:{_MULT_ALTERNATION})"
 _CURRENCY_AMOUNT_RE = re.compile(
     r"(?:(?P<cur1>\bRp\.?|\bIDR|\bUSD|\$)[ \t]*(?P<amt1>\d(?:[\d.,]*\d)?)"
     r"(?:[ \t]*(?P<mul1>" + _MULT_PATTERN + r")\b)?)"

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -13,12 +13,15 @@ innocence cases, per cicatrix family #3.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
 
 from backend.services.integrations.wa_finalize import (
+    _AMOUNT_MULTIPLIERS,
     _KG_WORKFLOW_TRAILER,
+    _MULT_PATTERN,
     _WHATSAPP_HARD_SEND_LIMIT,
     FinalizeOutcome,
     finalize_wa_answer,
@@ -155,6 +158,120 @@ def test_pricing_veto_ignores_amounts_without_a_currency_marker() -> None:
 def test_pricing_veto_floor_skips_noise_amounts() -> None:
     # "Rp 5" (per page, say) is below any real IDR price — noise, not a price.
     assert price_tokens_outside_sources("Rp 5 per page.", ["no numbers"]) == []
+
+
+# ── English magnitude words: the 2026-08-30 total-bypass regression ──────
+#
+# Before the fix, "billion"/"million" were unknown to _MULT_PATTERN, so the
+# regex kept only the bare decimal ("2.5" -> 25), which fell UNDER the IDR floor
+# and was discarded before the source-membership check. The consequence was not
+# a miss in one direction but a hole in both: an invented English-worded price
+# was never caught, and a correct digit-grouped answer was rejected against an
+# English-worded source that actually supported it. Each case below fails on the
+# pre-fix code — verified by re-running this file against it, not assumed.
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # GUILT — an invented amount must be caught whatever word it wears.
+        ("Modal disetornya IDR 2.5 billion.", ["IDR:2500000000"]),
+        ("Biayanya IDR 999 billion, dijamin.", ["IDR:999000000000"]),
+        ("The fee is USD 4 million.", ["USD:4000000"]),
+        ("Setoran USD 250 thousand.", ["USD:250000"]),
+        # Plural forms an LLM writes even though a price rarely takes them.
+        ("The fee is USD 5 millions.", ["USD:5000000"]),
+        # Finance shorthand, the sibling of the "bn" the list already had.
+        ("Cost: USD 12 mn.", ["USD:12000000"]),
+    ],
+)
+def test_pricing_veto_catches_english_magnitude_words(
+    text: str, expected: list[str]
+) -> None:
+    assert price_tokens_outside_sources(text, ["nothing relevant here"]) == expected
+
+
+def test_pricing_veto_accepts_a_digit_answer_backed_by_an_english_source() -> None:
+    """The live false positive: curated_qa states the figure in English prose.
+
+    This is the exact shape measured on the bot on 2026-08-30 — the retrieved
+    evidence said "IDR 2.5 billion", the answer said "Rp 2.500.000.000", and the
+    veto rejected a CORRECT answer because it could not canonicalize its own
+    source. Grounding must not depend on which numeral form each side chose.
+    """
+    source = "Minimum paid-up capital for a PT PMA is IDR 2.5 billion."
+    assert price_tokens_outside_sources("Modalnya Rp 2.500.000.000.", [source]) == []
+
+
+def test_pricing_veto_accepts_an_english_answer_backed_by_a_digit_source() -> None:
+    """The mirror direction — and an honest note about what this test proves.
+
+    Replayed against the pre-fix code this one PASSES, for the wrong reason: the
+    English answer was discarded under the floor, so "no offender" meant "never
+    looked", not "grounded". It is kept as a fence on the post-fix behavior, not
+    as evidence of the bug — the eight tests that DO go red on pre-fix code are
+    where that evidence lives.
+    """
+    source = "Rp 2.500.000.000 adalah syarat modal disetor minimum."
+    assert price_tokens_outside_sources("It is IDR 2.5 billion.", [source]) == []
+
+
+def test_pricing_veto_english_words_do_not_over_match_ordinary_prose() -> None:
+    """Innocence arm (cicatrix family #3): a longer word is not a multiplier.
+
+    "millionaire" must not turn a nearby "USD 20" into twenty million — the word
+    boundary is what stops it, and a pattern built by joining alternatives is
+    exactly where that guarantee gets lost.
+    """
+    assert (
+        price_tokens_outside_sources(
+            "He is a millionaire, but the fee is only USD 20.", ["USD 20"]
+        )
+        == []
+    )
+    # And an unknown magnitude word must not silently become a multiplier.
+    assert price_tokens_outside_sources("USD 20 zillion.", ["USD 20"]) == []
+
+
+def test_pricing_veto_multiplier_pattern_is_derived_from_the_table() -> None:
+    """The pattern and the table cannot be allowed to drift apart.
+
+    ``_canonical_value`` indexes ``_AMOUNT_MULTIPLIERS[multiplier.lower()]`` with
+    no ``.get`` fallback, so a token the PATTERN matches but the TABLE lacks is a
+    KeyError raised inside the finalize path — a crash, not a missed veto. This
+    test is the tripwire for that coupling: it fails if anyone adds a token to
+    one side only, and it fails if the alternation stops being longest-first
+    (which is what keeps "millions" from being pre-empted by "million").
+    """
+    alternatives = _MULT_PATTERN[len("(?:") : -len(")")].split("|")
+    unescaped = [re.sub(r"\\(.)", r"\1", a) for a in alternatives]
+    assert set(unescaped) == set(_AMOUNT_MULTIPLIERS)
+    assert [len(a) for a in unescaped] == sorted(
+        (len(a) for a in unescaped), reverse=True
+    )
+
+
+def test_pricing_veto_still_reads_the_indonesian_forms_it_always_did() -> None:
+    # Regression fence: widening the vocabulary must not disturb what worked.
+    assert price_tokens_outside_sources("Rp 99 juta.", ["Rp 99.000.000"]) == []
+    assert price_tokens_outside_sources("Rp 3,5 jt.", ["Rp 3.500.000"]) == []
+    assert price_tokens_outside_sources("Rp 2,5 miliar.", ["2500000000"]) == []
+    assert price_tokens_outside_sources("Rp 98 juta.", ["Rp 99.000.000"]) == [
+        "IDR:98000000"
+    ]
+
+
+def test_pricing_veto_bare_currency_word_remains_out_of_scope() -> None:
+    """A KNOWN, deliberately unclosed hole — asserted so it cannot rot silently.
+
+    "2,5 miliar rupiah" carries no Rp/IDR/USD marker, so this veto never sees it.
+    Widening the CURRENCY vocabulary only ever adds rejections, and the live bot
+    was already rejecting 4 of 5 battery questions on 2026-08-30; that change
+    needs its own false-positive measurement rather than riding along here. If a
+    later PR closes it, this test SHOULD fail — read it as the marker of a scope
+    boundary, not as an assertion that the behavior is desirable.
+    """
+    assert price_tokens_outside_sources("Modalnya 2,5 miliar rupiah.", []) == []
 
 
 # ── Secret-egress scan (pure function): guilt and innocence ──────────────


### PR DESCRIPTION
## The defect

The WhatsApp pricing veto (`price_tokens_outside_sources`, `wa_finalize.py`) exists to stop the bot asserting a price it cannot source. An amount wearing an English magnitude word was **invisible to it** — not under-matched, invisible.

Measured on `origin/main` before this change, literal return values:

```
price_tokens_outside_sources("...IDR 2.5 billion.", [])          -> []
price_tokens_outside_sources("...IDR 999 billion.", [])          -> []     <- INVENTED, no source at all
price_tokens_outside_sources("Rp 2.500.000.000", [<curated_qa>]) -> ["IDR:2500000000"]
```

The 999-billion control is the one that matters: it proves this is the rule, not an accident of one value.

**Mechanism.** With `billion` absent from `_MULT_PATTERN`, the regex keeps only the bare `999`; `_canonical_value` returns `999`; `999 < _VETO_FLOORS["IDR"]` discards it **before** the source-membership check ever runs. The amount is never validated as grounded *and* never caught as hallucinated.

**It was already costing us live, in the other direction.** The `curated_qa` entry for PT PMA paid-up capital states the figure as `"IDR 2.5 billion"`. So a **correct** digit-grouped answer was rejected against the very evidence that supported it — the mechanism behind the `finalize_pricing_outside_package` rejections measured on the live bot on 2026-08-30 (4 of 5 battery questions blocked).

## The cure

- Add the English magnitudes (`thousand`/`million`/`billion`/`trillion` + plurals, and `mn` as the sibling of the `bn` already present).
- **Derive `_MULT_PATTERN` from `_AMOUNT_MULTIPLIERS`**, longest-alternative-first, so regex and table can no longer drift apart. Not tidiness: `_canonical_value` indexes the dict with **no `.get()`**, so a token the pattern matches and the table lacks raises a `KeyError` *inside the finalize path* — a crash, not a missed veto.

## Evidence

- **8 of the new cases go RED** when replayed against the pre-fix module — verified by swapping in `origin/main`'s file and re-running, not asserted.
- Both arms per cicatrix family #3: **guilt** (invented English amounts now caught) and **innocence** (`millionaire` must not turn a nearby `USD 20` into twenty million; `zillion` must not become a multiplier; every Indonesian form behaves exactly as before).
- One test asserts the pattern/table derivation itself, so this cannot silently regress.
- One new test is **documented as passing for the wrong reason pre-fix** and kept only as a post-fix fence, rather than counted as evidence.
- Measured: **46 passed** in `test_wa_finalize.py`; **380 passed** across `backend/tests/unit/services/integrations/` + `test_wa_codex_leg.py`.

## Deliberately not in scope, and asserted so it cannot rot

A bare currency **word** (`"2,5 miliar rupiah"`, no `Rp`/`IDR`/`USD` marker) is still invisible to this veto. Widening the *currency-marker* vocabulary only ever **adds** rejections, and the bot is already over-rejecting — that change needs its own false-positive measurement rather than riding along here. `test_pricing_veto_bare_currency_word_remains_out_of_scope` pins the boundary: if a later PR closes it, that test *should* fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhakhSmQUDzdUUFJHn3gyo