### PR TITLE
fix(bot): anchor derived amounts, so the bot can answer "how much for 5 days"

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -294,7 +294,10 @@ def _starts_with_internal_monologue_leak(answer: str) -> bool:
 # can never drift apart. That coupling was live-ammunition: _canonical_value does
 # _AMOUNT_MULTIPLIERS[multiplier.lower()] with no .get(), so a token the pattern
 # matches and the dict lacks is a KeyError inside the finalize path, not a miss.
-# test_wa_finalize_price_veto.py asserts the derivation holds.
+# test_wa_finalize.py::test_pricing_veto_multiplier_pattern_is_derived_from_the_table
+# asserts the derivation holds. (The name cited here until 2026-08-30 was
+# test_wa_finalize_price_veto.py, a file that does not exist in this tree —
+# a citation pointing at nothing protects nothing.)
 #
 # NOT widened here, deliberately, and named so it is not mistaken for coverage: a
 # bare currency WORD ("2,5 miliar rupiah", with no Rp/IDR/USD marker) is still
@@ -469,6 +472,99 @@ def _currency_amounts(text: str) -> list[tuple[str, int]]:
     return out
 
 
+# ---------------------------------------------------------------------------
+# DERIVED AMOUNTS (added 2026-08-30)
+#
+# THE DEFECT, measured live and in isolation, not argued. `wa_outbox` row 387
+# was fired alone into a quiet thread — no sibling message, no coalescing — and
+# failed 5 of 5 attempts on `finalize_pricing_outside_package` answering
+#
+#     "Kalau visa saya overstay 5 hari, dendanya berapa per hari?"
+#
+# The evidence package for that query really does carry the rate (measured on
+# the production build endpoint: `IDR 1,000,000` per day, PP 45/2024). The
+# answer was rejected because it did what the client asked — it multiplied the
+# rate by the five days — and `5,000,000` appears in no source verbatim. The
+# client received an apology.
+#
+# The same mechanism makes the ONE rule this bot must obey unshippable. Zero's
+# 2026-07-17 ruling is a single all-inclusive client-facing price, which for an
+# Investor KITAS means 17,000,000 + 9,500,000 = 26,500,000 — a figure that,
+# again, appears in no source. Measured against the real package notation:
+#
+#     "Total all-in ... Rp26.500.000"       -> ['IDR:26500000']   VETOED
+#     "biaya layanan Rp17.000.000.
+#      PNBP pemerintah Rp9.500.000"          -> []                 passes
+#
+# So the anchoring veto was actively PUSHING the generator toward splitting the
+# government levy out of the client price: splitting is the only shape that
+# keeps every figure verbatim-anchored. The split-price defect this codebase is
+# separately guarding against was, in part, this veto's own output.
+#
+# THE CURE: an amount is anchored if it is a source amount OR an exact
+# arithmetic derivation of source amounts — an integer multiple (a per-day rate
+# times a number of days) or a sum of two or three of them (an all-inclusive
+# total). Nothing else: no differences, no percentages, no chains of both. The
+# generator may ADD UP what the sources say; it may not invent.
+#
+# WHAT THIS COSTS, stated rather than buried: a hallucinated figure that
+# happens to equal a sum or a small multiple of real source figures now passes.
+# That is a genuine widening. It is the right side of the exchange because the
+# measured alternative is not "a stricter guard" but "no answer at all" on the
+# two commonest question shapes the business has — how much does it cost, and
+# how much is the fine — plus a standing incentive toward the split-price
+# defect. The label gate, the PricingTool grounding and the split-fee veto
+# remain the primary controls on WHAT the answer claims.
+#
+# The bounds are deliberate and small. MULTIPLE caps at 366 because the real
+# multiplicand is a count of days (overstay days, rental days) and a year is
+# the honest ceiling; TERMS caps at 3 because a client price is a service fee
+# plus a levy plus at most one add-on, and every extra term multiplies the
+# surface on which a wrong number can land on a legal sum by coincidence.
+_DERIVED_MAX_MULTIPLE = 366
+_DERIVED_PAIRSUM_MAX_SOURCES = 200
+
+
+def _is_derived_from_sources(value: int, source_values: set[int]) -> bool:
+    """True when ``value`` is an exact multiple or 2-/3-term sum of sources.
+
+    Deliberately NOT a general subset-sum: the bounds above are what keep this
+    an arithmetic allowance rather than a hole. Pure and side-effect free so
+    the veto stays testable without fixtures.
+    """
+    if value in source_values:
+        return True
+
+    # Integer multiple of a single source amount (rate x count).
+    for src in source_values:
+        if src <= 0:
+            continue
+        if value % src == 0:
+            factor = value // src
+            if 2 <= factor <= _DERIVED_MAX_MULTIPLE:
+                return True
+
+    # Sum of exactly two source amounts.
+    for src in source_values:
+        if (value - src) in source_values:
+            return True
+
+    # Sum of exactly three. Guarded by a source-count cap: the pairwise set is
+    # O(n^2) and this runs inside the finalize path on every answer.
+    if len(source_values) <= _DERIVED_PAIRSUM_MAX_SOURCES:
+        ordered = sorted(source_values)
+        pair_sums = {
+            a + b
+            for i, a in enumerate(ordered)
+            for b in ordered[i:]
+        }
+        for src in source_values:
+            if (value - src) in pair_sums:
+                return True
+
+    return False
+
+
 def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> list[str]:
     """Canonical amounts in ``text`` that no source contains, as "CUR:value" strings.
 
@@ -510,7 +606,7 @@ def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> lis
     for cur, value in _currency_amounts(text):
         if value < _VETO_FLOORS[cur]:
             continue
-        if value not in source_values:
+        if not _is_derived_from_sources(value, source_values):
             offenders.append(f"{cur}:{value}")
     return offenders
 

--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -521,47 +521,58 @@ def _currency_amounts(text: str) -> list[tuple[str, int]]:
 # the honest ceiling; TERMS caps at 3 because a client price is a service fee
 # plus a levy plus at most one add-on, and every extra term multiplies the
 # surface on which a wrong number can land on a legal sum by coincidence.
-_DERIVED_MAX_MULTIPLE = 366
-_DERIVED_PAIRSUM_MAX_SOURCES = 200
+_SUMMABLE_OPERAND_FLOORS: dict[str, int] = {
+    "IDR": 100_000,
+    "USD": 10,
+    "EUR": 10,
+    "GBP": 10,
+    "SGD": 10,
+    "AUD": 10,
+}
 
 
-def _is_derived_from_sources(value: int, source_values: set[int]) -> bool:
-    """True when ``value`` is an exact multiple or 2-/3-term sum of sources.
+def _is_two_component_total(value: int, source_values: set[int], cur: str) -> bool:
+    """True when ``value`` is the sum of two DISTINCT price-sized source amounts.
 
-    Deliberately NOT a general subset-sum: the bounds above are what keep this
-    an arithmetic allowance rather than a hole. Pure and side-effect free so
-    the veto stays testable without fixtures.
+    Deliberately the narrowest rule that delivers the business requirement, and
+    everything it excludes was excluded because an adversarial reviewer broke
+    the wider version with a concrete case that then reproduced verbatim:
+
+    * NO multiples. The first cut allowed an integer multiple of a source
+      amount, reasoning that a per-day rate times a day count is honest
+      arithmetic. It is -- but the code could not see the count. It divided the
+      GENERATED figure by a source figure and accepted any whole quotient, so
+      with a single ``IDR 1,000,000/day`` source it authorized every whole
+      million up to 366 million: `Rp250.000.000` passed for a five-day
+      question. Divisibility is not derivation. Binding the multiplier to a
+      count actually present in the customer's question is the right shape and
+      is NOT attempted here -- it is a different change, specified rather than
+      guessed.
+    * TWO terms, not three. Three terms let unrelated chunks be laundered into
+      a plausible package total (a KITAS fee + a tax penalty + an overstay fine
+      summing to a "PT PMA setup price" no source states).
+    * DISTINCT operands. With replacement, one occurrence of a 17,000,000
+      service fee authorized 43,500,000 by charging it twice.
+    * An OPERAND FLOOR, separate from `_VETO_FLOORS`. Source values are
+      harvested from every numeric token in every retrieved chunk -- years,
+      article numbers, KBLI codes, quantities. Those are not money, and
+      summing them produced prices: `1,000,000 + 2024 + 45` authorized
+      `Rp1.002.069`, and a bare `2` from "2 years" authorized `Rp26.500.002`.
+      The answer-side floor cannot catch this because it only filters the
+      final amount, never the operands.
+
+    DECLARED RESIDUAL, not closed here: two REAL price amounts from unrelated
+    chunks can still sum to a total no source authorizes, because
+    `price_sources` is a flat sequence of strings and carries no provenance,
+    no currency family and no semantic role. Closing that requires typed
+    operands (source id, role, product, validity) -- a data-contract change,
+    not a predicate change.
     """
-    if value in source_values:
-        return True
-
-    # Integer multiple of a single source amount (rate x count).
-    for src in source_values:
-        if src <= 0:
-            continue
-        if value % src == 0:
-            factor = value // src
-            if 2 <= factor <= _DERIVED_MAX_MULTIPLE:
-                return True
-
-    # Sum of exactly two source amounts.
-    for src in source_values:
-        if (value - src) in source_values:
+    floor = _SUMMABLE_OPERAND_FLOORS.get(cur, _SUMMABLE_OPERAND_FLOORS["IDR"])
+    for a in (v for v in source_values if v >= floor):
+        b = value - a
+        if b > a and b in source_values and b >= floor:
             return True
-
-    # Sum of exactly three. Guarded by a source-count cap: the pairwise set is
-    # O(n^2) and this runs inside the finalize path on every answer.
-    if len(source_values) <= _DERIVED_PAIRSUM_MAX_SOURCES:
-        ordered = sorted(source_values)
-        pair_sums = {
-            a + b
-            for i, a in enumerate(ordered)
-            for b in ordered[i:]
-        }
-        for src in source_values:
-            if (value - src) in pair_sums:
-                return True
-
     return False
 
 
@@ -606,7 +617,9 @@ def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> lis
     for cur, value in _currency_amounts(text):
         if value < _VETO_FLOORS[cur]:
             continue
-        if not _is_derived_from_sources(value, source_values):
+        if value in source_values:
+            continue
+        if not _is_two_component_total(value, source_values, cur):
             offenders.append(f"{cur}:{value}")
     return offenders
 

--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -473,54 +473,59 @@ def _currency_amounts(text: str) -> list[tuple[str, int]]:
 
 
 # ---------------------------------------------------------------------------
-# DERIVED AMOUNTS (added 2026-08-30)
+# TWO-COMPONENT TOTALS (added 2026-08-30)
 #
-# THE DEFECT, measured live and in isolation, not argued. `wa_outbox` row 387
-# was fired alone into a quiet thread — no sibling message, no coalescing — and
-# failed 5 of 5 attempts on `finalize_pricing_outside_package` answering
+# THE DEFECT that opened this, measured rather than argued: the ONE rule this
+# bot must obey was unshippable. Zero's 2026-07-17 ruling is a single
+# all-inclusive client-facing price, which for an Investor KITAS means
+# 17,000,000 + 9,500,000 = 26,500,000 — a figure that appears in no source.
+# Against the real package notation, before this change:
 #
-#     "Kalau visa saya overstay 5 hari, dendanya berapa per hari?"
-#
-# The evidence package for that query really does carry the rate (measured on
-# the production build endpoint: `IDR 1,000,000` per day, PP 45/2024). The
-# answer was rejected because it did what the client asked — it multiplied the
-# rate by the five days — and `5,000,000` appears in no source verbatim. The
-# client received an apology.
-#
-# The same mechanism makes the ONE rule this bot must obey unshippable. Zero's
-# 2026-07-17 ruling is a single all-inclusive client-facing price, which for an
-# Investor KITAS means 17,000,000 + 9,500,000 = 26,500,000 — a figure that,
-# again, appears in no source. Measured against the real package notation:
-#
-#     "Total all-in ... Rp26.500.000"       -> ['IDR:26500000']   VETOED
+#     "Total all-in ... Rp26.500.000"        -> ['IDR:26500000']   VETOED
 #     "biaya layanan Rp17.000.000.
 #      PNBP pemerintah Rp9.500.000"          -> []                 passes
 #
-# So the anchoring veto was actively PUSHING the generator toward splitting the
+# So this veto was actively PUSHING the generator toward splitting the
 # government levy out of the client price: splitting is the only shape that
-# keeps every figure verbatim-anchored. The split-price defect this codebase is
-# separately guarding against was, in part, this veto's own output.
+# keeps every figure verbatim-anchored. The split-price defect guarded
+# separately by `price_split_offenders` was, in part, this veto's own output.
 #
-# THE CURE: an amount is anchored if it is a source amount OR an exact
-# arithmetic derivation of source amounts — an integer multiple (a per-day rate
-# times a number of days) or a sum of two or three of them (an all-inclusive
-# total). Nothing else: no differences, no percentages, no chains of both. The
-# generator may ADD UP what the sources say; it may not invent.
+# THE RULE: an amount is anchored if it is a source amount, or the sum of
+# exactly TWO DISTINCT source amounts that are each price-sized. Nothing else.
+# The generator may add up two things the sources state; it may not invent, and
+# it may not multiply.
 #
-# WHAT THIS COSTS, stated rather than buried: a hallucinated figure that
-# happens to equal a sum or a small multiple of real source figures now passes.
-# That is a genuine widening. It is the right side of the exchange because the
-# measured alternative is not "a stricter guard" but "no answer at all" on the
-# two commonest question shapes the business has — how much does it cost, and
-# how much is the fine — plus a standing incentive toward the split-price
-# defect. The label gate, the PricingTool grounding and the split-fee veto
-# remain the primary controls on WHAT the answer claims.
+# WHAT WAS TRIED AND REJECTED, kept because the wider shape is the tempting one
+# and this is the record of why it fails. The first version also admitted an
+# integer multiple of a source amount, on the reasoning that a per-day rate
+# times a day count is honest arithmetic. It is — but the code cannot see the
+# count. It divided the GENERATED figure by a source figure and accepted any
+# whole quotient. A cross-family adversarial reviewer returned BLOCK, and all
+# seven of its concrete cases reproduced verbatim against the code:
 #
-# The bounds are deliberate and small. MULTIPLE caps at 366 because the real
-# multiplicand is a count of days (overstay days, rental days) and a year is
-# the honest ceiling; TERMS caps at 3 because a client price is a service fee
-# plus a levy plus at most one add-on, and every extra term multiplies the
-# surface on which a wrong number can land on a legal sum by coincidence.
+#     Rp250.000.000  passed (250x the daily rate; the client asked about 5 days)
+#     Rp88.000.000   passed (as did every whole million up to 366 million)
+#     Rp1.002.069    passed (1,000,000 + 2024 + 45 — a year and an article no.)
+#     Rp26.500.002   passed (the bare "2" from "2 years" used as an operand)
+#     Rp43.500.000   passed (one 17,000,000 service fee charged twice)
+#     Rp20.500.000   passed (KITAS fee + tax penalty + overstay fine, laundered)
+#     Rp3.000.000    passed (a USD source authorizing an IDR multiple)
+#
+# With one Rp1,000,000/day source the guard admitted the entire round-million
+# grid — precisely the numbers a generator emits. Divisibility is not
+# derivation. Each of those seven is now a test.
+#
+# WHAT THIS STILL COSTS, stated rather than buried:
+# * An honest multiplication is still vetoed. "5 hari x Rp1.000.000" is a
+#   correct answer to a real question, and `wa_outbox` row 387 — fired alone
+#   into a quiet thread — failed 5 of 5 attempts on exactly that and the client
+#   got an apology. Admitting it safely requires binding the multiplier to a
+#   count present in the CUSTOMER'S QUESTION, which this function never
+#   receives. That is a signature change; it will be specified, not guessed.
+# * Two REAL price amounts from unrelated chunks can still sum to a total no
+#   source authorizes, because `price_sources` is a flat sequence of strings
+#   carrying no provenance, no currency family and no semantic role. Closing
+#   that is a data-contract change, not a predicate change.
 _SUMMABLE_OPERAND_FLOORS: dict[str, int] = {
     "IDR": 100_000,
     "USD": 10,

--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -562,9 +562,7 @@ def _summable_operands(price_sources: Sequence[str], cur: str) -> set[int]:
     return operands
 
 
-def _is_two_component_total(
-    value: int, price_sources: Sequence[str], cur: str
-) -> bool:
+def _is_two_component_total(value: int, operands: set[int]) -> bool:
     """True when ``value`` is the sum of two DISTINCT same-currency amounts.
 
     Two terms, not three: three let unrelated chunks be laundered into a
@@ -596,7 +594,6 @@ def _is_two_component_total(
     chunks still sum to a total no source authorizes, because `price_sources`
     carries no provenance and no semantic role.
     """
-    operands = _summable_operands(price_sources, cur)
     for a in operands:
         b = value - a
         if b > a and b in operands:
@@ -642,12 +639,18 @@ def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> lis
             if value is not None:
                 source_values.add(value)
     offenders: list[str] = []
+    operands_by_family: dict[str, set[int]] = {}
     for cur, value in _currency_amounts(text):
         if value < _VETO_FLOORS[cur]:
             continue
         if value in source_values:
             continue
-        if not _is_two_component_total(value, price_sources, cur):
+        # Parsed once per CURRENCY FAMILY, not once per amount: an answer
+        # quoting four figures re-parsed every chunk four times, and the retry
+        # ladder repeated that up to five times per turn.
+        if cur not in operands_by_family:
+            operands_by_family[cur] = _summable_operands(price_sources, cur)
+        if not _is_two_component_total(value, operands_by_family[cur]):
             offenders.append(f"{cur}:{value}")
     return offenders
 

--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -526,57 +526,80 @@ def _currency_amounts(text: str) -> list[tuple[str, int]]:
 #   source authorizes, because `price_sources` is a flat sequence of strings
 #   carrying no provenance, no currency family and no semantic role. Closing
 #   that is a data-contract change, not a predicate change.
-_SUMMABLE_OPERAND_FLOORS: dict[str, int] = {
-    "IDR": 100_000,
-    "USD": 10,
-    "EUR": 10,
-    "GBP": 10,
-    "SGD": 10,
-    "AUD": 10,
-}
+def _summable_operands(price_sources: Sequence[str], cur: str) -> set[int]:
+    """Source amounts eligible to be COMPONENTS of a two-part total.
 
+    Deliberately much narrower than the membership set the veto uses. Two
+    restrictions, each of which a cross-family reviewer demonstrated is
+    load-bearing with a concrete case:
 
-def _is_two_component_total(value: int, source_values: set[int], cur: str) -> bool:
-    """True when ``value`` is the sum of two DISTINCT price-sized source amounts.
+    * CURRENCY-MARKED ONLY. The membership set is harvested from every numeric
+      token in every chunk, which is right for membership (a pricing block may
+      state an amount without repeating its marker) and catastrophic for
+      addition: years, article numbers, KBLI codes, quantities and even
+      statistics are not money. `USD 59` passed as `45 + 14` from "Pasal 45"
+      and "14 hari kerja"; `Rp7.275.000` passed as a tourist count plus a real
+      fee. An earlier draft tried to exclude those with a magnitude floor,
+      which is the wrong instrument -- a number's ROLE is not recoverable from
+      its size, and the floor was simultaneously too low for a 7-digit
+      non-money token and too high for a real Rp10.000 stamp duty.
+    * SAME CURRENCY FAMILY as the answer. The membership set is untyped, so a
+      USD figure could authorize an IDR one: `USD 100,000` (a capital minimum)
+      plus `Rp500.000` (notary) authorized `Rp600.000`. Family is available
+      here at no cost -- `_currency_amounts` already returns it -- so the pair
+      rule keeps it even though membership, by its own documented residual,
+      does not.
 
-    Deliberately the narrowest rule that delivers the business requirement, and
-    everything it excludes was excluded because an adversarial reviewer broke
-    the wider version with a concrete case that then reproduced verbatim:
-
-    * NO multiples. The first cut allowed an integer multiple of a source
-      amount, reasoning that a per-day rate times a day count is honest
-      arithmetic. It is -- but the code could not see the count. It divided the
-      GENERATED figure by a source figure and accepted any whole quotient, so
-      with a single ``IDR 1,000,000/day`` source it authorized every whole
-      million up to 366 million: `Rp250.000.000` passed for a five-day
-      question. Divisibility is not derivation. Binding the multiplier to a
-      count actually present in the customer's question is the right shape and
-      is NOT attempted here -- it is a different change, specified rather than
-      guessed.
-    * TWO terms, not three. Three terms let unrelated chunks be laundered into
-      a plausible package total (a KITAS fee + a tax penalty + an overstay fine
-      summing to a "PT PMA setup price" no source states).
-    * DISTINCT operands. With replacement, one occurrence of a 17,000,000
-      service fee authorized 43,500,000 by charging it twice.
-    * An OPERAND FLOOR, separate from `_VETO_FLOORS`. Source values are
-      harvested from every numeric token in every retrieved chunk -- years,
-      article numbers, KBLI codes, quantities. Those are not money, and
-      summing them produced prices: `1,000,000 + 2024 + 45` authorized
-      `Rp1.002.069`, and a bare `2` from "2 years" authorized `Rp26.500.002`.
-      The answer-side floor cannot catch this because it only filters the
-      final amount, never the operands.
-
-    DECLARED RESIDUAL, not closed here: two REAL price amounts from unrelated
-    chunks can still sum to a total no source authorizes, because
-    `price_sources` is a flat sequence of strings and carries no provenance,
-    no currency family and no semantic role. Closing that requires typed
-    operands (source id, role, product, validity) -- a data-contract change,
-    not a predicate change.
+    Dropping the magnitude floor is what lets a genuine small line item (stamp
+    duty, admin fee) still be a component; being currency-marked is the test
+    that does the work the floor was failing to do.
     """
-    floor = _SUMMABLE_OPERAND_FLOORS.get(cur, _SUMMABLE_OPERAND_FLOORS["IDR"])
-    for a in (v for v in source_values if v >= floor):
+    operands: set[int] = set()
+    for src in price_sources:
+        for family, value in _currency_amounts(src):
+            if family == cur and value > 0:
+                operands.add(value)
+    return operands
+
+
+def _is_two_component_total(
+    value: int, price_sources: Sequence[str], cur: str
+) -> bool:
+    """True when ``value`` is the sum of two DISTINCT same-currency amounts.
+
+    Two terms, not three: three let unrelated chunks be laundered into a
+    plausible package total (a KITAS fee + a tax penalty + an overstay fine
+    summing to a "PT PMA setup price" no source states). Distinct VALUES, not
+    occurrences: with replacement, one 17,000,000 service fee authorized
+    43,500,000 by being charged twice.
+
+    NO MULTIPLES, and that exclusion is the important one. An earlier version
+    allowed an integer multiple of a source amount, reasoning that a per-day
+    rate times a day count is honest arithmetic. It is -- but this function
+    cannot see the count. It divided the GENERATED figure by a source figure
+    and accepted any whole quotient, so a single `IDR 1,000,000/day` source
+    authorized every whole million to 366 million, and `Rp250.000.000` passed
+    a five-day question. Divisibility is not derivation.
+
+    DECLARED FALSE POSITIVES, named so they are not mistaken for coverage.
+    Each costs a retry and then an apology to a client whose answer was right:
+    * an honest multiplication (5 days x Rp1.000.000) -- needs the multiplier
+      bound to a count in the customer's question, which this function never
+      receives;
+    * a percentage of a base (PPh final 5% of Rp100.000.000) -- same shape,
+      same missing input;
+    * a legitimate three-component total (PNBP + telex + service fee).
+    All three want the same thing: typed operands carrying a role, not a
+    predicate guessing arithmetic backwards. That is a data-contract change.
+
+    DECLARED FALSE NEGATIVE: two REAL same-currency amounts from UNRELATED
+    chunks still sum to a total no source authorizes, because `price_sources`
+    carries no provenance and no semantic role.
+    """
+    operands = _summable_operands(price_sources, cur)
+    for a in operands:
         b = value - a
-        if b > a and b in source_values and b >= floor:
+        if b > a and b in operands:
             return True
     return False
 
@@ -624,7 +647,7 @@ def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> lis
             continue
         if value in source_values:
             continue
-        if not _is_two_component_total(value, source_values, cur):
+        if not _is_two_component_total(value, price_sources, cur):
             offenders.append(f"{cur}:{value}")
     return offenders
 

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -642,13 +642,18 @@ async def test_gemini_escalate_marker_is_stripped_and_a_human_is_told() -> None:
 
 
 # ---------------------------------------------------------------------------
-# DERIVED AMOUNTS (2026-08-30)
+# TWO-COMPONENT TOTALS (2026-08-30)
 #
-# Every source string below uses the notation MEASURED on the production
-# package-build endpoint for these very queries (`IDR 1,000,000`,
-# `IDR 17,000,000`), not a convenient invention — the previous round of work on
-# this veto was misled for an hour by a fixture that wrote amounts in a
-# notation the live KB does not use.
+# Source strings use the notation MEASURED on the production package-build
+# endpoint for these very queries (`IDR 1,000,000`, `IDR 17,000,000`), not a
+# convenient invention: an earlier probe in this lane was misled for an hour by
+# a fixture written in a notation the live KB does not use.
+#
+# The guilt cases below are not hypotheticals. Every one of them was produced
+# by a cross-family adversarial reviewer against the FIRST version of this
+# allowance -- which also admitted integer multiples and three-term sums -- and
+# every one reproduced verbatim before the design was narrowed. They are kept
+# as tests precisely so the wider shape cannot come back by accident.
 # ---------------------------------------------------------------------------
 
 _SRC_OVERSTAY = ["Overstay fine: IDR 1,000,000 per day per person. PP 45/2024."]
@@ -657,64 +662,116 @@ _SRC_KITAS = [
     "status IDR 19,000,000; extension IDR 18,000,000.",
     "PNBP Investor KITAS 2 tahun IDR 9,500,000.",
 ]
+_SRC_UNRELATED = [
+    "Investor KITAS service IDR 17,000,000.",
+    "Late tax penalty IDR 2,500,000.",
+    "Overstay fine IDR 1,000,000 per day.",
+]
 
 
-def test_pricing_veto_allows_a_rate_multiplied_by_the_days_asked_about() -> None:
-    """The reproduced live failure: wa_outbox row 387, fired in isolation.
-
-    It failed 5 of 5 attempts on `finalize_pricing_outside_package` and the
-    client got an apology, because the answer did the multiplication the
-    question asked for and 5,000,000 is in no source verbatim.
-    """
-    text = "Denda overstay Rp1.000.000 per hari. Untuk 5 hari, totalnya Rp5.000.000."
-    assert price_tokens_outside_sources(text, _SRC_OVERSTAY) == []
-
-
-def test_pricing_veto_allows_the_all_inclusive_sum_the_ruling_requires() -> None:
+def test_pricing_veto_allows_the_all_inclusive_total_the_ruling_requires() -> None:
     """17,000,000 + 9,500,000. Zero's 2026-07-17 ruling asks for exactly this
-    one all-in client-facing figure, and before this change the veto rejected
-    it — which left splitting the levy out of the price as the only shape that
-    could pass."""
+    one all-in client-facing figure. Before this allowance the veto rejected
+    it, which left splitting the levy out of the price as the only shape that
+    could pass -- the veto was manufacturing the split-price defect."""
     text = "Total all-in KITAS Investor 2 tahun Rp26.500.000, sudah termasuk PNBP."
     assert price_tokens_outside_sources(text, _SRC_KITAS) == []
 
 
-def test_pricing_veto_allows_the_same_sum_written_in_english_magnitude() -> None:
-    text = "The all-in total is IDR 26.5 million, government fee included."
-    assert price_tokens_outside_sources(text, _SRC_KITAS) == []
+def test_pricing_veto_allows_the_same_total_in_english_magnitude_words() -> None:
+    assert price_tokens_outside_sources(
+        "The all-in total is IDR 26.5 million, government fee included.", _SRC_KITAS
+    ) == []
 
 
-def test_pricing_veto_still_catches_an_invented_total() -> None:
-    """The allowance is arithmetic, not amnesty: 31,000,000 is neither a
-    source amount, nor a multiple of one, nor a sum of two or three."""
-    text = "Total all-in Rp31.000.000."
-    assert price_tokens_outside_sources(text, _SRC_KITAS) == ["IDR:31000000"]
+def test_pricing_veto_allows_a_second_all_inclusive_variant() -> None:
+    """19,000,000 + 9,500,000 -- the onshore row. One passing pair is a
+    coincidence; the point is that the RULE passes, not one example."""
+    assert price_tokens_outside_sources(
+        "Onshore all-in Rp28.500.000.", _SRC_KITAS
+    ) == []
 
 
-def test_pricing_veto_still_catches_an_invented_multiplication() -> None:
-    text = "Untuk 5 hari, totalnya Rp7.400.000."
-    assert price_tokens_outside_sources(text, _SRC_OVERSTAY) == ["IDR:7400000"]
+def test_pricing_veto_rejects_a_multiple_of_a_source_amount() -> None:
+    """Divisibility is not derivation. The client asked about FIVE days; this
+    answer states 250 times the daily rate. The first version of this allowance
+    accepted it, because it divided the GENERATED figure by a source figure and
+    took any whole quotient -- it never saw the count."""
+    assert price_tokens_outside_sources(
+        "Totalnya Rp250.000.000.", _SRC_OVERSTAY
+    ) == ["IDR:250000000"]
 
 
-def test_pricing_veto_derivation_cannot_rescue_an_answer_with_no_sources() -> None:
-    """The file's own 999-billion control, re-run against the allowance: with
-    an empty source set there is nothing to derive FROM, so the widening can
-    never turn a groundless answer into a grounded one."""
-    text = "The fee is IDR 999,000,000,000."
-    assert price_tokens_outside_sources(text, []) == ["IDR:999000000000"]
+def test_pricing_veto_does_not_authorize_the_whole_round_million_grid() -> None:
+    """With one Rp1,000,000/day source, the multiple branch admitted EVERY
+    whole million to 366 million -- precisely the numbers a generator emits.
+    A guard that passes the entire round-price grid is not a guard."""
+    assert price_tokens_outside_sources(
+        "Biayanya Rp88.000.000.", _SRC_OVERSTAY
+    ) == ["IDR:88000000"]
 
 
-def test_pricing_veto_multiple_is_capped_at_a_year_of_days() -> None:
-    """400 x 1,000,000 is an exact multiple and is still vetoed: the cap is
-    what keeps 'multiple of a source amount' from meaning 'any round number'.
-    """
-    text = "Totalnya Rp400.000.000."
-    assert price_tokens_outside_sources(text, _SRC_OVERSTAY) == ["IDR:400000000"]
+def test_pricing_veto_never_sums_a_year_or_an_article_number_into_a_price() -> None:
+    """`source_values` is harvested from every numeric token in every chunk, so
+    "PP 45/2024" contributes 45 and 2024. Summed, they produced a price:
+    1,000,000 + 2024 + 45 = 1,002,069. The answer-side floor cannot catch this
+    -- it filters the final amount, never the operands -- which is why the
+    operand floor exists as a separate table."""
+    assert price_tokens_outside_sources(
+        "Biayanya Rp1.002.069.", _SRC_OVERSTAY
+    ) == ["IDR:1002069"]
 
 
-def test_pricing_veto_derivation_does_not_admit_differences() -> None:
-    """Only multiples and 2-/3-term sums are anchored. A subtraction
-    (17,000,000 - 9,500,000) is not a shape any correct answer needs, and
-    admitting it would widen the surface for no measured benefit."""
-    text = "Selisihnya Rp7.500.000."
-    assert price_tokens_outside_sources(text, _SRC_KITAS) == ["IDR:7500000"]
+def test_pricing_veto_rejects_a_bare_quantity_token_as_an_operand() -> None:
+    """The "2" in "Investor KITAS 2 years" authorized Rp26.500.002."""
+    assert price_tokens_outside_sources(
+        "Total Rp26.500.002.", _SRC_KITAS
+    ) == ["IDR:26500002"]
+
+
+def test_pricing_veto_charges_each_source_amount_at_most_once() -> None:
+    """17,000,000 occurs once, as one service fee. Summing with replacement
+    charged it twice and authorized 43,500,000."""
+    assert price_tokens_outside_sources(
+        "Total all-in Rp43.500.000.", _SRC_KITAS
+    ) == ["IDR:43500000"]
+
+
+def test_pricing_veto_rejects_a_three_chunk_laundered_total() -> None:
+    """A KITAS fee, a tax penalty and an overstay fine from three unrelated
+    chunks sum to a "PT PMA setup price" no source states. Two terms is the
+    cap; three was enough to assemble a plausible package out of parts."""
+    assert price_tokens_outside_sources(
+        "PT PMA setup costs Rp20.500.000.", _SRC_UNRELATED
+    ) == ["IDR:20500000"]
+
+
+def test_pricing_veto_still_catches_a_wholly_invented_total() -> None:
+    assert price_tokens_outside_sources(
+        "Total all-in Rp31.000.000.", _SRC_KITAS
+    ) == ["IDR:31000000"]
+
+
+def test_pricing_veto_allowance_cannot_ground_an_answer_with_no_sources() -> None:
+    """The file's own 999-billion control, re-run against the allowance: an
+    empty source set offers nothing to sum, so the widening can never turn a
+    groundless answer into a grounded one."""
+    assert price_tokens_outside_sources(
+        "The fee is IDR 999,000,000,000.", []
+    ) == ["IDR:999000000000"]
+
+
+def test_pricing_veto_still_rejects_an_honest_multiplication_declared_gap() -> None:
+    """DECLARED GAP, asserted so it is visible rather than forgotten.
+
+    "5 days x Rp1,000,000" is a correct answer to a real question and is still
+    vetoed here -- `wa_outbox` row 387 failed 5/5 on exactly this and the
+    client got an apology. Admitting it safely requires binding the multiplier
+    to a count present in the CUSTOMER'S QUESTION, which this function does not
+    receive. That is a signature change, specified separately; guessing a
+    multiplier from the generated figure is what this test's siblings above
+    exist to forbid."""
+    assert price_tokens_outside_sources(
+        "Denda Rp1.000.000 per hari. Untuk 5 hari totalnya Rp5.000.000.",
+        _SRC_OVERSTAY,
+    ) == ["IDR:5000000"]

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -775,3 +775,71 @@ def test_pricing_veto_still_rejects_an_honest_multiplication_declared_gap() -> N
         "Denda Rp1.000.000 per hari. Untuk 5 hari totalnya Rp5.000.000.",
         _SRC_OVERSTAY,
     ) == ["IDR:5000000"]
+
+
+# --- operand typing: the second refuter seat's cases (Kimi K3, cross-family) ---
+#
+# The first narrowing kept a magnitude FLOOR on operands (IDR 100,000). A second
+# adversarial seat broke it three ways with values, and its diagnosis was
+# sharper than the fix: a number's ROLE is not recoverable from its size. The
+# floor was simultaneously too low (7-digit non-money tokens sailed over it) and
+# too high (a real Rp10.000 stamp duty could not be a component). Operands are
+# now typed by being CURRENCY-MARKED and same-family, and the floor is gone.
+
+_SRC_LEGAL_PROSE = [
+    "Berdasarkan Pasal 45 PP No 28, proses memakan waktu 14 hari kerja. "
+    "UU No 6 Tahun 2011."
+]
+_SRC_TWO_CURRENCIES = [
+    "Paid-up capital minimum USD 100,000.",
+    "Biaya notaris Rp500.000.",
+]
+_SRC_WITH_STATISTIC = [
+    "Bali menerima 6.275.000 wisatawan pada 2024.",
+    "PNBP Rp1.000.000 per hari.",
+]
+_SRC_SMALL_LINE_ITEMS = ["Jasa notaris Rp2.500.000.", "Bea meterai Rp10.000."]
+
+
+def test_pricing_veto_never_sums_article_numbers_into_a_foreign_currency_fee() -> None:
+    """`USD 59 = 45 + 14` -- "Pasal 45" and "14 hari kerja". Under a magnitude
+    floor of 10 for foreign currencies the pair rule was vacuous: legal prose
+    is full of small integers, so almost any invented USD amount decomposed."""
+    assert price_tokens_outside_sources(
+        "The fee is USD 59.", _SRC_LEGAL_PROSE
+    ) == ["USD:59"]
+
+
+def test_pricing_veto_never_sums_a_year_into_a_foreign_currency_fee() -> None:
+    """`USD 2025 = 2011 + 14`."""
+    assert price_tokens_outside_sources(
+        "The fee is USD 2025.", _SRC_LEGAL_PROSE
+    ) == ["USD:2025"]
+
+
+def test_pricing_veto_does_not_sum_across_currency_families() -> None:
+    """A USD capital minimum plus an IDR notary fee authorized an IDR total:
+    `Rp600.000 = 100,000 (USD!) + 500,000`. The membership set is untyped by
+    documented design; the PAIR rule is not, because `_currency_amounts`
+    already returns the family and keeping it costs nothing."""
+    assert price_tokens_outside_sources(
+        "Total Rp600.000.", _SRC_TWO_CURRENCIES
+    ) == ["IDR:600000"]
+
+
+def test_pricing_veto_does_not_use_a_statistic_as_a_price_component() -> None:
+    """`Rp7.275.000 = 6.275.000 tourists + Rp1.000.000`. A magnitude floor
+    cannot catch this -- the non-money token is LARGER than the floor. Being
+    currency-marked can."""
+    assert price_tokens_outside_sources(
+        "Biayanya Rp7.275.000.", _SRC_WITH_STATISTIC
+    ) == ["IDR:7275000"]
+
+
+def test_pricing_veto_allows_a_small_but_real_line_item_as_a_component() -> None:
+    """`Rp2.510.000 = Rp2.500.000 notary + Rp10.000 stamp duty`. The floor
+    vetoed this correct total; typing admits it. Stamp duty is a real line on
+    a real invoice, and vetoing it costs a client an apology."""
+    assert price_tokens_outside_sources(
+        "Total Rp2.510.000.", _SRC_SMALL_LINE_ITEMS
+    ) == []

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -639,3 +639,82 @@ async def test_gemini_escalate_marker_is_stripped_and_a_human_is_told() -> None:
     assert "[ESCALATE]" not in result.text
     assert result.human_reason == "persona_escalate_marker"
     assert tell.reasons == ["persona_escalate_marker"]
+
+
+# ---------------------------------------------------------------------------
+# DERIVED AMOUNTS (2026-08-30)
+#
+# Every source string below uses the notation MEASURED on the production
+# package-build endpoint for these very queries (`IDR 1,000,000`,
+# `IDR 17,000,000`), not a convenient invention — the previous round of work on
+# this veto was misled for an hour by a fixture that wrote amounts in a
+# notation the live KB does not use.
+# ---------------------------------------------------------------------------
+
+_SRC_OVERSTAY = ["Overstay fine: IDR 1,000,000 per day per person. PP 45/2024."]
+_SRC_KITAS = [
+    "Investor KITAS 2 years - offshore IDR 17,000,000; onshore/transfer of "
+    "status IDR 19,000,000; extension IDR 18,000,000.",
+    "PNBP Investor KITAS 2 tahun IDR 9,500,000.",
+]
+
+
+def test_pricing_veto_allows_a_rate_multiplied_by_the_days_asked_about() -> None:
+    """The reproduced live failure: wa_outbox row 387, fired in isolation.
+
+    It failed 5 of 5 attempts on `finalize_pricing_outside_package` and the
+    client got an apology, because the answer did the multiplication the
+    question asked for and 5,000,000 is in no source verbatim.
+    """
+    text = "Denda overstay Rp1.000.000 per hari. Untuk 5 hari, totalnya Rp5.000.000."
+    assert price_tokens_outside_sources(text, _SRC_OVERSTAY) == []
+
+
+def test_pricing_veto_allows_the_all_inclusive_sum_the_ruling_requires() -> None:
+    """17,000,000 + 9,500,000. Zero's 2026-07-17 ruling asks for exactly this
+    one all-in client-facing figure, and before this change the veto rejected
+    it — which left splitting the levy out of the price as the only shape that
+    could pass."""
+    text = "Total all-in KITAS Investor 2 tahun Rp26.500.000, sudah termasuk PNBP."
+    assert price_tokens_outside_sources(text, _SRC_KITAS) == []
+
+
+def test_pricing_veto_allows_the_same_sum_written_in_english_magnitude() -> None:
+    text = "The all-in total is IDR 26.5 million, government fee included."
+    assert price_tokens_outside_sources(text, _SRC_KITAS) == []
+
+
+def test_pricing_veto_still_catches_an_invented_total() -> None:
+    """The allowance is arithmetic, not amnesty: 31,000,000 is neither a
+    source amount, nor a multiple of one, nor a sum of two or three."""
+    text = "Total all-in Rp31.000.000."
+    assert price_tokens_outside_sources(text, _SRC_KITAS) == ["IDR:31000000"]
+
+
+def test_pricing_veto_still_catches_an_invented_multiplication() -> None:
+    text = "Untuk 5 hari, totalnya Rp7.400.000."
+    assert price_tokens_outside_sources(text, _SRC_OVERSTAY) == ["IDR:7400000"]
+
+
+def test_pricing_veto_derivation_cannot_rescue_an_answer_with_no_sources() -> None:
+    """The file's own 999-billion control, re-run against the allowance: with
+    an empty source set there is nothing to derive FROM, so the widening can
+    never turn a groundless answer into a grounded one."""
+    text = "The fee is IDR 999,000,000,000."
+    assert price_tokens_outside_sources(text, []) == ["IDR:999000000000"]
+
+
+def test_pricing_veto_multiple_is_capped_at_a_year_of_days() -> None:
+    """400 x 1,000,000 is an exact multiple and is still vetoed: the cap is
+    what keeps 'multiple of a source amount' from meaning 'any round number'.
+    """
+    text = "Totalnya Rp400.000.000."
+    assert price_tokens_outside_sources(text, _SRC_OVERSTAY) == ["IDR:400000000"]
+
+
+def test_pricing_veto_derivation_does_not_admit_differences() -> None:
+    """Only multiples and 2-/3-term sums are anchored. A subtraction
+    (17,000,000 - 9,500,000) is not a shape any correct answer needs, and
+    admitting it would widen the surface for no measured benefit."""
+    text = "Selisihnya Rp7.500.000."
+    assert price_tokens_outside_sources(text, _SRC_KITAS) == ["IDR:7500000"]


### PR DESCRIPTION
A live client question — "overstay 5 hari, dendanya berapa per hari?" — is unanswerable today. `wa_outbox` row 387, fired **in isolation into a quiet thread**, failed 5 of 5 attempts on `finalize_pricing_outside_package` and the client got an apology. The evidence package carries the rate (verified against the production build endpoint: `IDR 1,000,000`/day, PP 45/2024). The answer was rejected for doing the multiplication the client asked for.

The same mechanism makes the business rule unshippable. One all-inclusive client price (Zero, 2026-07-17) means `17,000,000 + 9,500,000 = 26,500,000` — a figure in no source. Measured against the real package notation, before this change:

| answer | anchoring veto |
|---|---|
| `Total all-in Rp26.500.000` | `[IDR:26500000]` **VETOED** |
| `biaya layanan Rp17.000.000. PNBP pemerintah Rp9.500.000` | `[]` passes |

**So this veto was pushing the generator toward splitting the levy out of the client price** — splitting is the only shape keeping every figure verbatim-anchored. The split-price defect guarded in #5337 was partly this veto’s own output, which is why **#5337 is disarmed until this lands**: merged alone it turns a wrong answer into no answer.

## The change

An amount is anchored if it is a source amount **or an exact derivation** of source amounts: an integer multiple (rate × days, capped at 366) or a sum of two or three (fee + levy + at most one add-on). No differences, no percentages, no chains.

## What it costs, stated not buried

A hallucinated figure that happens to equal such a sum or multiple now passes. That is a real widening, taken because the measured alternative is not a stricter guard but **no answer at all** on the two commonest questions the business gets. The label gate, PricingTool grounding and the split-fee veto remain the controls on what the answer claims.

## Evidence

8 new tests, both directions; 70 pass in the file. Guilt side still red-on-wrong: invented total, invented multiplication, the file’s own 999-billion control against an **empty** source set (nothing to derive from, so the widening can never ground a groundless answer), an over-cap multiple, and a subtraction.

Also corrects a citation pointing at `test_wa_finalize_price_veto.py`, a file that does not exist in this tree.