### PR TITLE
fix(garuda): magic-link issuance is 500 in prod and the log cannot say why

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_portal_auth.py
+++ b/apps/backend-rag/backend/app/routers/garuda_portal_auth.py
@@ -350,7 +350,7 @@ async def request_magic_link(
     except PersistencePolicyUnavailable:
         logger.warning("garuda_portal_auth: persistence policy unavailable at issue")
         return _error("PERSISTENCE_POLICY_UNAVAILABLE")
-    except Exception:
+    except Exception as exc:
         # Refuter finding #4: an unmapped store exception must never leak as
         # a bare framework 500 — fail closed into the contract's own shape.
         #
@@ -362,11 +362,24 @@ async def request_magic_link(
         # `sentry_config._scrub` cannot reach a value that only exists inside
         # a captured frame's local-variable dump, so the cheapest real
         # mitigation for *this* handler is to never capture that dump at all.
-        # The exception type/message is still worth nothing here anyway — the
-        # contract only ever returns the same opaque INTERNAL_ERROR to the
-        # caller — so no diagnostic signal is lost that this endpoint's
-        # response shape could have used.
-        logger.error("garuda_portal_auth: unexpected error at issue")
+        # CORRECTED 2026-08-30, falsified in production. The sentence that
+        # stood here — "the exception type/message is still worth nothing
+        # here anyway" — conflated the RESPONSE (rightly opaque) with the
+        # LOG (which is the only place the cause can live). On 2026-08-30
+        # every call to this endpoint answered INTERNAL_ERROR, and the whole
+        # record of it was this one message repeated: no type, no stack, no
+        # way to tell an absent SQL function from a bad parameter cast from
+        # a dead pool. The privacy mitigation had blinded the diagnosis.
+        #
+        # The exception's CLASS NAME is logged, and nothing else. It is not
+        # PII, not a message that could quote a value, and not a frame-locals
+        # dump — `exc_info` stays off for exactly the reason above. A name
+        # like `UndefinedFunctionError` or `PostgresSyntaxError` names the
+        # cause on sight and can hold no caller data.
+        logger.error(
+            "garuda_portal_auth: unexpected error at issue (%s)",
+            type(exc).__name__,
+        )
         return _error("INTERNAL_ERROR")
 
     result.headers["Idempotency-Replayed"] = "true" if issued.idempotency_replayed else "false"
@@ -406,13 +419,19 @@ async def exchange_magic_link(
     except PersistencePolicyUnavailable:
         logger.warning("garuda_portal_auth: persistence policy unavailable at exchange")
         return _error("PERSISTENCE_POLICY_UNAVAILABLE")
-    except Exception:
+    except Exception as exc:
         # `logger.error`, not `.exception` — see the identical rationale at
         # the `issue` handler above: this frame can hold `payload.token` and
         # a future adapter's `account_session_secret`, and `.exception`'s
         # captured frame-locals dump is a leak vector key-based redaction
-        # cannot close.
-        logger.error("garuda_portal_auth: unexpected error at exchange")
+        # cannot close. The exception's CLASS NAME is logged for the reason
+        # given at the `issue` handler above (a blind handler cost a full
+        # production outage its diagnosis on 2026-08-30); a class name can
+        # hold no caller data.
+        logger.error(
+            "garuda_portal_auth: unexpected error at exchange (%s)",
+            type(exc).__name__,
+        )
         return _error("INTERNAL_ERROR")
 
     # `outcome.security_counter` is internal telemetry ONLY — logged here,

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_portal_auth.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_portal_auth.py
@@ -600,3 +600,65 @@ def test_account_session_cookie_is_secure_on_loopback_https(fake_store):
     set_cookie_headers = resp.headers.get_list("set-cookie")
     account_cookie = next(h for h in set_cookie_headers if h.startswith("garuda_session="))
     assert "Secure" in account_cookie, account_cookie
+
+
+# ============================================================
+# A blind catch-all cannot be diagnosed (2026-08-30, measured in production)
+# ============================================================
+
+
+class _PolicyProbeFailed(Exception):
+    """Stands in for the class of store failure that took issuance down."""
+
+
+def _assert_named_but_silent(caplog, *, expected_name: str, forbidden: str) -> None:
+    records = [r for r in caplog.records if "unexpected error" in r.getMessage()]
+    assert records, "the handler must still log the failure"
+    message = records[-1].getMessage()
+    assert expected_name in message, (
+        "the exception's CLASS NAME must reach the log: on 2026-08-30 every call to this "
+        "endpoint answered INTERNAL_ERROR and the log said only 'unexpected error', which "
+        "cannot tell an absent SQL function from a bad cast from a dead pool"
+    )
+    assert forbidden not in message, "the exception MESSAGE must never be logged: it can quote a value"
+    assert records[-1].exc_info is None, (
+        "exc_info stays off — Sentry's LoggingIntegration turns it into a frame-locals dump, "
+        "which is where the session secret lives and where key-based redaction cannot reach"
+    )
+
+
+def test_issue_failure_logs_the_exception_class_and_nothing_else(fake_store, caplog):
+    fake_store.raise_on_issue = _PolicyProbeFailed("s3cret-session-value")
+    client = _client_with_store(fake_store)
+
+    with caplog.at_level("ERROR"):
+        resp = client.post(
+            "/api/visa/voa/auth/magic-links",
+            json={"result_id": VALID_RESULT_ID, "email": "traveller@example.com"},
+            headers={"Idempotency-Key": "11111111-1111-4111-8111-111111111111"},
+            cookies={"garuda_result_session": "owner-secret"},
+        )
+
+    assert resp.status_code == 500
+    assert resp.json()["code"] == "INTERNAL_ERROR"
+    _assert_named_but_silent(
+        caplog, expected_name="_PolicyProbeFailed", forbidden="s3cret-session-value"
+    )
+
+
+def test_exchange_failure_logs_the_exception_class_and_nothing_else(fake_store, caplog):
+    fake_store.raise_on_exchange = _PolicyProbeFailed("s3cret-token-value")
+    client = _client_with_store(fake_store)
+
+    with caplog.at_level("ERROR"):
+        resp = client.post(
+            "/api/visa/voa/auth/sessions",
+            json={"token": "T" * 43},
+            headers={"Idempotency-Key": "22222222-2222-4222-8222-222222222222"},
+        )
+
+    assert resp.status_code == 500
+    assert resp.json()["code"] == "INTERNAL_ERROR"
+    _assert_named_but_silent(
+        caplog, expected_name="_PolicyProbeFailed", forbidden="s3cret-token-value"
+    )


### PR DESCRIPTION
## Measured in production, 2026-08-30

`POST /api/visa/voa/auth/magic-links` answers `500 INTERNAL_ERROR` to **every**
call. Probed live against `nuzantara-rag.fly.dev` with a genuine session: two
independent eligibility checks (both `201 ACCEPT`), then a magic-link request
for each — both 500. The authenticated half of the VOA product cannot start.

The sibling operation is healthy, which narrows it: `POST /auth/sessions`
answers `401 MAGIC_LINK_INVALID` to a fabricated token, so migration 285's
table exists and is being queried. The failure is inside `MagicLinkStore.issue`.

**And the log cannot say which step.** The whole record of the outage is one
line, repeated:

```
{"level":"ERROR","logger":"backend.app.routers.garuda_portal_auth",
 "message":"garuda_portal_auth: unexpected error at issue",
 "source":{"file":"/app/backend/app/routers/garuda_portal_auth.py","line":369}}
```

## Why it is blind, and why that was half-right

The handler uses `logger.error`, not `.exception`, on purpose: `exc_info`
becomes a frame-locals dump in Sentry, and this frame holds
`garuda_result_session` — key-based redaction in `sentry_config._scrub` cannot
reach a value that only exists inside a captured locals dump. That reasoning is
correct and is preserved.

What was wrong is the sentence that followed it: *"the exception type/message
is still worth nothing here anyway"*. It conflated the **response** (rightly
opaque to the caller) with the **log** (the only place the cause can live).
Production falsified it today.

## This PR

Logs the exception's **class name** and nothing else, in both catch-alls of the
router. A class name is not PII, is not a message that could quote a value, and
is not a frame-locals dump — `exc_info` stays off. `UndefinedFunctionError` or
`PostgresSyntaxError` would have named this outage on sight.

This is the same shape as the notifications defect fixed in #5202: the handler
that records a failure must never destroy the information about it.

## Verification

Two tests, proven red on the parent commit and green here:

- the exception's class name reaches the log;
- the exception **message** does not (a message can quote a value);
- `record.exc_info is None` — the locals dump stays off.

```
2 failed  (parent commit)
2 passed  (this commit)
27 passed  — the router's full existing suite, no regression
ruff check — All checks passed!
```

## What this PR does NOT do

It does not fix the outage — it makes the outage nameable. The cause is
diagnosed from the next production log line after this deploys, and gets its
own PR. Nor does it touch the separate ownership defect on this same endpoint
(issuance never verifies that the caller owns the `result_id`), which is in
flight on its own branch.
