### PR TITLE
fix(garuda-orders): L3 error envelope + privacy headers on the frozen contract

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_orders_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_orders_router.py
@@ -26,8 +26,11 @@ from __future__ import annotations
 
 import hashlib
 import os
+from collections.abc import Awaitable, Callable
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
 
 from backend.services.garuda_orders.errors import (
     NoOpenLateCase,
@@ -91,8 +94,69 @@ def _require_flag() -> None:
 # first exception) — proved empirically, not assumed, by
 # `test_garuda_voa_flag_ordering.py`, which fails red against the OLD
 # per-handler-body placement and passes green here.
+
+
+class _ContractErrorRoute(APIRoute):
+    """Rewrite every `HTTPException` this router raises into the frozen
+    `errors.yaml` envelope, with the SAME privacy headers success paths get
+    (Gear-3 gate finding on PR #4959's follow-up: the 28 bare
+    `raise HTTPException(status_code=X, detail={"code": Y, "retryable": Z})`
+    call sites below — spread across the router-level dependency
+    (`_require_flag`), a parameter dependency (`get_repository`), plain
+    helper coroutines called directly from handler bodies
+    (`_require_magic_session_actor`, `_require_staff_actor`,
+    `_idempotency_key`), and the five handler bodies themselves — each
+    produced FastAPI's default `{"detail": {...}}` envelope instead of the
+    contract's flat `{"code", "retryable", "message_key"}` shape, AND lost
+    the `_privacy_headers()` a success response gets, because raising builds
+    a brand-new `Response` FastAPI's own exception handling constructs,
+    never the `response` object handlers mutate.
+
+    `garuda_voa_public.py`'s `_ContractErrorRoute` (the model this
+    replicates, per LANES.md file-ownership discipline — this is a
+    same-shaped LOCAL copy, not a shared import) catches two SPECIFIC
+    exception types because neither one carries a reusable `code` (a
+    framework `RequestValidationError` and a bespoke `_FeatureDisabled`
+    sentinel with none). Every one of THIS file's exceptions already IS an
+    `HTTPException` whose `detail` already names the exact contract `code`
+    — so catching `HTTPException` itself and reading `detail["code"]` is
+    the direct generalisation of that same idea to 28 call sites through
+    ONE catch, instead of converting each `raise` to a hand-written
+    `return _error(...)` with 28 chances for a status/code typo to drift
+    from the `errors.yaml` entry it is supposed to mirror. Whichever layer
+    raises — router-level dependency, parameter dependency, a plain
+    `await helper(...)` inside a handler body, or the handler body itself —
+    the exception propagates through THIS route's own dispatch (dependency
+    resolution included; same ordering argument as
+    `garuda_voa_public._require_public_enabled`'s docstring) before
+    Starlette's global `ExceptionMiddleware` ever sees it, so catching it
+    here is exactly as complete as a bespoke sentinel per site would be.
+
+    A caught `HTTPException` whose `detail` is not one of `_ERROR_CATALOG`'s
+    codes (defensive — nothing in this file raises one today) is re-raised
+    untouched rather than guessed at.
+    """
+
+    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+        downstream = super().get_route_handler()
+
+        async def handler(request: Request) -> Response:
+            try:
+                return await downstream(request)
+            except HTTPException as exc:
+                code = exc.detail.get("code") if isinstance(exc.detail, dict) else None
+                if code not in _ERROR_CATALOG:
+                    raise
+                return _error(code)
+
+        return handler
+
+
 router = APIRouter(
-    prefix="/api/visa/voa", tags=["garuda-orders"], dependencies=[Depends(_require_flag)]
+    prefix="/api/visa/voa",
+    tags=["garuda-orders"],
+    route_class=_ContractErrorRoute,
+    dependencies=[Depends(_require_flag)],
 )
 
 
@@ -100,6 +164,47 @@ def _privacy_headers(response: Response) -> None:
     response.headers["Cache-Control"] = "no-store, private"
     response.headers["Referrer-Policy"] = "no-referrer"
     response.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
+
+
+#: `errors.yaml` — (http_status, retryable, message_key), restricted to the
+#: codes THIS router's own 28 `raise HTTPException(...)` call sites can ever
+#: emit. Each tuple is a verbatim copy of that code's `x-http-status` /
+#: `retryable` / `message_key` consts in
+#: `products/garuda-voa/contracts/errors.yaml` (frozen, orchestrator-owned)
+#: — never hand-typed independently of the `raise` sites below, whose
+#: `detail={"code": ..., "retryable": ...}` values `_ContractErrorRoute`
+#: cross-checks against this table at request time.
+_ERROR_CATALOG: dict[str, tuple[int, bool, str]] = {
+    "GARUDA_PUBLIC_DISABLED": (404, False, "garuda_voa.error.unavailable"),
+    "SERVICE_UNAVAILABLE": (503, True, "garuda_voa.error.service_unavailable"),
+    "SESSION_REQUIRED": (401, False, "garuda_voa.error.session_required"),
+    "IDEMPOTENCY_KEY_REQUIRED": (400, False, "garuda_voa.error.idempotency_key_required"),
+    "INVALID_REQUEST": (422, False, "garuda_voa.error.invalid_request"),
+    "RESULT_NOT_FOUND": (404, False, "garuda_voa.error.result_not_found"),
+    "IDEMPOTENCY_CONFLICT": (409, False, "garuda_voa.error.idempotency_conflict"),
+    "ORDER_NOT_READY": (409, False, "garuda_voa.error.order_not_ready"),
+    "PERSISTENCE_POLICY_UNAVAILABLE": (503, False, "garuda_voa.error.sale_unavailable"),
+    "PRICE_UNRESOLVABLE": (503, False, "garuda_voa.error.sale_unavailable"),
+    "PAYMENT_PROVIDER_UNAVAILABLE": (503, True, "garuda_voa.error.payment_provider_unavailable"),
+    "ORDER_NOT_FOUND": (404, False, "garuda_voa.error.order_not_found"),
+    "WEBHOOK_SIGNATURE_INVALID": (401, False, "garuda_voa.error.webhook_signature_invalid"),
+    "INVALID_STATE_TRANSITION": (409, False, "garuda_voa.error.invalid_state_transition"),
+}
+
+
+def _error(code: str) -> JSONResponse:
+    """One error tuple, one call site — the body is EXACTLY the 3 contract
+    fields. Privacy headers go through the SAME `_privacy_headers()` helper
+    every success response already uses, so there is one place (not two)
+    that can drift from the contract's `x-public-privacy-response-headers`.
+    """
+    status_code, retryable, message_key = _ERROR_CATALOG[code]
+    response = JSONResponse(
+        status_code=status_code,
+        content={"code": code, "retryable": retryable, "message_key": message_key},
+    )
+    _privacy_headers(response)
+    return response
 
 
 def get_repository(request: Request) -> GarudaOrderRepository:

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_envelope.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_envelope.py
@@ -1,0 +1,195 @@
+"""L3 error envelope + privacy-header contract compliance (PR #4959 F2
+follow-up).
+
+`garuda_orders_router.py`'s 28 `raise HTTPException(status_code=X,
+detail={"code": Y, "retryable": Z})` call sites used to produce FastAPI's
+default `{"detail": {"code": ..., "retryable": ...}}` body — the contract
+(`products/garuda-voa/contracts/errors.yaml`) declares a FLAT
+`{"code", "retryable", "message_key"}` shape, exactly what `garuda_voa_public
+.py`'s `_ContractErrorRoute` + `_error()` already produce for L2. The nested
+shape also carried none of the three `_privacy_headers()` a success response
+gets: raising builds a brand-new `Response` via FastAPI's own exception
+handling, never the `response` object handlers mutate.
+
+Three representative error paths, one per HTTP-status family the task asked
+for (a validation 4xx, an authorization 4xx, and the 503), each proven
+red-before / green-after against `garuda_orders_router.py`'s own
+`_ContractErrorRoute` fix — NOT the sibling `garuda_voa_public.py`, which was
+already correct. None of these need Postgres: every fixture here is a fake,
+same shape as `test_garuda_staff_actor_async_verifier.py`'s.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from backend.app.routers import garuda_orders_router
+
+_SESSION_COOKIE = "garuda_session"
+_ACTOR = "result-envelope-test-000000"
+
+
+@pytest.fixture(autouse=True)
+def _garuda_public_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "true")
+
+
+async def _verifier_returns_fixed_actor(cookie: str) -> str | None:
+    """Stand-in magic-link verifier — no Postgres, no `PostgresMagicLinkStore`.
+    Accepts any non-empty cookie value and returns the same fixed actor."""
+    return _ACTOR if cookie else None
+
+
+class _NeverCalledRepository:
+    """Fake `GarudaOrderRepository` for `Depends(get_repository)` — any
+    method call is a test failure. Used only where the test's own error
+    path must be reached BEFORE the repository is ever touched (matches
+    `test_garuda_staff_actor_async_verifier.py`'s fixture of the same
+    name/shape)."""
+
+    async def create_order_and_checkout(self, **kwargs):  # pragma: no cover
+        raise AssertionError(
+            "create_order_and_checkout was called — the 422 body "
+            "check did not reject the request before touching the "
+            "repository"
+        )
+
+
+def _app(**state) -> FastAPI:
+    application = FastAPI()
+    application.include_router(garuda_orders_router.router)
+    for key, value in state.items():
+        setattr(application.state, key, value)
+    return application
+
+
+def _assert_privacy_headers(headers) -> None:
+    assert headers.get("cache-control") == "no-store, private"
+    assert headers.get("referrer-policy") == "no-referrer"
+    assert headers.get("x-robots-tag") == "noindex, nofollow, noarchive"
+
+
+class TestSessionRequiredEnvelope:
+    """401 SESSION_REQUIRED — the authorization 4xx.
+
+    No verifier wired at all (production's actual state until L4's session
+    verifier is composed onto `app.state`), no cookie sent: `_require_magic_
+    session_actor` raises before any `Depends()` (`get_repository`,
+    `garuda_db_pool`) is ever touched, so this needs no fakes beyond the
+    bare app.
+    """
+
+    async def test_envelope_is_flat_contract_shape(self) -> None:
+        app = _app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get("/api/visa/voa/orders/ord_envelope_test_0000")
+
+        assert resp.status_code == 401, resp.text
+        assert resp.json() == {
+            "code": "SESSION_REQUIRED",
+            "retryable": False,
+            "message_key": "garuda_voa.error.session_required",
+        }
+        assert "detail" not in resp.json()
+
+    async def test_privacy_headers_are_present(self) -> None:
+        app = _app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get("/api/visa/voa/orders/ord_envelope_test_0001")
+
+        assert resp.status_code == 401, resp.text
+        _assert_privacy_headers(resp.headers)
+
+
+class TestInvalidRequestEnvelope:
+    """422 INVALID_REQUEST — the validation 4xx.
+
+    Verifier + repository both wired (a fake repository whose methods must
+    NEVER be called — the malformed body must be rejected before the
+    handler ever reaches `repository.create_order_and_checkout`), a valid
+    session cookie and idempotency key, and a body that fails the
+    `review_confirmed is not True` check.
+    """
+
+    async def test_envelope_is_flat_contract_shape(self) -> None:
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_order_repository=_NeverCalledRepository(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.post(
+                "/api/visa/voa/orders",
+                cookies={_SESSION_COOKIE: "any-nonempty-cookie-value"},
+                headers={"Idempotency-Key": "envelope-test-invalid-request-0001"},
+                json={"result_id": _ACTOR, "review_confirmed": False},
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json() == {
+            "code": "INVALID_REQUEST",
+            "retryable": False,
+            "message_key": "garuda_voa.error.invalid_request",
+        }
+        assert "detail" not in resp.json()
+
+    async def test_privacy_headers_are_present(self) -> None:
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_order_repository=_NeverCalledRepository(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.post(
+                "/api/visa/voa/orders",
+                cookies={_SESSION_COOKIE: "any-nonempty-cookie-value"},
+                headers={"Idempotency-Key": "envelope-test-invalid-request-0002"},
+                json={"result_id": _ACTOR, "review_confirmed": False},
+            )
+
+        assert resp.status_code == 422, resp.text
+        _assert_privacy_headers(resp.headers)
+
+
+class TestServiceUnavailableEnvelope:
+    """503 SERVICE_UNAVAILABLE.
+
+    A valid session (via the fake verifier — no Postgres) but no
+    `garuda_db_pool` wired at all, exactly `TestDbPoolDegradationIsFiveOhThreeNotFiveHundred`'s
+    "absent" case in `test_garuda_orders_ownership.py`, reused here without
+    the Postgres-backed fixtures that file needs for its OTHER (ownership)
+    assertions.
+    """
+
+    async def test_envelope_is_flat_contract_shape(self) -> None:
+        app = _app(garuda_magic_session_verifier=_verifier_returns_fixed_actor)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(
+                "/api/visa/voa/orders/ord_envelope_test_0002",
+                cookies={_SESSION_COOKIE: "any-nonempty-cookie-value"},
+            )
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json() == {
+            "code": "SERVICE_UNAVAILABLE",
+            "retryable": True,
+            "message_key": "garuda_voa.error.service_unavailable",
+        }
+        assert "detail" not in resp.json()
+
+    async def test_privacy_headers_are_present(self) -> None:
+        app = _app(garuda_magic_session_verifier=_verifier_returns_fixed_actor)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(
+                "/api/visa/voa/orders/ord_envelope_test_0003",
+                cookies={_SESSION_COOKIE: "any-nonempty-cookie-value"},
+            )
+
+        assert resp.status_code == 503, resp.text
+        _assert_privacy_headers(resp.headers)

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_ownership.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_ownership.py
@@ -271,7 +271,7 @@ class TestSessionVerification:
     async def test_absent_cookie_is_rejected(self, client: AsyncClient) -> None:
         resp = await client.get("/api/visa/voa/orders/ord_absent_0000000000")
         assert resp.status_code == 401
-        assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
+        assert resp.json()["code"] == "SESSION_REQUIRED"
 
     async def test_unknown_cookie_value_is_rejected(self, client: AsyncClient) -> None:
         resp = await client.get(
@@ -279,7 +279,7 @@ class TestSessionVerification:
             cookies={_SESSION_COOKIE: "not-a-real-session-secret"},
         )
         assert resp.status_code == 401
-        assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
+        assert resp.json()["code"] == "SESSION_REQUIRED"
 
     async def test_expired_session_is_rejected(self, pool, client: AsyncClient) -> None:
         raw_secret = "expired-secret-0000000000000000000000000000"
@@ -294,7 +294,7 @@ class TestSessionVerification:
             cookies={_SESSION_COOKIE: raw_secret},
         )
         assert resp.status_code == 401
-        assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
+        assert resp.json()["code"] == "SESSION_REQUIRED"
 
     async def test_a_valid_session_reaches_past_the_401(self, pool, client: AsyncClient) -> None:
         """Positive control: a live, unexpired session gets PAST the auth
@@ -307,7 +307,7 @@ class TestSessionVerification:
             cookies={_SESSION_COOKIE: raw_secret},
         )
         assert resp.status_code == 404
-        assert resp.json()["detail"]["code"] == "ORDER_NOT_FOUND"
+        assert resp.json()["code"] == "ORDER_NOT_FOUND"
 
 
 # ============================================================
@@ -330,7 +330,7 @@ class TestGetOrderOwnership:
             cookies={_SESSION_COOKIE: raw_secret_a},
         )
         assert resp.status_code == 404
-        assert resp.json()["detail"]["code"] == "ORDER_NOT_FOUND"
+        assert resp.json()["code"] == "ORDER_NOT_FOUND"
 
     async def test_a_session_can_read_its_own_order_and_only_the_frozen_fields(
         self, pool, client: AsyncClient
@@ -381,7 +381,7 @@ class TestBrowserReturnObservationOwnership:
             json={"return_nonce": "n" * 20},
         )
         assert resp.status_code == 404
-        assert resp.json()["detail"]["code"] == "ORDER_NOT_FOUND"
+        assert resp.json()["code"] == "ORDER_NOT_FOUND"
 
         row = await pool.fetchrow(
             "SELECT browser_observation, browser_return_nonce FROM garuda_orders WHERE order_id = $1",
@@ -437,7 +437,7 @@ class TestCreateOrderOwnership:
             },
         )
         assert resp.status_code == 404
-        assert resp.json()["detail"]["code"] == "RESULT_NOT_FOUND"
+        assert resp.json()["code"] == "RESULT_NOT_FOUND"
 
         count = await pool.fetchval(
             "SELECT count(*) FROM garuda_orders WHERE result_id_ref = $1", "result-b-create-0000000"
@@ -537,7 +537,7 @@ class TestDbPoolDegradationIsFiveOhThreeNotFiveHundred:
             cookies={_SESSION_COOKIE: raw_secret},
         )
         assert resp.status_code == 503, resp.text
-        assert resp.json()["detail"]["code"] == "SERVICE_UNAVAILABLE"
+        assert resp.json()["code"] == "SERVICE_UNAVAILABLE"
 
     async def test_explicit_none_garuda_db_pool_is_503_not_500(
         self, pool, magic_link_store: PostgresMagicLinkStore, repository: GarudaOrderRepository
@@ -556,7 +556,7 @@ class TestDbPoolDegradationIsFiveOhThreeNotFiveHundred:
             cookies={_SESSION_COOKIE: raw_secret},
         )
         assert resp.status_code == 503, resp.text
-        assert resp.json()["detail"]["code"] == "SERVICE_UNAVAILABLE"
+        assert resp.json()["code"] == "SERVICE_UNAVAILABLE"
 
 
 # ============================================================
@@ -635,7 +635,7 @@ class TestTrackerDoesNotDependOnThePaymentProvider:
             f"wired: {resp.text}. A paid customer cannot see their own order because a "
             "credential they never touch is absent."
         )
-        assert resp.json()["detail"]["code"] == "ORDER_NOT_FOUND"
+        assert resp.json()["code"] == "ORDER_NOT_FOUND"
 
     async def test_creating_an_order_still_503s_without_the_repository(
         self, pool, magic_link_store: PostgresMagicLinkStore
@@ -671,4 +671,4 @@ class TestTrackerDoesNotDependOnThePaymentProvider:
             cookies={_SESSION_COOKIE: raw_secret},
         )
         assert resp.status_code == 503, resp.text
-        assert resp.json()["detail"]["code"] == "SERVICE_UNAVAILABLE"
+        assert resp.json()["code"] == "SERVICE_UNAVAILABLE"

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_staff_actor_async_verifier.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_staff_actor_async_verifier.py
@@ -92,7 +92,7 @@ class TestStaffActorAsyncVerifierIsAwaited:
                 json={"resolution": "honoured", "staff_reference": "ref-1"},
             )
         assert resp.status_code == 401
-        assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
+        assert resp.json()["code"] == "SESSION_REQUIRED"
 
     async def test_no_verifier_wired_is_still_401(self) -> None:
         """Baseline: today's actual production state (nothing wired) must
@@ -110,7 +110,7 @@ class TestStaffActorAsyncVerifierIsAwaited:
                 json={"resolution": "honoured", "staff_reference": "ref-1"},
             )
         assert resp.status_code == 401
-        assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
+        assert resp.json()["code"] == "SESSION_REQUIRED"
 
     async def test_missing_authorization_header_is_401(self) -> None:
         app = _make_app(verifier=_async_verifier_returns_none)
@@ -122,4 +122,4 @@ class TestStaffActorAsyncVerifierIsAwaited:
                 json={"resolution": "honoured", "staff_reference": "ref-1"},
             )
         assert resp.status_code == 401
-        assert resp.json()["detail"]["code"] == "SESSION_REQUIRED"
+        assert resp.json()["code"] == "SESSION_REQUIRED"

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_flag_ordering.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_flag_ordering.py
@@ -100,15 +100,16 @@ def test_dark_by_flag_beats_body_validation_and_repository_wiring(
         f"anonymous existence-and-liveness oracle on a route this same PR "
         f"is adding to the public allowlist."
     )
-    # Two contract-error-body shapes coexist on purpose here, and unifying
-    # them is a separate, out-of-scope concern from this test's ordering
-    # claim: `garuda_voa_public.py` / `garuda_portal_auth.py` use the
-    # `_ContractErrorRoute` + `_error()` shape (`{"code": ..., ...}` at the
-    # top level); `garuda_orders_router.py` raises a bare `HTTPException`,
-    # whose default FastAPI envelope nests the same payload under
-    # `"detail"`. Both are asserted here because this test's job is
-    # "flag beats body validation and repository wiring", not "all three
-    # GARUDA routers share one error envelope".
+    # CORRECTED: all three GARUDA lanes now share one error envelope.
+    # `garuda_orders_router.py` used to raise a bare `HTTPException`, whose
+    # default FastAPI envelope nests the payload under `"detail"` instead of
+    # the contract's flat top-level shape — fixed by giving it its own
+    # `_ContractErrorRoute` (garuda_orders_router.py, mirroring
+    # `garuda_voa_public.py`'s) that catches `HTTPException` and rewrites it
+    # through `_error()`. The `body.get("detail") or {}` fallback is kept
+    # only so this test doesn't regress silently if a FOURTH lane is ever
+    # added here before it gets the same treatment — every GARUDA route this
+    # test currently exercises answers at the top level.
     body = response.json()
     code = body.get("code") or (body.get("detail") or {}).get("code")
     assert code == "GARUDA_PUBLIC_DISABLED", body


### PR DESCRIPTION
## Summary

`garuda_orders_router.py` (GARUDA VOA L3 — checkout/orders) raises 28 bare
`HTTPException(status_code=X, detail={"code": ..., "retryable": ...})`
across a router-level dependency, a parameter dependency, plain helper
coroutines, and its 5 handler bodies. Every one of them:

- broke the frozen contract's envelope — FastAPI's default shape nests
  the payload under `"detail"`, while `products/garuda-voa/contracts/errors.yaml`
  declares a flat `{"code", "retryable", "message_key"}` body (the shape
  L2's `garuda_voa_public.py` already gets right);
- lost the 3 privacy headers (`Cache-Control`, `Referrer-Policy`,
  `X-Robots-Tag`) success responses get, because raising builds a brand-new
  `Response` via FastAPI's own exception handling, never the `response`
  object handlers mutate.

## What changed

- Censused all raise sites: **28** `raise HTTPException(...)` (not the ~28
  estimate handed off — verified with `grep -c`), covering **14 distinct
  error codes**. Cross-checked every one against
  `products/garuda-voa/contracts/errors.yaml`: all 14 already used the
  exact contract status code + `retryable`, so **none needed changing** —
  this is purely a response-construction fix, no status/code drift.
- Added a local `_ContractErrorRoute` (same shape as `garuda_voa_public.py`'s,
  kept as a per-file copy per LANES.md file-ownership discipline, not a
  shared import) that catches `HTTPException`, reads `detail["code"]`,
  looks it up in a new `_ERROR_CATALOG`, and rewrites the response via a new
  `_error()` helper — which reuses the router's existing `_privacy_headers()`
  helper rather than duplicating a header dict.
- This catches every one of the 28 sites uniformly (router-level dep,
  parameter dep, or handler body — all execute inside the same per-route
  dispatch our route class wraps), so none of the 28 `raise` statements
  themselves needed touching — lower risk than converting each site to
  `return _error(...)` by hand, with the same net effect.
- Updated the 2 existing tests that asserted the old nested
  `resp.json()["detail"]["code"]` shape (`test_garuda_orders_ownership.py`,
  `test_garuda_staff_actor_async_verifier.py`) to the new flat shape, and
  corrected a comment in `test_garuda_voa_flag_ordering.py` that described
  the now-removed shape divergence between L2 and L3.
- New `test_garuda_orders_envelope.py`: 3 representative error paths (401
  SESSION_REQUIRED / authz, 422 INVALID_REQUEST / validation, 503
  SERVICE_UNAVAILABLE), each asserting the flat envelope AND the privacy
  headers. None need Postgres (fakes throughout, same pattern as
  `test_garuda_staff_actor_async_verifier.py`).

## Test plan

- [x] Red-before: reverted just the router change, ran the new test file →
      6/6 failed with the exact defect described (nested `detail`, no
      privacy headers).
- [x] Green-after: restored the fix → 6/6 pass.
- [x] `test_garuda_staff_actor_async_verifier.py`, `test_garuda_voa_flag_ordering.py`,
      `test_garuda_public_enabled_readers_agree.py`, `test_webhook_router.py`,
      `test_garuda_portal_auth_mounted.py`, `test_api_process_wires_the_state_its_routers_read.py`
      — 32 passed, 0 failed (no Postgres required).
- [x] `ruff check` + `ruff format --check` clean on all changed files.
- [ ] `test_garuda_orders_ownership.py` and `test_funnel_end_to_end_http.py`
      (Postgres-backed) could not be run locally: this machine's local
      `nuzantara_test` DB is missing `garuda_account_sessions` /
      `garuda_voa_check_idempotency` (migrations not applied) — reproduced
      as pre-existing by stashing this PR's router change and hitting the
      identical `UndefinedTableError`, so it is not a regression from this
      diff. `test_garuda_orders_ownership.py`'s assertions were still
      updated by inspection (mechanical `["detail"]["code"]` →
      `["code"]`); CI's Postgres has the migrations applied and is the
      real gate for that file.

Not armed for auto-merge — leaving that to the conductor's independent
review per the ship-lifecycle rule (generator ≠ grader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142VSuDn5fqCvckyb4JMeYz