### PR TITLE
fix(nlm): two NLM watchers were searching through a retired door and calling the silence "no changes"

### DIFF
--- a/apps/evaluator/nlm_deep_research/freshness_monitor.py
+++ b/apps/evaluator/nlm_deep_research/freshness_monitor.py
@@ -48,8 +48,19 @@ FRESHNESS_STATE_FILE = _DIR / "freshness_monitor_state.json"
 _BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 _CHAT_ID = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "")
 
-# Gemini CLI timeout for web search queries
-GEMINI_TIMEOUT = 120
+# Web-search CLI used for regulatory monitoring. `agy` (Antigravity) — NOT the
+# legacy `gemini` CLI, whose auth tier is dead: it answers every call with
+# IneligibleTierError and that failure was being reported as "0 changes".
+WEB_SEARCH_CLI = "agy"
+
+# Timeout handed to the CLI itself, and the extra grace we give subprocess.run
+# on top of it so the CLI's own timeout fires first and we see its message
+# rather than a bare TimeoutExpired.
+WEB_SEARCH_TIMEOUT = 120
+WEB_SEARCH_GRACE = 30
+
+# Kept as an alias: external callers and older tests import this name.
+GEMINI_TIMEOUT = WEB_SEARCH_TIMEOUT
 
 # Max remediation queries per run (avoid NLM rate limiting)
 MAX_REMEDIATIONS_PER_RUN = 3
@@ -103,11 +114,20 @@ RESEARCH_TRIGGER_DELAY = 30  # seconds
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _run_gemini_search(query: str, timeout: int = GEMINI_TIMEOUT) -> str | None:
-    """Run Gemini CLI with web search for regulatory monitoring.
+def _run_web_search(query: str, timeout: int = WEB_SEARCH_TIMEOUT) -> str | None:
+    """Run a web-grounded search for regulatory monitoring via the `agy` CLI.
 
-    Uses gemini -p for headless mode with built-in web search.
-    No API SDK — uses CLI tool.
+    WHY NOT `gemini`: this function used to shell out to the legacy `gemini`
+    CLI, which has been answering every call with
+    `IneligibleTierError: This client is no longer supported for Gemini Code
+    Assist for individuals ... migrate to the Antigravity suite`. The monitor
+    swallowed that (see `run_scan`) and reported "Changes detected: 0" on every
+    domain of every recorded run — a green cron watching nothing. `agy` is the
+    Antigravity CLI the error message itself points at, and the one the repo's
+    own doctrine has named since the legacy CLI was deprecated.
+
+    The prompt is passed as an ARGUMENT to `-p`, never on stdin: `agy` reads
+    print-mode prompts from argv only, and a piped prompt is silently dropped.
     """
     prompt = (
         f"Search the web for: {query}\n\n"
@@ -117,21 +137,21 @@ def _run_gemini_search(query: str, timeout: int = GEMINI_TIMEOUT) -> str | None:
     )
     try:
         result = subprocess.run(
-            ["gemini", "-p", prompt, "--model", "gemini-3-flash-preview"],
-            capture_output=True, text=True, timeout=timeout,
+            [WEB_SEARCH_CLI, "-p", prompt, "--print-timeout", f"{timeout}s"],
+            capture_output=True, text=True, timeout=timeout + WEB_SEARCH_GRACE,
         )
         if result.returncode != 0:
-            logger.warning("Gemini CLI error: %s", result.stderr.strip()[:200])
+            logger.warning("%s error: %s", WEB_SEARCH_CLI, result.stderr.strip()[:200])
             return None
         return result.stdout.strip() or None
     except subprocess.TimeoutExpired:
-        logger.warning("Gemini search timeout after %ds", timeout)
+        logger.warning("web search timeout after %ds", timeout)
         return None
     except FileNotFoundError:
-        logger.error("gemini CLI not found — is it installed?")
+        logger.error("%s CLI not found — is it installed?", WEB_SEARCH_CLI)
         return None
     except Exception as exc:
-        logger.error("Gemini search error: %s", exc)
+        logger.error("web search error: %s", exc)
         return None
 
 
@@ -214,6 +234,12 @@ def run_scan(dry_run: bool = False) -> dict[str, Any]:
     result: dict[str, Any] = {
         "status": "ok",
         "domains_scanned": 0,
+        # domains_scanned counts ATTEMPTS; domains_answered counts the ones that
+        # came back with anything at all. The gap between them is the whole
+        # difference between "nothing changed" and "I cannot see" — and until
+        # 2026-08-31 only the first number existed, so five consecutive auth
+        # failures rendered as a calm "Changes detected: 0".
+        "domains_answered": 0,
         "changes_detected": 0,
         "research_triggered": 0,
         "dry_run": dry_run,
@@ -236,13 +262,15 @@ def run_scan(dry_run: bool = False) -> dict[str, Any]:
             logger.info("  DRY RUN: would search for '%s'", query[:60])
             continue
 
-        response = _run_gemini_search(query)
+        response = _run_web_search(query)
 
         if not response:
-            logger.warning("  No response from Gemini for %s", name)
-            result["errors"].append(f"{name}: no Gemini response")
+            logger.warning("  No response from the web-search CLI for %s", name)
+            result["errors"].append(f"{name}: no web-search response")
             time.sleep(5)
             continue
+
+        result["domains_answered"] += 1
 
         # Check if change detected — filter out error noise
         _noise_markers = ("MCP issues detected", "error", "failed to", "I am searching", "I will search")
@@ -302,8 +330,16 @@ def run_scan(dry_run: bool = False) -> dict[str, Any]:
             msg_lines.append(f"✅ {result['research_triggered']} ricerche NLM avviate")
         _send_telegram("\n".join(msg_lines))
 
+    # BLIND is not PARTIAL. A run where no domain answered at all has observed
+    # nothing, and its "changes_detected: 0" is not a finding — it is the
+    # absence of one. Reporting that as `partial` (which main() exits 0 on) is
+    # exactly how this organ ran green for its whole recorded log while every
+    # single call failed authentication. `dry_run` never counts as blind: it
+    # deliberately makes no calls.
     if result["errors"]:
         result["status"] = "partial"
+    if not dry_run and result["domains_scanned"] > 0 and result["domains_answered"] == 0:
+        result["status"] = "blind"
 
     return result
 
@@ -615,7 +651,14 @@ def main() -> None:
         result = run_scan(dry_run=args.dry_run)
         print(f"\nScan: {result['status']}")
         print(f"  Domains scanned: {result['domains_scanned']}")
-        print(f"  Changes detected: {result['changes_detected']}")
+        print(f"  Domains that answered: {result['domains_answered']}")
+        if result["status"] == "blind":
+            # Never print a bare "Changes detected: 0" for a run that saw
+            # nothing — that line is what made the failure look like a result.
+            print("  Changes detected: UNKNOWN — no domain answered, this run "
+                  "observed nothing")
+        else:
+            print(f"  Changes detected: {result['changes_detected']}")
         print(f"  Research triggered: {result['research_triggered']}")
         if result["errors"]:
             print(f"  Errors: {result['errors']}")

--- a/apps/evaluator/nlm_deep_research/gap_scanner.py
+++ b/apps/evaluator/nlm_deep_research/gap_scanner.py
@@ -555,15 +555,22 @@ def run_layer_b(dry_run: bool = False) -> dict[str, Any]:
 # Max remediation targets per run (NLM rate limiting)
 MAX_REMEDIATIONS_PER_RUN = 3
 
-# Gemini search timeout
-GEMINI_TIMEOUT = 120
+# Web-search CLI. NOT `gemini`: that binary's individual tier was retired
+# ("IneligibleTierError: ... migrate to the Antigravity suite"), and because
+# _run_web_search swallows a non-zero return code into None, every remediation
+# run since then reported "no content found" instead of "I cannot search".
+# `agy` IS the Antigravity CLI the error names. Its prompt must go in argv —
+# a piped prompt is silently dropped.
+WEB_SEARCH_CLI = "agy"
+WEB_SEARCH_TIMEOUT = 120
+GEMINI_TIMEOUT = WEB_SEARCH_TIMEOUT  # kept as an alias for older importers
 
 # Delay between NLM source_add calls
 REMEDIATION_DELAY = 15  # seconds
 
 
-def _run_gemini_search(query: str) -> str | None:
-    """Use Gemini CLI (built-in web search) to find content for a gap topic."""
+def _run_web_search(query: str) -> str | None:
+    """Use the web-search CLI to find content for a gap topic."""
     prompt = (
         f"Search the web for: {query}\n\n"
         "Provide a comprehensive 300-500 word summary of the most recent and authoritative "
@@ -572,24 +579,24 @@ def _run_gemini_search(query: str) -> str | None:
     )
     try:
         result = subprocess.run(
-            ["gemini", "-p", prompt, "--model", "gemini-3-flash-preview"],
-            capture_output=True, text=True, timeout=GEMINI_TIMEOUT,
+            [WEB_SEARCH_CLI, "-p", prompt, "--print-timeout", f"{WEB_SEARCH_TIMEOUT}s"],
+            capture_output=True, text=True, timeout=WEB_SEARCH_TIMEOUT + 30,
         )
         if result.returncode != 0:
-            logger.warning("Gemini CLI error: %s", result.stderr.strip()[:200])
+            logger.warning("Web-search CLI error: %s", result.stderr.strip()[:200])
             return None
         output = result.stdout.strip()
         if not output or "NO_RESULT" in output.upper():
             return None
         return output
     except subprocess.TimeoutExpired:
-        logger.warning("Gemini search timeout for: %s", query[:60])
+        logger.warning("Web search timeout for: %s", query[:60])
         return None
     except FileNotFoundError:
-        logger.error("gemini CLI not found in PATH")
+        logger.error("%s CLI not found in PATH", WEB_SEARCH_CLI)
         return None
     except Exception as exc:
-        logger.error("Gemini search error: %s", exc)
+        logger.error("Web search error: %s", exc)
         return None
 
 
@@ -630,6 +637,10 @@ def run_remediation(dry_run: bool = False) -> dict[str, Any]:
         "stale_topics_found": 0,
         "sources_added": 0,
         "search_failed": 0,
+        # searches_attempted vs searches_answered: search_failed alone cannot
+        # tell "found nothing" from "could not look", because both land here.
+        "searches_attempted": 0,
+        "searches_answered": 0,
         "dry_run": dry_run,
         "errors": [],
         "remediated": [],
@@ -676,12 +687,15 @@ def run_remediation(dry_run: bool = False) -> dict[str, Any]:
             result["remediated"].append({"domain": domain, "topic": topic, "status": "dry_run"})
             continue
 
-        content = _run_gemini_search(search_query)
+        result["searches_attempted"] += 1
+        content = _run_web_search(search_query)
         if not content:
             logger.warning("  No content found for: %s", topic[:60])
             result["search_failed"] += 1
             result["errors"].append(f"{domain}/{topic[:40]}: no search result")
             continue
+
+        result["searches_answered"] += 1
 
         # Title includes domain label and topic for easy identification
         source_title = f"[{label}] {topic[:80]} — {_now_iso()[:10]}"
@@ -717,8 +731,24 @@ def run_remediation(dry_run: bool = False) -> dict[str, Any]:
                 msg_lines.append(f"  • {item['domain']}: {item['topic'][:50]}")
         _send_telegram("\n".join(msg_lines))
 
+    # A run where every search failed added nothing AND saw nothing — and the
+    # Telegram block above only fires when sources_added > 0, so before this
+    # branch existed a fully blind remediation was completely silent.
+    blind = (
+        not dry_run
+        and result["searches_attempted"] > 0
+        and result["searches_answered"] == 0
+    )
     if result["errors"]:
         result["status"] = "partial"
+    if blind:
+        result["status"] = "blind"
+        _send_telegram(
+            "🕳️ <b>Gap Remediation BLIND</b>\n"
+            f"{result['searches_attempted']} ricerche tentate, 0 risposte.\n"
+            "Nessuna fonte aggiunta perché la ricerca web non vede — "
+            "non perché non ci fosse nulla da trovare."
+        )
 
     return result
 
@@ -826,7 +856,11 @@ def main() -> None:
         print(f"  GAP topics found: {result['gap_topics_found']}")
         print(f"  STALE topics found: {result['stale_topics_found']}")
         print(f"  Sources added: {result['sources_added']}")
+        print(f"  Searches attempted: {result['searches_attempted']}")
+        print(f"  Searches answered: {result['searches_answered']}")
         print(f"  Search failed: {result['search_failed']}")
+        if result["status"] == "blind":
+            print("  BLIND — no search answered; this run observed nothing")
         if result["errors"]:
             print(f"  Errors: {result['errors']}")
         sys.exit(0 if result["status"] in ("ok", "partial") else 1)

--- a/apps/evaluator/nlm_deep_research/tests/test_freshness_monitor.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_freshness_monitor.py
@@ -6,7 +6,7 @@ All external calls (gemini CLI, nlm CLI, Telegram) are mocked.
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from apps.evaluator.nlm_deep_research.freshness_monitor import (
     MAX_REMEDIATIONS_PER_RUN,
@@ -79,7 +79,7 @@ class TestRegulatoryDomains:
 # ---------------------------------------------------------------------------
 
 class TestRunScan:
-    def test_dry_run_skips_gemini(self):
+    def test_dry_run_skips_the_web_search(self):
         result = run_scan(dry_run=True)
         assert result["status"] == "ok"
         assert result["dry_run"] is True
@@ -87,10 +87,13 @@ class TestRunScan:
         assert result["changes_detected"] == 0
         assert result["research_triggered"] == 0
 
-    def test_no_change_detected(self, tmp_path, monkeypatch):
+    def test_every_domain_silent_is_blind_not_partial(self, tmp_path, monkeypatch):
+        """No domain answered -> BLIND. This test used to assert `partial`, and
+        that assertion is why the organ ran green through 13 consecutive runs in
+        which every single call failed authentication."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
         monkeypatch.setattr(
-            "apps.evaluator.nlm_deep_research.freshness_monitor._run_gemini_search",
+            "apps.evaluator.nlm_deep_research.freshness_monitor._run_web_search",
             lambda query: None,
         )
         monkeypatch.setattr(
@@ -98,15 +101,47 @@ class TestRunScan:
             tmp_path / "state.json",
         )
         result = run_scan(dry_run=False)
-        assert result["status"] == "partial"  # errors for missing Gemini responses
-        assert result["changes_detected"] == 0
+        assert result["status"] == "blind"
+        assert result["domains_scanned"] == len(REGULATORY_DOMAINS)
+        assert result["domains_answered"] == 0
         assert result["research_triggered"] == 0
+
+    def test_one_domain_answering_is_partial_not_blind(self, tmp_path, monkeypatch):
+        """Innocence: blindness must mean NOTHING was seen, not "something failed".
+        A single answering domain keeps the run at `partial`, which exits 0."""
+        seen: list[str] = []
+
+        def one_answers(query: str) -> str | None:
+            seen.append(query)
+            return "NO_CHANGE" if len(seen) == 1 else None
+
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
+        monkeypatch.setattr(
+            "apps.evaluator.nlm_deep_research.freshness_monitor._run_web_search",
+            one_answers,
+        )
+        monkeypatch.setattr(
+            "apps.evaluator.nlm_deep_research.freshness_monitor.FRESHNESS_STATE_FILE",
+            tmp_path / "state.json",
+        )
+        with patch("apps.evaluator.nlm_deep_research.freshness_monitor.time") as mock_time:
+            mock_time.sleep = lambda s: None
+            result = run_scan(dry_run=False)
+        assert result["status"] == "partial"
+        assert result["domains_answered"] == 1
+
+    def test_dry_run_is_never_blind(self):
+        """dry_run makes no calls by design; calling that blindness would turn
+        every rehearsal into a false alarm."""
+        result = run_scan(dry_run=True)
+        assert result["status"] == "ok"
+        assert result["domains_answered"] == 0
 
     def test_no_change_string_not_detected(self, tmp_path, monkeypatch):
         """Response containing NO_CHANGE should not count as a change."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
         monkeypatch.setattr(
-            "apps.evaluator.nlm_deep_research.freshness_monitor._run_gemini_search",
+            "apps.evaluator.nlm_deep_research.freshness_monitor._run_web_search",
             lambda query: "NO_CHANGE",
         )
         monkeypatch.setattr(
@@ -124,7 +159,7 @@ class TestRunScan:
         call_log = []
 
         monkeypatch.setattr(
-            "apps.evaluator.nlm_deep_research.freshness_monitor._run_gemini_search",
+            "apps.evaluator.nlm_deep_research.freshness_monitor._run_web_search",
             lambda query: "NUOVA NORMATIVA: aggiornamento recente",
         )
 
@@ -153,7 +188,7 @@ class TestRunScan:
         call_log = []
 
         monkeypatch.setattr(
-            "apps.evaluator.nlm_deep_research.freshness_monitor._run_gemini_search",
+            "apps.evaluator.nlm_deep_research.freshness_monitor._run_web_search",
             lambda query: "cambio normativo rilevato",
         )
 
@@ -174,12 +209,12 @@ class TestRunScan:
             run_scan(dry_run=False)
         assert len(call_log) <= MAX_REMEDIATIONS_PER_RUN
 
-    def test_gemini_none_does_not_crash(self, tmp_path, monkeypatch):
-        """None response from Gemini should record error but not crash."""
+    def test_a_silent_search_cli_does_not_crash_the_scan(self, tmp_path, monkeypatch):
+        """A None from the web-search CLI must be recorded, never raised."""
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "")
 
         monkeypatch.setattr(
-            "apps.evaluator.nlm_deep_research.freshness_monitor._run_gemini_search",
+            "apps.evaluator.nlm_deep_research.freshness_monitor._run_web_search",
             lambda query: None,
         )
         monkeypatch.setattr(
@@ -189,7 +224,7 @@ class TestRunScan:
         with patch("apps.evaluator.nlm_deep_research.freshness_monitor.time") as mock_time:
             mock_time.sleep = lambda s: None
             result = run_scan(dry_run=False)
-        assert result["status"] in ("ok", "partial")
+        assert result["status"] == "blind"
         assert result["changes_detected"] == 0
 
 
@@ -380,3 +415,29 @@ class TestGetStatus:
         # Should return defaults without crashing
         assert status["last_scan"] is None
         assert status["scan_count"] == 0
+
+
+from apps.evaluator.nlm_deep_research import freshness_monitor  # noqa: E402
+
+
+class TestTheDoorIsTheAntigravityCli:
+    """The prompt MUST travel in argv. `agy` silently drops a piped prompt —
+    it returns 0 with generic output, so a stdin regression would look like a
+    working search forever. And the binary must not drift back to `gemini`,
+    whose individual tier is retired."""
+
+    def test_prompt_goes_in_argv_never_stdin(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="content", stderr="")
+            freshness_monitor._run_web_search("KITAS requirements 2025")
+        argv, kwargs = mock_run.call_args[0][0], mock_run.call_args[1]
+        assert argv[0] == freshness_monitor.WEB_SEARCH_CLI == "agy"
+        assert argv[1] == "-p"
+        assert "KITAS" in argv[2], "the prompt must be argv[2], not piped"
+        assert "input" not in kwargs and "stdin" not in kwargs
+
+    def test_the_retired_gemini_binary_is_never_invoked(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="content", stderr="")
+            freshness_monitor._run_web_search("KITAS requirements 2025")
+        assert mock_run.call_args[0][0][0] != "gemini"

--- a/apps/evaluator/nlm_deep_research/tests/test_gap_remediation.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_gap_remediation.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 from apps.evaluator.nlm_deep_research.gap_scanner import (
     MAX_REMEDIATIONS_PER_RUN,
     _add_source_to_notebook,
-    _run_gemini_search,
+    _run_web_search,
     run_remediation,
 )
 
@@ -47,48 +47,48 @@ SAMPLE_MATRIX = {
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: _run_gemini_search
+# Unit tests: _run_web_search
 # ---------------------------------------------------------------------------
 
 
-class TestRunGeminiSearch:
+class TestRunWebSearch:
     def test_returns_content_on_success(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0, stdout="Immigration regulation update 2025...", stderr=""
             )
-            result = _run_gemini_search("KITAS requirements 2025")
+            result = _run_web_search("KITAS requirements 2025")
         assert result is not None
         assert "Immigration" in result
 
     def test_returns_none_on_no_result_marker(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="NO_RESULT", stderr="")
-            result = _run_gemini_search("obscure topic")
+            result = _run_web_search("obscure topic")
         assert result is None
 
     def test_returns_none_on_nonzero_exit(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
-            result = _run_gemini_search("something")
+            result = _run_web_search("something")
         assert result is None
 
-    def test_returns_none_if_gemini_not_found(self):
+    def test_returns_none_if_the_cli_is_not_found(self):
         with patch("subprocess.run", side_effect=FileNotFoundError):
-            result = _run_gemini_search("something")
+            result = _run_web_search("something")
         assert result is None
 
     def test_returns_none_on_timeout(self):
         import subprocess
 
         with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gemini", 120)):
-            result = _run_gemini_search("something")
+            result = _run_web_search("something")
         assert result is None
 
     def test_returns_none_on_empty_output(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-            result = _run_gemini_search("something")
+            result = _run_web_search("something")
         assert result is None
 
 
@@ -188,7 +188,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 side_effect=fake_gemini,
             ),
             patch(
@@ -236,7 +236,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 side_effect=fake_gemini,
             ),
             patch(
@@ -252,7 +252,7 @@ class TestRunRemediation:
         assert result["sources_added"] == MAX_REMEDIATIONS_PER_RUN
 
     def test_handles_gemini_failure_gracefully(self, tmp_path):
-        """If Gemini returns nothing, record error but continue with next topic."""
+        """If the search CLI returns nothing, record it and continue — and say BLIND."""
         matrix_file = tmp_path / "coverage_matrix.json"
         matrix_file.write_text(json.dumps(SAMPLE_MATRIX))
 
@@ -262,7 +262,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 return_value=None,
             ),
             patch("time.sleep"),
@@ -271,7 +271,10 @@ class TestRunRemediation:
 
         assert result["sources_added"] == 0
         assert result["search_failed"] == MAX_REMEDIATIONS_PER_RUN
-        assert result["status"] == "partial"
+        assert result["searches_attempted"] == MAX_REMEDIATIONS_PER_RUN
+        assert result["searches_answered"] == 0
+        # BLIND, not partial: nothing was added because nothing could be seen.
+        assert result["status"] == "blind"
 
     def test_marks_remediated_topics_as_fresh_in_matrix(self, tmp_path):
         """After adding a source, the topic should be marked FRESH in the matrix."""
@@ -291,7 +294,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 return_value="Updated KITAS information 2025...",
             ),
             patch(
@@ -322,7 +325,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 return_value="Some content",
             ),
             patch(
@@ -341,8 +344,10 @@ class TestRunRemediation:
         assert "Remediation" in call_text
         assert "Fonti aggiunte" in call_text
 
-    def test_no_telegram_when_nothing_added(self, tmp_path):
-        """If no sources were added, no Telegram notification."""
+    def test_a_fully_blind_run_still_speaks(self, tmp_path):
+        """The "sources added" Telegram block only fires when something WAS
+        added, so a run that could not search at all used to be perfectly
+        silent — the loudest failure mode there is."""
         matrix_file = tmp_path / "coverage_matrix.json"
         matrix_file.write_text(json.dumps(SAMPLE_MATRIX))
 
@@ -352,7 +357,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 return_value=None,
             ),
             patch(
@@ -360,9 +365,11 @@ class TestRunRemediation:
             ) as mock_tg,
             patch("time.sleep"),
         ):
-            run_remediation(dry_run=False)
+            result = run_remediation(dry_run=False)
 
-        mock_tg.assert_not_called()
+        assert result["status"] == "blind"
+        mock_tg.assert_called_once()
+        assert "BLIND" in mock_tg.call_args[0][0]
 
     def test_empty_matrix_returns_ok_with_zero_counts(self, tmp_path):
         matrix_file = tmp_path / "coverage_matrix.json"
@@ -392,7 +399,7 @@ class TestRunRemediation:
                 matrix_file,
             ),
             patch(
-                "apps.evaluator.nlm_deep_research.gap_scanner._run_gemini_search",
+                "apps.evaluator.nlm_deep_research.gap_scanner._run_web_search",
                 return_value="Content found",
             ),
             patch(
@@ -430,3 +437,29 @@ class TestRemediationCLI:
 
         # Should exit 0 (empty matrix = ok)
         mock_exit.assert_called_once_with(0)
+
+
+from apps.evaluator.nlm_deep_research import gap_scanner  # noqa: E402
+
+
+class TestTheDoorIsTheAntigravityCli:
+    """The prompt MUST travel in argv. `agy` silently drops a piped prompt —
+    it returns 0 with generic output, so a stdin regression would look like a
+    working search forever. And the binary must not drift back to `gemini`,
+    whose individual tier is retired."""
+
+    def test_prompt_goes_in_argv_never_stdin(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="content", stderr="")
+            _run_web_search("KITAS requirements 2025")
+        argv, kwargs = mock_run.call_args[0][0], mock_run.call_args[1]
+        assert argv[0] == gap_scanner.WEB_SEARCH_CLI == "agy"
+        assert argv[1] == "-p"
+        assert "KITAS" in argv[2], "the prompt must be argv[2], not piped"
+        assert "input" not in kwargs and "stdin" not in kwargs
+
+    def test_the_retired_gemini_binary_is_never_invoked(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="content", stderr="")
+            _run_web_search("KITAS requirements 2025")
+        assert mock_run.call_args[0][0][0] != "gemini"


### PR DESCRIPTION
## What was measured

`freshness_monitor` (Pro cron, daily 22:00 UTC) and `gap_scanner --remediate` (Pro cron, Sunday 20:30 UTC) both reach the web through the `gemini` CLI. That binary's individual tier was retired and now answers every call with:

```
Error authenticating: IneligibleTierError: This client is no longer supported for
Gemini Code Assist for individuals ... migrate to the Antigravity suite of products
```

Both call sites swallow a non-zero return code into `None`. Both then read `None` as *"this domain reported nothing new."*

Measured on Pro, not inferred:

| organ | evidence |
|---|---|
| `freshness_monitor` | all **13** recorded runs printed `Changes detected: 0` + `Done (exit=0)`; the auth error is present in the **very first** log line |
| `gap_scanner --remediate` | the auth error appears **9×** in `~/logs/cron-tmp/gap-scanner.log` |

The remediation path is worse than merely wrong: its Telegram block only fires when `sources_added > 0`, so a run that could see nothing at all **said nothing at all**.

## Two defects, both fixed

**1. The door.** `agy` is the Antigravity CLI the error message itself names, and it is already armed on Pro. Both call sites now use it. The prompt goes in **argv** — `agy` silently drops a piped prompt and still exits 0, so a stdin regression would look like a working search forever.

**2. The silence.** New `blind` state, distinct from `partial`. A run with `domains_scanned > 0` and `domains_answered == 0` has observed nothing; its "changes detected: 0" is the *absence* of a finding, not a finding. `blind` exits non-zero, refuses to print the reassuring zero, and on the remediation path sends the alert that silence used to suppress. `dry_run` is never blind — it makes no calls by design.

## PROVE-LIVE

Ran the exact argv shape from Pro:

```
agy -p "Search the web for: Imigrasi Indonesia peraturan terbaru 2026 e-VOA..." --print-timeout 120s
EXIT=0
```

Returned web-grounded content citing `evisa.imigrasi.go.id` and the All Indonesia arrival declaration.

## Verification

45 tests pass. Five mutations, each caught by a **named** test:

| mutation | red tests |
|---|---|
| drop the freshness `blind` branch | 2 |
| never increment `domains_answered` | 1 |
| let `blind` ignore `dry_run` | 2 |
| drop the gap_scanner `blind` branch + its alert | 2 |
| point the door back at `gemini` | 4 |

Two tests that previously **asserted the defect** — `test_no_change_detected` and `test_no_telegram_when_nothing_added` — now assert the cure. They are why the blindness survived review: the suite had written it down as correct.

Refs: superscar family **#2** (green ≠ working — read the OUTPUT).