### PR TITLE
fix(garuda-voa): contract-parity gate checked only 3 of 13 declared operations

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_orders_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_orders_router.py
@@ -293,7 +293,67 @@ def _idempotency_key(idempotency_key: str | None) -> str:
     return idempotency_key
 
 
-@router.post("/orders", status_code=201)
+#: Status codes THIS router's own call sites (plus the router-level
+#: `_require_flag` dependency and the top-level exception handler /
+#: rate-limit middleware every route shares) can genuinely produce today,
+#: per operation. Documentation only, changes no behaviour — without this,
+#: FastAPI only knows each decorator's own success `status_code` plus its
+#: automatic 422, which is the exact drift class
+#: `test_garuda_voa_openapi_parity.py` measured for this router on
+#: 2026-08-30 (the same disease that file's docstring already describes for
+#: `garuda_voa_public.py`, reproduced here for L3).
+#:
+#: Three of these five sets are deliberately NOT a full transcription of the
+#: frozen contract's declared codes for that operationId — the gaps are
+#: real, separate defects (not an OpenAPI-documentation oversight), and
+#: documenting a status this router cannot yet produce would be exactly the
+#: false-schema-entry mistake `garuda_voa_public.py::_error_responses`'s
+#: docstring warns against. Each omission is named, cited, and pinned by
+#: `_KNOWN_STATUS_CODE_GAPS` in the parity test rather than silently closed
+#: here:
+#:   - `observePaymentBrowserReturn` has no `409` — `GarudaOrderRepository.
+#:     record_browser_return_observation` (repository.py) unconditionally
+#:     overwrites `browser_return_nonce` on a mismatch instead of raising an
+#:     `IdempotencyConflict`, so the contract's declared conflict code can
+#:     never fire.
+#:   - `receivePaymentWebhook` has no `202`/`400`/`409` — `202` (quarantine)
+#:     is a response shape this handler's body never constructs, and
+#:     `400`/`409` are Idempotency-Key-shaped codes for a parameter this
+#:     operation deliberately stopped taking (see the handler's own comment
+#:     above); the frozen contract's `responses` block was not updated to
+#:     match, and this module never edits the contract.
+#:   - `resolveLateOrder` has no `403` — `_require_staff_actor` only ever
+#:     returns 401 or a verified actor (see its docstring: the real staff
+#:     authority verifier is "wired nowhere today"), so `ACCESS_DENIED` has
+#:     no code path that can raise it yet.
+_OPERATION_STATUS_CODES: dict[str, tuple[int, ...]] = {
+    "createOrderFromCheck": (400, 401, 404, 409, 422, 429, 500, 503),
+    "getOrderAndPractice": (401, 404, 500, 503),
+    "observePaymentBrowserReturn": (400, 401, 404, 422, 500, 503),
+    "receivePaymentWebhook": (401, 404, 422, 500, 503),
+    "resolveLateOrder": (400, 401, 404, 409, 422, 500, 503),
+}
+
+
+def _status_responses(operation_id: str) -> dict[int, dict[str, object]]:
+    """Build a minimal FastAPI `responses=` dict from `_OPERATION_STATUS_CODES`
+    — status codes only, no message-key detail, since this router raises bare
+    `HTTPException(detail={"code": ..., "retryable": ...})` rather than the
+    catalog-driven `_error()` helper `garuda_voa_public.py`/`garuda_portal_
+    auth.py` use (see PR #5300 for the in-flight fix to this router's error
+    envelope itself — orthogonal to this OpenAPI-schema-documentation fix)."""
+    return {
+        status_code: {"description": "See `products/garuda-voa/contracts/errors.yaml`."}
+        for status_code in _OPERATION_STATUS_CODES[operation_id]
+    }
+
+
+@router.post(
+    "/orders",
+    status_code=201,
+    operation_id="createOrderFromCheck",
+    responses=_status_responses("createOrderFromCheck"),
+)
 async def create_order_from_check(
     request: Request,
     response: Response,
@@ -377,7 +437,11 @@ async def create_order_from_check(
     return body_out
 
 
-@router.get("/orders/{order_id}")
+@router.get(
+    "/orders/{order_id}",
+    operation_id="getOrderAndPractice",
+    responses=_status_responses("getOrderAndPractice"),
+)
 async def get_order_and_practice(
     order_id: str,
     request: Request,
@@ -429,7 +493,12 @@ async def get_order_and_practice(
     return body_out
 
 
-@router.post("/orders/{order_id}/browser-return-observations", status_code=204)
+@router.post(
+    "/orders/{order_id}/browser-return-observations",
+    status_code=204,
+    operation_id="observePaymentBrowserReturn",
+    responses=_status_responses("observePaymentBrowserReturn"),
+)
 async def observe_payment_browser_return(
     order_id: str,
     request: Request,
@@ -454,7 +523,12 @@ async def observe_payment_browser_return(
         ) from exc
 
 
-@router.post("/webhooks/payment", status_code=204)
+@router.post(
+    "/webhooks/payment",
+    status_code=204,
+    operation_id="receivePaymentWebhook",
+    responses=_status_responses("receivePaymentWebhook"),
+)
 async def receive_payment_webhook(
     request: Request,
     response: Response,
@@ -510,7 +584,11 @@ async def receive_payment_webhook(
         await repository.handle_refund_event(event, canonical_payload_sha256=digest)
 
 
-@router.post("/staff/orders/{order_id}/late-resolution")
+@router.post(
+    "/staff/orders/{order_id}/late-resolution",
+    operation_id="resolveLateOrder",
+    responses=_status_responses("resolveLateOrder"),
+)
 async def resolve_late_order(
     order_id: str,
     request: Request,

--- a/apps/backend-rag/backend/app/routers/garuda_portal_auth.py
+++ b/apps/backend-rag/backend/app/routers/garuda_portal_auth.py
@@ -128,6 +128,56 @@ def _error(code: str) -> JSONResponse:
     return response
 
 
+#: Per-operation error-code membership — identical rationale and shape to
+#: `garuda_voa_public.py`'s twin (duplicated, not imported, per LANES.md
+#: file-ownership discipline). `RATE_LIMITED`/`INTERNAL_ERROR` are included
+#: for both operations even where no call site below raises them directly:
+#: they are cross-cutting (rate-limit middleware, the top-level exception
+#: handler) per that same established convention. Never hand-typed status
+#: codes elsewhere: `_error_responses()` below always derives from
+#: `_ERROR_CATALOG` through this map.
+_OPERATION_ERROR_CODES: dict[str, tuple[str, ...]] = {
+    "requestMagicLink": (
+        "IDEMPOTENCY_KEY_REQUIRED",
+        "GARUDA_PUBLIC_DISABLED",
+        "IDEMPOTENCY_CONFLICT",
+        "INVALID_REQUEST",
+        "RATE_LIMITED",
+        "INTERNAL_ERROR",
+        "PERSISTENCE_POLICY_UNAVAILABLE",
+    ),
+    "exchangeMagicLink": (
+        "IDEMPOTENCY_KEY_REQUIRED",
+        "MAGIC_LINK_INVALID",
+        "GARUDA_PUBLIC_DISABLED",
+        "IDEMPOTENCY_CONFLICT",
+        "INVALID_REQUEST",
+        "RATE_LIMITED",
+        "INTERNAL_ERROR",
+        "PERSISTENCE_POLICY_UNAVAILABLE",
+    ),
+}
+
+
+def _error_responses(operation_id: str) -> dict[int | str, dict[str, object]]:
+    """Build a FastAPI `responses=` dict for `operation_id` from
+    `_ERROR_CATALOG`, grouped by HTTP status — documentation only, changes no
+    behaviour. Identical shape to `garuda_voa_public.py`'s twin.
+
+    Measured 2026-08-30 (`test_garuda_voa_openapi_parity.py` widening): without
+    this, neither route below documented anything past the decorator's own
+    success code and the framework's automatic 422 — the exact drift that
+    test file's docstring already describes for L2, reproduced here for L4.
+    """
+    by_status: dict[int, list[str]] = {}
+    for code in _OPERATION_ERROR_CODES[operation_id]:
+        status_code, _retryable, _message_key = _ERROR_CATALOG[code]
+        by_status.setdefault(status_code, []).append(code)
+    return {
+        status_code: {"description": " / ".join(codes)} for status_code, codes in by_status.items()
+    }
+
+
 def _public_enabled() -> bool:
     return os.environ.get(_FEATURE_FLAG_ENV, "").strip().lower() in {"1", "true", "yes"}
 
@@ -301,6 +351,7 @@ def _set_account_session_cookie(response: Response, request: Request, secret: st
     "/magic-links",
     operation_id="requestMagicLink",
     status_code=202,
+    responses=_error_responses("requestMagicLink"),
 )
 async def request_magic_link(
     payload: MagicLinkRequest,
@@ -390,6 +441,7 @@ async def request_magic_link(
     "/sessions",
     operation_id="exchangeMagicLink",
     status_code=204,
+    responses=_error_responses("exchangeMagicLink"),
 )
 async def exchange_magic_link(
     request: Request,
@@ -439,9 +491,7 @@ async def exchange_magic_link(
     # magic_link_expired / magic_link_replay / magic_link_invalid, the HTTP
     # shape below is byte-identical: one 401, no other field.
     if not outcome.authorized:
-        logger.info(
-            "garuda_portal_auth: exchange denied (counter=%s)", outcome.security_counter
-        )
+        logger.info("garuda_portal_auth: exchange denied (counter=%s)", outcome.security_counter)
         return _error("MAGIC_LINK_INVALID")
 
     # Refuter finding #8: a store MUST NOT report authorized=True on a FRESH
@@ -455,9 +505,7 @@ async def exchange_magic_link(
         )
         return _error("INTERNAL_ERROR")
 
-    logger.info(
-        "garuda_portal_auth: exchange authorized (counter=%s)", outcome.security_counter
-    )
+    logger.info("garuda_portal_auth: exchange authorized (counter=%s)", outcome.security_counter)
     result = Response(status_code=204)
     result.headers.update(_PRIVACY_HEADERS)
     result.headers["Idempotency-Replayed"] = "true" if outcome.idempotency_replayed else "false"

--- a/apps/backend-rag/backend/app/routers/garuda_voa_public.py
+++ b/apps/backend-rag/backend/app/routers/garuda_voa_public.py
@@ -64,6 +64,7 @@ from backend.services.garuda_flow.public_api import (
 
 logger = get_logger(__name__)
 
+
 class _FeatureDisabled(Exception):
     """Sentinel raised by the router-level `_require_public_enabled`
     dependency below — see that function's docstring for why this exists
@@ -242,8 +243,7 @@ def _error_responses(operation_id: str) -> dict[int | str, dict[str, object]]:
         status_code, _retryable, _message_key = _ERROR_CATALOG[code]
         by_status.setdefault(status_code, []).append(code)
     return {
-        status_code: {"description": " / ".join(codes)}
-        for status_code, codes in by_status.items()
+        status_code: {"description": " / ".join(codes)} for status_code, codes in by_status.items()
     }
 
 
@@ -278,7 +278,20 @@ def _error_responses(operation_id: str) -> dict[int | str, dict[str, object]]:
 # existing wrapper, never replacing one. `create_app()` already has exactly
 # this pattern for a different reason (`_openapi_with_visa_decision_conditionals`)
 # — this reuses that shape rather than inventing a new one.
-_NO_VALIDATION_ERROR_OPERATIONS = frozenset({"getEligibilityResult", "deleteEligibilityResult"})
+#
+# `getOrderAndPractice` (L3, `garuda_orders_router.py`) joined this set
+# 2026-08-30: identical shape — `order_id: str` is a bare, unconstrained path
+# capture validated by hand inside the handler (ownership-filtered query),
+# never a Pydantic path constraint — so FastAPI's blanket "any parameterized
+# route gets a 422" default fires there for exactly the same unreachable
+# reason as the two operations below. Measured by
+# `test_garuda_voa_openapi_parity.py`'s widened parity check, which is the
+# only place that noticed this router's schema at all before 2026-08-30 (see
+# that module's own docstring for L3's status-code documentation gap more
+# broadly).
+_NO_VALIDATION_ERROR_OPERATIONS = frozenset(
+    {"getEligibilityResult", "deleteEligibilityResult", "getOrderAndPractice"}
+)
 
 
 def strip_unreachable_validation_errors(schema: dict) -> dict:

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_openapi_parity.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_openapi_parity.py
@@ -59,12 +59,47 @@ skip — this repo already has one gate that skipped by exactly this
 mechanism (`products/garuda-voa/contracts/tests/test_contract_invariants.py`
 before its own hardening) and one instance of that pattern in a live
 codebase is the whole lesson.
+
+Widened 2026-08-30 (team-lead F1 mandate, PR #4959's gate-completeness
+follow-up): `_MOUNTED_OPERATION_IDS` used to be a hand-typed 3-item
+allowlist covering only `garuda_voa_public.py`'s three operations — a gate
+that "passes even if code and contract diverge on everything not in that
+list." Measured that day: the frozen contract declares **13** operations;
+**10** of them are genuinely mounted (this router's 3, plus L4
+`garuda_portal_auth.py`'s `requestMagicLink`/`exchangeMagicLink`, plus L3
+`garuda_orders_router.py`'s `createOrderFromCheck`/`getOrderAndPractice`/
+`observePaymentBrowserReturn`/`receivePaymentWebhook`/`resolveLateOrder`) and
+**3** have no router at all (`uploadIntakeDocument`, `listIntakeDocuments`,
+`transitionPractice`). None of the 7 L3/L4 operations were checked before
+this widening — 5 of them were not even *resolvable* by operationId (their
+decorators never set `operation_id=`, so FastAPI auto-generated one from the
+Python function name), and the 2 that were resolvable (`requestMagicLink`/
+`exchangeMagicLink`) had the identical missing-`responses=` disease this
+file's docstring already described for L2. Both routers were fixed
+alongside this widening (`garuda_orders_router.py` and
+`garuda_portal_auth.py`; `garuda_voa_public.py`'s `_NO_VALIDATION_ERROR_
+OPERATIONS` gained `getOrderAndPractice`, the same bare-`str`-path-param
+auto-422 already described above for L2).
+
+Three of the 10 mounted operations still do not fully match the frozen
+contract after that fix, for reasons that are real, separate product
+defects — not test-file bugs, and not fixable by touching this test file,
+a `responses=` kwarg, or the frozen contract (which every router's own
+docstring says none of them may edit). `_KNOWN_STATUS_CODE_GAPS` below
+names each one explicitly, cites the exact code path (or absence of one)
+responsible, and is guarded (`test_known_status_code_gaps_are_still_true`)
+so a future fix to the underlying defect — closing the gap without updating
+this dict — fails the suite rather than silently going unnoticed the other
+way. This mirrors, for a second kind of gap, the same "explicit + guarded,
+never silent" discipline `_NOT_YET_BUILT_OPERATION_IDS` already applies to
+the 3 never-mounted operations.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 # Importing this module BUILDS the deployed `main_api` FastAPI app as a
@@ -76,24 +111,7 @@ import yaml
 from backend.app import main_api as _main_api_module
 
 _CONTRACT_PATH = (
-    Path(__file__).resolve().parents[6]
-    / "products"
-    / "garuda-voa"
-    / "contracts"
-    / "openapi.yaml"
-)
-
-# operationIds this router MOUNTS today (garuda_voa_public.py module
-# docstring: "Implements exactly three operations"). Everything else the
-# frozen contract declares (magic-link, intake documents, orders, webhooks,
-# staff practice transitions) belongs to a lane with no router landed yet —
-# the contract is contract-first and is allowed to be ahead of the build.
-_MOUNTED_OPERATION_IDS = frozenset(
-    {
-        "createEligibilityCheck",
-        "getEligibilityResult",
-        "deleteEligibilityResult",
-    }
+    Path(__file__).resolve().parents[6] / "products" / "garuda-voa" / "contracts" / "openapi.yaml"
 )
 
 
@@ -150,13 +168,143 @@ def _live_operations() -> dict[str, tuple[str, str, set[str]]]:
     return _operations_by_id(_main_api_module.app.openapi())
 
 
+def _live_path_methods() -> set[tuple[str, str]]:
+    """Every (path, HTTP method) the live app answers, independent of
+    operationId — used only to prove a NOT-YET-BUILT operation is genuinely
+    absent (an operationId-keyed lookup would trivially "miss" a route that
+    exists under some OTHER operationId at that same path/method, which is
+    not the claim this guard needs to prove)."""
+    out: set[tuple[str, str]] = set()
+    schema = _main_api_module.app.openapi()
+    for path, methods in schema["paths"].items():
+        if not isinstance(methods, dict):
+            continue
+        for method, op in methods.items():
+            if isinstance(op, dict):
+                out.add((path, method.upper()))
+    return out
+
+
+# operationIds the frozen contract declares that NO router file exposes a
+# path for at all today (measured 2026-08-30 via `_live_path_methods()`
+# against every path `_frozen_schema()` declares) — magic-link/customer-
+# intake/payment/staff-practice lanes ahead of a router landing, per
+# `products/garuda-voa/LANES.md`. Contract-first is allowed to be ahead of
+# the build; what is NOT allowed is this fact going unverified. Guarded by
+# `test_declared_not_yet_built_operations_are_genuinely_absent_from_the_live_app`
+# below — if a future PR mounts a router for one of these paths, that test
+# starts failing, forcing the operationId out of this set (removing it here
+# is sufficient: it then falls into `_MOUNTED_OPERATION_IDS` automatically
+# and gets full status-parity coverage from the parametrized test, with zero
+# new test code required).
+_NOT_YET_BUILT_OPERATION_IDS = frozenset(
+    {
+        "uploadIntakeDocument",
+        "listIntakeDocuments",
+        "transitionPractice",
+    }
+)
+
+# Mounted operations whose live status-code set does not fully match the
+# frozen contract for reasons that are real, separate product defects — see
+# the module docstring's "Widened 2026-08-30" paragraph for the one-line
+# summary of each. Each entry names EXACTLY the codes the frozen contract
+# declares that the live router cannot yet produce; nothing here is a status
+# code the live schema is missing merely for lack of `responses=`
+# documentation (`_assert_status_parity` below folds these into the live set
+# before comparing, so real drift beyond what is named here still fails the
+# suite). Guarded by `test_known_status_code_gaps_are_still_true`: if the
+# underlying defect is fixed and the code path starts producing one of these
+# statuses, that guard fails, forcing the fix's PR to shrink this entry (or
+# remove it, once its set is empty) rather than leaving a stale exemption
+# that quietly stops checking anything.
+_KNOWN_STATUS_CODE_GAPS: dict[str, frozenset[str]] = {
+    # `GarudaOrderRepository.record_browser_return_observation`
+    # (repository.py) unconditionally overwrites `browser_return_nonce` on a
+    # mismatch instead of raising `IdempotencyConflict` — the contract's
+    # declared 409 IDEMPOTENCY_CONFLICT has no code path that can raise it.
+    "observePaymentBrowserReturn": frozenset({"409"}),
+    # `receive_payment_webhook` (garuda_orders_router.py) never constructs a
+    # 202 (the quarantine response shape) and deliberately stopped reading
+    # Idempotency-Key (see that handler's own comment) — the frozen
+    # contract's `responses` block for 400/409 was not updated to match when
+    # the parameter was removed, and this module never edits the contract.
+    "receivePaymentWebhook": frozenset({"202", "400", "409"}),
+    # `_require_staff_actor` (garuda_orders_router.py) only ever returns 401
+    # or a verified actor — the real staff-authority verifier is "wired
+    # nowhere today" per that function's own docstring, so ACCESS_DENIED (403)
+    # has no code path that can raise it yet.
+    "resolveLateOrder": frozenset({"403"}),
+}
+
+# Derived, not hand-typed: every frozen operationId except the ones
+# EXPLICITLY declared not-yet-built above. A newly-mounted contract
+# operation is automatically included here (and therefore automatically
+# gets full parity coverage from the parametrized test below) the moment its
+# operationId stops appearing in `_NOT_YET_BUILT_OPERATION_IDS` — nobody has
+# to remember to add it to a second list.
+_MOUNTED_OPERATION_IDS: frozenset[str] = (
+    frozenset(_operations_by_id(_frozen_schema())) - _NOT_YET_BUILT_OPERATION_IDS
+)
+
+
 def test_contract_file_is_readable_and_declares_mounted_operations():
     """Guilt+innocence anchor for the fixture itself (cicatrix #6/#2): if this
-    fails, the two parametrized tests below would otherwise report a
+    fails, the parametrized parity test below would otherwise report a
     misleading per-operation KeyError instead of "the fixture is broken"."""
     frozen_ops = _operations_by_id(_frozen_schema())
     missing = _MOUNTED_OPERATION_IDS - frozen_ops.keys()
     assert not missing, f"frozen contract no longer declares: {sorted(missing)}"
+
+
+def test_declared_not_yet_built_operations_are_genuinely_absent_from_the_live_app():
+    """Guard for `_NOT_YET_BUILT_OPERATION_IDS` (cicatrix #3 discipline: a
+    static allowlist needs a test that fails when it goes stale, not a
+    silence). If a future PR mounts a router that answers one of these
+    paths, this test starts failing — the fix is to remove that operationId
+    from `_NOT_YET_BUILT_OPERATION_IDS`, which automatically moves it into
+    `_MOUNTED_OPERATION_IDS` and under full status-parity coverage."""
+    frozen_ops = _operations_by_id(_frozen_schema())
+    live_pairs = _live_path_methods()
+    for operation_id in _NOT_YET_BUILT_OPERATION_IDS:
+        path, method, _codes = frozen_ops[operation_id]
+        assert (path, method) not in live_pairs, (
+            f"{operation_id}: declared NOT YET BUILT in this test file, but "
+            f"{method} {path} now answers live — move it out of "
+            f"_NOT_YET_BUILT_OPERATION_IDS so it gets real parity coverage"
+        )
+
+
+def test_known_status_code_gaps_are_declared_only_for_mounted_operations():
+    """Guilt+innocence anchor for `_KNOWN_STATUS_CODE_GAPS`: every key must
+    be a real mounted operation (never one already covered by
+    `_NOT_YET_BUILT_OPERATION_IDS` — those two lists are disjoint by
+    construction, and a name in both would mean one of them is wrong)."""
+    declared = set(_KNOWN_STATUS_CODE_GAPS)
+    assert declared <= _MOUNTED_OPERATION_IDS, (
+        f"_KNOWN_STATUS_CODE_GAPS names operation(s) not in "
+        f"_MOUNTED_OPERATION_IDS: {sorted(declared - _MOUNTED_OPERATION_IDS)}"
+    )
+
+
+def test_known_status_code_gaps_are_still_true():
+    """The other half of the guard: each declared-missing code must
+    genuinely be ABSENT from the live schema today. If a fix lands that
+    makes one of these codes reachable without updating
+    `_KNOWN_STATUS_CODE_GAPS`, this fails — the parametrized parity test
+    below would otherwise silently start passing on a narrower comparison
+    than the contract actually requires, exactly the "gate that stops
+    checking and nobody notices" failure mode this whole file exists to
+    prevent."""
+    live_ops = _live_operations()
+    for operation_id, missing_codes in _KNOWN_STATUS_CODE_GAPS.items():
+        _path, _method, live_codes = live_ops[operation_id]
+        overlap = missing_codes & live_codes
+        assert not overlap, (
+            f"{operation_id}: _KNOWN_STATUS_CODE_GAPS declares {sorted(overlap)} "
+            f"as unreachable, but the live schema now documents them — shrink "
+            f"or remove this entry instead of leaving a stale exemption"
+        )
 
 
 def test_live_router_exposes_every_mounted_operation():
@@ -165,16 +313,9 @@ def test_live_router_exposes_every_mounted_operation():
     assert not missing, f"live router no longer exposes: {sorted(missing)}"
 
 
-def test_live_status_codes_match_frozen_contract_for_create_eligibility_check():
-    _assert_status_parity("createEligibilityCheck")
-
-
-def test_live_status_codes_match_frozen_contract_for_get_eligibility_result():
-    _assert_status_parity("getEligibilityResult")
-
-
-def test_live_status_codes_match_frozen_contract_for_delete_eligibility_result():
-    _assert_status_parity("deleteEligibilityResult")
+@pytest.mark.parametrize("operation_id", sorted(_MOUNTED_OPERATION_IDS))
+def test_live_status_codes_match_frozen_contract(operation_id: str) -> None:
+    _assert_status_parity(operation_id)
 
 
 def _assert_status_parity(operation_id: str) -> None:
@@ -186,26 +327,35 @@ def _assert_status_parity(operation_id: str) -> None:
         f"{operation_id}: path/method drifted — "
         f"live={live_method} {live_path} frozen={frozen_method} {frozen_path}"
     )
-    assert live_codes == frozen_codes, (
-        f"{operation_id}: live status codes {sorted(live_codes)} != "
+    known_gap = _KNOWN_STATUS_CODE_GAPS.get(operation_id, frozenset())
+    reconciled_codes = live_codes | known_gap
+    assert reconciled_codes == frozen_codes, (
+        f"{operation_id}: live status codes {sorted(live_codes)} "
+        f"(+ declared gap {sorted(known_gap)}) != "
         f"frozen contract {sorted(frozen_codes)} — "
-        f"missing from live schema: {sorted(frozen_codes - live_codes)}, "
+        f"missing and NOT declared as a known gap: "
+        f"{sorted(frozen_codes - reconciled_codes)}, "
         f"advertised by live but not in contract: {sorted(live_codes - frozen_codes)}"
     )
 
 
-def test_unmounted_frozen_operations_are_counted_not_failed():
-    """The frozen contract legitimately declares ~10 operations no lane has
-    mounted a router for yet (magic-links, sessions, documents, orders,
-    webhooks, staff transitions). This test exists to make that count
-    VISIBLE — never to fail the build over it. If a future PR mounts one of
-    these, move its operationId into `_MOUNTED_OPERATION_IDS` above and add
-    a dedicated `_assert_status_parity` call for it; do not widen this
-    test's assertion to cover it implicitly."""
+def test_not_yet_built_operations_are_counted_not_silently_ignored():
+    """The frozen contract legitimately declares 3 operations no lane has
+    mounted a router for yet. This test exists to make that count VISIBLE
+    — never to fail the build over it — and to catch accidental double-
+    counting between the two tracked sets."""
     frozen_ops = _operations_by_id(_frozen_schema())
-    unmounted = sorted(set(frozen_ops) - _MOUNTED_OPERATION_IDS)
-    print(f"garuda-voa: {len(unmounted)} frozen operation(s) not yet mounted: {unmounted}")
-    assert len(frozen_ops) >= len(_MOUNTED_OPERATION_IDS), (
-        "frozen contract declares fewer operations than this router mounts — "
-        "the contract file itself regressed"
+    accounted = _MOUNTED_OPERATION_IDS | _NOT_YET_BUILT_OPERATION_IDS
+    assert accounted == frozen_ops.keys(), (
+        "every frozen operationId must land in exactly one of "
+        "_MOUNTED_OPERATION_IDS / _NOT_YET_BUILT_OPERATION_IDS — "
+        f"unaccounted: {sorted(frozen_ops.keys() - accounted)}, "
+        f"phantom (declared but not in the frozen contract): "
+        f"{sorted(accounted - frozen_ops.keys())}"
+    )
+    print(
+        f"garuda-voa: {len(_NOT_YET_BUILT_OPERATION_IDS)} frozen operation(s) "
+        f"not yet mounted: {sorted(_NOT_YET_BUILT_OPERATION_IDS)}; "
+        f"{len(_MOUNTED_OPERATION_IDS)} mounted and checked for status "
+        f"parity ({len(_KNOWN_STATUS_CODE_GAPS)} with a declared, guarded gap)"
     )


### PR DESCRIPTION
## Summary

`test_garuda_voa_openapi_parity.py`'s `_MOUNTED_OPERATION_IDS` was a
hand-typed 3-item allowlist covering only `garuda_voa_public.py`'s three
operations. It passed even if code and contract diverged on everything not
in that list — the exact class of self-limiting gate PR #4959's follow-up
mandate asked to close.

## Measured (F1 mandate)

The frozen contract (`products/garuda-voa/contracts/openapi.yaml`) declares
**13** operations. **10** are genuinely mounted:

- 3 already checked: `createEligibilityCheck`, `getEligibilityResult`,
  `deleteEligibilityResult` (`garuda_voa_public.py`)
- **7 never checked before this PR**: `requestMagicLink`/`exchangeMagicLink`
  (`garuda_portal_auth.py`, L4) and `createOrderFromCheck`/
  `getOrderAndPractice`/`observePaymentBrowserReturn`/
  `receivePaymentWebhook`/`resolveLateOrder` (`garuda_orders_router.py`, L3)

**3** have no router at all: `uploadIntakeDocument`, `listIntakeDocuments`,
`transitionPractice` — contract-first is allowed to be ahead of the build.

Of the 7 never-checked operations: 5 weren't even *resolvable* by
operationId (their decorators never set `operation_id=`, so FastAPI
auto-generated one from the Python function name — `create_order_from_
check_api_visa_voa_orders_post`, etc.), and the 2 that were resolvable
(`requestMagicLink`/`exchangeMagicLink`) had the identical missing-
`responses=` disease this file's docstring already described for L2.

## What changed

- **`garuda_portal_auth.py`**: added `_OPERATION_ERROR_CODES` +
  `_error_responses()` (same pattern as `garuda_voa_public.py`) so
  `requestMagicLink`/`exchangeMagicLink` document their real status codes.
- **`garuda_orders_router.py`**: added `operation_id=` to all 5 decorators
  (matching the contract exactly) and `responses=` documenting the codes
  each handler's own call sites can genuinely produce — orthogonal to
  #5300's error-envelope fix (rebased on top of it cleanly, no conflicts:
  that PR rewrites raise-site response *shape*, this one only touches
  decorator kwargs).
- **`garuda_voa_public.py`**: `getOrderAndPractice` joins
  `_NO_VALIDATION_ERROR_OPERATIONS` — same bare-`str`-path-param bogus-422
  already stripped for `getEligibilityResult`/`deleteEligibilityResult`.
- **Test file**: `_MOUNTED_OPERATION_IDS` is now **derived** — every frozen
  operationId minus an explicit, guarded `_NOT_YET_BUILT_OPERATION_IDS` (the
  3 above). A new test fails if any of those 3 ever start answering live,
  forcing them out of that set (which then gets them full parity coverage
  automatically — no new test code needed).

### The 3 that still don't fully match — real product gaps, not test-file bugs

`_KNOWN_STATUS_CODE_GAPS` names each explicitly, cites the exact cause, and
is guarded (`test_known_status_code_gaps_are_still_true`) so closing the gap
without updating the dict fails the suite:

- `observePaymentBrowserReturn` missing `409` — `GarudaOrderRepository.
  record_browser_return_observation` unconditionally overwrites a mismatched
  nonce instead of raising `IdempotencyConflict`.
- `receivePaymentWebhook` missing `202`/`400`/`409` — the handler never
  constructs a 202 (quarantine) response, and deliberately stopped reading
  `Idempotency-Key`; the frozen contract's `responses` block for 400/409
  was not updated to match when that parameter was removed. This module
  never edits the frozen contract.
- `resolveLateOrder` missing `403` — `_require_staff_actor` only ever
  returns 401 or a verified actor; the real staff-authority verifier is
  "wired nowhere today" per its own docstring, so `ACCESS_DENIED` has no
  code path yet.

None of these are fixable by touching the OpenAPI schema, the test file, or
the frozen contract (orchestrator-owned) — they need actual business-logic
decisions (conflict-detection semantics, quarantine response design, staff
authority model) out of scope for a contract-parity gate PR.

## Test plan

- [x] Red-before: reverted the 3 router files (kept the new test file),
      ran the suite → 9 failed / 7 passed, exactly the drift described
      above (5× KeyError on unresolvable operationId, 2× status-set
      mismatch on undocumented codes).
- [x] Green-after: restored the router fixes → 16 passed.
- [x] Guilt test: temporarily added `403` to `resolveLateOrder`'s
      documented codes without updating `_KNOWN_STATUS_CODE_GAPS` →
      `test_known_status_code_gaps_are_still_true` failed as designed;
      reverted.
- [x] Rebased onto fresh `origin/main` (post-#5300 merge) — no conflicts,
      16/16 still pass.
- [x] Adjacent suites unaffected: `test_garuda_orders_envelope.py`,
      `test_garuda_portal_auth_mounted.py`, `test_garuda_portal_auth.py`,
      `test_garuda_public_enabled_readers_agree.py`,
      `test_garuda_staff_actor_async_verifier.py`,
      `test_garuda_voa_flag_ordering.py`,
      `test_garuda_voa_public_root_allowlist.py`, `test_garuda_voa_public.py`,
      `test_mutating_routes_are_gated.py`, `test_webhook_router.py` — 100
      passed, 0 failed.
- [x] `test_garuda_orders_ownership.py` (Postgres-backed) errors locally
      with `UndefinedTableError` on `garuda_account_sessions` — pre-existing
      on this machine (missing migrations), already documented as such in
      #5300's own test plan; not a regression from this diff.
- [x] `ruff check` + `ruff format --check` clean on all 4 changed files.

Not armed for auto-merge — leaving that to the conductor's independent
review per the ship-lifecycle rule (generator ≠ grader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142VSuDn5fqCvckyb4JMeYz