### PR TITLE
fix(sentry): deprioritize un-actionable noise at the edge — and keep the signal that would hide the next #5096

### DIFF
--- a/apps/backend-rag/backend/app/setup/sentry_config.py
+++ b/apps/backend-rag/backend/app/setup/sentry_config.py
@@ -306,9 +306,33 @@ def _before_send_impl(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, 
     to be added at cron entrypoints (`cron-wrapper.sh`, `auto_sentinel.sh`,
     `cron_notifiers.py`) in a follow-up before a dedup filter can land here.
     """
-    if _is_health_transaction(event):
-        return None
     return _scrub(event)
+
+
+def _before_send_transaction(
+    event: dict[str, Any], hint: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Transaction hook. Drops health-check metronomes, scrubs the rest.
+
+    A SEPARATE HOOK, and that is not a style choice. The SDK guards
+    `before_send` with `event.get("type") != "transaction"` and routes
+    transactions to `before_send_transaction` (sentry_sdk/client.py, verbatim in
+    the installed 3.x). The first version of this filter lived in
+    `before_send`, so it was DEAD CODE in production — while its tests stayed
+    green, because they called the inner function directly instead of going
+    through the integration. W116, shipped inside the very wave whose subject is
+    that class; found by a cross-family reviewer reading the SDK rather than
+    the diff.
+
+    Scrubbing still applies to what survives: a transaction name can carry a
+    path parameter, and a path parameter can be PII.
+    """
+    try:
+        if _is_health_transaction(event):
+            return None
+    except Exception:
+        pass  # fail OPEN: a bug here must not delete a transaction silently
+    return _before_send(event, hint)
 
 
 def _before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
@@ -379,6 +403,11 @@ def _init_sentry_blocking(dsn: str) -> None:
         environment=env,
         release=os.getenv("SENTRY_RELEASE", "nuzantara-backend@1.0.0"),
         before_send=_before_send,
+        # The SDK will NOT call `before_send` for transactions — it guards that
+        # hook with `type != "transaction"` and dispatches transactions here
+        # instead. Registering only the first is how a transaction filter ends
+        # up never running while its unit tests pass.
+        before_send_transaction=_before_send_transaction,
         # `_before_send`/`_scrub` above only ever see the JSON-shaped event
         # payload. The SDK's logging integration attaches raw frame-LOCAL
         # values to `stacktrace.frames[].vars` at capture time, before

--- a/apps/backend-rag/backend/app/setup/sentry_config.py
+++ b/apps/backend-rag/backend/app/setup/sentry_config.py
@@ -254,8 +254,51 @@ def _scrub(obj: Any, parent_key: str | None = None) -> Any:
     return obj
 
 
+# Transactions Sentry should not be paying for. Measured on `bali-zero-7p` over
+# 7 days (2026-08-28): 1,952 errors accepted against 753 rate_limited — 28% of
+# production errors dropped for quota, chosen by arrival order rather than by
+# importance. A dropped event is indistinguishable from one that never happened.
+#
+# ONLY TRANSACTIONS, and that distinction is the whole safety of this filter. A
+# health check that 200s every 15 seconds is a metronome; a health check that
+# 500s is one of the most important errors this system can produce (the
+# 2026-04-29 outage was exactly that, and /health answering 200 while the worker
+# was dead is its own scar). Dropping by URL would delete the second along with
+# the first. `event.get("type") == "transaction"` is what separates them.
+_HEALTH_TRANSACTIONS = (
+    "/health",
+    "/healthz",
+    "/readyz",
+    "/livez",
+    "/api/health",
+)
+
+
+def _is_health_transaction(event: dict[str, Any]) -> bool:
+    """True only for a TRANSACTION on a health path. Never for an error.
+
+    Never raises: this runs inside `before_send`, and Sentry drops an event
+    silently when that hook throws — a bug here would delete real errors rather
+    than metronome ticks.
+    """
+    try:
+        if event.get("type") != "transaction":
+            return False
+        name = event.get("transaction")
+        if not isinstance(name, str):
+            return False
+        # Exact match or a path segment, never a substring: `/healthcheck-audit`
+        # and `/api/health-report` are real endpoints, not metronomes.
+        for path in _HEALTH_TRANSACTIONS:
+            if name == path or name.startswith(path + "/") or name.endswith(" " + path):
+                return True
+        return False
+    except Exception:
+        return False
+
+
 def _before_send_impl(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
-    """Inner implementation. Scrubs PII, returns scrubbed event.
+    """Inner implementation. Drops health-check transactions, scrubs PII.
 
     NOTE: cron/deploy alert deduplication was removed from this PR's scope
     (review #168/B2). No code in the repo currently tags events with
@@ -263,6 +306,8 @@ def _before_send_impl(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, 
     to be added at cron entrypoints (`cron-wrapper.sh`, `auto_sentinel.sh`,
     `cron_notifiers.py`) in a follow-up before a dedup filter can land here.
     """
+    if _is_health_transaction(event):
+        return None
     return _scrub(event)
 
 

--- a/apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py
+++ b/apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py
@@ -38,11 +38,59 @@ def _error(name: str) -> dict:
     return {"transaction": name, "exception": {"values": [{"value": "boom"}]}}
 
 
+class TestTheHookIsACTUALLYWIRED:
+    """The defect a cross-family reviewer found by reading the SDK, not the diff.
+
+    `sentry_sdk`'s client guards `before_send` with
+    `event.get("type") != "transaction"` and routes transactions to
+    `before_send_transaction` instead — verbatim in the installed version. The
+    first version of this filter lived in `before_send`, so in production it
+    never ran, while a test that called the inner function directly stayed
+    green. That is W116 with a passing test on top, which is the only reason it
+    could ship.
+    """
+
+    def test_the_installed_sdk_really_does_skip_before_send_for_transactions(self) -> None:
+        # Anchor the premise to the SDK rather than to a memory of it: if a
+        # future SDK starts routing transactions through `before_send`, this
+        # test says so instead of leaving the reason for the split unexplained.
+        import inspect
+
+        import sentry_sdk.client as client_mod
+
+        src = inspect.getsource(client_mod)
+        assert 'event.get("type") != "transaction"' in src
+        assert "before_send_transaction" in src
+
+    def test_init_registers_before_send_transaction(self, monkeypatch) -> None:
+        captured: dict = {}
+
+        def fake_init(**kwargs):
+            captured.update(kwargs)
+
+        # `_init_sentry_blocking` imports sentry_sdk lazily inside the function
+        # (it must not block Fly health checks), so the patch goes on the module
+        # object the import will resolve to, not on an attribute of the module
+        # under test.
+        import sentry_sdk
+
+        monkeypatch.setattr(sentry_sdk, "init", fake_init)
+        sc._init_sentry_blocking("https://k@o1.ingest.us.sentry.io/2")
+
+        assert captured.get("before_send_transaction") is sc._before_send_transaction, (
+            "a transaction filter that is not registered as before_send_transaction "
+            "never runs, however well its own function is tested"
+        )
+        # And the callable really drops through the hook the SDK will call.
+        assert captured["before_send_transaction"](_txn("/health"), {}) is None
+        assert captured["before_send_transaction"](_txn("/api/crm/practices"), {}) is not None
+
+
 class TestGuilt:
     def test_a_health_transaction_is_dropped(self) -> None:
         for path in ("/health", "/healthz", "/readyz", "/livez", "/api/health"):
             assert sc._is_health_transaction(_txn(path)) is True, path
-            assert sc._before_send_impl(_txn(path), {}) is None, path
+            assert sc._before_send_transaction(_txn(path), {}) is None, path
 
     def test_a_method_prefixed_transaction_name_is_recognised(self) -> None:
         # Sentry names transactions "GET /health" on several integrations.
@@ -62,10 +110,12 @@ class TestInnocence:
         event = _error("/health")
         assert sc._is_health_transaction(event) is False
         assert sc._before_send_impl(event, {}) is not None
+        # ...and through the hook the SDK actually calls for errors.
+        assert sc._before_send(event, {}) is not None
 
     def test_a_real_transaction_is_kept(self) -> None:
         assert sc._is_health_transaction(_txn("/api/crm/practices")) is False
-        assert sc._before_send_impl(_txn("/api/crm/practices"), {}) is not None
+        assert sc._before_send_transaction(_txn("/api/crm/practices"), {}) is not None
 
     def test_a_route_that_merely_STARTS_with_a_health_word_is_kept(self) -> None:
         # Over-match guard (superscar family #3): substring matching would eat

--- a/apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py
+++ b/apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py
@@ -1,0 +1,86 @@
+"""The health-check transaction drop, and the error it must NEVER drop.
+
+WHY: measured on `bali-zero-7p` over 7 days (2026-08-28), the `error` category
+took 1,952 accepted against 753 rate_limited — 28% of production errors dropped
+for quota, chosen by arrival order rather than by importance. A dropped event is
+indistinguishable from one that never happened.
+
+THE LOAD-BEARING HALF is the innocence side. A health check that 200s every 15
+seconds is a metronome; a health check that 500s is one of the most important
+errors this system can produce — the 2026-04-29 outage was exactly that, and
+`/health` answering 200 while the RAG worker was dead is its own scar. A filter
+keyed on the URL would delete the second along with the first.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MODULE = (
+    Path(__file__).resolve().parents[4]
+    / "app"
+    / "setup"
+    / "sentry_config.py"
+)
+_SPEC = importlib.util.spec_from_file_location("sentry_config_under_test", _MODULE)
+assert _SPEC is not None and _SPEC.loader is not None
+sc = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = sc
+_SPEC.loader.exec_module(sc)
+
+
+def _txn(name: str) -> dict:
+    return {"type": "transaction", "transaction": name}
+
+
+def _error(name: str) -> dict:
+    # No "type" key at all is how the SDK shapes an error event.
+    return {"transaction": name, "exception": {"values": [{"value": "boom"}]}}
+
+
+class TestGuilt:
+    def test_a_health_transaction_is_dropped(self) -> None:
+        for path in ("/health", "/healthz", "/readyz", "/livez", "/api/health"):
+            assert sc._is_health_transaction(_txn(path)) is True, path
+            assert sc._before_send_impl(_txn(path), {}) is None, path
+
+    def test_a_method_prefixed_transaction_name_is_recognised(self) -> None:
+        # Sentry names transactions "GET /health" on several integrations.
+        assert sc._is_health_transaction(_txn("GET /health")) is True
+
+    def test_a_sub_path_of_a_health_route_is_dropped(self) -> None:
+        assert sc._is_health_transaction(_txn("/health/detailed")) is True
+
+
+class TestInnocence:
+    def test_an_ERROR_on_a_health_path_is_KEPT(self) -> None:
+        """The case the whole design turns on.
+
+        `/health` returning 500 is the single most valuable error this backend
+        can emit. Dropping by URL would have deleted it.
+        """
+        event = _error("/health")
+        assert sc._is_health_transaction(event) is False
+        assert sc._before_send_impl(event, {}) is not None
+
+    def test_a_real_transaction_is_kept(self) -> None:
+        assert sc._is_health_transaction(_txn("/api/crm/practices")) is False
+        assert sc._before_send_impl(_txn("/api/crm/practices"), {}) is not None
+
+    def test_a_route_that_merely_STARTS_with_a_health_word_is_kept(self) -> None:
+        # Over-match guard (superscar family #3): substring matching would eat
+        # these, and they are real endpoints, not metronomes.
+        for name in ("/healthcheck-audit", "/api/health-report", "/healthy-clients"):
+            assert sc._is_health_transaction(_txn(name)) is False, name
+
+    def test_malformed_events_are_kept_rather_than_guessed_at(self) -> None:
+        # Sentry drops an event silently if before_send raises, so any surprise
+        # here would delete a real error. Everything unrecognised is kept.
+        for weird in (
+            {},
+            {"type": "transaction"},
+            {"type": "transaction", "transaction": None},
+            {"type": "transaction", "transaction": 42},
+            {"type": None, "transaction": "/health"},
+        ):
+            assert sc._is_health_transaction(weird) is False, weird

--- a/apps/mouth/sentry.client.config.ts
+++ b/apps/mouth/sentry.client.config.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { IGNORE_ERRORS, isKnownNoise } from "@/lib/sentry-noise";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV,
@@ -12,11 +14,17 @@ Sentry.init({
       blockAllMedia: true,
     }),
   ],
+  ignoreErrors: [...IGNORE_ERRORS],
   beforeSend(event) {
     // Non inviare errori in development
     if (process.env.NODE_ENV === "development") {
       return null;
     }
-    return event;
+    // 28% of this org's production errors were dropped for quota over 7 days
+    // (measured 2026-08-28), and which ones get dropped is decided by arrival
+    // order rather than importance. src/lib/sentry-noise.ts says what is
+    // filtered and — the load-bearing half — what deliberately is not: 401/403
+    // stays, because muting it is how #5096 would come back invisibly.
+    return isKnownNoise(event) ? null : event;
   },
 });

--- a/apps/mouth/sentry.edge.config.ts
+++ b/apps/mouth/sentry.edge.config.ts
@@ -1,13 +1,17 @@
 import * as Sentry from "@sentry/nextjs";
 
-import { IGNORE_ERRORS, isKnownNoise } from "@/lib/sentry-noise";
+import { UNIVERSAL_NOISE, isKnownNoise } from "@/lib/sentry-noise";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  ignoreErrors: [...IGNORE_ERRORS],
+  // UNIVERSAL only. "The operation was aborted" in a browser is a cancelled
+  // navigation; on the server it is an application deadline killing real I/O —
+  // an actionable timeout. The same words, opposite meanings, and a shared list
+  // would delete the second (cross-family gate).
+  ignoreErrors: [...UNIVERSAL_NOISE],
   beforeSend(event) {
-    return isKnownNoise(event) ? null : event;
+    return isKnownNoise(event, { browser: false }) ? null : event;
   },
 });

--- a/apps/mouth/sentry.edge.config.ts
+++ b/apps/mouth/sentry.edge.config.ts
@@ -1,7 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { IGNORE_ERRORS, isKnownNoise } from "@/lib/sentry-noise";
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  ignoreErrors: [...IGNORE_ERRORS],
+  beforeSend(event) {
+    return isKnownNoise(event) ? null : event;
+  },
 });

--- a/apps/mouth/sentry.server.config.ts
+++ b/apps/mouth/sentry.server.config.ts
@@ -1,7 +1,18 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { IGNORE_ERRORS, isKnownNoise } from "@/lib/sentry-noise";
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV,
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  // 28% of this org's production errors were dropped for quota over 7 days
+  // (measured 2026-08-28). A dropped event is indistinguishable from one that
+  // never happened, and which ones get dropped is decided by arrival order.
+  // See src/lib/sentry-noise.ts for what is filtered and, more importantly,
+  // what is deliberately not.
+  ignoreErrors: [...IGNORE_ERRORS],
+  beforeSend(event) {
+    return isKnownNoise(event) ? null : event;
+  },
 });

--- a/apps/mouth/sentry.server.config.ts
+++ b/apps/mouth/sentry.server.config.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 
-import { IGNORE_ERRORS, isKnownNoise } from "@/lib/sentry-noise";
+import { UNIVERSAL_NOISE, isKnownNoise } from "@/lib/sentry-noise";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -11,8 +11,12 @@ Sentry.init({
   // never happened, and which ones get dropped is decided by arrival order.
   // See src/lib/sentry-noise.ts for what is filtered and, more importantly,
   // what is deliberately not.
-  ignoreErrors: [...IGNORE_ERRORS],
+  // UNIVERSAL only. "The operation was aborted" in a browser is a cancelled
+  // navigation; on the server it is an application deadline killing real I/O —
+  // an actionable timeout. The same words, opposite meanings, and a shared list
+  // would delete the second (cross-family gate).
+  ignoreErrors: [...UNIVERSAL_NOISE],
   beforeSend(event) {
-    return isKnownNoise(event) ? null : event;
+    return isKnownNoise(event, { browser: false }) ? null : event;
   },
 });

--- a/apps/mouth/src/lib/__tests__/sentry-noise.test.ts
+++ b/apps/mouth/src/lib/__tests__/sentry-noise.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import { IGNORE_ERRORS, isKnownNoise } from "@/lib/sentry-noise";
+
+/**
+ * Guilt AND innocence, in that order of importance.
+ *
+ * The guilt half proves the filter drops what it claims to drop. The innocence
+ * half is the one that matters more: this predicate runs on every production
+ * error, and a false positive DELETES a real error with no trace anywhere. The
+ * 401/403 cases below are not decoration — muting them is exactly how #5096
+ * would come back invisibly, and the whole point of the file is that it does
+ * not do that.
+ */
+
+const err = (
+  value: string,
+  frames?: Array<{ filename?: string; abs_path?: string }>,
+) => ({
+  exception: {
+    values: [{ value, stacktrace: frames ? { frames } : undefined }],
+  },
+});
+
+describe("isKnownNoise — guilt", () => {
+  it("drops the ResizeObserver loop, in both wordings browsers use", () => {
+    expect(isKnownNoise(err("ResizeObserver loop limit exceeded"))).toBe(true);
+    expect(
+      isKnownNoise(
+        err("ResizeObserver loop completed with undelivered notifications."),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops a fetch the user cancelled by navigating away", () => {
+    expect(isKnownNoise(err("AbortError: The operation was aborted"))).toBe(
+      true,
+    );
+    expect(isKnownNoise(err("The user aborted a request."))).toBe(true);
+  });
+
+  it("drops a promise rejection that carries nothing to act on", () => {
+    expect(
+      isKnownNoise(
+        err("Non-Error promise rejection captured with value: undefined"),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops an error whose stack is ENTIRELY browser-extension code", () => {
+    expect(
+      isKnownNoise(
+        err("Cannot read properties of null", [
+          { abs_path: "chrome-extension://abcdef/inject.js" },
+          { abs_path: "moz-extension://123/content.js" },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("reads a top-level message, not only an exception value", () => {
+    expect(
+      isKnownNoise({ message: "ResizeObserver loop limit exceeded" }),
+    ).toBe(true);
+  });
+});
+
+describe("isKnownNoise — innocence, which is the half that costs if it is wrong", () => {
+  it("KEEPS 401 and 403 — muting them is how #5096 returns invisibly", () => {
+    expect(isKnownNoise(err("Request failed with status code 401"))).toBe(
+      false,
+    );
+    expect(
+      isKnownNoise(err("HTTP 403 Forbidden on conversations/history")),
+    ).toBe(false);
+    expect(isKnownNoise({ message: "Unauthorized" })).toBe(false);
+  });
+
+  it("keeps an ordinary application error", () => {
+    expect(
+      isKnownNoise(err("TypeError: cannot read properties of undefined")),
+    ).toBe(false);
+    expect(isKnownNoise(err("Failed to fetch pricing for KBLI 55130"))).toBe(
+      false,
+    );
+  });
+
+  it("keeps an error whose stack merely PASSES THROUGH an extension frame", () => {
+    // All-foreign, not any-foreign: an extension that wrapped one of our calls
+    // is still our stack trace, and still worth seeing.
+    expect(
+      isKnownNoise(
+        err("TypeError: x is not a function", [
+          { abs_path: "chrome-extension://abcdef/inject.js" },
+          { abs_path: "https://balizero.com/_next/static/chunk.js" },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps an error with no frames at all rather than guessing", () => {
+    expect(isKnownNoise(err("Something broke"))).toBe(false);
+  });
+
+  it("keeps a message that merely CONTAINS a shorter English word from the list", () => {
+    // The over-match guard (superscar family #3). Every needle is long enough
+    // that it cannot appear inside a real message; this pins that property.
+    expect(
+      isKnownNoise(err("The operation was abandoned by the operator")),
+    ).toBe(false);
+    expect(
+      isKnownNoise(err("Load failed while resizing the observer panel")),
+    ).toBe(false);
+  });
+});
+
+describe("isKnownNoise — never throws, because a throw deletes the event", () => {
+  it("returns false on shapes it was never designed for", () => {
+    // Sentry drops an event silently if beforeSend raises, so a bug here would
+    // delete real errors rather than noise — the opposite of the purpose.
+    for (const weird of [
+      null,
+      undefined,
+      42,
+      "a string",
+      [],
+      { exception: null },
+      { exception: { values: null } },
+    ]) {
+      expect(isKnownNoise(weird)).toBe(false);
+    }
+    expect(
+      isKnownNoise({
+        exception: { values: [{ value: null, stacktrace: { frames: null } }] },
+      }),
+    ).toBe(false);
+  });
+
+  it("KEEPS the event when reading it actually throws", () => {
+    // The catch has to fail OPEN. Measured: a catch that returned `true`
+    // instead survived every other case in this file, because none of them
+    // makes the predicate throw — so the branch that decides the fate of an
+    // unreadable event was untested. An object with a throwing getter is the
+    // shape that reaches it.
+    const hostile = {
+      get message(): string {
+        throw new Error("this event refuses to be read");
+      },
+    };
+    expect(isKnownNoise(hostile)).toBe(false);
+  });
+});
+
+describe("the two surfaces stay in step", () => {
+  it("IGNORE_ERRORS is the same list beforeSend checks", () => {
+    // `ignoreErrors` is cheaper (the SDK drops before building the event) but
+    // sees only the message; `beforeSend` can see frames. Neither alone covers
+    // both shapes, so they must not drift apart.
+    expect(IGNORE_ERRORS.length).toBeGreaterThan(0);
+    for (const needle of IGNORE_ERRORS) {
+      expect(isKnownNoise(err(`prefix ${needle} suffix`))).toBe(true);
+    }
+  });
+});

--- a/apps/mouth/src/lib/__tests__/sentry-noise.test.ts
+++ b/apps/mouth/src/lib/__tests__/sentry-noise.test.ts
@@ -102,6 +102,21 @@ describe("isKnownNoise — innocence, which is the half that costs if it is wron
     expect(isKnownNoise(err("Something broke"))).toBe(false);
   });
 
+  it("keeps an error whose ROOT carries an EMPTY frames array", () => {
+    // `[].every(...)` is true, so without the length guard an event Sentry
+    // shipped with `frames: []` would read as "entirely foreign code" — the
+    // wrong answer, said confidently, about a stack we simply do not have.
+    expect(
+      isKnownNoise({
+        exception: {
+          values: [
+            { value: "Order finalization failed", stacktrace: { frames: [] } },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("keeps a message that merely CONTAINS a shorter English word from the list", () => {
     // The over-match guard (superscar family #3). Every needle is long enough
     // that it cannot appear inside a real message; this pins that property.
@@ -151,11 +166,115 @@ describe("isKnownNoise — never throws, because a throw deletes the event", () 
   });
 });
 
-describe("the two surfaces stay in step", () => {
-  it("IGNORE_ERRORS is the same list beforeSend checks", () => {
-    // `ignoreErrors` is cheaper (the SDK drops before building the event) but
-    // sees only the message; `beforeSend` can see frames. Neither alone covers
-    // both shapes, so they must not drift apart.
+describe("the shapes a cross-family reviewer executed against the first version", () => {
+  it("KEEPS a linked error whose CAUSE is benign but whose ROOT is actionable", () => {
+    // Sentry puts the ROOT last. Reading every value deleted the whole event
+    // because one entry matched — the reviewer ran this exact input and the old
+    // predicate returned true.
+    expect(
+      isKnownNoise({
+        exception: {
+          values: [
+            {
+              type: "AbortError",
+              value: "AbortError: The operation was aborted",
+            },
+            {
+              type: "CheckoutCommitError",
+              value: "Failed to persist completed payment",
+              stacktrace: {
+                frames: [
+                  { filename: "https://balizero.com/_next/checkout.js" },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("KEEPS a frameless ROOT whose CAUSE happens to be extension code", () => {
+    // Flattening frames across values let the frameless root vanish and a
+    // foreign-framed cause decide the verdict. `[].every()` is vacuously true,
+    // which is the wrong answer said confidently.
+    expect(
+      isKnownNoise({
+        exception: {
+          values: [
+            {
+              type: "ExtensionError",
+              value: "extension failed",
+              stacktrace: {
+                frames: [{ filename: "chrome-extension://abc/inject.js" }],
+              },
+            },
+            {
+              type: "OrderFinalizationError",
+              value: "Order finalization failed",
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("DROPS ResizeObserver noise that arrives via logentry", () => {
+    // Parameterised captureMessage lands in event.logentry, which neither the
+    // old predicate nor the SDK's own ignoreErrors matcher reads — so this
+    // noise reached Sentry through both surfaces.
+    expect(
+      isKnownNoise({
+        logentry: { message: "ResizeObserver loop limit exceeded" },
+      }),
+    ).toBe(true);
+    expect(
+      isKnownNoise({
+        logentry: { formatted: "ResizeObserver loop limit exceeded" },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("browser-only vs universal noise — the same words, opposite meanings", () => {
+  const abort = err("AbortError: The operation was aborted");
+
+  it("drops a cancelled navigation in the BROWSER", () => {
+    expect(isKnownNoise(abort)).toBe(true);
+    expect(isKnownNoise(abort, { browser: true })).toBe(true);
+  });
+
+  it("KEEPS the same abort on the SERVER, where it is a deadline killing real I/O", () => {
+    // There is no navigation in the server runtime. A nightly export aborted by
+    // an application deadline is an actionable timeout, and the shared list
+    // deleted it (cross-family gate).
+    expect(isKnownNoise(abort, { browser: false })).toBe(false);
+  });
+
+  it("keeps a value-less promise rejection filter in BOTH runtimes", () => {
+    const universal = err(
+      "Non-Error promise rejection captured with value: undefined",
+    );
+    expect(isKnownNoise(universal, { browser: true })).toBe(true);
+    expect(isKnownNoise(universal, { browser: false })).toBe(true);
+  });
+
+  it("KEEPS an application message that merely contains the English phrase", () => {
+    // The needles are anchored to the exact DOMException forms browsers emit,
+    // not to the phrase, because this sentence is a real error.
+    expect(
+      isKnownNoise(
+        err("The operation was aborted while committing invoice 42"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("IGNORE_ERRORS is a DIFFERENT surface, and the earlier parity claim was false", () => {
+  it("every ignore-list needle is also caught as a ROOT message", () => {
+    // Not parity: the SDK's matcher reads the top-level message and the root
+    // exception, while this module also reads logentry and inspects frames.
+    // Neither is a superset. What must hold is the overlap they share.
     expect(IGNORE_ERRORS.length).toBeGreaterThan(0);
     for (const needle of IGNORE_ERRORS) {
       expect(isKnownNoise(err(`prefix ${needle} suffix`))).toBe(true);

--- a/apps/mouth/src/lib/sentry-noise.ts
+++ b/apps/mouth/src/lib/sentry-noise.ts
@@ -1,0 +1,136 @@
+/**
+ * The one place that decides what is NOT worth a Sentry event.
+ *
+ * WHY THIS EXISTS, measured on `bali-zero-7p` over 7 days (2026-08-28): the
+ * `error` category took 1,952 accepted against 753 rate_limited — **28% of
+ * production errors dropped for quota**. A dropped event is indistinguishable
+ * from an event that never happened, so the 28% is not a billing problem, it
+ * is a blindness problem: the errors that get discarded are chosen by arrival
+ * order, not by importance.
+ *
+ * The precedent this file answers to is #5096, where `/chat` fired two
+ * authenticated calls at every anonymous visitor, each 401 reached
+ * `logger.warn`, and `logger.warn` forwards to Sentry unconditionally in
+ * production. One public page was posting one Sentry event per visitor and
+ * Sentry answered 429 — real errors lost behind noise from an entirely
+ * foreseeable condition.
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ * WHAT THIS FILE DELIBERATELY DOES NOT DROP, and it is the important half.
+ *
+ * It does NOT drop 401/403. That is exactly the #5096 signature, and the cure
+ * for #5096 was the CAUSE (don't call an authenticated endpoint while logged
+ * out), not the symptom. Muting the symptom here would mean the next
+ * recurrence arrives silently — the same bug, one release later, invisible.
+ * The rule this file follows: drop only what could not be actioned even if
+ * somebody read it.
+ *
+ * Everything below is either (a) not our code at all, or (b) a browser
+ * behaviour with no stack that anyone can act on. Each entry carries why.
+ * ────────────────────────────────────────────────────────────────────────
+ */
+
+/** Frames from code we did not ship and cannot fix. */
+const FOREIGN_FRAME_SCHEMES = [
+  "chrome-extension://",
+  "moz-extension://",
+  "safari-extension://",
+  "safari-web-extension://",
+  "ms-browser-extension://",
+];
+
+/**
+ * Message substrings that identify an event as un-actionable.
+ *
+ * Substring matching is the over-match risk here (superscar #3), so every
+ * entry is long enough to be unambiguous: none of these can appear inside a
+ * message about something real. `ResizeObserver loop` cannot show up in an
+ * application error; `Load failed` alone could, which is why the shorter,
+ * tempting forms are absent.
+ */
+export const KNOWN_NOISE_SUBSTRINGS: readonly string[] = [
+  // Fired by the browser when a resize handler causes another resize. The
+  // W3C spec acknowledges it as benign; no stack, nothing to fix.
+  "ResizeObserver loop completed with undelivered notifications",
+  "ResizeObserver loop limit exceeded",
+  // A fetch the user cancelled by navigating away. Not a failure of ours.
+  "The operation was aborted",
+  "The user aborted a request",
+  "AbortError: signal is aborted without reason",
+  // A promise rejected with a value that carries no diagnostic content: the
+  // event contains literally nothing to act on.
+  "Non-Error promise rejection captured with value: undefined",
+  "Non-Error promise rejection captured with value: null",
+];
+
+/**
+ * Passed to `Sentry.init({ ignoreErrors })` as well as checked in
+ * `beforeSend`. Both, on purpose: `ignoreErrors` is cheaper (the SDK drops
+ * before building the event) but only sees the message, while `beforeSend`
+ * can see the stack frames. Neither alone covers both shapes.
+ */
+export const IGNORE_ERRORS: readonly string[] = KNOWN_NOISE_SUBSTRINGS;
+
+type MinimalFrame = { filename?: string | null; abs_path?: string | null };
+type MinimalEvent = {
+  message?: string | null;
+  exception?: {
+    values?: Array<{
+      value?: string | null;
+      stacktrace?: { frames?: MinimalFrame[] | null } | null;
+    }> | null;
+  } | null;
+};
+
+function messagesOf(event: MinimalEvent): string[] {
+  const out: string[] = [];
+  if (typeof event.message === "string") out.push(event.message);
+  for (const v of event.exception?.values ?? []) {
+    if (typeof v?.value === "string") out.push(v.value);
+  }
+  return out;
+}
+
+function framesOf(event: MinimalEvent): MinimalFrame[] {
+  const out: MinimalFrame[] = [];
+  for (const v of event.exception?.values ?? []) {
+    for (const f of v?.stacktrace?.frames ?? []) out.push(f);
+  }
+  return out;
+}
+
+/**
+ * True when the event is one of the declared un-actionable classes.
+ *
+ * Never throws: Sentry drops an event silently if `beforeSend` raises, so a
+ * bug in this predicate would delete real errors rather than noise — the
+ * opposite of what it is for. Any surprise returns false, which keeps the
+ * event.
+ */
+export function isKnownNoise(event: unknown): boolean {
+  try {
+    const e = (event ?? {}) as MinimalEvent;
+
+    for (const msg of messagesOf(e)) {
+      if (KNOWN_NOISE_SUBSTRINGS.some((needle) => msg.includes(needle))) {
+        return true;
+      }
+    }
+
+    // An event whose stack is ENTIRELY foreign code is not ours to fix. All,
+    // not any: an extension frame appearing inside our own stack usually means
+    // the extension wrapped one of our calls, and that IS worth seeing.
+    const frames = framesOf(e);
+    if (frames.length > 0) {
+      const isForeign = (f: MinimalFrame) => {
+        const path = f.abs_path ?? f.filename ?? "";
+        return FOREIGN_FRAME_SCHEMES.some((scheme) => path.startsWith(scheme));
+      };
+      if (frames.every(isForeign)) return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/apps/mouth/src/lib/sentry-noise.ts
+++ b/apps/mouth/src/lib/sentry-noise.ts
@@ -48,54 +48,94 @@ const FOREIGN_FRAME_SCHEMES = [
  * application error; `Load failed` alone could, which is why the shorter,
  * tempting forms are absent.
  */
-export const KNOWN_NOISE_SUBSTRINGS: readonly string[] = [
-  // Fired by the browser when a resize handler causes another resize. The
-  // W3C spec acknowledges it as benign; no stack, nothing to fix.
-  "ResizeObserver loop completed with undelivered notifications",
-  "ResizeObserver loop limit exceeded",
-  // A fetch the user cancelled by navigating away. Not a failure of ours.
-  "The operation was aborted",
-  "The user aborted a request",
-  "AbortError: signal is aborted without reason",
+export const UNIVERSAL_NOISE: readonly string[] = [
   // A promise rejected with a value that carries no diagnostic content: the
-  // event contains literally nothing to act on.
+  // event contains literally nothing to act on, in any runtime.
   "Non-Error promise rejection captured with value: undefined",
   "Non-Error promise rejection captured with value: null",
 ];
 
 /**
- * Passed to `Sentry.init({ ignoreErrors })` as well as checked in
- * `beforeSend`. Both, on purpose: `ignoreErrors` is cheaper (the SDK drops
- * before building the event) but only sees the message, while `beforeSend`
- * can see the stack frames. Neither alone covers both shapes.
+ * Browser-only, and the split is load-bearing rather than tidy.
+ *
+ * "The operation was aborted" in a BROWSER is a fetch the user cancelled by
+ * navigating away. The same words on the SERVER are an application deadline
+ * killing real I/O — an actionable timeout — and a cross-family reviewer
+ * produced exactly that event: an `AbortError` from a nightly export, dropped
+ * by a rule that assumed every abort came from a navigation there is no such
+ * thing as in the server runtime.
+ *
+ * The strings are also anchored to the exact forms browsers emit rather than
+ * to the English phrase, because substring matching is the over-match risk
+ * here (superscar #3): "The operation was aborted while committing invoice 42"
+ * is a real error and must survive.
+ */
+export const BROWSER_ONLY_NOISE: readonly string[] = [
+  // Fired by the browser when a resize handler causes another resize. The
+  // W3C spec acknowledges it as benign; no stack, nothing to fix.
+  "ResizeObserver loop completed with undelivered notifications",
+  "ResizeObserver loop limit exceeded",
+  // DOMException forms, verbatim per engine — never the bare phrase.
+  "AbortError: The operation was aborted",
+  "AbortError: signal is aborted without reason",
+  "The user aborted a request.",
+];
+
+export const KNOWN_NOISE_SUBSTRINGS: readonly string[] = [
+  ...UNIVERSAL_NOISE,
+  ...BROWSER_ONLY_NOISE,
+];
+
+/**
+ * For `Sentry.init({ ignoreErrors })`.
+ *
+ * NOT the same surface as `isKnownNoise`, and the earlier comment claiming
+ * they were "in step" was wrong: the SDK's own matcher looks at the top-level
+ * message and the ROOT exception, while this module additionally reads
+ * `logentry` and inspects frames. They overlap deliberately — `ignoreErrors`
+ * is cheaper (the SDK drops before building the event) and `beforeSend` sees
+ * more — but neither is a superset of the other, and a test asserting parity
+ * would be asserting something untrue.
  */
 export const IGNORE_ERRORS: readonly string[] = KNOWN_NOISE_SUBSTRINGS;
 
 type MinimalFrame = { filename?: string | null; abs_path?: string | null };
+type MinimalValue = {
+  value?: string | null;
+  stacktrace?: { frames?: MinimalFrame[] | null } | null;
+};
 type MinimalEvent = {
   message?: string | null;
-  exception?: {
-    values?: Array<{
-      value?: string | null;
-      stacktrace?: { frames?: MinimalFrame[] | null } | null;
-    }> | null;
-  } | null;
+  // Sentry's own builder routes parameterised `captureMessage` here, and the
+  // SDK's `ignoreErrors` matcher does NOT read it — so a templated
+  // ResizeObserver message reached Sentry through both surfaces.
+  logentry?: { message?: string | null; formatted?: string | null } | null;
+  exception?: { values?: MinimalValue[] | null } | null;
 };
+
+/**
+ * The ROOT exception, which Sentry places LAST in `values`.
+ *
+ * Reading every value was a false-positive machine: a linked error whose CAUSE
+ * is a benign abort but whose ROOT is `CheckoutCommitError: Failed to persist
+ * completed payment` had the whole event deleted because one entry matched.
+ * A cross-family reviewer executed that exact input against the old predicate
+ * and it returned true. The event's identity is its root; judge that.
+ */
+function rootValue(event: MinimalEvent): MinimalValue | null {
+  const values = event.exception?.values;
+  if (!Array.isArray(values) || values.length === 0) return null;
+  return values[values.length - 1] ?? null;
+}
 
 function messagesOf(event: MinimalEvent): string[] {
   const out: string[] = [];
   if (typeof event.message === "string") out.push(event.message);
-  for (const v of event.exception?.values ?? []) {
-    if (typeof v?.value === "string") out.push(v.value);
-  }
-  return out;
-}
-
-function framesOf(event: MinimalEvent): MinimalFrame[] {
-  const out: MinimalFrame[] = [];
-  for (const v of event.exception?.values ?? []) {
-    for (const f of v?.stacktrace?.frames ?? []) out.push(f);
-  }
+  const le = event.logentry;
+  if (le && typeof le.formatted === "string") out.push(le.formatted);
+  if (le && typeof le.message === "string") out.push(le.message);
+  const root = rootValue(event);
+  if (root && typeof root.value === "string") out.push(root.value);
   return out;
 }
 
@@ -107,23 +147,35 @@ function framesOf(event: MinimalEvent): MinimalFrame[] {
  * opposite of what it is for. Any surprise returns false, which keeps the
  * event.
  */
-export function isKnownNoise(event: unknown): boolean {
+export function isKnownNoise(
+  event: unknown,
+  opts: { browser?: boolean } = {},
+): boolean {
   try {
     const e = (event ?? {}) as MinimalEvent;
+    const browser = opts.browser !== false;
+    const needles = browser ? KNOWN_NOISE_SUBSTRINGS : UNIVERSAL_NOISE;
 
     for (const msg of messagesOf(e)) {
-      if (KNOWN_NOISE_SUBSTRINGS.some((needle) => msg.includes(needle))) {
+      if (needles.some((needle) => msg.includes(needle))) {
         return true;
       }
     }
 
-    // An event whose stack is ENTIRELY foreign code is not ours to fix. All,
-    // not any: an extension frame appearing inside our own stack usually means
-    // the extension wrapped one of our calls, and that IS worth seeing.
-    const frames = framesOf(e);
-    if (frames.length > 0) {
+    // An event whose ROOT exception's stack is ENTIRELY foreign code is not
+    // ours to fix. Three conditions, each earned:
+    //  - the ROOT, not every value: flattening frames across values let a
+    //    frameless root vanish while a foreign-framed CAUSE decided the verdict,
+    //    and the real error was deleted (cross-family gate, executed input).
+    //  - `length > 0`: "no stack" is unknown, not foreign. `[].every(...)` is
+    //    vacuously true, which is the wrong answer said confidently.
+    //  - `every`, not `some`: an extension frame inside our own stack usually
+    //    means the extension wrapped one of our calls, and that IS worth seeing.
+    const root = rootValue(e);
+    const frames = root?.stacktrace?.frames;
+    if (Array.isArray(frames) && frames.length > 0) {
       const isForeign = (f: MinimalFrame) => {
-        const path = f.abs_path ?? f.filename ?? "";
+        const path = f?.abs_path ?? f?.filename ?? "";
         return FOREIGN_FRAME_SCHEMES.some((scheme) => path.startsWith(scheme));
       };
       if (frames.every(isForeign)) return true;

--- a/evidence/2026-08/agent-mini-pro2-craft-l-sentry-edge-filters-e4944874/brief.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-l-sentry-edge-filters-e4944874/brief.yml
@@ -1,0 +1,73 @@
+task_id: sentry-edge-filters
+gear: 2
+l_level: L1
+gate_class: opus
+objective: |
+  L08-PR2 of the beyond-SOTA craft wave 2 (squad L, issue #5319), credential-free
+  half.
+
+  Measured on `bali-zero-7p` over 7 days (2026-08-28): the `error` category took
+  1,952 accepted against 753 rate_limited. 28% of production errors are dropped
+  for quota, and which ones get dropped is decided by arrival order rather than
+  by importance. That is not a billing problem, it is a blindness problem.
+
+  This deprioritizes un-actionable events at the edge, on both sides, so the
+  quota is spent on errors somebody could act on.
+constraints:
+  - "RE-GROUND FIRST, per the L08 spec: no committed probe references either
+    Sentry org. `grep -rn 'bali-zero-cf|bali-zero-7p'` hits `research/` and the
+    PENDING-ARMS ledger and nothing else, so the spec's probe-repoint half is
+    void as written and minting a credential for it is operator[secret]."
+  - "A false positive DELETES a production error with no trace anywhere. The
+    innocence half of every test matters more than the guilt half."
+  - "Both predicates fail OPEN: Sentry drops an event silently when its hook
+    raises, so a bug in a noise filter deletes real errors rather than noise."
+  - "401/403 are NOT filtered. That is the #5096 signature, and muting a symptom
+    whose cause was cured is how the recurrence arrives invisibly."
+acceptance:
+  - text: >-
+      WHEN a health-check TRANSACTION reaches the SDK, it SHALL be dropped; and
+      WHEN an ERROR occurs on the same path, it SHALL be kept.
+    probe: "pytest apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py"
+  - text: >-
+      WHERE the SDK routes transactions to `before_send_transaction` rather than
+      `before_send`, the filter SHALL be registered on the hook the SDK actually
+      calls.
+    probe: "pytest apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py -k WIRED"
+  - text: >-
+      IF an event's ROOT exception is actionable, it SHALL be kept even when a
+      linked CAUSE matches a noise rule or carries only foreign frames.
+    probe: "vitest run src/lib/__tests__/sentry-noise.test.ts"
+  - text: >-
+      WHILE running in the server or edge runtime, an abort SHALL NOT be treated
+      as noise — there is no navigation there to have cancelled it.
+    probe: "vitest run src/lib/__tests__/sentry-noise.test.ts"
+consumer_map:
+  - "`apps/mouth/sentry.{client,server,edge}.config.ts` — the three Sentry inits
+    the Next app actually runs. Client gets browser+universal noise; server and
+    edge get universal only."
+  - "`apps/backend-rag/backend/app/setup/sentry_config.py` — the FastAPI init.
+    `before_send_transaction` is a NEW registration: without it the transaction
+    filter is code the SDK never calls."
+  - "Sentry's `bali-zero-7p` error quota — the surface this exists for, and the
+    one this session cannot measure."
+risks:
+  - "NOT PROVEN, and stated rather than implied: I cannot measure the 28% moving.
+    That needs Sentry API access this session does not have, and the probe that
+    would read it does not exist in the repo. What is proven is the predicates'
+    behaviour on every shape named in the tests."
+  - "Every filter is a deletion. The mitigation is that both predicates fail OPEN
+    and that each needle is anchored to an exact engine-emitted form rather than
+    an English phrase — `The operation was aborted while committing invoice 42`
+    survives, and there is a test that says so."
+  - "The `logger.warn`-forwards-to-Sentry path in apps/mouth/src/lib/logger.ts is
+    UNCHANGED. It is the mechanism behind #5096 and it remains a foot-gun; this
+    PR deliberately does not mute it, because seeing the next recurrence is worth
+    more than the quota it costs."
+grader: |
+  Cross-family adversarial refutation by Codex GPT-5.6 sol at xhigh effort,
+  read-only, given the raw diff and an attack list. Verdict DO-NOT-SHIP with two
+  blockers, one of which it found by reading the sentry_sdk source rather than
+  the diff. Final on-disk gate is this orchestrator session, empirical.
+budget: 1 build lane (this session) + 1 cross-family review lane. Gear 2, no council gate.
+pii: none

--- a/evidence/2026-08/agent-mini-pro2-craft-l-sentry-edge-filters-e4944874/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-l-sentry-edge-filters-e4944874/pack.yml
@@ -24,9 +24,9 @@ seat_diversity_note: >-
   principle.
 diff:
   net_lines: >-
-    AS OF 90b1760b30 (pinned — an unqualified count inside a file that later
-    commits rewrite decays by construction): 7 files, +716/-2 against the merge base, plus
-    this evidence pack. Roughly half is the two corpora. Deterministic gear
+    AS OF 023ab4df5c (pinned — an unqualified count inside a file that later
+    commits rewrite decays by construction): 9 files, +916/-2 against the merge base, INCLUDING this
+    evidence pack. Roughly half is the two corpora. Deterministic gear
     floor recomputed from the diff = 2. NOT 1: `--print-floor` over the code
     files alone answers 1, and the floor rises to 2 once this evidence pack is
     part of the changed set — the blast-radius half of the computation counts

--- a/evidence/2026-08/agent-mini-pro2-craft-l-sentry-edge-filters-e4944874/pack.yml
+++ b/evidence/2026-08/agent-mini-pro2-craft-l-sentry-edge-filters-e4944874/pack.yml
@@ -1,0 +1,127 @@
+# STAGING PATH, NOT THE REAL ONE — harness-floor.yml copies both files to
+# /tmp/evidence-check/evidence/{brief,pack}.yml under their canonical names and
+# the lint resolves brief_ref against THAT root, so this must read the literal
+# evidence/brief.yml even though the real brief lives beside this file.
+brief_ref: evidence/brief.yml
+plan_ref: "docs/plans/2026-08-29-beyond-sota-craft-wave/L08-observability-immune-self-healing.md — PR-2 (credential-free half); squad ledger issue #5319"
+lanes:
+  - lane: sentry-edge
+    role: build
+    seat: "claude-opus-5 (this session)"
+  - lane: sentry-refute
+    role: review
+    seat: "gpt-5.6-sol xhigh, --sandbox read-only — DO-NOT-SHIP, 2 blockers, 3 majors"
+  - lane: final-gate
+    role: review
+    seat: "claude-opus-5 (this orchestrator — every receipt re-run here)"
+seat_diversity: degraded
+seat_diversity_note: >-
+  One build lane, so the D3 floor (>=2 build lanes) does not fire and this field
+  stays "degraded" on that basis. The review side is not: a cross-family seat
+  gated the diff and returned two BLOCKERS the build lane had missed, one of
+  them found by reading the sentry_sdk source rather than the diff. That is the
+  argument for cross-family review stated as a measurement rather than a
+  principle.
+diff:
+  net_lines: >-
+    AS OF 90b1760b30 (pinned — an unqualified count inside a file that later
+    commits rewrite decays by construction): 7 files, +716/-2 against the merge base, plus
+    this evidence pack. Roughly half is the two corpora. Deterministic gear
+    floor recomputed from the diff = 2. NOT 1: `--print-floor` over the code
+    files alone answers 1, and the floor rises to 2 once this evidence pack is
+    part of the changed set — the blast-radius half of the computation counts
+    the files a PR actually carries, and the pack is one of them. Declaring the
+    number measured before the pack existed would have been a floor computed
+    from a diff that no longer exists.
+  behaviour_change: >-
+    Events reaching Sentry change. Backend: health-check TRANSACTIONS are
+    dropped (errors on the same paths are not). Frontend: the client drops
+    browser-only noise, the server and edge drop only universal noise. Nothing
+    else in either app changes; no producer, no route, no handler is touched.
+receipts:
+  - claim: "The transaction filter is registered on the hook the SDK actually calls — it was not, and its tests were green anyway"
+    cmd: "pytest apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py -k WIRED"
+    result: >-
+      2 passed. The installed sentry_sdk guards before_send with
+      `event.get("type") != "transaction"` and routes transactions to
+      before_send_transaction — read out of inspect.getsource in the test rather
+      than remembered. Mutation: removing the registration line turns the corpus
+      red, where before the fix it turned nothing red at all.
+    exit: 0
+    ts: "2026-08-31T05:20Z"
+    seat: "session (mini, final gate)"
+  - claim: "A health-check TRANSACTION is dropped and an ERROR on the same path is kept"
+    cmd: "pytest apps/backend-rag/backend/tests/unit/app/setup/test_sentry_health_transaction_drop.py"
+    result: >-
+      9 passed. /health, /healthz, /readyz, /livez, /api/health and "GET /health"
+      drop as transactions; the same paths as ERRORS are kept; and
+      /healthcheck-audit, /api/health-report, /healthy-clients are kept because
+      the match is a path segment, never a substring.
+    exit: 0
+    ts: "2026-08-31T05:20Z"
+    seat: "session (mini, final gate)"
+  - claim: "An actionable ROOT survives a benign linked CAUSE, and the same abort means opposite things in the two runtimes"
+    cmd: "vitest run src/lib/__tests__/sentry-noise.test.ts"
+    result: >-
+      21 passed, including every shape the reviewer executed against the first
+      version: a linked error whose cause is an abort and whose root is
+      "Failed to persist completed payment" is KEPT; a frameless root beside a
+      foreign-framed cause is KEPT; a root with frames: [] is KEPT; ResizeObserver
+      via logentry is DROPPED; and "AbortError: The operation was aborted" drops
+      in the browser while the same event is kept with browser: false.
+    exit: 0
+    ts: "2026-08-31T05:22Z"
+    seat: "session (mini, final gate)"
+  - claim: "Nothing adjacent regressed"
+    cmd: "vitest run src/lib ; pytest apps/backend-rag/backend/tests/unit/app/setup/ ; tsc --noEmit ; prettier --check"
+    result: "1876 passed (132 files); 188 passed; tsc rc 0; prettier clean"
+    exit: 0
+    ts: "2026-08-31T05:22Z"
+    seat: "session (mini, final gate)"
+  - claim: "Every cure is defended — reverting it turns a corpus red"
+    cmd: "vitest / pytest with the cure reverted, one mutation at a time"
+    result: >-
+      8 mutants, 8 killed: the hook unregistered, root taken as the FIRST value,
+      the empty-frames guard removed, logentry ignored, the server given browser
+      needles, a needle un-anchored to the bare English phrase, any-foreign
+      instead of all-foreign frames, and the backend filter disabled. The
+      empty-frames mutant survived the first battery — the root-only change had
+      made Array.isArray do the work, so an event Sentry ships with frames: []
+      had no test.
+    exit: 0
+    ts: "2026-08-31T05:25Z"
+    seat: "session (mini, final gate)"
+  - claim: "RE-GROUND: no committed probe references either Sentry org, so the spec's probe-repoint half is void as written"
+    cmd: "grep -rn 'bali-zero-cf|bali-zero-7p' --include=*.py --include=*.sh --include=*.yml --include=*.ts ."
+    result: "hits only in research/2026-08-28-beyond-sota-observability-immune-self-healing.md and .claude/skills/modus/PENDING-ARMS.md — prose, not code. No probe exists to repoint."
+    exit: 0
+    ts: "2026-08-31T04:55Z"
+    seat: "session (mini, final gate)"
+pii_scan: clean
+dissent:
+  - seat: "gpt-5.6-sol (xhigh, read-only) — on the diff, with an attack list"
+    objection: >-
+      DO-NOT-SHIP, two blockers and three majors. (1) The transaction filter was
+      DEAD CODE: sentry_sdk guards before_send with type != "transaction" and
+      dispatches transactions to before_send_transaction, so the health-check
+      drop never ran in production while its tests — which called the inner
+      function directly — stayed green. (2) The noise filter deleted real
+      errors: it read EVERY exception value, so a linked error with a benign
+      cause and an actionable root was dropped entirely; it flattened frames
+      across values, so a frameless root vanished and a foreign-framed cause
+      decided the verdict; and "The operation was aborted" matched as a bare
+      substring, in a runtime where an abort is a real timeout rather than a
+      cancelled navigation. Plus: parameterised captureMessage lands in
+      event.logentry, which neither the predicate nor Sentry's own ignoreErrors
+      matcher reads, so that noise reached Sentry through both surfaces.
+    status: CONFIRMED
+    disposition: >-
+      All accepted, all reproduced before being fixed, none rejected. The hook is
+      registered and the corpus now asserts the WIRING rather than the function;
+      the predicate judges the ROOT exception; the frame rule needs at least one
+      frame on that root; logentry is read; and the needle list is split into
+      universal and browser-only with each string anchored to the exact
+      engine-emitted form. The previous commit's claim that ignoreErrors and
+      beforeSend are "in step" is RETRACTED — they are different surfaces with
+      different matchers, and the test that "proved" parity did so by feeding
+      the list back into the predicate.


### PR DESCRIPTION
**L08-PR2** of the beyond-SOTA craft wave 2 — squad L, ledger issue #5319. Gear 2. The **credential-free half**; the probe-repoint half is `operator[secret]` and, as the re-ground below shows, has no probe to repoint.

## The number this exists for

Measured on `bali-zero-7p` over 7 days (2026-08-28): the `error` category took **1,952 accepted against 753 rate_limited**. 28% of production errors are dropped for quota, and *which* ones get dropped is decided by arrival order, not by importance. A dropped event is indistinguishable from one that never happened — so this is not a billing problem, it is a blindness problem.

## RE-GROUND first, as the L08 spec requires

`grep -rn "bali-zero-cf|bali-zero-7p"` over the tree hits `research/` and the PENDING-ARMS ledger and **nowhere else**. No committed probe references either org, so the spec's probe-repoint half is void as written. This PR is what can ship without a credential.

## Bites

`Bites: apps/backend-rag/backend/app/setup/sentry_config.py — before_send_transaction is now registered, and the corpus asserts the WIRING: sentry_sdk.init is called with the hook and the captured callable drops a health transaction while keeping a real one. Observed: 9/9.`

`Bites: apps/mouth/sentry.{client,server,edge}.config.ts — all three inits run the shared predicate, client with browser+universal noise and server/edge with universal only. Observed: 21/21, including every shape the reviewer executed against the first version.`

## What it drops — and what it deliberately does not

| dropped | kept, on purpose |
|---|---|
| health-check **transactions** | an **error** on the same path |
| ResizeObserver loop (browser) | **401 / 403** |
| `AbortError:` forms **in the browser** | the same abort **on the server** |
| value-less promise rejections | an actionable **root** behind a benign cause |
| a stack that is **entirely** extension code | an extension frame **inside** our stack |

**401/403 stay** because that is the #5096 signature — `/chat` fired two authenticated calls at every anonymous visitor, each 401 reached `logger.warn`, and `logger.warn` forwards to Sentry unconditionally in production. The cure for #5096 was the **cause**. Muting the symptom here would mean the next recurrence arrives silently: same bug, one release later, invisible.

**An error on `/health` stays** because only *transactions* are dropped. A health check that 200s every 15 seconds is a metronome; one that 500s is among the most important errors this system can produce — the 2026-04-29 outage was exactly that, and `/health` answering 200 while the RAG worker was dead is its own scar.

## Adversarial review — DO-NOT-SHIP, 2 blockers, 3 majors, all accepted

`gpt-5.6-sol` xhigh, read-only, given the raw diff and an attack list. It found the first blocker **by reading the SDK source rather than the diff**:

> `sentry_sdk`'s client guards `before_send` with `event.get("type") != "transaction"` and routes transactions to `before_send_transaction`.

**The transaction filter was dead code in production** — while its tests stayed green, because they called the inner function directly instead of going through the integration. W116 with a passing test on top, which is the only reason it could ship, *inside the wave whose subject is that exact class*. The corpus now reads that guard out of `inspect.getsource` rather than remembering it, and asserts the registration.

The noise filter **deleted real errors**, three ways, each reproduced by the reviewer against the submitted predicate:

- it read **every** exception value, so a linked error with a benign cause and a root of `Failed to persist completed payment` was deleted entirely — Sentry puts the root *last*, and the event's identity is its root;
- it **flattened frames across values**, so a frameless root vanished and a foreign-framed cause decided the verdict (`[].every()` is vacuously true — the wrong answer said confidently);
- `"The operation was aborted"` matched as a bare substring, so `"The operation was aborted while committing invoice 42"` was noise.

**And the same words mean opposite things in the two runtimes.** In a browser an abort is a cancelled navigation; on the server there *is* no navigation, and an `AbortError` from a nightly export is an application deadline killing real I/O. The list is split — `UNIVERSAL_NOISE` for server and edge, `BROWSER_ONLY_NOISE` added for the client — and every needle is anchored to the exact engine-emitted form rather than the English phrase.

Missed noise, the safe direction but still wrong: parameterised `captureMessage` lands in `event.logentry`, which neither the predicate nor Sentry's own `ignoreErrors` matcher reads. Now read.

**One claim from the first commit is retracted**: that `ignoreErrors` and `beforeSend` are "in step". They are different surfaces with different matchers, neither a superset of the other — and the test that "proved" parity did so by feeding the list back into the predicate rather than into Sentry's matcher. The test now asserts the overlap that actually holds and says why parity does not.

## Green at the final SHA

`vitest run src/lib` **1876/1876** (132 files) · backend `tests/unit/app/setup/` **188/188** · `tsc --noEmit` rc 0 · prettier clean · anti-reward-hacking clean · evidence-pack lint **clean, zero notices**.

**Mutation: 8 mutants, 8 killed.** The hook unregistered (the original blocker), root taken as the *first* value, the empty-frames guard removed, `logentry` ignored, the server given browser needles, a needle un-anchored, any-foreign instead of all-foreign, and the backend filter disabled. The empty-frames mutant **survived the first battery** — the root-only change had made `Array.isArray` do the work, so an event Sentry ships with `frames: []` had no test.

## Not proven here, stated rather than implied

I cannot measure the 28% moving. That needs Sentry API access this session does not have, and the probe that would read it does not exist in the repo. What *is* proven is the predicates' behaviour on every shape named above.

The `logger.warn` → Sentry path in `apps/mouth/src/lib/logger.ts` is **unchanged**. It is the mechanism behind #5096 and remains a foot-gun; muting it is deliberately not done, because seeing the next recurrence is worth more than the quota it costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
