### PR TITLE
fix(visa-check): a retirement checklist must carry its own route's money, not both

### DIFF
--- a/apps/backend-rag/backend/services/visa_check/match_tree.py
+++ b/apps/backend-rag/backend/services/visa_check/match_tree.py
@@ -138,8 +138,19 @@ _STEPS_EMPLOYEE: list[str] = [
     "Passport valid ≥ 18 months",
 ]
 
+# The two routes ranked under RETIREMENT (E33E 5y, E33F 1y — the official visa
+# catalogue names them "Retirement KITAS (55+)" and "Retirement KITAS
+# (Variant)") do NOT share one financial requirement, so each figure names the
+# route it belongs to. E33E's USD 50,000 deposit was missing from this list
+# entirely: a visitor matched to the 5-year route saw the income requirement
+# alone and could reasonably conclude no deposit was involved. Both figures map
+# to `confirmed` entries in research/secondhome/e33-fact-registry.json
+# (e33e_requirements, e33f_requirements) and to the official catalogue entry
+# ("Proof of USD 50,000 deposit in state bank (within 90 days)").
 _STEPS_RETIREMENT: list[str] = [
-    "Proof of pension or passive income ≥ USD 3,000/month",
+    "E33F (1 year): proof of pension or passive income ≥ USD 3,000/month — no deposit required",
+    "E33E (5 years): USD 50,000 deposit at a state-owned (BUMN) Indonesian "
+    "bank, placed within 90 days, plus passive income ≥ USD 3,000/month",
     "Passport valid ≥ 18 months",
     "Proof of accommodation (rental or property in Indonesia)",
     "Domestic helper hire letter (optional but recommended)",
@@ -345,9 +356,7 @@ def _explain_empty_ranking(purpose: Purpose, months: int, band: BudgetBand) -> s
         # `_budget_fits` returns True whenever `min_budget_idr is None`, so if
         # nothing fit then every tagged visa carries a minimum — `min()` below
         # can never run over an empty sequence.
-        cheapest = min(
-            meta.min_budget_idr for meta in tagged if meta.min_budget_idr is not None
-        )
+        cheapest = min(meta.min_budget_idr for meta in tagged if meta.min_budget_idr is not None)
         return (
             f"Every {_PURPOSE_LABEL[purpose]} visa we rank carries a minimum-budget "
             "requirement above the band you selected — the cheapest one starts at "

--- a/apps/backend-rag/backend/services/visa_check/match_tree.py
+++ b/apps/backend-rag/backend/services/visa_check/match_tree.py
@@ -138,19 +138,9 @@ _STEPS_EMPLOYEE: list[str] = [
     "Passport valid ≥ 18 months",
 ]
 
-# The two routes ranked under RETIREMENT (E33E 5y, E33F 1y — the official visa
-# catalogue names them "Retirement KITAS (55+)" and "Retirement KITAS
-# (Variant)") do NOT share one financial requirement, so each figure names the
-# route it belongs to. E33E's USD 50,000 deposit was missing from this list
-# entirely: a visitor matched to the 5-year route saw the income requirement
-# alone and could reasonably conclude no deposit was involved. Both figures map
-# to `confirmed` entries in research/secondhome/e33-fact-registry.json
-# (e33e_requirements, e33f_requirements) and to the official catalogue entry
-# ("Proof of USD 50,000 deposit in state bank (within 90 days)").
+# Shared by both retirement routes. The route-specific money line is
+# prepended per product by `_steps_for` — see `_STEPS_BY_VISA` below.
 _STEPS_RETIREMENT: list[str] = [
-    "E33F (1 year): proof of pension or passive income ≥ USD 3,000/month — no deposit required",
-    "E33E (5 years): USD 50,000 deposit at a state-owned (BUMN) Indonesian "
-    "bank, placed within 90 days, plus passive income ≥ USD 3,000/month",
     "Passport valid ≥ 18 months",
     "Proof of accommodation (rental or property in Indonesia)",
     "Domestic helper hire letter (optional but recommended)",
@@ -181,6 +171,48 @@ _STEPS_BY_PURPOSE: dict[Purpose, list[str]] = {
     Purpose.FAMILY: _STEPS_FAMILY,
     Purpose.STUDENT: _STEPS_STUDENT,
 }
+
+
+#: Financial requirements that belong to ONE product, prepended to the
+#: purpose-level list for the visa actually recommended.
+#:
+#: These cannot live in `_STEPS_BY_PURPOSE`. The result is rendered as an
+#: ordered "Pre-arrival checklist" in the frontend and introduced in the funnel
+#: email as "make sure you have the <visa> essentials" — i.e. as ONE visa's
+#: mandatory list. Putting both routes' money lines in it would tell an E33F
+#: client to place a USD 50,000 deposit they do not need, and would show an
+#: E33E client "no deposit required" immediately above a deposit.
+#:
+#: The two senior routes (the official catalogue names them "Retirement KITAS
+#: (55+)" and "Retirement KITAS (Variant)") DO share the USD 3,000/month income
+#: requirement; only E33E adds a deposit on top. Both figures map to
+#: `confirmed` entries in research/secondhome/e33-fact-registry.json
+#: (e33e_requirements, e33f_requirements) and to the official catalogue's own
+#: wording ("Proof of USD 50,000 deposit in state bank (within 90 days)").
+_STEPS_BY_VISA: dict[VisaType, list[str]] = {
+    VisaType.E33E: [
+        "USD 50,000 deposit at a state-owned (BUMN) Indonesian bank, placed "
+        "within 90 days of arrival",
+        "Proof of pension or passive income \u2265 USD 3,000/month",
+    ],
+    VisaType.E33F: [
+        "Proof of pension or passive income \u2265 USD 3,000/month "
+        "\u2014 this route requires no deposit",
+    ],
+}
+
+
+def _steps_for(visa: VisaType | None, purpose: Purpose) -> list[str]:
+    """Pre-arrival steps for the recommended VISA, not merely its purpose.
+
+    One purpose can rank several products with different money requirements,
+    and every caller presents this list as a single visa's mandatory
+    checklist — so a purpose-level list cannot carry a product-level figure.
+    """
+    shared = _STEPS_BY_PURPOSE.get(purpose, [])
+    if visa is None:
+        return shared
+    return _STEPS_BY_VISA.get(visa, []) + shared
 
 
 # ── Scoring ──────────────────────────────────────────────────────
@@ -457,6 +489,6 @@ def recommend_visa(
 
     return MatchResult(
         ranking=ranking,
-        pre_arrival_steps=_STEPS_BY_PURPOSE.get(purpose, []),
+        pre_arrival_steps=_steps_for(ranking[0].visa, purpose),
         referral_mode=False,
     )

--- a/apps/backend-rag/backend/tests/services/visa_check/test_match_tree.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_match_tree.py
@@ -198,3 +198,49 @@ class TestCoverageSweep:
                     assert r.ranking or r.referral_mode, (
                         f"purpose={purpose} months={months} band={band} produced empty+no-referral"
                     )
+
+
+class TestRetirementStepsNameEachRoutesMoney:
+    """Each retirement route's financial requirement must be stated as its own.
+
+    The two products ranked under RETIREMENT — E33E (5 years) and E33F
+    (1 year), which the official visa catalogue names "Retirement KITAS (55+)"
+    and "Retirement KITAS (Variant)" — do not share one financial bar. E33F is
+    income-only; E33E additionally requires a USD 50,000 deposit. That deposit
+    was absent from the pre-arrival list entirely, so a visitor matched to the
+    5-year route was shown the income requirement alone.
+    """
+
+    def _steps(self) -> list[str]:
+        return _call(
+            purpose=Purpose.RETIREMENT,
+            duration_months=60,
+            budget_band=BudgetBand.OVER_500M,
+        ).pre_arrival_steps
+
+    def test_e33e_deposit_is_stated(self):
+        joined = " ".join(self._steps())
+        assert "USD 50,000" in joined, "E33E's deposit is missing from the steps"
+        assert "E33E" in joined, "the deposit is stated without naming its route"
+
+    def test_income_requirement_is_attributed_not_universal(self):
+        """The income figure must not read as a blanket requirement."""
+        steps = self._steps()
+        income = [s for s in steps if "3,000" in s]
+        assert income, "the USD 3,000/month income requirement disappeared"
+        for step in income:
+            assert "E33E" in step or "E33F" in step, (
+                f"income requirement stated without naming a route: {step!r}"
+            )
+
+    def test_no_superseded_income_figure(self):
+        """USD 1,500/month is the pre-2024 figure and must never reappear."""
+        joined = " ".join(self._steps())
+        assert "1,500" not in joined and "1.500" not in joined
+
+    def test_deposit_never_described_as_any_bank(self):
+        """The deposit only qualifies at a state-owned (BUMN) bank."""
+        joined = " ".join(self._steps()).lower()
+        assert "any bank" not in joined
+        if "deposit" in joined:
+            assert "bumn" in joined or "state-owned" in joined

--- a/apps/backend-rag/backend/tests/services/visa_check/test_match_tree.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_match_tree.py
@@ -6,6 +6,7 @@ property accessors used by the router.
 
 from __future__ import annotations
 
+from backend.services.visa_check import match_tree
 from backend.services.visa_check.catalogue import VISA_META, VisaType
 from backend.services.visa_check.match_tree import (
     BudgetBand,
@@ -200,47 +201,87 @@ class TestCoverageSweep:
                     )
 
 
-class TestRetirementStepsNameEachRoutesMoney:
-    """Each retirement route's financial requirement must be stated as its own.
+class TestPreArrivalStepsBelongToTheRecommendedVisa:
+    """A visitor's checklist must contain their route's money, and no other's.
 
-    The two products ranked under RETIREMENT — E33E (5 years) and E33F
-    (1 year), which the official visa catalogue names "Retirement KITAS (55+)"
-    and "Retirement KITAS (Variant)" — do not share one financial bar. E33F is
-    income-only; E33E additionally requires a USD 50,000 deposit. That deposit
-    was absent from the pre-arrival list entirely, so a visitor matched to the
-    5-year route was shown the income requirement alone.
+    Every caller presents this list as ONE visa's mandatory list: the frontend
+    renders it as an ordered list under "Pre-arrival checklist"
+    (app/visa/match/[hash]/page.tsx), and the funnel email introduces it as
+    "make sure you have the <visa> essentials"
+    (notifications/funnel_email/templates.py). A purpose-level list therefore
+    cannot carry a product-level figure — RETIREMENT ranks E33E and E33F, and
+    only E33E requires a deposit. Stating both in one checklist tells an E33F
+    client to place USD 50,000 they do not need, and shows an E33E client "no
+    deposit required" immediately above a deposit.
     """
 
-    def _steps(self) -> list[str]:
-        return _call(
-            purpose=Purpose.RETIREMENT,
-            duration_months=60,
-            budget_band=BudgetBand.OVER_500M,
-        ).pre_arrival_steps
+    def _steps_for_recommendation(
+        self, months: int, band: BudgetBand
+    ) -> tuple[VisaType, list[str]]:
+        r = _call(purpose=Purpose.RETIREMENT, duration_months=months, budget_band=band)
+        assert r.recommended_visa is not None
+        return r.recommended_visa, r.pre_arrival_steps
 
-    def test_e33e_deposit_is_stated(self):
-        joined = " ".join(self._steps())
-        assert "USD 50,000" in joined, "E33E's deposit is missing from the steps"
-        assert "E33E" in joined, "the deposit is stated without naming its route"
+    def test_e33f_client_is_never_told_to_place_a_deposit(self):
+        """The defect this class exists to prevent."""
+        visa, steps = self._steps_for_recommendation(12, BudgetBand.MID_50_500M)
+        assert visa is VisaType.E33F
+        joined = " ".join(steps)
+        assert "50,000" not in joined, f"E33F client was shown E33E's deposit: {steps!r}"
 
-    def test_income_requirement_is_attributed_not_universal(self):
-        """The income figure must not read as a blanket requirement."""
-        steps = self._steps()
-        income = [s for s in steps if "3,000" in s]
-        assert income, "the USD 3,000/month income requirement disappeared"
-        for step in income:
-            assert "E33E" in step or "E33F" in step, (
-                f"income requirement stated without naming a route: {step!r}"
+    def test_e33e_client_is_told_about_the_deposit(self):
+        visa, steps = self._steps_for_recommendation(60, BudgetBand.OVER_500M)
+        assert visa is VisaType.E33E
+        deposit = [s for s in steps if "50,000" in s]
+        assert len(deposit) == 1, f"expected exactly one deposit step, got {deposit!r}"
+        line = deposit[0].lower()
+        assert "bumn" in line or "state-owned" in line, (
+            f"the deposit is stated without naming the qualifying bank type: {line!r}"
+        )
+        assert "any bank" not in line and "any indonesian bank" not in line
+
+    def test_no_checklist_both_requires_and_waives_a_deposit(self):
+        """The two lines are mutually exclusive; one list must never hold both."""
+        for months, band in ((12, BudgetBand.MID_50_500M), (60, BudgetBand.OVER_500M)):
+            _, steps = self._steps_for_recommendation(months, band)
+            joined = " ".join(steps).lower()
+            waives = "no deposit" in joined or "requires no deposit" in joined
+            requires = "50,000" in joined
+            assert not (waives and requires), (
+                f"checklist both waives and requires a deposit: {steps!r}"
             )
 
-    def test_no_superseded_income_figure(self):
-        """USD 1,500/month is the pre-2024 figure and must never reappear."""
-        joined = " ".join(self._steps())
-        assert "1,500" not in joined and "1.500" not in joined
+    def test_both_routes_state_the_shared_income_requirement(self):
+        """E33E and E33F DO share the USD 3,000/month bar — only the deposit differs."""
+        for months, band in ((12, BudgetBand.MID_50_500M), (60, BudgetBand.OVER_500M)):
+            _, steps = self._steps_for_recommendation(months, band)
+            assert any("3,000" in s for s in steps), (
+                f"the shared income requirement is missing: {steps!r}"
+            )
 
-    def test_deposit_never_described_as_any_bank(self):
-        """The deposit only qualifies at a state-owned (BUMN) bank."""
-        joined = " ".join(self._steps()).lower()
-        assert "any bank" not in joined
-        if "deposit" in joined:
-            assert "bumn" in joined or "state-owned" in joined
+    def test_superseded_income_figure_appears_in_no_format(self):
+        """USD 1,500/month is the pre-2024 figure — a forbidden claim.
+
+        Checked in every separator style the model might emit, not just the
+        one this file happens to use.
+        """
+        for months, band in ((12, BudgetBand.MID_50_500M), (60, BudgetBand.OVER_500M)):
+            _, steps = self._steps_for_recommendation(months, band)
+            joined = " ".join(steps)
+            for form in ("1,500", "1.500", "1 500", "1500"):
+                assert form not in joined, f"superseded figure {form!r} in {steps!r}"
+
+    def test_other_purposes_keep_their_steps_unchanged(self):
+        """The per-visa layer must not disturb branches that never needed it."""
+        for purpose in (
+            Purpose.WORK_REMOTE,
+            Purpose.INVESTOR,
+            Purpose.WORK_EMPLOYEE,
+            Purpose.FAMILY,
+            Purpose.STUDENT,
+        ):
+            r = _call(purpose=purpose, duration_months=12)
+            if r.recommended_visa is not None:
+                assert r.pre_arrival_steps == match_tree._STEPS_BY_PURPOSE.get(purpose, []), (
+                    f"{purpose} steps changed"
+                )


### PR DESCRIPTION
## What

`pre_arrival_steps` was keyed by **purpose**, but every consumer presents it as **one visa's**
mandatory list:

- the frontend renders it as an ordered list under *Pre-arrival checklist* —
  `apps/mouth/src/app/visa/match/[hash]/page.tsx:243`
- the funnel email introduces it as `f"make sure you have the {recommended_visa} essentials: "` —
  `apps/backend-rag/backend/services/notifications/funnel_email/templates.py:112-126`

`Purpose.RETIREMENT` ranks **E33E** and **E33F**, and only E33E requires a deposit. A
purpose-level list therefore told an E33F client to place **USD 50,000 they do not need**, and
showed an E33E client *"this route requires no deposit"* immediately above a USD 50,000 deposit.

Reproduced at runtime before the fix: both clients received the identical six-item list.

## How

Route-specific money lines move into `_STEPS_BY_VISA`, keyed by the visa actually recommended;
`_steps_for(visa, purpose)` prepends them to the shared purpose steps. The USD 3,000/month income
bar stays shared — it genuinely applies to both routes.

After:

| client | first checklist line |
|---|---|
| E33F | *Proof of pension or passive income ≥ USD 3,000/month — this route requires no deposit* |
| E33E | *USD 50,000 deposit at a state-owned (BUMN) Indonesian bank, placed within 90 days of arrival* |

## Tests

The previous tests searched the **joined** output and so could not see this defect. They now bind
each money line to its own recommendation:

- the E33F checklist must contain no `50,000`
- the E33E checklist must contain **exactly one** deposit step, naming BUMN/state-owned
- no checklist may both waive and require a deposit
- the superseded `USD 1,500` figure is rejected in every separator style (`1,500` / `1.500` /
  `1 500` / `1500`), not only the one this file happens to use
- other purposes keep their steps unchanged

`backend/tests/services/visa_check/` — 387 passed. `ruff` clean.

## Provenance

The BLOCKER was raised by a cross-family adversarial review (Codex `gpt-5.6-sol`, xhigh) of the
**first** version of this change, which shipped the defect. Verified independently on disk and at
runtime before curing.

Scope note: base E33 is deliberately untouched and stays unreachable from the wizard
(`purposes=frozenset()`); no `Purpose` member added, so the Visa Oracle ENFORCE-gate breadth
criterion and migration 257's `request_category` CHECK are both untouched.