### PR TITLE
fix(visa-check): the E33 work claim was blind to the product's own name

### DIFF
--- a/apps/backend-rag/backend/services/visa_check/e33_claim_guard.py
+++ b/apps/backend-rag/backend/services/visa_check/e33_claim_guard.py
@@ -46,10 +46,19 @@ LEGACY_ERROR_REF = "legacy_error_list"
 # Context gate: patterns flagged ``requires_e33_context`` only fire when the
 # text is actually about the E33 / Second Home vertical, so unrelated answers
 # mentioning e.g. "USD 1,500" are not flagged.
-_E33_CONTEXT_RE = re.compile(
-    r"\bE33[A-Z]?\b|second[- ]home|rumah\s+kedua|silver\s+hair",
-    re.IGNORECASE,
-)
+#: Every name this product answers to — ONE vocabulary, used by the context gate
+#: below AND by any pattern that needs the product named NEAR its claim.
+#:
+#: `e33_permits_local_work` used to hardcode `\bE33[A-Z]?\b` in its own regex
+#: instead. It is the only pattern in the set that opted out of the shared gate,
+#: and it re-implemented it worse: "The Second Home visa allows you to work in
+#: Indonesia" passed in silence while the same sentence with "E33" fired. That
+#: is the name clients, marketing pages and the bot itself normally use, on the
+#: one claim in this guard that risks a client's immigration status rather than
+#: their money.
+_E33_NAME = r"(?:\bE33[A-Z]?\b|second[- ]home|rumah\s+kedua|silver\s+hair)"
+
+_E33_CONTEXT_RE = re.compile(_E33_NAME, re.IGNORECASE)
 
 E33_SAFE_FALLBACK_NOTE = (
     "Note: some details of the E33 Second Home visa are still pending written "
@@ -150,12 +159,12 @@ E33_FORBIDDEN_PATTERNS: tuple[ForbiddenPattern, ...] = (
     ),
     _p(
         "e33_permits_local_work",
-        rf"\bE33[A-Z]?\b[^.\n]{{0,60}}\b{_NEG}(?<!residence\s)(?<!stay\s)(?:allows?|permits?|authoriz\w*|entitle\w*)\b[^.\n]{{0,40}}\b(?:work|employment)\b"
-        rf"|\b{_NEG}work(?:ing)?\s+(?:legally\s+)?(?:in\s+Indonesia\s+)?on\s+(?:the\s+|an\s+)?E33"
+        rf"{_E33_NAME}[^.\n]{{0,60}}\b{_NEG}(?<!residence\s)(?<!stay\s)(?:allows?|permits?|authoriz\w*|entitle\w*)\b[^.\n]{{0,40}}\b(?:work|employment)\b"
+        rf"|\b{_NEG}work(?:ing)?\s+(?:legally\s+)?(?:in\s+Indonesia\s+)?on\s+(?:the\s+|an\s+)?{_E33_NAME}"
         # IT: "l'E33 permette/consente/autorizza ... lavorare/lavoro"
-        rf"|\bE33[A-Z]?\b[^.\n]{{0,60}}\b{_NEG}(?:permett\w+|consent\w+|autorizz\w+|abilit\w+)\b[^.\n]{{0,40}}\b(?:lavor\w+|impiego|occupazione)\b"
+        rf"|{_E33_NAME}[^.\n]{{0,60}}\b{_NEG}(?:permett\w+|consent\w+|autorizz\w+|abilit\w+)\b[^.\n]{{0,40}}\b(?:lavor\w+|impiego|occupazione)\b"
         # ID: "E33 memungkinkan/mengizinkan/membolehkan ... bekerja/kerja"
-        rf"|\bE33[A-Z]?\b[^.\n]{{0,60}}\b{_NEG}(?:memungkinkan|mengizinkan|membolehkan|memperbolehkan)\b[^.\n]{{0,40}}\b(?:bekerja|kerja|pekerjaan)\b",
+        rf"|{_E33_NAME}[^.\n]{{0,60}}\b{_NEG}(?:memungkinkan|mengizinkan|membolehkan|memperbolehkan)\b[^.\n]{{0,40}}\b(?:bekerja|kerja|pekerjaan)\b",
         "Base E33 is a pure residence permit — it does NOT authorize local employment",
         "e33_not_work_visa",
         ctx=False,

--- a/apps/backend-rag/backend/tests/services/visa_check/test_e33_claim_guard.py
+++ b/apps/backend-rag/backend/tests/services/visa_check/test_e33_claim_guard.py
@@ -672,3 +672,58 @@ class TestNegationGovernmentRules:
         assert not check_e33_claims(
             "Per E33, il deposito non può essere di USD 130.000 presso qualsiasi banca."
         )
+
+
+class TestTheWorkClaimKnowsTheProductsOwnName:
+    """ "Second Home" must reach the work pattern exactly as "E33" does.
+
+    This pattern was the only one of the ten with `requires_e33_context=False`:
+    it hardcoded `\\bE33[A-Z]?\\b` in its own regex rather than using the shared
+    context vocabulary, which already knew `second[- ]home`, `rumah kedua` and
+    `silver hair`. So the guard was blind to the name clients, marketing pages
+    and the bot itself normally use — on the one claim in this set that risks a
+    client's immigration status rather than their money.
+
+    A cross-family adversarial probe (2026-08-31) found it by inventing its own
+    sentences rather than reusing the corpus above; the negation corpus could
+    not have found it, because every sentence in it says "E33".
+    """
+
+    GUILTY = [
+        ("en-e33", "The E33 allows you to work in Indonesia."),
+        ("en-second-home", "The Second Home visa allows you to work in Indonesia."),
+        ("en-hyphen", "The Second-Home permit entitles you to employment in Indonesia."),
+        ("it-second-home", "Il visto Second Home ti permette di lavorare in Indonesia."),
+        ("id-rumah-kedua", "Visa Rumah Kedua memungkinkan Anda bekerja di Indonesia."),
+        ("id-second-home", "Visa Second Home mengizinkan Anda bekerja di Indonesia."),
+    ]
+
+    INNOCENT = [
+        ("en-negated", "The Second Home visa does not allow you to work in Indonesia."),
+        ("it-negated", "Il visto Second Home non ti permette di lavorare in Indonesia."),
+        ("id-negated", "Visa Rumah Kedua tidak mengizinkan Anda bekerja di Indonesia."),
+        (
+            "en-residence-carveout",
+            "The Second Home visa allows you to reside in Indonesia.",
+        ),
+    ]
+
+    @pytest.mark.parametrize(("label", "text"), GUILTY, ids=[x for x, _ in GUILTY])
+    def test_the_claim_fires_under_every_name_the_product_has(self, label, text):
+        assert "e33_permits_local_work" in {v.pattern_id for v in check_e33_claims(text)}, (
+            f"{label}: the work claim went unflagged — {text!r}"
+        )
+
+    @pytest.mark.parametrize(("label", "text"), INNOCENT, ids=[x for x, _ in INNOCENT])
+    def test_correct_sentences_under_those_names_stay_silent(self, label, text):
+        assert not check_e33_claims(text), f"{label} is correct but fired: {text!r}"
+
+    def test_the_name_vocabulary_has_exactly_one_definition(self):
+        """The context gate and the work pattern must not drift apart again."""
+        from backend.services.visa_check import e33_claim_guard as g
+
+        assert g._E33_CONTEXT_RE.pattern == g._E33_NAME
+        work = next(p for p in g.E33_FORBIDDEN_PATTERNS if p.pattern_id == "e33_permits_local_work")
+        assert "second[- ]home" in work.regex.pattern, (
+            "the work pattern no longer carries the shared name vocabulary"
+        )


### PR DESCRIPTION
## The defect

`e33_permits_local_work` was the **only one of the ten patterns with
`requires_e33_context=False`**. Rather than use the shared context gate, it hardcoded
`\bE33[A-Z]?\b` inside its own regex — and the shared gate, `_E33_CONTEXT_RE`, already knew
`second[- ]home`, `rumah kedua` and `silver hair`.

| sentence | before |
|---|---|
| `The E33 allows you to work in Indonesia.` | flagged |
| `The Second Home visa allows you to work in Indonesia.` | **silent** |

Both carry E33 context. Only one names the product the way clients, marketing pages and the bot
itself normally name it.

Of the ten forbidden claims this guard polices, this is the one that risks a client's **immigration
status** rather than their money — and it was the single pattern that opted out of the shared
vocabulary and re-implemented it worse.

## The fix

The names now live in one place, `_E33_NAME`. `_E33_CONTEXT_RE` is built from it, and all four
branches of the work pattern (EN × 2, IT, ID) interpolate it. One vocabulary, one definition.

A test pins that identity — `_E33_CONTEXT_RE.pattern == _E33_NAME`, and the work pattern must still
carry `second[- ]home` — so the two cannot silently drift apart again, which is exactly how this
started.

## Measurement

Guilt fires under **E33 / Second Home / Second-Home / Rumah Kedua**, across EN, IT and ID. Negated
sentences stay silent, and so does the residence-only carve-out
(`"The Second Home visa allows you to reside in Indonesia"` — the existing `(?<!residence\s)`
lookbehind still does its job).

`backend/tests/services/visa_check/` — **479 passed**, ruff clean.

Mutation-proven: re-hardcoding `\bE33[A-Z]?\b` in the English branch turns **exactly the two
English-name tests** red (`2 failed, 9 passed`), and nothing else.

## Provenance

Found by a cross-family adversarial probe that was told to **invent its own sentences** rather than
reuse the negation corpus added in #5360. That corpus could not have found this: every sentence in
it says "E33".

The same probe found lexical gaps that are **not** fixed here and should not be chased one at a
time — `US$1,500` and `fifteen hundred dollars` for the superseded figure, a split deposit written
as *"half at Bank Mandiri and half at BNI"*, *"any of Indonesia's banks"* for *any bank*. A regex
guard will not become semantically complete, which is an argument against arming
`E33_CLAIM_GUARD_ENFORCE` on the strength of these PRs, not for it. Recorded in the modus
PENDING-ARMS ledger.