### PR TITLE
fix(wa): close the simpler half of the pricing-veto bypass — foreign currency markers

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -328,23 +328,109 @@ _MULT_ALTERNATION = "|".join(
     sorted((re.escape(k) for k in _AMOUNT_MULTIPLIERS), key=len, reverse=True)
 )
 _MULT_PATTERN = f"(?:{_MULT_ALTERNATION})"
+
+# Currency MARKERS, marker -> family. Until 2026-08-30 this vocabulary lived
+# inline in the regex as `Rp|IDR|USD|$` and everything that was not `$`/`USD`
+# was folded into the IDR family. That was a second, SIMPLER bypass of this
+# veto than the English-multiplier one fixed in #5293 — it needed no magnitude
+# word at all. Measured on the parent commit, literal return values:
+#   price_tokens_outside_sources("Costa EUR 5000 in totale.", []) -> []
+#   price_tokens_outside_sources("The fee is SGD 8000.", [])      -> []
+#   price_tokens_outside_sources("The fee is AUD 8000.", [])      -> []
+# An invented foreign-currency price was never validated as grounded and never
+# caught as hallucinated, exactly as an English-worded one was not.
+#
+# Why the marker list alone would NOT have fixed it: with every family folded
+# into IDR, "EUR 500" canonicalized to IDR:500 and fell under the IDR floor of
+# 1000 — so adding the marker without a per-family floor changes nothing. The
+# family map and the floor table are one change, not two.
+#
+# Measured false-positive surface before widening (the reason the parent PR
+# deferred this axis, re-examined rather than assumed): in
+# apps/backend-rag/backend/kb/ the markers EUR, SGD, GBP and the euro sign do
+# not occur at all; across the whole app, word-bounded, EUR appears 19 times in
+# 14 files, AUD 3, GBP 2, SGD 1 — nearly all in tests and scripts, not in
+# retrievable content. So this widening closes a hole at almost no cost in new
+# rejections. It DOES newly veto a currency conversion the model computes
+# itself ("about EUR 600"), which is intended: an unsourced computed figure is
+# precisely what this veto exists to stop, and doctrine already forbids
+# improvising a price.
+#
+# WORD BOUNDARIES ARE LOAD-BEARING HERE, and this is not theoretical: the first
+# measurement of AUD's footprint returned "135 files" because it was counting
+# the substring inside FRAUD and AUDIT. A marker without \b would read an
+# amount out of the middle of an unrelated word — cicatrix family #3, committed
+# by the probe that was measuring for this very change. The alternation below
+# is derived from this table and every alphabetic marker is \b-anchored.
+_CURRENCY_MARKERS: dict[str, str] = {
+    "RP": "IDR",
+    "IDR": "IDR",
+    "USD": "USD",
+    "$": "USD",
+    "EUR": "EUR",
+    "EURO": "EUR",
+    "€": "EUR",
+    "GBP": "GBP",
+    "£": "GBP",
+    "SGD": "SGD",
+    "AUD": "AUD",
+}
+_SYMBOL_MARKERS = frozenset({"$", "€", "£"})
+
+
+def _marker_alternation() -> str:
+    """Regex alternation over _CURRENCY_MARKERS, longest first, \b-anchored.
+
+    Alphabetic markers get a LEADING \b so "AUD" cannot match inside "FRAUD";
+    symbols get none (\b before "$" would require a preceding word char). No
+    trailing \b is needed: both branches of _CURRENCY_AMOUNT_RE require digits
+    adjacent to the marker, which already excludes "EURO" matching "EUROPE".
+    """
+    parts = []
+    for marker in sorted(_CURRENCY_MARKERS, key=len, reverse=True):
+        escaped = re.escape(marker)
+        # "Rp." is written with a trailing dot as often as without.
+        if marker == "RP":
+            escaped += r"\.?"
+        parts.append(escaped if marker in _SYMBOL_MARKERS else r"\b" + escaped)
+    return "|".join(parts)
+
+
+_MARKER_PATTERN = _marker_alternation()
 _CURRENCY_AMOUNT_RE = re.compile(
-    r"(?:(?P<cur1>\bRp\.?|\bIDR|\bUSD|\$)[ \t]*(?P<amt1>\d(?:[\d.,]*\d)?)"
+    r"(?:(?P<cur1>" + _MARKER_PATTERN + r")[ \t]*(?P<amt1>\d(?:[\d.,]*\d)?)"
     r"(?:[ \t]*(?P<mul1>" + _MULT_PATTERN + r")\b)?)"
     r"|(?:(?P<amt2>\d(?:[\d.,]*\d)?)(?:[ \t]*(?P<mul2>" + _MULT_PATTERN + r")\b)?"
-    r"[ \t]*(?P<cur2>IDR|USD)\b)",
+    r"[ \t]*(?P<cur2>" + _MARKER_PATTERN + r"))",
     re.IGNORECASE,
 )
 
 # Veto floors per currency family: IDR prices below Rp 1.000 do not exist in
-# this business (and tiny amounts would fire on noise); dollar prices are real
-# from $10 up (the review's "$999" case must be vetoable).
-_VETO_FLOORS: dict[str, int] = {"USD": 10, "IDR": 1000}
+# this business (and tiny amounts would fire on noise); hard-currency prices
+# are real from 10 up (the review's "$999" case must be vetoable). EVERY family
+# in _CURRENCY_MARKERS must have an entry — _floor_for asserts it rather than
+# defaulting, because a missing floor would silently wave a whole currency
+# through, which is the failure this table exists to prevent.
+_VETO_FLOORS: dict[str, int] = {
+    "IDR": 1000,
+    "USD": 10,
+    "EUR": 10,
+    "GBP": 10,
+    "SGD": 10,
+    "AUD": 10,
+}
 
 
 def _canonical_currency(cur: str) -> str:
+    """Currency FAMILY for a matched marker.
+
+    The regex only ever matches markers derived from _CURRENCY_MARKERS, so the
+    lookup cannot miss; the explicit fallback is a fail-CLOSED default rather
+    than a KeyError, because folding an unknown marker into IDR keeps it inside
+    the veto (with the strictest floor) instead of dropping it on the floor.
+    """
     c = cur.strip().rstrip(".").upper()
-    return "USD" if c in ("$", "USD") else "IDR"
+    return _CURRENCY_MARKERS.get(c, "IDR")
 
 
 def _canonical_value(amount: str, multiplier: str | None) -> int | None:
@@ -396,6 +482,18 @@ def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> lis
     in a chunk could semantically launder a wrong "service fee" — accepted
     because the Gemini leg has the identical exposure today with NO veto at
     all, and the label gate + PricingTool grounding remain the primary control.
+
+    Second declared residual, made visible by the 2026-08-30 currency-family
+    change and deliberately NOT closed here: membership is tested on the VALUE
+    alone, not on (family, value), so a "USD 5000" in a source authorizes an
+    "EUR 5000" in the answer. Closing it would require dropping the bare-token
+    pass below — the one that lets a pricing block state an amount without
+    repeating its currency marker — and that pass is what keeps this veto from
+    failing off correct answers. Trading a certain false-positive regression
+    for a speculative laundering path is the wrong side of the exchange for a
+    guard that already over-rejects. Pinned by
+    test_pricing_veto_does_not_distinguish_currency_families so it cannot rot
+    into an unexamined assumption.
     """
     source_values: set[int] = set()
     for src in price_sources:

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -20,8 +20,10 @@ import pytest
 
 from backend.services.integrations.wa_finalize import (
     _AMOUNT_MULTIPLIERS,
+    _CURRENCY_MARKERS,
     _KG_WORKFLOW_TRAILER,
     _MULT_PATTERN,
+    _VETO_FLOORS,
     _WHATSAPP_HARD_SEND_LIMIT,
     FinalizeOutcome,
     finalize_wa_answer,
@@ -264,14 +266,105 @@ def test_pricing_veto_still_reads_the_indonesian_forms_it_always_did() -> None:
 def test_pricing_veto_bare_currency_word_remains_out_of_scope() -> None:
     """A KNOWN, deliberately unclosed hole — asserted so it cannot rot silently.
 
-    "2,5 miliar rupiah" carries no Rp/IDR/USD marker, so this veto never sees it.
-    Widening the CURRENCY vocabulary only ever adds rejections, and the live bot
-    was already rejecting 4 of 5 battery questions on 2026-08-30; that change
-    needs its own false-positive measurement rather than riding along here. If a
-    later PR closes it, this test SHOULD fail — read it as the marker of a scope
-    boundary, not as an assertion that the behavior is desirable.
+    "2,5 miliar rupiah" carries no Rp/IDR/USD/EUR/... marker, so this veto never
+    sees it. NOTE (2026-08-30): the FOREIGN-marker half of this boundary was
+    closed the same day — EUR/€/GBP/£/SGD/AUD are now markers with their own
+    families and floors, after measuring that they barely occur in retrievable
+    content. What survives here is only the bare Indonesian currency WORD, which
+    the bot does write and where widening would cost real false positives. If a
+    later PR closes that too, this test SHOULD fail — it marks a scope boundary,
+    it does not assert the behavior is desirable.
     """
     assert price_tokens_outside_sources("Modalnya 2,5 miliar rupiah.", []) == []
+
+
+# ── Currency families: the marker vocabulary was narrower than the amount
+# vocabulary, and bypassed the veto with no magnitude word at all ────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # GUILT — an invented foreign-currency price, no source at all.
+        ("Costa EUR 5000 in totale.", ["EUR:5000"]),
+        ("Costa €5000 in totale.", ["EUR:5000"]),
+        ("Il totale è EURO 5000.", ["EUR:5000"]),
+        ("The fee is EUR 5 million.", ["EUR:5000000"]),
+        ("The fee is SGD 8000.", ["SGD:8000"]),
+        ("The fee is AUD 8000.", ["AUD:8000"]),
+        ("The fee is £8000.", ["GBP:8000"]),
+        # Suffix form, the second branch of the regex.
+        ("Biayanya 8000 EUR.", ["EUR:8000"]),
+    ],
+)
+def test_pricing_veto_catches_foreign_currency_markers(
+    text: str, expected: list[str]
+) -> None:
+    assert price_tokens_outside_sources(text, ["nothing relevant"]) == expected
+
+
+def test_pricing_veto_accepts_a_grounded_foreign_amount() -> None:
+    # Innocence: widening the markers must not reject an amount that IS sourced.
+    assert price_tokens_outside_sources("Costa EUR 5000.", ["Total EUR 5000."]) == []
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # The measurement that motivated this change first reported "AUD in 135
+        # files" — it was counting the substring inside FRAUD and AUDIT. A marker
+        # without a leading \b reads an amount out of the middle of an unrelated
+        # word: cicatrix family #3, committed by the probe doing the measuring.
+        "This is FRAUD 8000 times over.",
+        "See AUDIT 8000 for detail.",
+        "EUROPE 2026 has 8000 attendees.",
+    ],
+)
+def test_pricing_veto_markers_do_not_match_inside_longer_words(text: str) -> None:
+    assert price_tokens_outside_sources(text, []) == []
+
+
+def test_pricing_veto_every_family_has_a_floor() -> None:
+    """A family without a floor would raise, or silently wave a currency through.
+
+    ``price_tokens_outside_sources`` indexes ``_VETO_FLOORS[cur]`` for every
+    matched amount, so a marker whose family is missing from the floor table is
+    a KeyError on live client text. This is the same pattern/table coupling that
+    #5293 removed from the multiplier side; here it is asserted rather than
+    derived, because the floors carry a judgment (1000 for IDR, 10 for hard
+    currency) that cannot be computed from the marker list.
+    """
+    assert set(_CURRENCY_MARKERS.values()) <= set(_VETO_FLOORS)
+
+
+def test_pricing_veto_foreign_floor_skips_noise_but_not_real_prices() -> None:
+    # A hard-currency floor of 10 must let a real price through and drop noise.
+    assert price_tokens_outside_sources("EUR 5 coffee.", []) == []
+    assert price_tokens_outside_sources("EUR 5000 fee.", []) == ["EUR:5000"]
+
+
+def test_pricing_veto_does_not_distinguish_currency_families() -> None:
+    """DECLARED RESIDUAL, pinned so it cannot rot into an assumption.
+
+    Source membership is tested on the VALUE alone, not on (family, value), so a
+    "USD 5000" in a source authorizes an "EUR 5000" in the answer. Closing it
+    would mean dropping the bare-token pass that lets a pricing block state an
+    amount without repeating its currency marker — and that pass is what stops
+    this veto failing off correct answers. A certain false-positive regression
+    traded for a speculative laundering path is the wrong side of the exchange
+    for a guard that already over-rejects. This test asserts what IS, not what
+    is desirable; if a later PR makes membership family-aware it should fail.
+    """
+    assert price_tokens_outside_sources("Il totale è EUR 5000.", ["USD 5000"]) == []
+
+
+def test_pricing_veto_idr_and_usd_behave_exactly_as_before() -> None:
+    # Regression fence: the families that already existed must not shift.
+    assert price_tokens_outside_sources("$999 flat.", ["no prices"]) == ["USD:999"]
+    assert price_tokens_outside_sources("Rp 500 per page.", ["no numbers"]) == []
+    assert price_tokens_outside_sources("Rp 99 juta.", ["Rp 99.000.000"]) == []
+    assert price_tokens_outside_sources("IDR 999 billion.", []) == ["IDR:999000000000"]
+    assert price_tokens_outside_sources("Rp.5.000.000", ["Rp 5.000.000"]) == []
 
 
 # ── Secret-egress scan (pure function): guilt and innocence ──────────────


### PR DESCRIPTION
Follow-up to #5293, which closed the pricing-veto bypass that needed an English magnitude word. This closes the one that needs **nothing at all**.

## The defect

`_CURRENCY_AMOUNT_RE` recognized only `Rp|IDR|USD|$`. The marker vocabulary was narrower than the amount vocabulary it guards. Measured on this PR's parent commit, literal return values from the shipped function:

```
price_tokens_outside_sources("Costa EUR 5000 in totale.", []) -> []
price_tokens_outside_sources("Costa €5000 in totale.", [])    -> []
price_tokens_outside_sources("Il totale è EURO 5000.", [])    -> []
price_tokens_outside_sources("The fee is SGD 8000.", [])      -> []
price_tokens_outside_sources("The fee is AUD 8000.", [])      -> []
price_tokens_outside_sources("The fee is £8000.", [])         -> []
price_tokens_outside_sources("$999 flat.", [...])  -> ["USD:999"]   # control, works
```

An invented foreign-currency price was never validated as grounded and never caught as hallucinated.

**Adding the markers alone would not have fixed it.** `_canonical_currency` folded everything that was not `$`/`USD` into the IDR family, so `EUR 500` canonicalized to `IDR:500` and fell under the IDR floor of 1000. Marker table, family map and per-family floors are one change, not three — and a family missing from the floor table raises `KeyError` on live client text, which `test_pricing_veto_every_family_has_a_floor` now asserts.

## The false-positive cost, measured before widening

The parent PR deferred this axis on the reasoning that widening markers "only ever adds rejections". That was true for the *Indonesian* bare word and wrong for foreign markers, so it was measured rather than re-guessed:

| marker | in `backend/kb/` | across the app (word-bounded) |
|---|---|---|
| `EUR` | 0 | 19 hits / 14 files |
| `€` | 0 | — |
| `SGD` | 0 | 1 |
| `GBP` / `£` | 0 | 2 |
| `AUD` | 0 | 3 |

Nearly all in tests and scripts, not retrievable content. This closes a hole at almost no cost in new rejections.

It **does** newly veto a currency conversion the model computes itself ("about EUR 600"). That is intended: an unsourced computed figure is exactly what this veto exists to stop, and doctrine already forbids improvising a price.

## Word boundaries are load-bearing — and this bit during the measurement

The first measurement of `AUD`'s footprint returned "135 files". It was counting the substring inside **FRAUD** and **AUDIT**. A marker without `\b` reads an amount out of the middle of an unrelated word — cicatrix family #3, committed by the probe measuring for this very change. Every alphabetic marker is `\b`-anchored, and `FRAUD 8000` / `AUDIT 8000` / `EUROPE 2026 … 8000` are asserted inert.

## Declared residual, pinned rather than hidden

Membership is tested on the **value alone**, not `(family, value)` — so a `USD 5000` in a source authorizes an `EUR 5000` in the answer. Closing it means dropping the bare-token pass that lets a pricing block state an amount without repeating its marker, and that pass is what keeps this veto from failing off correct answers. A certain false-positive regression traded for a speculative laundering path is the wrong side of the exchange for a guard that already over-rejects. `test_pricing_veto_does_not_distinguish_currency_families` asserts what **is**, not what is desirable — if a later PR makes membership family-aware, it should fail.

## Evidence

- Every new guilt input re-measured returning `[]` on a clean pre-cure tree (the import-level `_CURRENCY_MARKERS` reference makes a whole-file replay impossible, so the function was called directly on the unmodified tree instead of asserting).
- Guilt and innocence both present per family #3: invented foreign amounts caught; a **grounded** `EUR 5000` accepted; longer words inert; `EUR 5` below its floor.
- Measured: **62 passed** in `test_wa_finalize.py`; **396 passed** across `backend/tests/unit/services/integrations/` + `test_wa_codex_leg.py`.
- `test_pricing_veto_bare_currency_word_remains_out_of_scope` narrowed to what actually survives: the bare Indonesian currency **word**, where widening would cost real false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhakhSmQUDzdUUFJHn3gyo