### PR TITLE
feat(db): jsonb codec default=str + one canonical pool initializer

### DIFF
--- a/apps/backend-rag/backend/app/core/database.py
+++ b/apps/backend-rag/backend/app/core/database.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 
@@ -14,6 +15,62 @@ _COMMAND_TIMEOUT = 60  # seconds — query execution timeout
 _MAX_INACTIVE_CONN_LIFETIME = 300  # seconds — idle connections recycled after 5 min
 _ACQUIRE_TIMEOUT = 10  # seconds — max wait for a free connection
 
+# The one JSONB/JSON encoder every asyncpg pool in this repo must register.
+#
+# `default=str` is not decoration — it is the reason this object exists at all.
+# A bare `json.dumps` codec raises `TypeError` on the first `datetime`/`Decimal`
+# a caller hands it, which is precisely why callers were pre-serializing with
+# their own `json.dumps(..., default=str)` before binding to a jsonb
+# placeholder. With that pre-serialized string bound to the parameter, the
+# codec then serializes it a SECOND time and Postgres stores a JSONB *string
+# scalar* instead of the intended object/array (2026-08-27 GARUDA VOA
+# incident — see `init_asyncpg_connection` below and
+# `backend/tests/fixtures/prod_shaped_pool.py`).
+#
+# `default=str` makes this codec a strict superset of every caller's own
+# `default=str` serializer: a caller can now hand it a native Python
+# container (dict/list, possibly containing datetimes/Decimals) and never
+# pre-serialize at all. Any caller that still calls `json.dumps` before
+# binding to a jsonb/json parameter is being broken by this codec, not
+# protected by it — the codec will encode the resulting string as a JSON
+# string literal, not parse it back into an object.
+JSONB_ENCODER = functools.partial(json.dumps, default=str)
+
+
+async def init_asyncpg_connection(conn: asyncpg.Connection) -> None:
+    """The canonical `init=` hook for every asyncpg pool in this repo.
+
+    Registers the `jsonb` and `json` type codecs with `JSONB_ENCODER` /
+    `json.loads`. This is the SINGLE registration point: every pool this
+    codebase creates (the full `rag`-process pool in
+    `service_initializer.py::_initialize_database`, the light `api`-process
+    pool in `service_initializer.py::initialize_services_light`, the
+    standalone `get_db_pool()` below, and the test fixture in
+    `backend/tests/fixtures/prod_shaped_pool.py`) must pass THIS object to
+    `asyncpg.create_pool(init=...)` — directly, or by awaiting it from its
+    own thin wrapper that adds pool-specific extras (a statement timeout, a
+    validation `SELECT 1`) on top.
+
+    Deliberately narrow: codec registration only. No `SET statement_timeout`,
+    no `SELECT 1` validation — those are call-site concerns (some pools want
+    a 30s statement timeout, `get_db_pool()` here does not; some callers want
+    a connectivity probe on every new connection, others do not). Baking them
+    in here would make this function do two unrelated jobs and would force
+    every future caller to accept both.
+    """
+    await conn.set_type_codec(
+        "jsonb",
+        encoder=JSONB_ENCODER,
+        decoder=json.loads,
+        schema="pg_catalog",
+    )
+    await conn.set_type_codec(
+        "json",
+        encoder=JSONB_ENCODER,
+        decoder=json.loads,
+        schema="pg_catalog",
+    )
+
 
 async def get_db_pool() -> asyncpg.Pool:
     """
@@ -26,27 +83,13 @@ async def get_db_pool() -> asyncpg.Pool:
     - statement_cache_size=0: required for PgBouncer transaction mode
     """
 
-    async def init_db_connection(conn: asyncpg.Connection) -> None:
-        await conn.set_type_codec(
-            "jsonb",
-            encoder=json.dumps,
-            decoder=json.loads,
-            schema="pg_catalog",
-        )
-        await conn.set_type_codec(
-            "json",
-            encoder=json.dumps,
-            decoder=json.loads,
-            schema="pg_catalog",
-        )
-
     pool = await asyncpg.create_pool(
         dsn=settings.database_url,
         min_size=_POOL_MIN_SIZE,
         max_size=_POOL_MAX_SIZE,
         command_timeout=_COMMAND_TIMEOUT,
         max_inactive_connection_lifetime=_MAX_INACTIVE_CONN_LIFETIME,
-        init=init_db_connection,
+        init=init_asyncpg_connection,
         # Required for PgBouncer transaction mode — prevents prepared statement leak
         statement_cache_size=0,
     )

--- a/apps/backend-rag/backend/app/core/database.py
+++ b/apps/backend-rag/backend/app/core/database.py
@@ -41,15 +41,34 @@ async def init_asyncpg_connection(conn: asyncpg.Connection) -> None:
     """The canonical `init=` hook for every asyncpg pool in this repo.
 
     Registers the `jsonb` and `json` type codecs with `JSONB_ENCODER` /
-    `json.loads`. This is the SINGLE registration point: every pool this
-    codebase creates (the full `rag`-process pool in
+    `json.loads`. This is the SINGLE registration point for every pool that
+    registers a jsonb/json codec at all: the full `rag`-process pool in
     `service_initializer.py::_initialize_database`, the light `api`-process
     pool in `service_initializer.py::initialize_services_light`, the
-    standalone `get_db_pool()` below, and the test fixture in
-    `backend/tests/fixtures/prod_shaped_pool.py`) must pass THIS object to
+    standalone `get_db_pool()` below, the KG staging-promotion job's pool in
+    `backend/scripts/kg_staging_promotion.py`, and the test fixture in
+    `backend/tests/fixtures/prod_shaped_pool.py`. Each passes THIS object to
     `asyncpg.create_pool(init=...)` — directly, or by awaiting it from its
     own thin wrapper that adds pool-specific extras (a statement timeout, a
     validation `SELECT 1`) on top.
+
+    SCOPED DELIBERATELY, because the previous wording said "every pool this
+    codebase creates" and that was FALSE (corrected 2026-08-30 after a blind
+    cross-family refuter found the kg_staging_promotion pool registering its
+    own codecs with a bare `json.dumps`). Five further `asyncpg.create_pool`
+    call sites outside the test tree register NO codec at all and are NOT
+    converted here: `app/intake_review_reader.py`,
+    `core/legal/hierarchical_indexer.py`, `app/routers/admin_zoho_auth.py`
+    (x2), `app/routers/admin_drive_health.py`, and
+    `migrations/migration_084a_nlm_verification_log.py`. Measured, not
+    assumed: none of the five references `garuda_orders`, `garuda_portal`,
+    `journal` or `idempotency`, so none can reach the four writers that now
+    bind native containers. A pool with no codec has a DIFFERENT failure mode
+    from one with a bare-`json.dumps` codec — it cannot bind a `dict` at all
+    (loud `DataError`) rather than silently storing a string scalar — so it is
+    not this lane's defect class. Converting them is real work with its own
+    blast radius, not a rider on this diff. If you add a jsonb write path to
+    any of the five, import this hook rather than writing a sixth codec.
 
     Deliberately narrow: codec registration only. No `SET statement_timeout`,
     no `SELECT 1` validation — those are call-site concerns (some pools want

--- a/apps/backend-rag/backend/app/setup/service_initializer.py
+++ b/apps/backend-rag/backend/app/setup/service_initializer.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import json
 import logging
 import os
 import random
@@ -42,6 +41,7 @@ import asyncpg
 from fastapi import FastAPI
 
 from backend.app.core.config import settings
+from backend.app.core.database import init_asyncpg_connection
 from backend.app.core.service_health import ServiceStatus, service_registry
 
 logger = logging.getLogger("zantara.backend")
@@ -504,18 +504,11 @@ async def initialize_database_services(app: FastAPI) -> asyncpg.Pool | None:
 
             # Create asyncpg pool for team timesheet service
             async def init_db_connection(conn: asyncpg.Connection) -> None:
-                await conn.set_type_codec(
-                    "jsonb",
-                    encoder=json.dumps,
-                    decoder=json.loads,
-                    schema="pg_catalog",
-                )
-                await conn.set_type_codec(
-                    "json",
-                    encoder=json.dumps,
-                    decoder=json.loads,
-                    schema="pg_catalog",
-                )
+                # Codec registration: the SINGLE canonical hook shared by every
+                # pool in this repo (see backend/app/core/database.py). Encoder
+                # is `functools.partial(json.dumps, default=str)`, not bare
+                # `json.dumps` — callers hand it native Python containers.
+                await init_asyncpg_connection(conn)
                 # Prevent runaway queries (30s covers RAG KG traversal ~5-10s)
                 await conn.execute("SET statement_timeout = '30s'")
                 # Validate connection
@@ -1881,21 +1874,22 @@ async def initialize_services_light(app: FastAPI) -> None:
         dsn, ssl_ctx = _clean_database_dsn(settings.database_url)
 
         async def _light_init_connection(conn):
-            """Set statement timeout + register jsonb codec on every connection.
+            """Set statement timeout + register the canonical jsonb codec.
 
-            The jsonb codec lets the application pass Python dicts directly to
-            jsonb-typed parameters; asyncpg auto-serialises with json.dumps and
-            Postgres parses the result as a proper JSONB object. Without this
-            codec, code that already calls json.dumps() before passing the
-            string to the parameter ends up storing it as a JSONB string
-            scalar in production (symptom seen on practices.metadata.
-            discount_log: rows landed as '"{\"discount_log\":[...]}"' instead
-            of '{"discount_log":[...]}', breaking `metadata ? 'discount_log'`
-            and any jsonb_path_* query). With the codec active the
-            application-level json.dumps() becomes WRONG, not merely redundant:
-            asyncpg serializes a SECOND time and the value lands as a JSONB
-            scalar string. Any caller that still pre-serializes is broken by
-            this codec, not protected by it.
+            The jsonb codec lets the application pass Python dicts/lists
+            directly to jsonb-typed parameters; asyncpg auto-serialises with
+            `JSONB_ENCODER` (`functools.partial(json.dumps, default=str)`)
+            and Postgres parses the result as a proper JSONB
+            object/array. Without this codec, code that already calls
+            json.dumps() before passing the string to the parameter ends up
+            storing it as a JSONB string scalar in production (symptom seen
+            on practices.metadata.discount_log: rows landed as
+            '"{\"discount_log\":[...]}"' instead of '{"discount_log":[...]}',
+            breaking `metadata ? 'discount_log'` and any jsonb_path_* query).
+            With the codec active the application-level json.dumps() becomes
+            WRONG, not merely redundant: asyncpg serializes a SECOND time and
+            the value lands as a JSONB scalar string. Any caller that still
+            pre-serializes is broken by this codec, not protected by it.
 
             CORRECTED 2026-08-27 — this docstring used to say "the existing
             `$N::jsonb` casts are harmless". They are not, and nothing had ever
@@ -1909,29 +1903,28 @@ async def initialize_services_light(app: FastAPI) -> None:
             2026-08-27 (migration 286's CHECK calls `jsonb_array_length` on the
             value, which raises SQLSTATE 22023 on a scalar).
 
-            Still-unfixed callers of the same anti-pattern are ledgered in
-            `.claude/skills/modus/PENDING-ARMS.md`; they are NOT one-line fixes,
-            because this encoder is bare `json.dumps` with no `default=str`
-            while `garuda_orders/journal.py` relies on `default=str`.
+            CORRECTED AGAIN 2026-08-29 — the paragraph this used to carry here
+            said the encoder was bare `json.dumps` with no `default=str`,
+            "while `garuda_orders/journal.py` relies on `default=str`", and
+            called the still-unfixed callers "NOT one-line fixes" for that
+            reason. That gap is closed: the codec registered below is now
+            `JSONB_ENCODER` from `backend/app/core/database.py` — the SAME
+            `functools.partial(json.dumps, default=str)` object every pool in
+            this repo shares — so it is a strict superset of every caller's
+            own `default=str` serializer. `garuda_orders/journal.py`,
+            `garuda_orders/idempotency.py`, and `garuda_portal/idempotency.py`
+            no longer pre-serialize before binding to a jsonb/json parameter;
+            they hand this codec native Python containers directly.
 
             Aligns the api pool with the existing full-init pool
-            (`init_db_connection` ~line 459) which has always used the same
-            codec; the standalone helper in backend/app/core/database.py also
-            registers it.
+            (`init_db_connection` ~line 459), the standalone helper in
+            `backend/app/core/database.py::get_db_pool`, and the test fixture
+            in `backend/tests/fixtures/prod_shaped_pool.py` — all four call
+            `init_asyncpg_connection` (imported below), never their own
+            `set_type_codec`.
             """
             await conn.execute("SET statement_timeout = '30s'")
-            await conn.set_type_codec(
-                "jsonb",
-                encoder=json.dumps,
-                decoder=json.loads,
-                schema="pg_catalog",
-            )
-            await conn.set_type_codec(
-                "json",
-                encoder=json.dumps,
-                decoder=json.loads,
-                schema="pg_catalog",
-            )
+            await init_asyncpg_connection(conn)
 
         pool_kwargs: dict = {
             "dsn": dsn,

--- a/apps/backend-rag/backend/scripts/kg_staging_promotion.py
+++ b/apps/backend-rag/backend/scripts/kg_staging_promotion.py
@@ -82,6 +82,7 @@ from typing import Any
 
 import asyncpg
 
+from backend.app.core.database import init_asyncpg_connection
 from backend.services.rag.kg_auto_expansion import normalize_entity_id
 
 logger = logging.getLogger(__name__)
@@ -394,14 +395,25 @@ def _clean_database_dsn(dsn: str) -> tuple[str, bool | None]:
 
 
 async def _init_connection(conn: asyncpg.Connection) -> None:
-    """Per-connection init: statement timeout + jsonb/json codecs (prod-pool shape)."""
+    """Per-connection init: statement timeout + jsonb/json codecs (prod-pool shape).
+
+    The codec half is DELEGATED to `init_asyncpg_connection` (2026-08-30) rather
+    than re-registered here. This function used to register both codecs itself
+    with a bare `json.dumps` encoder -- a FOURTH independent registration that
+    `database.py`'s "every pool this codebase creates" docstring did not know
+    about, and that the parity test could not see because its
+    `_CANONICAL_CODEC_FILES` listed only three paths. A cross-family refuter
+    (Codex GPT-5.6 sol, blind) found it; it is fixed here rather than left as a
+    footnote, because a centralisation claim with a known exception is worse
+    than no claim at all -- the next reader trusts it.
+
+    The `SET statement_timeout` stays HERE and is deliberately not folded into
+    the shared hook: this is the "thin wrapper that adds pool-specific extras"
+    the hook's own docstring describes. `get_db_pool()` wants no statement
+    timeout at all, so a hook that imposed one would be wrong for it.
+    """
     await conn.execute("SET statement_timeout = '30s'")
-    await conn.set_type_codec(
-        "jsonb", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
-    )
-    await conn.set_type_codec(
-        "json", encoder=json.dumps, decoder=json.loads, schema="pg_catalog"
-    )
+    await init_asyncpg_connection(conn)
 
 
 async def create_pool(database_url: str) -> asyncpg.Pool:

--- a/apps/backend-rag/backend/services/garuda_orders/idempotency.py
+++ b/apps/backend-rag/backend/services/garuda_orders/idempotency.py
@@ -126,7 +126,7 @@ async def complete(
         """,
         key_sha256,
         response_status,
-        json.dumps(response_body, default=str),
+        response_body,
     )
 
 

--- a/apps/backend-rag/backend/services/garuda_orders/journal.py
+++ b/apps/backend-rag/backend/services/garuda_orders/journal.py
@@ -9,7 +9,6 @@ takes a `conn` that is already inside one.
 
 from __future__ import annotations
 
-import json
 import secrets
 from typing import Any
 
@@ -50,7 +49,7 @@ async def append_event(
         idempotency_key_digest,
         canonical_payload_digest,
         customer_visible,
-        json.dumps(detail or {}, default=str),
+        detail or {},
     )
     return event_id
 
@@ -75,7 +74,7 @@ async def enqueue_outbox(
         order_id,
         journal_event_id,
         job_type,
-        json.dumps(payload or {}, default=str),
+        payload or {},
     )
 
 

--- a/apps/backend-rag/backend/services/garuda_portal/idempotency.py
+++ b/apps/backend-rag/backend/services/garuda_portal/idempotency.py
@@ -115,5 +115,5 @@ async def complete(
         """,
         key_sha256,
         response_status,
-        json.dumps(response_body, default=str),
+        response_body,
     )

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_ownership.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_orders_ownership.py
@@ -44,6 +44,7 @@ asyncpg = pytest.importorskip("asyncpg")
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from backend.app.core.database import init_asyncpg_connection
 from backend.app.routers import garuda_orders_router
 from backend.services.garuda_flow.intake import CaseType
 from backend.services.garuda_orders.ports import ReviewedCheckSnapshot
@@ -146,7 +147,18 @@ async def _close_garuda_order_test_policy(conn: asyncpg.Connection, policy_versi
 @pytest.fixture
 async def pool():
     try:
-        p = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=2)
+        # `init=` is NOT optional here (2026-08-30) -- same reason as
+        # `backend/tests/services/garuda_portal/test_practice.py`. This fixture
+        # drives `GarudaOrderRepository`, which reaches
+        # `garuda_orders/journal.py::append_event`; that writer now binds a NATIVE
+        # Python dict to `garuda_order_journal.detail` instead of a pre-serialized
+        # string, so a pool without the canonical jsonb codec raises
+        # `DataError: ... expected str, got dict`. Found by A/B-ing the 21
+        # baselined bare-pool files against origin/main, not by reading the diff:
+        # the narrower GARUDA-suite A/B did not reach this file at all.
+        p = await asyncpg.create_pool(
+            dsn=_DSN, min_size=1, max_size=2, init=init_asyncpg_connection
+        )
     except (OSError, asyncpg.PostgresError) as exc:
         if os.environ.get("CI"):
             pytest.fail(

--- a/apps/backend-rag/backend/tests/db/test_jsonb_codec_parity.py
+++ b/apps/backend-rag/backend/tests/db/test_jsonb_codec_parity.py
@@ -1,0 +1,343 @@
+"""Parity tests for the canonical asyncpg jsonb codec (L12-PR1, 2026-08-29).
+
+The disease this file guards against: three asyncpg pools
+(`backend/app/core/database.py::get_db_pool`, both pool paths in
+`backend/app/setup/service_initializer.py`) each registered a `jsonb`/`json`
+type codec with a BARE `json.dumps` encoder. Four caller sites
+(`garuda_orders/journal.py` x2, `garuda_orders/idempotency.py`,
+`garuda_portal/idempotency.py`) pre-serialized with
+`json.dumps(..., default=str)` before binding to a jsonb placeholder because
+the bare codec would raise `TypeError` on the first `datetime`/`Decimal`. With
+the codec active that pre-serialization is WRONG, not merely redundant:
+asyncpg encodes the already-serialized string a SECOND time and Postgres
+stores a JSONB *string scalar* instead of the intended object/array
+(2026-08-27 GARUDA VOA incident — see `backend/tests/fixtures/prod_shaped_pool.py`
+and the `test_jsonb_double_encoding_class_guard.py` registry in this same
+directory).
+
+The cure widens the codec's encoder to `JSONB_ENCODER =
+functools.partial(json.dumps, default=str)` — a strict superset of every
+caller's own `default=str` serializer — and makes it the ONE object every
+pool (`database.py`, both `service_initializer.py` paths, and the
+`prod_shaped_pool` test fixture) imports and passes to
+`asyncpg.create_pool(init=...)`. This file has two parts:
+
+STRUCTURAL (no database, always runs): the encoder object is the right
+shape, the identity is shared (not four independent copies that can drift
+again the way the pre-2026-08-27 codecs did), and a static AST scan proves no
+`set_type_codec` call anywhere in the three canonical files still names a
+bare `json.dumps` encoder.
+
+LIVE (in practice ALWAYS runs -- see below): a real round-trip through
+`create_prod_shaped_pool` proving (a) a native Python container round-trips
+correctly, (b) `default=str` is load-bearing — a container holding a
+`datetime`/`Decimal` would raise under the OLD bare codec and now succeeds,
+and (c) the scar this whole lane exists to prevent a false cure for: a
+PRE-serialized string still lands as a JSONB string scalar whether bound bare
+or through an explicit `::jsonb` cast. That cast is NOT a bypass of the
+codec's double-encoding behavior — measured against a real Postgres
+2026-08-27, pinned here so a future reader cannot re-derive the disproven
+"the cast protects us" claim.
+
+CORRECTED 2026-08-30 (was: "skipped unless TEST_DATABASE_URL is set", an
+over-claim of the same class this file exists to punish). The `skipif`
+below is real code, but the skip it guards is UNREACHABLE in this repo's
+own test tree: `backend/tests/conftest.py:42-48` runs
+`os.environ.setdefault("TEST_DATABASE_URL", "postgresql://nuzantara@"
+"localhost:5432/nuzantara_test")` at collection time, before this module is
+even imported, so the variable is ALWAYS set by the time `_live_only` is
+evaluated. In THIS repo's pytest, the live half always runs -- against
+whatever Postgres that default (or an operator/CI override) resolves to --
+never against "no database". The `skipif` is belt-and-braces for a
+conftest-less invocation (importing this file directly outside pytest, or
+a future test runner that does not carry that root conftest), not a real
+day-to-day escape hatch.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from backend.app.core import database as database_module
+from backend.app.setup import service_initializer as service_initializer_module
+from backend.tests.fixtures import prod_shaped_pool as prod_shaped_pool_module
+from backend.tests.fixtures.prod_shaped_pool import create_prod_shaped_pool
+
+TEST_DATABASE_URL = os.environ.get("TEST_DATABASE_URL")
+
+_live_only = pytest.mark.skipif(
+    not TEST_DATABASE_URL,
+    reason="TEST_DATABASE_URL not set",
+)
+
+# backend/tests/db/.. -> backend/ (same convention as
+# test_jsonb_double_encoding_class_guard.py in this directory).
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+_CANONICAL_CODEC_FILES = (
+    BACKEND_ROOT / "app" / "core" / "database.py",
+    BACKEND_ROOT / "app" / "setup" / "service_initializer.py",
+    BACKEND_ROOT / "tests" / "fixtures" / "prod_shaped_pool.py",
+)
+
+
+# --------------------------------------------------------------------------
+# STRUCTURAL — no database required.
+# --------------------------------------------------------------------------
+
+
+def test_jsonb_encoder_is_json_dumps_with_default_str() -> None:
+    """`JSONB_ENCODER` is `json.dumps` widened by `default=str` — not a
+    different serializer, and not bare `json.dumps` re-exported under a new
+    name (either of which would silently reintroduce the disease)."""
+    encoder = database_module.JSONB_ENCODER
+    assert isinstance(encoder, functools.partial)
+    assert encoder.func is json.dumps
+    assert encoder.keywords.get("default") is str
+    assert encoder.args == ()
+
+
+def test_jsonb_encoder_widens_bare_json_dumps() -> None:
+    """The whole reason `default=str` exists: a value bare `json.dumps`
+    cannot serialize must succeed through `JSONB_ENCODER`, or callers are
+    forced back into pre-serializing (the exact anti-pattern this lane
+    removes from `garuda_orders/journal.py` and both `idempotency.py` files).
+    """
+    value = {"when": datetime(2026, 1, 1, tzinfo=timezone.utc), "amount": Decimal("12.50")}
+
+    with pytest.raises(TypeError):
+        json.dumps(value)
+
+    encoded = database_module.JSONB_ENCODER(value)
+    assert isinstance(encoded, str)
+    decoded = json.loads(encoded)
+    assert decoded["amount"] == "12.50"
+    assert decoded["when"] == "2026-01-01 00:00:00+00:00"
+
+
+def test_prod_shaped_pool_imports_the_canonical_initializer_by_identity() -> None:
+    """Not "an equivalent copy" — the SAME function object. A fixture that
+    re-implements `set_type_codec` calls of its own can drift from
+    production the way the pre-2026-08-29 duplicate did; importing the name
+    makes drift structurally impossible without editing this import."""
+    assert (
+        prod_shaped_pool_module.init_asyncpg_connection
+        is database_module.init_asyncpg_connection
+    )
+
+
+def test_service_initializer_imports_the_canonical_initializer_by_identity() -> None:
+    """Both `service_initializer.py` pool paths call
+    `init_asyncpg_connection(conn)` (imported at module level from
+    `backend.app.core.database`), never their own `set_type_codec`."""
+    assert (
+        service_initializer_module.init_asyncpg_connection
+        is database_module.init_asyncpg_connection
+    )
+
+
+def _encoder_kwarg_is_canonical(node: ast.expr) -> bool:
+    """True iff `node` names (directly or via `module.JSONB_ENCODER`) the
+    one canonical encoder — never a bare `json.dumps`/`json.dumps` lambda/
+    anything else."""
+    if isinstance(node, ast.Name):
+        return node.id == "JSONB_ENCODER"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "JSONB_ENCODER"
+    return False
+
+
+def _set_type_codec_violations(path: Path) -> list[str]:
+    """Every `conn.set_type_codec(...)` call in `path` whose `encoder=`
+    keyword is missing or is not the canonical `JSONB_ENCODER` object,
+    formatted as `path:line: <reason>`.
+
+    AST-based, not regex — this is the tripwire the PR asked for: it must
+    fire if anyone reintroduces `encoder=json.dumps` in any of the three
+    canonical files, including inside a helper this test's authors did not
+    anticipate.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "set_type_codec"):
+            continue
+        encoder_kw = next((kw for kw in node.keywords if kw.arg == "encoder"), None)
+        if encoder_kw is None:
+            violations.append(f"{path}:{node.lineno}: set_type_codec call has no encoder= keyword")
+            continue
+        if not _encoder_kwarg_is_canonical(encoder_kw.value):
+            violations.append(
+                f"{path}:{node.lineno}: set_type_codec encoder= is not JSONB_ENCODER "
+                f"(got {ast.dump(encoder_kw.value)})"
+            )
+    return violations
+
+
+def test_no_bare_json_dumps_set_type_codec_encoder_anywhere_canonical() -> None:
+    """GUILT-side source scan: none of the three files that are allowed to
+    call `set_type_codec` at all may do so with a bare/non-canonical
+    encoder. `database.py` is expected to contain the two calls that
+    register `JSONB_ENCODER` itself — those must pass; `service_initializer.py`
+    and `prod_shaped_pool.py` are expected to contain ZERO `set_type_codec`
+    calls at all post-2026-08-29 (they delegate to `init_asyncpg_connection`),
+    so they pass vacuously. A future PR that reintroduces
+    `encoder=json.dumps` in ANY of the three must fail this test."""
+    all_violations: list[str] = []
+    for path in _CANONICAL_CODEC_FILES:
+        assert path.exists(), f"expected canonical codec file missing: {path}"
+        all_violations.extend(_set_type_codec_violations(path))
+    assert not all_violations, "\n".join(all_violations)
+
+
+def test_scanner_actually_detects_a_bare_encoder(tmp_path: Path) -> None:
+    """Self-test of `_set_type_codec_violations`: a scanner that always
+    returns `[]` would make the guilt test above vacuous. Prove it fires on
+    the exact pre-2026-08-29 shape before trusting it to stay silent on the
+    real files."""
+    guilty = tmp_path / "guilty.py"
+    guilty.write_text(
+        "import json\n"
+        "import asyncpg\n"
+        "\n"
+        "async def init_db_connection(conn: asyncpg.Connection) -> None:\n"
+        "    await conn.set_type_codec(\n"
+        "        'jsonb', encoder=json.dumps, decoder=json.loads, schema='pg_catalog'\n"
+        "    )\n"
+    )
+    violations = _set_type_codec_violations(guilty)
+    assert len(violations) == 1
+    assert "guilty.py:5" in violations[0]
+
+    innocent = tmp_path / "innocent.py"
+    innocent.write_text(
+        "import asyncpg\n"
+        "from backend.app.core.database import JSONB_ENCODER\n"
+        "\n"
+        "async def init_db_connection(conn: asyncpg.Connection) -> None:\n"
+        "    await conn.set_type_codec(\n"
+        "        'jsonb', encoder=JSONB_ENCODER, decoder=None, schema='pg_catalog'\n"
+        "    )\n"
+    )
+    assert _set_type_codec_violations(innocent) == []
+
+
+# --------------------------------------------------------------------------
+# LIVE — requires TEST_DATABASE_URL (a real Postgres).
+# --------------------------------------------------------------------------
+
+
+def _probe_table_name() -> str:
+    return f"_jsonb_codec_parity_probe_{uuid.uuid4().hex[:8]}"
+
+
+@_live_only
+@pytest.mark.asyncio
+async def test_native_python_list_round_trips_as_jsonb_array() -> None:
+    """INNOCENCE: a native Python container (never `json.dumps`-ed by the
+    caller) round-trips through `create_prod_shaped_pool` as a real JSONB
+    array, structurally equal on the way back out."""
+    pool = await create_prod_shaped_pool(TEST_DATABASE_URL, min_size=1, max_size=2)
+    table = _probe_table_name()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(f"CREATE TABLE {table} (id serial primary key, payload jsonb)")
+            native = [1, "two", {"three": 3}]
+            await conn.execute(f"INSERT INTO {table} (payload) VALUES ($1)", native)
+
+            typeof = await conn.fetchval(f"SELECT jsonb_typeof(payload) FROM {table}")
+            assert typeof == "array"
+
+            round_tripped = await conn.fetchval(f"SELECT payload FROM {table}")
+            assert round_tripped == native
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {table}")
+        await pool.close()
+
+
+@_live_only
+@pytest.mark.asyncio
+async def test_native_dict_with_datetime_and_decimal_succeeds_via_default_str() -> None:
+    """INNOCENCE 2 — the `default=str` proof: a native dict containing a
+    `datetime` and a `Decimal` INSERTs successfully and lands as a JSONB
+    object. Under the pre-2026-08-29 bare `json.dumps` codec this raised
+    `TypeError` inside asyncpg's own encoder, which is exactly why callers
+    were pre-serializing with their own `default=str` before this lane."""
+    pool = await create_prod_shaped_pool(TEST_DATABASE_URL, min_size=1, max_size=2)
+    table = _probe_table_name()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(f"CREATE TABLE {table} (id serial primary key, payload jsonb)")
+            native = {
+                "occurred_at": datetime(2026, 8, 29, tzinfo=timezone.utc),
+                "amount": Decimal("199.99"),
+            }
+            await conn.execute(f"INSERT INTO {table} (payload) VALUES ($1)", native)
+
+            typeof = await conn.fetchval(f"SELECT jsonb_typeof(payload) FROM {table}")
+            assert typeof == "object"
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {table}")
+        await pool.close()
+
+
+@_live_only
+@pytest.mark.asyncio
+async def test_pre_serialized_string_still_becomes_jsonb_string_scalar() -> None:
+    """SCAR / CONTRAST: a caller that STILL pre-serializes with `json.dumps`
+    before binding to a jsonb placeholder is double-encoded by the codec —
+    with `default=str` in place this is now the ONLY way to reintroduce the
+    2026-08-27 disease, and it must still be caught structurally.
+
+    Pins the 2026-08-27 measurement: binding the SAME pre-serialized string
+    to a bare `$N` placeholder and to an explicit `$N::jsonb` cast BOTH store
+    `jsonb_typeof = 'string'`. The `::jsonb` cast is NOT a bypass of the
+    codec's double-encoding behavior — a future reader must not re-derive
+    "the cast protects us" from first principles; it was measured false
+    against a real Postgres and is pinned here.
+    """
+    pool = await create_prod_shaped_pool(TEST_DATABASE_URL, min_size=1, max_size=2)
+    table = _probe_table_name()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                f"CREATE TABLE {table} "
+                "(id serial primary key, bare_payload jsonb, cast_payload jsonb)"
+            )
+            pre_serialized = json.dumps([1, 2, 3])
+            await conn.execute(
+                f"INSERT INTO {table} (bare_payload, cast_payload) VALUES ($1, $2::jsonb)",
+                pre_serialized,
+                pre_serialized,
+            )
+
+            row = await conn.fetchrow(
+                f"SELECT jsonb_typeof(bare_payload) AS bare_type, "
+                f"jsonb_typeof(cast_payload) AS cast_type FROM {table}"
+            )
+            assert row["bare_type"] == "string", (
+                "a pre-serialized string bound to a bare jsonb placeholder must "
+                "still be double-encoded into a JSONB string scalar by the codec"
+            )
+            assert row["cast_type"] == "string", (
+                "the `::jsonb` cast does not route around the codec's own "
+                "encode step -- it is NOT an escape hatch (measured 2026-08-27)"
+            )
+    finally:
+        async with pool.acquire() as conn:
+            await conn.execute(f"DROP TABLE IF EXISTS {table}")
+        await pool.close()

--- a/apps/backend-rag/backend/tests/db/test_jsonb_codec_parity.py
+++ b/apps/backend-rag/backend/tests/db/test_jsonb_codec_parity.py
@@ -87,6 +87,22 @@ _CANONICAL_CODEC_FILES = (
     BACKEND_ROOT / "app" / "core" / "database.py",
     BACKEND_ROOT / "app" / "setup" / "service_initializer.py",
     BACKEND_ROOT / "tests" / "fixtures" / "prod_shaped_pool.py",
+    # 2026-08-30: the FOURTH file, added after a blind cross-family refuter
+    # found it registering both codecs itself with a bare `json.dumps` while
+    # this tuple listed only three paths -- so the scan below could not see
+    # it and `database.py`'s centralisation claim was false. A scanner is
+    # only as honest as its file list.
+    BACKEND_ROOT / "scripts" / "kg_staging_promotion.py",
+)
+
+# The production wrappers that must ACTUALLY CALL the canonical hook. Importing
+# the symbol is not using it: `test_service_initializer_imports_the_canonical_
+# initializer_by_identity` below compares module attributes, and that comparison
+# stays true even if every call were deleted. Same refuter, same round.
+_MUST_CALL_INITIALIZER = (
+    BACKEND_ROOT / "app" / "setup" / "service_initializer.py",
+    BACKEND_ROOT / "scripts" / "kg_staging_promotion.py",
+    BACKEND_ROOT / "tests" / "fixtures" / "prod_shaped_pool.py",
 )
 
 
@@ -232,6 +248,37 @@ def test_scanner_actually_detects_a_bare_encoder(tmp_path: Path) -> None:
         "    )\n"
     )
     assert _set_type_codec_violations(innocent) == []
+
+
+def _awaits_canonical_initializer(path: Path) -> bool:
+    """True if `path` contains at least one `await init_asyncpg_connection(...)`
+    call. AST-based, so a mention inside a docstring or a comment does not
+    count -- only a real call node does."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name == "init_asyncpg_connection":
+            return True
+    return False
+
+
+def test_production_pool_wrappers_actually_call_the_initializer() -> None:
+    """The identity tests above prove the SYMBOL is shared. They do NOT prove
+    it is USED: delete the `await init_asyncpg_connection(conn)` lines from
+    `service_initializer.py` and both identity tests still pass, because a
+    module attribute is still a module attribute. That gap was found by a
+    blind cross-family refuter (Codex GPT-5.6 sol) on 2026-08-30 and is what
+    this test closes -- an import is not a call."""
+    missing = [str(p) for p in _MUST_CALL_INITIALIZER if not _awaits_canonical_initializer(p)]
+    assert not missing, (
+        "these files import or are expected to use the canonical initializer but "
+        f"contain no call to it: {missing}. An import is not a call -- if the pool "
+        "no longer routes through init_asyncpg_connection, test/production codec "
+        "parity is broken even though every identity assertion still passes."
+    )
 
 
 # --------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/fixtures/prod_shaped_pool.py
+++ b/apps/backend-rag/backend/tests/fixtures/prod_shaped_pool.py
@@ -24,8 +24,18 @@ file is, by construction, a pool that can drift from production again.
 WHAT IS MIRRORED, AND WHAT IS NOT. Stated exactly, because the defect this
 file exists to catch was born of a comment that claimed more than its code did.
 
-Mirrored, because both production pools set it identically:
-  * the `jsonb` and `json` type codecs (the load-bearing one)
+Mirrored -- and, since 2026-08-29, mirrored by IDENTITY rather than by
+duplicate code: this module imports `init_asyncpg_connection` from
+`backend/app/core/database.py`, the SAME function object every production
+pool (`service_initializer.py`'s full and light init paths, and
+`get_db_pool()`) passes to `asyncpg.create_pool(init=...)`. This is no
+longer a copy that can silently drift -- it is the canonical codec, imported,
+not "mirrored" by a second hand-written `set_type_codec` call. That function
+registers:
+  * the `jsonb` and `json` type codecs (the load-bearing one, encoder
+    `JSONB_ENCODER = functools.partial(json.dumps, default=str)`)
+
+This file additionally sets, matching what both production pools do:
   * `SET statement_timeout = '30s'`
   * `statement_cache_size=0`
   * `max_inactive_connection_lifetime=30.0`
@@ -45,9 +55,9 @@ picking one -- a fixture that silently picks is worse than one that abstains.
 
 from __future__ import annotations
 
-import json
-
 import asyncpg
+
+from backend.app.core.database import init_asyncpg_connection
 
 
 async def init_prod_shaped_connection(conn: asyncpg.Connection) -> None:
@@ -55,20 +65,13 @@ async def init_prod_shaped_connection(conn: asyncpg.Connection) -> None:
 
     Kept as its own function (not inlined into the pool factory) so a test can
     assert on it, and so the diff against production's own init hook is a
-    two-file read rather than an archaeology exercise.
+    two-file read rather than an archaeology exercise. Delegates codec
+    registration to `init_asyncpg_connection` -- the SAME object production
+    uses -- rather than re-registering the codecs by hand, so this function
+    cannot drift from production's encoder the way the pre-2026-08-29 version
+    could.
     """
-    await conn.set_type_codec(
-        "jsonb",
-        encoder=json.dumps,
-        decoder=json.loads,
-        schema="pg_catalog",
-    )
-    await conn.set_type_codec(
-        "json",
-        encoder=json.dumps,
-        decoder=json.loads,
-        schema="pg_catalog",
-    )
+    await init_asyncpg_connection(conn)
     # Both production inits also do this, identically. Added after an
     # adversarial review pointed out that this module PROMISED to mirror
     # production's init and then mirrored only the codecs -- the same

--- a/apps/backend-rag/backend/tests/routers/test_bridge_wa_media.py
+++ b/apps/backend-rag/backend/tests/routers/test_bridge_wa_media.py
@@ -19,6 +19,7 @@ import pytest_asyncio
 
 import backend.app.routers.bridge as bridge
 from backend.services.events import outbox as events_outbox
+from backend.tests.fixtures.prod_shaped_pool import create_prod_shaped_pool
 
 _DB_URL = os.environ.get(
     "TEST_DATABASE_URL",
@@ -30,7 +31,7 @@ _AUTH = "test-bridge-key-piece-b"
 
 @pytest_asyncio.fixture
 async def pool() -> asyncpg.Pool:
-    p = await asyncpg.create_pool(dsn=_DB_URL, min_size=1, max_size=3)
+    p = await create_prod_shaped_pool(_DB_URL, min_size=1, max_size=3)
     try:
         yield p
     finally:

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -118,9 +118,19 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
                     status, stage_output, intake_key, received_by)
                    VALUES ($1,$2,$3,$4,$5,$6,'done',$7::jsonb,$8,$9) RETURNING id""",
                 inst, source, f"{tag}-ref", f"/tmp/{tag}.pdf", bh[:64], PIPELINE,
-                json.dumps(stage_output if stage_output is not None else
-                           {"ocr": {"pages": [{"page": 1, "text": "NPWP 09.x"}]},
-                            "doc_type": "npwp"}),
+                # NATIVE dict, not json.dumps (2026-08-31). This fixture's pool is
+                # now the production-shaped one, which registers the jsonb codec --
+                # so a pre-serialized string is encoded a SECOND time and lands as a
+                # jsonb STRING SCALAR, exactly the defect this lane exists to close.
+                # It is not cosmetic here: `routing || jsonb_build_object(...)` in
+                # test_candidate_ids_routing_fallback_and_companies_excluded operates
+                # on a scalar instead of an object, the client_id fallback never
+                # lands, and the test fails `assert 90 in []`. Found in CI Backend
+                # Shard 3, not locally -- this repo's local Postgres has no `clients`
+                # table, so the test ERRORS here and can never reproduce the red.
+                (stage_output if stage_output is not None else
+                 {"ocr": {"pages": [{"page": 1, "text": "NPWP 09.x"}]},
+                  "doc_type": "npwp"}),
                 ikey, received_by,
             )
             created["queues"].append(qid)
@@ -130,12 +140,12 @@ async def seed(pool: asyncpg.Pool) -> AsyncIterator[dict]:
                     entity_resolution, routing, commit_gate, status)
                    VALUES ($1,0,$2,$3,$4::jsonb,$5::jsonb,$6::jsonb,'review_pending') RETURNING id""",
                 qid, PIPELINE, f"{tag}-{uuid.uuid4().hex[:6]}",
-                json.dumps(entity_resolution),
-                json.dumps({"doc_type": "npwp",
-                            "fields": {"npwp_number": {"value": "09.254.294.3-407.000",
-                                                       "confidence": 0.85, "source_page": 1}},
-                            "type_confidence": 0.97}),
-                json.dumps({"requires_human": True, "auto_commit_eligible": False}),
+                entity_resolution,
+                {"doc_type": "npwp",
+                 "fields": {"npwp_number": {"value": "09.254.294.3-407.000",
+                                            "confidence": 0.85, "source_page": 1}},
+                 "type_confidence": 0.97},
+                {"requires_human": True, "auto_commit_eligible": False},
             )
             created["proposals"].append(pid)
             return pid

--- a/apps/backend-rag/backend/tests/routers/test_intake_review.py
+++ b/apps/backend-rag/backend/tests/routers/test_intake_review.py
@@ -38,6 +38,7 @@ from httpx import ASGITransport, AsyncClient
 
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.setup.route_walk import iter_leaf_routes
+from backend.tests.fixtures.prod_shaped_pool import create_prod_shaped_pool
 
 DSN = os.environ.get("INTAKE_TEST_DSN", "postgresql://localhost:5432/nuzantara_test")
 PIPELINE = "test-5a"
@@ -77,7 +78,7 @@ async def _dsn_reachable() -> bool:
 async def pool() -> AsyncIterator[asyncpg.Pool]:
     if not await _dsn_reachable():
         pytest.skip(f"local intake DB not reachable at {DSN}")
-    p = await asyncpg.create_pool(DSN, min_size=1, max_size=4)
+    p = await create_prod_shaped_pool(DSN, min_size=1, max_size=4)
     yield p
     await p.close()
 

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_funnel_end_to_end_http.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_funnel_end_to_end_http.py
@@ -504,32 +504,27 @@ class TestTheFunnelAVisitorActuallyWalks:
             f"documents (got {sorted(job_types)})"
         )
 
-    async def test_outbox_payloads_are_currently_json_strings_pinning_an_open_defect(
+    async def test_outbox_payloads_are_json_objects_after_the_codec_fix(
         self, client: AsyncClient, app: FastAPI, pool
     ) -> None:
-        """Pins the latent half of #5108 as it ACTUALLY is today.
+        """Pins the RESOLVED half of #5108 (2026-08-29, L12-PR1).
 
-        This was an `xfail(strict=True)` naming the codec defect as its reason.
-        An adversarial review falsified that encoding: `xfail` without `raises=`
-        treats ANY failure as expected, and it demonstrated the test still
-        reporting `xfailed` when the feature flag was off -- i.e. for a 404
-        routing failure, not the defect the reason named. A probe that cannot
-        distinguish its own cause is not a probe.
+        Was `test_outbox_payloads_are_currently_json_strings_pinning_an_open_
+        defect`, asserting `jsonb_typeof == "string"` as a characterization of
+        the then-open codec double-encoding defect (`.claude/skills/modus/
+        PENDING-ARMS.md`: `journal.py:53,78` pre-serialized with
+        `json.dumps(default=str)` against a codec whose encoder was a bare
+        `json.dumps`). The codec's encoder is now `JSONB_ENCODER =
+        functools.partial(json.dumps, default=str)`
+        (`backend/app/core/database.py`), and `journal.py` no longer
+        pre-serializes -- it hands the codec a native dict. This test is the
+        inversion its own prior docstring called for when that landed:
+        `jsonb_typeof` is asserted `object`, not `string`.
 
-        So it is a characterization test instead: the funnel walk below is
-        asserted NORMALLY (a routing or wiring break is a real red, named), and
-        the storage shape is pinned as `string`. When the codec decision lands
-        (`.claude/skills/modus/PENDING-ARMS.md`: `journal.py:53,78` pre-serialize
-        with `json.dumps(default=str)` against a codec whose encoder is a bare
-        `json.dumps`), THIS test goes red and says so -- invert it to `object`
-        and delete this paragraph.
-
-        Nothing is broken TODAY: `outbox_consumer.py:165` reads
-        `json.loads(raw) if isinstance(raw, str)`, and that compensation is
-        itself asserted in the test below. It still matters:
-        `payload->>'k'` in SQL returns NULL against a scalar string, and the
-        next reader written against the declared jsonb type gets a `str` where
-        its annotation promises `dict[str, Any]`.
+        `outbox_consumer.py:165`'s `json.loads(raw) if isinstance(raw, str)`
+        compensation is now dead code on this path (payloads decode to `dict`
+        already) but is left in place -- removing it is a separate decision,
+        still asserted present by the sibling test below.
         """
         result_id, body, _ = await _accepted_check(client)
         app.state._e2e_actor = result_id
@@ -564,11 +559,11 @@ class TestTheFunnelAVisitorActuallyWalks:
                 )
             ]
         assert kinds, "no outbox rows to judge"
-        assert all(k == "string" for k in kinds), (
-            f"outbox payloads have jsonb_typeof {kinds}. If they are now 'object', the "
-            "codec double-encoding is FIXED: flip this assertion to 'object', drop the "
-            "PENDING-ARMS row, and remove the compensating read this file pins below. "
-            "Any other value means something new."
+        assert all(k == "object" for k in kinds), (
+            f"outbox payloads have jsonb_typeof {kinds}, expected all 'object' now that "
+            "the codec's encoder is JSONB_ENCODER (functools.partial(json.dumps, "
+            "default=str)) and journal.py hands it native dicts (L12-PR1, 2026-08-29). "
+            "A 'string' result here means the double-encoding regressed."
         )
 
     async def test_the_only_current_reader_absorbs_the_double_encoding(

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
@@ -71,7 +71,19 @@ async def _connect() -> asyncpg.Connection:
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
-    await init_asyncpg_connection(conn)
+    # INSIDE the guard, and closing on failure (2026-08-30, found by a blind
+    # cross-family refuter). The first version of this fix awaited the codec
+    # registration OUTSIDE the try: a failure there escaped the skip/fail
+    # policy this helper exists to enforce AND leaked the connection that had
+    # just been opened. `set_type_codec` is a round trip to the server, so it
+    # can fail for exactly the reasons the guard above already handles.
+    try:
+        await init_asyncpg_connection(conn)
+    except (OSError, asyncpg.PostgresError) as exc:
+        await conn.close()
+        if os.environ.get("CI"):
+            pytest.fail(f"codec registration failed in CI at {_DSN}: {exc}")
+        pytest.skip(f"codec registration failed at {_DSN}: {exc}")
     return conn
 
 

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
@@ -28,6 +28,7 @@ import pytest
 
 asyncpg = pytest.importorskip("asyncpg")
 
+from backend.app.core.database import init_asyncpg_connection
 from backend.services.garuda_orders import journal
 from backend.services.garuda_orders.outbox_consumer import (
     DEFAULT_MAX_ATTEMPTS,
@@ -53,12 +54,25 @@ pytestmark = pytest.mark.asyncio
 
 
 async def _connect() -> asyncpg.Connection:
+    """A bare `asyncpg.connect()` -- no pool -- so it must register the SAME
+    canonical codec production pools do (2026-08-29): this file's own
+    docstring says rows are written through the production writers
+    (`journal.append_event`, `journal.enqueue_outbox`), and those writers now
+    hand a jsonb/json parameter a native Python container, relying on the
+    codec to encode it. Without `init_asyncpg_connection` here, this
+    connection has NO jsonb codec at all and asyncpg cannot bind a `dict` to
+    a jsonb-typed parameter -- exactly the test/production codec-parity gap
+    `backend/tests/fixtures/prod_shaped_pool.py` exists to close for pooled
+    connections; this is the same fix for a bare one.
+    """
     try:
-        return await asyncpg.connect(_DSN)
+        conn = await asyncpg.connect(_DSN)
     except (OSError, asyncpg.PostgresError) as exc:
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+    await init_asyncpg_connection(conn)
+    return conn
 
 
 @pytest.fixture

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_consumer.py
@@ -71,6 +71,9 @@ async def _connect() -> asyncpg.Connection:
         if os.environ.get("CI"):
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
+        raise  # unreachable: pytest.fail/skip always raise, but CodeQL's
+        # py/uninitialized-local-variable can't see that and flags `conn`
+        # below as reachable-unset without an explicit terminal raise here.
     # INSIDE the guard, and closing on failure (2026-08-30, found by a blind
     # cross-family refuter). The first version of this fix awaited the codec
     # registration OUTSIDE the try: a failure there escaped the skip/fail
@@ -84,6 +87,9 @@ async def _connect() -> asyncpg.Connection:
         if os.environ.get("CI"):
             pytest.fail(f"codec registration failed in CI at {_DSN}: {exc}")
         pytest.skip(f"codec registration failed at {_DSN}: {exc}")
+        raise  # same reasoning as the connect() guard above — keeps this
+        # branch symmetric and provably terminal instead of an implicit
+        # fallthrough that would return a connection with no jsonb codec.
     return conn
 
 

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_magic_link_store_integration.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_magic_link_store_integration.py
@@ -31,6 +31,10 @@ from backend.services.garuda_portal.magic_link_store import (
     _MAX_ISSUES_PER_EMAIL_PER_WINDOW,
     PostgresMagicLinkStore,
 )
+from backend.tests.fixtures.prod_shaped_pool import (
+    create_prod_shaped_pool,
+    init_prod_shaped_connection,
+)
 
 _DSN = (
     os.environ.get("GARUDA_L4_TEST_DSN")
@@ -110,7 +114,7 @@ async def _close_garuda_magic_link_test_policy(conn: asyncpg.Connection, policy_
 @pytest.fixture
 async def pool():
     try:
-        p = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=4)
+        p = await create_prod_shaped_pool(dsn=_DSN, min_size=1, max_size=4)
     except (OSError, asyncpg.PostgresError) as exc:
         if os.environ.get("CI"):
             pytest.fail(
@@ -461,11 +465,24 @@ def _make_counting_connection_class(counts: list[int]) -> type:
 @pytest.fixture
 async def counting_pool():
     """A SEPARATE pool (own connection class) so this file's other tests'
-    connections are never instrumented — only exchange() calls made
-    through `counting_store` below are counted."""
+    connections are never instrumented -- only exchange() calls made
+    through `counting_store` below are counted.
+
+    Also needs the canonical codec (2026-08-29): `counting_store` below
+    calls `.exchange()`, which writes through `garuda_portal/idempotency.py
+    ::complete()` -- that writer now hands a jsonb parameter a native Python
+    container and relies on the codec to encode it. `create_prod_shaped_pool`
+    does not expose `connection_class`, so this pool is built directly with
+    BOTH `connection_class=...` (for counting) and
+    `init=init_prod_shaped_connection` -- the SAME canonical init object
+    production and `create_prod_shaped_pool` use, not a re-implementation."""
     counts = [0]
     p = await asyncpg.create_pool(
-        dsn=_DSN, min_size=1, max_size=2, connection_class=_make_counting_connection_class(counts)
+        dsn=_DSN,
+        min_size=1,
+        max_size=2,
+        connection_class=_make_counting_connection_class(counts),
+        init=init_prod_shaped_connection,
     )
     yield p, counts
     await p.close()

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_practice.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_practice.py
@@ -24,6 +24,7 @@ import pytest
 
 asyncpg = pytest.importorskip("asyncpg")
 
+from backend.app.core.database import init_asyncpg_connection
 from backend.services.garuda_flow.intake import CaseType
 from backend.services.garuda_orders.idempotency import canonical_payload_sha256, scoped_key_sha256
 from backend.services.garuda_orders.models import Applicant
@@ -122,7 +123,20 @@ async def _close_garuda_order_test_policy(conn: asyncpg.Connection, policy_versi
 @pytest.fixture
 async def pool():
     try:
-        p = await asyncpg.create_pool(dsn=_DSN, min_size=1, max_size=2)
+        # `init=` is NOT optional here (2026-08-30). This fixture's rows are
+        # written through the production writers -- `GarudaOrderRepository` and
+        # `PracticeRepository` reach `garuda_orders/journal.py::append_event`,
+        # whose `detail` argument is now a NATIVE Python dict rather than a
+        # pre-serialized string. A pool without the canonical jsonb codec cannot
+        # bind a dict to a jsonb parameter and raises
+        # `DataError: invalid input for query argument $9 ... expected str, got dict`.
+        # Measured, not predicted: with a bare pool this file's six tests fail
+        # against a real Postgres while the same run on origin/main passes -- the
+        # test/production codec-parity gap this lane exists to close, caught by an
+        # A/B of the GARUDA suites rather than by argument.
+        p = await asyncpg.create_pool(
+            dsn=_DSN, min_size=1, max_size=2, init=init_asyncpg_connection
+        )
     except (OSError, asyncpg.PostgresError) as exc:
         if os.environ.get("CI"):
             pytest.fail(

--- a/docs/plans/2026-08-29-beyond-sota-craft-wave/L12-data-schema-migrations.md
+++ b/docs/plans/2026-08-29-beyond-sota-craft-wave/L12-data-schema-migrations.md
@@ -157,8 +157,8 @@ apps/backend-rag/.venv/bin/python -c "from pathlib import Path; assert '|| true'
 - **Every `pytest ... -q` above was unrunnable as written.** `main` now carries
   `scripts/pytest_guards/pytest_verbosity_guard.py`, which exits **RC=4** under
   `apps/backend-rag/pytest.ini` (whose `addopts` already lower verbosity) with
-  *"effective verbosity is -2: pytest would print no pass/fail tally, so this
-  run cannot be read as evidence that anything ran."* The `-q` flags are
+  _"effective verbosity is -2: pytest would print no pass/fail tally, so this
+  run cannot be read as evidence that anything ran."_ The `-q` flags are
   removed above. Measured, not reasoned: the first acceptance run of PR-1 died
   on exactly this.
 - **`298` -> `299`.** See PR-2's file list.

--- a/docs/plans/2026-08-29-beyond-sota-craft-wave/L12-data-schema-migrations.md
+++ b/docs/plans/2026-08-29-beyond-sota-craft-wave/L12-data-schema-migrations.md
@@ -23,7 +23,7 @@ Make database behavior provable at the application boundary: the panel measured 
 - [exists] `apps/backend-rag/backend/db/schema_audit.py` — current schema audit, which does not verify stored migration checksums.
 - [exists] `apps/backend-rag/backend/tests/db/test_post_d1_migrations_guard_ledger_owned_ddl.py` — runtime-role ownership guard for ledger-owned DDL.
 - [exists] `.github/workflows/restore-drill.yml` — current restore drill; application-level verification is incomplete.
-- [exists] `apps/backend-rag/backend/db/migrations_v2/297_wa_outbox_fall_off_reason_finalize_sub_reasons.sql` — highest migration present; `298` is the verified next free number.
+- [exists] `apps/backend-rag/backend/db/migrations_v2/297_wa_outbox_fall_off_reason_finalize_sub_reasons.sql` — highest migration present; `298` was the verified next free number WHEN THIS SPEC WAS WRITTEN; `298_garuda_payment_inbox_quarantine_reason.sql` landed since, so **299** is the next free number (measured on disk 2026-08-31, `ls migrations_v2 | sort -n | tail`). Corrected here rather than in a separate docs PR, per the wave-2 rule that spec corrections ride inside the lane PR.
 
 ## PR-1: feat(db): jsonb codec default=str + shared prod-shaped pool fixture + bare-create_pool lint
 
@@ -60,8 +60,8 @@ Make database behavior provable at the application boundary: the panel measured 
 ```bash
 source apps/backend-rag/.venv/bin/activate
 python scripts/lint_test_pool_codec_parity.py --root apps/backend-rag/backend/tests
-PYTHONPATH=apps/backend-rag pytest scripts/tests/test_lint_test_pool_codec_parity.py apps/backend-rag/backend/tests/db/test_jsonb_codec_parity.py apps/backend-rag/backend/tests/db/test_jsonb_double_encoding_class_guard.py -q
-PYTHONPATH=apps/backend-rag pytest apps/backend-rag/backend/tests/services/garuda_orders apps/backend-rag/backend/tests/services/garuda_portal apps/backend-rag/backend/tests/services/garuda_documents apps/backend-rag/backend/tests/services/garuda_ops -q
+PYTHONPATH=apps/backend-rag pytest scripts/tests/test_lint_test_pool_codec_parity.py apps/backend-rag/backend/tests/db/test_jsonb_codec_parity.py apps/backend-rag/backend/tests/db/test_jsonb_double_encoding_class_guard.py
+PYTHONPATH=apps/backend-rag pytest apps/backend-rag/backend/tests/services/garuda_orders apps/backend-rag/backend/tests/services/garuda_portal apps/backend-rag/backend/tests/services/garuda_documents apps/backend-rag/backend/tests/services/garuda_ops
 ```
 
 **Seats:** Implementer = Sonnet 5 subagent. Refuter = Kimi K3. Family exclusion binds the DIFF BUILDER's family, not the spec drafter's: builder is Anthropic (Sonnet 5 implementer under an Opus 5 orchestrator); the refuter must be a non-Anthropic family (Kimi K3 default, Codex GPT-5.6 sol for security-class diffs); a diff built by a non-Anthropic seat is refuted by a different family. Final gate = orchestrator Opus 5 xhigh.
@@ -74,7 +74,7 @@ PYTHONPATH=apps/backend-rag pytest apps/backend-rag/backend/tests/services/garud
 
 **Files:**
 
-- [proposed] `apps/backend-rag/backend/db/migrations_v2/298_schema_versions_provenance.sql`
+- [proposed] `apps/backend-rag/backend/db/migrations_v2/299_schema_versions_provenance.sql`
 - [exists] `apps/backend-rag/backend/db/migration_manager.py`
 - [exists] `apps/backend-rag/backend/db/schema_audit.py`
 - [exists] `apps/backend-rag/backend/tests/db/test_migrations.py`; [exists] `apps/backend-rag/backend/tests/db/test_schema_audit.py`; [exists] `apps/backend-rag/backend/tests/db/test_post_d1_migrations_guard_ledger_owned_ddl.py`
@@ -95,19 +95,19 @@ PYTHONPATH=apps/backend-rag pytest apps/backend-rag/backend/tests/services/garud
 
 **Acceptance:**
 
-- Guilt must turn RED: modify the bytes of an already recorded fixture migration, run the audit, and require a nonzero result naming migration `298`.
+- Guilt must turn RED: modify the bytes of an already recorded fixture migration, run the audit, and require a nonzero result naming migration `299`.
 - Innocence must stay GREEN: a fresh apply records the actual database role in `applied_as`, the selected origin in `applied_via`, a nonempty runner version, and an untampered audit passes.
 - Exact commands from `apps/backend-rag`:
 
 ```bash
 source .venv/bin/activate
-PYTHONPATH=. pytest backend/tests/db/test_migrations.py backend/tests/db/test_schema_audit.py backend/tests/db/test_post_d1_migrations_guard_ledger_owned_ddl.py -q
+PYTHONPATH=. pytest backend/tests/db/test_migrations.py backend/tests/db/test_schema_audit.py backend/tests/db/test_post_d1_migrations_guard_ledger_owned_ddl.py
 PYTHONPATH=. python -m backend.db.schema_audit
 ```
 
 **Seats:** Implementer = Sonnet 5 subagent. A Codex sandbox verifier must run upgrade, provenance assertions, downgrade, and post-downgrade assertions against a disposable database. Refuter = Kimi K3. Family exclusion binds the DIFF BUILDER's family, not the spec drafter's: builder is Anthropic (Sonnet 5 implementer under an Opus 5 orchestrator); the refuter must be a non-Anthropic family (Kimi K3 default, Codex GPT-5.6 sol for security-class diffs); a diff built by a non-Anthropic seat is refuted by a different family. Final gate = orchestrator Opus 5 xhigh.
 
-**Arming / prove-live:** Apply only through the normal release command after manual gate approval, then run `schema_audit` and query only migration `298` metadata. Proof records role name, origin, runner version, and checksum verdict without credentials or PII.
+**Arming / prove-live:** Apply only through the normal release command after manual gate approval, then run `schema_audit` and query only migration `299` metadata. Proof records role name, origin, runner version, and checksum verdict without credentials or PII.
 
 **Conflicts / order:** Migrations execute as the runtime role. Any DDL touching objects owned by `visa_ledger_owner` aborts the deploy. This migration must avoid those objects; if ownership preflight contradicts that assumption, suspend and require the temporary-GRANT operator[secret] ceremony. Squawk is mandatory, migration PRs are auto-merge-OFF, and the orchestrator merges manually after every gate.
 
@@ -141,7 +141,7 @@ PYTHONPATH=. python -m backend.db.schema_audit
 - Exact commands from repository root:
 
 ```bash
-apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_restore_drill_verify.py -q
+apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_restore_drill_verify.py
 apps/backend-rag/.venv/bin/python scripts/ci/restore_drill_verify.py --fixture scripts/tests/fixtures/restore_drill/healthy.json
 apps/backend-rag/.venv/bin/python -c "from pathlib import Path; assert '|| true' not in Path('.github/workflows/restore-drill.yml').read_text()"
 ```
@@ -151,6 +151,26 @@ apps/backend-rag/.venv/bin/python -c "from pathlib import Path; assert '|| true'
 **Arming / prove-live:** After merge, manually dispatch one restore drill against the approved isolated target. Close the PENDING-ARMS row only when all five per-invariant verdicts and the aggregate verdict are PASS.
 
 **Conflicts / order:** Land after PR-2 so restored schemas are checksum-audited. This PR does not authorize a production restore or relax notification failures.
+
+## Spec corrections applied in-lane (2026-08-31, Squad D')
+
+- **Every `pytest ... -q` above was unrunnable as written.** `main` now carries
+  `scripts/pytest_guards/pytest_verbosity_guard.py`, which exits **RC=4** under
+  `apps/backend-rag/pytest.ini` (whose `addopts` already lower verbosity) with
+  *"effective verbosity is -2: pytest would print no pass/fail tally, so this
+  run cannot be read as evidence that anything ran."* The `-q` flags are
+  removed above. Measured, not reasoned: the first acceptance run of PR-1 died
+  on exactly this.
+- **`298` -> `299`.** See PR-2's file list.
+- **PR-1's caller-fix scope was incomplete and the spec's own A/B requirement is
+  what exposed it.** Converting the four writers to native containers breaks any
+  test whose pool is bare. Two such files existed outside the spec's stated file
+  list (`services/garuda_portal/test_practice.py`,
+  `app/routers/test_garuda_orders_ownership.py`) and both are converted in PR-1,
+  because the spec's own ordering rule requires the caller fixes and the fixture
+  to land atomically. A third defect class was found by the blind refutation: a
+  FOURTH codec-registering pool (`backend/scripts/kg_staging_promotion.py`) that
+  the spec's three-file list did not name.
 
 ## Needs-ruling carried (Zero only)
 

--- a/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/brief.yml
@@ -1,0 +1,63 @@
+task_id: craft-d-l12-pr1-jsonb-codec
+gear: 2
+l_level: L2
+gate_class: opus
+objective: |
+  Close the JSONB double-encoding defect class at its root: make the asyncpg
+  codec a strict SUPERSET of what every caller already did by hand, make ONE
+  initializer object the thing every pool passes to `create_pool(init=...)`,
+  and drop the caller-side pre-serialization that the old bare encoder forced.
+
+  Three pools each registered their own `jsonb`/`json` codec with a BARE
+  `json.dumps` encoder. Four caller sites therefore pre-serialized with
+  `json.dumps(..., default=str)` -- the bare encoder raises `TypeError` on the
+  first `datetime`/`Decimal` -- and the codec then encoded that string a SECOND
+  time, so Postgres stored a JSONB *string scalar*. On 2026-08-27 that shape
+  answered HTTP 500 to GARUDA VOA's first customer action in production, while
+  the integration test passed 10/10 against a real Postgres with the real
+  migration: the test pool had no codec, so test and production disagreed about
+  what a jsonb parameter means.
+
+  This is the arming action for the 2026-08-27 PENDING-ARMS row, which
+  specified this cure almost verbatim.
+
+  SCOPE NOTE: this is PR 1 of the L12-PR1 split. It carries the codec, the
+  callers, the shared fixture, and the STRUCTURAL + LIVE halves of the parity
+  test. The REAL-CALL-SITE half (four production writers against the four real
+  jsonb columns) is the next PR; the lint + its shrink-only baseline + its CI
+  executor is the one after.
+constraints:
+  - "The codec widening must be a strict SUPERSET, never a behaviour change:
+    `json.dumps(x)` succeeding implies `json.dumps(x, default=str)` succeeds
+    with byte-identical output. `default=` is consulted ONLY for values that
+    were previously a hard `TypeError`. Nothing that worked can start failing."
+  - "The canonical initializer registers CODECS ONLY. The two production pools
+    and the test fixture set `statement_timeout='30s'` but `get_db_pool()` does
+    not, and the full pool additionally runs a `SELECT 1`. Folding those into
+    the shared hook would silently change behaviour for a standalone script
+    pool. Codec parity is the invariant that must not drift; the timeouts are
+    per-pool. (The GLM-5.2 counter-build argued the opposite -- see dissent.)"
+  - "Zero JSONB shape regressions -- established by A/B FAILURE-NAME-SET
+    identity against origin/main, not by argument and not by counts alone."
+  - "No client PII in any artifact. Live tests write synthetic rows to a
+    disposable local container and drop their temp table in a `finally`."
+  - "No production deploy and no production probe in this PR. Those are carried
+    by a PENDING-ARMS row, never implied by a green CI."
+acceptance:
+  - text: >-
+      WHEN `JSONB_ENCODER` is reverted to a bare `json.dumps`, the parity file
+      SHALL turn exactly 3 red inside the already-required backend shard.
+    probe: "pytest backend/tests/db/test_jsonb_codec_parity.py"
+  - text: >-
+      WHILE the codec is unreverted, the parity file SHALL be 9 green and the
+      pre-existing double-encoding class guard SHALL stay green beside it.
+    probe: "backend/tests/db/test_jsonb_double_encoding_class_guard.py"
+  - text: >-
+      WHERE a value is bound PRE-serialized, the stored shape SHALL still be a
+      JSONB string scalar -- bound bare AND through an explicit `::jsonb`
+      cast, because the cast is not a bypass of the codec's encode step.
+    probe: "test_pre_serialized_string_still_becomes_jsonb_string_scalar"
+  - text: >-
+      IF this diff is applied, THEN the FAILED/ERROR name set of both A/B
+      scopes SHALL be identical to origin/main.
+    probe: "git checkout origin/main -- apps/backend-rag/"

--- a/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/pack.yml
@@ -23,15 +23,33 @@ lanes:
       (NON-ANTHROPIC, cross-family, never the seat that built the diff)
 
 diff:
-  files: 15
-  net_lines: 525
-  measured_at: 6f9611022
+  files: 18
+  net_lines: 1247
+  measured_at: a1c710fbf
   note: >-
-    `git diff --no-renames --numstat $(git merge-base origin/main HEAD) HEAD`
-    -> 15 files, net 525 (435 at the first commit, +90 for the two defects the
-    blind refutation confirmed). The deterministic floor recomputed from
-    this PR's own changed-file set is 1 (`evidence_pack_lint.py --print-floor`);
-    the brief declares gear 2, so gear >= floor holds.
+    RE-MEASURED 2026-08-31 by the rescue session (orphaned-PR pickup after
+    squad D' orchestrator exited), as the last action before this commit,
+    because the figures this block previously declared (measured @6f9611022)
+    predate several later commits on this branch (the guarded init_asyncpg_connection close,
+    the canonical-files AST test, the five-pool docstring correction, and
+    this rescue's own CodeQL fix). `git diff --no-renames --numstat
+    $(git merge-base origin/main HEAD) HEAD` at a1c710fbf ->
+    `evidence_pack_lint.py --print-measured` reports "18 files, +1138/-146, 6
+    commits" (raw, unexcluded git-diff totals -- this is the figure the
+    countable-claims rule checks against). `net_lines: 1247` above is a
+    DIFFERENT number on purpose: CHURN (added+deleted) with the floor's own
+    fixtures/generated/vendor exclusion applied (`_size_term_net_lines()`),
+    which is 37 lower than the raw 1138+146=1284 because it excludes
+    tests/fixtures/prod_shaped_pool.py's 20+17 lines -- not a plain
+    add-minus-delete net, and not the raw countable-claims total either.
+    The deterministic floor recomputed from this PR's own final changed-file
+    set is now 2, source "size" (churn 1247 >= SIZE_GEAR2_THRESHOLD 400 but
+    below SIZE_GEAR3_THRESHOLD 1828; `evidence_pack_lint.py --print-floor` /
+    `--print-floor-source`) -- UP from the 1 this pack previously declared.
+    The brief already declares gear 2, so gear >= floor still holds; no gear
+    change needed, but a pack whose floor moved out from under it without a
+    note would have been exactly the kind of stale figure this rule exists
+    to catch.
 
 pii_scan: clean
 
@@ -231,6 +249,37 @@ receipts:
     ts: 2026-08-31T02:50Z
     seat: session (final gate, Opus 5 xhigh)
 
+  - claim: >-
+      RESCUE (2026-08-31): squad D''s orchestrator exited rc=0 and this PR
+      sat RED and unowned (CodeQL) until a rescue session picked it up.
+      CodeQL's own annotation (not the diff, per anti-hallucination
+      discipline) named a real py/uninitialized-local-variable-shaped gap
+      this diff introduced in _connect(): `conn` is assigned inside a try,
+      and CodeQL has no NoReturn model for pytest.fail/pytest.skip, so it
+      treats the except block as a possible fallthrough into a read of an
+      unset `conn`. Closed with an explicit terminal `raise` at the end of
+      BOTH except blocks (the second, guarding `init_asyncpg_connection`,
+      has the identical shape but was not itself flagged) rather than a
+      suppression comment, so the control flow is provably terminal to any
+      analyzer, not merely correct by pytest's actual unmodeled behavior.
+    cmd: >-
+      gh api repos/Bali-Zero/Teman2/check-runs/99294325113/annotations ;
+      then, after the fix, from apps/backend-rag: ruff check
+      backend/tests/services/garuda_orders/test_outbox_consumer.py ;
+      INTAKE_TEST_DSN=postgresql://test:test@localhost:55432/nuzantara_test
+      PYTHONPATH=. .venv/bin/python -m pytest
+      backend/tests/services/garuda_orders/test_outbox_consumer.py
+    result: >-
+      Annotation: path test_outbox_consumer.py, line 81, "Local variable
+      'conn' may be used before it is initialized." ruff: "All checks
+      passed!". pytest: "23 passed in 1.43s" against local docker
+      craftd-pg (127.0.0.1:55432, container `craftd-pg`) -- unchanged
+      behavior, as expected from dead-code-by-construction lines. Pushed at
+      a1c710fbf.
+    exit: 0
+    ts: 2026-08-31T03:20Z
+    seat: session (rescue, Opus 5)
+
 dissent:
   - seat: glm-5.2 (Alibaba TP1, non-Anthropic counter-build lane)
     objection: >-
@@ -366,3 +415,8 @@ notes:
     garuda_order_outbox both hold 0 rows) because they need a Xendit key
     nobody has provisioned -- so this is a fix-before-first-write, not a data
     repair."
+  - "RESCUE 2026-08-31: squad D''s orchestrator (craft2_launch.sh D2) exited
+    rc=0 at 02:09 and this PR was found red (CodeQL) and unowned. A rescue
+    session fixed the CodeQL finding (see the last receipt) and pushed
+    a1c710fbf to this same branch -- no other content changed. #5327, which
+    stacks on this branch, is a separate PR handled by the same rescue pass."

--- a/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/pack.yml
@@ -24,22 +24,26 @@ lanes:
 
 diff:
   files: 18
-  net_lines: 1247
-  measured_at: a1c710fbf
+  net_lines: 1301
+  measured_at: 073da4a47
   note: >-
     RE-MEASURED 2026-08-31 by the rescue session (orphaned-PR pickup after
-    squad D' orchestrator exited), as the last action before this commit,
-    because the figures this block previously declared (measured @6f9611022)
-    predate several later commits on this branch (the guarded init_asyncpg_connection close,
-    the canonical-files AST test, the five-pool docstring correction, and
-    this rescue's own CodeQL fix). `git diff --no-renames --numstat
-    $(git merge-base origin/main HEAD) HEAD` at a1c710fbf ->
-    `evidence_pack_lint.py --print-measured` reports "18 files, +1138/-146, 6
+    squad D' orchestrator exited), immediately before this commit (a wording
+    fix to this same pack's own text, see below -- its own trivial self-diff
+    at the actual final HEAD is not separately chased, the same accepted
+    convention used to close out PR#5327's pack), because the figures this
+    block previously declared (measured @6f9611022, and this note's own
+    prior revision @a1c710fbf) predate later commits on this branch (the
+    guarded init_asyncpg_connection close, the canonical-files AST test, the
+    five-pool docstring correction, this rescue's own CodeQL fix, and this
+    rescue's own first re-measurement commit). `git diff --no-renames
+    --numstat $(git merge-base origin/main HEAD) HEAD` at 073da4a47 ->
+    `evidence_pack_lint.py --print-measured` reports "18 files, +1192/-146, 7
     commits" (raw, unexcluded git-diff totals -- this is the figure the
-    countable-claims rule checks against). `net_lines: 1247` above is a
+    countable-claims rule checks against). `net_lines: 1301` above is a
     DIFFERENT number on purpose: CHURN (added+deleted) with the floor's own
     fixtures/generated/vendor exclusion applied (`_size_term_net_lines()`),
-    which is 37 lower than the raw 1138+146=1284 because it excludes
+    which is 37 lower than the raw 1192+146=1338 because it excludes
     tests/fixtures/prod_shaped_pool.py's 20+17 lines -- not a plain
     add-minus-delete net, and not the raw countable-claims total either.
     The deterministic floor recomputed from this PR's own final changed-file
@@ -266,9 +270,14 @@ receipts:
       gh api repos/Bali-Zero/Teman2/check-runs/99294325113/annotations ;
       then, after the fix, from apps/backend-rag: ruff check
       backend/tests/services/garuda_orders/test_outbox_consumer.py ;
-      INTAKE_TEST_DSN=postgresql://test:test@localhost:55432/nuzantara_test
-      PYTHONPATH=. .venv/bin/python -m pytest
-      backend/tests/services/garuda_orders/test_outbox_consumer.py
+      INTAKE_TEST_DSN set to the local craftd-pg container's connection
+      string (postgresql host localhost, port 55432, db nuzantara_test,
+      credentials matching the container's own POSTGRES_USER and
+      POSTGRES_PASSWORD env vars -- not written out as one joined string
+      here, because a scheme-colon-slash-slash-user-colon-pass-at-host
+      literal is exactly what detect-secrets' Basic Auth Credentials plugin
+      flags, even for a disposable local placeholder) PYTHONPATH=. .venv/bin/python -m
+      pytest backend/tests/services/garuda_orders/test_outbox_consumer.py
     result: >-
       Annotation: path test_outbox_consumer.py, line 81, "Local variable
       'conn' may be used before it is initialized." ruff: "All checks
@@ -278,6 +287,37 @@ receipts:
       a1c710fbf.
     exit: 0
     ts: 2026-08-31T03:20Z
+    seat: session (rescue, Opus 5)
+
+  - claim: >-
+      RESCUE, second finding: pushing a1c710fbf+073da4a47 turned the
+      required-adjacent "Detect Secrets" job red -- this pack's OWN receipt
+      text above had written the local test DSN as one joined
+      scheme-colon-slash-slash-user-colon-pass-at-host literal, which
+      detect-secrets' Basic Auth Credentials plugin flags regardless of the
+      credentials being a disposable local placeholder. Confirmed via the
+      real CI run's own triage summary (not guessed): 18 findings in this
+      PR's diff-scoped file set, 17 auto-approved by path-pattern rules
+      (pre-existing findings in test files, none this rescue's doing), 1
+      residue -- this pack.yml, line ~265, type "Basic Auth Credentials".
+      Reworded to describe the connection string's parts in prose instead
+      of as one joined literal; re-scanned locally with a disposable
+      baseline copy (never touching the real committed .secrets.baseline)
+      and confirmed zero findings for this file afterward.
+    cmd: >-
+      gh run view <run-id> --job <job-id> --log | grep -n 'Total findings|
+      Auto-approved|Residue|=== Residue by'; then, locally, a throwaway
+      `cp .secrets.baseline /tmp/... ; detect-secrets scan --baseline
+      /tmp/... <the 18 diff-scoped files>` before and after the wording fix
+    result: >-
+      Real CI run: "Total findings: 18. Auto-approved: 17. No rule matched:
+      1. Residue (unaudited): 1." with "Residue by file: 1
+      evidence/.../pack.yml" and "Residue by type: 1 Basic Auth
+      Credentials." Local re-scan after the wording fix: zero findings for
+      this file. The real committed .secrets.baseline was never touched --
+      every scan ran against a /tmp copy.
+    exit: 0
+    ts: 2026-08-31T05:10Z
     seat: session (rescue, Opus 5)
 
 dissent:

--- a/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/pack.yml
@@ -1,0 +1,368 @@
+brief_ref: evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/brief.yml
+plan_ref: >-
+  docs/plans/2026-08-29-beyond-sota-craft-wave/L12-data-schema-migrations.md
+  (PR-1), driven by SQUAD D' wave-2 issue #5317. This is PR 1 of the L12-PR1
+  split: codec + callers + shared fixture + the STRUCTURAL and LIVE halves of
+  the parity test. The REAL-CALL-SITE half and the lint/baseline/executor are
+  the two PRs that follow.
+
+lanes:
+  - lane: codec-build
+    role: build
+    seat: claude-sonnet-5 (rescued build, commits 655bcd5a6 + 2bce7031d) then
+      claude-opus-5 xhigh (this session — split, A/B, the two pool conversions
+      the A/B exposed, final on-disk gate)
+  - lane: codec-counterbuild
+    role: build
+    seat: glm-5.2 via Alibaba TP1 (NON-ANTHROPIC — D3 satisfied by a real
+      build lane, never seat_override). Dispatched BLIND on the problem
+      statement, never shown the diff.
+  - lane: codec-refuter
+    role: review
+    seat: codex gpt-5.6-sol, model_reasoning_effort=xhigh, --sandbox read-only
+      (NON-ANTHROPIC, cross-family, never the seat that built the diff)
+
+diff:
+  files: 15
+  net_lines: 525
+  measured_at: 6f9611022
+  note: >-
+    `git diff --no-renames --numstat $(git merge-base origin/main HEAD) HEAD`
+    -> 15 files, net 525 (435 at the first commit, +90 for the two defects the
+    blind refutation confirmed). The deterministic floor recomputed from
+    this PR's own changed-file set is 1 (`evidence_pack_lint.py --print-floor`);
+    the brief declares gear 2, so gear >= floor holds.
+
+pii_scan: clean
+
+receipts:
+  - claim: >-
+      INNOCENCE. With the diff, the parity test is fully green and the
+      pre-existing double-encoding class guard still passes alongside it.
+    cmd: >-
+      PYTHONPATH=apps/backend-rag .venv/bin/python -m pytest
+      backend/tests/db/test_jsonb_codec_parity.py
+      backend/tests/db/test_jsonb_double_encoding_class_guard.py
+      -p no:cacheprovider   test id:
+      test_pre_serialized_string_still_becomes_jsonb_string_scalar   (TEST_DATABASE_URL -> local docker craftd-pg,
+      postgres:15, 127.0.0.1:55432)
+    result: "20 passed in 2.29s"
+    exit: 0
+    ts: 2026-08-31T00:20Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      GUILT. Reverting only `JSONB_ENCODER` to a bare `json.dumps` turns the
+      parity test 3 red, naming the encoder shape, the datetime widening, and
+      the live round-trip. The revert was then restored byte-exactly, so the
+      shipped tree is unaffected by the experiment.
+    cmd: >-
+      sed -i '' 's/^JSONB_ENCODER = functools.partial(json.dumps,
+      default=str)$/JSONB_ENCODER = json.dumps/'
+      apps/backend-rag/backend/app/core/database.py && pytest
+      backend/tests/db/test_jsonb_codec_parity.py ; restore ; git diff
+      --exit-code apps/backend-rag/backend/app/core/database.py
+    result: >-
+      "3 failed, 6 passed in 0.34s", rc=1. FAILED
+      test_jsonb_encoder_is_json_dumps_with_default_str (AssertionError);
+      FAILED test_jsonb_encoder_widens_bare_json_dumps (TypeError: Object of
+      type datetime is not JSON serializable); FAILED
+      test_native_dict_with_datetime_and_decimal_succeeds_via_default_str
+      (asyncpg.exceptions.DataError, argument $1). Restore: `git diff
+      --exit-code` clean, rc=0.
+    exit: 1
+    ts: 2026-08-31T00:35Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      REGRESSION FOUND, then closed. The rescued build, run against the four
+      GARUDA suite directories, introduced SIX failures that origin/main does
+      not have -- all in services/garuda_portal/test_practice.py, whose pool
+      is bare. The caller fix binds a native dict to
+      `garuda_order_journal.detail`; a pool with no codec cannot.
+    cmd: >-
+      pytest backend/tests/services/garuda_orders backend/tests/services/garuda_portal
+      backend/tests/services/garuda_documents backend/tests/services/garuda_ops
+      -p no:cacheprovider, run once with the diff (A) and once with
+      `git checkout origin/main -- apps/backend-rag/` (B); FAILED name sets
+      compared with comm(1).
+    result: >-
+      A = "7 failed, 377 passed, 2 skipped, 40 errors". B = "1 failed, 383
+      passed, 2 skipped, 40 errors". comm -23 (A-only) = the six
+      test_practice.py tests, each `DataError: invalid input for query
+      argument $9 ... expected str, got dict`. comm -13 (B-only) = empty.
+    exit: 1
+    ts: 2026-08-31T00:45Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      A SECOND latent break existed that the first A/B could not reach,
+      because that A/B only covers four directories. Widening the A/B to all
+      21 collectible baselined bare-pool files found
+      app/routers/test_garuda_orders_ownership.py -- same class, different
+      directory.
+    cmd: >-
+      pytest $(the 21 non-conftest files enumerated in the lint's
+      infra/test-pool-parity/baseline.json) -p no:cacheprovider, A vs B as
+      above.
+    result: >-
+      A = "27 failed, 189 passed, 46 skipped, 99 errors". B = "26 failed, 190
+      passed, 46 skipped, 99 errors". comm -23 (A-only) = exactly
+      test_garuda_orders_ownership.py::TestCreateOrderOwnership::
+      test_a_session_can_create_an_order_matching_its_own_result_id.
+    exit: 1
+    ts: 2026-08-31T01:05Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      After converting BOTH exposed pools to `init=init_asyncpg_connection`,
+      both A/B scopes are identical to origin/main -- compared as sorted
+      FAILED/ERROR NAME SETS, not merely as counts. The residual failures are
+      pre-existing and environmental (`relation "practices" does not exist`
+      -- craftd-pg carries the GARUDA migrations but not all others) and are
+      byte-identical on both sides, so they are not this diff's.
+    cmd: >-
+      re-ran both scopes as A2; `diff /tmp/fail_A2.txt /tmp/fail_B.txt` and
+      `diff /tmp/basefail_A2.txt /tmp/basefail_B.txt`
+    result: >-
+      GARUDA suites A2 = "1 failed, 383 passed, 2 skipped, 40 errors",
+      diff vs B empty. 21 baselined files A2 = "26 failed, 190 passed, 46
+      skipped, 99 errors", diff vs B empty. Both IDENTICAL FAILURE SET.
+    exit: 0
+    ts: 2026-08-31T01:15Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      The guard has a real executor and can go red on a real PR:
+      `backend/tests/db/` is inside shard_tests.py's DEFAULT_TARGETS and the
+      only carve-out is `backend/tests/e2e`, so the parity file runs inside
+      the already-required backend shard. This is NOT a new workflow that
+      needs arming.
+    cmd: >-
+      grep -n 'DEFAULT_TARGETS\|EXCLUDED_DIRS' scripts/ci/shard_tests.py
+    result: >-
+      DEFAULT_TARGETS includes `backend/tests/`; EXCLUDED_DIRS carves out
+      `backend/tests/e2e` only. `backend/tests/db/` is therefore collected.
+    exit: 0
+    ts: 2026-08-31T01:20Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      D3: a real non-Anthropic BUILD lane ran, blind, and converged on the
+      shipped design's two load-bearing traps without being shown the diff.
+    cmd: >-
+      POST token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+      /chat/completions, model glm-5.2, key via
+      scripts/arsenal_probe.py::load_tp1_settings_key, prompt = problem
+      statement only (6 questions, diff withheld)
+    result: >-
+      4100 bytes. Q1 encoder: `functools.partial(json.dumps, default=str)`
+      with the same superset argument. Q3: "unconditional removal of the
+      pre-serialization". Q5 (the miss): "the implementer fixes the codec but
+      leaves the four json.dumps call sites untouched ... CI stays green if no
+      test asserts on the *shape* ... misdiagnoses it as 'codec change didn't
+      deploy'". Q6: "No, definitively false" on `::jsonb` as a bypass, with
+      the correct bind-phase mechanism. Divergences at Q2 and Q4 recorded in
+      dissent.
+    exit: 0
+    ts: 2026-08-31T01:30Z
+    seat: glm-5.2 (TP1, non-Anthropic build lane)
+
+  - claim: >-
+      A blind cross-family refutation (Codex GPT-5.6 sol, xhigh, read-only)
+      returned NO-DEFECT on the superset claim, the caller call-graph, the
+      ::jsonb scar test and the bare-pool sweep, and TWO CONFIRMED-DEFECTs:
+      the centralisation claim was false (a FOURTH pool registering its own
+      bare-json.dumps codec), and the identity assertions could not tell an
+      import from a call.
+    cmd: >-
+      codex --search exec -m gpt-5.6-sol -c model_reasoning_effort=xhigh
+      --sandbox read-only --skip-git-repo-check -o /tmp/codex_refute_out.txt
+      "<six-category attack prompt>" < /dev/null
+    result: >-
+      11340 bytes. "A. VERDICT: NO-DEFECT ... 21 input supportati, inclusi NaN,
+      infinities, -0.0, Unicode, interi arbitrariamente grandi, tuple e chiavi
+      non-stringa: zero differenze." "F. VERDICT: CONFIRMED-DEFECT. La
+      centralizzazione 'un codec per ogni pool del repo' e falsa ...
+      kg_staging_promotion.py:396-404". Process exit was 1 ONLY because the
+      read-only sandbox had no writable tmpdir for pytest -- the analysis
+      completed; judged by output, never by rc (W97).
+    exit: 1
+    ts: 2026-08-31T02:05Z
+    seat: codex gpt-5.6-sol (non-Anthropic refuter)
+
+  - claim: >-
+      Both CONFIRMED-DEFECTs re-verified on disk before being acted on, and
+      the fix for each is mutation-proven in both directions.
+    cmd: >-
+      sed -n '392,420p' apps/backend-rag/backend/scripts/kg_staging_promotion.py ;
+      grep -rn 'encoder=json.dumps' --include='*.py' apps/backend-rag/backend/ |
+      grep -v /tests/ ; then two mutations: replace both
+      `await init_asyncpg_connection(conn)` in service_initializer.py with
+      `pass`, and restore the bare set_type_codec in kg_staging_promotion.py
+    result: >-
+      F1 confirmed: kg_staging_promotion.py:400,403 were the only non-test
+      `encoder=json.dumps` in a real set_type_codec call. Mutation A (calls ->
+      pass): "1 failed, 9 passed", the failure being
+      test_production_pool_wrappers_actually_call_the_initializer. Mutation B
+      (bare codec restored): "2 failed, 8 passed". Unmutated: 10 passed. Both
+      restores verified byte-exact by `git diff --exit-code`.
+    exit: 0
+    ts: 2026-08-31T02:30Z
+    seat: session (final gate, Opus 5 xhigh)
+
+  - claim: >-
+      The refuter's D finding exposed a gap in this session's OWN verification:
+      routers/test_bridge_wa_media.py, routers/test_intake_review.py and
+      garuda_orders/test_outbox_consumer.py were in NEITHER A/B scope. A/B-ed
+      explicitly; they are clean.
+    cmd: >-
+      pytest the three files, A vs B (B = `git checkout origin/main --
+      apps/backend-rag/` with the new parity file removed), FAILED+ERROR name
+      sets compared with comm(1)
+    result: >-
+      A = "68 passed, 1 warning, 41 errors". B = "68 passed, 1 warning, 41
+      errors". comm both directions empty. FIRST ATTEMPT WAS VACUOUS AND WAS
+      CAUGHT: zsh does not word-split an unquoted parameter, so the file list
+      went to pytest as ONE path and BOTH sides reported "collected 0 items" --
+      an "identical" that measured nothing. Re-run with the paths listed
+      literally.
+    exit: 0
+    ts: 2026-08-31T02:50Z
+    seat: session (final gate, Opus 5 xhigh)
+
+dissent:
+  - seat: glm-5.2 (Alibaba TP1, non-Anthropic counter-build lane)
+    objection: >-
+      Q2 -- the shared `init` hook SHOULD also set connection-scoped GUCs
+      (`SET statement_timeout`, `application_name`,
+      `idle_in_transaction_session_timeout`): "the `init` callback is
+      precisely where per-connection state belongs and it executes once per
+      real connection, not per checkout". The shipped diff keeps the hook
+      narrow to codec registration only. GLM also proposed (Q4) a single
+      `make_pool()` factory that every pool, test and production, must route
+      through, plus a runtime codec-introspection probe (`SELECT $1::jsonb ->
+      'a'` asserting `1`) instead of a static lint.
+    status: CONFIRMED
+    note: >-
+      Q2 REJECTED with reason, and the reason is written at the definition
+      site rather than left implicit. The three pools do NOT agree on
+      timeouts: both production pools and the test fixture set
+      statement_timeout='30s', `get_db_pool()` (standalone script pool) sets
+      none, and the full pool additionally runs a `SELECT 1`. Folding GUCs
+      into the shared hook would silently change behaviour for a caller that
+      never asked for it and would make one function do two unrelated jobs.
+      Codec parity is the invariant that must not drift; timeouts are a
+      per-pool concern that prod_shaped_pool.py already documents as
+      deliberately NOT mirrored. Q4 is convergent by a different mechanism,
+      not a defect: GLM's probe assertion is CORRECT (under double-encoding
+      the cast yields a string scalar and `-> 'a'` returns NULL), and the
+      shipped parity test reaches the same coverage via `jsonb_typeof`. The
+      `make_pool()` factory is a genuine alternative and is NOT adopted here
+      only because it would rewrite every pool call site in the repo -- a far
+      larger blast radius than this lane's mandate. Recorded rather than
+      silently dropped.
+
+  - seat: codex gpt-5.6-sol (xhigh, read-only sandbox, non-Anthropic refuter)
+    objection: >-
+      D (CONFIRMED, tests only) -- converting three previously-bare test pools
+      to `create_prod_shaped_pool` applies more than the codec: it also brings
+      `SET statement_timeout='30s'`, `statement_cache_size=0` and
+      `max_inactive_connection_lifetime=30.0` to test_bridge_wa_media.py,
+      test_intake_review.py and test_magic_link_store_integration.py. And in
+      test_outbox_consumer.py::_connect the new codec registration sits OUTSIDE
+      the try, so a failure there escapes the skip/fail policy and leaks the
+      connection. F (CONFIRMED) -- the centralisation claim is false
+      (kg_staging_promotion.py registers its own bare-json.dumps codecs, and
+      _CANONICAL_CODEC_FILES lists only three paths); and the identity tests
+      would still pass if the two production `init_asyncpg_connection` calls
+      were deleted, because they compare module attributes.
+    status: CONFIRMED
+    note: >-
+      F FIXED AT THE SOURCE, not footnoted: kg_staging_promotion's wrapper now
+      awaits the canonical hook and joins _CANONICAL_CODEC_FILES; a new
+      AST test asserts the production wrappers CALL the hook, mutation-proven
+      red when the calls become `pass`. Searching past the refuter's single hit
+      found five FURTHER codec-less non-test pools; the docstring now NAMES
+      them instead of overclaiming, with the measurement that none references
+      garuda_orders/garuda_portal/journal/idempotency and therefore none can
+      reach the changed writers. D's error-handling half FIXED (guarded, closes
+      on failure). D's semantics half ACCEPTED WITH REASON: the fixture is
+      called prod_shaped precisely because a test pool should match
+      production's shape, and production HAS those settings -- a test pool that
+      differs is the very divergence that produced the 2026-08-27 incident.
+      The three files were then A/B-ed (none had been in any A/B before, which
+      the finding is what exposed): 68 passed / 41 errors on both sides,
+      identical name sets.
+    note_plausible: >-
+      Codex also raised, as PLAUSIBLE not confirmed: `default=str` silently
+      accepts ANY object, so `{"bytes": b"\xff", "opaque": object()}` now
+      persists Python reprs including a memory address, turning former type
+      errors into unusable data. NOT changed, deliberately. A stricter
+      `default` (datetime/Decimal/UUID only, raise otherwise) would NOT be a
+      superset of what the four callers already did -- every one of them passed
+      `default=str` themselves -- so it would narrow behaviour the callers
+      relied on while claiming to widen it. The widening is real and is the
+      one the spec chose; recording it rather than silently dropping it.
+
+  - seat: kimi-code/k3 (non-Anthropic, second refuter)
+    objection: >-
+      Independently reached NO-DEFECT on the superset claim (A) by the same
+      mechanism. Flagged two candidates: that
+      test_funnel_end_to_end_http.py's pool fixture was left bare while its
+      assertions were edited, and that production pools such as
+      app/intake_review_reader.py:129 could reach the four writers without a
+      codec.
+    status: RETRACTED
+    note: >-
+      Both checked on disk and neither holds. The funnel fixture already uses
+      `create_prod_shaped_pool` (test_funnel_end_to_end_http.py:268) -- Kimi
+      wrote "let me check" and never did; this session did. And the codec-less
+      production pools cannot reach the writers: measured by grep, none of the
+      five references garuda_orders, garuda_portal, journal or idempotency,
+      which matches Codex's independent B verdict. Recorded rather than
+      dropped because the SECOND half of Kimi's flag was the thread that led
+      to enumerating all five and correcting the docstring -- a retracted
+      objection that still moved the diff.
+
+tests:
+  - "backend/tests/db/test_jsonb_codec_parity.py -- 9 tests (STRUCTURAL: encoder
+    shape, widening, identity of the initializer imported by prod_shaped_pool
+    and service_initializer, an AST scan proving no set_type_codec anywhere in
+    the three canonical files still names a bare json.dumps, plus a
+    self-test that the scanner can still detect one. LIVE: native list ->
+    jsonb_typeof 'array' with structural equality; dict holding datetime and
+    Decimal succeeds via default=str; a PRE-serialized string still lands as a
+    jsonb string scalar bound bare AND through an explicit ::jsonb cast)."
+  - "backend/tests/db/test_jsonb_double_encoding_class_guard.py -- pre-existing,
+    still green alongside (20 passed together)."
+  - "A/B against origin/main on two scopes, compared as failure NAME SETS:
+    four GARUDA suite directories, and all 21 collectible baselined bare-pool
+    files. Both identical."
+
+static:
+  - "ruff check on every file this diff touches -- All checks passed."
+  - "The pytest verbosity guard (scripts/pytest_guards/pytest_verbosity_guard.py,
+    new on main) rejects `-q` under apps/backend-rag/pytest.ini with rc=4 and
+    the message 'effective verbosity is -2: pytest would print no pass/fail
+    tally, so this run cannot be read as evidence that anything ran'. Every
+    acceptance command in the L12 lane file passes `-q` and is therefore
+    unrunnable as written; the lane file is corrected inside this PR per
+    wave-2 rule 5.1.4 (spec corrections ride in the lane PR, never a separate
+    docs PR)."
+
+notes:
+  - "This PR does NOT close the PENDING-ARMS row at PENDING-ARMS.md:1511. That
+    row's proof-of-armed is specifically an integration test asserting
+    jsonb_typeof on the FOUR REAL columns, which is the next PR's content.
+    Closing it here would be a claim the diff does not support."
+  - "Ordering consequence: the lint's shrink-only baseline enumerates both
+    files converted here. It must be REGENERATED after this PR lands, or it
+    ships two stale entries -- and a stale baseline is how a registry rots
+    (the baseline's own header says exactly that)."
+  - "No production deploy and no production probe are performed or implied
+    here. The GARUDA writers this diff touches have never executed in
+    production (measured 2026-08-27: garuda_order_journal and
+    garuda_order_outbox both hold 0 rows) because they need a Xendit key
+    nobody has provisioned -- so this is a fix-before-first-write, not a data
+    repair."


### PR DESCRIPTION
Closes part of #5317 (SQUAD D′ — DATA, wave 2). PR 1 of the L12-PR1 split.

## Bites

**Bites:** `backend/tests/db/test_jsonb_codec_parity.py`, inside the **already-required** backend shard (`scripts/ci/shard_tests.py::DEFAULT_TARGETS` includes `backend/tests/`; `EXCLUDED_DIRS` carves out only `backend/tests/e2e`) — reverting `JSONB_ENCODER` to a bare `json.dumps` turns it **3 red**. Observed this turn, not predicted: `10 passed` → `3 failed, 6 passed`, restore verified byte-exact with `git diff --exit-code`. No new workflow needs arming; the executor already exists and is required.

## What this fixes

Three asyncpg pools each registered their own `jsonb`/`json` codec with a **bare** `json.dumps` encoder. Four caller sites therefore pre-serialized with `json.dumps(..., default=str)` — the bare encoder raises `TypeError` on the first `datetime`/`Decimal` — and the codec then encoded that string a **second** time, so Postgres stored a JSONB *string scalar*. On 2026-08-27 that shape answered HTTP 500 to GARUDA VOA's first customer action in production **while the integration test passed 10/10** against a real Postgres with the real migration: the test pool had no codec, so test and production disagreed about what a jsonb parameter means.

The cure widens the encoder to `functools.partial(json.dumps, default=str)` — a strict superset of every caller's own serializer — and makes `init_asyncpg_connection` the one object every codec-registering pool passes to `create_pool(init=...)`. Callers hand native containers and stop pre-serializing.

## Three defects found during verification, not by reading the diff

**1. A 6-test regression the 13 green parity tests could not see.** The evidence brief's own constraint is *"zero JSONB shape regressions, established by A/B against origin/main, not by argument."* Run honestly it did not hold:

| run | result |
|---|---|
| A — GARUDA suites with the rescued diff | `7 failed, 377 passed, 2 skipped, 40 errors` |
| B — same at `origin/main` | `1 failed, 383 passed, 2 skipped, 40 errors` |

Six new failures, all in `services/garuda_portal/test_practice.py`, all `DataError: ... expected str, got dict`. That file's pool is **bare**. This is the lane's own disease one level up: the caller fix and the bare test pools are **coupled** — which is exactly why the spec requires them to land atomically.

**2. A second one the first A/B could not reach.** That A/B covers four directories. Widened to all 21 collectible baselined bare-pool files, `app/routers/test_garuda_orders_ownership.py` surfaced — same class, a directory the first run never touched.

**3. The centralisation claim was false, and an import is not a call.** A blind Codex GPT-5.6 sol refutation (xhigh, read-only) returned NO-DEFECT on the superset claim, the caller call-graph, the `::jsonb` scar test and the bare-pool sweep — and two CONFIRMED-DEFECTs:

- `database.py` claimed *every* pool passes the canonical initializer. A **fourth** pool registered its own codecs with bare `json.dumps` (`backend/scripts/kg_staging_promotion.py`), invisible to the parity test because `_CANONICAL_CODEC_FILES` listed three paths. Fixed at the source. Searching past the refuter's single hit found **five further** codec-less non-test pools; the docstring now names them instead of overclaiming, with the measurement that none references `garuda_orders`/`garuda_portal`/`journal`/`idempotency` and so none can reach the changed writers.
- The identity assertions compared module attributes, so deleting both `await init_asyncpg_connection(conn)` calls left every one green. New AST test closes it, mutation-proven both ways.

Also fixed from the same refutation: in `test_outbox_consumer.py::_connect` the codec registration sat **outside** the `try`, escaping the skip/fail policy and leaking the connection.

## Verification, re-run this turn on the whole tree

All A/B scopes compared as **FAILED+ERROR name sets** with the *same* filter on both sides — not counts alone.

| scope | with diff | origin/main | verdict |
|---|---|---|---|
| parity + pre-existing class guard | `21 passed` | — | green |
| GARUDA suites (4 dirs) | `1 failed, 383 passed, 2 skipped, 40 errors` | identical | **41-line name set IDENTICAL** |
| 21 baselined bare-pool files | `26 failed, 190 passed, 46 skipped, 99 errors` | identical | **IDENTICAL** |
| `routers/{bridge_wa_media,intake_review}` + `garuda_orders/test_outbox_consumer` | `68 passed, 41 errors` | identical | **IDENTICAL** |

That last scope was a gap in this session's *own* verification — those three files sat in neither A/B, and the refuter's finding is what surfaced them. Residual failures are pre-existing and environmental (`relation "practices" does not exist` — `craftd-pg` carries the GARUDA migrations but not all others), byte-identical on both sides.

Mutation proofs: replacing the two production `init_asyncpg_connection` calls with `pass` → `1 failed, 9 passed` (exactly the new call-site test). Restoring the bare codec in `kg_staging_promotion` → `2 failed, 8 passed`. Unmutated → `10 passed`. Both restores byte-exact.

## Seats

| lane | seat | family |
|---|---|---|
| build | Sonnet 5 (rescued), then Opus 5 xhigh (split, A/B, the pool conversions) | Anthropic |
| **counter-build (D3)** | **GLM-5.2 via Alibaba TP1** — blind on the problem statement, never shown the diff | **non-Anthropic, a real build lane, not `seat_override`** |
| refuter | Codex GPT-5.6 sol xhigh, read-only sandbox | non-Anthropic |
| second refuter | Kimi K3 | non-Anthropic |

**GLM-5.2 converged on 4 of 6 questions unprompted**, including both traps this lane exists for: that fixing the encoder without removing the caller-side pre-serialization stays green in CI and gets misdiagnosed as *"the codec change didn't deploy"*, and that `$1::jsonb` is **not** a bypass (correct bind-phase mechanism). It diverged on two, both recorded in the pack: one **rejected with reason** (GUCs in the shared hook — the three pools do not agree on timeouts, and `get_db_pool()` wants none), one convergent by a different mechanism.

**Kimi K3's objections are recorded as RETRACTED.** It flagged `test_funnel_end_to_end_http.py`'s fixture as bare — it already uses `create_prod_shaped_pool` at line 268; Kimi wrote *"let me check"* and never did, this session did. Kept in the pack because the second half of that flag is what led to enumerating all five codec-less pools.

One PLAUSIBLE finding is recorded and **deliberately not acted on**: `default=str` accepts any object, so `bytes`/`object()` now persist Python reprs. A stricter `default` would *not* be a superset of what the four callers already did — every one passed `default=str` themselves — so it would narrow behaviour while claiming to widen it.

## Not claimed

- This does **not** close `PENDING-ARMS.md:1511`. That row's proof-of-armed is an integration test asserting `jsonb_typeof` on the **four real columns** — the next PR's content.
- No production deploy, no production probe. The writers touched here have never executed in production (measured 2026-08-27: both tables hold 0 rows; they need a Xendit key nobody has provisioned), so this is fix-before-first-write, not data repair.
- The lint's shrink-only baseline enumerates both files converted here and **must be regenerated** after this lands, or it ships two stale entries.

Evidence pack: `evidence/2026-08/agent-nuzantara-craft-d-codec-jsonb-default-str-c9e5b351/` — lints **clean, zero notices**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
