### PR TITLE
fix(visa-check): a negator must govern the E33 claim, not merely precede it

### DIFF
--- a/apps/backend-rag/backend/services/visa_check/e33_claim_guard.py
+++ b/apps/backend-rag/backend/services/visa_check/e33_claim_guard.py
@@ -85,7 +85,20 @@ class ClaimViolation:
 # Negation guard: fixed-width lookbehinds so that CORRECT cautionary phrasing
 # ("does NOT authorize employment", "approval is not guaranteed", "LPS does not
 # fully cover") is not flagged. Heuristic by design — the guard is log-only.
-_NEG = r"(?<!not\s)(?<!never\s)(?<!cannot\s)(?<!can't\s)(?<!doesn't\s)"
+# Negation guard. Python's re requires FIXED-WIDTH lookbehind, so each
+# negator is its own assertion rather than one alternation.
+#
+# Italian and Indonesian negators are here because the guard scans answers in
+# whichever language the client wrote in: `wrap_query_with_language_instruction`
+# (query_helpers.py) detects the query language and instructs the model to
+# reply in the same one, with an explicit Indonesian branch. A guard that only
+# knows English negation would fire on a correct Italian sentence that says a
+# thing is NOT allowed.
+_NEG = (
+    r"(?<!not\s)(?<!never\s)(?<!cannot\s)(?<!can't\s)(?<!doesn't\s)"
+    r"(?<!non\s)(?<!mai\s)(?<!senza\s)"
+    r"(?<!tidak\s)(?<!bukan\s)(?<!jangan\s)(?<!tanpa\s)"
+)
 
 
 def _p(
@@ -109,7 +122,13 @@ E33_FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
     ),
     _p(
         "second_home_any_bank",
-        r"\bany\s+(?:Indonesian\s+)?bank\b",
+        # IT: "qualsiasi/qualunque banca", "banca qualsiasi"
+        # ID: "bank mana saja / apa saja", "sembarang bank"
+        r"\bany\s+(?:Indonesian\s+)?bank\b"
+        r"|\b(?:qualsiasi|qualunque)\s+banca\b"
+        r"|\bbanca\s+(?:indonesiana\s+)?(?:qualsiasi|qualunque)\b"
+        r"|\bbank\s+(?:\w+\s+){0,2}?(?:mana|apa)\s+saja\b"
+        r"|\bsembarang\s+bank\b",
         "Deposit must be at a state-owned (BUMN) Indonesian bank, not 'any bank'",
         "e33_base_deposit_amount",
     ),
@@ -117,42 +136,81 @@ E33_FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
         "e33_itap_kitap_automatic_promise",
         r"\bautomatic(?:ally)?\b(?!\s+included)[^.\n]{0,25}\b(?:KITAP|ITAP)\b"
         r"|\b(?:KITAP|ITAP)\b[^.\n]{0,40}\bautomatic(?:ally)?\b(?!\s+included)"
-        r"|\bafter\s+3\s+years\b[^.\n]{0,50}\b(?:eligible|convert\w*|automatic\w*)\b[^.\n]{0,30}\b(?:KITAP|ITAP)\b",
+        r"|\bafter\s+3\s+years\b[^.\n]{0,50}\b(?:eligible|convert\w*|automatic\w*)\b[^.\n]{0,30}\b(?:KITAP|ITAP)\b"
+        # IT: "automatico/automatica/automaticamente"
+        r"|\bautomatic(?:o|a|amente)\b[^.\n]{0,30}\b(?:KITAP|ITAP)\b"
+        r"|\b(?:KITAP|ITAP)\b[^.\n]{0,40}\bautomatic(?:o|a|amente)\b"
+        r"|\bdopo\s+3\s+anni\b[^.\n]{0,50}\b(?:KITAP|ITAP)\b"
+        # ID: "otomatis", "setelah 3 tahun"
+        r"|\botomatis\b[^.\n]{0,30}\b(?:KITAP|ITAP)\b"
+        r"|\b(?:KITAP|ITAP)\b[^.\n]{0,40}\botomatis\b"
+        r"|\bsetelah\s+3\s+tahun\b[^.\n]{0,50}\b(?:KITAP|ITAP)\b",
         "ITAP/KITAP conversion after 3 years is pending confirmation — never promise it",
         "itap_after_3y_criteria",
     ),
     _p(
         "e33_permits_local_work",
         rf"\bE33[A-Z]?\b[^.\n]{{0,60}}\b{_NEG}(?<!residence\s)(?<!stay\s)(?:allows?|permits?|authoriz\w*|entitle\w*)\b[^.\n]{{0,40}}\b(?:work|employment)\b"
-        rf"|\b{_NEG}work(?:ing)?\s+(?:legally\s+)?(?:in\s+Indonesia\s+)?on\s+(?:the\s+|an\s+)?E33",
+        rf"|\b{_NEG}work(?:ing)?\s+(?:legally\s+)?(?:in\s+Indonesia\s+)?on\s+(?:the\s+|an\s+)?E33"
+        # IT: "l'E33 permette/consente/autorizza ... lavorare/lavoro"
+        rf"|\bE33[A-Z]?\b[^.\n]{{0,60}}\b{_NEG}(?:permett\w+|consent\w+|autorizz\w+|abilit\w+)\b[^.\n]{{0,40}}\b(?:lavor\w+|impiego|occupazione)\b"
+        # ID: "E33 memungkinkan/mengizinkan/membolehkan ... bekerja/kerja"
+        rf"|\bE33[A-Z]?\b[^.\n]{{0,60}}\b{_NEG}(?:memungkinkan|mengizinkan|membolehkan|memperbolehkan)\b[^.\n]{{0,40}}\b(?:bekerja|kerja|pekerjaan)\b",
         "Base E33 is a pure residence permit — it does NOT authorize local employment",
         "e33_not_work_visa",
         ctx=False,
     ),
     _p(
         "bsi_sharia_equivalence",
-        r"\b(?:BSI|Bank\s+Syariah\s+Indonesia)\b[^.\n]{0,80}\b(?:qualif\w*|accept\w*|state[- ]owned|BUMN|equivalent|counts?\s+as)\b",
+        r"\b(?:BSI|Bank\s+Syariah\s+Indonesia)\b[^.\n]{0,80}"
+        r"\b(?:qualif\w*|accept\w*|state[- ]owned|BUMN|equivalent|counts?\s+as"
+        # IT: equivalente / accettata / statale / vale come
+        r"|equivalen\w+|accettat\w+|statale|vale\s+come|conta\s+come"
+        # ID: setara / diterima / memenuhi syarat / milik negara
+        r"|setara|diterima|memenuhi\s+syarat|milik\s+negara)\b",
         "BSI (sharia) placement as qualifying state-bank deposit is unconfirmed — forbidden to claim",
         "bsi_sharia_accepted",
     ),
     _p(
         "split_deposit_accepted",
         r"\bsplit\b[^.\n]{0,40}\bdeposit\b|\bdeposit\b(?:(?!not|never|cannot|can't)[^.\n]){0,40}\bsplit\b"
-        r"|\bmultiple\s+(?:BUMN\s+|state[- ]owned\s+)?banks\b[^.\n]{0,50}\bdeposit\b",
+        r"|\bmultiple\s+(?:BUMN\s+|state[- ]owned\s+)?banks\b[^.\n]{0,50}\bdeposit\b"
+        # IT: dividere/suddividere/frazionare/ripartire il deposito; piu' banche
+        r"|\b(?:divid\w+|suddivid\w+|frazion\w+|ripart\w+)\b[^.\n]{0,40}\bdeposit\w*\b"
+        r"|\bdeposit\w*\b(?:(?!non|mai)[^.\n]){0,40}\b(?:divis\w+|suddivis\w+|frazionat\w+)\b"
+        r"|\bpi[uù]\s+banche\b[^.\n]{0,50}\bdeposit\w*\b"
+        # ID: membagi/memecah deposito; beberapa bank
+        r"|\b(?:membagi|memecah|memisahkan|dibagi|dipecah)\b[^.\n]{0,40}\bdeposit\w*\b"
+        r"|\bbeberapa\s+bank\b[^.\n]{0,50}\bdeposit\w*\b",
         "Splitting the USD 130,000 deposit across multiple banks is unconfirmed — forbidden to claim",
         "split_deposit_accepted",
     ),
     _p(
         "lps_full_coverage",
         rf"\bLPS\b[^.\n]{{0,60}}\b{_NEG}(?:full(?:y)?|100\s*%|entire(?:ly)?|whole)\b"
-        rf"|\b{_NEG}(?:full(?:y)?|100\s*%|entire(?:ly)?)\b[^.\n]{{0,40}}\b(?:covered|guaranteed|insured)\b[^.\n]{{0,30}}\b(?:by\s+)?LPS\b",
+        rf"|\b{_NEG}(?:full(?:y)?|100\s*%|entire(?:ly)?)\b[^.\n]{{0,40}}\b(?:covered|guaranteed|insured)\b[^.\n]{{0,30}}\b(?:by\s+)?LPS\b"
+        # IT: interamente/totalmente/completamente/integralmente
+        rf"|\bLPS\b[^.\n]{{0,60}}\b{_NEG}(?:interament\w+|totalment\w+|completament\w+|integralment\w+)\b"
+        rf"|\b{_NEG}(?:interament\w+|totalment\w+|completament\w+|integralment\w+)\b[^.\n]{{0,40}}\b(?:copert\w+|garantit\w+|assicurat\w+)\b[^.\n]{{0,30}}\bLPS\b"
+        # ID: sepenuhnya/seluruhnya/penuh
+        rf"|\bLPS\b[^.\n]{{0,60}}\b{_NEG}(?:sepenuhnya|seluruhnya|penuh)\b"
+        rf"|\b{_NEG}(?:sepenuhnya|seluruhnya|penuh)\b[^.\n]{{0,40}}\b(?:dijamin|ditanggung|diasuransikan)\b[^.\n]{{0,30}}\bLPS\b"
+        # Indonesian puts the adverb AFTER the verb ("dijamin sepenuhnya"),
+        # the reverse of the English and Italian word order above.
+        rf"|\b(?:dijamin|ditanggung|diasuransikan)\s+{_NEG}(?:sepenuhnya|seluruhnya|penuh)\b[^.\n]{{0,30}}\bLPS\b",
         "LPS deposit insurance has a cap — never claim it fully covers the E33 deposit",
         "usd_deposit_rates_and_lps_cap_confirmation",
     ),
     _p(
         "approval_guaranteed",
         rf"\b(?:approval|approved|application|visa)\b[^.\n]{{0,30}}\b(?:is\s+|are\s+)?{_NEG}guaranteed\b"
-        rf"|\b{_NEG}guaranteed\s+(?:approval|visa)\b",
+        rf"|\b{_NEG}guaranteed\s+(?:approval|visa)\b"
+        # IT: "l'approvazione e' garantita", "visto garantito"
+        rf"|\b(?:approvazione|domanda|visto|esito)\b[^.\n]{{0,30}}\b(?:[eè]\s+|sono\s+)?{_NEG}garantit[oaie]\b"
+        rf"|\b{_NEG}garantit[oa]\s+(?:l[ea']\s*)?(?:approvazione|visto)\b"
+        # ID: "persetujuan dijamin", "visa terjamin"
+        rf"|\b(?:persetujuan|permohonan|visa|hasil)\b[^.\n]{{0,30}}\b{_NEG}(?:dijamin|terjamin|pasti\s+disetujui)\b"
+        rf"|\b{_NEG}(?:dijamin|terjamin)\s+(?:persetujuan|visa)\b",
         "Visa approval is never guaranteed",
         LEGACY_ERROR_REF,
     ),
@@ -171,6 +229,55 @@ E33_FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
 )
 
 
+#: Sentence terminators. A negation only shields a claim inside its OWN
+#: sentence — "Approval is not guaranteed. You may split the deposit." must
+#: still flag the second clause.
+_SENTENCE_BOUNDARY_RE = re.compile(r"[.!?;\n]")
+
+#: Negators in the three languages this guard actually sees. The bot answers in
+#: whichever language the client wrote in (`wrap_query_with_language_instruction`),
+#: so an English-only negation guard fires on correct Italian and Indonesian
+#: sentences that say a thing is NOT allowed.
+_NEGATOR_RE = re.compile(
+    r"\b(?:not|never|cannot|can\'t|don\'t|doesn\'t|isn\'t|aren\'t|without|neither"
+    r"|non|mai|senza|nessun\w*"
+    r"|tidak|bukan|jangan|tanpa|belum)\b",
+    re.IGNORECASE,
+)
+
+#: How far back a negator may sit and still be read as negating this claim.
+#: Deliberately short. A wider window suppresses more false positives but buys
+#: it with FALSE NEGATIVES, and the two are not symmetric here: a false
+#: positive parks a correct answer for a human to glance at, while a false
+#: negative sends a forbidden claim to a client. When in doubt, flag.
+_NEGATION_WINDOW = 40
+
+
+def _is_negated(text: str, match_start: int, match_end: int) -> bool:
+    """True if a negator governs the claim spanning ``match_start:match_end``.
+
+    Replaces what fixed-width lookbehinds cannot express. Python's ``re``
+    requires a constant-width lookbehind, so the old ``_NEG`` prefix could only
+    see the single token immediately before the match: it caught "not
+    guaranteed" but missed "you cannot split the deposit" (three words back)
+    and "l'approvazione non e' garantita" (the copula sits in between). Both of
+    those are CORRECT sentences the guard was flagging — measured, on English
+    too, before this change.
+
+    The search is bounded twice: it never crosses a sentence boundary, and it
+    never looks further back than ``_NEGATION_WINDOW`` characters.
+    """
+    window_start = max(0, match_start - _NEGATION_WINDOW)
+    sentence_start = window_start
+    for boundary in _SENTENCE_BOUNDARY_RE.finditer(text, window_start, match_start):
+        sentence_start = boundary.end()
+    # Search up to match_END, not match_start: several patterns span the
+    # negator themselves. "KITAP is not automatic after 3 years" matches from
+    # "KITAP", so the "not" sits INSIDE the match and a look-behind-only search
+    # never sees it. Same for "l'approvazione non e' garantita".
+    return bool(_NEGATOR_RE.search(text, sentence_start, match_end))
+
+
 def check_e33_claims(text: str) -> list[ClaimViolation]:
     """Flag registry-forbidden E33 claims in ``text``.
 
@@ -185,6 +292,8 @@ def check_e33_claims(text: str) -> list[ClaimViolation]:
         if pattern.requires_e33_context and not has_context:
             continue
         for match in pattern.regex.finditer(text):
+            if _is_negated(text, match.start(), match.end()):
+                continue
             violations.append(
                 ClaimViolation(
                     pattern_id=pattern.pattern_id,

--- a/apps/backend-rag/backend/services/visa_check/e33_claim_guard.py
+++ b/apps/backend-rag/backend/services/visa_check/e33_claim_guard.py
@@ -232,18 +232,58 @@ E33_FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
 #: Sentence terminators. A negation only shields a claim inside its OWN
 #: sentence — "Approval is not guaranteed. You may split the deposit." must
 #: still flag the second clause.
-_SENTENCE_BOUNDARY_RE = re.compile(r"[.!?;\n]")
+#: A sentence boundary. A period BETWEEN DIGITS is a thousands separator, not
+#: the end of a sentence: Italian and Indonesian write the very figures this
+#: guard exists to police as "USD 130.000" / "USD 1.500". Reading those dots as
+#: full stops moved the search window past the negator and made the verdict
+#: depend on which locale's separator the sentence happened to use.
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?<!\d)\.(?!\d)|[!?;:\n]")
 
 #: Negators in the three languages this guard actually sees. The bot answers in
 #: whichever language the client wrote in (`wrap_query_with_language_instruction`),
 #: so an English-only negation guard fires on correct Italian and Indonesian
 #: sentences that say a thing is NOT allowed.
+#:
+#: PREPOSITIONAL negators are deliberately ABSENT — no "without", no "senza",
+#: no "tanpa". They open a phrase, they do not negate the claim that follows:
+#: "E33 allows you, without a separate permit, to work in Indonesia" asserts
+#: the forbidden claim while carrying a negator. Their removal costs a few
+#: false positives and closes a whole class of false negatives.
 _NEGATOR_RE = re.compile(
-    r"\b(?:not|never|cannot|can\'t|don\'t|doesn\'t|isn\'t|aren\'t|without|neither"
-    r"|non|mai|senza|nessun\w*"
-    r"|tidak|bukan|jangan|tanpa|belum)\b",
+    r"\b(?:not|never|cannot|can\'t|don\'t|doesn\'t|isn\'t|aren\'t|neither"
+    r"|non|mai|nessun\w*"
+    r"|tidak|bukan|jangan|belum)\b",
     re.IGNORECASE,
 )
+
+#: "not X **but** Y" — the negator governs X, and Y is asserted. A contrast
+#: marker between a negator and the claim therefore PROVES the negator does not
+#: reach it. This is the construction that broke the previous heuristic on 27
+#: adversarial sentences, among them "the required income is not USD 3,000 but
+#: USD 1,500 per month" — the superseded figure, stated as fact, silently
+#: suppressed because a "not" appeared earlier in the clause.
+_CONTRAST_RE = re.compile(
+    r"\b(?:but|rather|instead"
+    r"|ma|bensì|bensi|invece|anzi|piuttosto"
+    r"|melainkan|tetapi|namun|justru)\b",
+    re.IGNORECASE,
+)
+
+#: "not ONLY X" scopes the negation to the quantifier, never to the predicate:
+#: "E33 does not only allow residence, it also allows you to work" asserts the
+#: forbidden claim. Same for "approval is not merely likely; it is guaranteed".
+_SCOPE_LIMITER_RE = re.compile(
+    r"\W*\b(?:only|just|merely|simply"
+    r"|solo|soltanto|solamente|semplicemente"
+    r"|hanya|sekadar|sekedar|semata)\b",
+    re.IGNORECASE,
+)
+
+#: A negator fenced inside a comma-delimited aside governs the aside, not the
+#: predicate: "BSI, not Mandiri, qualifies as a state-owned bank" ASSERTS that
+#: BSI qualifies. The closing comma must fall before the claim ends, which is
+#: what separates the aside from an ordinary "not X, only Y" correction.
+_PARENTHETICAL_OPEN_RE = re.compile(r",\s*$")
 
 #: How far back a negator may sit and still be read as negating this claim.
 #: Deliberately short. A wider window suppresses more false positives but buys
@@ -254,28 +294,51 @@ _NEGATION_WINDOW = 40
 
 
 def _is_negated(text: str, match_start: int, match_end: int) -> bool:
-    """True if a negator governs the claim spanning ``match_start:match_end``.
+    """True if a negator GOVERNS the claim spanning ``match_start:match_end``.
 
-    Replaces what fixed-width lookbehinds cannot express. Python's ``re``
-    requires a constant-width lookbehind, so the old ``_NEG`` prefix could only
-    see the single token immediately before the match: it caught "not
-    guaranteed" but missed "you cannot split the deposit" (three words back)
-    and "l'approvazione non e' garantita" (the copula sits in between). Both of
-    those are CORRECT sentences the guard was flagging — measured, on English
-    too, before this change.
+    Presence is not government. The previous version answered "is there a
+    negator nearby", which a contrast clause turns into a silencer: an
+    adversarial matrix of 29 sentences that each state a forbidden claim after
+    negating something else was suppressed 27 times. Three tests now stand
+    between a negator and a suppression:
 
-    The search is bounded twice: it never crosses a sentence boundary, and it
-    never looks further back than ``_NEGATION_WINDOW`` characters.
+    1. it must lie in the same sentence (``_SENTENCE_BOUNDARY_RE``, which knows
+       a thousands separator from a full stop) and within ``_NEGATION_WINDOW``;
+    2. no contrast marker may sit between it and the claim — "not X **but** Y"
+       asserts Y;
+    3. it must not be a scope limiter — "not **only** X" asserts X.
+
+    The span searched runs to ``match_end``, not ``match_start``: several
+    patterns swallow the negator themselves ("KITAP is not automatic after 3
+    years" matches from "KITAP"), and those ARE correct cautionary sentences.
+    Rules 2 and 3 are what keep that span from becoming a loophole — they are
+    applied to the text between the negator and the end of the claim, so a
+    contrast inside the match disqualifies the negator exactly as one before it
+    does.
     """
     window_start = max(0, match_start - _NEGATION_WINDOW)
     sentence_start = window_start
     for boundary in _SENTENCE_BOUNDARY_RE.finditer(text, window_start, match_start):
         sentence_start = boundary.end()
-    # Search up to match_END, not match_start: several patterns span the
-    # negator themselves. "KITAP is not automatic after 3 years" matches from
-    # "KITAP", so the "not" sits INSIDE the match and a look-behind-only search
-    # never sees it. Same for "l'approvazione non e' garantita".
-    return bool(_NEGATOR_RE.search(text, sentence_start, match_end))
+
+    for negator in _NEGATOR_RE.finditer(text, sentence_start, match_end):
+        tail_start = negator.end()
+        if _SCOPE_LIMITER_RE.match(text, tail_start):
+            continue  # "not only" — the predicate is asserted, not denied
+        if _CONTRAST_RE.search(text, tail_start, match_end):
+            continue  # "not X but Y" — this negator governs X, not the claim
+        if (
+            _PARENTHETICAL_OPEN_RE.search(text, sentence_start, negator.start())
+            and text.find(",", tail_start, match_end) != -1
+        ):
+            continue  # ", not X," — an aside; the predicate is still asserted
+        if _SENTENCE_BOUNDARY_RE.search(text, tail_start, match_end):
+            # The negator sits INSIDE a match that swallowed a sentence break:
+            # "LPS does not cover a fraction; it fully covers the deposit."
+            # Government stops at the break, so it does not reach the claim.
+            continue
+        return True
+    return False
 
 
 def check_e33_claims(text: str) -> list[ClaimViolation]:

--- a/apps/backend-rag/backend/tests/services/visa_check/test_e33_claim_guard.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_e33_claim_guard.py
@@ -525,3 +525,150 @@ class TestNegationIsScopedToItsOwnSentence:
             "length whatsoever, and separately you may split the deposit."
         )
         assert "split_deposit_accepted" in {v.pattern_id for v in check_e33_claims(text)}
+
+
+#: Sentences that NEGATE SOMETHING ELSE and then state a forbidden claim.
+#:
+#: This corpus is the reason the negation check asks whether a negator GOVERNS
+#: the claim rather than whether one is nearby. An earlier version asked only
+#: for presence, and a cross-family adversarial review (Codex gpt-5.6-sol,
+#: 2026-08-31) silenced it on 27 of these 29 sentences — including "the
+#: required income is not USD 3,000 but USD 1,500 per month", which states the
+#: superseded figure this guard exists to catch, in the phrasing a model
+#: reaches for most naturally.
+#:
+#: Every entry here states a forbidden claim as fact. The guard MUST fire.
+NEGATOR_GOVERNMENT_GUILT: list[tuple[str, str]] = [
+    # "not X but Y" — the contrast marker proves the negator governs X
+    (
+        "en-income-contrast",
+        "About E33F: The required income is not USD 3,000 but USD 1,500 per month.",
+    ),
+    ("it-income-contrast", "Per E33F, il reddito non è USD 3.000 ma USD 1.500 al mese."),
+    (
+        "id-income-contrast",
+        "Untuk E33F, pendapatan bukan USD 3.000, melainkan USD 1.500 per bulan.",
+    ),
+    ("en-fee-contrast", "For E33, the fee is not IDR 13,000,000 but IDR 2,000,000."),
+    ("en-duration-contrast", "For E33, the first grant is not 1 year but 5-10 years."),
+    (
+        "en-lps-but-fully",
+        "For E33, LPS does not cover interest or bank fees, but fully covers the deposit.",
+    ),
+    (
+        "it-lps-cross-comma",
+        "Per E33, LPS non copre solo una parte, ma copre interamente il deposito.",
+    ),
+    # "not ONLY X" — the negation scopes to the quantifier, the predicate stands
+    (
+        "en-work-not-only",
+        "E33 does not only allow residence, it also allows you to work in Indonesia.",
+    ),
+    (
+        "it-work-non-solo",
+        "L'E33 non consente solo il soggiorno, ma consente anche di lavorare in Indonesia.",
+    ),
+    (
+        "id-work-tidak-hanya",
+        "E33 tidak hanya memungkinkan tinggal, tetapi juga memungkinkan Anda bekerja di Indonesia.",
+    ),
+    (
+        "en-kitap-contrast",
+        "For E33, after 3 years you become eligible, not merely considered, for KITAP.",
+    ),
+    ("en-approval-cross-semicolon", "For E33, approval is not merely likely; it is guaranteed."),
+    # a colon or semicolon introduces the assertion — government stops there
+    (
+        "en-any-bank-neg-restriction",
+        "For E33, the deposit rule is not restrictive: any Indonesian bank is acceptable.",
+    ),
+    ("it-any-bank-neg-restriction", "Per E33, non ci sono vincoli: qualsiasi banca va bene."),
+    (
+        "id-any-bank-neg-restriction",
+        "Untuk E33, tidak ada batasan: bank Indonesia mana saja bisa dipakai.",
+    ),
+    (
+        "en-lps-cross-semicolon",
+        "For E33, LPS does not cover a fraction; it fully covers the deposit.",
+    ),
+    # a comma-fenced aside negates the aside, not the predicate
+    ("en-bsi-parenthetical", "For E33, BSI, not Mandiri, qualifies as a state-owned bank."),
+    # prepositional "without/senza/tanpa" opens a phrase, it negates nothing
+    ("en-work-without", "E33 allows you, without a separate permit, to work in Indonesia."),
+    ("it-work-senza", "L'E33 consente, senza un permesso separato, di lavorare in Indonesia."),
+    (
+        "id-work-tanpa",
+        "E33 mengizinkan Anda, tanpa izin kerja tambahan, untuk bekerja di Indonesia.",
+    ),
+    (
+        "en-split-without",
+        "For E33, even without another account, you may split the deposit across banks.",
+    ),
+    (
+        "it-split-senza",
+        "Per E33, anche senza un conto separato, puoi dividere il deposito fra più banche.",
+    ),
+    ("en-approval-without", "For E33, even without collateral, approval is guaranteed."),
+    (
+        "en-split-two-clauses",
+        "For E33, you cannot apply without a deposit, but you may split the deposit across banks.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "text"),
+    NEGATOR_GOVERNMENT_GUILT,
+    ids=[label for label, _ in NEGATOR_GOVERNMENT_GUILT],
+)
+def test_a_negator_that_governs_something_else_does_not_shield_the_claim(
+    label: str, text: str
+) -> None:
+    violations = check_e33_claims(text)
+    assert violations, (
+        f"{label} states a forbidden claim as fact and the guard stayed silent: {text!r}"
+    )
+
+
+class TestNegationGovernmentRules:
+    """One named test per rule, so a regression names its own cause.
+
+    Each pair is the same claim twice: once genuinely denied (must stay
+    silent), once asserted behind a negator that governs something else (must
+    fire). A rule that stops working takes exactly one of these red.
+    """
+
+    def test_contrast_marker_breaks_government(self):
+        assert not check_e33_claims(_EN + "The required income is not USD 1,500 per month.")
+        assert check_e33_claims(_EN + "The income is not USD 3,000 but USD 1,500 per month.")
+
+    def test_scope_limiter_breaks_government(self):
+        assert not check_e33_claims(_EN + "Approval is not guaranteed.")
+        # No semicolon and no contrast marker: only the scope limiter stands
+        # between "not only" and a suppression here.
+        assert check_e33_claims(
+            _EN + "E33 does not only allow residence, it also allows you to work in Indonesia."
+        )
+
+    def test_colon_breaks_government(self):
+        assert not check_e33_claims(_EN + "The deposit cannot be placed at any bank.")
+        assert check_e33_claims(
+            _EN + "The deposit rule is not restrictive: any Indonesian bank is acceptable."
+        )
+
+    def test_comma_fenced_aside_breaks_government(self):
+        assert not check_e33_claims(_EN + "BSI does not qualify as a state-owned bank.")
+        assert check_e33_claims(_EN + "BSI, not Mandiri, qualifies as a state-owned bank.")
+
+    def test_prepositional_negators_never_govern(self):
+        # Not comma-fenced, so the aside rule cannot cover for this: the only
+        # reason "without" fails to suppress is that it is not a negator.
+        assert check_e33_claims(
+            _EN + "Without any doubt you may split the deposit across several banks."
+        )
+
+    def test_a_thousands_separator_is_not_a_sentence_boundary(self):
+        """`USD 130.000` must not end the sentence and expose the negator."""
+        assert not check_e33_claims(
+            "Per E33, il deposito non può essere di USD 130.000 presso qualsiasi banca."
+        )

--- a/apps/backend-rag/backend/tests/services/visa_check/test_e33_claim_guard.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_e33_claim_guard.py
@@ -11,6 +11,7 @@ path.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 from pathlib import Path
@@ -189,7 +190,7 @@ class TestGuardE33AnswerDetailed:
     def test_outcome_is_immutable_and_stdlib_only(self) -> None:
         outcome = guard_e33_answer_detailed(_E33 + "deposit at any Indonesian bank.")
         assert isinstance(outcome, GuardOutcome)
-        with pytest.raises(Exception):  # frozen dataclass -> FrozenInstanceError
+        with pytest.raises(dataclasses.FrozenInstanceError):
             outcome.answer = "tampered"  # type: ignore[misc]
 
     def test_guard_e33_answer_and_detailed_agree_on_text(self) -> None:
@@ -340,3 +341,187 @@ class TestRegistryFixture:
         legacy = " ".join(fixture["forbidden_legacy_errors"]).lower()
         for keyword in ("1,500", "2,000,000", "lps", "guaranteed", "kitap", "work"):
             assert keyword in legacy
+
+
+# ── Multilingual guilt + innocence (EN / IT / ID) ────────────────────
+#
+# The guard scans whatever the model answered, and the model answers in the
+# language the client wrote in: `wrap_query_with_language_instruction`
+# (query_helpers.py) detects the query language and instructs the model to
+# reply in the same one, with an explicit Indonesian branch. Before this
+# suite, every pattern body was English-only. Measured on the pre-change
+# build, 7 of the 10 patterns caught nothing in Italian or Indonesian — only
+# the three anchored to a NUMBER survived translation (USD 1,500, IDR
+# 2,000,000, "5-10 years"), because a digit reads the same in every language.
+#
+# Arming E33_CLAIM_GUARD_ENFORCE on that build would have parked English
+# answers for human review while letting the identical claim through in
+# Italian and Indonesian — and the logs would have looked healthy.
+# Cicatrix family #3, the UNDER-match twin (W82).
+
+_EN = "About the E33 Second Home visa: "
+_IT = "Riguardo al visto E33 Second Home: "
+_ID = "Tentang visa E33 Second Home: "
+
+#: (pattern_id, english, italian, indonesian) — each a REAL violation.
+MULTILINGUAL_GUILT: list[tuple[str, str, str, str]] = [
+    (
+        "e33f_superseded_income_usd1500",
+        _EN + "the E33F route requires USD 1,500/month passive income.",
+        _IT + "la via E33F richiede USD 1.500 al mese di reddito passivo.",
+        _ID + "jalur E33F membutuhkan pendapatan pasif USD 1.500 per bulan.",
+    ),
+    (
+        "second_home_any_bank",
+        _EN + "you can place the USD 130,000 deposit at any Indonesian bank.",
+        _IT + "puoi depositare i USD 130.000 presso qualsiasi banca indonesiana.",
+        _ID + "Anda dapat menempatkan deposito USD 130.000 di bank Indonesia mana saja.",
+    ),
+    (
+        "e33_itap_kitap_automatic_promise",
+        _EN + "after 3 years you are automatically eligible for KITAP.",
+        _IT + "dopo 3 anni si ottiene automaticamente il KITAP.",
+        _ID + "setelah 3 tahun Anda otomatis mendapatkan KITAP.",
+    ),
+    (
+        "e33_permits_local_work",
+        _EN + "the E33 allows you to work in Indonesia.",
+        _IT + "l'E33 permette di lavorare in Indonesia.",
+        _ID + "E33 memungkinkan Anda bekerja di Indonesia.",
+    ),
+    (
+        "bsi_sharia_equivalence",
+        _EN + "BSI qualifies as a state-owned bank for the deposit.",
+        _IT + "BSI e' equivalente a una banca statale per il deposito.",
+        _ID + "BSI setara dengan bank BUMN untuk deposito.",
+    ),
+    (
+        "split_deposit_accepted",
+        _EN + "you may split the deposit across multiple banks.",
+        _IT + "puoi dividere il deposito su piu' banche.",
+        _ID + "Anda bisa membagi deposito di beberapa bank.",
+    ),
+    (
+        "lps_full_coverage",
+        _EN + "the deposit is fully covered by LPS.",
+        _IT + "il deposito e' interamente coperto da LPS.",
+        _ID + "deposito dijamin sepenuhnya oleh LPS.",
+    ),
+    (
+        "approval_guaranteed",
+        _EN + "approval is guaranteed.",
+        _IT + "l'approvazione e' garantita.",
+        _ID + "persetujuan dijamin.",
+    ),
+    (
+        "idr_2m_fee_error",
+        _EN + "the government fee is IDR 2,000,000.",
+        _IT + "la tassa governativa e' IDR 2.000.000.",
+        _ID + "biaya pemerintah adalah IDR 2.000.000.",
+    ),
+    (
+        "second_home_first_grant_5_10_years",
+        _EN + "the first grant is 5-10 years.",
+        _IT + "il primo rilascio e' di 5-10 years.",
+        _ID + "izin pertama berlaku 5-10 years.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "pattern_id,text,language",
+    [
+        (pid, text, lang)
+        for pid, en, it, idn in MULTILINGUAL_GUILT
+        for lang, text in (("en", en), ("it", it), ("id", idn))
+    ],
+    ids=[f"{pid}-{lang}" for pid, _, _, _ in MULTILINGUAL_GUILT for lang in ("en", "it", "id")],
+)
+def test_every_pattern_fires_in_all_three_languages(
+    pattern_id: str, text: str, language: str
+) -> None:
+    """Each forbidden claim must be caught however the answer was phrased."""
+    fired = {v.pattern_id for v in check_e33_claims(text)}
+    assert pattern_id in fired, (
+        f"{pattern_id} is blind in {language}: {text!r} produced {sorted(fired)}"
+    )
+
+
+#: Sentences that are CORRECT and must produce ZERO violations. A guard that
+#: flags these is worse than no guard once armed: it parks exactly the answers
+#: that got the fact right, and it teaches whoever reads the queue to ignore it.
+MULTILINGUAL_INNOCENCE: list[tuple[str, str]] = [
+    # English negations — three of these were FALSE POSITIVES on the
+    # pre-change build, measured. The fixed-width look-behind could only see
+    # the single token before the match, so "you cannot split the deposit"
+    # (negator three words back) and "KITAP is not automatic" (negator inside
+    # the match) both fired.
+    ("en-negated-approval", _EN + "approval is not guaranteed."),
+    ("en-negated-split", _EN + "you cannot split the deposit across multiple banks."),
+    ("en-negated-lps", _EN + "the deposit is not fully covered by LPS."),
+    ("en-negated-automatic", _EN + "KITAP is not automatic after 3 years."),
+    ("en-negated-any-bank", _EN + "the deposit cannot sit at any Indonesian bank."),
+    ("en-negated-work", _EN + "the E33 does not allow you to work in Indonesia."),
+    # Italian negations
+    ("it-negated-approval", _IT + "l'approvazione non e' garantita."),
+    ("it-negated-split", _IT + "non puoi dividere il deposito su piu' banche."),
+    ("it-negated-lps", _IT + "il deposito non e' interamente coperto da LPS."),
+    ("it-negated-automatic", _IT + "il KITAP non e' automatico dopo 3 anni."),
+    ("it-negated-work", _IT + "l'E33 non permette di lavorare in Indonesia."),
+    # Indonesian negations
+    ("id-negated-approval", _ID + "persetujuan tidak dijamin."),
+    ("id-negated-split", _ID + "Anda tidak bisa membagi deposito di beberapa bank."),
+    ("id-negated-automatic", _ID + "KITAP tidak otomatis setelah 3 tahun."),
+    ("id-negated-work", _ID + "E33 tidak memungkinkan Anda bekerja di Indonesia."),
+    # Correct affirmative statements of the real requirements
+    (
+        "it-correct-deposit",
+        _IT + "il deposito di USD 130.000 deve essere intestato a te presso "
+        "una banca statale (BUMN) indonesiana.",
+    ),
+    ("it-correct-income", _IT + "E33F richiede USD 3.000 al mese di reddito passivo."),
+    (
+        "id-correct-deposit",
+        _ID + "deposito USD 130.000 harus atas nama Anda di bank BUMN.",
+    ),
+    # Same vocabulary, no E33 context at all
+    (
+        "unrelated-bank-sentence",
+        "Puoi aprire un conto presso qualsiasi banca indonesiana per le spese quotidiane.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,text",
+    MULTILINGUAL_INNOCENCE,
+    ids=[label for label, _ in MULTILINGUAL_INNOCENCE],
+)
+def test_correct_sentences_are_never_flagged(label: str, text: str) -> None:
+    violations = check_e33_claims(text)
+    assert not violations, (
+        f"{label} is a correct sentence but fired "
+        f"{[(v.pattern_id, v.matched_text) for v in violations]}"
+    )
+
+
+class TestNegationIsScopedToItsOwnSentence:
+    """A negation must not shield a violation in the NEXT sentence.
+
+    This is the failure mode a whole-text negation check would introduce: one
+    honest "not guaranteed" anywhere in the answer would silence every other
+    claim in it. A false negative here reaches a client, so the window is
+    bounded twice — by sentence, and by characters.
+    """
+
+    def test_violation_after_a_negated_clause_still_fires(self):
+        text = _EN + "Approval is not guaranteed. You may split the deposit across multiple banks."
+        assert "split_deposit_accepted" in {v.pattern_id for v in check_e33_claims(text)}
+
+    def test_distant_negator_does_not_reach_the_claim(self):
+        """A negator far outside the window must not suppress the claim."""
+        text = (
+            _EN + "This is not the place to discuss unrelated topics at any "
+            "length whatsoever, and separately you may split the deposit."
+        )
+        assert "split_deposit_accepted" in {v.pattern_id for v in check_e33_claims(text)}


### PR DESCRIPTION
## The defect

The E33 claim guard's negation check asked whether a negator appeared **near** a forbidden claim.
A contrast clause turns that question into a silencer.

A cross-family adversarial review (Codex `gpt-5.6-sol`, xhigh) built 29 sentences that each negate
something else and then state a forbidden claim as fact. **27 were suppressed.** Among them:

| sentence | guard said |
|---|---|
| *"The required income is not USD 3,000 but USD 1,500 per month."* | silent |
| *"For E33, the fee is not IDR 13,000,000 but IDR 2,000,000."* | silent |
| *"For E33, approval is not merely likely; it is guaranteed."* | silent |
| *"E33 does not only allow residence, it also allows you to work in Indonesia."* | silent |

The first is the superseded E33F figure — the single claim this guard was built to catch — in the
phrasing a model reaches for most naturally.

This is the expensive direction. The guard's degrade path parks an answer for a human, so a false
positive costs a glance; a false negative sends a forbidden claim to a client.

## The fix — five tests between a negator and a suppression

1. **Contrast marker** — "not X **but** Y" asserts Y, so the negator governs X.
2. **Scope limiter** — "not **only** X", "not **merely** likely" scope the negation to the
   quantifier, never the predicate.
3. **Sentence boundary**, wherever the negator sits. Needed because several patterns swallow the
   negator themselves (`"KITAP is not automatic after 3 years"` matches from `KITAP`), which is
   also why the span runs to `match_end` rather than `match_start`.
4. **Comma-fenced aside** — *"BSI, not Mandiri, qualifies"* asserts that BSI qualifies.
5. **Prepositional negators removed** — `without` / `senza` / `tanpa` open a phrase, they negate
   nothing: *"E33 allows you, without a separate permit, to work in Indonesia."*

Two boundary corrections come with it. A **colon** joins `;` — it introduces an assertion. And a
period **between digits** is no longer a full stop: Italian and Indonesian write the very figures
this guard polices as `USD 130.000`, so reading that dot as a sentence end moved the window past
the negator and made the verdict depend on which locale's thousands separator the sentence used.
That bug made the same claim fire in Italian and stay silent in English.

## Measurement

On the 29-sentence adversarial matrix plus 19 correct sentences across EN/IT/ID:

```
FALSE NEGATIVES 0/24   FALSE POSITIVES 0/19
```

The matrix is now the regression corpus (`NEGATOR_GOVERNMENT_GUILT`), and each rule has one named
test. **All six rules are mutation-proven** — disabling any one turns exactly its own test red:

| mutation | verdict |
|---|---|
| kill contrast rule | KILLED |
| kill scope-limiter rule | KILLED |
| kill colon boundary | KILLED |
| kill comma-aside rule | KILLED |
| restore prepositional negators | KILLED |
| make the full stop digit-blind | KILLED |

`backend/tests/services/visa_check/` — 462 passed. `ruff` clean.

## Not in scope

This PR makes the guard sound enough to be armable. It does **not** arm it —
`E33_CLAIM_GUARD_ENFORCE` stays absent, the guard stays log-only. Arming is a separate action
after this lands and is proven live.