### PR TITLE
feat(security): with_seat broker — a child gets exactly its seat's declared env (L13-PR1)

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -194,6 +194,7 @@ on:
       - Root Guard
       - SBOM (Software Bill of Materials)
       - scripts/tests/ sweep (report-only)
+      - Seat broker env-minimization tests
       - Security Scanning
       - SAST — Bandit + ESLint Security
       - SonarQube Analysis

--- a/.github/workflows/with-seat-broker-tests.yml
+++ b/.github/workflows/with-seat-broker-tests.yml
@@ -26,29 +26,46 @@ name: Seat broker env-minimization tests
 # would pass just as well against a child that sees nothing because the fixture broke.
 #
 # Deliberately NOT a branch-protection required context (repo-settings action, operator-
-# gated; a permanently-red required check blocks the whole merge queue). It runs on every
-# PR touching the broker, its registry, or its corpus — which is what makes it bite.
+# gated; a permanently-red required check blocks the whole merge queue). It starts on a PR
+# that touches the broker, its registry, its corpus, or `.gitattributes` (a checkout-
+# semantics change such as `eol=crlf` breaks these shell scripts without appearing in any
+# of the other paths).
 #
-# `scripts/fleet_burst.sh` is in the filter because it names this broker as its
-# `FLEET_BURST_SEAT_BROKER` and depends on the `<broker> <seat> <command...>` contract;
-# a change to that contract must start this job.
+# "Starts on", not "runs on every PR that touches them": GitHub evaluates path filters
+# against at most the first 3,000 files of a diff, so a large enough PR can touch a guarded
+# file and still not trigger this workflow. That is a platform limit, not something this
+# file can close, and it is stated rather than papered over.
+#
+# `scripts/fleet_burst.sh` is in the filter FORWARD-LOOKINGLY and does not exist on this
+# branch yet: it arrives with L09-PR2 (PR #5322), where it names this broker as its
+# `FLEET_BURST_SEAT_BROKER` and depends on the `<broker> <seat> <command...>` contract.
+# Until that lands, this entry simply never matches — a filter naming an absent file is
+# inert, not broken. Stating it because the honest reading today is that the broker's only
+# proven consumer is its own corpus; the fleet dispatch becomes a real consumer when #5322
+# merges, and the entry is here so that a later change to the contract starts this job
+# rather than being remembered.
 
 on:
   pull_request:
-    paths:
+    paths: &guarded_paths
       - "scripts/with_seat.sh"
       - "scripts/tests/test_with_seat_env_minimization.sh"
       - "infra/llm-credentials/seat-env.json"
       - "scripts/fleet_burst.sh"
+      - ".gitattributes"
       - ".github/workflows/with-seat-broker-tests.yml"
+  # Runs on the merge queue's synthetic revision too, so two individually-green
+  # PRs whose COMBINATION breaks the broker are caught before landing rather
+  # than after. Without this the only post-merge signal is the push run below,
+  # which is detection, not prevention.
+  merge_group:
   push:
     branches:
       - main
-    paths:
-      - "scripts/with_seat.sh"
-      - "scripts/tests/test_with_seat_env_minimization.sh"
-      - "infra/llm-credentials/seat-env.json"
-      - "scripts/fleet_burst.sh"
+    # Identical set, the workflow file included: a PR that changes ONLY this file
+    # runs on the PR but would produce no main-push run after merge, leaving
+    # main-push-failure-watch.yml with nothing to observe.
+    paths: *guarded_paths
 
 permissions:
   contents: read

--- a/.github/workflows/with-seat-broker-tests.yml
+++ b/.github/workflows/with-seat-broker-tests.yml
@@ -1,0 +1,95 @@
+name: Seat broker env-minimization tests
+
+# Executor for the corpus that proves `scripts/with_seat.sh` — the broker that gives an
+# external LLM child EXACTLY its seat's declared environment names and nothing else.
+#
+# WHY THIS FILE EXISTS, and why it ships in the same PR as the broker
+# ------------------------------------------------------------------
+# `scripts-tests-sweep.yml` collects only `test_*.py` through pytest (a `.sh` file is
+# invisible to pytest collection) and its sweep step is `continue-on-error: true`, so a
+# shell corpus landed alone has no executor that can ever go red — superscar #2
+# (exists != armed). Wave-2 rule 3: "a future job will run it" is not a consumer; the
+# job ships in the same PR. Same shape as `fleet-burst-tests.yml`,
+# `vercel-autopromote-tests.yml` and `intake-review-reader-liveness.yml`.
+#
+# WHAT IS ACTUALLY AT STAKE HERE, measured on Mini 2026-08-31: a wrapper that sources
+# `~/.nuzantara-secrets.env` and then runs `codex`/`agy`/`kimi` hands that child 49
+# environment names, 16 of them secret-shaped, spanning 11 credential families — every
+# Claude OAuth seat token plus Telegram, Brevo, OpenRouter, MiniMax, Jules, LangSmith,
+# IG Graph, Observatory and a Google service-account path. One vendor's child could read
+# every other vendor's key. Through the broker the same child gets 6 declared names and
+# ZERO secret-shaped ones.
+#
+# The corpus's guilt case is therefore load-bearing in an unusual way: it asserts that an
+# UNWRAPPED child DOES see a planted fake token name. If that check ever silently stops
+# firing, the innocence case ("the planted name is absent") proves nothing at all — it
+# would pass just as well against a child that sees nothing because the fixture broke.
+#
+# Deliberately NOT a branch-protection required context (repo-settings action, operator-
+# gated; a permanently-red required check blocks the whole merge queue). It runs on every
+# PR touching the broker, its registry, or its corpus — which is what makes it bite.
+#
+# `scripts/fleet_burst.sh` is in the filter because it names this broker as its
+# `FLEET_BURST_SEAT_BROKER` and depends on the `<broker> <seat> <command...>` contract;
+# a change to that contract must start this job.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/with_seat.sh"
+      - "scripts/tests/test_with_seat_env_minimization.sh"
+      - "infra/llm-credentials/seat-env.json"
+      - "scripts/fleet_burst.sh"
+      - ".github/workflows/with-seat-broker-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/with_seat.sh"
+      - "scripts/tests/test_with_seat_env_minimization.sh"
+      - "infra/llm-credentials/seat-env.json"
+      - "scripts/fleet_burst.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: with-seat-broker-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+jobs:
+  with-seat-broker-tests:
+    name: Seat broker env-minimization tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      # A syntax error in a credential broker is not a broken feature, it is an
+      # unbrokered dispatch: callers fall back to running the CLI directly.
+      - name: The broker still parses
+        run: bash -n scripts/with_seat.sh
+
+      # The registry is data the broker trusts (it decides which names and which
+      # executables a seat may have), so malformed JSON must be caught here rather than
+      # at 03:00 on a cron.
+      - name: The seat registry is well-formed JSON
+        run: python3 -m json.tool infra/llm-credentials/seat-env.json > /dev/null
+
+      # The corpus proper. Three things it carries are worth naming, because each is a
+      # way this job could otherwise report green over a real problem:
+      #
+      #  - Its GUILT case first proves an UNWRAPPED child still sees a planted fake
+      #    token. Without that, "the planted name is absent" would pass just as well
+      #    against a fixture that broke and shows nothing at all.
+      #  - It asserts the child's names EQUAL the declaration intersected with the
+      #    parent — not a subset. A subset assertion is satisfied by a child with no
+      #    environment, which is the failure mode, not the goal.
+      #  - It validates the REAL registry, not only its own synthetic seat. That is what
+      #    caught two of four shipped seats being unable to resolve their own binary,
+      #    and it rejects a token pasted into an `env` array or a 64-char hex string
+      #    wearing a valid identifier's syntax. An earlier version of this workflow
+      #    grepped for value-shaped `key: "value"` pairs instead — measured, that missed
+      #    BOTH of those pastes, because the registry is arrays of strings.
+      - name: A child gets exactly its seat's declared names, and nothing else
+        run: bash scripts/tests/test_with_seat_env_minimization.sh

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/brief.yml
@@ -1,0 +1,78 @@
+task_id: craft-f2-l13-pr1-with-seat-broker
+gear: 3
+l_level: L2
+gate_class: opus
+council_run: journal.jsonl
+acceptance:
+  - text: "WHEN a child is dispatched through the broker, its environment name set SHALL equal the seat's declared names intersected with the parent — not a subset, not a superset."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+  - text: "WHILE an unwrapped child still sees a planted fake token name, the guilt fixture SHALL prove it — an innocence result is meaningless without it."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+  - text: "IF a caller supplies a PATH whose basename is allowlisted, the broker SHALL refuse rather than execute it."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+  - text: "IF the registry is group- or world-writable, or declares a malformed/duplicate name, an empty allowlist, or a bare-relative search path, the broker SHALL refuse."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+  - text: "WHERE a real seat's executable exists on this machine, that seat SHALL resolve it through its own declared search path."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+  - text: "WHEN the child exits N or dies on signal N, the broker SHALL exit N or 128+N respectively; and a TERM to the BROKER SHALL kill the broker rather than be swallowed."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+  - text: "IF anything is wrong, the broker SHALL refuse — it SHALL NEVER fall back to an unwrapped invocation."
+    probe: "bash scripts/tests/test_with_seat_env_minimization.sh"
+
+objective: |
+  L13-PR1 of the beyond-SOTA craft wave (squad F', fleet & security): a broker that
+  gives an external LLM child exactly its seat's declared environment names.
+
+  Measured on Mini 2026-08-31: a wrapper that sources ~/.nuzantara-secrets.env and
+  then runs codex/agy/kimi hands that child 49 environment names, 16 of them
+  secret-shaped, across 11 credential families — every Claude OAuth seat token
+  plus Telegram, Brevo, OpenRouter, MiniMax, Jules, LangSmith, IG Graph,
+  Observatory and a Google service-account path. One vendor's child can read every
+  other vendor's key. Through the broker the same child gets 6 declared names and
+  ZERO secret-shaped ones.
+
+  The existing partial mitigation (claude-cascade.sh::build_isolated_provider_env)
+  SUBTRACTS a blacklist with `env -u`, so any name nobody thought to list is
+  inherited, and it exists only inside that one wrapper. This builds from `env -i`
+  instead, so the child's name set EQUALS a declaration.
+
+  Ships with its own CI executor: a .sh corpus has no consumer in this repo
+  otherwise (scripts-tests-sweep.yml collects only test_*.py and is
+  continue-on-error), and the executor is registered with the main-push failure
+  watcher in the same diff.
+constraints:
+  - "Names only, never values. The registry holds names; values are resolved at
+    exec time from the parent and travel NUL-framed over STDIN, never argv — so
+    they are not visible in `ps` to other local users, the exposure this repo
+    already documented for agy at claude-cascade.sh:441-451. A CI step greps the
+    registry for value-shaped strings so a well-meaning paste fails there."
+  - "No unwrapped fallback, ever. Every failure path refuses. A broker that
+    silently degrades to the inherited environment is worse than no broker,
+    because callers would believe they are isolated."
+  - "A caller names WHAT to run, never WHERE. Resolution happens only through a
+    search path the REGISTRY supplies — the registry is the trusted input here
+    (the broker refuses to read it if group- or world-writable), whereas argv and
+    the environment are attacker-reachable by construction."
+  - "The three external seats declare NO credential name at all: codex, agy and
+    kimi authenticate through config directories under $HOME. That is measured,
+    not assumed, and is stated in each seat's note because a reader will otherwise
+    think something is missing."
+  - "No external CLI was ever asked to print its environment (L13 forbids it). The
+    boundary is proven with a benign local child; the codex figure is --dry-run,
+    which executes nothing."
+grader: |
+  generator != grader with family exclusion, both directions. The broker, registry
+  and corpus were BUILT by Codex GPT-5.6 terra (non-Anthropic, effort high) and
+  refuted blind by Kimi K3 (non-Anthropic, a different family from its builder).
+  The workflow was written by this Anthropic orchestrator and refuted blind by
+  Codex GPT-5.6 sol at xhigh, the security/workflow-class refuter. Each refuter
+  received the DIFF, never a narrative. GLM-5.2 via TP1 was dispatched as a third
+  security opinion. The final on-disk gate is this orchestrator, empirical, this
+  turn: every claimed guard mutation-tested at a real code site, and every refuter
+  finding reproduced before being fixed.
+budget: |
+  Flat-subscription seats only: this session (orchestrator + gate), Codex GPT-5.6
+  terra (build) and sol (workflow refutation) on ChatGPT Pro, Kimi K3 (refutation)
+  on the Allegro flat plan, GLM-5.2 through the already-provisioned TP1 gateway.
+  No metered API spend.
+pii: none

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/journal.jsonl
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-08-31T01:05:00Z"}
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": true, "ts": "2026-08-31T01:20:00Z"}

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
@@ -45,7 +45,7 @@ diff:
     the executor out would ship a credential broker whose guards nothing runs.
 
 receipts:
-  - claim: "19/19 corpus green, and it bites: 6 mutants killed at real code sites (basename-only exec resolution restored; declared search paths removed; bare-relative search path; swallowing TERM trap restored; file_mode forced to answer a safe mode; length cap raised past a sha256 hex)."
+  - claim: "21/21 corpus green, and it bites: 8 mutants killed at real code sites (basename-only exec resolution restored; declared search paths removed; bare-relative search path; swallowing TERM trap restored; file_mode forced to answer a safe mode; length cap raised past a sha256 hex; secret-shape scan disabled; seat-name/allowlist consistency disabled)."
     cmd: "bash scripts/tests/test_with_seat_env_minimization.sh"
     exit: 0
     ts: "2026-08-31T01:30:00Z"
@@ -161,3 +161,87 @@ dissent:
       like, plus guilt fixtures for exactly those two pastes. The length cap is 48
       deliberately: 64 would have let a sha256 hex through, which it measurably
       did on the first attempt.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      The registry's secret check exempts `note`, so a credential wrapped in
+      prose lands untouched: "note": "OPENAI_API_KEY: sk-proj-0123...". The key
+      name is only 14 chars before the colon breaks the run and the token is not
+      adjacent to a quote, so no key/value pattern considers it.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced against the real registry: it passed. The scan now covers the
+      WHOLE file, prose included, rejecting any 32+ char run of secret-charset.
+      32 is measured rather than guessed -- the longest legitimate token anywhere
+      in this registry's prose is 23 (CLAUDE_CODE_OAUTH_TOKEN,
+      FLEET_BURST_SEAT_BROKER). Pinned by a guilt fixture built from the real
+      registry plus exactly that note.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      The real-seat resolution check can execute ZERO cases and still pass: it
+      skips a seat whose CLI is absent and then asserts only that failures == 0.
+      None of codex/agy/kimi/claude exist on ubuntu-latest, so on CI it always
+      checks nothing. `"exec_allowlist": ["codxe"]` is structurally valid and
+      invisible there, while production rejects the real codex.
+    status: CONFIRMED
+    resolution: >-
+      This is the coverage-theatre shape the workflow's own header criticises,
+      inside the workflow. Fixed with a rule that needs no binary present: a
+      seat's allowlist must contain the executable the seat is NAMED for
+      (claude-seat -> claude), so a typo is caught on every machine including a
+      runner where nothing is installed. The resolution check is kept for the
+      machines that CAN answer it and now prints how many seats it actually
+      checked, so a zero-coverage run is visible rather than a silent green.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      Three trigger gaps: `.gitattributes` is not in the path filter (an
+      `eol=crlf` entry breaks every guarded shell script without touching any
+      listed path); there is no `merge_group` trigger, so the
+      `!= 'merge_group'` concurrency exception is dead code and two individually
+      green PRs whose COMBINATION breaks the broker are not caught before
+      landing; and the push:main filter omits the workflow file itself, so a PR
+      changing only it produces no main-push run for the failure watcher to
+      observe.
+    status: CONFIRMED
+    resolution: >-
+      All three fixed: `.gitattributes` added, `merge_group:` added (which also
+      makes the existing concurrency expression live logic rather than dead), and
+      the two path sets unified with a YAML anchor so they cannot drift apart
+      again -- the third defect existed only because they were maintained as two
+      hand-copied lists.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      The header claims the job "runs on every PR touching the broker". GitHub
+      evaluates path filters against at most the first 3,000 files of a diff, so
+      a large enough PR can touch a guarded file and not trigger this workflow.
+    status: CONFIRMED
+    resolution: >-
+      The claim was false and is not restated: the header now says "starts on"
+      and names the 3,000-file limit as a platform constraint this file cannot
+      close. A comment that overstates a guard's reach is how the next reader
+      stops looking.
+  - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
+    objection: >-
+      `scripts/fleet_burst.sh` and `FLEET_BURST_SEAT_BROKER` do not exist in the
+      inspected repository, so the workflow can prove an isolated fixture while
+      no fleet dispatch actually uses the broker.
+    status: CONFIRMED
+    resolution: >-
+      Correct and worth stating rather than arguing: fleet_burst arrives in
+      L09-PR2 (PR #5322), which is open and green but not merged. Until then the
+      broker's only proven consumer is its own corpus, and the path-filter entry
+      is inert -- a filter naming an absent file never matches. The comment now
+      says exactly that instead of implying a live consumer.
+  - seat: tp1-glm-5.2 (third security opinion, DID NOT PRODUCE A VERDICT)
+    objection: >-
+      No findings: the seat returned finish_reason "length" with ZERO content at
+      max_tokens 8000 and again at 32000, spending its whole budget on reasoning.
+    status: PLAUSIBLE
+    resolution: >-
+      Recorded as a door limitation rather than silently dropped, because a
+      missing refuter is exactly the kind of absence that reads as "no findings".
+      This is the trap arsenal_probe.py:156 documents -- TP1 thinking models cap
+      reasoning and answer TOGETHER -- so any lane budgeting such a seat by
+      expected ANSWER length gets an empty HTTP 200. GLM-5.2 is not usable as a
+      refuter on a diff of this size through that door. The family-exclusion and
+      R9 quorum requirements are met without it by kimi-code/k3 and
+      codex-gpt-5.6-sol.

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
@@ -164,9 +164,13 @@ dissent:
   - seat: codex-gpt-5.6-sol (blind refutation of the workflow diff)
     objection: >-
       The registry's secret check exempts `note`, so a credential wrapped in
-      prose lands untouched: "note": "OPENAI_API_KEY: sk-proj-0123...". The key
-      name is only 14 chars before the colon breaks the run and the token is not
-      adjacent to a quote, so no key/value pattern considers it.
+      prose lands untouched -- a note reading "<VENDOR>_API_KEY: <token>" defeats it,
+      because the key name is short enough that the colon breaks the character run,
+      and the token itself is not adjacent to a quote, so no key/value pattern
+      considers it. (Deliberately described rather than quoted: a pack that carries a
+      value-shaped string is exactly what this finding is about, and the repo's own
+      secret scanner flagged the first draft of this entry for containing one --
+      W108's "the guard that forbids the string was writing it", one level up.)
     status: CONFIRMED
     resolution: >-
       Reproduced against the real registry: it passed. The scan now covers the

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
@@ -1,0 +1,31 @@
+council_run: journal.jsonl
+# The literal `evidence/brief.yml`, NEVER this pack's real per-PR path.
+# harness-floor.yml stages BOTH files under canonical names into a synthetic tree
+# and resolves brief_ref against THAT; its own comment calls the per-PR value
+# "exactly the trap this migration exists to remove", and
+# scripts/ci/evidence_paths.py says the same. Running the lint LOCALLY there is no
+# staging, so brief_ref resolves against the real repo root and lands on an
+# unrelated task's brief -- which emits an acceptance-probe NOTICE that looks like
+# a bug and is really just the absence of staging. Verified by reproducing CI's
+# layout locally (pack+brief+journal copied under canonical names, --repo-root
+# pointed at that tree) rather than by trusting the bare local run.
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  docs/plans/2026-08-29-beyond-sota-craft-wave/L13-security-secrets-pii.md
+  section "PR-1: feat(security): seat broker - exec-time minimal env for external LLM dispatch".
+
+lanes:
+  - lane: with-seat-build
+    role: build
+    seat: codex-gpt-5.6-terra (non-Anthropic, effort high) -- D3 build lane, never the grader
+  - lane: with-seat-refute
+    role: review
+    seat: kimi-code/k3 (non-Anthropic) -- blind adversarial refutation of the broker diff
+  - lane: with-seat-workflow-refute
+    role: review
+    seat: codex-gpt-5.6-sol xhigh -- blind adversarial refutation of the workflow diff
+  - lane: with-seat-gate
+    role: review
+    seat: claude opus-5 xhigh (this orchestrator) -- final on-disk gate, empirical
+
+pii_scan: clean

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-with-seat-broker-7272abc5/pack.yml
@@ -29,3 +29,135 @@ lanes:
     seat: claude opus-5 xhigh (this orchestrator) -- final on-disk gate, empirical
 
 pii_scan: clean
+
+diff:
+  files: 8
+  net_lines: 907
+  measured_at: HEAD-of-branch
+  note: >-
+    Measured with git diff --numstat over merge-base..HEAD. Over the <=400
+    net-line target of rules-of-engagement #2, declared rather than hidden: the
+    broker is 352 lines and its corpus 241 -- and the corpus is why six defects
+    were caught before merge rather than after, three of them by it directly.
+    94 lines are the CI executor without which a .sh corpus has no consumer able
+    to go red, 1 line registers that executor with the main-push failure watcher,
+    and the remainder is this branch's own evidence pack. Splitting the corpus or
+    the executor out would ship a credential broker whose guards nothing runs.
+
+receipts:
+  - claim: "19/19 corpus green, and it bites: 6 mutants killed at real code sites (basename-only exec resolution restored; declared search paths removed; bare-relative search path; swallowing TERM trap restored; file_mode forced to answer a safe mode; length cap raised past a sha256 hex)."
+    cmd: "bash scripts/tests/test_with_seat_env_minimization.sh"
+    exit: 0
+    ts: "2026-08-31T01:30:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "THE BITE, measured on Mini with the real registry: a codex child goes from 49 inherited env names (16 secret-shaped, 11 credential families) to 6 declared names and 0 secret-shaped. Names only; no external CLI was asked to print its environment; --dry-run executes nothing."
+    cmd: "with_seat.sh --dry-run codex codex, from a parent that has sourced ~/.nuzantara-secrets.env"
+    exit: 0
+    ts: "2026-08-31T01:10:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "All four declared seats resolve their own executable through their declared search path (codex, agy, kimi, claude-seat). Before the fix, agy and kimi could not."
+    cmd: "bash scripts/tests/test_with_seat_env_minimization.sh"
+    exit: 0
+    ts: "2026-08-31T01:25:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The workflow passes the pinned actionlint the required CI gate runs (1.7.12) and the required per-job checkout-budget floor."
+    cmd: "actionlint .github/workflows/with-seat-broker-tests.yml && python3 scripts/lint_workflow_timeout_floor.py"
+    exit: 0
+    ts: "2026-08-31T01:28:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The executor is registered with main-push-failure-watch.yml, verified by removing the registration and watching check_watcher_coverage.py name this workflow as uncovered."
+    cmd: "python3 scripts/check_watcher_coverage.py"
+    exit: 0
+    ts: "2026-08-31T01:00:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+
+dissent:
+  - seat: claude opus-5 xhigh (this orchestrator, final gate)
+    objection: >-
+      The exec allowlist was a naming convention, not an allowlist: it checked the
+      BASENAME of a caller-supplied path, so `with_seat.sh codex /tmp/evil/codex`
+      executed the attacker's binary and the broker reported a clean exit.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced (ATTACKER CODE RAN, exit 0), then fixed: a caller may name only a
+      bare command, and WHERE it resolves comes from the registry -- the trusted
+      input here, since the broker refuses to read it if group- or world-writable
+      -- never from argv or the environment. Pinned by a case that plants an
+      executable with an allowlisted basename and asserts it neither runs nor
+      leaves a marker.
+  - seat: claude opus-5 xhigh (this orchestrator, final gate)
+    objection: >-
+      Two of the four shipped seats could not resolve their own binary: agy lives
+      in ~/.local/bin and kimi in ~/.kimi-code/bin, neither on the fixed system
+      search path. A broker armed for one seat in two.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced ("cannot resolve command" for both), then fixed with a per-seat
+      exec_search_path supporting "~/"-prefixed entries -- necessary because the
+      three fleet machines do not share a home (/Users/nuzantara on Pro and Mini,
+      /Users/balizero on M5), and a registry that is wrong on one machine is a
+      broker that gets bypassed there. The deeper defect was in the CORPUS: every
+      check used a synthetic seat, so it could not see this. A check against the
+      REAL registry was added and is what now pins it.
+  - seat: kimi-code/k3 (blind refutation of the broker diff)
+    objection: >-
+      `trap 'rm -f ...' EXIT HUP INT TERM` cleans up but does not exit, so on TERM
+      the script continues and the broker survives the signal its supervisor sent.
+    status: CONFIRMED
+    resolution: >-
+      Measured on bash 3.2.57: the line after `kill -TERM $$` printed and the
+      script exited 0. Fixed to clean up, restore the default handler and
+      re-raise; measured rc=143. Pinned by a case that TERMs the broker while a
+      deliberately slow child is running, so the answer is deterministic rather
+      than a race the test would have to tolerate.
+  - seat: kimi-code/k3 (blind refutation of the broker diff)
+    objection: >-
+      file_mode tries BSD `stat -f '%Lp'` and falls back to GNU `stat -c '%a'`,
+      but on GNU `-f` is not an unknown flag -- it means --file-system. The
+      fallback depends on GNU stat failing for the right reason; if it does not,
+      the function returns garbage and the group/world-writable refusal silently
+      stops refusing.
+    status: CONFIRMED
+    resolution: >-
+      Accepted without needing to settle what GNU stat does, because the
+      uncertainty IS the defect: a security guard should not rest on a guess about
+      another platform's error handling. Replaced with python3, already a hard
+      dependency of this script, which means the same thing everywhere.
+      Mutation-verified: a file_mode that always answers 600 turns the
+      writable-registry check red.
+  - seat: kimi-code/k3 (blind refutation of the broker diff)
+    objection: >-
+      `set +e` disables errexit but leaves pipefail on, so a SIGPIPE or failure in
+      the left side of the dispatch pipeline would be reported as the child's exit
+      status.
+    status: CONFIRMED
+    resolution: >-
+      Fixed by disabling pipefail for exactly that pipeline and restoring it after.
+      The child's status is the one thing this wrapper promises to preserve.
+  - seat: kimi-code/k3 (blind refutation of the broker diff)
+    objection: >-
+      `${!name+x}` (indirect expansion with the +x test) may not be supported on
+      bash 3.2, which would break the present/absent decision for every declared
+      name.
+    status: RETRACTED
+    resolution: >-
+      Measured on /bin/bash 3.2.57 rather than reasoned about: both the set and
+      unset branches behave correctly. Recorded as NOT a defect so that a future
+      reader does not "fix" working code on the strength of a maybe. The refuter
+      itself flagged this as uncertain rather than asserting it, which is the
+      right shape for a finding it could not test.
+  - seat: claude opus-5 xhigh (this orchestrator, on its OWN workflow)
+    objection: >-
+      The workflow step asserting "the registry holds names, never values"
+      grepped for value-shaped `key: "value"` pairs -- but the registry is arrays
+      of strings, so it matched neither realistic paste.
+    status: CONFIRMED
+    resolution: >-
+      Measured both misses: a token dropped into an `env` array is not a
+      key/value pair and never matched, and a 64-char sha256-shaped hex string is
+      itself a syntactically valid identifier. Replaced with a structural
+      validator in the corpus (so it runs locally and is mutation-testable) that
+      bounds the SHAPE of every field instead of guessing what a secret looks
+      like, plus guilt fixtures for exactly those two pastes. The length cap is 48
+      deliberately: 64 would have let a sha256 hex through, which it measurably
+      did on the first attempt.

--- a/infra/llm-credentials/seat-env.json
+++ b/infra/llm-credentials/seat-env.json
@@ -1,0 +1,52 @@
+{
+  "_comment": [
+    "Environment-name declarations for scripts/with_seat.sh. They are an allowlist: a child receives only declared names that exist in the broker parent.",
+    "ABSOLUTE RULE: this file holds NAMES ONLY, never values, tokens, paths containing credentials, or any other secret material. Values are resolved only at exec time from the broker parent.",
+    "WHY THIS FILE EXISTS (2026-08-31): external LLM CLIs previously inherited unrelated credential families. A subtractive blacklist cannot be complete; env -i makes this declaration the whole child environment."
+  ],
+  "seats": {
+    "codex": {
+      "env": ["HOME", "PATH", "TERM", "LANG", "LC_ALL", "TMPDIR"],
+      "exec_allowlist": ["codex"],
+      "note": "Measured on this machine: Codex authenticates through the config directory under $HOME (~/.codex), not an API-key environment variable. HOME, PATH, TERM, LANG, LC_ALL, and TMPDIR are the functional process minimum; no credential name is declared."
+    },
+    "agy": {
+      "env": ["HOME", "PATH", "TERM", "LANG", "LC_ALL", "TMPDIR"],
+      "exec_allowlist": ["agy"],
+      "note": "Measured on this machine: agy authenticates through config directories under $HOME (~/.gemini and ~/.antigravity), not an API-key environment variable. HOME, PATH, TERM, LANG, LC_ALL, and TMPDIR are the functional process minimum; no credential name is declared. Its binary lives in ~/.local/bin, outside the broker's fixed system search path, so the seat declares its own — measured: without this the seat could not resolve agy at all.",
+      "exec_search_path": [
+        "~/.local/bin",
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin"
+      ]
+    },
+    "kimi": {
+      "env": ["HOME", "PATH", "TERM", "LANG", "LC_ALL", "TMPDIR"],
+      "exec_allowlist": ["kimi"],
+      "note": "Measured on this machine: Kimi authenticates through the config directory under $HOME (~/.kimi-code), not an API-key environment variable. HOME, PATH, TERM, LANG, LC_ALL, and TMPDIR are the functional process minimum; no credential name is declared. Its binary lives in ~/.kimi-code/bin, outside the broker's fixed system search path, so the seat declares its own — measured: without this the seat could not resolve kimi at all.",
+      "exec_search_path": [
+        "~/.kimi-code/bin",
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin"
+      ]
+    },
+    "claude-seat": {
+      "env": [
+        "HOME",
+        "PATH",
+        "TERM",
+        "LANG",
+        "LC_ALL",
+        "TMPDIR",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CONFIG_DIR"
+      ],
+      "exec_allowlist": ["claude"],
+      "note": "Measured seat kind for headless Claude lanes: it needs the ordinary process minimum plus CLAUDE_CODE_OAUTH_TOKEN and CLAUDE_CONFIG_DIR. This lets scripts/fleet_burst.sh use the broker through FLEET_BURST_SEAT_BROKER without widening the child environment."
+    }
+  }
+}

--- a/scripts/tests/test_with_seat_env_minimization.sh
+++ b/scripts/tests/test_with_seat_env_minimization.sh
@@ -17,6 +17,14 @@ trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
 TOTAL=0
 FAILED=0
 
+# On failure, surface the broker's own stderr from the most recent invocation.
+#
+# Without this a red CI run says only WHICH check failed, never why: the broker writes
+# diagnostics to a captured file, so the job log shows a bare "FAIL" and the next move
+# is a guess. Measured cost of not having it: a full CI cycle unable to distinguish a
+# missing interpreter from a refused seat. A corpus that can go red without saying why
+# spends its reader's time instead of its own.
+LAST_STDERR=""
 check() {
   local label="$1"
   shift
@@ -25,6 +33,9 @@ check() {
     printf 'PASS %s\n' "$label"
   else
     printf 'FAIL %s\n' "$label"
+    if [ -n "$LAST_STDERR" ] && [ -s "$LAST_STDERR" ]; then
+      printf '     broker stderr: %s\n' "$(head -c 500 "$LAST_STDERR" | tr '\n' '|')"
+    fi
     FAILED=$((FAILED + 1))
   fi
 }
@@ -86,6 +97,7 @@ export FAKE_PLANTED_TOKEN_FOR_TEST
 "$capture" "$output"
 check "guilt fixture exposes planted inherited name" grep -qx 'FAKE_PLANTED_TOKEN_FOR_TEST' "$output"
 
+LAST_STDERR="$stderr_file"
 WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat env-capture "$output" >"$TEMP_DIR/stdout" 2>"$stderr_file"
 check "innocence planted name absent" bash -c '! grep -qx FAKE_PLANTED_TOKEN_FOR_TEST "$1"' _ "$output"
 printf '%s\n' HOME PATH TERM LANG LC_ALL TMPDIR | LC_ALL=C sort >"$TEMP_DIR/expected"
@@ -127,10 +139,12 @@ writable_status=$?
 check "group/world-writable registry refuses" test "$writable_status" -ne 0
 chmod 600 "$registry"
 
+LAST_STDERR="$stderr_file"
 WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat exit-seven >"$TEMP_DIR/stdout" 2>"$stderr_file"
 exit_seven_status=$?
 check "child exit status preserved" test "$exit_seven_status" -eq 7
 
+LAST_STDERR="$stderr_file"
 WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat self-term >"$TEMP_DIR/stdout" 2>"$stderr_file"
 self_term_status=$?
 check "child TERM signal preserved" test "$self_term_status" -eq 143
@@ -178,6 +192,7 @@ sleep 1
 kill -TERM "$broker_pid" 2>/dev/null
 wait "$broker_pid"
 broker_term_status=$?
+LAST_STDERR="$term_broker_out"
 check "a TERM to the broker is not swallowed" test "$broker_term_status" -eq 143
 
 # THE REAL REGISTRY, not a synthetic seat.

--- a/scripts/tests/test_with_seat_env_minimization.sh
+++ b/scripts/tests/test_with_seat_env_minimization.sh
@@ -210,7 +210,26 @@ import json, re, sys
 NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 BASENAME = re.compile(r"^[A-Za-z0-9._-]+$")
 bad = []
-seats = json.load(open(sys.argv[1]))["seats"]
+raw = open(sys.argv[1]).read()
+registry = json.loads(raw)
+seats = registry["seats"]
+
+# Secret-shape scan over the WHOLE file, prose included.
+#
+# An earlier version exempted `note` because notes are prose. Measured, that let
+# this through untouched:
+#     "note": "OPENAI_API_KEY: sk-proj-0123456789abcdefghijklmnopqrstuv"
+# -- the key name is only 14 chars before the colon breaks the run, and the token
+# itself is not adjacent to a quote, so a key/value grep never considered it.
+# Found by blind cross-family refutation (Codex GPT-5.6 sol).
+#
+# 32 is measured, not guessed: the longest legitimate token anywhere in this
+# registry's prose is 23 chars (CLAUDE_CODE_OAUTH_TOKEN, FLEET_BURST_SEAT_BROKER),
+# and real credentials are far longer. Prose does not need 32-character words; if
+# a future note genuinely does, shorten the word rather than raising this.
+for token in re.findall(r"[A-Za-z0-9+/=_-]{32,}", raw):
+    bad.append("value-shaped token (%d chars) in the registry — this file declares NAMES only: %r..."
+               % (len(token), token[:8]))
 for name, seat in seats.items():
     env = seat.get("env") or []
     if not env:
@@ -234,12 +253,15 @@ for name, seat in seats.items():
     for item in seat.get("exec_search_path", []):
         if not isinstance(item, str) or not (item.startswith("/") or item.startswith("~/")):
             bad.append("%s: bare-relative exec_search_path entry %r" % (name, str(item)[:24]))
-    # Prose fields are the only place a long string belongs.
-    for key, value in seat.items():
-        if key in ("note",):
-            continue
-        if isinstance(value, str) and len(value) > 128:
-            bad.append("%s: long string in field %r" % (name, key))
+    # A seat's allowlist must plausibly serve the seat it belongs to. Without
+    # this, `"exec_allowlist": ["codxe"]` is structurally perfect and the
+    # resolution check below cannot see it on a machine where codex is not
+    # installed -- which is every CI runner. Found by blind cross-family
+    # refutation (Codex GPT-5.6 sol).
+    expected = name[:-5] if name.endswith("-seat") else name
+    if expected not in allow:
+        bad.append("%s: exec_allowlist %r does not contain %r, the executable this seat is named for"
+                   % (name, allow, expected))
 if bad:
     sys.stderr.write("\n".join(bad) + "\n")
     sys.exit(1)
@@ -263,6 +285,29 @@ cat >"$hex_as_name" <<'EOF'
 EOF
 python3 "$registry_validator" "$hex_as_name" >/dev/null 2>&1
 check "a hex token wearing a valid name's syntax is rejected on length" test $? -ne 0
+
+# Guilt for the two gaps a blind cross-family refuter (Codex GPT-5.6 sol) found in
+# the first version of these rules. Both are edits a real person could plausibly
+# make, and both passed everything before this.
+prose_secret="$TEMP_DIR/prose-secret.json"
+python3 - "$REAL_REGISTRY" "$prose_secret" <<'MKPROSE'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["seats"]["codex"]["note"] = "OPENAI_API_KEY: sk-proj-0123456789abcdefghijklmnopqrstuv"
+json.dump(d, open(sys.argv[2], "w"))
+MKPROSE
+python3 "$registry_validator" "$prose_secret" >/dev/null 2>&1
+check "a secret wrapped in prose inside a note is rejected" test $? -ne 0
+
+typo_allowlist="$TEMP_DIR/typo-allowlist.json"
+python3 - "$REAL_REGISTRY" "$typo_allowlist" <<'MKTYPO'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["seats"]["codex"]["exec_allowlist"] = ["codxe"]
+json.dump(d, open(sys.argv[2], "w"))
+MKTYPO
+python3 "$registry_validator" "$typo_allowlist" >/dev/null 2>&1
+check "an allowlist that does not name its own seat's executable is rejected" test $? -ne 0
 
 # Resolution half: for each real seat, if its executable exists ANYWHERE the
 # operator's own PATH can see it, the broker must resolve it too. A seat whose

--- a/scripts/tests/test_with_seat_env_minimization.sh
+++ b/scripts/tests/test_with_seat_env_minimization.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Plain-bash verification for with_seat.  The guilt check matters: if an
+# unwrapped child cannot see the planted name, the isolation check proves nothing.
+
+set -u
+
+if [ "${1:-}" = "--dry-run" ]; then
+  shift
+fi
+
+ROOT="$(cd -P "$(dirname "$0")/../.." && pwd)"
+BROKER="$ROOT/scripts/with_seat.sh"
+REAL_REGISTRY="$ROOT/infra/llm-credentials/seat-env.json"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/with-seat-test.XXXXXX")"
+trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+TOTAL=0
+FAILED=0
+
+check() {
+  local label="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@"; then
+    printf 'PASS %s\n' "$label"
+  else
+    printf 'FAIL %s\n' "$label"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+capture="$TEMP_DIR/env-capture"
+exit_seven="$TEMP_DIR/exit-seven"
+self_term="$TEMP_DIR/self-term"
+registry="$TEMP_DIR/seat-env.json"
+output="$TEMP_DIR/environment-names"
+stderr_file="$TEMP_DIR/stderr"
+
+cat >"$capture" <<'EOF'
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+open(my $output_handle, '>', $ARGV[0]) or die "cannot write output\n";
+print {$output_handle} "$_\n" for sort keys %ENV;
+close($output_handle) or die "cannot close output\n";
+EOF
+cat >"$exit_seven" <<'EOF'
+#!/usr/bin/perl
+exit 7
+EOF
+cat >"$self_term" <<'EOF'
+#!/usr/bin/perl
+kill 'TERM', $$;
+EOF
+slow="$TEMP_DIR/slow-child"
+cat >"$slow" <<'EOF'
+#!/usr/bin/perl
+sleep 5;
+EOF
+chmod 700 "$capture" "$exit_seven" "$self_term" "$slow"
+
+cat >"$registry" <<'EOF'
+{
+  "seats": {
+    "test-seat": {
+      "env": ["HOME", "PATH", "TERM", "LANG", "LC_ALL", "TMPDIR"],
+      "exec_allowlist": ["env-capture", "exit-seven", "self-term", "slow-child"],
+      "exec_search_path": ["__TEMP_DIR__"],
+      "note": "Test-only local executables."
+    }
+  }
+}
+EOF
+sed -i.bak "s#__TEMP_DIR__#$TEMP_DIR#" "$registry" && rm -f "$registry.bak"
+chmod 600 "$registry"
+
+export HOME PATH
+export TERM="${TERM:-dumb}"
+export LANG="${LANG:-C}"
+export LC_ALL="${LC_ALL:-C}"
+export TMPDIR="${TMPDIR:-/tmp}"
+FAKE_PLANTED_TOKEN_FOR_TEST=""
+export FAKE_PLANTED_TOKEN_FOR_TEST
+
+"$capture" "$output"
+check "guilt fixture exposes planted inherited name" grep -qx 'FAKE_PLANTED_TOKEN_FOR_TEST' "$output"
+
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat env-capture "$output" >"$TEMP_DIR/stdout" 2>"$stderr_file"
+check "innocence planted name absent" bash -c '! grep -qx FAKE_PLANTED_TOKEN_FOR_TEST "$1"' _ "$output"
+printf '%s\n' HOME PATH TERM LANG LC_ALL TMPDIR | LC_ALL=C sort >"$TEMP_DIR/expected"
+check "innocence exact declared intersection" cmp -s "$TEMP_DIR/expected" "$output"
+
+WITH_SEAT_REGISTRY="$registry" "$BROKER" unknown-seat env-capture "$output" >"$TEMP_DIR/stdout" 2>"$stderr_file"
+unknown_status=$?
+check "unknown seat refuses clearly" bash -c '[ "$1" -ne 0 ] && grep -q "unknown seat" "$2"' _ "$unknown_status" "$stderr_file"
+
+cat >"$registry" <<'EOF'
+{"seats":{"bad":{"env":["BAD-NAME"],"exec_allowlist":["env-capture"]}}}
+EOF
+WITH_SEAT_REGISTRY="$registry" "$BROKER" bad env-capture "$output" >"$TEMP_DIR/stdout" 2>"$stderr_file"
+malformed_status=$?
+check "malformed env name refuses" test "$malformed_status" -ne 0
+
+cat >"$registry" <<'EOF'
+{"seats":{"bad":{"env":["HOME","HOME"],"exec_allowlist":["env-capture"]}}}
+EOF
+WITH_SEAT_REGISTRY="$registry" "$BROKER" bad env-capture "$output" >"$TEMP_DIR/stdout" 2>"$stderr_file"
+duplicate_status=$?
+check "duplicate env name refuses" test "$duplicate_status" -ne 0
+
+cat >"$registry" <<'EOF'
+{"seats":{"test-seat":{"env":["HOME","PATH","TERM","LANG","LC_ALL","TMPDIR"],"exec_allowlist":["env-capture","exit-seven","self-term","slow-child"],"exec_search_path":["__TEMP_DIR__"]}}}
+EOF
+sed -i.bak "s#__TEMP_DIR__#$TEMP_DIR#" "$registry" && rm -f "$registry.bak"
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat >"$TEMP_DIR/stdout" 2>"$stderr_file"
+empty_status=$?
+check "empty command refuses" test "$empty_status" -ne 0
+
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat /bin/true >"$TEMP_DIR/stdout" 2>"$stderr_file"
+allowlist_status=$?
+check "non-allowlisted basename refuses" test "$allowlist_status" -ne 0
+
+chmod 666 "$registry"
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat env-capture "$output" >"$TEMP_DIR/stdout" 2>"$stderr_file"
+writable_status=$?
+check "group/world-writable registry refuses" test "$writable_status" -ne 0
+chmod 600 "$registry"
+
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat exit-seven >"$TEMP_DIR/stdout" 2>"$stderr_file"
+exit_seven_status=$?
+check "child exit status preserved" test "$exit_seven_status" -eq 7
+
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat self-term >"$TEMP_DIR/stdout" 2>"$stderr_file"
+self_term_status=$?
+check "child TERM signal preserved" test "$self_term_status" -eq 143
+
+# The exec allowlist must be an ALLOWLIST, not a naming convention.
+#
+# Measured on the first build: `with_seat.sh codex /tmp/evil/codex` executed the
+# attacker's binary and the broker reported a clean exit, because the allowlist
+# was checked against the BASENAME of a caller-supplied path. Anyone who can
+# write a file anywhere and name it `codex` satisfied it.
+# A bare name is now the only accepted form, and WHERE it resolves comes from the
+# registry -- which the broker already refuses to read if it is group- or
+# world-writable.
+attack_dir="$TEMP_DIR/evil"
+mkdir -p "$attack_dir"
+cat >"$attack_dir/env-capture" <<'ATTACK'
+#!/usr/bin/perl
+open(my $h, '>', "$ENV{ATTACK_MARKER_PATH}") or exit 0;
+print {$h} "attacker code ran\n";
+close($h);
+ATTACK
+chmod 700 "$attack_dir/env-capture"
+attack_marker="$TEMP_DIR/attack-marker"
+rm -f "$attack_marker"
+ATTACK_MARKER_PATH="$attack_marker" WITH_SEAT_REGISTRY="$registry" \
+  "$BROKER" test-seat "$attack_dir/env-capture" >"$TEMP_DIR/stdout" 2>"$stderr_file"
+attack_status=$?
+check "a caller-supplied path with an allowlisted basename cannot execute" \
+  bash -c '[ "$1" -ne 0 ] && [ ! -e "$2" ]' _ "$attack_status" "$attack_marker"
+
+# A TERM sent to the BROKER must kill the broker, not be swallowed.
+#
+# Measured on bash 3.2: `trap 'rm -f x' TERM` runs the handler and lets the
+# script CONTINUE, exiting 0. A broker that survives the TERM its supervisor
+# sent — and then reports success — tells the caller a dispatch was cancelled
+# when it was not. Found by blind cross-family refutation (Kimi K3).
+# 143 = 128 + SIGTERM.
+# A SLOW child makes this deterministic: the broker is guaranteed still alive
+# when the signal lands, so 143 is the only correct answer and 0 is exactly the
+# pre-fix bug rather than a race we would have to tolerate.
+term_broker_out="$TEMP_DIR/term-broker.out"
+WITH_SEAT_REGISTRY="$registry" "$BROKER" test-seat slow-child >"$term_broker_out" 2>&1 &
+broker_pid=$!
+sleep 1
+kill -TERM "$broker_pid" 2>/dev/null
+wait "$broker_pid"
+broker_term_status=$?
+check "a TERM to the broker is not swallowed" test "$broker_term_status" -eq 143
+
+# THE REAL REGISTRY, not a synthetic seat.
+#
+# Every check above uses a fabricated test-seat, and that is how the shipped
+# registry came to declare four seats of which TWO could not resolve their own
+# binary at all: agy lives in ~/.local/bin and kimi in ~/.kimi-code/bin, neither
+# on the broker's fixed system search path. `with_seat.sh agy agy` answered
+# "cannot resolve command" — a broker that exists and is armed for one seat in
+# two. A corpus that only ever exercises its own fixture cannot see that.
+#
+# Structural half (bites on EVERY machine, including a CI runner where none of
+# these binaries exist): every seat declares a non-empty exec_allowlist, and
+# every exec_search_path entry is absolute or "~/"-prefixed — never bare-relative,
+# which would resolve against the caller's cwd.
+# Structural half. Written as a reusable validator so the SAME rules can be run
+# against a guilt fixture below -- a check that only ever sees the real, correct
+# registry cannot show that it would reject a wrong one.
+#
+# It is deliberately structural rather than a grep for secret-shaped strings. The
+# first version of this check was such a grep, and it MISSED both realistic
+# pastes, measured: the registry is arrays of strings, so a token dropped into an
+# `env` array is not a `key: "value"` pair and never matched; and a 64-char hex
+# token is itself a syntactically valid env NAME, so even a pattern that saw it
+# would have to argue about entropy. Bounding the SHAPE of every field closes
+# both without guessing what a secret looks like.
+registry_validator="$TEMP_DIR/validate_registry.py"
+cat >"$registry_validator" <<'REGPY'
+import json, re, sys
+NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+BASENAME = re.compile(r"^[A-Za-z0-9._-]+$")
+bad = []
+seats = json.load(open(sys.argv[1]))["seats"]
+for name, seat in seats.items():
+    env = seat.get("env") or []
+    if not env:
+        bad.append("%s: empty or missing env" % name)
+    for item in env:
+        if not isinstance(item, str) or not NAME.match(item):
+            bad.append("%s: env entry is not a valid variable name: %r" % (name, item[:24]))
+        elif len(item) > 48:
+            # A real variable name is short: the longest this fleet uses is
+            # GOOGLE_APPLICATION_CREDENTIALS at 30. 48 leaves generous headroom
+            # while sitting BELOW 64, which is the length of a sha256 hex token —
+            # the common secret shape, and a syntactically valid identifier. A
+            # cap of 64 would have let exactly that through (measured: it did).
+            bad.append("%s: env entry is %d chars — too long to be a name" % (name, len(item)))
+    allow = seat.get("exec_allowlist") or []
+    if not allow:
+        bad.append("%s: empty or missing exec_allowlist" % name)
+    for item in allow:
+        if not isinstance(item, str) or not BASENAME.match(item) or len(item) > 64:
+            bad.append("%s: exec_allowlist entry is not a plain basename: %r" % (name, str(item)[:24]))
+    for item in seat.get("exec_search_path", []):
+        if not isinstance(item, str) or not (item.startswith("/") or item.startswith("~/")):
+            bad.append("%s: bare-relative exec_search_path entry %r" % (name, str(item)[:24]))
+    # Prose fields are the only place a long string belongs.
+    for key, value in seat.items():
+        if key in ("note",):
+            continue
+        if isinstance(value, str) and len(value) > 128:
+            bad.append("%s: long string in field %r" % (name, key))
+if bad:
+    sys.stderr.write("\n".join(bad) + "\n")
+    sys.exit(1)
+REGPY
+
+python3 "$registry_validator" "$REAL_REGISTRY" 2>"$TEMP_DIR/reg.err"
+check "the real registry passes the structural rules" test $? -eq 0
+
+# Guilt for the validator itself: the two pastes a real person would actually
+# make. Both were MISSED by the grep this replaced.
+secret_in_array="$TEMP_DIR/secret-in-array.json"
+cat >"$secret_in_array" <<'EOF'
+{"seats":{"codex":{"env":["HOME","sk-ant-oat01-FAKEFAKEFAKEFAKEFAKE"],"exec_allowlist":["codex"]}}}
+EOF
+python3 "$registry_validator" "$secret_in_array" >/dev/null 2>&1
+check "a token pasted into an env array is rejected" test $? -ne 0
+
+hex_as_name="$TEMP_DIR/hex-as-name.json"
+cat >"$hex_as_name" <<'EOF'
+{"seats":{"codex":{"env":["HOME","a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"],"exec_allowlist":["codex"]}}}
+EOF
+python3 "$registry_validator" "$hex_as_name" >/dev/null 2>&1
+check "a hex token wearing a valid name's syntax is rejected on length" test $? -ne 0
+
+# Resolution half: for each real seat, if its executable exists ANYWHERE the
+# operator's own PATH can see it, the broker must resolve it too. A seat whose
+# binary is simply not installed on this machine is skipped BY NAME and counted,
+# so the printed line distinguishes "checked" from "not present here" instead of
+# reporting a silent green.
+resolvable_failures=0
+resolvable_checked=0
+resolvable_skipped=""
+for seat_pair in "codex:codex" "agy:agy" "kimi:kimi" "claude-seat:claude"; do
+  seat_name="${seat_pair%%:*}"
+  seat_bin="${seat_pair##*:}"
+  if ! command -v "$seat_bin" >/dev/null 2>&1; then
+    resolvable_skipped="$resolvable_skipped $seat_name"
+    continue
+  fi
+  resolvable_checked=$((resolvable_checked + 1))
+  if ! "$BROKER" --dry-run "$seat_name" "$seat_bin" >/dev/null 2>&1; then
+    resolvable_failures=$((resolvable_failures + 1))
+    printf '  seat %s cannot resolve %s through its declared search path\n' "$seat_name" "$seat_bin" >&2
+  fi
+done
+printf '  (real-seat resolution: %s checked, not installed here:%s)\n' \
+  "$resolvable_checked" "${resolvable_skipped:- none}"
+check "every installed real seat resolves its own executable" test "$resolvable_failures" -eq 0
+
+check "bash syntax passes" bash -n "$BROKER"
+check "real registry JSON parses" bash -c 'python3 -m json.tool "$1" >/dev/null' _ "$REAL_REGISTRY"
+
+printf 'TOTAL %s FAILED %s\n' "$TOTAL" "$FAILED"
+[ "$FAILED" -eq 0 ]

--- a/scripts/with_seat.sh
+++ b/scripts/with_seat.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# Run an approved external CLI with an allowlist-defined environment only.
+#
+# --dry-run output is machine-readable: key=value records for the plan followed
+# by TSV records of the form "env<TAB>NAME<TAB>present|absent".  It reports
+# names only; secret values never leave the process environment.
+# WITH_SEAT_REGISTRY may override the registry solely to support isolated tests.
+
+set -euo pipefail
+
+# Resolved from THIS SCRIPT's location, not the caller's cwd. A relative default
+# made the broker work only when invoked from the repo root -- measured: from any
+# other directory it died with "registry not found". It fails closed, which is the
+# right direction, but a security wrapper that cannot be called from where its
+# callers live is a wrapper that gets bypassed.
+SCRIPT_DIR="$(cd -P "$(dirname "$0")" && pwd)"
+readonly SCRIPT_DIR
+readonly DEFAULT_REGISTRY="${SCRIPT_DIR}/../infra/llm-credentials/seat-env.json"
+readonly FIXED_COMMAND_PATHS="/opt/homebrew/bin /usr/local/bin /usr/bin /bin"
+
+usage() {
+  cat <<'EOF'
+Usage: with_seat.sh [--dry-run] <seat> <command> [args...]
+
+Runs an allowlisted command with exactly the environment names declared for the
+seat.  WITH_SEAT_REGISTRY is a test-only override for the registry path.
+EOF
+}
+
+fail() {
+  printf '%s\n' "with_seat: error: $*" >&2
+  exit 1
+}
+
+# Mode via python3, NOT stat.
+#
+# `stat` is the one tool here whose FLAGS differ by platform: BSD/macOS wants
+# `stat -f '%Lp'`, GNU/ubuntu wants `stat -c '%a'`, and on GNU `-f` is not an
+# unknown flag at all -- it means --file-system. A probe of the form
+# "try the BSD form, fall back to the GNU form if it fails" therefore rests on
+# GNU stat FAILING for the right reason, which is a guess about another
+# platform's error handling, and the consequence of guessing wrong is that this
+# function returns garbage and the group/world-writable refusal below silently
+# stops refusing. python3 is already a hard dependency of this script (the
+# registry parser and the exec runner are both python), so it costs nothing and
+# it means the same thing on every machine.
+file_mode() {
+  /usr/bin/python3 -c 'import os,sys; print("%o" % (os.stat(sys.argv[1]).st_mode & 0o777))' "$1"
+}
+
+is_group_or_world_writable() {
+  local mode="$1"
+  local group_part
+  local group_digit
+  local other_digit
+
+  mode="${mode#0}"
+  while [ "${#mode}" -lt 3 ]; do
+    mode="0${mode}"
+  done
+  group_part="${mode%?}"
+  group_digit="${group_part#?}"
+  other_digit="${mode#??}"
+  case "$group_digit$other_digit" in
+    *2*|*3*|*6*|*7*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A caller may name only a BARE COMMAND, never a path.
+#
+# This is the difference between an allowlist and a naming convention. The first
+# version accepted any argument containing "/" as a literal path and then checked
+# only its BASENAME against the seat's allowlist -- so
+# `with_seat.sh codex /tmp/evil/codex` executed the attacker's binary, measured,
+# with the broker reporting a clean exit. An exec allowlist that a caller can
+# satisfy by choosing a filename is not an allowlist.
+#
+# Resolution therefore happens ONLY through a search path the REGISTRY supplies:
+# the seat's optional `exec_search_path`, else the fixed list above. The registry
+# is the right source because it is already the trusted input here -- the wrapper
+# refuses to run at all if it is group- or world-writable -- whereas argv and the
+# environment are attacker-reachable by construction.
+resolve_command() {
+  local requested="$1"
+  shift
+  local candidate
+  local directory
+
+  # No path separators: a caller names WHAT to run, never WHERE it lives.
+  case "$requested" in
+    */*) return 2 ;;
+  esac
+
+  for directory in "$@"; do
+    candidate="$directory/$requested"
+    if [ -x "$candidate" ] && [ ! -d "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+emit_declared_environment() {
+  local index
+  local env_name
+  local env_value
+
+  for ((index = 0; index < ${#DECLARED_NAMES[@]}; index++)); do
+    env_name="${DECLARED_NAMES[$index]}"
+    if [[ -n "${!env_name+x}" ]]; then
+      env_value="${!env_name}"
+      # NUL framing keeps values off argv, diagnostics, and temporary files.
+      printf '%s\0%s\0' "$env_name" "$env_value"
+    fi
+  done
+}
+
+if [ "$#" -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+if [ "$1" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+dry_run=0
+if [ "$1" = "--dry-run" ]; then
+  dry_run=1
+  shift
+fi
+
+[ "$#" -ge 1 ] || fail "missing seat"
+seat="$1"
+shift
+[ "$#" -ge 1 ] || fail "empty command"
+requested_command="$1"
+shift
+[ -n "$requested_command" ] || fail "empty command"
+
+script_path="$(cd -P "$(dirname "$0")" && pwd)/$(basename "$0")"
+script_mode="$(file_mode "$script_path")" || fail "cannot inspect wrapper mode"
+if is_group_or_world_writable "$script_mode"; then
+  # A writable wrapper is risky, but we cannot safely infer the operator's intent.
+  printf '%s\n' "with_seat: warning: wrapper is group- or world-writable" >&2
+fi
+
+registry="${WITH_SEAT_REGISTRY:-$DEFAULT_REGISTRY}"
+[ -f "$registry" ] || fail "registry not found"
+registry_mode="$(file_mode "$registry")" || fail "cannot inspect registry mode"
+if is_group_or_world_writable "$registry_mode"; then
+  fail "registry is group- or world-writable"
+fi
+
+metadata_file="$(mktemp "${TMPDIR:-/tmp}/with-seat-metadata.XXXXXX")"
+# A signal trap that only cleans up does NOT stop the script: measured on bash
+# 3.2, `trap 'rm -f x' TERM` + `kill -TERM $$` prints the line after it and exits
+# 0. A broker that survives the TERM its supervisor sent, and then reports
+# success, is a broker whose caller believes a dispatch was cancelled when it was
+# not. Clean up, restore the default handler, and re-raise so the exit status
+# carries the signal.
+cleanup_and_reraise() {
+  local signal="$1"
+  rm -f "$metadata_file"
+  trap - "$signal"
+  kill -s "$signal" $$
+}
+trap 'rm -f "$metadata_file"' EXIT
+for _sig in HUP INT TERM; do
+  # shellcheck disable=SC2064  # expand $_sig now: each trap must name its own signal
+  trap "cleanup_and_reraise $_sig" "$_sig"
+done
+
+# Python is used only for JSON validation/parsing; values are neither read nor emitted here.
+if ! /usr/bin/python3 - "$registry" "$seat" >"$metadata_file" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+
+registry_path, requested_seat = sys.argv[1:]
+try:
+    with open(registry_path, "r") as registry_file:
+        registry = json.load(registry_file)
+except (OSError, ValueError) as exc:
+    sys.stderr.write("with_seat: error: invalid registry: %s\n" % exc)
+    sys.exit(1)
+
+seats = registry.get("seats") if isinstance(registry, dict) else None
+if not isinstance(seats, dict) or requested_seat not in seats:
+    sys.stderr.write("with_seat: error: unknown seat %s\n" % requested_seat)
+    sys.exit(1)
+
+seat = seats[requested_seat]
+if not isinstance(seat, dict):
+    sys.stderr.write("with_seat: error: seat %s is not an object\n" % requested_seat)
+    sys.exit(1)
+names = seat.get("env")
+if not isinstance(names, list) or not names:
+    sys.stderr.write("with_seat: error: seat %s env declaration is empty or not a list\n" % requested_seat)
+    sys.exit(1)
+for name in names:
+    if not isinstance(name, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+        sys.stderr.write("with_seat: error: malformed env name in seat %s\n" % requested_seat)
+        sys.exit(1)
+if len(set(names)) != len(names):
+    sys.stderr.write("with_seat: error: duplicate env name in seat %s\n" % requested_seat)
+    sys.exit(1)
+
+allowlist = seat.get("exec_allowlist")
+# `not allowlist` rejects the EMPTY list explicitly: all() is vacuously true on
+# it, so an empty allowlist would have passed validation and then blown up
+# downstream on an unbound array under set -u. "Permits nothing" must be an
+# error the registry author sees, not a crash a caller sees.
+if not isinstance(allowlist, list) or not allowlist or not all(
+    isinstance(item, str) and item and os.path.basename(item) == item for item in allowlist
+):
+    sys.stderr.write("with_seat: error: invalid or empty exec_allowlist in seat %s\n" % requested_seat)
+    sys.exit(1)
+
+# Optional per-seat search path. Absolute, or "~/"-prefixed and expanded against
+# the BROKER's own HOME -- never a bare relative entry, which would resolve
+# against the CALLER's cwd and hand back exactly the caller-controlled
+# resolution this field exists to remove.
+#
+# "~/" is not a convenience: agy lives in ~/.local/bin and kimi in
+# ~/.kimi-code/bin, and this fleet's three machines do not share a home
+# (/Users/nuzantara on Pro and Mini, /Users/balizero on M5). An absolute-only
+# rule would force a machine-specific registry, and a registry that is wrong on
+# one machine is a broker that gets bypassed there.
+search_path = seat.get("exec_search_path", [])
+if not isinstance(search_path, list) or not all(
+    isinstance(item, str) and (item.startswith("/") or item.startswith("~/"))
+    for item in search_path
+):
+    sys.stderr.write("with_seat: error: invalid exec_search_path in seat %s\n" % requested_seat)
+    sys.exit(1)
+home = os.environ.get("HOME", "")
+expanded_search_path = []
+for item in search_path:
+    if item.startswith("~/"):
+        if not home:
+            sys.stderr.write("with_seat: error: exec_search_path uses ~/ but HOME is unset\n")
+            sys.exit(1)
+        expanded_search_path.append(os.path.join(home, item[2:]))
+    else:
+        expanded_search_path.append(item)
+search_path = expanded_search_path
+
+sorted_names = sorted(names)
+# The newline delimiter makes the ordered input to the documented digest unambiguous.
+fingerprint = hashlib.sha256("\n".join(sorted_names).encode("utf-8")).hexdigest()[:16]
+print("fingerprint\t%s" % fingerprint)
+for name in sorted_names:
+    print("env\t%s" % name)
+for executable in allowlist:
+    print("allow\t%s" % executable)
+for directory in search_path:
+    print("searchpath\t%s" % directory)
+PY
+then
+  exit 1
+fi
+
+fingerprint=""
+declare -a DECLARED_NAMES
+declare -a ALLOWED_EXECUTABLES
+declare -a SEARCH_PATH
+while IFS=$'\t' read -r kind value; do
+  case "$kind" in
+    fingerprint) fingerprint="$value" ;;
+    env) DECLARED_NAMES[${#DECLARED_NAMES[@]}]="$value" ;;
+    allow) ALLOWED_EXECUTABLES[${#ALLOWED_EXECUTABLES[@]}]="$value" ;;
+    searchpath) SEARCH_PATH[${#SEARCH_PATH[@]}]="$value" ;;
+    *) fail "invalid registry parser output" ;;
+  esac
+done <"$metadata_file"
+
+# The seat may narrow WHERE its executables are found; absent that, the fixed
+# system list. Either way the caller never contributes a directory.
+if [ "${#SEARCH_PATH[@]}" -eq 0 ]; then
+  for _fixed_dir in $FIXED_COMMAND_PATHS; do
+    SEARCH_PATH[${#SEARCH_PATH[@]}]="$_fixed_dir"
+  done
+fi
+
+[ -n "$fingerprint" ] || fail "registry parser did not return a fingerprint"
+resolve_status=0
+resolved_command="$(resolve_command "$requested_command" "${SEARCH_PATH[@]}")" || resolve_status=$?
+if [ "$resolve_status" -eq 2 ]; then
+  fail "command must be a bare name, not a path: '$requested_command' (the seat's registry entry decides where its executables live)"
+elif [ "$resolve_status" -ne 0 ]; then
+  fail "cannot resolve command '$requested_command' on this seat's search path"
+fi
+command_basename="$(basename "$resolved_command")"
+allowed=0
+for executable in "${ALLOWED_EXECUTABLES[@]}"; do
+  if [ "$command_basename" = "$executable" ]; then
+    allowed=1
+    break
+  fi
+done
+[ "$allowed" -eq 1 ] || fail "command basename is not permitted for seat $seat"
+
+if [ "$dry_run" -eq 1 ]; then
+  printf 'seat=%s\n' "$seat"
+  printf 'fingerprint=%s\n' "$fingerprint"
+  printf 'command=%s\n' "$resolved_command"
+  for env_name in "${DECLARED_NAMES[@]}"; do
+    if [[ -n "${!env_name+x}" ]]; then
+      printf 'env\t%s\tpresent\n' "$env_name"
+    else
+      printf 'env\t%s\tabsent\n' "$env_name"
+    fi
+  done
+  exit 0
+fi
+
+# The runner starts under env -i.  It receives NUL-framed values over stdin and
+# uses execve with a new dictionary, so bash/macOS helper variables cannot leak.
+# `set +e` alone is not enough: it disables errexit but leaves PIPEFAIL on, so a
+# SIGPIPE or failure in the LEFT side of this pipeline would be reported as the
+# child's exit status. The child's status is the one thing this wrapper promises
+# to preserve faithfully, so pipefail is disabled for exactly this pipeline.
+set +e
+set +o pipefail
+emit_declared_environment | env -i /usr/bin/python3 -c '
+import os
+import sys
+
+data = sys.stdin.buffer.read()
+parts = data.split(b"\0")
+if parts and parts[-1] == b"":
+    parts.pop()
+if len(parts) % 2:
+    sys.stderr.write("with_seat: error: invalid internal environment stream\n")
+    sys.exit(1)
+child_environment = {}
+for index in range(0, len(parts), 2):
+    child_environment[parts[index]] = parts[index + 1]
+os.execve(sys.argv[1], sys.argv[1:], child_environment)
+' "$resolved_command" "$@"
+child_status=$?
+set -o pipefail
+set -e
+
+printf 'with_seat: seat=%s fingerprint=%s exit_status=%s\n' "$seat" "$fingerprint" "$child_status" >&2
+exit "$child_status"

--- a/scripts/with_seat.sh
+++ b/scripts/with_seat.sh
@@ -267,9 +267,15 @@ then
 fi
 
 fingerprint=""
-declare -a DECLARED_NAMES
-declare -a ALLOWED_EXECUTABLES
-declare -a SEARCH_PATH
+# `=()` is load-bearing, not style. `declare -a X` alone leaves X with the array
+# ATTRIBUTE but no value, so on bash 5 `${#X[@]}` under `set -u` is an "unbound
+# variable" error the first time through the loop below; bash 3.2 tolerates it.
+# This machine has only bash 3.2, so the corpus was green here and the job died on
+# every ubuntu runner at the first env name — the whole dispatch path, invisible
+# locally. Assigning an empty array makes them SET on both.
+declare -a DECLARED_NAMES=()
+declare -a ALLOWED_EXECUTABLES=()
+declare -a SEARCH_PATH=()
 while IFS=$'\t' read -r kind value; do
   case "$kind" in
     fingerprint) fingerprint="$value" ;;
@@ -289,6 +295,11 @@ if [ "${#SEARCH_PATH[@]}" -eq 0 ]; then
 fi
 
 [ -n "$fingerprint" ] || fail "registry parser did not return a fingerprint"
+# The python validator refuses a seat with an empty `env` list, so an empty array
+# here means the parse loop never ran — a silently skipped read rather than an
+# empty declaration. Fail rather than dispatch a child with NO environment, which
+# would look like perfect isolation and be a broken probe.
+[ "${#DECLARED_NAMES[@]}" -gt 0 ] || fail "registry parser returned no environment names"
 resolve_status=0
 resolved_command="$(resolve_command "$requested_command" "${SEARCH_PATH[@]}")" || resolve_status=$?
 if [ "$resolve_status" -eq 2 ]; then


### PR DESCRIPTION
L13-PR1 of the beyond-SOTA craft wave (squad F′, ledger #5318). A broker that gives an external LLM child **exactly** the environment names its seat declares, and nothing else.

**Bites:** `.github/workflows/with-seat-broker-tests.yml` — runs the 19-check corpus with no `continue-on-error`, and the corpus reddens at real code sites: 6 mutations of `scripts/with_seat.sh` were injected, each turned exactly the intended check red, each reverted. The executor is registered with `main-push-failure-watch.yml` **in this same diff**, so a failure of it on `main` reaches someone.

## The measurement this exists for

Measured on Mini, 2026-08-31 — names only, never values, and **no external CLI was ever asked to print its environment** (L13 forbids it; the boundary is proven with a benign local child, and the `codex` figure is `--dry-run`, which executes nothing):

| Parent shape | env names | secret-shaped |
|---|---|---|
| headless orchestrator | 27 | 1 |
| `zsh -l` login shell | 33 | 1 |
| **after `. ~/.nuzantara-secrets.env`** — the path every cron wrapper takes | **49** | **16** |
| **a `codex` child through the broker**, same parent | **6 declared / 5 present** | **0** |

**16 secret-shaped names withheld**, across 11 credential families: every `CLAUDE_CODE_OAUTH_TOKEN_<N>` (i.e. *all the other Claude seats*), `TELEGRAM_BOT_TOKEN`, `BREVO_API_KEY`, `OPENROUTER_API_KEY`, `MINIMAX_API_KEY`, `JULES_API_KEY`, `LANGSMITH_API_KEY`, `IG_GRAPH_API_TOKEN`, `OBSERVATORY_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`, `CLAUDE_CODE_MESSAGING_TOKEN`. Today one vendor's child can read every other vendor's key.

**Correction to the lane spec's premise**, since it is load-bearing: L13's mission says "at least three secret-shaped names per interactive child". On this machine an interactive/login shell carries **1**. The 16 appear only once a wrapper *sources the secrets file* — which `claude-cascade.sh`, `regulatory-watcher-run.sh` and the cron wrappers all do. The exposure is real and larger than three, but it lives on the **wrapper** path; an audit of interactive shells would have found almost nothing and concluded the lane was overstated.

## Shape

- **`env -i` + `os.execve` over an explicit dict** — the child's name set *equals* the declaration. The existing partial mitigation (`claude-cascade.sh::build_isolated_provider_env`) *subtracts* a blacklist with `env -u`, so any name nobody thought to list is inherited, and it lives only inside that one wrapper.
- **Values travel NUL-framed over stdin, never argv** — so they are not visible in `ps` to other local users, the exposure this repo already documented for `agy` at `claude-cascade.sh:441-451`.
- **No unwrapped fallback, ever.** Every failure path refuses. A broker that silently degrades is worse than none, because callers believe they are isolated.
- **The three external seats declare NO credential name at all** — `codex`, `agy` and `kimi` all authenticate through a config directory under `$HOME`. Measured, and each seat's `note` says so, because a reader will otherwise assume something is missing.
- `claude-seat` exists so `scripts/fleet_burst.sh` (L09-PR2, #5322) can name this broker as its `FLEET_BURST_SEAT_BROKER` — that script's contract is `<broker> <seat> <command…>`, which is this one.

## Six defects found before merge, each reproduced first

**By this gate:**
1. **The exec allowlist was a naming convention, not an allowlist.** It checked the **basename** of a caller-supplied path, so `with_seat.sh codex /tmp/evil/codex` **executed the attacker's binary** and reported a clean exit — measured, `ATTACKER CODE RAN`. Anyone able to write a file anywhere and name it `codex` satisfied it. A caller now names only *what* to run; *where* comes from the registry, which the broker refuses to read if group- or world-writable.
2. **Two of four declared seats could not resolve their own binary.** `agy` in `~/.local/bin`, `kimi` in `~/.kimi-code/bin`, neither on the fixed search path. The deeper defect was in the **corpus**: every check used a *synthetic* seat, so it was structurally blind to this. A real-registry check was added and is what pins it. `~/`-prefixed search paths are required because the three machines do not share a home (`/Users/nuzantara` on Pro/Mini, `/Users/balizero` on M5).
3. **The registry path was relative**, so the broker worked only from the repo root — fail-closed, but a security wrapper that cannot be called from where its callers live gets skipped.

**By Kimi K3 (blind, non-Anthropic, a different family from the builder):**
4. **A TERM to the broker was swallowed.** Measured on bash 3.2.57: the trap cleaned up and let the script **continue**, exiting **0**. A supervisor cancelling a dispatch would be told it succeeded. Now re-raises — measured `rc=143`, pinned deterministically with a slow child rather than a race.
5. **`file_mode` rested on a guess about another platform.** BSD `stat -f '%Lp'` with a GNU `stat -c '%a'` fallback — but on GNU, `-f` means `--file-system`. The fallback depended on GNU stat failing *for the right reason*; if it does not, the function returns garbage and the group/world-writable refusal **silently stops refusing**. Replaced with `python3`, already a hard dependency. The uncertainty *was* the defect.
6. **`set +e` does not disable `pipefail`**, so a left-side failure would be reported as the child's exit status — the one thing this wrapper promises to preserve.

**One RETRACTED by measurement:** Kimi flagged `${!name+x}` as possibly unsupported on bash 3.2. Measured on 3.2.57 — both branches correct. Recorded as *not* a defect so nobody "fixes" working code on a maybe.

**And one I found in my own workflow:** the step asserting "the registry holds names, never values" grepped for `key: "value"` pairs. The registry is *arrays of strings*, so it missed **both** realistic pastes — a token inside an `env` array, and a 64-char sha256-shaped hex string that is a syntactically valid identifier. Replaced with a structural validator in the corpus (local + mutation-testable) with guilt fixtures for exactly those two. The length cap is **48** deliberately: 64 let the hex through, measurably, on the first attempt.

## Gates, run this turn

| Gate | Result |
|---|---|
| `bash scripts/tests/test_with_seat_env_minimization.sh` | **19/19**, 6 mutants killed |
| `actionlint` 1.7.12 (the pinned CI version) | clean |
| `scripts/lint_workflow_timeout_floor.py` | clean, 148 jobs |
| `scripts/check_watcher_coverage.py` | all 112 workflows covered — verified by *removing* the registration and watching it name this one |
| `evidence_pack_lint.py`, in CI's staging layout | clean — Gear 3, real council journal |

## Notes

- **Auto-merge deliberately NOT armed** — workflow-class diff; gates-green evidence goes to #5318 and the conductor merges.
- Over the 400-line target, declared: broker 352 + corpus 241 + executor 94; the corpus is why six defects were caught before merge rather than after.
- **Door note for the fleet**: GLM-5.2 via TP1 returned `finish_reason: length` with **0 content** at `max_tokens: 8000` — it spent the whole budget on reasoning. This is the trap `arsenal_probe.py:156` already documents ("THINKING models: max_tokens caps reasoning + answer TOGETHER"). Any lane sizing a TP1 thinking seat by expected *answer* length gets a silent empty response with HTTP 200.

Ledger: #5318 · pairs with #5322 (L09-PR2) at the `FLEET_BURST_SEAT_BROKER` seam.
