### PR TITLE
feat(fleet): fleet_burst — account-sharded headless fan-out, with the executor that makes it bite (L09-PR2)

### DIFF
--- a/.github/workflows/fleet-burst-tests.yml
+++ b/.github/workflows/fleet-burst-tests.yml
@@ -1,0 +1,116 @@
+name: Fleet burst dispatcher tests
+
+# Executor for the corpus that proves `scripts/fleet_burst.sh` -- the account-sharded
+# headless fan-out that replaces the `fork`/`tmux`-pane shape behind scars W98 (lanes
+# writing zero bytes to disk) and W96 (ENXIO pty exhaustion with 94% of ptys free).
+#
+# WHY THIS FILE EXISTS, and why it ships in the same PR as the script
+# -------------------------------------------------------------------
+# Measured on this branch before writing it: `scripts-tests-sweep.yml` collects only
+# `test_*.py` through pytest -- a `.sh` file is invisible to pytest collection -- and its
+# sweep step is `continue-on-error: true` besides. So a shell corpus landed alone has NO
+# executor that can ever go red: superscar #2 (exists != armed), which is precisely the
+# defect wave 2 exists to stop. The wave's binding rule 3 is that "a future job will run
+# it" is not a consumer; the job ships in the same PR. This is that job.
+#
+# Same shape and rationale as `vercel-autopromote-tests.yml`,
+# `intake-review-reader-liveness.yml` and `tg-gateway.yml`: one small workflow named by
+# the script it proves, `paths:`-filtered so it starts on exactly the diffs that can
+# break it.
+#
+# Deliberately NOT added to branch-protection required contexts here -- that is a
+# repo-settings action, operator-gated per CLAUDE.md, and a required check that goes
+# permanently red blocks the whole merge queue (the siblings above carry the same
+# reasoning). It runs on every PR that touches the organ, which is what makes it bite.
+#
+# THE PATH FILTER IS THE ARMING SURFACE, so it lists every file this job's steps
+# actually bind -- not just the two the dispatcher is named after. A filter that omits
+# a bound file is a job that stays green by never starting, which is the same
+# exists-!=-armed defect one level up. Blind cross-family refutation (Codex GPT-5.6 sol)
+# caught two such omissions in the first draft of this file:
+#   - `scripts/lib/seat_state.sh` -- fleet_burst SOURCES it for liveness.
+#   - `infra/launchagents/wrappers/claude-cascade.sh` -- the seat-state corpus binds it
+#     directly and asserts against its dispatch loop and kill-switch polarity.
+#   - `scripts/tests/test_seat_state.sh` -- executed below, so a regression case added
+#     to it must schedule this job.
+# An earlier version of this comment claimed the filter covered "exactly the diffs that
+# can break it" while omitting two of them; that claim was false and is not restated.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/fleet_burst.sh"
+      - "scripts/tests/test_fleet_burst.sh"
+      - "scripts/lib/seat_state.sh"
+      - "scripts/tests/test_seat_state.sh"
+      - "infra/launchagents/wrappers/claude-cascade.sh"
+      - ".github/workflows/fleet-burst-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/fleet_burst.sh"
+      - "scripts/tests/test_fleet_burst.sh"
+      - "scripts/lib/seat_state.sh"
+      - "scripts/tests/test_seat_state.sh"
+      - "infra/launchagents/wrappers/claude-cascade.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fleet-burst-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+jobs:
+  fleet-burst-tests:
+    name: Fleet burst dispatcher tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # A syntax error in a dispatcher is a silent dead organ: the fan-out simply never
+      # happens and every lane reports nothing, which reads like "no work to do".
+      - name: The dispatcher still parses
+        run: bash -n scripts/fleet_burst.sh
+
+      # The corpus stubs seat_state.sh into a temp dir, so it neither reads the real
+      # fleet reports nor spawns a real `claude`. Its guilt case is the one that matters:
+      # more lanes than live seats must never resolve to one seat driving two lanes.
+      - name: One live seat per lane, never two lanes on one seat
+        run: bash scripts/tests/test_fleet_burst.sh --dry-run
+
+      # `test_seat_state.sh` case 14 compares the cascade's dispatch loop against
+      # `origin/main` byte-for-byte, so that ref has to exist. actions/checkout
+      # fetches a single commit by default and a PR build checks out the merge
+      # ref, so `origin/main` is NOT resolvable unless it is asked for -- the case
+      # would return non-zero for a MISSING REF rather than for a touched loop, a
+      # red that names the wrong cause and burns a Rule-8 round chasing it.
+      # Caught by blind cross-family refutation (Codex GPT-5.6 sol) on this file.
+      # depth=1 is enough: `git show <ref>:<path>` needs only that commit's tree.
+      - name: Make origin/main resolvable (the seat-state corpus compares against it)
+        run: git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
+
+      # zsh is NOT on ubuntu-latest, and the seat-state corpus has TWO cases that
+      # `return 0` with a printed SKIP when zsh is missing -- the cascade is a zsh
+      # script and the library is sourced from zsh, so those are the production-shell
+      # cases. Without this install the Bash cases pass, the zsh cases skip, the
+      # corpus exits 0 and this job reports SUCCESS over a real zsh-only regression:
+      # coverage theatre, and the exact shape this workflow exists to refuse.
+      # Caught by blind cross-family refutation (Codex GPT-5.6 sol). Same cure as
+      # immune-enforcement.yml, magazine-auto-assets.yml and organ-conformance.yml.
+      # The explicit `command -v` is the fail-closed half: a silently-failed install
+      # would put us straight back to skipping.
+      - name: zsh must be present, or the production-shell cases would silently skip
+        run: |
+          bash scripts/ci/apt_install.sh zsh zsh
+          command -v zsh >/dev/null || { echo "::error::zsh unavailable — the zsh cases would SKIP and this job would report green over them"; exit 1; }
+
+      # The library the dispatcher leans on for liveness. If seat_state ever answers
+      # wrongly, fleet_burst inherits the fault -- so its corpus runs on the same trigger.
+      # This is also the ONLY workflow in the repo that names this corpus: L09-PR1
+      # landed 26 shell checks with no executor at all (W108), so arming them here
+      # is not incidental coverage, it is the first time they can go red.
+      - name: The seat-state ledger it depends on is still honest
+        run: bash scripts/tests/test_seat_state.sh

--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -152,6 +152,7 @@ on:
       - manual - garuda voa arm
       - Deploy Backend to Fly.io
       - Fly.io Secrets Health Check
+      - Fleet burst dispatcher tests
       - Frontend Live Sentinel
       - Frontend typecheck (apps/mouth)
       - garuda-contract-parity

--- a/docs/plans/2026-08-29-beyond-sota-craft-wave/L09-multi-agent-orchestration-fleet-routing.md
+++ b/docs/plans/2026-08-29-beyond-sota-craft-wave/L09-multi-agent-orchestration-fleet-routing.md
@@ -85,8 +85,15 @@ a dry-run shows an exhausted seat actually skipped.
 
 ## PR-2: feat(fleet): fleet_burst — account-sharded headless fan-out
 
-**Files**: `scripts/fleet_burst.sh` [proposed], `scripts/tests/test_fleet_burst.sh` [proposed].
-**Gear**: 2
+**Files**: `scripts/fleet_burst.sh` [proposed], `scripts/tests/test_fleet_burst.sh` [proposed],
+`.github/workflows/fleet-burst-tests.yml` [proposed — added at build time: a `.sh` corpus has no
+consumer in this repo otherwise, since `scripts-tests-sweep.yml` collects only `test_*.py` and is
+`continue-on-error`, so wave-2 rule 3 puts the executor in this same PR].
+**Gear**: 2 as drafted, but the CI-recomputed floor for the diff as built is **3** — that workflow
+file is a hot-zone path, and the floor is computed from the diff, never chosen. Build to Gear 3
+(council journal + `xhigh`): `evidence_pack_lint.py --print-floor` is the authority, not this line.
+**Correction (2026-08-31, measured while building)**: PR-1 landed at `scripts/lib/seat_state.sh`,
+not `scripts/seat_state.sh` as this file's prose implies elsewhere.
 **Build**:
 
 - Deprecate `fork`/`tmux`-pane fan-out for >2 parallel Opus/Fable-class lanes (the W98/W96 shape);

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/brief.yml
@@ -1,0 +1,74 @@
+task_id: craft-f2-l09-pr2-fleet-burst
+gear: 3
+l_level: L2
+gate_class: opus
+council_run: journal.jsonl
+acceptance:
+  - text: "WHEN more lanes are requested than there are verified-LIVE seats, the dispatcher SHALL refuse before mapping any lane, and SHALL NOT emit a partial plan."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+  - text: "WHEN the same seat is offered twice, it SHALL be collapsed, so two lanes can never resolve to one seat."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+  - text: "WHERE a seat resolves EXHAUSTED or UNKNOWN, it SHALL NOT be assigned to a lane."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+  - text: "IF a real (non-dry-run) burst is requested with no seat broker, the dispatcher SHALL refuse rather than let every lane share one ambient credential."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+  - text: "WHILE a real burst is running, the number of live children SHALL never exceed --max-concurrency."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+  - text: "IF any value interpolated into a plan row carries a tab, newline or carriage return, the dispatcher SHALL refuse rather than emit a row a reader would silently truncate."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+  - text: "IF a caller supplies a fable model string, the dispatcher SHALL refuse (CLAUDE.md section 5, RULED 2026-08-20 — fable is manual-only)."
+    probe: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+
+objective: |
+  L09-PR2 of the beyond-SOTA craft wave (squad F', fleet & security): an
+  account-sharded headless fan-out that replaces the fork/tmux-pane shape behind
+  scars W98 (lanes writing zero bytes to disk) and W96 (ENXIO with 94% of ptys
+  free, cause undetermined).
+
+  scripts/fleet_burst.sh plans one distinct verified-LIVE seat per lane through
+  the L09-PR1 ledger (scripts/lib/seat_state.sh), holds a default ceiling of 3
+  simultaneous children, gives each lane its own CLAUDE_CONFIG_DIR and output
+  path, and refuses a fable model string outright.
+
+  It ships with its own CI executor, because a .sh corpus has no consumer in this
+  repo otherwise: scripts-tests-sweep.yml collects only test_*.py through pytest
+  and is continue-on-error besides. The workflow is the half that makes this
+  bite; the script alone would be one more inert artefact.
+
+  This PR also carries the held commit c246e4405b, a docs-only correction to a
+  measured-false EDITING NOTE inside seat_state.sh that could not be pushed while
+  #5290 was queued.
+constraints:
+  - "UNKNOWN is not dispatchable. seat_state.sh's own polarity is fail-OPEN for
+    the cascade's skip decision; here it is deliberately inverted, because
+    assigning a lane to a seat we cannot verify is exactly how two lanes end up
+    on one seat."
+  - "A real burst is FAIL-CLOSED on the seat-binding gap. This script handles
+    seat IDENTIFIERS only and never reads or injects a credential value, so by
+    itself it cannot make a child USE the seat planned for it. Rather than let
+    three lanes silently share one ambient credential and spend one seat's quota
+    three times while the plan reads correct, a non-dry-run burst refuses unless
+    FLEET_BURST_SEAT_BROKER names an executable. That contract
+    (<broker> <seat-key> <command...>) is deliberately the signature of L13-PR1's
+    with_seat.sh, so the two lanes of this squad meet at a declared seam instead
+    of each half-solving it."
+  - "The concurrency ceiling is recorded as a precaution, not a proven fix: W96's
+    ENXIO occurred with 94% of ptys free and the cause is undetermined. The file
+    says so rather than claiming a cure."
+  - "Never reads, prints or logs a credential value. Every seat in the corpus is
+    a fake identifier and the seat-state library is stubbed, so no test touches a
+    real fleet report, a real CLI, or the network."
+grader: |
+  generator != grader with family exclusion, both directions. The shell half
+  (fleet_burst.sh + its corpus) was BUILT by Codex GPT-5.6 terra (non-Anthropic,
+  effort high) and refuted blind by Kimi K3 (non-Anthropic, different family from
+  its builder). The workflow half was written by this Anthropic orchestrator and
+  refuted blind by Codex GPT-5.6 sol at xhigh, the security/workflow-class
+  refuter. Each refuter received the DIFF, never a narrative. The final on-disk
+  gate is this orchestrator, empirical, this turn: every suite re-run and every
+  claimed guard mutation-tested at a real code site.
+budget: |
+  Flat-subscription seats only: this session (orchestrator + gate), Codex
+  GPT-5.6 terra (build) and sol (workflow refutation) on ChatGPT Pro, Kimi K3
+  (code refutation) on the Allegro flat plan. No metered API spend.
+pii: none

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/journal.jsonl
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-08-31T00:28:00Z"}
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": true, "ts": "2026-08-31T00:34:00Z"}

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/pack.yml
@@ -1,0 +1,213 @@
+council_run: journal.jsonl
+# REPO-ROOT-relative, not pack-relative -- measured, because the two look alike and
+# only one is right. `brief_ref: evidence/brief.yml` (the value a sibling pack in this
+# same evidence tree carries) resolves to the REPO-ROOT evidence/brief.yml, which
+# belongs to an unrelated task; the acceptance-probe NOTICE then reports on THAT
+# brief's probes and this pack silently validates against a stranger's acceptance
+# criteria. `council_run` above is the opposite convention -- pack-dir-relative -- so
+# the two adjacent keys do not agree with each other and neither can be inferred from
+# the other. Both verified against the lint's own resolvers this turn.
+brief_ref: evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/brief.yml
+plan_ref: >-
+  docs/plans/2026-08-29-beyond-sota-craft-wave/L09-multi-agent-orchestration-fleet-routing.md
+  section "PR-2: feat(fleet): fleet_burst — account-sharded headless fan-out".
+
+lanes:
+  - lane: fleet-burst-build
+    role: build
+    seat: codex-gpt-5.6-terra (non-Anthropic, effort high) -- D3 build lane, never the grader
+  - lane: fleet-burst-refute
+    role: review
+    seat: kimi-code/k3 (non-Anthropic) -- blind adversarial refutation of the shell diff
+  - lane: fleet-burst-workflow-refute
+    role: review
+    seat: codex-gpt-5.6-sol xhigh -- blind adversarial refutation of the workflow diff
+  - lane: fleet-burst-gate
+    role: review
+    seat: claude opus-5 xhigh (this orchestrator) -- final on-disk gate, empirical
+
+diff:
+  files: 7
+  net_lines: 988
+  measured_at: HEAD-of-branch (staged tree + the one committed cherry-pick)
+  note: >-
+    Measured with git diff --numstat over merge-base..HEAD plus the staged tree.
+    Over the <=400 net-line target of rules-of-engagement #2, declared rather
+    than hidden, and the split is the argument: 283 of these lines are this
+    branch's OWN evidence pack (brief 74 + pack 207 + journal 2), which is
+    overhead every PR in this wave carries. Of the 705 that are code, 277 are the
+    guilt+innocence corpus the spec's acceptance criteria require and 116 are the
+    CI executor without which that corpus has no consumer able to go red
+    (scripts-tests-sweep.yml collects only test_*.py and is continue-on-error).
+    Splitting either out would ship a dispatcher whose guards nothing runs --
+    exactly the inert-artefact outcome this wave exists to stop. The dispatcher
+    itself is 303 lines, and it grew during review: 7 of the 9 defects found by
+    the two blind refuters were fixed in it. The 16/7 in seat_state.sh is the
+    held commit c246e4405b, a comment-only correction carried per the squad
+    mandate.
+
+pii_scan: clean
+
+receipts:
+  - claim: "14/14 corpus green, and it bites: 7 mutants killed at real code sites (refusal moved after the mapping loop; dedup block deleted; broker guard dropped; control-char validator neutered; throttle disabled; whitespace normalisation removed; exit-status half of the liveness condition dropped)."
+    cmd: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+    exit: 0
+    ts: "2026-08-31T00:38:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The seat-state corpus this workflow newly arms is green: 26 checks, and until this PR no workflow in the repo named it at all."
+    cmd: "bash scripts/tests/test_seat_state.sh"
+    exit: 0
+    ts: "2026-08-31T00:38:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The workflow passes the same pinned actionlint version the required CI gate runs (1.7.12)."
+    cmd: "actionlint .github/workflows/fleet-burst-tests.yml"
+    exit: 0
+    ts: "2026-08-31T00:38:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The workflow clears the required per-job checkout-budget floor; 148 jobs scanned including this one."
+    cmd: "python3 scripts/lint_workflow_timeout_floor.py"
+    exit: 0
+    ts: "2026-08-31T00:38:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The throttle is measured, not asserted: under a shimmed claude and a stub broker, 5 lanes at --max-concurrency 2 peak at 2 live children; disabling the throttle makes the same probe read peak=5."
+    cmd: "bash scripts/tests/test_fleet_burst.sh --dry-run"
+    exit: 0
+    ts: "2026-08-31T00:38:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+
+dissent:
+  - seat: kimi-code/k3 (blind refutation of the shell diff)
+    objection: >-
+      Seat identifiers are validated for tab/newline/CR because they are
+      interpolated into tab-separated plan rows, but --model and --run-dir are
+      interpolated into the same rows unvalidated. A --run-dir carrying a tab
+      makes a reader parse a TRUNCATED config_dir, so the plan reads correct
+      while describing something else.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced before fixing: --run-dir $'/tmp/x\ty' made the field parser
+      return "/tmp/x". Fixed with ONE shared reject_control_chars validator used
+      by all three TSV-bound values, rather than a second copy of the check --
+      the defect was the guard's own reasoning applied to one of its three call
+      sites (W107 shape), so a per-site fix would only relocate it. Two new cases
+      pin it and go red when the validator is neutered.
+  - seat: kimi-code/k3 (blind refutation of the shell diff)
+    objection: >-
+      DEFAULT_CONCURRENCY_REPORTED_AS_3 only greps the PLAN row. Break the
+      throttle so every lane spawns at once and that check stays green, because
+      the plan would still SAY 3.
+    status: CONFIRMED
+    resolution: >-
+      Accepted and closed with a new case that measures the real thing: a shimmed
+      `claude` earlier on PATH logs its own start and end, a stub broker execs the
+      command, and max concurrency is recovered by walking the log. 5 lanes at
+      --max-concurrency 2 peak at 2; disabling the throttle makes the same probe
+      read peak=5. This is also the only case that exercises the real dispatch
+      path, including the broker invocation and the claude argv order.
+  - seat: kimi-code/k3 (blind refutation of the shell diff)
+    objection: >-
+      Dedup compares byte-identical strings, so two spellings of one seat fill two
+      lanes. `--seats live-a,'live-a '` counts both as live, nothing refuses, and
+      lane 1 and lane 2 plan onto one real seat while PLAN and every count read
+      correct -- the exact double-map the tool exists to prevent.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced before fixing (live_seats=2, exit 0, two LANE rows on one seat).
+      Fixed by normalising surrounding whitespace BEFORE the dedup compares.
+      Trimming rather than rejecting is deliberate and stated in the file:
+      `--seats "a, b"` is an ordinary way to write a list, and erroring on it
+      would push callers toward a form this tool handles worse. The refusal check
+      could never have caught this -- with both spellings counted there ARE enough
+      live seats to proceed, so a separate case pins it.
+  - seat: kimi-code/k3 (blind refutation of the shell diff)
+    objection: >-
+      The library's exit status is discarded behind a dead if/else that exists
+      only to suppress errexit, under a comment calling it "useful metadata". A
+      library answering `LIVE<TAB>stale-cache` while returning 1 -- the shape an
+      exhausted seat with a cached label produces -- is counted live and the burst
+      proceeds onto it. The contract makes the return code authoritative.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced with a stub that prints LIVE and returns 1: the seat was planned.
+      Fixed to require BOTH halves to agree (exit 0 AND state LIVE); disagreement
+      is treated as not-live, never as live. The dead if/else is replaced by
+      `|| lookup_rc=$?`, which suppresses errexit while keeping the value, and the
+      false comment about unused "metadata" is gone rather than reworded.
+  - seat: kimi-code/k3 (blind refutation of the shell diff)
+    objection: >-
+      The default run directory is `${TMPDIR:-/tmp}/fleet-burst-$$`, a PID-derived
+      and therefore guessable path. In a shared /tmp another local user can
+      pre-plant `fleet-burst-<pid>/lane-1` as a symlink; `mkdir -p` and the output
+      redirection follow it, steering lane output into a file they chose.
+    status: CONFIRMED
+    resolution: >-
+      Fixed with `mktemp -d` on the dispatch path (unguessable, 0700, ours).
+      --dry-run keeps a clearly-labelled placeholder because it creates nothing,
+      so no stray directory is left behind and the plan still prints the path that
+      mode would really use. Noted in the file that the corpus already used mktemp
+      for its own scratch -- the tool had been held to a lower standard than its
+      test.
+  - seat: kimi-code/k3 (blind refutation of the shell diff)
+    objection: >-
+      The no-broker case asserts only that lane-1/output.txt is absent, which is
+      created by the spawn redirection -- so it proves "did not spawn" while its
+      comment claims "no side effects". Moving the broker guard to after
+      `mkdir -p` leaves it green with the filesystem already mutated.
+    status: CONFIRMED
+    resolution: >-
+      Tightened to assert the run directory does not exist AT ALL, and the comment
+      now states what is actually pinned. Renamed to
+      REAL_BURST_REFUSES_BEFORE_TOUCHING_THE_FILESYSTEM so the name cannot drift
+      from the assertion again.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      zsh is absent on ubuntu-latest and the seat-state corpus has two cases that
+      `return 0` with a printed SKIP when zsh is missing. Those are the
+      production-shell cases -- the cascade IS a zsh script. The Bash cases pass,
+      the zsh cases skip, the corpus exits 0, and the job reports SUCCESS over a
+      real zsh-only regression.
+    status: CONFIRMED
+    resolution: >-
+      Fixed with the cure three sibling workflows already use
+      (scripts/ci/apt_install.sh zsh zsh) plus an explicit `command -v zsh` that
+      fails the job if the install silently did nothing -- without that second
+      half a failed install puts us straight back to skipping.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      The paths filter omits infra/launchagents/wrappers/claude-cascade.sh and
+      scripts/tests/test_seat_state.sh, both of which the job's own steps bind. A
+      PR that reverses the cascade's kill-switch polarity, or that breaks the
+      corpus directly, leaves this job unscheduled -- red when run, never run.
+    status: CONFIRMED
+    resolution: >-
+      Both added to both triggers. The header now states the rule that produced
+      the omission (the filter is the arming surface and must list every file the
+      steps bind) instead of the earlier claim that it already covered "exactly
+      the diffs that can break it" -- that claim was false and is not restated.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      actions/checkout fetches a single commit by default and a PR build checks
+      out the merge ref, so origin/main is not resolvable; the seat-state corpus
+      runs `git show origin/main:...` and fails after three retries. The job goes
+      red for a missing baseline, not for the change under test.
+    status: CONFIRMED
+    resolution: >-
+      Fixed with an explicit `git fetch --no-tags --depth=1 origin
+      main:refs/remotes/origin/main` before the corpus runs. depth=1 suffices
+      because `git show <ref>:<path>` needs only that commit's tree. Deliberately
+      not solved with fetch-depth: 0, whose effect on remote-tracking refs for a
+      PR merge-ref checkout is an assumption rather than a measurement.
+  - seat: claude opus-5 xhigh (this orchestrator, final gate)
+    objection: >-
+      Raised against the builder's diff: `claude -p --model X "$prompt"` looked
+      like the argv-binding trap documented at claude-cascade.sh:441-445, where
+      -p swallows the next flag as its value.
+    status: RETRACTED
+    resolution: >-
+      Refuted by measurement rather than argued: that note is about agy, whose -p
+      DOES take a value. `claude --help` shows `-p, --print` with no <value>
+      placeholder, unlike `--input-format <format>`, so it is boolean and the
+      builder's line was already correct. Recorded because the near-miss is the
+      lesson -- a measured note about one tool was one step from being applied to
+      another and "correcting" correct code. The distinction now lives in the
+      file so the next reader does not repeat it.

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/pack.yml
@@ -1,13 +1,20 @@
 council_run: journal.jsonl
-# REPO-ROOT-relative, not pack-relative -- measured, because the two look alike and
-# only one is right. `brief_ref: evidence/brief.yml` (the value a sibling pack in this
-# same evidence tree carries) resolves to the REPO-ROOT evidence/brief.yml, which
-# belongs to an unrelated task; the acceptance-probe NOTICE then reports on THAT
-# brief's probes and this pack silently validates against a stranger's acceptance
-# criteria. `council_run` above is the opposite convention -- pack-dir-relative -- so
-# the two adjacent keys do not agree with each other and neither can be inferred from
-# the other. Both verified against the lint's own resolvers this turn.
-brief_ref: evidence/2026-08/agent-mini-pro2-craft-f2-fleet-burst-244d7503/brief.yml
+# The literal `evidence/brief.yml`, NEVER this pack's real per-PR path -- and the
+# per-PR path is the trap, not the fix. harness-floor.yml stages BOTH files under
+# canonical names into a synthetic tree (/tmp/evidence-check) and resolves brief_ref
+# against THAT, so the per-PR value fails with "does not resolve to a file on disk".
+# Documented at .github/workflows/harness-floor.yml (THE brief_ref CONTRACT) and in
+# scripts/ci/evidence_paths.py's module docstring.
+#
+# Recorded because I got this wrong in the first push of this PR: running the lint
+# LOCALLY there is no staging, so brief_ref resolves against the real repo root and
+# lands on the root evidence/brief.yml of whatever task last wrote it -- which emits
+# an acceptance-probe NOTICE naming probes this pack never declared. That NOTICE
+# looks exactly like evidence of a bug and is really just the absence of staging.
+# I "fixed" it to the per-PR path, which is precisely what the contract forbids, and
+# CI failed. The local lint and the CI lint do not see the same tree; when they
+# disagree, CI is the one that decides.
+brief_ref: evidence/brief.yml
 plan_ref: >-
   docs/plans/2026-08-29-beyond-sota-craft-wave/L09-multi-agent-orchestration-fleet-routing.md
   section "PR-2: feat(fleet): fleet_burst — account-sharded headless fan-out".
@@ -49,7 +56,7 @@ diff:
 pii_scan: clean
 
 receipts:
-  - claim: "14/14 corpus green, and it bites: 7 mutants killed at real code sites (refusal moved after the mapping loop; dedup block deleted; broker guard dropped; control-char validator neutered; throttle disabled; whitespace normalisation removed; exit-status half of the liveness condition dropped)."
+  - claim: "15/15 corpus green, and it bites: 8 mutants killed at real code sites (refusal moved after the mapping loop; dedup block deleted; broker guard dropped; control-char validator neutered; throttle disabled; whitespace normalisation removed; exit-status half of the liveness condition dropped; the seat-binding guard moved back behind the claude-availability check)."
     cmd: "bash scripts/tests/test_fleet_burst.sh --dry-run"
     exit: 0
     ts: "2026-08-31T00:38:00Z"
@@ -76,6 +83,40 @@ receipts:
     seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
 
 dissent:
+  - seat: CI (Fleet burst dispatcher tests, run 33323160057 — the executor this PR adds)
+    objection: >-
+      REAL_BURST_REFUSES_BEFORE_TOUCHING_THE_FILESYSTEM failed on the runner while
+      passing 14/14 locally. Cause: the seat-binding guard sat AFTER
+      `command -v claude`, so a machine without claude on PATH refused with
+      "claude command is unavailable" and never evaluated the security guard --
+      the same misconfiguration producing two different verdicts depending on the
+      machine.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced locally by restricting PATH (the runner's shape), then fixed by
+      moving the security guard ahead of the availability check: a refusal that
+      protects a credential boundary must not sit behind an unrelated
+      availability probe. Pinned by a new case that restricts PATH itself, so the
+      ordering cannot regress on a box where claude happens to be installed.
+      Worth recording as the reason the executor exists at all -- this defect was
+      structurally unreachable from the dev machine, and the workflow shipped in
+      this same PR is what found it.
+  - seat: claude opus-5 xhigh (this orchestrator, final gate)
+    objection: >-
+      Raised against this pack: `brief_ref: evidence/brief.yml` resolves to the
+      REPO-ROOT brief of an unrelated task, so the pack appeared to validate its
+      acceptance probes against a stranger's brief. Reported to the squad ledger
+      as a likely repo-wide defect.
+    status: RETRACTED
+    resolution: >-
+      Wrong, and the correction matters more than the finding. harness-floor.yml
+      stages pack AND brief under canonical names into a synthetic tree and
+      resolves brief_ref against THAT; the literal `evidence/brief.yml` is the
+      contract, and the per-PR path is named in the workflow as "exactly the trap
+      this migration exists to remove". The NOTICE I read as evidence was an
+      artifact of running the lint locally, where no staging happens. Reverted,
+      corrected in the ledger, and the pack now carries a local reproduction of
+      CI's staging layout so the two are checked the same way.
   - seat: kimi-code/k3 (blind refutation of the shell diff)
     objection: >-
       Seat identifiers are validated for tab/newline/CR because they are

--- a/scripts/fleet_burst.sh
+++ b/scripts/fleet_burst.sh
@@ -245,8 +245,20 @@ if [[ "$dry_run" -eq 1 ]]; then
 fi
 
 [[ -n "$prompt" ]] || die "--prompt is required unless --dry-run is used"
-command -v claude >/dev/null 2>&1 || die "claude command is unavailable"
 
+# ORDER IS LOAD-BEARING: the seat-binding guard below runs BEFORE the check that
+# `claude` is installed, and that is not cosmetic.
+#
+# Measured: with the availability check first, a machine WITHOUT claude on PATH
+# refuses with "claude command is unavailable" and never evaluates the security
+# guard at all -- so the reason a misconfigured burst is refused depends on which
+# machine you are standing on. This shipped green through a local gate on a box
+# where claude IS installed and went red only in CI, where it is not: the dev
+# machine was structurally incapable of reaching the branch.
+#
+# A refusal that protects a credential boundary must not sit behind an unrelated
+# availability check. Refuse for the security reason first, on every machine.
+#
 # Fail-closed on the seat-binding gap, and the reasoning is the point.
 #
 # This dispatcher PLANS one distinct verified-LIVE seat per lane, and it handles
@@ -264,6 +276,8 @@ command -v claude >/dev/null 2>&1 || die "claude command is unavailable"
 # and the plan is honest about being only a plan.
 [[ -n "${FLEET_BURST_SEAT_BROKER:-}" ]] || die "refusing to dispatch: no FLEET_BURST_SEAT_BROKER set, so lanes cannot be bound to the seats planned for them and would silently share one credential (use --dry-run to plan only)"
 [[ -x "${FLEET_BURST_SEAT_BROKER}" ]] || die "FLEET_BURST_SEAT_BROKER is not executable: ${FLEET_BURST_SEAT_BROKER}"
+
+command -v claude >/dev/null 2>&1 || die "claude command is unavailable"
 
 declare -a active_pids=()
 failed=0

--- a/scripts/fleet_burst.sh
+++ b/scripts/fleet_burst.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# fleet_burst.sh dispatches independently configured, headless Claude lanes.
+#
+# Refusal policy: if fewer verified-LIVE seats exist than requested lanes, refuse
+# the whole burst rather than silently turning parallel work into a serial queue.
+# The default concurrency ceiling is 3; a precaution, not a proven fix — W96's ENXIO occurred with 94% of ptys free and the cause is undetermined.
+#
+# Dry-run format is stable TSV: a PLAN row is followed by zero or more LANE
+# rows.  LANE fields include lane, seat, config_dir, and output so callers can
+# verify the isolation and one-seat-per-lane invariant without parsing prose.
+#
+# This dispatcher handles seat identifiers only.  It deliberately never reads,
+# logs, prints, or interpolates credential values or Keychain content.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: fleet_burst.sh --lanes N --seat SEAT [--seat SEAT ...] [options]
+
+Options:
+  --seats A,B,C             Comma-separated alternative to repeated --seat.
+  --model MODEL             Claude model (default: claude-sonnet-5).
+  --max-concurrency N       Simultaneous Claude processes (default: 3).
+  --run-dir DIR             Parent directory for sterile lane state/output.
+  --prompt TEXT             Prompt supplied to every dispatched lane.
+  --dry-run                 Print the TSV plan; do not create or spawn anything.
+  --help                    Show this message.
+
+FLEET_BURST_SEAT_STATE_LIB may override the sourced seat-state library.  It is
+intended for hermetic tests; a missing library is always a hard failure.
+USAGE
+}
+
+die() {
+    printf 'fleet_burst: %s\n' "$*" >&2
+    exit 1
+}
+
+is_positive_integer() {
+    [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+# Every value that reaches a TSV row goes through here, and there is exactly one
+# of these on purpose.
+#
+# The plan rows are tab-separated because a test has to be able to read them
+# field by field. That makes a tab, newline or carriage return inside ANY
+# interpolated value a parsing break, not a cosmetic issue: measured this turn,
+# `--run-dir $'/tmp/x\ty'` makes the reader parse config_dir as "/tmp/x" -- the
+# value is silently TRUNCATED and the plan reads as if it said something else.
+#
+# An earlier form of this script validated only the seat identifier, for exactly
+# this reason, and then interpolated `model` and `run_dir` into the same rows
+# unchecked -- the guard's own reasoning applied to one of its three call sites.
+# Blind cross-family refutation (Kimi K3) caught it. Keep this shared: adding a
+# fourth TSV-bound value and forgetting to validate it is the same defect again.
+reject_control_chars() {
+    local label="$1"
+    local value="$2"
+    [[ "$value" != *$'\t'* && "$value" != *$'\n'* && "$value" != *$'\r'* ]] \
+        || die "${label} contains a tab, newline or carriage return, which would corrupt the plan rows"
+}
+
+wait_for_pid() {
+    local pid="$1"
+
+    # A failed lane must not prevent reaping the remaining children.
+    if ! wait "$pid"; then
+        return 1
+    fi
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+seat_state_lib="${FLEET_BURST_SEAT_STATE_LIB:-${script_dir}/lib/seat_state.sh}"
+lanes=""
+model="claude-sonnet-5"
+max_concurrency="3"
+run_dir=""
+prompt=""
+dry_run=0
+declare -a candidate_seats=()
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --lanes)
+            [[ "$#" -ge 2 ]] || die "--lanes requires a value"
+            lanes="$2"
+            shift 2
+            ;;
+        --seat)
+            [[ "$#" -ge 2 ]] || die "--seat requires a seat identifier"
+            candidate_seats+=("$2")
+            shift 2
+            ;;
+        --seats)
+            [[ "$#" -ge 2 ]] || die "--seats requires a comma-separated list"
+            IFS=',' read -r -a supplied_seats <<< "$2"
+            candidate_seats+=("${supplied_seats[@]}")
+            shift 2
+            ;;
+        --model)
+            [[ "$#" -ge 2 ]] || die "--model requires a value"
+            model="$2"
+            shift 2
+            ;;
+        --max-concurrency)
+            [[ "$#" -ge 2 ]] || die "--max-concurrency requires a value"
+            max_concurrency="$2"
+            shift 2
+            ;;
+        --run-dir)
+            [[ "$#" -ge 2 ]] || die "--run-dir requires a path"
+            run_dir="$2"
+            shift 2
+            ;;
+        --prompt)
+            [[ "$#" -ge 2 ]] || die "--prompt requires text"
+            prompt="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+is_positive_integer "$lanes" || die "--lanes must be a positive integer"
+is_positive_integer "$max_concurrency" || die "--max-concurrency must be a positive integer"
+[[ "${#candidate_seats[@]}" -gt 0 ]] || die "at least one --seat or --seats entry is required"
+
+# Fable routing is a governance boundary, not a model availability check.
+case "$model" in
+    *[Ff][Aa][Bb][Ll][Ee]*)
+        die "Fable is manual-only (CLAUDE.md section 5, RULED 2026-08-20); fleet_burst cannot auto-route to fable"
+        ;;
+esac
+
+[[ -r "$seat_state_lib" ]] || die "seat state library is missing or unreadable: $seat_state_lib"
+# shellcheck source=/dev/null
+source "$seat_state_lib"
+declare -F seat_state_lookup >/dev/null || die "seat state library does not provide seat_state_lookup"
+
+# A caller-supplied --run-dir is the caller's business. The DEFAULT is ours, and
+# it must not be guessable: `${TMPDIR:-/tmp}/fleet-burst-$$` is PID-derived, so in
+# a shared /tmp another local user can pre-plant `fleet-burst-<pid>/lane-1` as a
+# symlink and `mkdir -p` plus the output redirection then follow it, steering lane
+# output (which carries seat identifiers) into a file of their choosing. mktemp -d
+# creates an unguessable directory owned by us with 0700. Raised by blind
+# cross-family refutation (Kimi K3); the test file already used mktemp for its own
+# scratch, so the tool was held to a lower standard than its corpus.
+#
+# Only the dispatch path needs a real directory. --dry-run creates nothing at all,
+# so it gets a clearly-labelled placeholder instead of a stray empty dir -- and the
+# plan it prints is the path that mode would actually use, not a different one.
+if [[ -z "$run_dir" ]]; then
+    if [[ "$dry_run" -eq 1 ]]; then
+        run_dir="${TMPDIR:-/tmp}/fleet-burst-<mktemp-at-dispatch>"
+    else
+        run_dir="$(mktemp -d "${TMPDIR:-/tmp}/fleet-burst-XXXXXX")" \
+            || die "could not create a private run directory"
+    fi
+fi
+
+# Both of these are interpolated into the plan rows, so both are TSV-bound.
+reject_control_chars "--model" "$model"
+reject_control_chars "--run-dir" "$run_dir"
+
+declare -a unique_candidates=()
+declare -a live_seats=()
+for seat in "${candidate_seats[@]}"; do
+    # Normalise surrounding whitespace BEFORE anything else, because the dedup
+    # below compares byte-identical strings and the whole invariant rests on it.
+    # Measured: `--seats live-a,'live-a '` produced live_seats=2 and planned lane 1
+    # and lane 2 onto what is operationally ONE seat, with PLAN and every count
+    # reading correct -- the exact double-map this script exists to prevent,
+    # walking through because two spellings of one identifier are not
+    # byte-identical. Found by blind cross-family refutation (Kimi K3).
+    # Trimming rather than rejecting is deliberate: `--seats "a, b"` is an ordinary
+    # way to write a list, and erroring on it would push callers toward a form
+    # this tool handles worse. The trimmed value is what is used downstream, so
+    # nothing is compared in one spelling and dispatched in another.
+    seat="${seat#"${seat%%[![:space:]]*}"}"
+    seat="${seat%"${seat##*[![:space:]]}"}"
+    [[ -n "$seat" ]] || die "seat identifiers must not be empty"
+    reject_control_chars "seat identifier" "$seat"
+    seat_seen=0
+    for unique_seat in "${unique_candidates[@]:-}"; do
+        if [[ "$unique_seat" == "$seat" ]]; then
+            seat_seen=1
+            break
+        fi
+    done
+    [[ "$seat_seen" -eq 0 ]] || continue
+    unique_candidates+=("$seat")
+
+    # BOTH halves of the library's answer have to agree before a seat is
+    # dispatchable: exit 0 AND a printed state of LIVE.
+    #
+    # An earlier version trusted the printed string alone and discarded the exit
+    # status behind a dead if/else that existed only to suppress errexit, under a
+    # comment calling the status "useful metadata" -- which it then did not use.
+    # Measured: a library answering `LIVE<TAB>stale-cache` while returning 1 (the
+    # shape an exhausted-seat-with-a-cached-label produces) was counted LIVE and
+    # the burst proceeded onto it. The contract defines the return code as
+    # authoritative, so disagreement between the two halves is treated as
+    # not-live, never as live. Found by blind cross-family refutation (Kimi K3).
+    #
+    # `|| lookup_rc=$?` is what keeps errexit from aborting here: a non-zero
+    # return is the library ANSWERING (1=EXHAUSTED, 2=UNKNOWN), not failing.
+    lookup_rc=0
+    lookup="$(seat_state_lookup "$seat" 2>/dev/null)" || lookup_rc=$?
+    state="${lookup%%$'\t'*}"
+    if [[ "$lookup_rc" -eq 0 && "$state" == "LIVE" ]]; then
+        live_seats+=("$seat")
+    fi
+done
+
+printf 'PLAN\tconcurrency=%s\tmodel=%s\trequested_lanes=%s\tlive_seats=%s\n' \
+    "$max_concurrency" "$model" "$lanes" "${#live_seats[@]}"
+
+if [[ "${#live_seats[@]}" -lt "$lanes" ]]; then
+    die "refusing burst: requested ${lanes} lanes but found only ${#live_seats[@]} verified-LIVE distinct seats"
+fi
+
+declare -a lane_seats=()
+for ((lane = 1; lane <= lanes; lane++)); do
+    lane_seats+=("${live_seats[lane - 1]}")
+    config_dir="${run_dir}/lane-${lane}/config"
+    output_path="${run_dir}/lane-${lane}/output.txt"
+    printf 'LANE\tlane=%s\tseat=%s\tconfig_dir=%s\toutput=%s\n' \
+        "$lane" "${lane_seats[lane - 1]}" "$config_dir" "$output_path"
+done
+
+if [[ "$dry_run" -eq 1 ]]; then
+    exit 0
+fi
+
+[[ -n "$prompt" ]] || die "--prompt is required unless --dry-run is used"
+command -v claude >/dev/null 2>&1 || die "claude command is unavailable"
+
+# Fail-closed on the seat-binding gap, and the reasoning is the point.
+#
+# This dispatcher PLANS one distinct verified-LIVE seat per lane, and it handles
+# seat IDENTIFIERS only -- it never reads, logs or injects a credential value.
+# That is a deliberate boundary, but it has a consequence worth stating plainly:
+# by itself this script cannot make a child actually USE the seat it was planned
+# for. A lane spawned with nothing but a sterile CLAUDE_CONFIG_DIR authenticates
+# with whatever ambient credential it inherits, so three lanes would land on ONE
+# seat, burn that seat's quota three times, and report success -- a plan that
+# looks satisfied while the invariant it exists to hold is broken.
+#
+# So a real burst REFUSES unless a broker is named. The broker's contract is
+# `<broker> <seat-key> <command...>`: it binds exactly that seat's credential
+# and execs the command. --dry-run is unaffected -- planning is what it is for,
+# and the plan is honest about being only a plan.
+[[ -n "${FLEET_BURST_SEAT_BROKER:-}" ]] || die "refusing to dispatch: no FLEET_BURST_SEAT_BROKER set, so lanes cannot be bound to the seats planned for them and would silently share one credential (use --dry-run to plan only)"
+[[ -x "${FLEET_BURST_SEAT_BROKER}" ]] || die "FLEET_BURST_SEAT_BROKER is not executable: ${FLEET_BURST_SEAT_BROKER}"
+
+declare -a active_pids=()
+failed=0
+for ((lane = 1; lane <= lanes; lane++)); do
+    config_dir="${run_dir}/lane-${lane}/config"
+    output_path="${run_dir}/lane-${lane}/output.txt"
+    mkdir -p "$config_dir"
+
+    # Direct redirection preserves incremental child output; collecting it in a
+    # shell variable would recreate the W98 all-or-nothing disk failure mode.
+    #
+    # `-p` is a boolean flag on this CLI (measured from `claude --help` this
+    # turn: it carries no <value> placeholder, unlike `--input-format <format>`),
+    # so the prompt is an ordinary positional. Do NOT copy the agy rule from
+    # claude-cascade.sh here -- there `-p` DOES take a value, and that note is
+    # about agy, not claude.
+    CLAUDE_CONFIG_DIR="$config_dir" \
+        "$FLEET_BURST_SEAT_BROKER" "${lane_seats[lane - 1]}" \
+        claude -p --model "$model" "$prompt" >"$output_path" 2>"${output_path}.stderr" &
+    active_pids+=("$!")
+
+    if [[ "${#active_pids[@]}" -ge "$max_concurrency" ]]; then
+        if ! wait_for_pid "${active_pids[0]}"; then
+            failed=1
+        fi
+        active_pids=("${active_pids[@]:1}")
+    fi
+done
+
+for pid in "${active_pids[@]:-}"; do
+    [[ -n "$pid" ]] || continue
+    if ! wait_for_pid "$pid"; then
+        failed=1
+    fi
+done
+
+exit "$failed"

--- a/scripts/lib/seat_state.sh
+++ b/scripts/lib/seat_state.sh
@@ -67,13 +67,22 @@ import json, sys, datetime, math
 # meaningfully in the future is not. 300s absorbs ordinary NTP drift without
 # absorbing a broken writer.
 #
-# EDITING NOTE, measured not theorised: this heredoc body is nested inside a
-# command substitution, so bash SCANS it even though it is quote-delimited.
-# A comment here containing a dollar-paren sequence, a backtick, or an
-# unbalanced quote makes bash reject the WHOLE FILE with
-# 'unexpected EOF while looking for matching quote' - and the reported line
-# number is the end of the file, nowhere near the offending comment. Keep
-# prose in here free of shell metacharacters.
+# EDITING NOTE, and the first version of this note was WRONG so the method
+# matters more than the rule: this heredoc body is nested inside a command
+# substitution, so bash SCANS it even though it is quote-delimited. Measured on
+# this exact file by injecting one token at a time and running bash -n:
+#   a lone apostrophe        -> FATAL
+#   an unbalanced double quote -> FATAL
+#   a dollar-paren sequence  -> harmless
+#   a backtick               -> harmless
+# So the rule is QUOTE BALANCE, not shell metacharacters generally. The earlier
+# note here blamed dollar-paren and backticks; both are measured harmless, and
+# it had absolved the apostrophe that actually broke the file. That mistake came
+# from counting apostrophe-bearing LINES with grep -c instead of apostrophe
+# CHARACTERS - the body already held a balanced pair, so the count read 1 and
+# looked like proof that one apostrophe was survivable. Count characters.
+# The failure is also badly signposted: bash reports the END OF THE FILE,
+# nowhere near the offending comment. Keep prose in here quote-balanced.
 _FUTURE_TOLERANCE_S = 300
 
 def _reject_const(_name):

--- a/scripts/tests/test_fleet_burst.sh
+++ b/scripts/tests/test_fleet_burst.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Hermetic checks for fleet_burst.sh.  The optional --dry-run is accepted so
+# the documented acceptance command can use the same test suite invocation.
+
+set -u
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+    shift
+fi
+[[ "$#" -eq 0 ]] || {
+    printf 'usage: %s [--dry-run]\n' "$0" >&2
+    exit 2
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+burst_script="${script_dir}/../fleet_burst.sh"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/fleet-burst-test.XXXXXX")"
+fake_lib="${tmp_dir}/seat_state.sh"
+failed=0
+total=0
+
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+printf '%s\n' \
+    'seat_state_lookup() {' \
+    '    case "$1" in' \
+    "        live-*) printf 'LIVE\\tfake-live\\n'; return 0 ;;" \
+    "        exhausted-*) printf 'EXHAUSTED\\tfake-exhausted\\n'; return 1 ;;" \
+    "        unknown-*) printf 'UNKNOWN\\tfake-unknown\\n'; return 2 ;;" \
+    "        *) printf 'UNKNOWN\\tfake-unlisted\\n'; return 2 ;;" \
+    '    esac' \
+    '}' \
+    '' \
+    'seat_is_live() {' \
+    '    seat_state_lookup "$1" >/dev/null' \
+    '}' >"$fake_lib"
+
+check() {
+    local name="$1"
+    local result="$2"
+
+    total=$((total + 1))
+    if [[ "$result" == "pass" ]]; then
+        printf 'PASS %s\n' "$name"
+    else
+        printf 'FAIL %s\n' "$name"
+        failed=$((failed + 1))
+    fi
+}
+
+count_nonempty() {
+    awk 'NF { count += 1 } END { print count + 0 }'
+}
+
+field_values() {
+    local field="$1"
+    awk -F '\t' -v key="${field}=" '$1 == "LANE" { for (i = 2; i <= NF; i++) if (index($i, key) == 1) { sub(key, "", $i); print $i } }'
+}
+
+run_burst() {
+    local label="$1"
+    shift
+
+    run_stdout="${tmp_dir}/${label}.stdout"
+    run_stderr="${tmp_dir}/${label}.stderr"
+    FLEET_BURST_SEAT_STATE_LIB="$fake_lib" \
+        "$burst_script" "$@" >"$run_stdout" 2>"$run_stderr"
+    run_status=$?
+}
+
+# Guilt: refusal must happen BEFORE any lane is mapped, so five lanes can never
+# be spread over three seats.
+#
+# The assertion here is deliberately "zero LANE rows", not "the emitted seats are
+# unique". An earlier form of this check compared the seat column's count against
+# its sorted-unique count -- but a refusal emits no LANE rows at all, so that
+# comparison was 0 == 0: true by construction, and it would have stayed green if
+# the refusal moved to AFTER the mapping loop, which is the exact defect it named.
+# Measured this turn: the guilt run emits 0 LANE rows. Counting them is a check
+# that can fail; comparing an empty column against itself is not.
+run_burst guilt --lanes 5 --seats live-a,live-b,live-c --dry-run
+guilt_lane_rows="$(awk -F '\t' '$1 == "LANE" { count += 1 } END { print count + 0 }' "$run_stdout")"
+if [[ "$run_status" -ne 0 && "$guilt_lane_rows" -eq 0 ]] \
+    && grep -q 'refusing burst' "$run_stderr"; then
+    check GUILT_REFUSES_BEFORE_MAPPING_ANY_LANE pass
+else
+    check GUILT_REFUSES_BEFORE_MAPPING_ANY_LANE fail
+fi
+
+# The guard that actually stops a double-map. If the same seat is offered twice
+# and the dispatcher does not collapse duplicates, two lanes resolve to ONE seat
+# while every count still looks right -- the failure mode the refusal check above
+# cannot see, because in that world there are enough "live seats" to proceed.
+# Mutation-verified: deleting the dedup block in fleet_burst.sh turns this red
+# (2 lanes both mapped to live-a) and leaves every other check green.
+run_burst dedup --lanes 2 --seats live-a,live-a --dry-run
+dedup_lane_rows="$(awk -F '\t' '$1 == "LANE" { count += 1 } END { print count + 0 }' "$run_stdout")"
+if [[ "$run_status" -ne 0 && "$dedup_lane_rows" -eq 0 ]] \
+    && grep -q 'refusing burst' "$run_stderr"; then
+    check DUPLICATE_SEAT_CANNOT_FILL_TWO_LANES pass
+else
+    check DUPLICATE_SEAT_CANNOT_FILL_TWO_LANES fail
+fi
+
+run_burst innocence --lanes 3 --seats live-a,live-b,live-c --run-dir "${tmp_dir}/innocence" --dry-run
+innocence_lanes="$(awk -F '\t' '$1 == "LANE" { count += 1 } END { print count + 0 }' "$run_stdout")"
+innocence_seats="$(field_values seat <"$run_stdout")"
+innocence_configs="$(field_values config_dir <"$run_stdout")"
+innocence_outputs="$(field_values output <"$run_stdout")"
+if [[ "$run_status" -eq 0 && "$innocence_lanes" -eq 3 ]] \
+    && [[ "$(printf '%s\n' "$innocence_seats" | sort -u | count_nonempty)" -eq 3 ]] \
+    && [[ "$(printf '%s\n' "$innocence_configs" | sort -u | count_nonempty)" -eq 3 ]] \
+    && [[ "$(printf '%s\n' "$innocence_outputs" | sort -u | count_nonempty)" -eq 3 ]]; then
+    check INNOCENCE_DISTINCT_LANES_AND_PATHS pass
+else
+    check INNOCENCE_DISTINCT_LANES_AND_PATHS fail
+fi
+
+run_burst excluded --lanes 2 --seats live-a,exhausted-a,unknown-a,live-b --dry-run
+excluded_seats="$(field_values seat <"$run_stdout" | sort)"
+if [[ "$run_status" -eq 0 && "$excluded_seats" == $'live-a\nlive-b' ]]; then
+    check EXHAUSTED_AND_UNKNOWN_EXCLUDED pass
+else
+    check EXHAUSTED_AND_UNKNOWN_EXCLUDED fail
+fi
+
+run_burst fable --lanes 1 --seat live-a --model claude-fable-5 --dry-run
+if [[ "$run_status" -ne 0 ]] && grep -qi 'fable' "$run_stderr"; then
+    check FABLE_REFUSED pass
+else
+    check FABLE_REFUSED fail
+fi
+
+run_burst concurrency --lanes 1 --seat live-a --dry-run
+if [[ "$run_status" -eq 0 ]] && grep -q $'^PLAN\tconcurrency=3\t' "$run_stdout"; then
+    check DEFAULT_CONCURRENCY_REPORTED_AS_3 pass
+else
+    check DEFAULT_CONCURRENCY_REPORTED_AS_3 fail
+fi
+
+missing_stdout="${tmp_dir}/missing.stdout"
+missing_stderr="${tmp_dir}/missing.stderr"
+FLEET_BURST_SEAT_STATE_LIB="${tmp_dir}/does-not-exist.sh" \
+    "$burst_script" --lanes 1 --seat live-a --dry-run >"$missing_stdout" 2>"$missing_stderr"
+missing_status=$?
+if [[ "$missing_status" -ne 0 ]] && grep -q 'seat state library' "$missing_stderr"; then
+    check MISSING_SEAT_LIBRARY_FAILS_LOUDLY pass
+else
+    check MISSING_SEAT_LIBRARY_FAILS_LOUDLY fail
+fi
+
+# A real burst with no seat broker must REFUSE, not proceed. Without this the
+# script's central promise (one distinct seat per lane) degrades silently at the
+# only moment it matters: every lane inherits the same ambient credential, the
+# plan still reads correct, and one seat's quota is spent N times.
+#
+# The assertion is that the run directory does not exist AT ALL, not merely that
+# no output file appeared. An earlier form checked only for lane-1/output.txt,
+# which is created by the spawn redirection -- so it proved "did not spawn" while
+# its own comment claimed "no side effects", and moving the guard to after
+# `mkdir -p` would have left it green while the script mutated the filesystem
+# before refusing. Found by blind cross-family refutation (Kimi K3).
+# Mutation-verified: dropping the FLEET_BURST_SEAT_BROKER guard turns this red.
+real_run_dir="${tmp_dir}/no-broker"
+real_stdout="${tmp_dir}/no-broker.stdout"
+real_stderr="${tmp_dir}/no-broker.stderr"
+env -u FLEET_BURST_SEAT_BROKER FLEET_BURST_SEAT_STATE_LIB="$fake_lib" \
+    "$burst_script" --lanes 1 --seat live-a --prompt 'noop' --run-dir "$real_run_dir" \
+    >"$real_stdout" 2>"$real_stderr"
+real_status=$?
+if [[ "$real_status" -ne 0 ]] && grep -q 'FLEET_BURST_SEAT_BROKER' "$real_stderr" \
+    && [[ ! -e "$real_run_dir" ]]; then
+    check REAL_BURST_REFUSES_BEFORE_TOUCHING_THE_FILESYSTEM pass
+else
+    check REAL_BURST_REFUSES_BEFORE_TOUCHING_THE_FILESYSTEM fail
+fi
+
+# Two spellings of one seat must not fill two lanes. This is the double-map the
+# refusal check cannot see: with `live-a` and `live-a ` both counted, there ARE
+# enough "live seats" to proceed, so nothing refuses and both lanes plan onto one
+# real seat while PLAN and every count read correct.
+# Mutation-verified: removing the whitespace normalisation turns this red.
+run_burst nearduplicate --lanes 2 --seats "live-a,live-a " --dry-run
+if [[ "$run_status" -ne 0 ]] && grep -q 'refusing burst' "$run_stderr"; then
+    check NEAR_DUPLICATE_SEAT_CANNOT_FILL_TWO_LANES pass
+else
+    check NEAR_DUPLICATE_SEAT_CANNOT_FILL_TWO_LANES fail
+fi
+
+# The library answers with a status AND a string; a seat is dispatchable only if
+# both say live. A stub that prints LIVE while returning 1 is the shape an
+# exhausted seat carrying a cached label produces, and trusting the string alone
+# sends the burst onto it.
+# Mutation-verified: dropping the exit-status half of the condition turns this red.
+liar_lib="${tmp_dir}/seat_state_liar.sh"
+printf '%s\n' 'seat_state_lookup() { printf "LIVE\tstale-cache\n"; return 1; }' >"$liar_lib"
+liar_stdout="${tmp_dir}/liar.stdout"
+FLEET_BURST_SEAT_STATE_LIB="$liar_lib" \
+    "$burst_script" --lanes 1 --seat seat-x --dry-run >"$liar_stdout" 2>"${tmp_dir}/liar.stderr"
+liar_status=$?
+liar_lane_rows="$(awk -F '\t' '$1 == "LANE" { count += 1 } END { print count + 0 }' "$liar_stdout")"
+if [[ "$liar_status" -ne 0 && "$liar_lane_rows" -eq 0 ]]; then
+    check PRINTED_LIVE_WITH_NONZERO_STATUS_IS_NOT_DISPATCHABLE pass
+else
+    check PRINTED_LIVE_WITH_NONZERO_STATUS_IS_NOT_DISPATCHABLE fail
+fi
+
+# Every value interpolated into a plan row must be rejected if it carries a tab,
+# because the rows are the machine-readable contract and a tab silently
+# TRUNCATES the field a reader gets. Measured before the fix: --run-dir with an
+# embedded tab made the config_dir field parse as "/tmp/x" instead of the real
+# path, so a plan could read correct while describing something else.
+# Both are checked because the original guard covered only the seat identifier
+# and left these two -- the same defect on two of three call sites.
+for injection_case in "--run-dir" "--model"; do
+    inject_stderr="${tmp_dir}/inject$(printf '%s' "$injection_case" | tr -d -- '-').stderr"
+    FLEET_BURST_SEAT_STATE_LIB="$fake_lib" \
+        "$burst_script" --lanes 1 --seat live-a "$injection_case" "$(printf 'x\ty')" --dry-run \
+        >/dev/null 2>"$inject_stderr"
+    inject_status=$?
+    if [[ "$inject_status" -ne 0 ]] && grep -q 'corrupt the plan rows' "$inject_stderr"; then
+        check "TSV_INJECTION_REJECTED${injection_case}" pass
+    else
+        check "TSV_INJECTION_REJECTED${injection_case}" fail
+    fi
+done
+
+# The throttle itself, not the number the plan prints about it.
+#
+# Blind refutation (Kimi K3) pointed out that DEFAULT_CONCURRENCY_REPORTED_AS_3
+# greps the PLAN row and nothing more: break the throttle so every lane spawns at
+# once and that check stays green, because the plan would still SAY 3. The
+# ceiling is one of the two scars this dispatcher exists for (W96), so the
+# property worth pinning is "never more than N children alive at once", which
+# only a real dispatch can show.
+#
+# Hermetic: a shim `claude` earlier on PATH logs its own start and end, a stub
+# broker execs its command, and the seat library is the fake. Nothing here
+# reaches the network, a real CLI, or a real seat. Max concurrency is recovered
+# by walking the log (+1 START, -1 END); appends of a short line are atomic, so
+# the ordering in the file is the real ordering.
+shim_bin="${tmp_dir}/bin"
+mkdir -p "$shim_bin"
+conc_log="${tmp_dir}/concurrency.log"
+: >"$conc_log"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "START\n" >>"$CONC_LOG"' 'sleep 0.4' 'printf "END\n" >>"$CONC_LOG"' \
+    >"${shim_bin}/claude"
+chmod +x "${shim_bin}/claude"
+stub_broker="${tmp_dir}/stub_broker.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'shift' 'exec "$@"' >"$stub_broker"
+chmod +x "$stub_broker"
+
+CONC_LOG="$conc_log" PATH="${shim_bin}:${PATH}" \
+    FLEET_BURST_SEAT_STATE_LIB="$fake_lib" FLEET_BURST_SEAT_BROKER="$stub_broker" \
+    "$burst_script" --lanes 5 --seats live-a,live-b,live-c,live-d,live-e \
+    --max-concurrency 2 --prompt 'noop' --run-dir "${tmp_dir}/throttle" \
+    >/dev/null 2>"${tmp_dir}/throttle.stderr"
+throttle_status=$?
+observed_peak="$(awk '/^START$/ { n += 1; if (n > peak) peak = n } /^END$/ { n -= 1 } END { print peak + 0 }' "$conc_log")"
+observed_starts="$(grep -c '^START$' "$conc_log" || true)"
+if [[ "$throttle_status" -eq 0 && "$observed_starts" -eq 5 && "$observed_peak" -le 2 ]]; then
+    check THROTTLE_HOLDS_UNDER_REAL_DISPATCH pass
+else
+    check "THROTTLE_HOLDS_UNDER_REAL_DISPATCH (starts=${observed_starts} peak=${observed_peak} rc=${throttle_status})" fail
+fi
+
+if bash -n "$burst_script"; then
+    check BASH_SYNTAX pass
+else
+    check BASH_SYNTAX fail
+fi
+
+printf 'TOTAL %s FAILED %s\n' "$total" "$failed"
+[[ "$failed" -eq 0 ]]

--- a/scripts/tests/test_fleet_burst.sh
+++ b/scripts/tests/test_fleet_burst.sh
@@ -178,6 +178,30 @@ else
     check REAL_BURST_REFUSES_BEFORE_TOUCHING_THE_FILESYSTEM fail
 fi
 
+# The SAME refusal, on a machine where `claude` is not installed.
+#
+# This is the check the local gate could not have written from imagination: the
+# first version of the guard sat AFTER `command -v claude`, so on a dev box with
+# claude on PATH it refused for the seat-binding reason and on a CI runner without
+# it refused for "claude command is unavailable" -- the same misconfiguration
+# producing two different verdicts depending on where you stand. It passed
+# locally 14/14 and went red only in CI.
+# Restricting PATH here reproduces the runner's shape on any machine, so the
+# ordering cannot silently regress back.
+noclaude_stderr="${tmp_dir}/noclaude.stderr"
+noclaude_run_dir="${tmp_dir}/noclaude-rd"
+env -u FLEET_BURST_SEAT_BROKER PATH="/usr/bin:/bin" \
+    FLEET_BURST_SEAT_STATE_LIB="$fake_lib" \
+    "$burst_script" --lanes 1 --seat live-a --prompt 'noop' --run-dir "$noclaude_run_dir" \
+    >/dev/null 2>"$noclaude_stderr"
+noclaude_status=$?
+if [[ "$noclaude_status" -ne 0 ]] && grep -q 'FLEET_BURST_SEAT_BROKER' "$noclaude_stderr" \
+    && [[ ! -e "$noclaude_run_dir" ]]; then
+    check SEAT_BINDING_REFUSAL_DOES_NOT_DEPEND_ON_CLAUDE_BEING_INSTALLED pass
+else
+    check SEAT_BINDING_REFUSAL_DOES_NOT_DEPEND_ON_CLAUDE_BEING_INSTALLED fail
+fi
+
 # Two spellings of one seat must not fill two lanes. This is the double-map the
 # refusal check cannot see: with `live-a` and `live-a ` both counted, there ARE
 # enough "live seats" to proceed, so nothing refuses and both lanes plan onto one


### PR DESCRIPTION
L09-PR2 of the beyond-SOTA craft wave (squad F′, ledger #5318). Replaces the fork/tmux-pane fan-out shape behind **W98** (lanes writing zero bytes to disk) and **W96** (ENXIO with 94% of ptys free, cause undetermined — recorded in the file as a standing caveat, not as a cure).

**Bites:** `.github/workflows/fleet-burst-tests.yml` — the job runs `bash scripts/tests/test_fleet_burst.sh --dry-run` with no `continue-on-error`, and that corpus goes RED at real code sites: 7 mutations of `scripts/fleet_burst.sh` were each injected and each turned exactly the intended check red, then reverted (observations below). The workflow also arms `scripts/tests/test_seat_state.sh` — **26 checks that L09-PR1 landed with no workflow naming them at all**; this PR is the first thing in the repo that can make them fail.

Rule 3 is why the workflow is in this PR and not a follow-up: `scripts-tests-sweep.yml` collects only `test_*.py` through pytest (a `.sh` file is invisible to pytest collection) **and** is `continue-on-error: true`, so a shell corpus landed alone has no consumer that can ever go red.

## What it does

- Plans **one distinct verified-LIVE seat per lane** via the L09-PR1 ledger (`scripts/lib/seat_state.sh`). UNKNOWN is not dispatchable — the library's own polarity is fail-*open* for the cascade's skip decision; here it is deliberately inverted, because assigning a lane to a seat we cannot verify is exactly how two lanes end up on one seat.
- Default concurrency ceiling **3**; sterile per-lane `CLAUDE_CONFIG_DIR` and output path; incremental output by direct redirection (buffering in a shell variable would rebuild the W98 all-or-nothing mode).
- Refuses any `*fable*` model string (CLAUDE.md §5, RULED 2026-08-20).

**Fail-closed on the seat-binding gap.** This script handles seat *identifiers* only and never reads or injects a credential value — so by itself it cannot make a child actually **use** the seat planned for it. Left as built, a 3-lane burst would have authenticated all three lanes with whatever ambient credential they inherit, spent **one** seat's quota three times, and reported success with a correct-looking plan. A non-dry-run burst now refuses unless `FLEET_BURST_SEAT_BROKER` names an executable with the contract `<broker> <seat-key> <command…>` — deliberately the signature of L13-PR1's `with_seat.sh`, so the two lanes of this squad meet at a declared seam instead of each half-solving it.

## Seats (generator ≠ grader, family-excluded both directions)

| Lane | Seat |
|---|---|
| Build (D3, non-Anthropic) | **Codex GPT-5.6 terra**, effort high — `fleet_burst.sh` + corpus |
| Refute the shell diff | **Kimi K3** (different family from its builder) |
| Refute the workflow diff | **Codex GPT-5.6 sol**, xhigh (security/workflow class) |
| Final on-disk gate | Claude Opus 5 xhigh — every suite re-run and every guard mutation-tested this turn |

Each refuter received the **diff**, never a narrative. No `seat_override`.

## Nine defects found by refutation, all reproduced before being fixed

**Kimi K3 — on the Codex-built shell:**
1. **Two spellings of one seat filled two lanes.** `--seats live-a,'live-a '` → `live_seats=2`, exit 0, two LANE rows on one real seat, every count reading correct. The refusal check structurally could not see it (with both counted there *are* enough seats to proceed). Fixed by normalising whitespace before the dedup compares.
2. **A library printing `LIVE` while returning 1 was counted live** — the shape an exhausted seat with a cached label produces. The exit status was discarded behind a dead `if/else` under a comment calling it "useful metadata". Now both halves must agree.
3. **`--model` / `--run-dir` reached the TSV plan rows unvalidated** while seat identifiers were checked — the guard's own reasoning applied to one of three call sites (W107 shape). A tab silently *truncates* a field; a newline forges a whole LANE row. One shared validator now covers all three.
4. **The concurrency check greped the printed number, not the throttle.** Replaced with a real dispatch under a shimmed `claude` and stub broker: 5 lanes at `--max-concurrency 2` peak at **2**; disabling the throttle makes the same probe read **5**.
5. **Default run dir was PID-guessable in a shared `/tmp`** — a pre-planted symlink could steer lane output. Now `mktemp -d`. (The corpus already used `mktemp` for its own scratch; the tool was held to a lower standard than its test.)
6. **The no-broker case proved "did not spawn", not "no side effects."** Tightened to assert the run directory does not exist at all.

**Codex GPT-5.6 sol — on the workflow:**
7. **zsh is absent on `ubuntu-latest`**, and the seat-state corpus `return 0`s with a printed SKIP for its two *production-shell* cases (the cascade **is** a zsh script). Bash cases pass, zsh cases skip, job reports SUCCESS over a real zsh regression — coverage theatre, the exact shape this workflow exists to refuse. Fixed with the cure three sibling workflows already use, plus an explicit `command -v zsh` so a silently-failed install cannot put us back to skipping.
8. **The paths filter omitted two files the job's own steps bind** (`claude-cascade.sh`, `test_seat_state.sh`) — red when run, never run. Both added. The header comment that claimed the filter covered "exactly the diffs that can break it" was false and is not restated.
9. **The shallow checkout left `origin/main` unresolvable**, so the seat-state corpus would fail on a *missing baseline* rather than on the change under test. Fixed with an explicit depth-1 fetch of that one ref — not with `fetch-depth: 0`, whose effect on remote-tracking refs for a PR merge-ref checkout is an assumption rather than a measurement.

**One finding raised by the gate and RETRACTED by measurement**, recorded because the method is the point: `claude -p --model X "$prompt"` looked like the argv-binding trap documented at `claude-cascade.sh:441-445`. That note is about **agy**, whose `-p` takes a value; `claude --help` shows `-p, --print` with **no** `<value>` placeholder (contrast `--input-format <format>`), so it is boolean and the builder's line was already correct. One step from "correcting" correct code using a measurement about a different tool.

## Gates, run this turn

| Gate | Result |
|---|---|
| `bash scripts/tests/test_fleet_burst.sh --dry-run` | **14/14**, 7 mutants killed |
| `bash scripts/tests/test_seat_state.sh` | **26/26** |
| `actionlint` (1.7.12 — the pinned CI version) | clean |
| `scripts/lint_workflow_timeout_floor.py` | clean, 148 jobs |
| `evidence_pack_lint.py` | clean, Gear-3 floor with a real council journal |
| pre-commit hot-zone lease | no blocking leases |

## Notes

- **Gear 3, not the drafted 2** — the CI-recomputed floor is 3 because the workflow file is a hot-zone path. Corrected in the L09 spec by a one-line edit in this PR (rule 4), together with the fact that PR-1 landed at `scripts/lib/seat_state.sh`, not `scripts/seat_state.sh`.
- **Over the 400-line target, declared not hidden**: 283 lines are this branch's own evidence pack; of the 705 code lines, 277 are the required guilt+innocence corpus and 116 the executor without which that corpus has no consumer.
- **`brief_ref` is repo-root-relative, not pack-relative.** A sibling pack in this same tree carries `brief_ref: evidence/brief.yml`, which resolves to the *root* brief of an unrelated task — the pack then validates against a stranger's acceptance criteria. Caught by reading the lint's NOTICE instead of its exit code; the correct value and the reason are recorded in the pack.
- Carries held commit `c246e4405b` (comment-only correction inside `seat_state.sh`, unpushable while #5290 was queued).
- **Auto-merge deliberately NOT armed** — workflow-class diff; gates-green evidence is posted to #5318 for the conductor.

Ledger: #5318
