### PR TITLE
fix(watchdog): portal_deadline_watchdog joined a users table that does not exist

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_portal_deadline_watchdog.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_portal_deadline_watchdog.py
@@ -10,6 +10,49 @@ import pytest
 from scripts.portal_deadline_watchdog import _format_message, _iter_due, _log_sent, run
 
 
+class _RecordingConnection:
+    """Captures every SQL string the watchdog sends, without hitting a real DB."""
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    async def fetch(self, sql, *args):
+        self.statements.append(sql)
+        return []
+
+
+class TestDueQueryTargetsARealTable:
+    """Pins the sibling defect to PR #5202's ``NotificationService`` fix.
+
+    That PR cured ``_get_team_leader_email``, which queried ``users`` — a
+    relation that does not exist in this database — and left a note that
+    this file carries three more identical ``JOIN users u`` occurrences.
+    Portal-login accounts are rows in ``team_members`` with
+    ``role='client'`` (``migration_031_client_portal.py`` extends
+    ``team_members`` with ``linked_client_id``/``portal_access`` for exactly
+    this purpose), never a separate ``users`` table.
+    """
+
+    @pytest.mark.asyncio
+    async def test_queries_team_members_and_never_the_absent_users_table(self) -> None:
+        conn = _RecordingConnection()
+
+        await _iter_due(conn)
+
+        assert len(conn.statements) == 1
+        sql = conn.statements[0].lower()
+        assert "team_members" in sql, "client portal accounts live in team_members"
+        assert "from users" not in sql, (
+            'relation "users" does not exist in this database — the sibling query in '
+            "notifications/service.py raised UndefinedTableError 362 times in 14 days "
+            "before PR #5202"
+        )
+        assert "join users" not in sql, (
+            "this file carried three JOIN users occurrences against the same "
+            "non-existent relation, called out by PR #5202 as unfixed"
+        )
+
+
 def test_format_message_mentions_label_and_date() -> None:
     due = date(2026, 6, 15)
     msg = _format_message("Visa expiry", due)

--- a/apps/backend-rag/scripts/portal_deadline_watchdog.py
+++ b/apps/backend-rag/scripts/portal_deadline_watchdog.py
@@ -36,6 +36,18 @@ logger = logging.getLogger("portal_deadline_watchdog")
 
 # ── Query selects users with WA opt-in who have a deadline within 30 days
 #    that hasn't already been WA-notified in the last 7 days.
+#
+# Portal-login accounts are NOT a separate `users` table — that relation does
+# not exist in this database (same defect PR #5202 cured on the sibling query
+# in notifications/service.py). Client portal accounts are rows in
+# `team_members` with `role='client'`: migration_031_client_portal.py extends
+# team_members with `linked_client_id`/`portal_access` for exactly this
+# purpose ("Extends team_members for client authentication"). The predicate
+# below mirrors the one live path that resolves this same entity —
+# magic_link_service.py's `role='client' AND active=true AND
+# portal_access=true AND linked_client_id IS NOT NULL` — rather than the
+# email-matching shape used for staff lookups, which does not apply here:
+# this join is by FK (`linked_client_id`), not by email string.
 _SELECT_DUE = """
 SELECT
     np.user_id,
@@ -51,7 +63,11 @@ JOIN (
            'Visa expiry'   AS label,
            c.visa_expiry   AS due_date
     FROM clients c
-    JOIN users u ON u.linked_client_id = c.id
+    JOIN team_members u
+        ON u.linked_client_id = c.id
+       AND u.role = 'client'
+       AND u.active = TRUE
+       AND u.portal_access = TRUE
     WHERE c.visa_expiry IS NOT NULL
       AND c.visa_expiry BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '30 days'
 
@@ -62,7 +78,11 @@ JOIN (
            'Passport expiry' AS label,
            c.passport_expiry AS due_date
     FROM clients c
-    JOIN users u ON u.linked_client_id = c.id
+    JOIN team_members u
+        ON u.linked_client_id = c.id
+       AND u.role = 'client'
+       AND u.active = TRUE
+       AND u.portal_access = TRUE
     WHERE c.passport_expiry IS NOT NULL
       AND c.passport_expiry BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '30 days'
 
@@ -74,7 +94,11 @@ JOIN (
            p.expiry_date::date AS due_date
     FROM practices p
     JOIN practice_types pt ON pt.id = p.practice_type_id
-    JOIN users u ON u.linked_client_id = p.client_id
+    JOIN team_members u
+        ON u.linked_client_id = p.client_id
+       AND u.role = 'client'
+       AND u.active = TRUE
+       AND u.portal_access = TRUE
     WHERE p.expiry_date IS NOT NULL
       AND (p.client_visible IS TRUE OR p.client_visible IS NULL)
       AND p.status NOT IN ('cancelled', 'rejected')


### PR DESCRIPTION
The same defect class PR #5202 cured in `notifications/service.py`, left standing in a sibling: `apps/backend-rag/scripts/portal_deadline_watchdog.py` joined `users` three times (lines 54, 65, 77). That table does not exist in this database — in production the notifications copy of this mistake raised `UndefinedTableError` 362 times in 14 days.

**The correct shape is NOT the one the notifications fix used**, and the lane that did this work said so instead of copying it. `_get_team_leader_email` matches `clients.assigned_to` (free text) against a staff e-mail, hence its case-insensitive compare. These three joins are an FK join resolving a *client's own portal login*, and client portal accounts live in `team_members` with `role = 'client'` — the store was extended for exactly this by `migration_031_client_portal.py` (`ALTER TABLE team_members ADD COLUMN IF NOT EXISTS linked_client_id INTEGER REFERENCES clients(id)`). The predicate now matches what `magic_link_service.py`, `auth.py` and `portal.py` already use for the same entity:

```sql
JOIN team_members u
    ON u.linked_client_id = c.id      -- p.client_id in the practices subquery
   AND u.role = 'client'
   AND u.active = TRUE
   AND u.portal_access = TRUE
```

**Verified against the live catalog** (read-only role, this session, not read from a migration file): `team_members` carries `linked_client_id integer`, `portal_access boolean`, `role varchar`, `active boolean`; there are 525 `role='client'` rows, 519 with `linked_client_id` and 524 with `portal_access`. Neither `active` nor `portal_access` is ever NULL on those rows, so `= TRUE` excludes nothing that `IS NOT FALSE` would have kept.

**Test**: `TestDueQueryTargetsARealTable` in `backend/tests/unit/scripts/test_portal_deadline_watchdog.py`, a recording fake connection modelled on `test_service_db_contracts.py`, asserting the emitted SQL contains `team_members` and never `from users` / `join users`. 6 passed.

Deterministic floor for this file set is 1.