### PR TITLE
fix(queue-unstick): a permanent merge=union divergence was reported as a transient race

### DIFF
--- a/scripts/queue_unstick.py
+++ b/scripts/queue_unstick.py
@@ -429,6 +429,46 @@ def do_update_branch(
     return "ok", f"update-branch OK PR #{number}: {out.strip() or 'requested'}"
 
 
+def _union_merged_changed_paths(
+    *, repo_root: Path, base_ref: str, pr_ref: str, timeout: int = 25
+) -> list[str]:
+    """Paths this PR changes that `.gitattributes` marks `merge=union`.
+
+    Read-only, and deliberately fail-quiet: every failure returns `[]`, which
+    makes the caller fall back to its pre-existing "race" wording. An empty
+    list therefore means "no union path FOUND", never "no union path EXISTS" —
+    so this can only ever add a diagnosis, never suppress one.
+    """
+    rc, out, _err = _run(
+        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...{pr_ref}"],
+        timeout=timeout,
+    )
+    if rc != 0:
+        return []
+    paths = [p for p in out.splitlines() if p.strip()]
+    if not paths:
+        return []
+    # `check-attr` is given the paths after `--`, so a leading-dash filename is
+    # not read as a flag. Capped because a huge PR would otherwise blow argv.
+    rc, out, _err = _run(
+        ["git", "-C", str(repo_root), "check-attr", "merge", "--", *paths[:200]],
+        timeout=timeout,
+    )
+    if rc != 0:
+        return []
+    union: list[str] = []
+    for line in out.splitlines():
+        # Format is `<path>: merge: <value>`. Split from the RIGHT: a path may
+        # legitimately contain ": " and a left split would truncate it.
+        head, sep, value = line.rpartition(": ")
+        if not sep or value.strip() != "union":
+            continue
+        path = head[: -len(": merge")] if head.endswith(": merge") else None
+        if path:
+            union.append(path)
+    return union
+
+
 def get_conflicting_files(pr: dict, *, repo_root: Path = REPO_ROOT, timeout: int = 25) -> str:
     """Best-effort LOCAL merge simulation (git merge-tree --write-tree
     --name-only) to name the real conflicting files, without ever touching
@@ -464,8 +504,33 @@ def get_conflicting_files(pr: dict, *, repo_root: Path = REPO_ROOT, timeout: int
         )
         lines = [line for line in out.splitlines() if line.strip()]
         if rc == 0:
-            # No conflict after all (race: PR was updated between the
-            # GraphQL read and this probe) — say so plainly, don't lie.
+            # GitHub says DIRTY and the local merge says clean. There are two
+            # causes, and they want OPPOSITE responses, so naming the right one
+            # is the whole value of this branch.
+            #
+            #   1. A race: the PR moved between the GraphQL read and this probe.
+            #      Transient — the next tick reports it correctly.
+            #   2. A `merge=union` path. git's merge driver resolves the file by
+            #      concatenating both sides and exits 0; GitHub's merge queue
+            #      does NOT honour `.gitattributes` merge drivers and reports a
+            #      real conflict. PERMANENT — re-probing can never clear it, and
+            #      only a hand rebase of that file will.
+            #
+            # Measured 2026-08-31 on PRs #5331 and #5373: both were DIRTY on
+            # GitHub with `merge-tree` rc=0, and both touched the repo's single
+            # union-merged path, `.claude/skills/modus/PENDING-ARMS.md`. Reported
+            # as a race, that is a permanent condition wearing a transient label.
+            union = _union_merged_changed_paths(
+                repo_root=repo_root, base_ref=base_ref, pr_ref=pr_ref, timeout=timeout
+            )
+            if union:
+                shown = ", ".join(union[:5]) + (" (+more)" if len(union) > 5 else "")
+                return (
+                    f"none locally, but this is NOT a race: {shown} carries "
+                    "`merge=union` in .gitattributes, which git's merge-tree honours "
+                    "and GitHub's merge queue does not. Re-probing will never clear "
+                    "it — the cure is a hand rebase of that file."
+                )
             return "none (merge-tree found no conflict at probe time)"
         # First line is the (conflicted) tree OID; the rest, with
         # --name-only, are the conflicting paths.

--- a/scripts/tests/test_queue_unstick.py
+++ b/scripts/tests/test_queue_unstick.py
@@ -450,3 +450,100 @@ def test_hold_labels_are_case_insensitive():
     pr = make_pr(50, merge_state_status="BEHIND", minutes_since_commit=30, labels=["Hold"])
     plan = qu.plan_actions([pr], NOW)
     assert plan["skipped"][50] == "hold_label"
+
+
+# ---------------------------------------------------------------------------
+# _union_merged_changed_paths — guilt + innocence against a REAL git repo.
+#
+# These build an actual repository rather than stubbing `_run`, because the
+# behaviour under test is entirely `git check-attr`'s: a fake would encode my
+# belief about its output format and agree with itself (superscar #9 / W114 —
+# a fake and the code it checks share the same imagination).
+# ---------------------------------------------------------------------------
+
+import subprocess as _sp  # noqa: E402
+
+
+def _git(repo, *args):
+    _sp.run(["git", "-C", str(repo), *args], check=True,
+            capture_output=True, text=True)
+
+
+def _repo_with(tmp_path, gitattributes: str | None):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+    if gitattributes is not None:
+        (repo / ".gitattributes").write_text(gitattributes)
+    (repo / "ledger.md").write_text("base\n")
+    (repo / "plain.txt").write_text("base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    _git(repo, "branch", "base-ref")
+    (repo / "ledger.md").write_text("base\npr row\n")
+    (repo / "plain.txt").write_text("base\npr line\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "pr")
+    _git(repo, "branch", "pr-ref")
+    return repo
+
+
+def test_union_path_is_named_when_the_pr_touches_one(tmp_path):
+    """GUILT: the changed file carries merge=union -> it is reported."""
+    repo = _repo_with(tmp_path, "ledger.md merge=union\n")
+    found = qu._union_merged_changed_paths(
+        repo_root=repo, base_ref="base-ref", pr_ref="pr-ref"
+    )
+    assert found == ["ledger.md"]
+
+
+def test_non_union_paths_are_not_named(tmp_path):
+    """INNOCENCE: a PR touching only ordinary files reports nothing, so the
+    caller keeps its pre-existing 'race' wording."""
+    repo = _repo_with(tmp_path, "ledger.md merge=union\n")
+    _git(repo, "checkout", "-q", "-b", "plain-only", "base-ref")
+    (repo / "plain.txt").write_text("base\nonly this\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "plain only")
+    found = qu._union_merged_changed_paths(
+        repo_root=repo, base_ref="base-ref", pr_ref="plain-only"
+    )
+    assert found == []
+
+
+def test_no_gitattributes_at_all_reports_nothing(tmp_path):
+    """INNOCENCE: the same diff, with no merge driver declared anywhere."""
+    repo = _repo_with(tmp_path, None)
+    found = qu._union_merged_changed_paths(
+        repo_root=repo, base_ref="base-ref", pr_ref="pr-ref"
+    )
+    assert found == []
+
+
+def test_a_path_containing_a_colon_survives_the_parse(tmp_path):
+    """`check-attr` prints `<path>: merge: <value>`; splitting from the LEFT
+    would truncate a path that legitimately contains ': '."""
+    # DOUBLE quotes: `.gitattributes` rejects a single-quoted pattern outright
+    # ("name.md' is not a valid attribute name"), which silently yields
+    # `merge: unspecified` and would make this test pass for the wrong reason.
+    repo = _repo_with(tmp_path, '"weird: name.md" merge=union\n')
+    _git(repo, "checkout", "-q", "-b", "colon", "base-ref")
+    (repo / "weird: name.md").write_text("x\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "colon path")
+    found = qu._union_merged_changed_paths(
+        repo_root=repo, base_ref="base-ref", pr_ref="colon"
+    )
+    assert found == ["weird: name.md"]
+
+
+def test_a_broken_repo_returns_empty_rather_than_raising(tmp_path):
+    """The probe is fail-quiet by design: an unusable repo must degrade to the
+    caller's existing wording, never crash the daemon's tick."""
+    empty = tmp_path / "not-a-repo"
+    empty.mkdir()
+    assert qu._union_merged_changed_paths(
+        repo_root=empty, base_ref="base-ref", pr_ref="pr-ref"
+    ) == []


### PR DESCRIPTION
## The defect

`get_conflicting_files` runs a local `git merge-tree` when GitHub reports a PR DIRTY, so the fleet-watch daemon can name the conflicting files. When that probe exits **0** — GitHub says conflict, git says clean — it reported:

```
conflicting files: none (merge-tree found no conflict at probe time)
```

The parenthetical attributes the disagreement to a **race**: the PR moved between the GraphQL read and the probe. That cause is real. It is not the only one, and the other wants the opposite response.

## The second cause, measured

`.gitattributes` declares exactly one union-merged path:

```
.claude/skills/modus/PENDING-ARMS.md merge=union
```

git's merge driver resolves that file by concatenating both sides and exits 0. **GitHub's merge queue does not honour `.gitattributes` merge drivers at all** and reports a genuine conflict. The two tools are both right about different merges.

Measured on 2026-08-31, on two PRs the daemon reported within ten seconds of each other:

| PR | GitHub | local `merge-tree` | touches a union path? |
|---|---|---|---|
| #5331 | DIRTY | rc=0, no conflict | **yes** — `PENDING-ARMS.md` |
| #5373 | DIRTY | rc=0, no conflict | **yes** — `PENDING-ARMS.md` |

This condition is **permanent**. Re-probing can never clear it; only a hand rebase of that file will. Reporting it as a race tells the reader to wait for something that waiting cannot fix — which is worse than saying nothing, because it names a cure.

## The change

`_union_merged_changed_paths()` asks `git check-attr merge` about the paths the PR actually changes. When the rc=0 branch finds one, the message becomes:

```
conflicting files: none locally, but this is NOT a race: .claude/skills/modus/PENDING-ARMS.md
carries `merge=union` in .gitattributes, which git's merge-tree honours and GitHub's merge
queue does not. Re-probing will never clear it — the cure is a hand rebase of that file.
```

**Fail-quiet by construction.** Every failure path returns `[]` and the caller falls back to the pre-existing race wording, so this can only ever *add* a diagnosis, never suppress one. An empty list means "no union path **found**", never "no union path **exists**" — and the docstring says so, because that distinction is the whole safety argument.

The daemon still refuses to touch the branch. This changes only what it tells you.

## Verification

**End-to-end against the real PR that produced the confusing message**, not a fixture:

```
PR #5331 union-merged paths: ['.claude/skills/modus/PENDING-ARMS.md']
```

**Tests build a real git repository** rather than stubbing `_run`, because the behaviour under test is entirely `git check-attr`'s output format — a fake would encode my belief about that format and then agree with itself (superscar #9 / W114: a fake and the code it checks share the same imagination).

- **Guilt** — a changed file carrying `merge=union` is named.
- **Innocence** — a PR touching only ordinary files reports nothing; so does a repo with no `.gitattributes` at all.
- A path containing `": "` survives the parse (`check-attr` prints `<path>: merge: <value>`; splitting from the left would truncate it).
- A broken repo returns `[]` rather than raising — the daemon's tick must not die on a bad checkout.

`36 passed in 0.90s`.

## One thing worth saying about how this was verified

The colon-path test **failed on its first run**, and the fixture was wrong, not the code: `.gitattributes` requires **double** quotes, and my single-quoted pattern was rejected outright by git —

```
name.md' is not a valid attribute name: .gitattributes:1
weird: name.md: merge: unspecified
```

— which silently produced `unspecified` and would have made the test pass for the wrong reason had I written the assertion the other way round. I probed git directly to find out which side was wrong instead of adjusting the code until the test went green. The comment naming that trap ships with the test.

Gear floor **1** (`--print-floor`), no hot-zone hit, 2 files, +164/−2.