### PR TITLE
docs(curated-qa): two READMEs described a state that is not the case

### DIFF
--- a/apps/backend-rag/data/curated_qa/README.md
+++ b/apps/backend-rag/data/curated_qa/README.md
@@ -5,8 +5,19 @@ This directory holds **normalized, pre-vetted Q&A JSONL files** consumed by
 (`.jsonl`), one row per question.
 
 Files are produced by the converters in `scripts/curated_qa_convert_e33.py`
-(or hand-authored following the same schema) and are meant to be
-**repo-reviewable** — this is the audit trail behind the safety invariant:
+(or hand-authored following the same schema).
+
+> **Where the audit trail actually lives.** This directory is matched by
+> `.gitignore` (`apps/backend-rag/data/curated_qa/*`), and no `.jsonl` has ever
+> been committed into it — measured 2026-08-31, zero adds across all branches.
+> It is a local staging area for the harvester, not a repo-reviewable record,
+> and reading this file as if it were one has already misled a session. The
+> reviewable trail is `research/curated-qa-corrections-<date>/`, which IS
+> committed and carries the per-row review rationale. What is actually being
+> served is the production Qdrant `curated_qa` collection — the only way to
+> know a row is live is to probe it.
+
+These files back the safety invariant:
 
 > NO verbatim serving from any similarity-based layer; verbatim only from
 > exact-match FAQ cache with pre-vetted provenance.

--- a/research/curated-qa-corrections-2026-07-21/README.md
+++ b/research/curated-qa-corrections-2026-07-21/README.md
@@ -8,9 +8,19 @@ adversarial_review: exempt-corrections-index
 
 > **Status:** Rounds 1-2 (`property-villa-rental`, `visa-second-home-variants`,
 > `visa-catalog-sweep`) were applied + re-harvested to prod on 2026-07-20.
-> **Round 3 (this PR)** adds 2 more files — `visa-golden-investor.jsonl` +
-> `visa-working-kitas-depth.jsonl` — NOT yet applied (harvest recipe in the
-> "Round 3" section at the end). Round 1-2 detail below is preserved as-is.
+> **Round 3** adds 2 more files — `visa-golden-investor.jsonl` +
+> `visa-working-kitas-depth.jsonl`. These were described here as "NOT yet
+> applied" until 2026-08-31, when a read-only probe of the production Qdrant
+> `curated_qa` collection found **every row of both files already live**:
+> 22/22 from `visa-golden-investor.jsonl` (batch `visa-d7ab2bf05258`) and 20/20
+> from `visa-working-kitas-depth.jsonl` (batch `visa-65d03713975b`), zero
+> absent, each file carrying a single batch id. The harvest recipe in the
+> "Round 3" section at the end is therefore a record of how it was applied, not
+> a to-do. Round 1-2 detail below is preserved as-is.
+>
+> The round-3 correction that matters most is Q17's — base E33 is **not** a work
+> visa. Verified live in the same probe: the point is `active: true`,
+> `invalidated_at: null`, and its answer carries the corrected sentence.
 
 Drafted after independently verifying 8 disputed team-review corrections
 against official sources (see the 3 research captures in `research/property/`


### PR DESCRIPTION
Both claims were found while checking whether the E33 round-3 correction still needed harvesting.
Neither survived a probe.

## 1 — Round 3 is applied, not pending

`research/curated-qa-corrections-2026-07-21/README.md` said round 3
(`visa-golden-investor.jsonl`, `visa-working-kitas-depth.jsonl`) was **"NOT yet applied"**.

A read-only probe of the production Qdrant `curated_qa` collection (808 points, status green)
found **every row of both files already live**:

| file | rows live | absent | batch id |
|---|---|---|---|
| `visa-golden-investor.jsonl` | 22 / 22 | 0 | `visa-d7ab2bf05258` |
| `visa-working-kitas-depth.jsonl` | 20 / 20 | 0 | `visa-65d03713975b` |

Single batch id per file, which is what a completed harvest of that file looks like.

The correction that matters most in round 3 is Q17's — **base E33 is not a work visa**. Verified
directly: the point is `active: true`, `invalidated_at: null`, and its answer carries the
corrected sentence *"the base E33 Second Home is NOT a work visa — it does not by itself authorize
you to work or be employed in Indonesia"*, with the team-review note in its `law_refs`.

Following that README as a to-do would have re-harvested rows that are already correct.

## 2 — The audit trail is not where its own README says

`apps/backend-rag/data/curated_qa/README.md` calls its own directory the **"repo-reviewable"**
audit trail behind the verbatim-serving safety invariant.

That directory is matched by `.gitignore:62` (`apps/backend-rag/data/curated_qa/*`), and **no
`.jsonl` has ever been committed into it** — zero adds across all branches. It holds one file: that
README.

It is a local staging area for the harvester. The reviewable trail is
`research/curated-qa-corrections-<date>/`, which is committed and carries the per-row rationale.
What is actually served is the Qdrant collection, and the only way to know a row is live is to
probe it. The README now says so.

## Scope

Documentation only. No data, no harvester, no collection touched. The safety invariant itself is
restated unchanged — only the sentence about *where* its evidence lives is corrected.