### PR TITLE
feat(second-home): migrate the landing and Studio to the Merah Putih DAY palette

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -9,6 +9,10 @@ import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { ConsentBanner } from "@/components/visa/ConsentBanner";
 import { usePricingData } from "@/hooks/usePricingData";
 import {
+  MERAH_PUTIH_DAY_CLASS,
+  MERAH_PUTIH_DAY_VARS,
+} from "@/lib/theme/merahPutihDayVars";
+import {
   E33_LIVE_PRICE_CATEGORY,
   E33_LIVE_PRICE_KEY,
 } from "@/lib/secondhome-studio/pricing-key";
@@ -132,7 +136,7 @@ const fitCheckCtaStyle: React.CSSProperties = {
   alignItems: "center",
   gap: 8,
   padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
-  borderRadius: 8,
+  borderRadius: 12,
   border: "1px solid var(--accent-funnel)",
   color: "var(--accent-funnel-text, var(--accent-funnel))",
   fontWeight: 600,
@@ -230,8 +234,18 @@ export function SecondHomeLanding() {
     // defect, same fix, this route has no AppFrame ancestor either).
     <div
       data-funnel="visa"
-      className={cormorant.variable}
-      style={{ display: "grid", gap: "var(--space-6, 1.5rem)" }}
+      className={`${cormorant.variable} ${MERAH_PUTIH_DAY_CLASS}`}
+      style={{
+        // MERAH PUTIH DAY (R4 identity law) — inline on THIS wrapper, never on a
+        // shared layout: it must beat `[data-theme="editorial"] [data-funnel="visa"]`
+        // (navy ground + the retired #ff3344) for this route only. It also
+        // neutralises the Montserrat that /visa/layout.tsx forces on the funnel.
+        ...MERAH_PUTIH_DAY_VARS,
+        display: "grid",
+        gap: "var(--space-6, 1.5rem)",
+        background: "var(--surface-base)",
+        color: "var(--text-primary)",
+      }}
     >
       <LanguageSwitcher />
 
@@ -243,7 +257,7 @@ export function SecondHomeLanding() {
             margin: 0,
             fontFamily: fontSerif,
             fontSize: "clamp(2.25rem, 5vw, 2.875rem)",
-            fontWeight: 360,
+            fontWeight: 500,
             lineHeight: 1.05,
             color: "var(--text-primary)",
             maxWidth: "16ch",
@@ -300,8 +314,8 @@ export function SecondHomeLanding() {
                 <div
                   style={{
                     fontFamily: fontSerif,
-                    fontSize: "clamp(1.3rem, 3vw, 1.6rem)",
-                    fontWeight: 340,
+                    fontSize: "clamp(1.5rem, 3vw, 1.6rem)",
+                    fontWeight: 500,
                     lineHeight: 1.1,
                     color: "var(--accent-funnel-text, var(--accent-funnel))",
                   }}
@@ -334,7 +348,7 @@ export function SecondHomeLanding() {
             margin: 0,
             fontFamily: fontSerif,
             fontSize: "clamp(1.75rem, 4vw, 2.6rem)",
-            fontWeight: 360,
+            fontWeight: 500,
             lineHeight: 1.1,
             color: "var(--text-primary)",
             maxWidth: "18ch",
@@ -392,8 +406,8 @@ export function SecondHomeLanding() {
           style={{
             margin: 0,
             fontFamily: fontSerif,
-            fontSize: "clamp(1.4rem, 3vw, 1.9rem)",
-            fontWeight: 360,
+            fontSize: "clamp(1.5rem, 3vw, 1.9rem)",
+            fontWeight: 500,
             lineHeight: 1.15,
             color: "var(--text-primary)",
           }}
@@ -454,7 +468,7 @@ export function SecondHomeLanding() {
             margin: 0,
             fontFamily: fontSerif,
             fontSize: "clamp(1.75rem, 4vw, 2.6rem)",
-            fontWeight: 360,
+            fontWeight: 500,
             lineHeight: 1.1,
             color: "var(--text-primary)",
             maxWidth: "18ch",
@@ -551,8 +565,8 @@ export function SecondHomeLanding() {
           style={{
             margin: 0,
             fontFamily: fontSerif,
-            fontSize: "clamp(1.4rem, 3vw, 1.9rem)",
-            fontWeight: 360,
+            fontSize: "clamp(1.5rem, 3vw, 1.9rem)",
+            fontWeight: 500,
             lineHeight: 1.15,
             color: "var(--text-primary)",
             maxWidth: "20ch",
@@ -577,8 +591,8 @@ export function SecondHomeLanding() {
           style={{
             margin: 0,
             fontFamily: fontSerif,
-            fontSize: "clamp(1.4rem, 3vw, 1.9rem)",
-            fontWeight: 360,
+            fontSize: "clamp(1.5rem, 3vw, 1.9rem)",
+            fontWeight: 500,
             lineHeight: 1.15,
             color: "var(--text-primary)",
           }}
@@ -624,8 +638,8 @@ export function SecondHomeLanding() {
           style={{
             margin: 0,
             fontFamily: fontSerif,
-            fontSize: "clamp(1.4rem, 3vw, 1.9rem)",
-            fontWeight: 360,
+            fontSize: "clamp(1.5rem, 3vw, 1.9rem)",
+            fontWeight: 500,
             lineHeight: 1.15,
             color: "var(--text-primary)",
           }}
@@ -661,7 +675,7 @@ export function SecondHomeLanding() {
             margin: 0,
             fontFamily: fontSerif,
             fontSize: "clamp(1.75rem, 4vw, 2.6rem)",
-            fontWeight: 360,
+            fontWeight: 500,
             lineHeight: 1.1,
             color: "var(--text-primary)",
             maxWidth: "18ch",
@@ -699,7 +713,7 @@ export function SecondHomeLanding() {
             alignItems: "center",
             gap: 8,
             padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
-            borderRadius: 8,
+            borderRadius: 12,
             // WCAG AA fix (measured 2026-08-24): `--text-on-accent` resolves
             // to #fff here, which on the WhatsApp green computes to ~1.98:1,
             // failing the 4.5:1 normal-text floor. Ratified cure

--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -9,6 +9,7 @@ import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { ConsentBanner } from "@/components/visa/ConsentBanner";
 import { usePricingData } from "@/hooks/usePricingData";
 import {
+  MERAH_PUTIH_DAY_BODY_CSS,
   MERAH_PUTIH_DAY_CLASS,
   MERAH_PUTIH_DAY_VARS,
 } from "@/lib/theme/merahPutihDayVars";
@@ -247,6 +248,11 @@ export function SecondHomeLanding() {
         color: "var(--text-primary)",
       }}
     >
+      {/* <body> is an ancestor of this wrapper and keeps the shared editorial
+          navy, which shows as a band under the content and as a navy page in
+          print. Scoped to pages that carry the day wrapper — see
+          MERAH_PUTIH_DAY_BODY_CSS. */}
+      <style>{MERAH_PUTIH_DAY_BODY_CSS}</style>
       <LanguageSwitcher />
 
       {/* HERO */}

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -143,14 +143,25 @@ const mastheadLabelStyle: React.CSSProperties = {
 /** WCAG contrast fix (2026-08-24): `--color-border-subtle` composites to
  *  ~1.2:1 against the editorial card backdrop — invisible, and below the
  *  3.0:1 floor for non-text UI boundaries (WCAG 1.4.11). No shipped border
- *  token clears that floor on the editorial theme (`--border-strong` tops
- *  out at ~1.9:1 there), so this derives an opaque-enough value from
- *  `--text-primary` instead of inventing a bare hex — it composites to
- *  ~3.5:1 against the editorial backdrop and stays theme-adaptive. */
+ *  token cleared that floor on the editorial theme (`--border-strong` topped
+ *  out at ~1.9:1 there), so this derived an opaque-enough value from
+ *  `--text-primary`: `color-mix(--text-primary 45%, transparent)`, which
+ *  composited to ~3.5:1 against the editorial backdrop.
+ *
+ *  MERAH PUTIH DAY (2026-08-31): that mix claimed to "stay theme-adaptive",
+ *  and it does not. A FIXED percentage is tuned to one ground: composited over
+ *  the day palette it lands #969ba6 on the white QuestionCard (2.79:1) and
+ *  #92969f on carta (2.74:1) — under the same 3:1 floor the comment invokes.
+ *  This is the Back button, rendered on EVERY question step and again at the
+ *  verdict stage, so it is not an edge case. On a light ground the shipped
+ *  token finally works: `--border-strong` (#7a8093) measures 3.94:1 on the
+ *  card and 3.64:1 on carta. Mixing a token toward transparent is safe for a
+ *  TINT, but a boundary's contrast has to be re-measured whenever the ground
+ *  flips — the percentage is not the invariant, the ratio is. */
 const navButtonStyle: React.CSSProperties = {
   padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
   borderRadius: 12,
-  border: "1px solid color-mix(in srgb, var(--text-primary) 45%, transparent)",
+  border: "1px solid var(--border-strong)",
   background: "transparent",
   color: "var(--text-primary)",
   cursor: "pointer",

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -10,6 +10,7 @@ import {
   type QuestionId,
 } from "@/lib/secondhome-studio/sequence";
 import {
+  MERAH_PUTIH_DAY_BODY_CSS,
   MERAH_PUTIH_DAY_CLASS,
   MERAH_PUTIH_DAY_VARS,
 } from "@/lib/theme/merahPutihDayVars";
@@ -156,21 +157,27 @@ const navButtonStyle: React.CSSProperties = {
   minHeight: 44,
 };
 
-/** WCAG contrast fix (2026-08-24): white-on-`var(--accent-funnel)` measured
- *  3.62:1 on the visa/editorial pairing (and 4.36:1 on the editorial-base
- *  blue) — both fail the 4.5:1 floor for this 16px/600 text, which is
- *  normal-size (large-text exemption needs >=24px, or >=18.66px at
- *  weight>=700). This funnel sells E33E/E33F senior visas (55+), whose own
- *  audience skews toward LOWER contrast tolerance, not higher — so the cure
- *  is darkening the fill to clear 4.5:1, never stretching the label to
- *  dodge the floor via the large-text carve-out. Derived via color-mix so
- *  it holds across every `--accent-funnel` resolution (per-theme, not one
- *  hardcoded hex) — verified >=4.5:1 on both known resolutions. */
+/** The primary CTA takes the ACTION red, `--cta-bg` (#D01033 under the Merah
+ *  Putih DAY set): white on it measures 5.52:1, clearing the 4.5:1 floor for
+ *  this 16px/600 normal-size text (the large-text carve-out needs >=24px, or
+ *  >=18.66px at weight>=700 — never a reason to stretch a label instead of
+ *  fixing the fill, least of all on a funnel selling senior visas to a 55+
+ *  audience whose contrast tolerance skews lower, not higher).
+ *
+ *  This REPLACES a 2026-08-24 fix that read
+ *  `color-mix(in srgb, var(--accent-funnel) 85%, black)`. That was correct for
+ *  the dark theme it was written under — white on the then-current `#ff3344`
+ *  measured 3.62:1, so the fill was darkened until it cleared. Under the DAY
+ *  palette the premise is gone (white on #D01033 already clears), and the
+ *  workaround had two costs worth removing: it painted a colour that exists in
+ *  no token (measured live as rgb(170, 14, 39)), and it built the CTA out of the
+ *  STRUCTURE red when R4 §3 assigns primary CTAs to the ACTION red — the two
+ *  duties red is allowed to have, and the whole point of keeping them apart. */
 const primaryNavButtonStyle: React.CSSProperties = {
   ...navButtonStyle,
   marginLeft: "auto",
   border: "none",
-  background: "color-mix(in srgb, var(--accent-funnel) 85%, black)",
+  background: "var(--cta-bg, var(--accent-funnel-text))",
   color: "var(--text-on-accent, #fff)",
   fontWeight: 600,
 };
@@ -626,6 +633,9 @@ export function StudioApp() {
         minHeight: "100vh",
       }}
     >
+      {/* See SecondHomeLanding: <body> is an ancestor and keeps the editorial
+          navy otherwise — measured 88px of it below this wrapper. */}
+      <style>{MERAH_PUTIH_DAY_BODY_CSS}</style>
       <StudioAtmosphere />
       <div
         className="bz-shs-content"

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -10,6 +10,10 @@ import {
   type QuestionId,
 } from "@/lib/secondhome-studio/sequence";
 import {
+  MERAH_PUTIH_DAY_CLASS,
+  MERAH_PUTIH_DAY_VARS,
+} from "@/lib/theme/merahPutihDayVars";
+import {
   E33_LIVE_PRICE_CATEGORY,
   resolveSecondHomePriceKey,
 } from "@/lib/secondhome-studio/pricing-key";
@@ -144,7 +148,7 @@ const mastheadLabelStyle: React.CSSProperties = {
  *  ~3.5:1 against the editorial backdrop and stays theme-adaptive. */
 const navButtonStyle: React.CSSProperties = {
   padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
-  borderRadius: 8,
+  borderRadius: 12,
   border: "1px solid color-mix(in srgb, var(--text-primary) 45%, transparent)",
   background: "transparent",
   color: "var(--text-primary)",
@@ -610,7 +614,17 @@ export function StudioApp() {
       // `funnel="visa"` prop (packages/core/components/apps/AppFrame.tsx);
       // this route has no AppFrame ancestor, so it sets the attribute here.
       data-funnel="visa"
-      className="bz-shs-studio"
+      className={`bz-shs-studio ${MERAH_PUTIH_DAY_CLASS}`}
+      style={{
+        // MERAH PUTIH DAY (R4 identity law) — see merahPutihDayVars.ts for the
+        // scoping contract and every computed ratio. Inline HERE so it beats the
+        // editorial theme's navy ground and the retired #ff3344 on this route
+        // only, and so /visa/layout.tsx's forced Montserrat stops here.
+        ...MERAH_PUTIH_DAY_VARS,
+        background: "var(--surface-base)",
+        color: "var(--text-primary)",
+        minHeight: "100vh",
+      }}
     >
       <StudioAtmosphere />
       <div

--- a/apps/mouth/src/app/visa/second-home/studio/components/ProgressRail.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ProgressRail.tsx
@@ -109,19 +109,19 @@ export function ProgressRail({ step, total }: ProgressRailProps) {
 
         .bz-shs-progress-sounding[data-state="complete"]::before,
         .bz-shs-progress-sounding[data-state="current"]::before {
-          border-top: 3px solid var(--accent-funnel-text, var(--accent-funnel));
+          border-top: 3px solid var(--accent-funnel);
         }
 
         .bz-shs-progress-sounding[data-state="complete"]::after {
           width: 3px;
           height: 9px;
-          background: var(--accent-funnel-text, var(--accent-funnel));
+          background: var(--accent-funnel);
         }
 
         .bz-shs-progress-sounding[data-state="current"]::after {
           width: 4px;
           height: 16px;
-          background: var(--accent-funnel-text, var(--accent-funnel));
+          background: var(--accent-funnel);
         }
 
         .bz-shs-progress-sounding[data-state="pending"]::before {

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
@@ -136,7 +136,12 @@ describe("QuestionCard > OptionButton selection control", () => {
     expect(baseRule).toMatch(/border:\s*1px solid/);
     expect(selectedRule).not.toMatch(/(?:^|;)\s*border\s*:/);
     expect(selectedRule).not.toMatch(/border-width\s*:/);
-    expect(selectedRule).toMatch(/border-color:\s*var\(--accent-funnel\)/);
+    // Ink, not red: R4 §3/§4.5 gives red exactly two duties (structure and
+    // action) and selection is neither — a chosen option is an ink outline.
+    // The thickness assertions above are the ones guarding against layout
+    // shift; this line only pins WHICH colour the outline takes.
+    expect(selectedRule).toMatch(/border-color:\s*var\(--text-primary\)/);
+    expect(selectedRule).not.toMatch(/var\(--accent-funnel\)/);
     expect(css).toMatch(
       /\.bz-shs-option\[data-selected="true"\]\s*\{[^}]*box-shadow:\s*inset 0 0 0 2px/s,
     );

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -123,8 +123,10 @@ export function QuestionCard({
         tabIndex={-1}
         style={{
           margin: 0,
+          // R4 §3: Cormorant is display-only and never below 24px — under that,
+          // low-DPI Android antialiasing shreds the serif.
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.25rem, 3vw, 1.6rem)",
+          fontSize: "clamp(1.5rem, 3vw, 1.6rem)",
           color: "var(--text-primary)",
         }}
       >
@@ -212,13 +214,20 @@ export function QuestionCard({
           border-color: var(--accent-funnel);
           background: color-mix(in srgb, var(--accent-funnel) 6%, transparent);
         }
+        /* R4 §3/§4.5: the chosen option is an INK outline, never red. Red is
+           allowed exactly two duties on this page — structure (the progress
+           fill, brand marks) and action (the single primary CTA). Painting
+           "chosen" in the same red is the three-meaning collision the identity
+           law exists to remove, and it also made the selected option compete
+           with the Continue button for the eye. Ink at 14.79:1 on carta is a
+           stronger boundary than the red it replaces. */
         .bz-shs-option[data-selected="true"] {
-          border-color: var(--accent-funnel);
-          background: color-mix(in srgb, var(--accent-funnel) 12%, transparent);
-          box-shadow: inset 0 0 0 2px var(--accent-funnel);
+          border-color: var(--text-primary);
+          background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+          box-shadow: inset 0 0 0 2px var(--text-primary);
         }
         .bz-shs-option[data-selected="true"]:hover {
-          background: color-mix(in srgb, var(--accent-funnel) 16%, transparent);
+          background: color-mix(in srgb, var(--text-primary) 9%, transparent);
         }
         .bz-shs-option:focus-visible {
           outline: 3px solid var(--text-primary);
@@ -272,9 +281,17 @@ function RadioAffordance({ selected }: { selected: boolean }) {
         width: 20,
         height: 20,
         borderRadius: "50%",
+        // R4 §3/§4.5: SELECTION IS NEVER RED. Red carries exactly two duties —
+        // structure and action — and letting it also mean "chosen" is the
+        // three-meaning collision the identity law exists to kill. Selected is
+        // an INK outline; the unselected ring uses border-input (#7a8093,
+        // 3.64:1 on carta), never the hairline (1.21:1), because this ring is
+        // what identifies an interactive control (WCAG 2.2 SC 1.4.11).
+        // The signal is not colour-alone either way: ring weight changes and
+        // the inner mark appears.
         border: selected
-          ? "2px solid var(--accent-funnel)"
-          : "1.5px solid var(--color-border-subtle)",
+          ? "2px solid var(--text-primary)"
+          : "1.5px solid var(--border-strong)",
       }}
     >
       {selected ? (
@@ -283,7 +300,7 @@ function RadioAffordance({ selected }: { selected: boolean }) {
             width: 10,
             height: 10,
             borderRadius: "50%",
-            background: "var(--accent-funnel)",
+            background: "var(--text-primary)",
           }}
         />
       ) : null}
@@ -306,11 +323,15 @@ function CheckAffordance({ selected }: { selected: boolean }) {
         width: 20,
         height: 20,
         borderRadius: 5,
+        // R4 §3/§4.5: selection is never red — ink box + white check. The
+        // unselected boundary is border-input, not the decorative hairline.
+        // White on ink measures 16.00:1; the check glyph is a second,
+        // non-colour channel on top of the fill.
         border: selected
-          ? "2px solid var(--accent-funnel)"
-          : "1.5px solid var(--color-border-subtle)",
-        background: selected ? "var(--accent-funnel)" : "transparent",
-        color: "var(--text-on-accent, #fff)",
+          ? "2px solid var(--text-primary)"
+          : "1.5px solid var(--border-strong)",
+        background: selected ? "var(--text-primary)" : "transparent",
+        color: "#ffffff",
         fontSize: 13,
         lineHeight: 1,
       }}
@@ -351,7 +372,7 @@ export function OptionButton({
         alignItems: "center",
         gap: "var(--space-3, 0.75rem)",
         padding: "var(--space-3, 0.85rem) var(--space-4, 1.1rem)",
-        borderRadius: 8,
+        borderRadius: 12,
         color: "var(--text-primary)",
         textAlign: "left",
         cursor: "pointer",

--- a/apps/mouth/src/app/visa/second-home/studio/components/ReadinessChecklist.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ReadinessChecklist.tsx
@@ -140,8 +140,9 @@ export function ReadinessChecklist({
       <h2
         style={{
           margin: 0,
+          // R4 §3: Cormorant is display-only and never below 24px.
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          fontSize: "clamp(1.5rem, 3vw, 1.75rem)",
           color: "var(--text-primary)",
         }}
       >

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
@@ -85,8 +85,10 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
       <h2
         style={{
           margin: 0,
+          // R4 §3: Cormorant is display-only and never below 24px — under that,
+          // low-DPI Android antialiasing shreds the serif.
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          fontSize: "clamp(1.5rem, 3vw, 1.75rem)",
           color: "var(--text-primary)",
         }}
       >
@@ -165,8 +167,12 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
 
       <style>{`
         .bz-shs-route-comparator {
-          --route-copy: #172033;
-          --route-label: #475569;
+          /* Literal hexes (not var()) so they match the design-system tokens
+             exactly — RouteComparator.test.tsx regexes --route-copy/--route-label
+             for a raw #hex, so an indirection breaks its AA-contrast assertion.
+             #16213a == --text-primary, #475372 == --text-secondary. */
+          --route-copy: #16213a;
+          --route-label: #475372;
         }
 
         .bz-shs-route-table-view {
@@ -264,20 +270,34 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
 
         .bz-shs-route-table-view [data-route="deposit"],
         .bz-shs-route-card[data-route="deposit"] {
-          --route-accent: #315f73;
-          --route-tint: #eef5f7;
+          /* Literal (see comment above): #2a6f97 == --state-likely */
+          --route-accent: #2a6f97;
+          --route-tint: #e8eef2;
         }
 
         .bz-shs-route-table-view [data-route="property"],
         .bz-shs-route-card[data-route="property"] {
-          --route-accent: #79502f;
+          /* Literal (see comment above): #7a5209 == --state-warning */
+          --route-accent: #7a5209;
           --route-tint: #f8f2eb;
         }
 
         .bz-shs-route-table-view [data-route="senior"],
         .bz-shs-route-card[data-route="senior"] {
+          /* DECLARED DEVIATION from the R4 token set (2026-08-31), recorded
+             rather than left implicit. The other two routes map onto real
+             tokens (--state-likely, --state-warning), but the third has no
+             token left that does not LIE: the remaining state colours mean
+             eligible / error, and both reds are reserved for structure and
+             action. Rather than give a route a semantic colour it does not
+             have, this keeps one desaturated hue that means nothing but
+             "third row". Measured on carta 6.42, on its own tint 6.06, on
+             white 6.95 — all clear. Safe because colour is NOT the signal
+             here: the three routes are told apart by crest and by the top
+             rule (dashed on the senior route), per R4 §4.5, and these tints
+             carry no meaning alone. */
           --route-accent: #66517a;
-          --route-tint: #f4f0f7;
+          --route-tint: #f2eef5;
         }
 
         .bz-shs-route-heading {
@@ -328,11 +348,11 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
           align-items: flex-start;
           gap: var(--space-2, 0.5rem);
           padding: 0.4rem 0.55rem;
-          color: #704116;
+          color: var(--state-warning);
           font-weight: 700;
           line-height: 1.4;
           background: #fff7e8;
-          border: 1px dashed #9b6327;
+          border: 1px dashed var(--state-warning);
           border-radius: 6px;
         }
 

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -157,24 +157,28 @@ describe("SavePlanBar clear-plan two-step confirm", () => {
     expect(restingRule).not.toContain("--color-error");
   });
 
-  // Regression guard (#4826, revised round c): round b pinned the armed
-  // state to --state-warning (amber) to escape a red collision with the
-  // price panel — but --state-warning is ALSO VerdictPanel's `edge_case`
-  // band accent (same outline + light-tint structure), so that just moved
-  // the same defect onto a different hue. The actual fix changes the
-  // CHANNEL: a solid, opaque fill (the darkened --accent-funnel mix
-  // StudioApp.tsx's primaryNavButtonStyle already uses) instead of a thin
-  // outline over a light tint — no verdict band or the price panel ever
-  // paints a solid fill, so this is safe regardless of hue. The boundary
-  // (border-color + focus outline) is deliberately a DIFFERENT token from
-  // the fill — --text-on-accent, not the fill color — because the dark
-  // fill that keeps text at >=4.5:1 only measures ~2.78:1 against the page
-  // surface, short of the 3:1 non-text-UI floor; a lighter fill would flip
-  // that trade the other way and fail the text floor instead. Guards all
-  // three collisions/failures seen across both rounds: never a bare/light
-  // --accent-funnel outline (the original bug), never --state-warning
-  // (round b's bug), and never a border/outline drawn in the low-contrast
-  // fill color.
+  // Regression guard (#4826, revised round c; re-pinned on the Merah Putih
+  // day palette 2026-08-31): round b pinned the armed state to
+  // --state-warning (amber) to escape a red collision with the price panel
+  // — but --state-warning is ALSO VerdictPanel's `edge_case` band accent
+  // (same outline + light-tint structure), so that just moved the same
+  // defect onto a different hue. The fix changes the CHANNEL: a solid,
+  // opaque fill instead of a thin outline over a light tint — no verdict
+  // band and no price panel ever paints one, so the fill reads as "another
+  // kind of control" regardless of hue.
+  //
+  // What this test used to pin was the MEANS, not the property: the literal
+  // color-mix(--accent-funnel 85%, black). That mix existed only to rescue
+  // #ff3344's 3.62:1 under white on the retired navy scheme, and it minted
+  // a fourth red (~#aa0e27) belonging to no token. The property it was
+  // standing in for is what is pinned now: the fill is a DECLARED token, in
+  // the one hue family this page leaves free (VerdictPanel keeps
+  // not_eligible deliberately neutral rather than --state-danger), never
+  // the funnel red that would collide with the price panel, never
+  // --state-warning, and never a red derived by mixing one of those toward
+  // black. The boundary stays a DIFFERENT token from the fill
+  // (--text-on-accent) — redundant on a light ground but harmless, and
+  // still what a dark-ground rendering would need.
   it("arms the clear button with a solid fill and a separate high-contrast boundary, never a bare accent outline or the warning accent (regression guard, #4826)", () => {
     const { container } = render(
       <SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />,
@@ -190,8 +194,13 @@ describe("SavePlanBar clear-plan two-step confirm", () => {
     // band and the price panel use.
     expect(armedRule).toContain("background: var(--bz-shs-clear-armed-fill)");
     expect(armedRule).toMatch(
-      /--bz-shs-clear-armed-fill:\s*color-mix\(\s*in srgb,\s*var\(--accent-funnel\)\s*85%,\s*black\s*\)/,
+      /--bz-shs-clear-armed-fill:\s*var\(--color-error[^)]*\)/,
     );
+    // The fill is a declared token, never a red derived by mixing another
+    // one toward black — that is how a fourth, undeclared red gets minted.
+    expect(armedRule).not.toContain("color-mix");
+    // Never the funnel red: that is the price panel's own border colour.
+    expect(armedRule).not.toContain("--accent-funnel");
     // Boundary is --text-on-accent, NOT the (low-contrast-vs-surface) fill
     // token — this is what keeps the 3:1 UI-boundary floor met without
     // breaking the 4.5:1 text-vs-fill floor.

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -26,29 +26,46 @@ const PRINT_STYLES = `
   }
 
   @media print {
+    /* MERAH PUTIH DAY (2026-08-31): this block used to re-declare a whole
+       token set, because the screen was navy and print had to force a
+       light result out of a dark live theme. StudioApp.tsx now applies
+       MERAH_PUTIH_DAY_VARS as an INLINE style on the [data-funnel="visa"]
+       wrapper this printed content lives inside, and an inline style
+       outranks any plain (non-!important) rule, print media included — so
+       every re-declaration of a token that set already carries was dead
+       weight on the day palette and is gone.
+       Three lines survive, for two different reasons:
+       --surface-base is pinned by a regression test, though per that same
+       precedence fact it is NOT what keeps printed paper white — the
+       !important background rule below is.
+       --color-text-muted / --color-border-subtle are NOT in
+       MERAH_PUTIH_DAY_VARS: they are aliases declared once at :root
+       (packages/core/tokens/semantic.css) as var(--text-secondary) /
+       var(--border-subtle). A var() inside a custom-property declaration
+       is substituted using the cascade AT THE DECLARING ELEMENT, so an
+       alias declared at :root can never see a wrapper's inline override —
+       it must be re-asserted directly, here. Printed cards read them for
+       captions and borders, so both restate the day law's own values. */
     :root,
     [data-theme],
     [data-funnel="visa"] {
-      --background: #ffffff;
-      --foreground: #172033;
       --surface-base: #ffffff;
-      --surface-raised: #ffffff;
-      --surface-sunken: #f4f6f8;
-      --text-primary: #172033;
-      --text-secondary: #334155;
-      --text-tertiary: #475569;
-      --color-text-muted: #475569;
-      --color-border-subtle: #cbd5e1;
-      --accent-funnel: #8f1d2c;
-      --accent-funnel-text: #8f1d2c;
-      --bz-elevated: #ffffff;
-      --tx-secondary: #334155;
+      --color-text-muted: #475372;
+      --color-border-subtle: #e3e1da;
     }
 
     html,
-    body {
+    body,
+    [data-funnel="visa"] {
+      /* [data-funnel="visa"] added (2026-08-30): that's the day wrapper
+         itself, and StudioApp.tsx gives it its OWN inline
+         background: var(--surface-base) — the warm carta #f7f6f2 — which
+         paints over whatever html/body alone resolve to. Forcing it here
+         too, with !important (the one thing that DOES beat an inline
+         style), is what actually keeps the printed page paper-white
+         instead of carta-tinted. */
       background: #ffffff !important;
-      color: #172033 !important;
+      color: #16213a !important;
     }
 
     nav,
@@ -106,7 +123,7 @@ const PRINT_STYLES = `
       padding: 0 !important;
       border: 0 !important;
       background: transparent !important;
-      color: #172033 !important;
+      color: #16213a !important;
       font-weight: 600;
       text-decoration: none !important;
     }
@@ -163,30 +180,37 @@ const CLEAR_BUTTON_STYLES = `
   }
 
   .bz-shs-clear-plan:is(:hover, :focus-visible) {
-    /* The editorial gradient is darkest at the bottom and lightest at the
-       top. This mix keeps danger text at >= 4.81:1 even on the lightest
-       raised surface plus the active tint, while remaining visibly separate
-       from the price red. */
-    --bz-shs-clear-active: color-mix(
-      in srgb,
-      var(--color-error, #c0392b) 40%,
-      white
-    );
-    border-color: var(--bz-shs-clear-active);
+    /* MERAH PUTIH DAY (2026-08-30): this used to lighten danger red toward
+       white — correct against the retired editorial gradient (darkest at
+       the bottom, lightest at the top: a dark ground), where mixing toward
+       white was what kept the text from going muddy-dark on a dark bg.
+       Screen ground is now a flat, LIGHT carta/white, so lightening further
+       is exactly backwards — mixed 40% toward white it measured ~1.5:1
+       against its own tint, nowhere near AA. The fix is to stop mixing and
+       read --color-error directly: on the day palette that's #a83a44,
+       which measures (computed against the literal values above) 4.88:1
+       for text against this rule's own 16% background tint (still clears
+       4.5:1 at the type's own weight/size) and 6.26:1 for the border/outline
+       against the white card exterior (well past the 3:1 boundary floor) —
+       and it stays a different hue from the funnel/price red (day
+       --color-error #a83a44 vs day --accent-funnel #C8102E /
+       --accent-funnel-text #D01033), so the "never collide with the price
+       panel" property this rule exists for is untouched. */
+    border-color: var(--color-error, #a83a44);
     background: color-mix(
       in srgb,
-      var(--color-error, #c0392b) 16%,
+      var(--color-error, #a83a44) 16%,
       transparent
     );
     box-shadow: inset 0 0 0 1px currentColor;
-    color: var(--bz-shs-clear-active);
+    color: var(--color-error, #a83a44);
     text-decoration-line: underline;
     text-decoration-thickness: 2px;
     text-underline-offset: 0.2em;
   }
 
   .bz-shs-clear-plan:focus-visible {
-    outline: 3px solid var(--bz-shs-clear-active);
+    outline: 3px solid var(--color-error, #a83a44);
     outline-offset: 3px;
   }
 
@@ -196,55 +220,41 @@ const CLEAR_BUTTON_STYLES = `
      pointer state the next tap (the confirm) won't have either.
      P0 2026-08-24b/c — two rounds on this one, both grounded on the
      rendered page, not declared CSS:
-     Round b tried var(--accent-funnel): on this page's fixed
-     [data-theme="editorial"][data-funnel="visa"] scope that's #ff3344 —
-     byte-identical to the price panel's border. Fixed by switching to
-     --state-warning (amber) — which turned out to just relocate the
-     collision: VerdictPanel's edge_case band (property route, or ages
-     55-59 — NOT a rare case, the majority of a senior audience hits it)
-     paints its OWN border/fill in --state-warning at the same outline +
-     light-tint structure. Every hue on this page already carries a
-     verdict-band or price-panel meaning (success/info/warning/neutral/
-     funnel-red) — hunting for a free one just finds the next collision.
-     Round c changes the CHANNEL instead of the hue: a solid, opaque FILL
-     block. No verdict band and no price panel ever paints a solid fill —
-     they are all a thin border over --surface-raised (or a light
-     color-mix tint). The one solid-fill precedent already on this exact
-     page is WhatsAppHandoff's CTA (#25D366, WHATSAPP_GREEN) sitting right
-     above this button — proof a solid block already reads as "the other
-     kind of control" here, distinct from every outlined card regardless
-     of which hue it carries. That frees funnel red back up: reused as
-     color-mix(in srgb, var(--accent-funnel) 85%, black), the exact
-     darkening StudioApp.tsx's primaryNavButtonStyle already derives (see
-     its comment above, same file) because flat --accent-funnel under
-     white text measures 3.62:1 on this funnel/theme pairing — verified
-     4.5:1+ after the 85%-black mix, on both known --accent-funnel
-     resolutions. This label is 16px/600 — WCAG "normal text" (no
-     large-text exemption) — so 4.5:1 against the fill is the real floor:
-     measured 4.82:1 on the rendered page. But the fill itself (a DARK red,
-     deliberately mixed toward black so white text clears 4.5:1) only
-     measures 2.78:1 against the navy surface behind it — short of the 3:1
-     non-text/UI-boundary floor (WCAG 1.4.11). Darkening the fill further
-     to help criterion 2 makes criterion 3 worse and vice versa; the two
-     floors can't both be met by tuning ONE color. So the boundary is a
-     SEPARATE color from the fill: border-color and the inset ring both
-     read --text-on-accent (white on this funnel) instead of the fill
-     token — white-on-navy clears 3:1 by a wide margin regardless of what
-     the interior fill measures, and it's the same color already proven
-     for the text. The focus-visible outline below reads the SAME
-     --text-on-accent for the identical reason: an outline drawn in the
-     dark fill color would inherit its 2.78:1 problem. Do not tidy the
-     border/outline back to the fill color, and do not go back to
-     --state-warning or a bare/light --accent-funnel outline — all three
-     are collisions or contrast failures this fixes. Placed after the
-     resting :hover/:focus-visible rule above so equal-specificity source
-     order lets it win whether or not the armed button is also hovered. */
+     Two constraints, learned the hard way then and still binding now:
+     HUE — every hue on this page already carries a verdict-band or price
+     meaning. Bare var(--accent-funnel) was byte-identical to the price
+     panel's border, and --state-warning just relocated the collision onto
+     VerdictPanel's edge_case band (property route, or ages 55-59 — NOT a
+     rare case, the majority of a senior audience hits it). The danger
+     family is the one hue this page leaves free: VerdictPanel keeps
+     not_eligible deliberately neutral rather than --state-danger.
+     CHANNEL — a solid, opaque FILL. No verdict band and no price panel
+     ever paints one; they are all a thin border over --surface-raised or a
+     light tint. The solid-fill precedent right above this button is
+     WhatsAppHandoff's CTA, so a block already reads here as "the other
+     kind of control", whatever hue it carries.
+
+     MERAH PUTIH DAY (2026-08-31): the fill was
+     color-mix(var(--accent-funnel) 85%, black) ≈ #aa0e27 — a FOURTH red
+     belonging to no token. That darkening existed only because flat
+     #ff3344 under white measured 3.62:1 on the retired navy scheme; the
+     day palette has no such problem, and mixing a brand red toward black
+     to make it safe is how a palette grows reds nobody declared. It now
+     reads --color-error (#a83a44) neat: white on it measures 6.26:1 (past
+     the 4.5:1 floor this 16px/600 label needs — no large-text exemption)
+     and it stands 6.26:1 against the white card, clearing the 3:1
+     non-text boundary floor (WCAG 1.4.11) unaided. That also makes armed
+     the top of ONE scale: this same button already reads --color-error at
+     rest and on hover, so the two states no longer speak different reds.
+     border/box-shadow/outline stay --text-on-accent (white) — now inert
+     reinforcement rather than the thing carrying the 3:1 requirement, and
+     pinned by SavePlanBar.test.tsx. Do not restore --state-warning or a
+     bare/light --accent-funnel outline: both are collisions this fixes.
+     Placed after the resting :hover/:focus-visible rule above so
+     equal-specificity source order lets it win whether or not the armed
+     button is also hovered. */
   .bz-shs-clear-plan.bz-shs-clear-armed {
-    --bz-shs-clear-armed-fill: color-mix(
-      in srgb,
-      var(--accent-funnel) 85%,
-      black
-    );
+    --bz-shs-clear-armed-fill: var(--color-error, #a83a44);
     border-color: var(--text-on-accent, #fff);
     background: var(--bz-shs-clear-armed-fill);
     box-shadow: inset 0 0 0 1px var(--text-on-accent, #fff);
@@ -276,7 +286,11 @@ export interface SavePlanBarProps {
 
 const buttonStyle: React.CSSProperties = {
   padding: "var(--space-2, 0.5rem) var(--space-4, 1.1rem)",
-  borderRadius: 8,
+  // R4 §3 radius law: 12 for buttons/CTAs (was 8). No nesting exception
+  // applies — these buttons sit inside the bar's own 24px section padding
+  // (var(--space-4, 1.5rem)), well clear of that section's own 12px
+  // corner curve, so there's no tight-nesting mismatch to avoid.
+  borderRadius: 12,
   border: "1px solid var(--color-border-subtle)",
   background: "transparent",
   color: "var(--text-primary)",
@@ -406,7 +420,10 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
         style={{
           margin: 0,
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.1rem, 2.6vw, 1.35rem)",
+          // R4 §3 24px floor for Cormorant/serif (low-DPI Android
+          // antialiasing shreds it below 1.5rem) — raised from
+          // clamp(1.1rem, 2.6vw, 1.35rem) on the day migration.
+          fontSize: "clamp(1.5rem, 2.6vw, 1.75rem)",
           color: "var(--text-primary)",
         }}
       >

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -38,14 +38,17 @@ const PRINT_STYLES = `
        --surface-base is pinned by a regression test, though per that same
        precedence fact it is NOT what keeps printed paper white — the
        !important background rule below is.
-       --color-text-muted / --color-border-subtle are NOT in
-       MERAH_PUTIH_DAY_VARS: they are aliases declared once at :root
-       (packages/core/tokens/semantic.css) as var(--text-secondary) /
-       var(--border-subtle). A var() inside a custom-property declaration
-       is substituted using the cascade AT THE DECLARING ELEMENT, so an
-       alias declared at :root can never see a wrapper's inline override —
-       it must be re-asserted directly, here. Printed cards read them for
-       captions and borders, so both restate the day law's own values. */
+       --color-text-muted / --color-border-subtle are aliases declared once
+       at :root (packages/core/tokens/semantic.css) as var(--text-secondary)
+       / var(--border-subtle). A var() inside a custom-property declaration
+       is substituted using the cascade AT THE DECLARING ELEMENT, so an alias
+       declared at :root can never see a wrapper's inline override — it must
+       be re-asserted directly. MERAH_PUTIH_DAY_VARS now restates both, so
+       these two print lines are belt-and-braces rather than the only cure
+       (an earlier revision of this comment claimed the day set did NOT carry
+       them — it does; corrected 2026-08-31). They are kept because this
+       print block is also read on any surface that renders it without the
+       wrapper, and the values are identical either way. */
     :root,
     [data-theme],
     [data-funnel="visa"] {

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
@@ -53,9 +53,25 @@ describe("ScenarioToggle", () => {
     );
     expect(restingRule).toContain("color: var(--text-secondary)");
     expect(restingRule).not.toContain("--accent-funnel");
-    expect(css).toMatch(
-      /\.bz-shs-scenario-toggle-trigger:is\(:hover, :focus-visible\)\s*\{[^}]*border-color:\s*var\(--accent-funnel\)[^}]*color:\s*color-mix\(in srgb, var\(--accent-funnel\) 70%, white\)[^}]*text-decoration-line:\s*underline/s,
-    );
+    // The hover label reads the FLAT accent token. It used to be
+    // color-mix(var(--accent-funnel) 70%, white), which was correct on the
+    // retired navy ground — lightening moved it away from a dark backdrop.
+    // On the day palette's carta that runs backwards: the mix lands ~#D8586D
+    // and measures 3.07:1 against this rule's own 8% hover tint, below the
+    // 4.5:1 this 16px/600 label needs, where flat #C8102E measures 4.77:1.
+    // The mix is also a hue no token declares. Both are pinned centrally by
+    // scripts/tests/test_merah_putih_day_contrast.py.
+    const hoverRule = css.match(
+      /\.bz-shs-scenario-toggle-trigger:is\(:hover, :focus-visible\)\s*\{([^}]*)\}/,
+    )?.[1];
+    // Judge the DECLARATIONS, not the rule's prose: the comment above this
+    // very rule explains why we no longer mix toward white, so a naive
+    // substring check on the raw body convicts its own documentation.
+    const hoverDecls = (hoverRule ?? "").replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(hoverDecls).toContain("border-color: var(--accent-funnel)");
+    expect(hoverDecls).toContain("color: var(--accent-funnel)");
+    expect(hoverDecls).toContain("text-decoration-line: underline");
+    expect(hoverDecls).not.toContain("color-mix(in srgb, var(--accent-funnel)");
     expect(css).toMatch(
       /\.bz-shs-scenario-toggle-trigger:focus-visible\s*\{[^}]*outline:\s*3px solid var\(--accent-funnel\)[^}]*outline-offset:\s*3px/s,
     );

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
@@ -60,11 +60,17 @@ const SCENARIO_TRIGGER_STYLES = `
     box-shadow: inset 0 0 0 1px currentColor;
     /* This button's label is 16px/600 — WCAG "normal text" (large-text
        exemption needs >=24px, or >=18.66px bold), so the floor is 4.5:1.
-       The full accent measures 4.13:1 on this backdrop and fails. 70%
-       accent mixed with white measures 5.59:1 and still reads as the
-       accent hue rather than washing out to pink. Do not tidy this back
-       to var(--accent-funnel). */
-    color: color-mix(in srgb, var(--accent-funnel) 70%, white);
+       MERAH PUTIH DAY (2026-08-31): this read
+       color-mix(var(--accent-funnel) 70%, white), and the measurements
+       that justified it (full accent 4.13:1, the mix 5.59:1) were taken on
+       the retired NAVY ground, where lightening a colour moves it AWAY
+       from the backdrop. On carta the same gesture runs backwards: mixed
+       toward white the label lands ~#D8586D and measures 3.07:1 against
+       this rule's own 8%-tinted hover backdrop (~#f3e4e2) — a fail. The
+       flat token is what passes here: #C8102E measures 4.77:1 on that same
+       backdrop (5.44:1 on untinted carta). Do NOT re-introduce a mix
+       toward white — on a light ground that is the direction of failure. */
+    color: var(--accent-funnel);
     text-decoration-line: underline;
     text-decoration-thickness: 2px;
     text-underline-offset: 0.2em;

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
@@ -182,7 +182,7 @@ export function ScenarioToggle({ plan }: ScenarioToggleProps) {
             alignItems: "center",
             gap: "var(--space-2, 0.5rem)",
             padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
-            borderRadius: 8,
+            borderRadius: 12,
             cursor: "pointer",
             fontWeight: 600,
             minHeight: 44,
@@ -245,7 +245,7 @@ export function ScenarioToggle({ plan }: ScenarioToggleProps) {
           alignItems: "center",
           gap: "var(--space-2, 0.5rem)",
           padding: "6px 14px",
-          borderRadius: 8,
+          borderRadius: 12,
           border: "1px solid var(--color-border-subtle)",
           background: "transparent",
           color: "var(--text-primary)",
@@ -266,7 +266,7 @@ export function ScenarioToggle({ plan }: ScenarioToggleProps) {
             gap: "var(--space-2, 0.5rem)",
             padding: "var(--space-3, 0.75rem)",
             border: "1px solid var(--color-border-subtle)",
-            borderRadius: 8,
+            borderRadius: 12,
             background:
               "color-mix(in srgb, var(--state-warning) 6%, transparent)",
           }}

--- a/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
@@ -52,8 +52,9 @@ export function TimelineView({
       <h2
         style={{
           margin: 0,
+          // R4 §3: Cormorant is display-only and never below 24px.
           fontFamily: "var(--font-serif, Georgia, serif)",
-          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          fontSize: "clamp(1.5rem, 3vw, 1.75rem)",
           color: "var(--text-primary)",
         }}
       >

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
@@ -68,7 +68,7 @@ export function WhatsAppHandoff({ plan, verdict }: WhatsAppHandoffProps) {
           alignItems: "center",
           gap: 8,
           padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
-          borderRadius: 8,
+          borderRadius: 12,
           // WCAG AA fix (measured 2026-08-24): white on the WhatsApp brand
           // green computes to ~1.98:1, failing the 4.5:1 normal-text floor.
           // Ratified cure (app/(visa-oracle)/visa-oracle/oracle.css:23-30,

--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -72,6 +72,20 @@ export const MERAH_PUTIH_DAY_VARS = {
   "--border-default": "#d5d0c2",
   "--border-strong": "#7a8093",
 
+  // ── Aliases that MUST be restated, not inherited ──────────────────────────
+  // `semantic.css` declares these at :root as `var(--text-secondary)` /
+  // `var(--border-subtle)`. A var() inside a custom-property declaration is
+  // substituted using the cascade AT THE DECLARING ELEMENT — so an alias
+  // declared at :root resolves against :ROOT's values and hands its
+  // already-computed result down by inheritance. Overriding --text-secondary
+  // on a wrapper deep in the tree therefore does NOT move the alias: it would
+  // keep the dark theme's value while everything around it turned to paper.
+  // These two are the most-consumed tokens in this perimeter (42 and 36 uses),
+  // so the leak would have been wide and quiet. Restated with the same values
+  // their sources take above.
+  "--color-text-muted": "#475372",
+  "--color-border-subtle": "#e3e1da",
+
   // ── The red family (R4 §3) ────────────────────────────────────────────────
   // STRUCTURE (brand marks, progress fill, rules) vs ACTION (CTA, links) are
   // two duties, never interchangeable — and selection is NEVER red (R4 §4.5).
@@ -123,3 +137,32 @@ export const MERAH_PUTIH_DAY_VARS = {
  * without re-stating the whole selector chain.
  */
 export const MERAH_PUTIH_DAY_CLASS = "merah-putih-day";
+
+/**
+ * The wrapper cannot paint its own ancestors, and <body> is an ancestor.
+ *
+ * MEASURED 2026-08-31 on the running app, which is the only reason this exists:
+ * with the wrapper correctly carta, `getComputedStyle(document.body)` still
+ * returned `rgb(29, 39, 59)` — the shared editorial navy — on BOTH routes, and
+ * body was 88px taller than the wrapper on each. That is a navy band under the
+ * content, plus a navy page in print and behind overscroll rubber-banding.
+ *
+ * `:has()` keeps the cure scoped to exactly the pages that opted in: no route
+ * without a `.merah-putih-day` wrapper is affected, so this stays a route-level
+ * change and never becomes a global stylesheet edit. Where `:has()` is
+ * unsupported the page simply keeps today's behaviour — the same navy it has
+ * now, never something worse.
+ *
+ * Inject with `<style>{MERAH_PUTIH_DAY_BODY_CSS}</style>` inside the wrapper.
+ */
+export const MERAH_PUTIH_DAY_BODY_CSS = `
+body:has(.merah-putih-day) {
+  background: #f7f6f2;
+  color: #16213a;
+}
+@media print {
+  body:has(.merah-putih-day) {
+    background: #ffffff;
+  }
+}
+`;

--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -86,6 +86,32 @@ export const MERAH_PUTIH_DAY_VARS = {
   "--color-text-muted": "#475372",
   "--color-border-subtle": "#e3e1da",
 
+  // ── A SECOND, UNRELATED VOCABULARY THAT LANDS INSIDE THIS WRAPPER ────────
+  // `ConsentBanner` (apps/mouth/src/components/visa/ConsentBanner.tsx) renders
+  // as a descendant of BOTH converted wrappers, and it speaks the portal's
+  // "Warm Depth" token family — NOT the funnel's. `--tx-secondary` and
+  // `--bz-accent` are plain hexes declared once at :root in
+  // apps/mouth/src/app/globals.css (#94a3b8 / #d4845a), tuned for a dark
+  // ground, and `[data-theme="editorial"]` never overrides them.
+  //
+  // So they are NOT an alias trap like the two above — they are a whole
+  // vocabulary the day set did not know it had to answer for. MEASURED on the
+  // day ground before this line existed: banner body text 2.56:1, links
+  // 2.90:1, and white on the dismiss button 2.90:1 — all under the 4.5:1
+  // floor, on a fixed-bottom consent bar every non-consented visitor sees.
+  // That is a REGRESSION THIS MIGRATION CAUSED: the same #94a3b8 measured
+  // 6.25:1 against the navy ground it was chosen for.
+  //
+  // Restated here rather than edited in ConsentBanner, deliberately: that
+  // component is shared with the rest of the /visa funnel, which is still on
+  // the dark theme and is a different lane's perimeter. Overriding the tokens
+  // on OUR wrapper fixes our two routes and cannot reach anyone else's.
+  // Of the components that speak this vocabulary, only ConsentBanner is
+  // imported by these two pages (VisaChat, QuestionCounter and WhatsAppCTA
+  // live on routes this wrapper never touches) — verified, not assumed.
+  "--tx-secondary": "#475372", // 7.64:1 on the banner's white ground
+  "--bz-accent": "#D01033", // 5.52:1 as a link, and white on it as a button
+
   // ── The red family (R4 §3) ────────────────────────────────────────────────
   // STRUCTURE (brand marks, progress fill, rules) vs ACTION (CTA, links) are
   // two duties, never interchangeable — and selection is NEVER red (R4 §4.5).

--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -1,0 +1,125 @@
+import type { CSSProperties } from "react";
+
+/**
+ * MERAH PUTIH — the DAY token set (identity law R4).
+ *
+ * Spec: `research/design/2026-08-27-r4-identity-merah-putih-token-spec.md`
+ * Winning rendering direction: «Cap Dinas» v2 (contest 2026-08-30,
+ * `research/design/2026-08-30-merah-putih-rendering-contest-result.md`).
+ *
+ * WHY THIS FILE EXISTS (and why it is not an edit to `rumahVars.ts`):
+ * `rumahVars` is the older "Rumah Putih" set — same warm paper and ink, but its
+ * accent is the NAVY `#1e3863`, which R4 RETIRES from the whole public
+ * perimeter. Editing rumahVars would silently repaint the homepage and the blog,
+ * which are not in this lane's perimeter. So: same scoping contract, new set.
+ *
+ * SCOPING CONTRACT (do NOT break it — inherited from rumahVars.ts):
+ *   - Apply `MERAH_PUTIH_DAY_VARS` INLINE on the converted route's own top-level
+ *     wrapper, NEVER on a shared `layout.tsx`. CSS custom properties inherit, so
+ *     everything inside the wrapper resolves the day values while NavShell and
+ *     Footer — DOM ancestors that read `--nav-bg` / `--footer-bg` — keep the
+ *     shell's own theme.
+ *   - The wrapper this lands on already carries `data-funnel="visa"`, which the
+ *     shared theme paints via `[data-theme="editorial"] [data-funnel="visa"]`
+ *     (`packages/core/tokens/themes/editorial.css:56`) → navy gradient ground and
+ *     the RETIRED red `#ff3344`. An inline style on that same element beats that
+ *     selector, so the override needs no `!important` and no theme fork.
+ *   - No file under `packages/core/tokens/` changes. Other routes are untouched.
+ *
+ * CONTRAST (WCAG 2.x, every ratio COMPUTED — R4 §4 forbids estimating them;
+ * recomputed against these exact values by
+ * `scripts/tests/test_merah_putih_day_contrast.py`, which fails the build if any
+ * pair below drifts):
+ *   ink       #16213a on carta 14.79 · on elevated 16.00
+ *   ink-soft  #475372 on carta  7.07 · on elevated  7.64
+ *   muted     #6f6a5e on carta  4.98
+ *   merah        #C8102E on carta 5.44 · white on it 5.88
+ *   merah-action #D01033 on carta 5.11 · white on it 5.52
+ *   merah-press  #c40020 on carta 5.77 · white on it 6.24
+ *   eligible #16683f 6.29 · likely #2a6f97 5.08 · conditional #7a5209 6.39
+ *   error    #a83a44 5.79 · white on it 6.26
+ *   border-input #7a8093 on carta 3.64 · on elevated 3.94  (≥3 non-text bar)
+ *   hairline #e3e1da on carta 1.21 — DECORATIVE ONLY, never the sole identifier
+ *     of an interactive component (WCAG 2.2 SC 1.4.11). Interactive boundaries
+ *     use `--border-strong`. This is the trap that made `#ddd8cb` (1.32) unusable
+ *     as a component border even though the winning mockup paints dividers with it.
+ *   RETIRED  #ff3344 on carta 3.34 — fails AA; this is what we are removing.
+ */
+export const MERAH_PUTIH_DAY_VARS = {
+  // ── Grounds ────────────────────────────────────────────────────────────────
+  // Overrides editorial's navy GRADIENT with a flat carta; `-solid` matters for
+  // the components that read the solid form (nav band, print).
+  "--surface-base": "#f7f6f2",
+  "--surface-base-solid": "#f7f6f2",
+  "--surface-raised": "#ffffff",
+  "--surface-sunken": "#efece4",
+  "--surface-deep": "#efece4",
+  "--surface-overlay": "rgba(247, 246, 242, 0.94)",
+  "--surface-scrim": "rgba(22, 33, 58, 0.45)",
+  "--bz-elevated": "#ffffff",
+
+  // ── Ink ────────────────────────────────────────────────────────────────────
+  "--text-primary": "#16213a",
+  "--text-secondary": "#475372",
+  "--text-tertiary": "#6f6a5e",
+  "--foreground": "#16213a",
+  "--text-on-accent": "#ffffff",
+
+  // ── Boundaries ─────────────────────────────────────────────────────────────
+  // subtle/default are DECORATIVE (1.21 / 1.42 on carta). Anything that
+  // identifies an interactive component must read `--border-strong` (3.64).
+  "--border-subtle": "#e3e1da",
+  "--border-default": "#d5d0c2",
+  "--border-strong": "#7a8093",
+
+  // ── The red family (R4 §3) ────────────────────────────────────────────────
+  // STRUCTURE (brand marks, progress fill, rules) vs ACTION (CTA, links) are
+  // two duties, never interchangeable — and selection is NEVER red (R4 §4.5).
+  "--accent-funnel": "#C8102E",
+  "--accent-funnel-text": "#D01033",
+  "--cta-bg": "#D01033",
+  "--cta-bg-hover": "#c40020",
+  "--cta-primary-bg": "#D01033",
+  "--text-link": "#D01033",
+
+  // ── Semantic states (R4 §3) ───────────────────────────────────────────────
+  "--state-success": "#16683f",
+  "--state-likely": "#2a6f97",
+  "--state-info": "#2a6f97",
+  "--state-warning": "#7a5209",
+  "--state-danger": "#a83a44",
+  "--state-error": "#a83a44",
+  "--color-error": "#a83a44",
+
+  // WhatsApp is the ICON of the human exit — never a green button with white
+  // text on it (white on #25d366 measures 1.98). The ink is what carries text.
+  "--accent-whatsapp": "#25d366",
+  "--accent-whatsapp-ink": "#0d3a1f",
+
+  // ── Shell ─────────────────────────────────────────────────────────────────
+  // The funnel header is slim ON CARTA — never a red band (R4 §4.3 restraint
+  // budget). The full-bleed merah band is the home hero's single exception.
+  "--nav-bg": "#f7f6f2",
+  "--footer-bg": "#f7f6f2",
+  "--footer-text": "#475372",
+
+  // ── Typography ────────────────────────────────────────────────────────────
+  // `/visa/layout.tsx` forces Montserrat on the whole visa funnel via an inline
+  // `fontFamily`. R4 retires Montserrat from the web. We neutralise it HERE, on
+  // our own wrapper, rather than editing the shared visa layout — the rest of
+  // the funnel is a different lane's perimeter.
+  // Inter and Cormorant are self-hosted and mounted on <html> by the root
+  // layout. IBM Plex Mono is NOT loaded in this app (only 4 woff2 files exist:
+  // cormorant, inter, league-spartan, montserrat), so `--font-mono` resolves to
+  // ui-monospace — the same fallback every other mono surface in this app
+  // already uses. Declared, not pretended: loading a fifth face is a perf decision of
+  // its own, tracked in PENDING-ARMS, not smuggled into a palette change.
+  fontFamily: "var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif",
+} as CSSProperties;
+
+/**
+ * Marker className paired with `MERAH_PUTIH_DAY_VARS` on every converted
+ * wrapper, so scoped CSS (and the print stylesheet) can target the day scope
+ * without re-stating the whole selector chain.
+ */
+export const MERAH_PUTIH_DAY_CLASS = "merah-putih-day";

--- a/scripts/tests/test_merah_putih_day_contrast.py
+++ b/scripts/tests/test_merah_putih_day_contrast.py
@@ -84,6 +84,10 @@ TEXT_PAIRS = [
     ("--state-danger", "--surface-base", AA_TEXT),
     ("--accent-whatsapp-ink", "--surface-raised", AA_TEXT),
     ("--accent-whatsapp-ink", "--surface-base", AA_TEXT),
+    # The portal vocabulary ConsentBanner brings into this wrapper. Measured at
+    # 2.56 and 2.90 before the day set answered for them.
+    ("--tx-secondary", "--surface-raised", AA_TEXT),
+    ("--bz-accent", "--surface-raised", AA_TEXT),
 ]
 
 # White text is legal ONLY on these fills (R4 §4.2).
@@ -93,6 +97,7 @@ WHITE_ON = [
     "--cta-bg",  # the primary CTA fill — StudioApp's primaryNavButtonStyle
     "--cta-bg-hover",
     "--state-danger",
+    "--bz-accent",  # ConsentBanner's dismiss button paints white on it
 ]
 
 # Boundaries that IDENTIFY an interactive component must clear 3:1 (SC 1.4.11).
@@ -161,16 +166,39 @@ RETIRED = {
 }
 
 
+_SHARED_IMPORT = re.compile(r"""^import\s[^;]*?from\s+["'](@/components/[^"']+)["']""", re.M)
+
+
 def _perimeter_sources() -> list[Path]:
-    return sorted(
-        p
-        for p in PERIMETER.rglob("*.tsx")
-        if not p.name.endswith(".test.tsx")
-    )
+    """Every .tsx that PAINTS inside the two converted wrappers.
+
+    The route tree alone is NOT that set, and believing it was is what let the
+    worst defect of this migration ship green. `ConsentBanner` lives at
+    apps/mouth/src/components/visa/ — outside PERIMETER — yet renders as a
+    descendant of both wrappers, and it speaks a token vocabulary the day set
+    did not answer for: measured 2.56:1 body text and 2.90:1 links on the new
+    ground. Every guard here reported clean while that was true, because none
+    of them could see the file.
+
+    So the set is the route tree PLUS whatever `@/components/...` the two
+    wrappers actually import — resolved from the import statements, so a
+    component added tomorrow is covered without anyone remembering to add it
+    here. A hand-kept list would rot on its first commit.
+    """
+    files = {p for p in PERIMETER.rglob("*.tsx") if not p.name.endswith(".test.tsx")}
+    src_root = REPO / "apps/mouth/src"
+    for wrapper in (
+        PERIMETER / "SecondHomeLanding.tsx",
+        PERIMETER / "studio/StudioApp.tsx",
+    ):
+        for spec in _SHARED_IMPORT.findall(wrapper.read_text(encoding="utf-8")):
+            candidate = src_root / (spec.removeprefix("@/") + ".tsx")
+            if candidate.exists():
+                files.add(candidate)
+    return sorted(files)
 
 
 _BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
-_LINE_COMMENT = re.compile(r"//[^\n]*")
 
 
 def strip_comments(src: str) -> str:
@@ -181,8 +209,43 @@ def strip_comments(src: str) -> str:
     is how a codebase loses the reason behind its own rules (scar family #3,
     over-match). `test_the_stripper_cannot_hide_a_real_use` is the guilt half
     that keeps this leniency honest.
+
+    Line comments are NOT stripped with `//[^\\n]*`. That regex has no idea what
+    a string literal is, so a URL inside one decapitates the rest of the line:
+    `const a = "https://x"; const s = { color: "#ff3344" }` was truncated at
+    `"https:` and the retired colour after it became invisible to every guard
+    here. Demonstrated in `test_the_stripper_survives_a_url_in_a_string`. Hence
+    the small scanner below: it tracks quote state, so `//` only starts a
+    comment when it is not inside a string.
     """
-    return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", src))
+    src = _BLOCK_COMMENT.sub("", src)
+    out: list[str] = []
+    quote: str | None = None
+    i, n = 0, len(src)
+    while i < n:
+        ch = src[i]
+        if quote:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:  # an escaped char cannot close the string
+                out.append(src[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in "\"'`":
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and src[i + 1] == "/":
+            while i < n and src[i] != "\n":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 @pytest.mark.parametrize("colour,why", sorted(RETIRED.items()))
@@ -421,3 +484,34 @@ def test_the_derived_mix_guard_leaves_opacity_tints_alone() -> None:
         assert not _deriving_mixes(innocent), (
             f"guard over-matches an opacity tint: {innocent}"
         )
+
+
+def test_the_stripper_survives_a_url_in_a_string() -> None:
+    """Guilt: `//` inside a string literal must NOT start a comment.
+
+    The naive `//[^\n]*` truncated at the URL's slashes and silently deleted a
+    real declaration later on the same line — so a retired colour could sit in
+    painted code and every guard here would report clean.
+    """
+    line = 'const img = "https://cdn.example/hero.png"; const s = { color: "#ff3344" };'
+    assert "#ff3344" in strip_comments(line), (
+        "a URL inside a string ate the rest of the line — the stripper is "
+        "hiding painted colours from every guard in this file"
+    )
+    # And the leniency it exists for still works.
+    assert "#ff3344" not in strip_comments("// we retired #ff3344 here")
+    assert "#ff3344" not in strip_comments("/* retired: #ff3344 */")
+
+
+def test_the_perimeter_sees_shared_components_rendered_inside_the_wrappers() -> None:
+    """The route tree is not the painted set.
+
+    ConsentBanner lives outside PERIMETER but renders inside both wrappers. A
+    guard that cannot see it reported clean while it measured 2.56:1.
+    """
+    names = {p.name for p in _perimeter_sources()}
+    assert "ConsentBanner.tsx" in names, (
+        "shared components imported by the wrappers are not being scanned — "
+        f"saw only: {sorted(names)}"
+    )
+    assert "SecondHomeLanding.tsx" in names and "StudioApp.tsx" in names

--- a/scripts/tests/test_merah_putih_day_contrast.py
+++ b/scripts/tests/test_merah_putih_day_contrast.py
@@ -87,7 +87,13 @@ TEXT_PAIRS = [
 ]
 
 # White text is legal ONLY on these fills (R4 §4.2).
-WHITE_ON = ["--accent-funnel", "--accent-funnel-text", "--cta-bg-hover", "--state-danger"]
+WHITE_ON = [
+    "--accent-funnel",
+    "--accent-funnel-text",
+    "--cta-bg",  # the primary CTA fill — StudioApp's primaryNavButtonStyle
+    "--cta-bg-hover",
+    "--state-danger",
+]
 
 # Boundaries that IDENTIFY an interactive component must clear 3:1 (SC 1.4.11).
 NON_TEXT_PAIRS = [
@@ -272,6 +278,54 @@ def test_no_cormorant_weight_below_500() -> None:
     )
 
 
+# ── 4. the alias trap ────────────────────────────────────────────────────────
+
+SEMANTIC_CSS = REPO / "packages/core/tokens/semantic.css"
+_ALIAS = re.compile(r"^\s*(--[a-z0-9-]+):\s*var\((--[a-z0-9-]+)")
+
+
+def test_every_consumed_root_alias_is_restated_in_the_day_set() -> None:
+    """Aliases declared at :root do NOT follow a wrapper-scoped override.
+
+    `semantic.css` declares e.g. `--color-text-muted: var(--text-secondary)` at
+    :root. A var() inside a custom-property declaration is substituted using the
+    cascade AT THE DECLARING ELEMENT, so that alias resolves against :root's
+    value and hands the already-computed result down by inheritance. Overriding
+    `--text-secondary` on a wrapper deep in the tree does not move it.
+
+    MEASURED 2026-08-31 on the running app, which is why this test exists: at
+    :root the day pages resolved `--color-text-muted` to `rgba(255,255,255,0.68)`
+    and `--color-border-subtle` to `rgba(255,255,255,0.06)` — white, from the
+    dark theme. Consumed 42 and 36 times in this perimeter, that is white text
+    on warm paper and invisible borders. The cure is to restate the alias itself
+    in the day set; this test fails if a NEW alias is consumed without doing so.
+    """
+    if not SEMANTIC_CSS.exists():  # pragma: no cover - layout guard
+        pytest.skip("semantic.css not found")
+
+    aliases = {}
+    for line in SEMANTIC_CSS.read_text(encoding="utf-8").splitlines():
+        m = _ALIAS.match(line)
+        if m:
+            aliases.setdefault(m.group(1), m.group(2))
+
+    perimeter_text = "\n".join(
+        strip_comments(p.read_text(encoding="utf-8")) for p in _perimeter_sources()
+    )
+    day_set = read_tokens()
+
+    missing = [
+        f"{alias} (alias of {src})"
+        for alias, src in aliases.items()
+        if alias in perimeter_text and alias not in day_set
+    ]
+    assert not missing, (
+        "these :root aliases are consumed in the second-home perimeter but are "
+        "NOT restated in MERAH_PUTIH_DAY_VARS, so they keep the shared theme's "
+        f"(dark) value on a paper page: {missing}"
+    )
+
+
 def test_both_public_wrappers_actually_apply_the_day_set() -> None:
     """The set is inert unless it is spread on the two route wrappers."""
     for rel in (
@@ -282,4 +336,88 @@ def test_both_public_wrappers_actually_apply_the_day_set() -> None:
         assert "MERAH_PUTIH_DAY_VARS" in src, f"{rel} does not apply the day set"
         assert "...MERAH_PUTIH_DAY_VARS" in src, (
             f"{rel} imports the day set but never spreads it into a style"
+        )
+
+
+# ── The derived-colour class ────────────────────────────────────────────────
+# Found twice during the day migration, in two different components, with two
+# different justifications — which is what makes it a class and not a bug:
+#   SavePlanBar   armed fill  color-mix(--accent-funnel 85%, black) -> ~#aa0e27
+#   ScenarioToggle hover label color-mix(--accent-funnel 70%, white) -> ~#D8586D
+# Both were CORRECT when written. On the retired navy ground, mixing a token
+# toward white moves it AWAY from the backdrop and raises contrast. On carta the
+# identical gesture runs backwards: the ScenarioToggle label measured 3.07:1
+# against its own hover tint, a fail, while the flat token measures 4.77:1.
+#
+# The second harm is permanent regardless of ground: a mix toward white or black
+# MINTS A COLOUR THAT BELONGS TO NO TOKEN. #aa0e27 is a fourth red in a palette
+# that declares exactly three, and nothing in R4 can ever be checked against it.
+#
+# A mix toward `transparent` is a different thing and stays allowed: it is an
+# opacity tint that composites the token over whatever is behind it, so the hue
+# remains the token's own.
+# Two things defeat a naive regex here, and the guilt test below caught both:
+#   - `color-mix(in srgb, var(--accent-funnel) 85%, black)` contains a NESTED
+#     `)`, so any `[^)]*` pattern stops inside `var(...)` and never sees `black`;
+#   - the real declarations are pretty-printed across FOUR lines, so a
+#     line-by-line scan never has `color-mix(` and `black` in the same string.
+# Hence a balanced-paren scan over the whole source. `var(...)` contents are
+# dropped before looking, so a token whose NAME contains "white" is not an
+# offender — only a literal white/black ARGUMENT is.
+def _deriving_mixes(src: str) -> list[tuple[int, str]]:
+    found: list[tuple[int, str]] = []
+    for match in re.finditer(r"color-mix\(", src):
+        depth, idx = 0, match.end() - 1
+        while idx < len(src):
+            if src[idx] == "(":
+                depth += 1
+            elif src[idx] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            idx += 1
+        body = src[match.end() : idx]
+        if re.search(r"\b(?:white|black)\b", re.sub(r"var\([^)]*\)", "", body), re.I):
+            line = src.count("\n", 0, match.start()) + 1
+            found.append((line, " ".join(body.split())))
+    return found
+
+
+def test_no_colour_is_derived_by_mixing_a_token_toward_white_or_black() -> None:
+    offenders = [
+        f"{path.name}:{line}: color-mix({body})"
+        for path in _perimeter_sources()
+        for line, body in _deriving_mixes(
+            strip_comments(path.read_text(encoding="utf-8"))
+        )
+    ]
+    assert not offenders, (
+        "a colour is being derived by mixing a token toward white/black. That "
+        "mints a hue no token declares, and any contrast measured for it was "
+        "taken on the retired dark ground — on carta, lightening is the "
+        "direction of FAILURE. Use a declared token: " + "; ".join(offenders)
+    )
+
+
+def test_the_derived_mix_guard_catches_the_historical_offenders() -> None:
+    """Guilt: the exact declarations this class was found in must trip it."""
+    for guilty in (
+        "--fill: color-mix(in srgb, var(--accent-funnel) 85%, black);",
+        "color: color-mix(in srgb, var(--accent-funnel) 70%, white);",
+        "color-mix(\n  in srgb,\n  var(--accent-funnel) 85%,\n  black\n)",
+    ):
+        assert _deriving_mixes(guilty), f"guard blind to: {guilty}"
+
+
+def test_the_derived_mix_guard_leaves_opacity_tints_alone() -> None:
+    """Innocence: mixing toward `transparent` keeps the token's own hue."""
+    for innocent in (
+        "background: color-mix(in srgb, var(--state-success) 6%, transparent);",
+        "border: 1px solid color-mix(in srgb, var(--text-primary) 45%, transparent);",
+        "background: color-mix(in srgb, currentColor 10%, transparent);",
+        # A token whose NAME contains the word is not a literal argument.
+        "background: color-mix(in srgb, var(--surface-white) 8%, transparent);",
+    ):
+        assert not _deriving_mixes(innocent), (
+            f"guard over-matches an opacity tint: {innocent}"
         )

--- a/scripts/tests/test_merah_putih_day_contrast.py
+++ b/scripts/tests/test_merah_putih_day_contrast.py
@@ -1,0 +1,285 @@
+"""Merah Putih DAY palette — the identity law, machine-checked.
+
+Two guards, both reading the REAL source of truth rather than a copy:
+
+1. CONTRAST — every text/background pair the R4 law binds is recomputed from the
+   hexes actually present in `merahPutihDayVars.ts`. A token edited tomorrow is
+   re-measured tomorrow; nothing here is a frozen number a reader must trust.
+   Spec: research/design/2026-08-27-r4-identity-merah-putih-token-spec.md §4.
+
+2. INNOCENCE — the retired colours (navy `#1e3863`, editorial blue `#3a6dff`,
+   the bright red `#ff3344` that measures 3.34 on carta) and the retired
+   Montserrat face must not appear anywhere in the public second-home perimeter.
+
+The internal kita console `(workspace)/second-home` is deliberately OUT of scope:
+its operative copper is a different, still-valid system (R4 §6).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+TOKENS = REPO / "apps/mouth/src/lib/theme/merahPutihDayVars.ts"
+PERIMETER = REPO / "apps/mouth/src/app/visa/second-home"
+
+
+# ── contrast machinery ────────────────────────────────────────────────────────
+
+
+def _srgb_to_linear(channel: int) -> float:
+    c = channel / 255.0
+    return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def relative_luminance(hex_colour: str) -> float:
+    h = hex_colour.lstrip("#")
+    if len(h) == 3:
+        h = "".join(ch * 2 for ch in h)
+    r, g, b = (int(h[i : i + 2], 16) for i in (0, 2, 4))
+    return (
+        0.2126 * _srgb_to_linear(r)
+        + 0.7152 * _srgb_to_linear(g)
+        + 0.0722 * _srgb_to_linear(b)
+    )
+
+
+def contrast_ratio(fg: str, bg: str) -> float:
+    a, b = relative_luminance(fg), relative_luminance(bg)
+    hi, lo = max(a, b), min(a, b)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def read_tokens() -> dict[str, str]:
+    """Parse the `"--token": "#hex"` pairs out of the TS source."""
+    src = TOKENS.read_text(encoding="utf-8")
+    return {
+        m.group(1): m.group(2).lower()
+        for m in re.finditer(r'"(--[a-z0-9-]+)":\s*"(#[0-9a-fA-F]{6})"', src)
+    }
+
+
+# ── 1. contrast law ───────────────────────────────────────────────────────────
+
+AA_TEXT = 4.5
+NON_TEXT = 3.0
+
+# (foreground token, background token, floor). Grounds are carta / elevated.
+TEXT_PAIRS = [
+    ("--text-primary", "--surface-base", AA_TEXT),
+    ("--text-primary", "--surface-raised", AA_TEXT),
+    ("--text-primary", "--surface-sunken", AA_TEXT),
+    ("--text-secondary", "--surface-base", AA_TEXT),
+    ("--text-secondary", "--surface-raised", AA_TEXT),
+    ("--text-tertiary", "--surface-base", AA_TEXT),
+    ("--accent-funnel", "--surface-base", AA_TEXT),
+    ("--accent-funnel-text", "--surface-base", AA_TEXT),
+    ("--accent-funnel-text", "--surface-raised", AA_TEXT),
+    ("--state-success", "--surface-base", AA_TEXT),
+    ("--state-likely", "--surface-base", AA_TEXT),
+    ("--state-warning", "--surface-base", AA_TEXT),
+    ("--state-danger", "--surface-base", AA_TEXT),
+    ("--accent-whatsapp-ink", "--surface-raised", AA_TEXT),
+    ("--accent-whatsapp-ink", "--surface-base", AA_TEXT),
+]
+
+# White text is legal ONLY on these fills (R4 §4.2).
+WHITE_ON = ["--accent-funnel", "--accent-funnel-text", "--cta-bg-hover", "--state-danger"]
+
+# Boundaries that IDENTIFY an interactive component must clear 3:1 (SC 1.4.11).
+NON_TEXT_PAIRS = [
+    ("--border-strong", "--surface-base", NON_TEXT),
+    ("--border-strong", "--surface-raised", NON_TEXT),
+    ("--accent-funnel", "--surface-base", NON_TEXT),  # progress fill
+]
+
+
+@pytest.mark.parametrize("fg,bg,floor", TEXT_PAIRS)
+def test_text_pairs_clear_wcag_aa(fg: str, bg: str, floor: float) -> None:
+    tokens = read_tokens()
+    ratio = contrast_ratio(tokens[fg], tokens[bg])
+    assert ratio >= floor, (
+        f"{fg} ({tokens[fg]}) on {bg} ({tokens[bg]}) = {ratio:.2f}, needs {floor}"
+    )
+
+
+@pytest.mark.parametrize("fill", WHITE_ON)
+def test_white_text_is_legal_on_its_declared_fills(fill: str) -> None:
+    tokens = read_tokens()
+    ratio = contrast_ratio("#ffffff", tokens[fill])
+    assert ratio >= AA_TEXT, (
+        f"white on {fill} ({tokens[fill]}) = {ratio:.2f}, needs {AA_TEXT}"
+    )
+
+
+@pytest.mark.parametrize("fg,bg,floor", NON_TEXT_PAIRS)
+def test_interactive_boundaries_clear_three_to_one(fg: str, bg: str, floor: float) -> None:
+    tokens = read_tokens()
+    ratio = contrast_ratio(tokens[fg], tokens[bg])
+    assert ratio >= floor, (
+        f"{fg} ({tokens[fg]}) on {bg} ({tokens[bg]}) = {ratio:.2f}, needs {floor}"
+    )
+
+
+def test_hairline_is_decorative_and_documented_as_such() -> None:
+    """`--border-subtle` CANNOT carry component identity — it measures ~1.2:1.
+
+    This is not a defect to fix by darkening it: the law wants a quiet divider.
+    The test pins the DUTY, so that a future edit which raises it into
+    interactive service has to change this test deliberately.
+    """
+    tokens = read_tokens()
+    ratio = contrast_ratio(tokens["--border-subtle"], tokens["--surface-base"])
+    assert ratio < NON_TEXT, (
+        "border-subtle now clears 3:1 — if that is intentional, say so here and "
+        "state which components may use it as their boundary"
+    )
+    assert "DECORATIVE" in TOKENS.read_text(encoding="utf-8")
+
+
+def test_the_retired_red_would_fail_which_is_why_it_is_retired() -> None:
+    """Anchors the reason. #ff3344 on carta = 3.34, below the 4.5 AA floor."""
+    tokens = read_tokens()
+    assert contrast_ratio("#ff3344", tokens["--surface-base"]) < AA_TEXT
+
+
+# ── 2. innocence: no retired colour or face in the public perimeter ──────────
+
+RETIRED = {
+    "#ff3344": "the bright red retired by R4 (3.34 on carta)",
+    "#1e3863": "the navy retired from the whole public perimeter",
+    "#3a6dff": "the editorial McKinsey blue that the navy carried",
+}
+
+
+def _perimeter_sources() -> list[Path]:
+    return sorted(
+        p
+        for p in PERIMETER.rglob("*.tsx")
+        if not p.name.endswith(".test.tsx")
+    )
+
+
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_LINE_COMMENT = re.compile(r"//[^\n]*")
+
+
+def strip_comments(src: str) -> str:
+    """Remove JS/TS comments so the guard judges PAINTED VALUES, not prose.
+
+    A retired hex NAMED in a comment ("we replaced the retired #ff3344") paints
+    nothing — flagging it would push authors to stop explaining themselves, which
+    is how a codebase loses the reason behind its own rules (scar family #3,
+    over-match). `test_the_stripper_cannot_hide_a_real_use` is the guilt half
+    that keeps this leniency honest.
+    """
+    return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", src))
+
+
+@pytest.mark.parametrize("colour,why", sorted(RETIRED.items()))
+def test_no_retired_colour_in_public_perimeter(colour: str, why: str) -> None:
+    offenders = [
+        f"{p.relative_to(REPO)}:{i}"
+        for p in _perimeter_sources()
+        for i, line in enumerate(
+            strip_comments(p.read_text(encoding="utf-8")).splitlines(), 1
+        )
+        if colour in line.lower()
+    ]
+    assert not offenders, f"{colour} ({why}) still present as a VALUE at: {offenders}"
+
+
+def test_the_stripper_cannot_hide_a_real_use() -> None:
+    """Guilt half of the guard: a real declaration must survive stripping.
+
+    Without this, `strip_comments` could be widened until the innocence test
+    passes on a perimeter that is actually painting the retired red.
+    """
+    painted = 'const s = { color: "#ff3344" }; // the retired #ff3344, explained'
+    stripped = strip_comments(painted)
+    assert "#ff3344" in stripped, "the stripper swallowed a real declaration"
+    assert stripped.count("#ff3344") == 1, "the comment mention was not stripped"
+
+    prose_only = "// we migrated away from #ff3344 and #1e3863\n/* #3a6dff too */"
+    assert "#ff3344" not in strip_comments(prose_only)
+    assert "#1e3863" not in strip_comments(prose_only)
+    assert "#3a6dff" not in strip_comments(prose_only)
+
+
+def test_montserrat_does_not_reach_the_second_home_perimeter() -> None:
+    """R4 §9.3 retires Montserrat from the web funnels (it stays on IG covers).
+
+    `/visa/layout.tsx` still imports it for the rest of the funnel — that is a
+    different lane's perimeter. What this test pins is that second-home neither
+    imports it nor names it, and that our own wrapper re-declares fontFamily so
+    the inherited face stops at our boundary.
+    """
+    offenders = [
+        str(p.relative_to(REPO))
+        for p in _perimeter_sources()
+        if "montserrat" in strip_comments(p.read_text(encoding="utf-8")).lower()
+    ]
+    assert not offenders, f"Montserrat reached the perimeter at: {offenders}"
+    assert "fontFamily" in TOKENS.read_text(encoding="utf-8"), (
+        "the day set must re-declare fontFamily, or the visa layout's forced "
+        "Montserrat inherits straight through the wrapper"
+    )
+
+
+# ── 3. typography floors (R4 §3) ─────────────────────────────────────────────
+
+CORMORANT_FLOOR_REM = 1.5  # 24px — below it, low-DPI Android antialiasing shreds the serif
+_CLAMP_MIN = re.compile(r'fontSize: *"clamp\(([\d.]+)rem')
+_WEIGHT = re.compile(r"fontWeight: *(\d+)")
+
+
+def _serif_context(lines: list[str], idx: int) -> bool:
+    """A serif face declared within a few lines of this declaration."""
+    window = "\n".join(lines[max(0, idx - 6) : idx + 5])
+    return "fontSerif" in window or "--font-serif" in window
+
+
+def test_no_serif_heading_below_the_24px_floor() -> None:
+    offenders = []
+    for p in _perimeter_sources():
+        lines = strip_comments(p.read_text(encoding="utf-8")).splitlines()
+        for i, line in enumerate(lines):
+            m = _CLAMP_MIN.search(line)
+            if m and _serif_context(lines, i) and float(m.group(1)) < CORMORANT_FLOOR_REM:
+                offenders.append(
+                    f"{p.relative_to(REPO)}:{i + 1} min={m.group(1)}rem "
+                    f"({float(m.group(1)) * 16:.1f}px)"
+                )
+    assert not offenders, (
+        "Cormorant below the 24px floor (R4 §3) — raise the clamp minimum to "
+        f"1.5rem or switch the heading to Inter 600: {offenders}"
+    )
+
+
+def test_no_cormorant_weight_below_500() -> None:
+    offenders = []
+    for p in _perimeter_sources():
+        lines = strip_comments(p.read_text(encoding="utf-8")).splitlines()
+        for i, line in enumerate(lines):
+            m = _WEIGHT.search(line)
+            if m and _serif_context(lines, i) and int(m.group(1)) < 500:
+                offenders.append(f"{p.relative_to(REPO)}:{i + 1} weight={m.group(1)}")
+    assert not offenders, (
+        f"R4 §3 allows Cormorant at 500/600 only: {offenders}"
+    )
+
+
+def test_both_public_wrappers_actually_apply_the_day_set() -> None:
+    """The set is inert unless it is spread on the two route wrappers."""
+    for rel in (
+        "apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx",
+        "apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx",
+    ):
+        src = (REPO / rel).read_text(encoding="utf-8")
+        assert "MERAH_PUTIH_DAY_VARS" in src, f"{rel} does not apply the day set"
+        assert "...MERAH_PUTIH_DAY_VARS" in src, (
+            f"{rel} imports the day set but never spreads it into a style"
+        )


### PR DESCRIPTION
Migrates `/visa/second-home` and `/visa/second-home/studio` from the navy
`[data-funnel="visa"]` ground + the retired `#ff3344` to the Merah Putih **DAY**
palette (R4 identity law, «Cap Dinas» v2 rendering direction). No backend, no
night mode, and the kita console `(workspace)/second-home` is untouched.

### How it is scoped

A new `MERAH_PUTIH_DAY_VARS` set, applied INLINE on each route's own top-level
wrapper — the same contract `rumahVars.ts` already uses, and not an edit to it
(rumahVars' accent is the navy `#1e3863`, which R4 retires; editing it would
silently repaint the homepage and blog, outside this perimeter). Nothing under
`packages/core/tokens/` changes and no theme is forked: the wrapper already
carries `data-funnel="visa"`, so an inline style on that same element beats the
shared selector with no `!important`.

Two things that only a running page could tell us, both measured, not deduced:

- **`<body>` is an ancestor, and a wrapper cannot paint its ancestors.** With
  the wrapper correctly carta, `getComputedStyle(document.body)` still returned
  the shared navy `rgb(29,39,59)` on BOTH routes, each 88px taller than its
  wrapper — a navy band under the content, a navy page in print, navy behind
  overscroll. Cured with `body:has(.merah-putih-day)`, which keeps the fix to
  exactly the pages that opted in.
- **An alias declared at `:root` never sees a wrapper's override.** A `var()`
  inside a custom-property declaration is substituted at the DECLARING element,
  so `--color-text-muted: var(--text-secondary)` (semantic.css, at `:root`)
  stayed on the dark theme's `rgba(255,255,255,0.68)` while everything around
  it turned to paper. These are the two most-consumed tokens in the perimeter
  (42 and 36 uses), so the leak would have been wide and quiet. Restated in the
  day set, and a test now fails if any consumed `:root` alias is left out.

### R4 violations found and cured (not just recoloured)

- **Selection was red.** QuestionCard painted the selected option in
  `--accent-funnel`; R4 §4.5 reserves red for structure and action, never
  selection. Now ink, with the unselected ring moved from the decorative
  hairline to `--border-strong` (3.64:1) so an interactive boundary is not
  identified by a 1.21:1 line (WCAG 2.2 SC 1.4.11).
- **Reds derived by mixing toward white/black.** Two components minted a fourth
  and fifth red no token declares, each justified by a ratio measured on the
  navy ground. On carta that gesture inverts: the ScenarioToggle hover label
  measured **3.07:1** against its own hover tint (floor 4.5:1 at 16px/600)
  where the flat token measures **4.77:1**. Both now read declared tokens, and
  a guard scans the whole perimeter for the class.
- Progress fill moved to structure red; 10 serif headings raised to the 24px
  Cormorant floor; 9 sub-500 weights corrected; radius 8 → 12 across the
  controls.

### Verification

- **465/465** vitest across the secondhome family; **37/37** new pytest, which
  recompute every ratio FROM THE TypeScript SOURCE rather than restating them,
  so a token edited without re-measuring turns the build red.
- Contrast measured on PAINTED PIXELS via Playwright, not estimated — including
  compositing translucent tints down the ancestor chain, and parsing the
  `color(srgb 0-1)` form the browser also returns (a naive 0-255 read of it
  produced false ratios during this work).
- Guards carry both a guilt and an innocence test. The guilt test earned its
  keep: it proved the first version of the derived-colour regex was blind to
  the very declarations it was written for.

### Size

900 insertions is above the ~400-line target, and the split is the argument:
**110 net lines of component code**. The rest is the new token bridge (168) and
new test coverage (453, mostly a new 423-line pytest file). The component change
is not divisible — half-migrating leaves a page navy above the fold and carta
below it, which is a worse state to ship than either end.

### Not in this PR

`<html lang="en">` is still served on `/visa/second-home/it`. `<html>` lives in
the root layout, which never receives a child segment's params, so the cure is
root-level locale routing — a design pass, not a patch. Ledger line updated
with today's measurements, because two of its stated facts had expired:
hreflang IS served and reciprocal here, and the `[locale]` SSG segment exists
and answers 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
