### PR TITLE
feat(proprioception): tailnet policy drift receptor — declared vs enforced (L13-PR2)

### DIFF
--- a/.github/workflows/check-tailnet-acl.yml
+++ b/.github/workflows/check-tailnet-acl.yml
@@ -25,6 +25,17 @@ on:
       - "infra/tailscale/policy.hujson"
       - "scripts/tests/test_tailnet_acl_deny_by_default.py"
       - "scripts/tests/fixtures/tailnet_acl/**"
+      # L13-PR2: the drift receptor and its corpus live in the same domain as the ACL
+      # guard above, so they share this executor rather than growing a fourth workflow.
+      # The guard asks "is the DECLARED policy still deny-by-default"; the receptor asks
+      # "is the declared policy the one actually ENFORCED". Different questions, same
+      # blast radius, and a change to policy.hujson can redden either.
+      - "scripts/tailnet_policy_drift.py"
+      - "scripts/tests/test_tailnet_policy_drift.py"
+      - "scripts/tests/fixtures/tailnet_netmap_*.json"
+      - "scripts/proprioception.py"
+      - "scripts/tests/test_proprioception_tri_state_exit.py"
+      - "scripts/tests/test_proprioception_run_wrap_exit_code.py"
       - ".github/workflows/check-tailnet-acl.yml"
 
 permissions:
@@ -54,3 +65,41 @@ jobs:
         run: |
           set -euo pipefail
           python -m pytest scripts/tests/test_tailnet_acl_deny_by_default.py -q
+
+      # The receptor that asks whether the declared policy is the ENFORCED one.
+      # Its guilt fixture is the real allow-all shape recorded from `tailscale debug
+      # netmap`; its innocence fixture matches policy.hujson's grants. Neither makes a
+      # network call. The third state matters as much as the other two: an unreadable
+      # netmap must answer BLIND, never CLEAN.
+      - name: Declared policy vs enforced filter — DIVERGED, CLEAN and BLIND all pinned
+        run: |
+          set -euo pipefail
+          python -m pytest scripts/tests/test_tailnet_policy_drift.py -q
+
+      # The receptor is only useful if proprioception files its three states correctly.
+      # `parse: exit_code` maps every non-zero to DIVERGED, which would report BLIND
+      # ("could not read the enforced state") as observed drift — opposite remedies,
+      # same verdict. These two corpora pin the tri-state mapping and prove the old
+      # parser genuinely disagrees.
+      - name: A BLIND probe is filed as unprobeable, never as drift
+        run: |
+          set -euo pipefail
+          python -m pytest scripts/tests/test_proprioception_tri_state_exit.py \
+                           scripts/tests/test_proprioception_run_wrap_exit_code.py -q
+
+      # A registry entry the validator rejects is a receptor that never runs.
+      - name: The receptor is registered and the registry still validates
+        run: |
+          set -euo pipefail
+          python scripts/proprioception.py --selftest
+          python - <<'PY'
+          import importlib.util, sys
+          spec = importlib.util.spec_from_file_location("p", "scripts/proprioception.py")
+          m = importlib.util.module_from_spec(spec); sys.modules["p"] = m
+          spec.loader.exec_module(m)
+          ids = [e["id"] for e in m.DEFAULT_REGISTRY]
+          assert "tailnet_policy_drift" in ids, f"receptor not registered: {ids}"
+          entry = next(e for e in m.DEFAULT_REGISTRY if e["id"] == "tailnet_policy_drift")
+          assert entry["parse"] == "tri_state_exit", entry["parse"]
+          print("receptor registered with parse:", entry["parse"])
+          PY

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-tailnet-drift-receptor-658dabc0/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-tailnet-drift-receptor-658dabc0/brief.yml
@@ -1,0 +1,61 @@
+task_id: craft-f2-l13-pr2-tailnet-drift-receptor
+gear: 3
+l_level: L2
+gate_class: opus
+council_run: journal.jsonl
+acceptance:
+  - text: "WHEN the recorded allow-all netmap is compared with policy.hujson, the receptor SHALL exit 1 and report DIVERGED."
+    probe: "python3 -m pytest scripts/tests/test_tailnet_policy_drift.py -q"
+  - text: "WHEN an enforced filter matches the declared grants, the receptor SHALL exit 0 and report CLEAN."
+    probe: "python3 -m pytest scripts/tests/test_tailnet_policy_drift.py -q"
+  - text: "IF the enforced state cannot be read — missing CLI, unreadable netmap, wrong schema, non-JSON, contradictory prefix — the receptor SHALL exit 2 and report BLIND, and SHALL NEVER report CLEAN."
+    probe: "python3 -m pytest scripts/tests/test_tailnet_policy_drift.py -q"
+  - text: "WHERE a probe exits 2, proprioception SHALL file it as UNPROBEABLE, never as DIVERGED."
+    probe: "python3 -m pytest scripts/tests/test_proprioception_tri_state_exit.py -q"
+  - text: "WHILE emitting any verdict, the receptor SHALL declare what it did NOT compare, and SHALL NOT emit a node name, address, identity or credential."
+    probe: "python3 -m pytest scripts/tests/test_tailnet_policy_drift.py -q"
+  - text: "IF the receptor is not registered in the proprioception registry with parse tri_state_exit, CI SHALL fail."
+    probe: "python3 scripts/proprioception.py --selftest"
+
+objective: |
+  L13-PR2 of the beyond-SOTA craft wave (squad F', fleet & security): a read-only
+  receptor that asks whether the tailnet policy this repo DECLARES is the policy the
+  node actually ENFORCES — plus a tri-state parse mode so "I could not look" stops
+  being filed as "I looked and they differ".
+
+  Measured live on Mini: exit 1, DIVERGED. Declared 8 rule-shapes on narrow TCP ports
+  (22, 443, 4317, 6379, 8990, 11434); enforced 2 rule-shapes, ALL ports, on
+  icmp+tcp+udp+ICMPv6. That is the allow-all tailnet policy.hujson's own header
+  records, detected with no node name, address or identity reaching the output.
+
+  DIVERGED is the correct answer here and no session can clear it: applying
+  policy.hujson is operator[GUI] in the Tailscale admin console, because the fleet
+  holds no API token. The receptor exists to keep that gap visible and dated.
+constraints:
+  - "It observes and never applies. Applying policy is out of scope by design."
+  - "BLIND may never resolve to CLEAN. Missing CLI, unreadable netmap, unknown
+    schema, non-JSON input and a self-contradictory prefix are all BLIND."
+  - "No node name, address, identity or credential in any output — evidence carries
+    rule SHAPE only. Sanitisation covers IPv4, IPv6 (a Tailscale netmap is half
+    IPv6), MagicDNS names and email, and applies to `reason` as well as `evidence`."
+  - "The comparison is SOURCE-BLIND and says so on every verdict. policy.hujson
+    grants by identity; the netmap has already resolved identities to addresses;
+    mapping between them would require the node<->identity table this tool must
+    never hold. Declared, not hidden."
+  - "Fixtures are sanitized recordings of the REAL schema (Srcs/Dsts), not the older
+    SrcIPs/DstPorts shape this tailnet never emits."
+grader: |
+  generator != grader with family exclusion. scripts/tailnet_policy_drift.py, its
+  corpus and its fixtures were BUILT by Codex GPT-5.6 terra (non-Anthropic, effort
+  high) and refuted blind by Kimi K3 (non-Anthropic, different family from its
+  builder) — which did not review but reconstructed the script in a scratch dir and
+  ran a battery against it. The proprioception wiring (tri_state_exit, the registry
+  entry, the boundary class) was written by this Anthropic orchestrator, and the
+  workflow class is refuted by Codex GPT-5.6 sol at xhigh. Final on-disk gate is this
+  orchestrator, empirical, this turn: every finding reproduced before being fixed and
+  every guard mutation-tested at a real code site.
+budget: |
+  Flat-subscription seats only: this session, Codex GPT-5.6 terra (build) and sol
+  (workflow refutation) on ChatGPT Pro, Kimi K3 (refutation) on the Allegro flat
+  plan. No metered API spend.
+pii: none

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-tailnet-drift-receptor-658dabc0/journal.jsonl
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-tailnet-drift-receptor-658dabc0/journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-08-31T02:05:00Z"}
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": true, "ts": "2026-08-31T02:20:00Z"}

--- a/evidence/2026-08/agent-mini-pro2-craft-f2-tailnet-drift-receptor-658dabc0/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-f2-tailnet-drift-receptor-658dabc0/pack.yml
@@ -1,0 +1,153 @@
+council_run: journal.jsonl
+# The literal evidence/brief.yml — the staging-layout contract harness-floor.yml
+# enforces, NOT this pack's per-PR path (which that workflow calls "exactly the trap
+# this migration exists to remove"). Verified by reproducing CI's staging layout
+# locally rather than trusting the bare local lint, which sees no staging.
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  docs/plans/2026-08-29-beyond-sota-craft-wave/L13-security-secrets-pii.md
+  section "PR-2: feat(proprioception): tailnet policy drift receptor".
+
+lanes:
+  - lane: tailnet-drift-build
+    role: build
+    seat: codex-gpt-5.6-terra (non-Anthropic, effort high) -- D3 build lane, never the grader
+  - lane: tailnet-drift-refute
+    role: review
+    seat: kimi-code/k3 (non-Anthropic) -- blind adversarial refutation; reconstructed and RAN the script
+  - lane: tailnet-drift-workflow-refute
+    role: review
+    seat: codex-gpt-5.6-sol xhigh -- workflow-class refutation
+  - lane: tailnet-drift-gate
+    role: review
+    seat: claude opus-5 xhigh (this orchestrator) -- final on-disk gate, empirical
+
+diff:
+  files: 7
+  net_lines: 1274
+  measured_at: HEAD-of-branch
+  note: >-
+    Over the <=400 net-line target, declared: the receptor and its corpus are the
+    bulk, and the corpus is what caught seven defects before merge. The
+    proprioception change is deliberately small (one parse mode, one boundary class,
+    one registry entry) because that file is shared and delicate -- it was written by
+    this orchestrator rather than delegated for the same reason.
+
+pii_scan: clean
+
+receipts:
+  - claim: "18/18 receptor corpus, and it bites: 7 mutants killed at real code sites (escape branch reverted; Bits discarded; scope disclosure dropped; IPv4-only redactor restored; reason left unsanitised; live schema removed; sanitizer neutered)."
+    cmd: "python3 -m pytest scripts/tests/test_tailnet_policy_drift.py -q"
+    exit: 0
+    ts: "2026-08-31T02:30:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "PROVE-LIVE on Mini against the node's REAL enforced state: exit 1, DIVERGED. Declared 8 rule-shapes on ports 22,443,4317,6379,8990,11434 (tcp); enforced 2 rule-shapes, ALL ports, icmp+tcp+udp+ICMPv6. No node name, address or identity in the output."
+    cmd: "python3 scripts/tailnet_policy_drift.py --policy infra/tailscale/policy.hujson"
+    exit: 1
+    ts: "2026-08-31T02:00:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "The consumer files it correctly: through proprioception's real wrap path the receptor resolves to a verdict, and a BLIND probe resolves to UNPROBEABLE rather than DIVERGED."
+    cmd: "run_wrap() against the registered tailnet_policy_drift entry"
+    exit: 0
+    ts: "2026-08-31T02:00:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+  - claim: "17/17 proprioception corpora (tri_state_exit + the pre-existing exit_code suite), registry valid at 14 probes, and the 44-check tailnet ACL guard this workflow already ran is unaffected."
+    cmd: "python3 -m pytest scripts/tests/test_proprioception_tri_state_exit.py scripts/tests/test_proprioception_run_wrap_exit_code.py scripts/tests/test_tailnet_acl_deny_by_default.py -q && python3 scripts/proprioception.py --selftest"
+    exit: 0
+    ts: "2026-08-31T02:30:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+
+  - claim: "The tri-state mapping holds on its own, and one case proves the contrast is REAL rather than claimed: it feeds the same BLIND input to the old _parse_exit_code and asserts that parser genuinely answers DIVERGED."
+    cmd: "python3 -m pytest scripts/tests/test_proprioception_tri_state_exit.py -q"
+    exit: 0
+    ts: "2026-08-31T02:30:00Z"
+    seat: "claude opus-5 xhigh (orchestrator, final on-disk gate)"
+
+dissent:
+  - seat: kimi-code/k3 (blind refutation; reconstructed and executed the script)
+    objection: >-
+      `Bits` is validated and then discarded, under a comment claiming the address
+      string already carries the prefix. That is true for `Net` and false for the old
+      schema's `IP`, a bare address whose prefix lives only in `Bits`.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced: {"IP": "10.0.0.1", "Bits": 8} yielded 10.0.0.1/32 instead of
+      10.0.0.0/8 -- silently NARROWER, and narrowing an enforced grant is the direction
+      that makes a broad reality compare equal to a narrow declaration and read CLEAN.
+      Bits is authoritative when the address carries no prefix; when both are present
+      and disagree the answer is BLIND, not a silent pick.
+  - seat: kimi-code/k3 (blind refutation)
+    objection: >-
+      False CLEAN by source erasure: sources collapse to any-vs-specific, so an
+      enforced rule granting the same ports from a DIFFERENT node compares equal.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced at full strength -- replacing EVERY source in the matching fixture
+      with a node that should hold no grant still compares equal. NOT closable here,
+      and the honest response was to stop the verdict claiming more than it checks
+      rather than to fake a fix: policy.hujson grants by IDENTITY while the netmap has
+      already resolved identities to addresses, and bridging them needs the
+      node<->identity table this tool must never hold. A `comparison_scope` field now
+      travels with every result, CLEAN especially, and a test pins the limitation so
+      that closing it later -- or silently narrowing the comparison so it merely looks
+      closed -- both surface.
+  - seat: kimi-code/k3 (blind refutation)
+    objection: >-
+      The redactor is IPv4-and-email only: an IPv6 address passes through, and node
+      NAMES are not redacted at all even though the spec forbids them in output.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced both. A Tailscale netmap carries fd7a:115c:a1e0::/48 addresses, so
+      IPv4-only was blind to half of every node's identity. Added IPv6 and MagicDNS
+      patterns; whole-string rejection kept, because a partially-scrubbed line invites
+      trust in the rest of it. Declared limit retained: a bare hostname with no domain
+      is unmatched, since widening further would eat `policy.hujson` and turn every
+      evidence line into "redacted".
+  - seat: kimi-code/k3 (blind refutation)
+    objection: >-
+      `reason` is not sanitised, and proprioception forwards it into its own report.
+    status: CONFIRMED
+    resolution: >-
+      Sanitised like evidence. Every reason emitted today is a constant, which is
+      exactly why it was easy to miss -- `reason` is the field a future contributor
+      reaches for when they want to say WHY, which is when an address gets
+      interpolated, and it would then travel one hop further than they were looking.
+  - seat: claude opus-5 xhigh (this orchestrator, final gate)
+    objection: >-
+      The HuJSON stripper's escape branch was unreachable: it compared a
+      one-character slice against a TWO-character literal, so an escaped quote ended
+      the string early and the remainder was re-scanned as structure.
+    status: CONFIRMED
+    resolution: >-
+      Reproduced ({"a": "he said \\" // x"} truncated and raised JSONDecodeError),
+      then fixed. It failed toward BLIND rather than CLEAN, so never a security hole
+      -- but a receptor blind on a VALID policy loses the same visibility by a slower
+      route. The corpus already covered an UNESCAPED // inside a string and passed
+      throughout, which is why the two cases are separate: they look identical and
+      only one was broken.
+  - seat: claude opus-5 xhigh (this orchestrator, final gate)
+    objection: >-
+      The tool parsed only the SrcIPs/DstPorts schema, which this tailnet does not
+      emit, and both fixtures encoded that shape.
+    status: CONFIRMED
+    resolution: >-
+      Measured with `tailscale debug netmap`: the live rule carries
+      Srcs/Dsts/Net/Ports. The tool behaved correctly in the way that matters (BLIND
+      rather than a guess) but was blind on every real node while its corpus proved it
+      against a format no netmap produces. Both schemas are accepted now and both
+      fixtures were rewritten in the live shape, sanitized -- the 14 source CIDRs
+      become RFC 5737 ranges, since only "several specific" vs "any" is load-bearing.
+      Destinations are deliberately NOT sanitized: they are already published in
+      policy.hujson, and changing them would break the comparison the CLEAN path
+      exists to exercise.
+  - seat: claude opus-5 xhigh (this orchestrator, on its own proprioception wiring)
+    objection: >-
+      The first tri_state_exit implementation parsed the JSON body BEFORE branching on
+      the exit code, so a malformed body could turn a known verdict into UNPROBEABLE.
+    status: CONFIRMED
+    resolution: >-
+      Restructured so the exit code is authoritative and a bad body costs detail, never
+      the verdict -- otherwise the mode hands its meaning back to the schema it was
+      chosen to be independent of. An unexpected exit code is UNPROBEABLE, never
+      DIVERGED: schema drift must not normalise into a verdict, the rule findings_list
+      already follows.

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -892,12 +892,22 @@ def _tri_state_evidence(data: object) -> tuple[int, list[str]]:
     body only enriches the report.
     """
     if isinstance(data, dict):
-        ev = [str(x)[:160] for x in data.get("evidence", []) if x][:5]
+        raw = data.get("evidence")
+        # A STRING is not a list of findings. Iterating one yields its CHARACTERS:
+        # measured, {"evidence": "100.107.22.111"} produced 5 "findings"
+        # ['1','0','0','.','1'] — a count and a body that are both nonsense, and a
+        # fragment of an address in the report besides. Found by blind cross-family
+        # refutation (Kimi K3).
+        ev = [str(x)[:160] for x in raw if x][:5] if isinstance(raw, list) else []
         reason = data.get("reason")
         if reason and not ev:
             ev = [str(reason)[:160]]
-        return (len(ev) or 1), ev
-    return 1, []
+        # `len(ev) or 1` claimed ONE finding while showing NONE. The count must
+        # describe what is actually there; a DIVERGED verdict with no legible
+        # evidence is honestly reported as 1 unexplained finding only when the probe
+        # gave us nothing at all, and that is what the caller passes through.
+        return len(ev), ev
+    return 0, []
 
 
 def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]]:
@@ -932,10 +942,25 @@ def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]
         # from a tool that promised three is schema drift, and schema drift must not
         # normalize into a verdict (the same rule findings_list follows above).
         if rc == 0:
+            # The exit code is authoritative, but a body that CONTRADICTS it is a
+            # contract violation, not enrichment — and the docstring's claim that
+            # "the body only enriches" was enforced in one direction only: rc=2 with
+            # a CLEAN body was tested, rc=0 with a BLIND body was not. A probe that
+            # exits 0 while printing BLIND has not agreed with itself, and filing
+            # that as RECONCILED is exactly the "green over an unknown" this parse
+            # mode exists to prevent. Found by blind cross-family refutation (Kimi K3).
+            body = _lenient_json(out)
+            if isinstance(body, dict):
+                stated = str(body.get("verdict", "")).upper()
+                if stated and stated not in ("CLEAN", "RECONCILED", "OK"):
+                    return UNPROBEABLE, 0, [
+                        f"probe exited 0 but its body says {stated!r} — exit code and "
+                        "body disagree, so neither is trusted"
+                    ]
             return RECONCILED, 0, []
         if rc == 1:
             n, ev = _tri_state_evidence(_lenient_json(out))
-            return DIVERGED, n, ev
+            return DIVERGED, (n or 1), ev
         if rc == 2:
             _, ev = _tri_state_evidence(_lenient_json(out))
             return UNPROBEABLE, 0, ev or [f"probe reported BLIND (exit {rc})"]
@@ -1005,9 +1030,12 @@ DEFAULT_REGISTRY: list[dict] = [
                      "Tailscale admin console (operator[GUI], runbook "
                      "docs/runbooks/tailnet-acl-apply.md) -- do NOT try to close it from "
                      "a session, and do NOT apply policy from this tool: it observes "
-                     "only. BLIND means the enforced state could not be read at all "
-                     "(no tailscale CLI, unreadable netmap, or insufficient "
-                     "permission); that is a visibility problem, not drift."),
+                     "only. BLIND means no comparison was made -- usually lost "
+                     "visibility (no tailscale CLI, unreadable netmap, insufficient "
+                     "permission) but ALSO a tool-side limit: an unparseable policy, a "
+                     "netmap schema this parser does not know, a self-contradictory "
+                     "prefix, or an unexpected crash. Read the reason field; it names "
+                     "which. Either way it is NOT drift, and no healer should act on it."),
     },
     {
         "id": "git_alignment", "type": "builtin", "target": "git_alignment",

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -75,6 +75,7 @@ KNOWN_BOUNDARY_CLASSES = [
     "seat<->armed",             # AI-seat credential/quota vs live probe (arsenal, #2)
     "worktree<->gate",          # does git actually invoke a pre-push hook in this worktree (#2)
     "tunnel<->reachable",       # declared network tunnel/forward vs live reachability (2026-08-21)
+    "declared<->enforced",      # policy-as-code in the repo vs what the node actually enforces (L13, 2026-08-31)
 ]
 
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
@@ -871,6 +872,34 @@ def _parse_exit_code(rc: int, out: str, err: str) -> tuple[str, int, list[str]]:
     return DIVERGED, n, ev
 
 
+def _lenient_json(out: str) -> object:
+    """Best-effort JSON, never raising. Used ONLY by tri_state_exit, where the exit
+    code already carries the verdict: a body that fails to parse must cost detail,
+    never the verdict itself."""
+    try:
+        return json.loads(out.strip() or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def _tri_state_evidence(data: object) -> tuple[int, list[str]]:
+    """Evidence lines for `parse: tri_state_exit`, from the probe's own JSON.
+
+    Deliberately tolerant: a tri-state probe's VERDICT is carried by its exit code,
+    which run_wrap has already read, so a body that is missing, null or shaped
+    differently must not turn a known verdict into UNPROBEABLE — that would hand the
+    exit code's meaning back to the schema it was chosen to be independent of. The
+    body only enriches the report.
+    """
+    if isinstance(data, dict):
+        ev = [str(x)[:160] for x in data.get("evidence", []) if x][:5]
+        reason = data.get("reason")
+        if reason and not ev:
+            ev = [str(reason)[:160]]
+        return (len(ev) or 1), ev
+    return 1, []
+
+
 def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]]:
     argv = [a.replace("{repo}", str(root)) for a in entry["target"]]
     if argv[0].startswith("python") and len(argv) > 1:
@@ -887,6 +916,30 @@ def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]
     parse = entry.get("parse", "exit_code")
     if parse == "exit_code":
         return _parse_exit_code(rc, out, err)
+    if parse == "tri_state_exit":
+        # For a probe that distinguishes "I looked and they match" from "I looked and
+        # they differ" from "I could not look at all".
+        #
+        # `exit_code` cannot express the third: it maps EVERY non-zero to DIVERGED, so a
+        # receptor reporting BLIND (exit 2) would be filed as real drift. That is the
+        # more dangerous direction than it first appears — a BLIND that reads as DIVERGED
+        # sends a healer to reconcile a difference nobody has actually observed, and it
+        # makes "we cannot see the enforced state" indistinguishable from "we can see it
+        # and it is wrong". They have opposite remedies: one needs an operator to restore
+        # visibility, the other needs the policy applied.
+        #
+        # Anything OTHER than 0/1/2 is UNPROBEABLE, not DIVERGED: an unknown exit code
+        # from a tool that promised three is schema drift, and schema drift must not
+        # normalize into a verdict (the same rule findings_list follows above).
+        if rc == 0:
+            return RECONCILED, 0, []
+        if rc == 1:
+            n, ev = _tri_state_evidence(_lenient_json(out))
+            return DIVERGED, n, ev
+        if rc == 2:
+            _, ev = _tri_state_evidence(_lenient_json(out))
+            return UNPROBEABLE, 0, ev or [f"probe reported BLIND (exit {rc})"]
+        return UNPROBEABLE, 0, [f"tri_state_exit: unexpected exit {rc} (expected 0, 1 or 2)"]
     try:
         data = json.loads(out.strip() or "null")
     except json.JSONDecodeError:
@@ -922,6 +975,40 @@ def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]
 # ---------------------------------------------------------------- registry
 
 DEFAULT_REGISTRY: list[dict] = [
+    {
+        # The tailnet's DECLARED policy vs the filter the node actually enforces.
+        #
+        # This probe is expected to answer DIVERGED on this fleet today, and that is the
+        # correct answer rather than a defect to suppress: infra/tailscale/policy.hujson
+        # is PROPOSED and NOT APPLIED, and the live packet filter (measured 2026-08-11
+        # from M5, re-confirmed 2026-08-29) is one allow-all rule -- every node ->
+        # 0.0.0.0/0, ports 0-65535, TCP+UDP+ICMP. Applying the policy is operator[GUI]
+        # (admin console; the fleet holds no Tailscale API token), so no session can
+        # clear this finding by working harder. It exists to keep the gap VISIBLE and
+        # dated until an operator closes it.
+        #
+        # parse: tri_state_exit, not exit_code, and the distinction is load-bearing.
+        # exit_code maps every non-zero to DIVERGED, which would file BLIND ("I could
+        # not read the enforced state") as real drift. Those have opposite remedies --
+        # DIVERGED needs the policy applied, BLIND needs an operator to restore
+        # visibility -- so collapsing them sends a healer to reconcile a difference
+        # nobody has observed.
+        "id": "tailnet_policy_drift", "type": "wrap",
+        "target": ["python3", "{repo}/scripts/tailnet_policy_drift.py",
+                   "--policy", "{repo}/infra/tailscale/policy.hujson"],
+        "class": "declared<->enforced",
+        "boundary": "infra/tailscale/policy.hujson <-> the packet filter this node enforces",
+        "machines": ["all"], "tags": ["fast"], "timeout_sec": 30,
+        "severity": "P1",
+        "parse": "tri_state_exit",
+        "fix_hint": ("DIVERGED here is expected until policy.hujson is applied in the "
+                     "Tailscale admin console (operator[GUI], runbook "
+                     "docs/runbooks/tailnet-acl-apply.md) -- do NOT try to close it from "
+                     "a session, and do NOT apply policy from this tool: it observes "
+                     "only. BLIND means the enforced state could not be read at all "
+                     "(no tailscale CLI, unreadable netmap, or insufficient "
+                     "permission); that is a visibility problem, not drift."),
+    },
     {
         "id": "git_alignment", "type": "builtin", "target": "git_alignment",
         "class": "checkout<->origin",

--- a/scripts/tailnet_policy_drift.py
+++ b/scripts/tailnet_policy_drift.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Compare declared Tailscale ACL rule shapes with the local packet filter.
+
+This is deliberately read-only.  The current fleet's recorded default allow-all
+filter diverges from infra/tailscale/policy.hujson; that is expected until an
+operator applies the policy in the Tailscale admin console.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import ipaddress
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+VERDICT_CLEAN = "CLEAN"
+VERDICT_DIVERGED = "DIVERGED"
+VERDICT_BLIND = "BLIND"
+
+_EMAIL_RE = re.compile(r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+")
+_IP_RE = re.compile(
+    r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?(?![\w.])"
+)
+_PROTO_NAMES = {1: "icmp", 6: "tcp", 17: "udp"}
+
+
+class BlindError(Exception):
+    """An input was not safe enough to interpret as an enforced policy."""
+
+
+@dataclass(frozen=True, order=True)
+class RuleShape:
+    """Comparable rule form; values never leave this process unredacted."""
+
+    source_class: str
+    destination: str
+    first_port: int
+    last_port: int
+    protocols: tuple[int, ...]
+
+
+def strip_hujson(source: str) -> str:
+    """Remove HuJSON comments and trailing commas without touching string content."""
+
+    without_comments: list[str] = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(source):
+        character = source[index]
+        following = source[index + 1] if index + 1 < len(source) else ""
+        if in_string:
+            without_comments.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                # A SINGLE backslash. The original compared a one-character slice
+                # against "\\\\", a TWO-character literal, so this branch could never
+                # be taken: an escaped quote inside a string ended the string early and
+                # everything after it was re-scanned as structure. Measured before the
+                # fix: {"a": "he said \\" // x", "b": 1} truncated to
+                # {"a": "he said \\" and raised JSONDecodeError. It fails toward BLIND
+                # rather than CLEAN, so it was never a security hole -- but it would
+                # make the receptor blind on a perfectly valid policy, which is the
+                # same lost visibility by a slower route.
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+        if character == '"':
+            in_string = True
+            without_comments.append(character)
+            index += 1
+        elif character == "/" and following == "/":
+            index += 2
+            while index < len(source) and source[index] not in "\r\n":
+                index += 1
+        elif character == "/" and following == "*":
+            end = source.find("*/", index + 2)
+            if end == -1:
+                raise BlindError("POLICY_HUJSON_UNTERMINATED_COMMENT")
+            index = end + 2
+        else:
+            without_comments.append(character)
+            index += 1
+
+    uncommented = "".join(without_comments)
+    normalized: list[str] = []
+    index = 0
+    in_string = False
+    escaped = False
+    while index < len(uncommented):
+        character = uncommented[index]
+        if in_string:
+            normalized.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+        if character == '"':
+            in_string = True
+            normalized.append(character)
+        elif character == ",":
+            cursor = index + 1
+            while cursor < len(uncommented) and uncommented[cursor].isspace():
+                cursor += 1
+            if cursor >= len(uncommented) or uncommented[cursor] not in "}]":
+                normalized.append(character)
+        else:
+            normalized.append(character)
+        index += 1
+    return "".join(normalized)
+
+
+def parse_hujson(source: str) -> dict[str, Any]:
+    """Parse the small HuJSON subset used by the checked-in ACL policy."""
+
+    try:
+        parsed = json.loads(strip_hujson(source))
+    except json.JSONDecodeError as error:
+        raise BlindError("POLICY_HUJSON_PARSE_FAILED") from error
+    if not isinstance(parsed, dict):
+        raise BlindError("POLICY_ROOT_NOT_OBJECT")
+    return parsed
+
+
+def policy_fingerprint(policy: dict[str, Any]) -> str:
+    """Return a stable short hash of normalized, parsed policy content."""
+
+    normalized = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_port_range(value: str) -> tuple[int, int]:
+    if value == "*":
+        return 0, 65535
+    if value.isdecimal():
+        port = int(value)
+        if 0 <= port <= 65535:
+            return port, port
+    if value.count("-") == 1:
+        first_text, last_text = value.split("-", 1)
+        if first_text.isdecimal() and last_text.isdecimal():
+            first, last = int(first_text), int(last_text)
+            if 0 <= first <= last <= 65535:
+                return first, last
+    raise BlindError("POLICY_PORT_SHAPE_UNSUPPORTED")
+
+
+def _policy_protocols(value: Any) -> tuple[int, ...]:
+    values = [value] if isinstance(value, str) else value
+    if not isinstance(values, list) or not values or not all(isinstance(item, str) for item in values):
+        raise BlindError("POLICY_PROTOCOL_SHAPE_UNSUPPORTED")
+    protocol_numbers = {name: number for number, name in _PROTO_NAMES.items()}
+    try:
+        return tuple(sorted({protocol_numbers[item.lower()] for item in values}))
+    except KeyError as error:
+        raise BlindError("POLICY_PROTOCOL_SHAPE_UNSUPPORTED") from error
+
+
+def _source_class(sources: list[Any]) -> str:
+    if not sources or not all(isinstance(source, str) for source in sources):
+        raise BlindError("POLICY_SOURCE_SHAPE_UNSUPPORTED")
+    if "*" in sources:
+        if len(sources) != 1:
+            raise BlindError("POLICY_SOURCE_SHAPE_UNSUPPORTED")
+        return "any-source"
+    return "specific-source"
+
+
+def policy_shapes(policy: dict[str, Any]) -> set[RuleShape]:
+    """Reduce static ACL grants to rule shapes, deliberately ignoring identities.
+
+    Tailscale expands an unbound tag destination to no concrete packet-filter
+    entry.  It therefore has no local IP/CIDR shape until a tagged device exists,
+    and is excluded here rather than guessed at.
+    """
+
+    hosts = policy.get("hosts")
+    rules = policy.get("acls")
+    if not isinstance(hosts, dict) or not isinstance(rules, list):
+        raise BlindError("POLICY_ACL_SHAPE_UNSUPPORTED")
+    host_networks: dict[str, str] = {}
+    for alias, address in hosts.items():
+        if not isinstance(alias, str) or not isinstance(address, str):
+            raise BlindError("POLICY_HOSTS_SHAPE_UNSUPPORTED")
+        try:
+            host_networks[alias] = str(ipaddress.ip_network(address, strict=False))
+        except ValueError as error:
+            raise BlindError("POLICY_HOSTS_SHAPE_UNSUPPORTED") from error
+
+    shapes: set[RuleShape] = set()
+    for rule in rules:
+        if not isinstance(rule, dict) or rule.get("action") != "accept":
+            raise BlindError("POLICY_ACL_RULE_SHAPE_UNSUPPORTED")
+        source = _source_class(rule.get("src"))
+        protocols = _policy_protocols(rule.get("proto"))
+        destinations = rule.get("dst")
+        if not isinstance(destinations, list) or not destinations or not all(isinstance(item, str) for item in destinations):
+            raise BlindError("POLICY_DESTINATION_SHAPE_UNSUPPORTED")
+        for destination in destinations:
+            if ":" not in destination:
+                raise BlindError("POLICY_DESTINATION_SHAPE_UNSUPPORTED")
+            target, port_text = destination.rsplit(":", 1)
+            first_port, last_port = _parse_port_range(port_text)
+            if target.startswith("tag:"):
+                continue
+            try:
+                target_network = host_networks[target]
+            except KeyError as error:
+                raise BlindError("POLICY_DESTINATION_SHAPE_UNSUPPORTED") from error
+            shapes.add(RuleShape(source, target_network, first_port, last_port, protocols))
+    if not shapes:
+        raise BlindError("POLICY_HAS_NO_CONCRETE_ACL_SHAPES")
+    return shapes
+
+
+def _netmap_source_class(value: Any) -> str:
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) for item in value):
+        raise BlindError("NETMAP_SOURCE_SHAPE_UNSUPPORTED")
+    if "*" in value:
+        if len(value) != 1:
+            raise BlindError("NETMAP_SOURCE_SHAPE_UNSUPPORTED")
+        return "any-source"
+    for source in value:
+        try:
+            ipaddress.ip_network(source, strict=False)
+        except ValueError as error:
+            raise BlindError("NETMAP_SOURCE_SHAPE_UNSUPPORTED") from error
+    return "specific-source"
+
+
+def _netmap_protocols(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, list) or not value or not all(isinstance(item, int) and not isinstance(item, bool) for item in value):
+        raise BlindError("NETMAP_PROTOCOL_SHAPE_UNSUPPORTED")
+    if any(item < 0 or item > 255 for item in value):
+        raise BlindError("NETMAP_PROTOCOL_SHAPE_UNSUPPORTED")
+    return tuple(sorted(set(value)))
+
+
+def _netmap_rule_fields(rule: dict) -> tuple[Any, Any]:
+    """Return (sources, destinations) for either PacketFilter schema.
+
+    MEASURED on this fleet 2026-08-31 with `tailscale debug netmap`: the live rule
+    carries `Srcs` (a list of CIDR strings) and `Dsts` (a list of
+    {"Net": "<cidr>", "Ports": {"First": n, "Last": n}}), alongside `IPProto`,
+    `SrcCaps` and `Caps`.
+
+    The first version of this file parsed only `SrcIPs`/`DstPorts` -- an older shape
+    that this tailnet does not emit. It behaved CORRECTLY in the sense that mattered
+    (it answered BLIND rather than guessing), but it was blind on every real node, and
+    its fixtures encoded a schema that does not exist, so the corpus was proving the
+    tool against a format it would never meet. Both schemas are accepted now; the newer
+    one is what the fleet actually speaks.
+
+    Unknown shape still raises BLIND. That polarity is the whole design: a schema guess
+    that is wrong must cost visibility, never correctness.
+    """
+    if "Srcs" in rule or "Dsts" in rule:
+        return rule.get("Srcs"), rule.get("Dsts")
+    return rule.get("SrcIPs"), rule.get("DstPorts")
+
+
+def _netmap_destination(destination: Any) -> tuple[str, int, int]:
+    """One destination -> (network, first_port, last_port), for either schema.
+
+    `Net` is the live key; `IP` is the older one. `Bits`, when present, is accepted
+    but not trusted as authoritative -- the CIDR string already carries the prefix
+    length, and two sources of the same fact that can disagree are a way to be wrong
+    twice.
+    """
+    if not isinstance(destination, dict):
+        raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
+    address = destination.get("Net", destination.get("IP"))
+    ports = destination.get("Ports")
+    if not isinstance(address, str) or not isinstance(ports, dict):
+        raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
+    bits = destination.get("Bits")
+    if bits is not None and (not isinstance(bits, int) or isinstance(bits, bool)):
+        raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
+    first, last = ports.get("First"), ports.get("Last")
+    if (
+        not isinstance(first, int)
+        or isinstance(first, bool)
+        or not isinstance(last, int)
+        or isinstance(last, bool)
+        or not 0 <= first <= last <= 65535
+    ):
+        raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
+    try:
+        network = str(ipaddress.ip_network(address, strict=False))
+    except ValueError as error:
+        raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED") from error
+    return network, first, last
+
+
+def netmap_shapes(netmap: Any) -> set[RuleShape]:
+    """Reduce an enforced PacketFilter to comparable rule SHAPES.
+
+    Both the live schema (`Srcs`/`Dsts`) and the older one (`SrcIPs`/`DstPorts`) are
+    accepted; anything else is BLIND. Losing visibility is always safer here than
+    claiming a clean comparison from a guessed parse.
+    """
+
+    packet_filter = netmap if isinstance(netmap, list) else netmap.get("PacketFilter") if isinstance(netmap, dict) else None
+    if not isinstance(packet_filter, list):
+        raise BlindError("NETMAP_PACKET_FILTER_MISSING_OR_INVALID")
+    shapes: set[RuleShape] = set()
+    for rule in packet_filter:
+        if not isinstance(rule, dict):
+            raise BlindError("NETMAP_RULE_SHAPE_UNSUPPORTED")
+        raw_sources, destinations = _netmap_rule_fields(rule)
+        source = _netmap_source_class(raw_sources)
+        protocols = _netmap_protocols(rule.get("IPProto"))
+        if not isinstance(destinations, list) or not destinations:
+            raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
+        for destination in destinations:
+            network, first, last = _netmap_destination(destination)
+            shapes.add(RuleShape(source, network, first, last, protocols))
+    if not shapes:
+        raise BlindError("NETMAP_PACKET_FILTER_EMPTY")
+    return shapes
+
+
+def sanitize_evidence(value: str) -> str:
+    """Reject sensitive-looking strings before they can enter public output."""
+
+    if not isinstance(value, str) or _EMAIL_RE.search(value) or _IP_RE.search(value):
+        return "redacted-sensitive-evidence"
+    return value
+
+
+def _port_description(shapes: Iterable[RuleShape]) -> str:
+    ranges = sorted({(shape.first_port, shape.last_port) for shape in shapes})
+    rendered = ["all" if first == 0 and last == 65535 else str(first) if first == last else f"{first}-{last}" for first, last in ranges]
+    return ",".join(rendered)
+
+
+def _protocol_description(shapes: Iterable[RuleShape]) -> str:
+    values = sorted({protocol for shape in shapes for protocol in shape.protocols})
+    return ",".join(_PROTO_NAMES.get(value, f"protocol-{value}") for value in values)
+
+
+def describe_shapes(label: str, shapes: set[RuleShape]) -> str:
+    source_classes = "/".join(sorted({shape.source_class for shape in shapes}))
+    destinations = {shape.destination for shape in shapes}
+    destination_class = "internet-any" if destinations == {"0.0.0.0/0"} else "specific-destination"
+    return sanitize_evidence(
+        f"{label}: {len(shapes)} rule-shapes ({source_classes} -> {destination_class}; "
+        f"ports: {_port_description(shapes)}; protocols: {_protocol_description(shapes)})"
+    )
+
+
+def emit_result(
+    verdict: str,
+    fingerprint: str | None,
+    evidence: Iterable[str] = (),
+    reason: str | None = None,
+) -> int:
+    """Write the stable public result and return its prescribed process status."""
+
+    payload: dict[str, Any] = {
+        "verdict": verdict,
+        "policy_fingerprint": fingerprint,
+        "evidence": [sanitize_evidence(item) for item in evidence],
+    }
+    if verdict == VERDICT_BLIND:
+        payload["reason"] = reason or "UNKNOWN_BLIND_REASON"
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return {VERDICT_CLEAN: 0, VERDICT_DIVERGED: 1, VERDICT_BLIND: 2}[verdict]
+
+
+def _read_fixture(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise BlindError("NETMAP_FIXTURE_UNREADABLE") from error
+    except OSError as error:
+        raise BlindError("NETMAP_FIXTURE_UNREADABLE") from error
+    except UnicodeDecodeError as error:
+        raise BlindError("NETMAP_FIXTURE_UNREADABLE") from error
+    except json.JSONDecodeError as error:
+        raise BlindError("NETMAP_FIXTURE_PARSE_FAILED") from error
+
+
+def _read_live_netmap() -> Any:
+    try:
+        completed = subprocess.run(
+            ["tailscale", "debug", "netmap"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+        )
+    except FileNotFoundError as error:
+        raise BlindError("TAILSCALE_UNAVAILABLE") from error
+    except (OSError, subprocess.SubprocessError) as error:
+        raise BlindError("NETMAP_COMMAND_FAILED") from error
+    try:
+        return json.loads(completed.stdout)
+    except (TypeError, json.JSONDecodeError) as error:
+        raise BlindError("NETMAP_COMMAND_OUTPUT_INVALID") from error
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only Tailscale policy drift check.",
+        epilog="The recorded live default allow-all fleet policy is expected to report DIVERGED until an operator applies the declared policy.",
+    )
+    parser.add_argument("--policy", required=True, type=Path, help="Declared HuJSON ACL policy")
+    parser.add_argument("--netmap-fixture", type=Path, help="Recorded sanitized netmap; makes no subprocess call")
+    parser.add_argument("--json", action="store_true", help="Retained for explicit machine-readable invocation")
+    args = parser.parse_args(argv)
+
+    fingerprint: str | None = None
+    try:
+        try:
+            policy_source = args.policy.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            raise BlindError("POLICY_UNREADABLE") from error
+        policy = parse_hujson(policy_source)
+        fingerprint = policy_fingerprint(policy)
+        declared = policy_shapes(policy)
+        netmap = _read_fixture(args.netmap_fixture) if args.netmap_fixture else _read_live_netmap()
+        enforced = netmap_shapes(netmap)
+    except BlindError as error:
+        return emit_result(VERDICT_BLIND, fingerprint, reason=str(error))
+
+    evidence = [describe_shapes("declared", declared), describe_shapes("enforced", enforced)]
+    verdict = VERDICT_CLEAN if declared == enforced else VERDICT_DIVERGED
+    return emit_result(verdict, fingerprint, evidence)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tailnet_policy_drift.py
+++ b/scripts/tailnet_policy_drift.py
@@ -29,6 +29,22 @@ _EMAIL_RE = re.compile(r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Z
 _IP_RE = re.compile(
     r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?:/\d{1,2})?(?![\w.])"
 )
+# IPv6, and this is not a hypothetical here: a Tailscale netmap carries addresses in
+# fd7a:115c:a1e0::/48, so an IPv4-only redactor is blind to HALF of every node's
+# identity. Found by blind cross-family refutation (Kimi K3). Deliberately loose --
+# any run of hex groups separated by colons, with or without a prefix -- because this
+# is a redactor: over-matching costs a legible evidence line, under-matching publishes
+# a node address in a public repo.
+_IPV6_RE = re.compile(r"(?<![\w:])(?:[0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}(?:/\d{1,3})?(?![\w:])")
+# MagicDNS names. The spec forbids a NODE NAME in output, and neither of the two
+# patterns above sees one: `nuzantara.tail461666.ts.net` is not an address.
+# Scoped to the ts.net suffix on purpose -- a general "anything dotted" rule would
+# redact `policy.hujson` and `0-65535`, turning every evidence line into noise. That
+# leaves a bare hostname with no domain unmatched, which is a declared LIMIT rather
+# than an oversight: no code path here emits one, and the fix for that would be to
+# stop building evidence from untrusted strings, not to widen this regex until it
+# eats its own output.
+_MAGICDNS_RE = re.compile(r"(?<![\w.])[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.ts\.net\b")
 _PROTO_NAMES = {1: "icmp", 6: "tcp", 17: "udp"}
 
 
@@ -277,10 +293,22 @@ def _netmap_rule_fields(rule: dict) -> tuple[Any, Any]:
 def _netmap_destination(destination: Any) -> tuple[str, int, int]:
     """One destination -> (network, first_port, last_port), for either schema.
 
-    `Net` is the live key; `IP` is the older one. `Bits`, when present, is accepted
-    but not trusted as authoritative -- the CIDR string already carries the prefix
-    length, and two sources of the same fact that can disagree are a way to be wrong
-    twice.
+    `Net` is the live key; `IP` is the older one.
+
+    `Bits` IS AUTHORITATIVE when the address carries no prefix of its own, and an
+    earlier version of this function got that exactly backwards: it validated `Bits`
+    and then discarded it under a comment claiming "the CIDR string already carries
+    the prefix length". That is true for `Net` (a CIDR string) and FALSE for the old
+    schema's `IP`, which is a bare address whose prefix lives only in `Bits`.
+    Measured: {"IP": "10.0.0.1", "Bits": 8} produced 10.0.0.1/32 instead of
+    10.0.0.0/8 -- a silently NARROWER network, and narrowing an enforced grant is the
+    direction that can make a broad reality compare equal to a narrow declaration and
+    read CLEAN. Found by blind cross-family refutation (Kimi K3).
+
+    When BOTH are present and they disagree, the answer is BLIND rather than a pick:
+    two sources of the same fact that contradict each other are a way to be wrong
+    twice, and this tool's whole polarity is that uncertainty costs visibility, never
+    correctness.
     """
     if not isinstance(destination, dict):
         raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
@@ -289,7 +317,7 @@ def _netmap_destination(destination: Any) -> tuple[str, int, int]:
     if not isinstance(address, str) or not isinstance(ports, dict):
         raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
     bits = destination.get("Bits")
-    if bits is not None and (not isinstance(bits, int) or isinstance(bits, bool)):
+    if bits is not None and (not isinstance(bits, int) or isinstance(bits, bool) or bits < 0):
         raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
     first, last = ports.get("First"), ports.get("Last")
     if (
@@ -301,10 +329,20 @@ def _netmap_destination(destination: Any) -> tuple[str, int, int]:
     ):
         raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED")
     try:
-        network = str(ipaddress.ip_network(address, strict=False))
+        if "/" in address:
+            network = ipaddress.ip_network(address, strict=False)
+            if bits is not None and bits != network.prefixlen:
+                # The two disagree. Refuse to choose.
+                raise BlindError("NETMAP_DESTINATION_PREFIX_CONFLICT")
+        elif bits is not None:
+            network = ipaddress.ip_network(f"{address}/{bits}", strict=False)
+        else:
+            network = ipaddress.ip_network(address, strict=False)
+    except BlindError:
+        raise
     except ValueError as error:
         raise BlindError("NETMAP_DESTINATION_SHAPE_UNSUPPORTED") from error
-    return network, first, last
+    return str(network), first, last
 
 
 def netmap_shapes(netmap: Any) -> set[RuleShape]:
@@ -336,10 +374,18 @@ def netmap_shapes(netmap: Any) -> set[RuleShape]:
 
 
 def sanitize_evidence(value: str) -> str:
-    """Reject sensitive-looking strings before they can enter public output."""
+    """Reject sensitive-looking strings before they can enter public output.
 
-    if not isinstance(value, str) or _EMAIL_RE.search(value) or _IP_RE.search(value):
+    Whole-string rejection rather than substring replacement: a partially-scrubbed
+    line invites the reader to trust the rest of it, and this output lands in a
+    public repo.
+    """
+
+    if not isinstance(value, str):
         return "redacted-sensitive-evidence"
+    for pattern in (_EMAIL_RE, _IP_RE, _IPV6_RE, _MAGICDNS_RE):
+        if pattern.search(value):
+            return "redacted-sensitive-evidence"
     return value
 
 
@@ -364,6 +410,26 @@ def describe_shapes(label: str, shapes: set[RuleShape]) -> str:
     )
 
 
+#: What a CLEAN verdict does and does NOT assert. Emitted with every result.
+#
+# The two sides speak different vocabularies and no amount of care closes that here:
+# policy.hujson grants by IDENTITY (users, groups, tag:*), while the netmap has already
+# RESOLVED those identities into node CIDRs. Mapping one to the other would require this
+# tool to hold the node<->identity table -- exactly the data it is forbidden to touch or
+# emit. So sources are compared only as any-vs-specific.
+#
+# Measured consequence, found by blind cross-family refutation (Kimi K3): take the
+# matching fixture, replace EVERY source with a node that should hold no grant at all,
+# and the comparison still reports equal. A reader who takes CLEAN to mean "the right
+# nodes have the right access" would be wrong. So the scope travels with every verdict
+# instead of living in a docstring nobody reads at 03:00.
+COMPARISON_SCOPE = (
+    "destination-network + port-range + protocol-set, and source only as "
+    "any-vs-specific; SOURCE IDENTITY IS NOT COMPARED (policy grants by identity, "
+    "the netmap has already resolved identities to addresses)"
+)
+
+
 def emit_result(
     verdict: str,
     fingerprint: str | None,
@@ -376,9 +442,18 @@ def emit_result(
         "verdict": verdict,
         "policy_fingerprint": fingerprint,
         "evidence": [sanitize_evidence(item) for item in evidence],
+        # Travels with EVERY verdict, CLEAN included -- especially CLEAN. A limit a
+        # reader has to go looking for is a limit that gets forgotten.
+        "comparison_scope": COMPARISON_SCOPE,
     }
     if verdict == VERDICT_BLIND:
-        payload["reason"] = reason or "UNKNOWN_BLIND_REASON"
+        # Sanitised like evidence. Every reason this tool emits today is a constant, so
+        # nothing leaks right now -- but `reason` is the field a future contributor
+        # reaches for when they want to say WHY, which is exactly when an address or a
+        # hostname gets interpolated. The proprioception harness also forwards `reason`
+        # into its own report, so an unsanitised value would travel one hop further
+        # than the person adding it was looking.
+        payload["reason"] = sanitize_evidence(reason or "UNKNOWN_BLIND_REASON")
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
     return {VERDICT_CLEAN: 0, VERDICT_DIVERGED: 1, VERDICT_BLIND: 2}[verdict]
 

--- a/scripts/tailnet_policy_drift.py
+++ b/scripts/tailnet_policy_drift.py
@@ -100,11 +100,20 @@ def strip_hujson(source: str) -> str:
             index += 2
             while index < len(source) and source[index] not in "\r\n":
                 index += 1
+            # A comment is WHITESPACE, not nothing. Deleting it outright concatenates
+            # the tokens on either side: measured, `{"a": 1/**/2}` became `{"a": 12}`,
+            # which parses cleanly as a DIFFERENT document with a different value and a
+            # different fingerprint. The input is invalid HuJSON, and the contract is
+            # that invalid input costs visibility (BLIND) -- silently reinterpreting it
+            # into a valid document is the one outcome that contract forbids. Found by
+            # blind cross-family refutation (Kimi K3).
+            without_comments.append(" ")
         elif character == "/" and following == "*":
             end = source.find("*/", index + 2)
             if end == -1:
                 raise BlindError("POLICY_HUJSON_UNTERMINATED_COMMENT")
             index = end + 2
+            without_comments.append(" ")
         else:
             without_comments.append(character)
             index += 1
@@ -187,6 +196,15 @@ def _policy_protocols(value: Any) -> tuple[int, ...]:
         raise BlindError("POLICY_PROTOCOL_SHAPE_UNSUPPORTED") from error
 
 
+#: Policy source tokens that mean "many principals", not one named host. Classifying
+#: these as "specific-source" let a tailnet-wide grant (`autogroup:member`) compare
+#: equal to a /16 of strangers -- the comparison is already source-blind by
+#: construction (see COMPARISON_SCOPE), and calling a broad grant "specific" made the
+#: one source signal it DOES carry point the wrong way. Found by blind cross-family
+#: refutation (Kimi K3).
+_BROAD_SOURCE_PREFIXES = ("autogroup:", "group:", "tag:")
+
+
 def _source_class(sources: list[Any]) -> str:
     if not sources or not all(isinstance(source, str) for source in sources):
         raise BlindError("POLICY_SOURCE_SHAPE_UNSUPPORTED")
@@ -194,6 +212,8 @@ def _source_class(sources: list[Any]) -> str:
         if len(sources) != 1:
             raise BlindError("POLICY_SOURCE_SHAPE_UNSUPPORTED")
         return "any-source"
+    if any(source.startswith(_BROAD_SOURCE_PREFIXES) for source in sources):
+        return "broad-source"
     return "specific-source"
 
 
@@ -234,10 +254,19 @@ def policy_shapes(policy: dict[str, Any]) -> set[RuleShape]:
             first_port, last_port = _parse_port_range(port_text)
             if target.startswith("tag:"):
                 continue
-            try:
-                target_network = host_networks[target]
-            except KeyError as error:
-                raise BlindError("POLICY_DESTINATION_SHAPE_UNSUPPORTED") from error
+            if target == "*":
+                # "*:*" is the commonest ACL spelling and it is not ambiguous: it means
+                # every address. Treating it as an unknown host alias made the tool
+                # answer BLIND on a fully readable, VALID policy -- and made the
+                # registry fix_hint ("BLIND means the enforced state could not be
+                # read") false, since the cause was a tool-side gap rather than lost
+                # visibility. Found by blind cross-family refutation (Kimi K3).
+                target_network = "0.0.0.0/0"
+            else:
+                try:
+                    target_network = host_networks[target]
+                except KeyError as error:
+                    raise BlindError("POLICY_DESTINATION_SHAPE_UNSUPPORTED") from error
             shapes.add(RuleShape(source, target_network, first_port, last_port, protocols))
     if not shapes:
         raise BlindError("POLICY_HAS_NO_CONCRETE_ACL_SHAPES")
@@ -250,6 +279,14 @@ def _netmap_source_class(value: Any) -> str:
     if "*" in value:
         if len(value) != 1:
             raise BlindError("NETMAP_SOURCE_SHAPE_UNSUPPORTED")
+        return "any-source"
+    # A default route IS "any", however it is spelled. The netmap expresses sources as
+    # CIDRs, so an allow-all filter arrives as 0.0.0.0/0 (and ::/0), never as the
+    # literal "*" the policy side uses -- classifying those as "specific-source" made
+    # the two sides disagree about a rule they both call universal. Found while writing
+    # the test that proves coverage-canonicalisation is wired to the verdict: the
+    # fixture was correct and the classifier was not.
+    if any(source in ("0.0.0.0/0", "::/0") for source in value):
         return "any-source"
     for source in value:
         try:
@@ -371,6 +408,45 @@ def netmap_shapes(netmap: Any) -> set[RuleShape]:
     if not shapes:
         raise BlindError("NETMAP_PACKET_FILTER_EMPTY")
     return shapes
+
+
+def canonical_coverage(shapes: set[RuleShape]) -> frozenset[tuple[str, str, int, int, int]]:
+    """Reduce a set of rule shapes to the ACCESS THEY ACTUALLY GRANT.
+
+    Two filters that permit exactly the same traffic must compare equal, and before
+    this they did not: a policy declaring `db:5432-5433` compared DIVERGED against an
+    enforced pair of `{5432,5432}` and `{5433,5433}` on the same network and protocol
+    — identical coverage, split differently. Same for protocol lists: one rule listing
+    [6, 17] versus two rules listing [6] and [17].
+
+    That is not a cosmetic mismatch. Whether this receptor can EVER report CLEAN after
+    an operator correctly applies policy.hujson would otherwise depend on how tailscaled
+    happens to split ranges and protocol lists — a CLEAN signal that is unstable under
+    the applicator's own normalisation is a CLEAN signal nobody can trust, and a
+    receptor permanently stuck on DIVERGED is one people learn to ignore. Found by
+    blind cross-family refutation (Kimi K3).
+
+    The canonical form splits every shape per-protocol, then merges overlapping and
+    ADJACENT port intervals per (source-class, destination, protocol). Adjacency
+    matters as much as overlap: 5432-5432 and 5433-5433 touch without overlapping.
+    """
+    by_key: dict[tuple[str, str, int], list[tuple[int, int]]] = {}
+    for shape in shapes:
+        for protocol in shape.protocols:
+            by_key.setdefault((shape.source_class, shape.destination, protocol), []).append(
+                (shape.first_port, shape.last_port)
+            )
+    canonical: set[tuple[str, str, int, int, int]] = set()
+    for (source_class, destination, protocol), intervals in by_key.items():
+        merged: list[list[int]] = []
+        for first, last in sorted(intervals):
+            if merged and first <= merged[-1][1] + 1:
+                merged[-1][1] = max(merged[-1][1], last)
+            else:
+                merged.append([first, last])
+        for first, last in merged:
+            canonical.add((source_class, destination, protocol, first, last))
+    return frozenset(canonical)
 
 
 def sanitize_evidence(value: str) -> str:
@@ -514,9 +590,32 @@ def main(argv: list[str] | None = None) -> int:
         enforced = netmap_shapes(netmap)
     except BlindError as error:
         return emit_result(VERDICT_BLIND, fingerprint, reason=str(error))
+    except RecursionError:
+        # Named separately because str() on it is unhelpful and the traceback is huge.
+        return emit_result(VERDICT_BLIND, fingerprint, reason="POLICY_TOO_DEEPLY_NESTED")
+    except Exception as error:  # noqa: BLE001 -- deliberate, see below
+        # ANY unexpected failure is BLIND, never a crash.
+        #
+        # Before this, `main` caught only BlindError, so an unhandled exception left a
+        # traceback on stderr and exited 1 — and exit 1 is DIVERGED. The harness then
+        # filed real, actionable drift for a probe that had determined nothing at all,
+        # with zero evidence lines to explain it. Measured by blind cross-family
+        # refutation (Kimi K3) with a deeply-nested policy: RecursionError, empty
+        # stdout, exit 1, reported as drift.
+        #
+        # A bare `except Exception` is usually a smell; here it is the contract. This
+        # process has exactly three legal answers and "crashed" is not among them, so
+        # every path that is not a determination must land on the one that means "I
+        # could not look". The type name is included so the cause is still findable;
+        # str(error) is NOT, because an exception message is the most likely place for
+        # an address or path to appear and it would then reach a public artifact.
+        return emit_result(VERDICT_BLIND, fingerprint,
+                           reason=f"UNEXPECTED_{type(error).__name__}")
 
     evidence = [describe_shapes("declared", declared), describe_shapes("enforced", enforced)]
-    verdict = VERDICT_CLEAN if declared == enforced else VERDICT_DIVERGED
+    # Compared as COVERAGE, not as rule bookkeeping: see canonical_coverage.
+    verdict = (VERDICT_CLEAN if canonical_coverage(declared) == canonical_coverage(enforced)
+               else VERDICT_DIVERGED)
     return emit_result(verdict, fingerprint, evidence)
 
 

--- a/scripts/tests/fixtures/tailnet_netmap_allow_all_2026_08_11.json
+++ b/scripts/tests/fixtures/tailnet_netmap_allow_all_2026_08_11.json
@@ -1,0 +1,46 @@
+{
+  "_comment": [
+    "SANITIZED recording of this tailnet's ENFORCED packet filter — the allow-all state.",
+    "",
+    "Recorded from `tailscale debug netmap` on Mini, 2026-08-31; the same one-rule",
+    "allow-all shape infra/tailscale/policy.hujson's header records as measured from M5 on",
+    "2026-08-11 and re-confirmed 2026-08-29. The date in this filename is that measurement,",
+    "not the day the file was written.",
+    "",
+    "SANITIZED: the live rule lists 14 source CIDRs, one per tailnet node. Those identify",
+    "devices, and this repo is public, so they are replaced with RFC 5737 documentation",
+    "ranges. Only the SHAPE is load-bearing here — 'several specific sources' vs 'any' —",
+    "and the shape is preserved exactly. Nothing else in the rule identifies anyone:",
+    "0.0.0.0/0 and ::/0 are the destinations, and IPProto 6/17/1/58 is TCP/UDP/ICMPv4/ICMPv6.",
+    "",
+    "What makes this DIVERGED against policy.hujson: every port (0-65535) to the whole",
+    "internet on four protocols, versus the policy's narrow per-service TCP grants."
+  ],
+  "PacketFilter": [
+    {
+      "Srcs": [
+        "192.0.2.1/32",
+        "192.0.2.2/32",
+        "192.0.2.3/32",
+        "198.51.100.1/32",
+        "198.51.100.2/32",
+        "198.51.100.3/32",
+        "203.0.113.1/32",
+        "203.0.113.2/32",
+        "203.0.113.3/32",
+        "203.0.113.4/32",
+        "203.0.113.5/32",
+        "203.0.113.6/32",
+        "203.0.113.7/32",
+        "203.0.113.8/32"
+      ],
+      "SrcCaps": null,
+      "Dsts": [
+        { "Net": "0.0.0.0/0", "Ports": { "First": 0, "Last": 65535 } },
+        { "Net": "::/0", "Ports": { "First": 0, "Last": 65535 } }
+      ],
+      "Caps": [],
+      "IPProto": [6, 17, 1, 58]
+    }
+  ]
+}

--- a/scripts/tests/fixtures/tailnet_netmap_policy_match.json
+++ b/scripts/tests/fixtures/tailnet_netmap_policy_match.json
@@ -1,0 +1,127 @@
+{
+  "_comment": [
+    "SANITIZED structural fixture matching the concrete host grants in infra/tailscale/policy.hujson.",
+    "",
+    "Uses the LIVE PacketFilter schema (Srcs/Dsts/Net/Ports), measured on this fleet",
+    "2026-08-31 \u2014 not the older SrcIPs/DstPorts shape this file originally carried. A",
+    "fixture in a format the real netmap never emits proves the tool against a world that",
+    "does not exist.",
+    "",
+    "Source addresses are RFC 5737 documentation ranges, not node addresses: this repo is",
+    "public, and the comparison classifies a source only as 'specific' vs 'any', so the",
+    "identities were never load-bearing. The DESTINATIONS and PORTS are truthful \u2014 they are",
+    "what makes this fixture match the policy and therefore exercise the CLEAN path.",
+    "The DESTINATION addresses are the three fleet hosts, and they are deliberately NOT sanitized: they are already published in infra/tailscale/policy.hujson and infra/tailscale/README.md, this fixture exists to MATCH that policy, and replacing them would break the very comparison the CLEAN path is meant to exercise. The tool's own OUTPUT still never carries them \u2014 evidence says 'specific-destination', never an address."
+  ],
+  "PacketFilter": [
+    {
+      "Srcs": ["192.0.2.10/32"],
+      "SrcCaps": null,
+      "Dsts": [
+        {
+          "Net": "100.93.236.6/32",
+          "Ports": {
+            "First": 22,
+            "Last": 22
+          }
+        },
+        {
+          "Net": "100.93.236.6/32",
+          "Ports": {
+            "First": 6379,
+            "Last": 6379
+          }
+        },
+        {
+          "Net": "100.93.236.6/32",
+          "Ports": {
+            "First": 11434,
+            "Last": 11434
+          }
+        },
+        {
+          "Net": "100.93.236.6/32",
+          "Ports": {
+            "First": 8990,
+            "Last": 8990
+          }
+        },
+        {
+          "Net": "100.110.186.116/32",
+          "Ports": {
+            "First": 22,
+            "Last": 22
+          }
+        }
+      ],
+      "Caps": [],
+      "IPProto": [6]
+    },
+    {
+      "Srcs": ["198.51.100.10/32"],
+      "SrcCaps": null,
+      "Dsts": [
+        {
+          "Net": "100.107.22.111/32",
+          "Ports": {
+            "First": 22,
+            "Last": 22
+          }
+        }
+      ],
+      "Caps": [],
+      "IPProto": [6]
+    },
+    {
+      "Srcs": ["203.0.113.10/32"],
+      "SrcCaps": null,
+      "Dsts": [
+        {
+          "Net": "100.107.22.111/32",
+          "Ports": {
+            "First": 22,
+            "Last": 22
+          }
+        },
+        {
+          "Net": "100.107.22.111/32",
+          "Ports": {
+            "First": 443,
+            "Last": 443
+          }
+        },
+        {
+          "Net": "100.93.236.6/32",
+          "Ports": {
+            "First": 22,
+            "Last": 22
+          }
+        },
+        {
+          "Net": "100.93.236.6/32",
+          "Ports": {
+            "First": 4317,
+            "Last": 4317
+          }
+        }
+      ],
+      "Caps": [],
+      "IPProto": [6]
+    },
+    {
+      "Srcs": ["192.0.2.10/32"],
+      "SrcCaps": null,
+      "Dsts": [
+        {
+          "Net": "100.107.22.111/32",
+          "Ports": {
+            "First": 443,
+            "Last": 443
+          }
+        }
+      ],
+      "Caps": [],
+      "IPProto": [6]
+    }
+  ]
+}

--- a/scripts/tests/test_proprioception_tri_state_exit.py
+++ b/scripts/tests/test_proprioception_tri_state_exit.py
@@ -1,0 +1,147 @@
+"""Tests for proprioception.py's `parse: "tri_state_exit"` wrap parser (L13-PR2).
+
+WHY THIS PARSE MODE EXISTS. `parse: "exit_code"` maps EVERY non-zero exit to DIVERGED.
+That is right for a two-state tool ("clean" / "not clean"), and wrong for a receptor
+that distinguishes three answers:
+
+    0  CLEAN     I looked, and they match.
+    1  DIVERGED  I looked, and they differ.
+    2  BLIND     I could not look at all.
+
+Filing BLIND as DIVERGED is worse than it first sounds. The two have OPPOSITE remedies:
+DIVERGED needs the declared policy applied, BLIND needs an operator to restore
+visibility. Collapsing them sends a healer to reconcile a difference nobody has
+observed, and makes "we cannot see the enforced state" indistinguishable from "we can
+see it and it is wrong". `scripts/tailnet_policy_drift.py` is the first such probe: on
+this fleet the tailnet is allow-all and `policy.hujson` is proposed-not-applied, so its
+honest answers are DIVERGED (policy unapplied) or BLIND (no readable netmap) — never
+CLEAN. Reporting BLIND as drift would have made the receptor look like it had measured
+something it never saw.
+
+Each test names the mutation it would survive, because a parser test that only asserts
+the happy mapping is satisfied by a parser that ignores rc entirely.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "proprioception.py"
+_spec = importlib.util.spec_from_file_location("proprioception", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+prop = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prop)  # type: ignore[union-attr]
+
+
+def _entry() -> dict:
+    return {
+        "id": "probe_under_test",
+        "type": "wrap",
+        "target": ["python3", "{repo}/scripts/tailnet_policy_drift.py"],
+        "parse": "tri_state_exit",
+    }
+
+
+def _run(rc: int, out: str, err: str = "", monkeypatch=None) -> tuple[str, int, list[str]]:
+    """Drive run_wrap with a stubbed subprocess so the mapping is exercised without
+    needing the real probe on disk (and without a network call, ever)."""
+    entry = _entry()
+
+    def fake_sh(argv, timeout=None, cwd=None):  # noqa: ARG001
+        return rc, out, err
+
+    original_sh = prop.sh
+    original_exists = Path.exists
+    prop.sh = fake_sh  # type: ignore[assignment]
+    Path.exists = lambda self: True  # type: ignore[method-assign]
+    try:
+        return prop.run_wrap(Path("/repo"), entry, timeout=5)
+    finally:
+        prop.sh = original_sh  # type: ignore[assignment]
+        Path.exists = original_exists  # type: ignore[method-assign]
+
+
+# ------------------------------------------------------------------ the three states
+
+def test_exit_zero_is_reconciled() -> None:
+    """Mutation it survives: a parser that returns DIVERGED unconditionally."""
+    status, n, _ = _run(0, json.dumps({"verdict": "CLEAN", "evidence": []}))
+    assert status == prop.RECONCILED
+    assert n == 0
+
+
+def test_exit_one_is_diverged_and_carries_the_probe_evidence() -> None:
+    """Mutation it survives: a parser that drops the body and reports a bare count."""
+    body = json.dumps({"verdict": "DIVERGED",
+                       "evidence": ["1 rule: any-source -> 0.0.0.0/0 ports 0-65535"]})
+    status, n, ev = _run(1, body)
+    assert status == prop.DIVERGED
+    assert n == 1
+    assert any("0-65535" in e for e in ev)
+
+
+def test_exit_two_is_unprobeable_not_diverged() -> None:
+    """THE POINT OF THIS PARSE MODE. Under `parse: exit_code` this same input returns
+    DIVERGED — the collapse this mode exists to prevent. Mutation it survives: routing
+    rc==2 through _parse_exit_code."""
+    body = json.dumps({"verdict": "BLIND", "reason": "tailscale CLI not present"})
+    status, n, ev = _run(2, body)
+    assert status == prop.UNPROBEABLE
+    assert status != prop.DIVERGED
+    assert n == 0
+    assert any("tailscale CLI not present" in e for e in ev)
+
+    # And the contrast is real, not asserted: the OLD parser genuinely disagrees.
+    old_status, _, _ = prop._parse_exit_code(2, body, "")
+    assert old_status == prop.DIVERGED
+
+
+# ------------------------------------------------------- the exit code stays authoritative
+
+def test_unparseable_body_does_not_override_the_exit_code() -> None:
+    """A tri-state probe's verdict lives in its EXIT CODE. If a malformed body could
+    turn a known verdict into UNPROBEABLE, the mode would hand its meaning back to the
+    schema it was chosen to be independent of. Detail may be lost; the verdict may not.
+    Mutation it survives: parsing JSON before the rc branch (the shape this parser
+    originally had, corrected during review)."""
+    status, _, _ = _run(1, "this is not json at all")
+    assert status == prop.DIVERGED
+
+    status, _, _ = _run(0, "")
+    assert status == prop.RECONCILED
+
+    status, _, ev = _run(2, "<html>gateway error</html>")
+    assert status == prop.UNPROBEABLE
+    assert ev  # still says something, even with no parseable body
+
+
+def test_unexpected_exit_code_is_unprobeable_never_diverged() -> None:
+    """A tool that promised three states and returned a fourth has drifted from its
+    contract, and schema drift must not normalize into a verdict — the same rule
+    findings_list already follows. Mutation it survives: a final `else: DIVERGED`."""
+    status, n, ev = _run(3, json.dumps({"verdict": "???"}))
+    assert status == prop.UNPROBEABLE
+    assert status != prop.DIVERGED
+    assert n == 0
+    assert any("unexpected exit 3" in e for e in ev)
+
+
+def test_blind_never_reports_as_clean() -> None:
+    """The fail-safe polarity, stated as its own case because it is the one property a
+    security receptor may never lose: no BLIND input may resolve to RECONCILED."""
+    for body in ("", "null", "not json", json.dumps({"verdict": "BLIND"}),
+                 json.dumps({"verdict": "CLEAN"})):
+        status, _, _ = _run(2, body)
+        assert status == prop.UNPROBEABLE, f"BLIND body {body!r} resolved to {status}"
+        assert status != prop.RECONCILED
+
+
+# ------------------------------------------------------------------ registry integrity
+
+def test_selftest_still_passes_with_the_new_mode_registered() -> None:
+    """The registry validator must accept the new entry; a parse mode the validator
+    rejects would be dead on arrival."""
+    errs = prop.validate_registry(prop.DEFAULT_REGISTRY)
+    assert errs == [], errs

--- a/scripts/tests/test_proprioception_tri_state_exit.py
+++ b/scripts/tests/test_proprioception_tri_state_exit.py
@@ -117,6 +117,33 @@ def test_unparseable_body_does_not_override_the_exit_code() -> None:
     assert ev  # still says something, even with no parseable body
 
 
+def test_a_string_evidence_body_is_not_iterated_as_characters() -> None:
+    """`evidence` must be a LIST. Iterating a string yields its characters: measured,
+    {"evidence": "100.107.22.111"} produced 5 "findings" — ['1','0','0','.','1'] — a
+    count and a body that are both nonsense, plus a fragment of an address in the
+    report. Mutation it survives: dropping the isinstance(list) check."""
+    status, n, ev = _run(1, json.dumps({"verdict": "DIVERGED", "evidence": "100.107.22.111"}))
+    assert status == prop.DIVERGED
+    assert ev == [], ev
+    assert n == 1, "a DIVERGED verdict with no legible evidence is one unexplained finding"
+
+
+def test_exit_zero_with_a_contradicting_body_is_unprobeable() -> None:
+    """The exit code is authoritative, but a body that CONTRADICTS it means the probe
+    has not agreed with itself. Filing that as RECONCILED is green-over-an-unknown,
+    the exact thing this parse mode exists to prevent — and the symmetry was enforced
+    in one direction only (rc=2 with a CLEAN body was tested; rc=0 with a BLIND body
+    was not)."""
+    status, _, ev = _run(0, json.dumps({"verdict": "BLIND", "reason": "no netmap"}))
+    assert status == prop.UNPROBEABLE
+    assert status != prop.RECONCILED
+    assert any("disagree" in e for e in ev), ev
+
+    # An agreeing body, or no body at all, still reconciles.
+    assert _run(0, json.dumps({"verdict": "CLEAN"}))[0] == prop.RECONCILED
+    assert _run(0, "")[0] == prop.RECONCILED
+
+
 def test_unexpected_exit_code_is_unprobeable_never_diverged() -> None:
     """A tool that promised three states and returned a fourth has drifted from its
     contract, and schema drift must not normalize into a verdict — the same rule

--- a/scripts/tests/test_tailnet_policy_drift.py
+++ b/scripts/tests/test_tailnet_policy_drift.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "tailnet_policy_drift.py"
+POLICY = REPO_ROOT / "infra" / "tailscale" / "policy.hujson"
+FIXTURES = Path(__file__).parent / "fixtures"
+ALLOW_ALL = FIXTURES / "tailnet_netmap_allow_all_2026_08_11.json"
+POLICY_MATCH = FIXTURES / "tailnet_netmap_policy_match.json"
+
+
+def run_tool(*arguments: str) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--policy", str(POLICY), *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    return completed, json.loads(completed.stdout)
+
+
+def load_module() -> object:
+    spec = importlib.util.spec_from_file_location("tailnet_policy_drift", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_guilt_allow_all_diverges_from_declared_policy() -> None:
+    completed, output = run_tool("--netmap-fixture", str(ALLOW_ALL))
+
+    assert completed.returncode == 1
+    assert output["verdict"] == "DIVERGED"
+
+
+def test_innocence_matching_filter_is_clean() -> None:
+    completed, output = run_tool("--netmap-fixture", str(POLICY_MATCH), "--json")
+
+    assert completed.returncode == 0
+    assert output["verdict"] == "CLEAN"
+
+
+def test_blind_for_unreadable_fixture_never_claims_clean(tmp_path: Path) -> None:
+    completed, output = run_tool("--netmap-fixture", str(tmp_path / "missing-netmap.json"))
+
+    assert completed.returncode == 2
+    assert output["verdict"] == "BLIND"
+    assert output["verdict"] != "CLEAN"
+
+
+def test_blind_for_valid_json_with_wrong_netmap_schema(tmp_path: Path) -> None:
+    fixture = tmp_path / "wrong-schema.json"
+    fixture.write_text('{"PacketFilter": {}}', encoding="utf-8")
+
+    completed, output = run_tool("--netmap-fixture", str(fixture))
+
+    assert completed.returncode == 2
+    assert output["verdict"] == "BLIND"
+
+
+def test_blind_for_non_json_netmap(tmp_path: Path) -> None:
+    fixture = tmp_path / "not-json.json"
+    fixture.write_text("not JSON", encoding="utf-8")
+
+    completed, output = run_tool("--netmap-fixture", str(fixture))
+
+    assert completed.returncode == 2
+    assert output["verdict"] == "BLIND"
+
+
+def test_hujson_parser_preserves_double_slash_inside_string() -> None:
+    module = load_module()
+    parsed = module.parse_hujson('{"url":"https://example.test/a//b", // a comment\n "items":[1,],}')
+
+    assert parsed["url"] == "https://example.test/a//b"
+    assert parsed["items"] == [1]
+
+
+def test_hujson_stripper_handles_an_ESCAPED_quote_inside_a_string() -> None:
+    """The escape branch was unreachable: it compared a one-character slice against
+    "\\\\", a TWO-character literal, so `escaped` was never set. An escaped quote then
+    ended the string early and the remainder was re-scanned as structure — the `//`
+    inside this string was eaten as a comment and the document truncated.
+
+    Measured before the fix, this exact input raised
+    JSONDecodeError("Unterminated string"). It fails toward BLIND rather than CLEAN, so
+    it was never a security hole, but a receptor that goes blind on a valid policy has
+    lost the same visibility by a slower route.
+
+    The sibling test below covers an UNESCAPED `//` inside a string and passed
+    throughout — which is why this one is separate: the two look like the same case and
+    only one of them was ever broken.
+    """
+    module = load_module()
+    parsed = module.parse_hujson('{"a": "he said \\" // not a comment", "b": 1}')
+
+    assert parsed["a"] == 'he said " // not a comment'
+    assert parsed["b"] == 1
+
+
+def test_output_redacts_ip_and_email_from_evidence() -> None:
+    command = (
+        "import importlib.util,sys; "
+        f"spec=importlib.util.spec_from_file_location('drift',{str(SCRIPT)!r}); "
+        "module=importlib.util.module_from_spec(spec); sys.modules[spec.name]=module; spec.loader.exec_module(module); "
+        "module.emit_result('CLEAN','0123456789abcdef',['contact owner@example.com at 203.0.113.7'])"
+    )
+    completed = subprocess.run([sys.executable, "-c", command], capture_output=True, check=False, text=True)
+
+    assert completed.returncode == 0
+    assert "owner@example.com" not in completed.stdout
+    assert "203.0.113.7" not in completed.stdout
+    assert json.loads(completed.stdout)["evidence"] == ["redacted-sensitive-evidence"]
+
+
+def test_both_packet_filter_schemas_parse_to_the_same_shapes(tmp_path: Path) -> None:
+    """The LIVE schema is Srcs/Dsts (measured on this fleet 2026-08-31); the older one is
+    SrcIPs/DstPorts. The first version of this tool understood only the older one, so it
+    answered BLIND on every real node while its fixtures encoded a format the netmap
+    never emits — a corpus proving the tool against a world that does not exist.
+
+    Both must reduce to identical rule shapes, or the two paths are not the same probe.
+    """
+    module = load_module()
+    live = {"PacketFilter": [{"Srcs": ["192.0.2.1/32"], "SrcCaps": None,
+                              "Dsts": [{"Net": "0.0.0.0/0",
+                                        "Ports": {"First": 0, "Last": 65535}}],
+                              "Caps": [], "IPProto": [6, 17]}]}
+    legacy = {"PacketFilter": [{"SrcIPs": ["192.0.2.1/32"],
+                                "DstPorts": [{"IP": "0.0.0.0/0", "Bits": None,
+                                              "Ports": {"First": 0, "Last": 65535}}],
+                                "IPProto": [6, 17]}]}
+
+    assert module.netmap_shapes(live) == module.netmap_shapes(legacy)
+
+
+def test_the_guilt_fixture_uses_the_LIVE_schema(tmp_path: Path) -> None:
+    """Pins the fixture to the format the fleet actually speaks. Without this the fixture
+    can silently drift back to a shape no real netmap produces, and every other case here
+    would stay green while proving nothing about a live node."""
+    fixture = json.loads(ALLOW_ALL.read_text())
+    rule = fixture["PacketFilter"][0]
+
+    assert "Srcs" in rule and "Dsts" in rule, "guilt fixture must use the live schema"
+    assert "Net" in rule["Dsts"][0]
+
+
+def test_no_tailnet_node_address_appears_in_any_tool_output() -> None:
+    """The tool's evidence describes rule SHAPE, never identity. The fixtures necessarily
+    contain the fleet's own host addresses (they are already published in policy.hujson
+    and are what makes the CLEAN comparison meaningful) — so the property that matters is
+    that none of them reach the OUTPUT."""
+    for fixture in (ALLOW_ALL, POLICY_MATCH):
+        completed, _ = run_tool("--netmap-fixture", str(fixture))
+        combined = completed.stdout + completed.stderr
+        assert not re.search(r"\b100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+", combined), \
+            f"a tailnet-range address reached the output for {fixture.name}"
+
+
+def test_policy_fingerprint_is_stable_and_changes_with_policy_content(tmp_path: Path) -> None:
+    first, first_output = run_tool("--netmap-fixture", str(POLICY_MATCH))
+    second, second_output = run_tool("--netmap-fixture", str(POLICY_MATCH))
+    changed_policy = tmp_path / "changed-policy.hujson"
+    changed_policy.write_text(POLICY.read_text(encoding="utf-8").replace('"proto":  "tcp"', '"proto":  "udp"', 1), encoding="utf-8")
+    changed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--policy", str(changed_policy), "--netmap-fixture", str(POLICY_MATCH)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    changed_output = json.loads(changed.stdout)
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert first_output["policy_fingerprint"] == second_output["policy_fingerprint"]
+    assert changed_output["policy_fingerprint"] != first_output["policy_fingerprint"]

--- a/scripts/tests/test_tailnet_policy_drift.py
+++ b/scripts/tests/test_tailnet_policy_drift.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import pytest
 import re
+import tempfile
 import subprocess
 import sys
 from pathlib import Path
@@ -273,6 +274,140 @@ def test_a_blind_reason_carrying_an_address_is_redacted() -> None:
 
     assert "100.107.22.111" not in completed.stdout
     assert json.loads(completed.stdout)["reason"] == "redacted-sensitive-evidence"
+
+
+def test_an_unexpected_crash_is_BLIND_not_DIVERGED() -> None:
+    """`main` caught only BlindError, so any other exception exited 1 — and exit 1 IS
+    DIVERGED. The harness then filed real, actionable drift for a probe that had
+    determined nothing, with zero evidence to explain it. A crash is not a finding."""
+    deep = '{"hosts":{"db":"10.0.0.1"},"acls":' + "[" * 400 + "]" * 400 + "}"
+    policy = Path(tempfile.mkstemp(suffix=".hujson")[1])
+    policy.write_text(deep, encoding="utf-8")
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--policy", str(policy),
+             "--netmap-fixture", str(ALLOW_ALL)],
+            capture_output=True, check=False, text=True)
+        assert completed.returncode == 2, completed.stderr[:400]
+        assert json.loads(completed.stdout)["verdict"] == "BLIND"
+        assert "Traceback" not in completed.stderr
+    finally:
+        policy.unlink(missing_ok=True)
+
+
+def test_any_unexpected_exception_is_BLIND_and_leaks_no_message(capsys, monkeypatch) -> None:
+    """The RecursionError case above exercises a NAMED clause. This one exercises the
+    generic backstop, which is the whole point of it: every malformed policy I could
+    craft is already caught as BlindError (the validation is thorough), so the only
+    honest way to reach the backstop is to force an exception it was never told about.
+
+    Also pins that `str(error)` is NOT emitted: an exception message is the likeliest
+    place for an address or a filesystem path to appear, and this output lands in a
+    public repo. The type name is enough to find the cause.
+    """
+    module = load_module()
+
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("boom /Users/someone/secret-path 100.107.22.111")
+
+    monkeypatch.setattr(module, "policy_shapes", explode)
+    status = module.main(["--policy", str(POLICY), "--netmap-fixture", str(ALLOW_ALL)])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert status == 2
+    assert payload["verdict"] == "BLIND"
+    assert payload["reason"] == "UNEXPECTED_RuntimeError"
+    assert "boom" not in json.dumps(payload)
+    assert "100.107.22.111" not in json.dumps(payload)
+
+
+def test_coverage_canonicalisation_is_actually_WIRED_to_the_verdict(tmp_path: Path) -> None:
+    """The unit test above proves canonical_coverage() computes the right thing; this
+    one proves main() USES it. Reverting the call site to a raw set comparison left
+    every other case green — a fix that is correct and unreachable is not a fix."""
+    policy = tmp_path / "split.hujson"
+    policy.write_text(
+        '{"hosts":{"db":"10.1.0.0/24"},'
+        '"acls":[{"action":"accept","proto":"tcp","src":["*"],"dst":["db:5432-5433"]}]}',
+        encoding="utf-8")
+    netmap = tmp_path / "split-netmap.json"
+    netmap.write_text(json.dumps({"PacketFilter": [{
+        "Srcs": ["0.0.0.0/0"], "SrcCaps": None, "Caps": [], "IPProto": [6],
+        "Dsts": [{"Net": "10.1.0.0/24", "Ports": {"First": 5432, "Last": 5432}},
+                 {"Net": "10.1.0.0/24", "Ports": {"First": 5433, "Last": 5433}}]}]}),
+        encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--policy", str(policy),
+         "--netmap-fixture", str(netmap)],
+        capture_output=True, check=False, text=True)
+
+    assert completed.returncode == 0, completed.stdout
+    assert json.loads(completed.stdout)["verdict"] == "CLEAN"
+
+
+def test_star_destination_resolves_instead_of_going_blind(tmp_path: Path) -> None:
+    """`*:*` is the commonest ACL spelling and it is unambiguous. Treating it as an
+    unknown host alias made the tool answer BLIND on a fully readable, VALID policy —
+    and made the registry's fix_hint ("BLIND means the enforced state could not be
+    read") false, because the cause was a tool-side gap, not lost visibility."""
+    policy = tmp_path / "star.hujson"
+    policy.write_text(
+        '{"hosts":{"db":"10.1.0.0/24"},'
+        '"acls":[{"action":"accept","proto":"tcp","src":["*"],"dst":["*:*"]}]}',
+        encoding="utf-8")
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--policy", str(policy),
+         "--netmap-fixture", str(ALLOW_ALL)],
+        capture_output=True, check=False, text=True)
+
+    assert completed.returncode != 2, "a resolvable policy must not be BLIND"
+    assert json.loads(completed.stdout)["verdict"] in ("CLEAN", "DIVERGED")
+
+
+def test_a_broad_source_is_not_called_specific() -> None:
+    """The comparison is source-blind by construction, but the one source signal it DOES
+    carry must not point the wrong way: `autogroup:member` is every user device on the
+    tailnet, and calling that "specific-source" let a tailnet-wide grant read like a
+    single named host."""
+    module = load_module()
+    assert module._source_class(["autogroup:member"]) == "broad-source"
+    assert module._source_class(["group:eng"]) == "broad-source"
+    assert module._source_class(["100.64.0.1"]) == "specific-source"
+    assert module._source_class(["*"]) == "any-source"
+
+
+def test_a_comment_is_whitespace_not_nothing() -> None:
+    """Deleting a comment outright concatenates the tokens on either side: `{"a": 1/**/2}`
+    became `{"a": 12}`, which parses cleanly as a DIFFERENT document with a different
+    value and a different fingerprint. Invalid input must cost visibility, never be
+    silently reinterpreted into a valid document."""
+    module = load_module()
+    assert module.strip_hujson('{"a": 1/**/2}') == '{"a": 1 2}'
+    with pytest.raises(module.BlindError):
+        module.parse_hujson('{"a": 1/**/2}')
+
+
+def test_identical_coverage_split_differently_is_CLEAN_not_DIVERGED() -> None:
+    """Whether this receptor can EVER report CLEAN after an operator applies the policy
+    must not depend on how tailscaled happens to split port ranges and protocol lists.
+    A CLEAN signal unstable under the applicator's own normalisation is one nobody can
+    trust; a receptor permanently stuck on DIVERGED is one people learn to ignore."""
+    module = load_module()
+    shape = module.RuleShape
+    one_range = {shape("specific-source", "10.1.0.0/24", 5432, 5433, (6,))}
+    split_range = {shape("specific-source", "10.1.0.0/24", 5432, 5432, (6,)),
+                   shape("specific-source", "10.1.0.0/24", 5433, 5433, (6,))}
+    one_proto = {shape("specific-source", "10.1.0.0/24", 22, 22, (6, 17))}
+    split_proto = {shape("specific-source", "10.1.0.0/24", 22, 22, (6,)),
+                   shape("specific-source", "10.1.0.0/24", 22, 22, (17,))}
+    with_gap = {shape("specific-source", "10.1.0.0/24", 5432, 5432, (6,)),
+                shape("specific-source", "10.1.0.0/24", 5435, 5435, (6,))}
+
+    assert module.canonical_coverage(one_range) == module.canonical_coverage(split_range)
+    assert module.canonical_coverage(one_proto) == module.canonical_coverage(split_proto)
+    # ...and a real GAP must still differ, or the merge has erased a difference.
+    assert module.canonical_coverage(one_range) != module.canonical_coverage(with_gap)
 
 
 def test_policy_fingerprint_is_stable_and_changes_with_policy_content(tmp_path: Path) -> None:

--- a/scripts/tests/test_tailnet_policy_drift.py
+++ b/scripts/tests/test_tailnet_policy_drift.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import pytest
 import re
 import subprocess
 import sys
@@ -164,6 +165,114 @@ def test_no_tailnet_node_address_appears_in_any_tool_output() -> None:
         combined = completed.stdout + completed.stderr
         assert not re.search(r"\b100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+", combined), \
             f"a tailnet-range address reached the output for {fixture.name}"
+
+
+def test_old_schema_Bits_is_authoritative_when_the_address_has_no_prefix() -> None:
+    """`Bits` was validated and then DISCARDED, under a comment claiming the address
+    string already carried the prefix. True for `Net` (a CIDR); false for the old
+    schema's `IP`, a bare address whose prefix lives only in `Bits`.
+
+    Measured before the fix: {"IP": "10.0.0.1", "Bits": 8} yielded 10.0.0.1/32 instead
+    of 10.0.0.0/8 — silently NARROWER, and narrowing an enforced grant is the direction
+    that can make a broad reality compare equal to a narrow declaration and read CLEAN.
+    """
+    module = load_module()
+    shapes = module.netmap_shapes({"PacketFilter": [{
+        "SrcIPs": ["192.0.2.1/32"],
+        "DstPorts": [{"IP": "10.0.0.1", "Bits": 8, "Ports": {"First": 0, "Last": 65535}}],
+        "IPProto": [6]}]})
+
+    assert {shape.destination for shape in shapes} == {"10.0.0.0/8"}
+
+
+def test_a_prefix_that_contradicts_Bits_is_BLIND_not_a_silent_pick() -> None:
+    """Two sources of the same fact that disagree are a way to be wrong twice. When the
+    CIDR says /24 and Bits says 8, refusing to choose is the only answer consistent with
+    this tool's polarity: uncertainty costs visibility, never correctness."""
+    module = load_module()
+    with pytest.raises(module.BlindError):
+        module.netmap_shapes({"PacketFilter": [{
+            "Srcs": ["192.0.2.1/32"],
+            "Dsts": [{"Net": "10.0.0.0/24", "Bits": 8, "Ports": {"First": 0, "Last": 65535}}],
+            "IPProto": [6]}]})
+
+
+def test_every_verdict_declares_what_it_did_NOT_compare() -> None:
+    """The known limit must travel with the verdict, CLEAN most of all.
+
+    Blind cross-family refutation (Kimi K3) showed the comparison is satisfied when
+    EVERY source is swapped for a node that should hold no grant: policy.hujson grants
+    by identity, the netmap has already resolved identities to addresses, and mapping
+    one to the other would need the node<->identity table this tool must never hold.
+    That limit is real and is not closable here — so it is declared on every result
+    rather than left in a docstring. A reader who takes CLEAN to mean "the right nodes
+    have the right access" would be wrong, and the output now says so itself.
+    """
+    for fixture in (ALLOW_ALL, POLICY_MATCH):
+        _, payload = run_tool("--netmap-fixture", str(fixture))
+        scope = payload.get("comparison_scope", "")
+        assert "SOURCE IDENTITY IS NOT COMPARED" in scope, payload
+
+
+def test_the_known_source_blindness_is_reproducible_and_documented() -> None:
+    """Pins the limitation itself, so a future change that silently NARROWS the
+    comparison (making this pass for the wrong reason) or one that finally closes it
+    both show up here rather than passing unnoticed."""
+    module = load_module()
+    fixture = json.loads(POLICY_MATCH.read_text())
+    for rule in fixture["PacketFilter"]:
+        rule["Srcs"] = ["198.51.100.254/32"]   # a node with no such grant
+
+    declared = module.policy_shapes(module.parse_hujson(POLICY.read_text()))
+    enforced = module.netmap_shapes(fixture)
+
+    assert declared == enforced, (
+        "source identity is now being compared — good, but COMPARISON_SCOPE and this "
+        "test must be updated together so the declared limit stops overstating itself"
+    )
+
+
+def test_redaction_covers_ipv6_magicdns_and_the_blind_reason() -> None:
+    """The redactor was IPv4-and-email only. That is blind to HALF of every node's
+    identity here — a Tailscale netmap carries addresses in fd7a:115c:a1e0::/48 — and
+    to node NAMES entirely, which the spec forbids in output by name. `reason` was not
+    sanitised at all, and the proprioception harness forwards it into its own report,
+    so anything interpolated there would have travelled one hop further than the
+    person adding it was looking. Found by blind cross-family refutation (Kimi K3).
+
+    Declared limit, kept deliberately: a BARE hostname with no domain is not matched.
+    Widening the pattern until it catches those would also eat `policy.hujson` and
+    `0-65535` and turn every evidence line into "redacted".
+    """
+    module = load_module()
+
+    for leak in ("node fd7a:115c:a1e0::1 replied",
+                 "node nuzantara.tail461666.ts.net replied",
+                 "contact owner@example.com at 203.0.113.7"):
+        assert module.sanitize_evidence(leak) == "redacted-sensitive-evidence", leak
+
+    # ...and the real evidence lines must survive, or the redactor has eaten its output.
+    for keep in ("declared: 8 rule-shapes (specific-source -> specific-destination; "
+                 "ports: 22,443,4317,6379,8990,11434; protocols: tcp)",
+                 "enforced: 1 rule-shapes (any-source -> internet-any; ports: all)"):
+        assert module.sanitize_evidence(keep) == keep, keep
+
+
+def test_a_blind_reason_carrying_an_address_is_redacted() -> None:
+    """`reason` travels into the proprioception report, so it needs the same treatment
+    as evidence. Exercised through the real process, so it is the shipped path."""
+    command = (
+        "import importlib.util,sys; "
+        f"spec=importlib.util.spec_from_file_location('drift',{str(SCRIPT)!r}); "
+        "m=importlib.util.module_from_spec(spec); sys.modules[spec.name]=m; "
+        "spec.loader.exec_module(m); "
+        "m.emit_result('BLIND','0123456789abcdef',[],'could not reach 100.107.22.111')"
+    )
+    completed = subprocess.run([sys.executable, "-c", command],
+                               capture_output=True, check=False, text=True)
+
+    assert "100.107.22.111" not in completed.stdout
+    assert json.loads(completed.stdout)["reason"] == "redacted-sensitive-evidence"
 
 
 def test_policy_fingerprint_is_stable_and_changes_with_policy_content(tmp_path: Path) -> None:


### PR DESCRIPTION
L13-PR2 of the beyond-SOTA craft wave (squad F′, ledger #5318). A read-only receptor that asks whether the tailnet policy this repo **declares** is the policy the node actually **enforces** — plus a tri-state parse mode so "I could not look" stops being filed as "I looked and they differ".

**Bites:** `.github/workflows/check-tailnet-acl.yml` (extended, same domain — not a fourth workflow) runs the receptor corpus, both proprioception corpora, and asserts the receptor is *registered* with `parse: tri_state_exit`. A registry entry the validator rejects is a receptor that never runs.

**PROVE-LIVE, on Mini, against the node's real enforced state:**

```
exit 1  DIVERGED
declared: 8 rule-shapes (specific-source -> specific-destination; ports: 22,443,4317,6379,8990,11434; protocols: tcp)
enforced: 2 rule-shapes (specific-source -> specific-destination; ports: all; protocols: icmp,tcp,udp,protocol-58)
```

That is the allow-all tailnet `policy.hujson`'s own header records — detected with **no node name, address or identity in the output**. DIVERGED is the *correct* answer and no session can clear it: applying the policy is `operator[GUI]` in the admin console, because the fleet holds no Tailscale API token. The receptor exists to keep that gap visible and dated.

## Why the parse mode

`proprioception.py`'s `parse: exit_code` maps **every** non-zero to DIVERGED. For a probe answering 0/1/2 that files BLIND as observed drift — and the two have **opposite remedies**: DIVERGED needs the policy applied, BLIND needs an operator to restore visibility. Collapsing them sends a healer to reconcile a difference nobody saw. One case proves the contrast is *real* rather than claimed: it feeds the same BLIND input to the old parser and asserts it genuinely answers DIVERGED.

## Seven defects found before merge, each reproduced first

**Kimi K3** (blind, non-Anthropic — it did not review, it *reconstructed the script in a scratch dir and ran a battery against it*):

1. **`Bits` was validated then discarded.** True that `Net` carries its own prefix; false for the old schema's `IP`, a bare address whose prefix lives only in `Bits`. Measured: `{"IP":"10.0.0.1","Bits":8}` → `10.0.0.1/32` instead of `10.0.0.0/8` — silently **narrower**, and narrowing an enforced grant is the direction that makes a broad reality compare equal to a narrow declaration and read CLEAN. When the two disagree the answer is now BLIND, not a silent pick.
2. **False CLEAN by source erasure.** Reproduced at full strength: replace **every** source in the matching fixture with a node that should hold no grant at all, and the comparison still reports equal. **Not closable here, and I did not fake a fix** — `policy.hujson` grants by *identity* while the netmap has already *resolved* identities to addresses, and bridging them needs the node↔identity table this tool must never hold. So a `comparison_scope` field now travels with **every** verdict, CLEAN especially, and a test pins the limitation so that closing it later — or silently narrowing the comparison so it merely *looks* closed — both surface.
3. **The redactor was IPv4-and-email only.** A Tailscale netmap carries `fd7a:115c:a1e0::/48` addresses, so it was blind to half of every node's identity — and to node **names** entirely, which the spec forbids by name. Added IPv6 + MagicDNS. Declared limit kept: a bare hostname with no domain is unmatched, because widening further would eat `policy.hujson` and turn every evidence line into "redacted".
4. **`reason` was not sanitized**, and proprioception forwards it into its own report — so an address interpolated there would travel one hop further than the person adding it was looking. Every reason emitted today is a constant, which is exactly why it was easy to miss.

**This gate:**

5. **The HuJSON stripper's escape branch was unreachable** — it compared a one-character slice against a *two*-character literal, so an escaped quote ended the string early and the remainder was re-scanned as structure. It failed toward BLIND rather than CLEAN, so never a security hole, but a receptor blind on a **valid** policy loses the same visibility by a slower route. The corpus already covered an *unescaped* `//` inside a string and passed throughout — the two look identical and only one was broken, which is why they are separate cases.
6. **The tool parsed a schema this tailnet does not emit.** Measured with `tailscale debug netmap`: the live rule carries `Srcs`/`Dsts`/`Net`/`Ports`, not `SrcIPs`/`DstPorts`. It behaved correctly in the way that matters — BLIND rather than a guess — but was blind on **every real node**, while both fixtures encoded a format no netmap produces. Both schemas are accepted now, and both fixtures were rewritten in the live shape.
7. **My own `tri_state_exit` parsed the JSON body before branching on the exit code**, so a malformed body could turn a known verdict into UNPROBEABLE — handing the mode's meaning back to the schema it exists to be independent of. The exit code is authoritative now.

## Sanitization of the fixtures

The guilt fixture's 14 source CIDRs are RFC 5737 documentation ranges: only "several specific sources" vs "any" is load-bearing, and this repo is public. The **destinations** are deliberately *not* sanitized — they are already published in `policy.hujson` and `infra/tailscale/README.md`, and changing them would break the very comparison the CLEAN path exists to exercise. The tool's own output never carries them regardless: evidence says `specific-destination`, never an address.

## Gates, run this turn

| Gate | Result |
|---|---|
| `test_tailnet_policy_drift.py` | **18/18**, 7 mutants killed |
| `test_proprioception_tri_state_exit.py` + the pre-existing `run_wrap_exit_code` suite | **17/17** |
| `test_tailnet_acl_deny_by_default.py` (the guard this workflow already ran) | 44/44, unaffected |
| `proprioception.py --selftest` | registry valid, 14 probes |
| `actionlint` 1.7.12 · timeout floor · watcher coverage | clean |
| `evidence_pack_lint.py`, in CI's staging layout | clean — Gear 3, real journal |

## Notes

- **Auto-merge deliberately NOT armed** — workflow-class diff; gates-green evidence goes to #5318 and the conductor merges.
- A new boundary class `declared<->enforced` joins the taxonomy: policy-as-code in the repo vs what the node actually enforces. Nothing existing covered it.
- Over the 400-line target, declared. The `proprioception.py` change is deliberately small (one parse mode, one class, one registry entry) because that file is shared and delicate — written by this orchestrator rather than delegated for that reason.

Ledger: #5318
