### PR TITLE
fix(agent_start): cleanup skip message named an unchecked cause on HEAD rename

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -1219,6 +1219,20 @@ def _content_subset_ok(
     return added_lines.issubset(main_lines)
 
 
+def _worktree_head_branch(worktree: Path) -> str:
+    """Short branch name HEAD points to inside ``worktree``, or "" if detached
+    or unreadable. Factored out of ``_branch_in_origin_main`` so a caller can
+    tell "HEAD is on a different branch than the one under judgement" (e.g. a
+    mid-flight `git checkout -b <rename>`) apart from "HEAD's branch genuinely
+    has commits not in origin/main" — two distinct causes that function's own
+    fail-safe collapses to the same False, and reporting the wrong one wastes
+    a future reader's time re-deriving what was actually checked."""
+    head = _run_git(
+        ["symbolic-ref", "--quiet", "--short", "HEAD"], cwd=worktree, check=False
+    )
+    return head.stdout.strip() if head.returncode == 0 else ""
+
+
 def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) -> bool:
     """True iff the worktree's HEAD is fully merged into ``origin/main``.
 
@@ -1301,10 +1315,7 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
         # Fail-safe to False on detached/renamed/unreadable HEAD: we have not
         # DISPROVEN the branch is merged, we have failed to ask about it, and
         # cannot-verify must never read as proven (W84).
-        head = _run_git(
-            ["symbolic-ref", "--quiet", "--short", "HEAD"], cwd=worktree, check=False
-        )
-        actual = head.stdout.strip() if head.returncode == 0 else ""
+        actual = _worktree_head_branch(worktree)
         if actual != expect_branch:
             logger.warning(
                 "content-merge probe declined for %s: HEAD is %s, not the branch "
@@ -1586,16 +1597,39 @@ def cmd_cleanup(
                 )
                 continue
             if not _branch_in_origin_main(wt, expect_branch=meta.branch):
-                logger.warning(
-                    "cleanup skip %s — branch %s has commits not in origin/main "
-                    "(W80: unmerged work, refusing to reap its only checkout)",
-                    meta.task_id,
-                    meta.branch,
-                )
-                print(
-                    f"WARN: skip {meta.task_id} (branch '{meta.branch}' has "
-                    "unmerged commits not in origin/main) — protecting checkout"
-                )
+                actual_head = _worktree_head_branch(wt)
+                if actual_head and actual_head != meta.branch:
+                    # Not a merge-status finding at all — HEAD was renamed
+                    # mid-flight (e.g. `git checkout -b <new>` inside the
+                    # worktree) and the registry still names the old branch.
+                    # Reporting "has commits not in origin/main" here would be
+                    # a claim this code path never actually checked (W65 —
+                    # even a guard's own diagnostic can hallucinate a specific
+                    # cause it never verified).
+                    logger.warning(
+                        "cleanup skip %s — worktree HEAD is on branch %s, "
+                        "registered branch is %s (renamed mid-flight?) — "
+                        "cannot verify merge status, protecting checkout",
+                        meta.task_id,
+                        actual_head,
+                        meta.branch,
+                    )
+                    print(
+                        f"WARN: skip {meta.task_id} (HEAD is on '{actual_head}', "
+                        f"registered branch is '{meta.branch}') — cannot verify "
+                        "merge status, protecting checkout"
+                    )
+                else:
+                    logger.warning(
+                        "cleanup skip %s — branch %s has commits not in origin/main "
+                        "(W80: unmerged work, refusing to reap its only checkout)",
+                        meta.task_id,
+                        meta.branch,
+                    )
+                    print(
+                        f"WARN: skip {meta.task_id} (branch '{meta.branch}' has "
+                        "unmerged commits not in origin/main) — protecting checkout"
+                    )
                 continue
         try:
             _remove_worktree(wt, meta.branch, delete_branch=False)

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -979,6 +979,34 @@ def test_cleanup_skips_branch_not_in_origin_main(fake_repo, capsys, monkeypatch)
     assert "origin/main" in out
 
 
+def test_cleanup_head_renamed_mid_flight_message_is_honest(fake_repo, capsys, monkeypatch):
+    """Guilt: an expired, clean, idle, no-live-process worktree whose HEAD was
+    renamed mid-flight (`git checkout -b <new>`, no new commits — trivially an
+    ancestor of origin/main) must still be protected, since the registered
+    branch name is no longer what HEAD actually is — but the skip message must
+    say THAT, not assert the unrelated, unverified "has commits not in
+    origin/main" — a real defect found live 2026-08-31 (healer tick): the
+    message named a specific cause `_branch_in_origin_main` never checked,
+    which cost a future reader a live `merge-base --is-ancestor` re-derivation
+    to disprove a false claim from the tool's own diagnostic."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "renamed", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    subprocess.run(
+        ["git", "checkout", "-b", "renamed-branch"],
+        cwd=wt, check=True, capture_output=True, text=True,
+    )
+    _backdate_worktree_mtime(wt, minutes=120)  # idle on mtime
+    monkeypatch.setattr(mod, "_worktree_has_live_process", lambda p: False)
+    rc = mod.cmd_cleanup()
+    assert rc == 0  # protection, not a failure
+    assert wt.exists()  # still not reapable: registry can't vouch for HEAD
+    out = capsys.readouterr().out
+    assert "renamed-branch" in out  # names the branch HEAD is actually on
+    assert "cannot verify" in out.lower()
+    assert "unmerged commits not in origin/main" not in out
+
+
 def test_cleanup_reaps_when_no_process_and_merged(fake_repo, monkeypatch):
     """W80 case (3): the ONLY auto-reapable state — expired + clean + idle +
     NO live process AND branch merged into origin/main. Both W80 guards pass,


### PR DESCRIPTION
## Summary
- `cmd_cleanup`'s W80 guard correctly refuses to reap a worktree whose HEAD doesn't match its registered branch (renamed mid-flight), but the log/print message claimed "branch X has commits not in origin/main" — a specific cause `_branch_in_origin_main` never actually checked in that code path.
- Found live 2026-08-31 (Mini healer tick): `.worktrees/craft-f2-fleet-security` (registered branch `agent/mini-pro2/craft-f2/fleet-security`, HEAD actually on the renamed+merged `tailnet-drift-receptor`) printed this false claim. Independently verified with `git merge-base --is-ancestor agent/mini-pro2/craft-f2/fleet-security origin/main` → true (zero unique commits) — the opposite of what cleanup reported.
- Extracted `_worktree_head_branch()` (was inline in `_branch_in_origin_main`), reused it at the `cmd_cleanup` call site to distinguish "HEAD mismatch, cannot verify" from "genuinely unmerged commits" and print the honest one. Safety behavior is unchanged in both cases (still refuses to reap, still protective) — only the diagnostic text changes.

## Test plan
- [x] New guilt test `test_cleanup_head_renamed_mid_flight_message_is_honest`: worktree with HEAD renamed to an unregistered branch (zero new commits, trivially merged) — asserts worktree stays protected AND the message names the actual branch + "cannot verify", never the false "unmerged commits" claim.
- [x] `apps/backend-rag/.venv/bin/pytest scripts/tests/test_agent_start.py -k "cleanup or branch_in_origin_main or release" -q` → 32 passed
- [x] `apps/backend-rag/.venv/bin/pytest scripts/tests/test_agent_start.py -q` (full file) → 84 passed, 1 skipped (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)