### PR TITLE
fix(db): stage the checksum verifier — it was armed against a database it had never been measured against

### DIFF
--- a/apps/backend-rag/backend/db/schema_audit.py
+++ b/apps/backend-rag/backend/db/schema_audit.py
@@ -210,6 +210,50 @@ LEGACY_CHECKSUM_ALLOWLIST: dict[int, str] = {
 }
 
 
+# Enforcement stage for the two CHECKSUM findings, and only those two.
+#
+# This verifier was armed fail-closed on 2026-08-30 (#5335) against a
+# production `_schema_versions` it had never been measured against: 17 rows
+# carry a symbolic checksum ('manual_apply', 'manual-fix', 'manual', '', and
+# one MD5) and 8 more disagree with the file on disk. All 25 predate the check.
+# The result was exactly the outage this module's own comment above warns
+# about -- every backend deploy failed its `release_command` from 19:02 UTC
+# onward, stranding 25+ merged commits, because a row written in January can
+# never become verifiable no matter how long the deploy stays broken.
+#
+# So the two checksum findings default to WARNING: still computed, still
+# printed, still in the JSON, but they do not abort a deploy on state that was
+# already there. Enforcement is one env var away -- the same canary shape the
+# rest of this repo uses (E33_CLAIM_GUARD_ENFORCE, VISA_ENGINE_EVALUATE_MODE)
+# -- so arming it later is `fly secrets set`, not a revert of the check.
+#
+# What must be true before flipping it: the 17 symbolic rows are in
+# SYMBOLIC_CHECKSUM_ALLOWLIST with their MEASURED values, and the 8 mismatches
+# are reconciled or given a mechanism of their own (they have none today --
+# there is no allowlist for a mismatch, by design).
+#
+# DELIBERATELY NOT DEMOTED: every other finding in this module. A pending
+# migration, a duplicate number, a tracking divergence or a missing required
+# table still fails the deploy, because each of those describes something the
+# CURRENT deploy is about to get wrong.
+_CHECKSUM_ENFORCE_ENV = "SCHEMA_AUDIT_CHECKSUM_ENFORCE"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _checksum_severity() -> str:
+    """Severity for the checksum findings: "warning" unless explicitly armed.
+
+    Read per call, never cached at import: the release_command is a fresh
+    process, but a long-lived caller must not be pinned to the value the
+    module happened to see first.
+    """
+    return (
+        "error"
+        if os.environ.get(_CHECKSUM_ENFORCE_ENV, "").strip().lower() in _TRUTHY
+        else "warning"
+    )
+
+
 def _migration_sql_by_number() -> dict[int, Path]:
     """On-disk migration files keyed by number, discovered the same way the
     runner discovers them so the audit cannot drift from what actually applies."""
@@ -275,7 +319,7 @@ async def _check_migration_checksums(
             findings.append(
                 Finding(
                     code="migration_checksum_unallowed_sentinel",
-                    severity="error",
+                    severity=_checksum_severity(),
                     message=(
                         f"migration {number} ({row['migration_name']}) stores "
                         f"{stored!r}, which is not a sha256 digest, and the pair "
@@ -303,7 +347,7 @@ async def _check_migration_checksums(
             findings.append(
                 Finding(
                     code="migration_checksum_mismatch",
-                    severity="error",
+                    severity=_checksum_severity(),
                     message=(
                         f"migration {number} ({row['migration_name']}) does not match the "
                         "file on disk: the text applied to this database is not the text "
@@ -586,10 +630,16 @@ async def run_audit(
 def _format_human(report: AuditReport) -> str:
     lines = ["=" * 70, "SCHEMA AUDIT", "=" * 70]
     lines.append(f"Checks run: {', '.join(report.checks_run)}")
+    errors = sum(1 for f in report.findings if f.severity == "error")
+    warnings = len(report.findings) - errors
+    # A warning-only report must never render as an empty success. The whole
+    # risk of demoting a finding is that the summary line starts impersonating
+    # "nothing was found" -- so the count is always stated, on both branches.
+    suffix = f" ({warnings} warning(s))" if warnings else ""
     if report.ok:
-        lines.append("Result: OK — no errors")
+        lines.append(f"Result: OK — no errors{suffix}")
     else:
-        lines.append(f"Result: FAIL — {len(report.findings)} finding(s)")
+        lines.append(f"Result: FAIL — {errors} error(s){suffix}")
     for f in report.findings:
         lines.append("")
         lines.append(f"[{f.severity.upper()}] {f.code}")

--- a/apps/backend-rag/backend/tests/db/test_migration_checksum_verification.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_checksum_verification.py
@@ -25,6 +25,7 @@ from backend.db.schema_audit import (
     LEGACY_CHECKSUM_SENTINEL,
     SYMBOLIC_CHECKSUM_ALLOWLIST,
     _check_migration_checksums,
+    _checksum_severity,
     _migration_sql_by_number,
 )
 
@@ -249,7 +250,11 @@ async def test_a_tampered_row_is_caught_and_names_the_migration_number() -> None
         assert len(findings) == 1, findings
         f = findings[0]
         assert f.code == "migration_checksum_mismatch"
-        assert f.severity == "error"
+        # Default stage is WARNING (see `_checksum_severity`): the finding is
+        # raised in full, it just does not abort a deploy over state that
+        # predates the check. `SCHEMA_AUDIT_CHECKSUM_ENFORCE` flips it, and
+        # `TestChecksumEnforcementStage` below owns both halves of that.
+        assert f.severity == "warning"
         assert "299" in f.message
         assert f.details["migration_number"] == 299
         assert f.details["stored_checksum"] != f.details["recomputed_checksum"]
@@ -505,6 +510,167 @@ async def test_an_allowlisted_row_carrying_a_DIFFERENT_symbolic_value_still_erro
             "The allowlist must excuse one exact value, not a migration forever."
         )
         assert findings[0].code == "migration_checksum_unallowed_sentinel"
+    finally:
+        await conn.execute(f"DROP TABLE IF EXISTS {SCRATCH_TABLE}")
+        await conn.close()
+
+
+# --------------------------------------------------------------------------
+# ENFORCEMENT STAGE -- the checksum findings are staged, and the staging is
+# itself an adversarial surface.
+#
+# Demoting a finding has exactly one catastrophic failure mode: the finding
+# stops being COMPUTED, and the absence reads as health. Every test below is
+# aimed at that, not at the severity string.
+# --------------------------------------------------------------------------
+
+
+class TestChecksumEnforcementStage:
+    """GUILT and INNOCENCE for `_checksum_severity` and its blast radius."""
+
+    def test_the_default_stage_is_warning(self, monkeypatch) -> None:
+        """INNOCENCE. Unset means observe, and unset is the production state.
+
+        A verifier armed fail-closed against a database it was never measured
+        against is an outage, not a check -- which is what happened on
+        2026-08-30 between 19:02 UTC and this fix.
+        """
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
+        assert _checksum_severity() == "warning"
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on", " True "])
+    def test_the_env_var_arms_it(self, monkeypatch, raw: str) -> None:
+        """GUILT. Arming must actually arm -- including the shapes a human
+        types into `fly secrets set`, and including stray whitespace, which is
+        how a secret set from a shell heredoc arrives."""
+        monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raw)
+        assert _checksum_severity() == "error", f"{raw!r} failed to arm the check"
+
+    @pytest.mark.parametrize("raw", ["", "0", "false", "no", "off", "maybe", "warning"])
+    def test_a_non_truthy_value_does_not_arm_it(self, monkeypatch, raw: str) -> None:
+        """INNOCENCE, and the half that bites: a flag whose OFF value silently
+        reads as ON turns a staged rollout into the outage it was staging
+        around. `"false"` in particular is a non-empty string, and a naive
+        truthiness test would arm on it."""
+        monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raw)
+        assert _checksum_severity() == "warning", f"{raw!r} wrongly armed the check"
+
+    def test_the_stage_is_read_per_call_not_frozen_at_import(self, monkeypatch) -> None:
+        """A value cached at import time cannot be armed by a secret set after
+        the process starts, and the failure is silent: the env var is present,
+        the check stays demoted, and nobody learns why."""
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
+        assert _checksum_severity() == "warning"
+        monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", "1")
+        assert _checksum_severity() == "error"
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
+        assert _checksum_severity() == "warning"
+
+    def test_only_the_two_checksum_findings_are_staged(self) -> None:
+        """SCOPE. Everything else in this module still fails the deploy.
+
+        A pending migration, a duplicate number, a tracking divergence or a
+        missing required table each describe something the CURRENT deploy is
+        about to get wrong -- unlike a checksum row written in January, which
+        no amount of waiting makes verifiable. Read off the SOURCE rather than
+        by calling every check, because the point is that no future edit
+        quietly widens the demotion while the callers still look fine.
+        """
+        import inspect
+        import re
+
+        from backend.db import schema_audit
+
+        source = inspect.getsource(schema_audit)
+        # Pair each `code="..."` with the `severity=...` that follows it, which
+        # is how the Finding constructors are written throughout this module.
+        pairs = re.findall(
+            r'code="(?P<code>[a-z_]+)",\s*\n\s*severity=(?P<sev>[^,\n]+),', source
+        )
+        assert pairs, "no code/severity pairs found — the parse, not the module, is broken"
+        staged = {code for code, sev in pairs if sev == "_checksum_severity()"}
+        assert staged == {
+            "migration_checksum_unallowed_sentinel",
+            "migration_checksum_mismatch",
+        }, f"the set of staged findings changed: {sorted(staged)}"
+        for code, sev in pairs:
+            if code not in staged:
+                assert sev == '"error"', (
+                    f"{code} is no longer a hard error (severity={sev}); the "
+                    "demotion has leaked past the two checksum findings"
+                )
+
+    def test_a_warning_only_report_does_not_block_but_an_error_does(self) -> None:
+        """The actual deploy semantics, asserted on the object the
+        `release_command` exit code is derived from -- not on the severity
+        string, which is only a means to it."""
+        from backend.db.schema_audit import AuditReport, Finding
+
+        warn = Finding(code="c", severity="warning", message="m", details={})
+        err = Finding(code="c", severity="error", message="m", details={})
+        assert AuditReport(checks_run=["x"], findings=[warn, warn]).ok is True
+        assert AuditReport(checks_run=["x"], findings=[warn, err]).ok is False
+
+    def test_the_summary_line_never_hides_a_warning(self) -> None:
+        """The one thing a demotion must not buy: silence. A report carrying
+        warnings and no errors must SAY it carries warnings on its headline
+        line, because that line is what a human reads in a deploy log before
+        deciding whether to scroll."""
+        from backend.db.schema_audit import AuditReport, Finding, _format_human
+
+        warn = Finding(
+            code="migration_checksum_mismatch", severity="warning", message="m", details={}
+        )
+        text = _format_human(AuditReport(checks_run=["migration_checksums"], findings=[warn]))
+        headline = next(line for line in text.splitlines() if line.startswith("Result:"))
+        assert "warning" in headline, f"a warning-only report headlined as clean: {headline!r}"
+        assert "migration_checksum_mismatch" in text, "the finding itself vanished from the report"
+
+        clean = _format_human(AuditReport(checks_run=["migration_checksums"], findings=[]))
+        clean_headline = next(line for line in clean.splitlines() if line.startswith("Result:"))
+        assert "warning" not in clean_headline, (
+            f"a genuinely clean report claims warnings: {clean_headline!r}"
+        )
+
+
+@_live_only
+async def test_a_staged_finding_is_still_a_complete_finding() -> None:
+    """THE test of this change. Demotion must move the severity and NOTHING
+    else -- same code, same message, same details, same count. If a demoted
+    finding were also a thinner finding, the deploy log would stop carrying
+    what an operator needs to act, and the check would be disarmed in
+    substance while looking staged on paper.
+    """
+    import asyncpg
+
+    conn = await asyncpg.connect(TEST_DATABASE_URL)
+    try:
+        await _fresh_versions_table(conn, SCRATCH_TABLE)
+        path = _migration_sql_by_number()[299]
+        await conn.execute(
+            f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
+            "VALUES ($1, $2, $3)",
+            path.name, 299, hashlib.sha256(b"not what is on disk").hexdigest(),
+        )
+        # Same table, same row, read twice -- the only variable is the stage.
+        os.environ.pop("SCHEMA_AUDIT_CHECKSUM_ENFORCE", None)
+        staged = await _check_migration_checksums(
+            _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
+        )
+        os.environ["SCHEMA_AUDIT_CHECKSUM_ENFORCE"] = "1"
+        try:
+            armed = await _check_migration_checksums(
+                _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
+            )
+        finally:
+            os.environ.pop("SCHEMA_AUDIT_CHECKSUM_ENFORCE", None)
+
+        assert len(staged) == len(armed) == 1, (staged, armed)
+        assert staged[0].severity == "warning"
+        assert armed[0].severity == "error"
+        assert staged[0].code == armed[0].code
+        assert staged[0].message == armed[0].message
+        assert staged[0].details == armed[0].details
     finally:
         await conn.execute(f"DROP TABLE IF EXISTS {SCRATCH_TABLE}")
         await conn.close()


### PR DESCRIPTION
## 🔴 Every backend deploy has been failing for ~3 hours

`release_command` exits 1 on `schema_audit`, so nothing ships. Live `build_sha` is still `f537609969` (the 17:15 build); **25+ merged commits are stranded**, including two of mine and every PR merged after 19:02 UTC.

## The cause, and the comment that predicted it

#5335 added migration-checksum verification. Its own comment, in the same file, says:

> those against real sha256 digests would have failed the `release_command` on a PERFECTLY HEALTHY production database: a verifier turned into an outage, which is the worst possible outcome for a check whose whole purpose is to make deploys safer.

It shipped with a **four-entry** allowlist. Production carries **25 rows it does not cover** — read out of the failing run, not guessed:

| code | n | values seen |
|---|---|---|
| `migration_checksum_unallowed_sentinel` | 17 | `'manual_apply'` (2,3,4,5) · `'manual-fix'` (22,26) · `'manual'` (34) · `''` (6,19,23,40,41,42,43,44,45) · one MD5 (182) |
| `migration_checksum_mismatch` | 8 | 127, 157, 158, 186, 192, 200, 207, 217 |

All 25 **predate the check**. None describes anything *this* deploy is about to get wrong, and no amount of waiting makes a row written in January verifiable — so fail-closed here is not a check that will eventually pass. It is a permanent outage.

## The change

The two checksum findings are **staged**, the way this repo stages every other new guard (`E33_CLAIM_GUARD_ENFORCE`, `VISA_ENGINE_EVALUATE_MODE`):

- default `warning` — computed, printed, in the JSON, but not deploy-aborting;
- `SCHEMA_AUDIT_CHECKSUM_ENFORCE` flips both to `error`.

**Arming later is `fly secrets set`, not a revert of the verification.** The code comment records what must be true first: the 17 symbolic rows in the allowlist with their *measured* values, and the 8 mismatches reconciled or given a mechanism of their own (they have none today — there is no allowlist for a mismatch, by design).

### Deliberately NOT touched

`pending_migrations`, `tracking_divergence*`, `tracking_duplicate*`, `required_tables`, `client_email_uniqueness`. Each of those **is** about the deploy in flight, and each still fails it. Verified from the failing run that all 25 findings are the two demoted codes and the other four checks contributed **zero** — so production goes to **0 errors / 25 warnings**, and the deploy proceeds with every finding still printed.

## The corpus is aimed at the real risk

Demoting a finding has exactly one catastrophic failure mode: it stops being *computed*, and the silence reads as health. So:

- **`test_a_staged_finding_is_still_a_complete_finding`** runs the same row twice, staged and armed, and asserts identical `code`, `message`, `details` and count.
- **`_format_human` now states the warning count on its headline line in both branches** — a warning-only report cannot render as `OK — no errors` and nothing else.
- **`test_only_the_two_checksum_findings_are_staged`** parses the module source and fails if a third finding is ever demoted.
- Flag parsing has guilt **and** innocence, including `"false"` (a non-empty string a naive truthiness test would arm on) and whitespace (how a secret set from a heredoc arrives).

### Mutation-proven — each killed by the test that should kill it

| mutation | killed by |
|---|---|
| `_checksum_severity` always `error` | 11 tests |
| always `warning` | 8 tests |
| a third finding demoted | `test_only_the_two_checksum_findings_are_staged` |
| staged finding loses its `details` | `test_a_staged_finding_is_still_a_complete_finding` |
| warning suffix removed from the headline | `test_the_summary_line_never_hides_a_warning` |
| staged ⇒ `continue` (blindness) | completeness + tamper test |

31 passed against a real Postgres 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)