### PR TITLE
fix(imigrasi-mirror): the signed pack cited two portal pages the mirror never fetched, and nothing guarded the snapshot filename

### DIFF
--- a/scripts/imigrasi_mirror/run.py
+++ b/scripts/imigrasi_mirror/run.py
@@ -2,7 +2,7 @@
 """imigrasi.go.id scoped mirror — crawl, snapshot, diff, alert.
 
 Usage:
-    run.py --tier daily              # 9 pages: 4 subject lists + FAQ + index + 3 regional
+    run.py --tier daily              # 15 pages (count asserted in urls.py, not narrated here)
     run.py --tier weekly             # 114 per-visa-code pages
     run.py --tier all                # everything
     run.py --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset (dry-run scope)

--- a/scripts/imigrasi_mirror/urls.py
+++ b/scripts/imigrasi_mirror/urls.py
@@ -13,7 +13,11 @@ downstream-of-policy surface the client actually reads, a second independent
 witness to a rule change), and the TPI entry-point list — the 122 immigration
 checkpoints (airports / seaports / land-border posts) where VoA is actually
 granted, the operational counterpart to the subject lists (WHO may get VoA vs
-WHERE it is issued). ~127 pages total (13 "daily" + 114 "weekly").
+WHERE it is issued). v3 (2026-08-31) adds the last two RulePack
+OFFICIAL_PORTAL urls that were cited but never mirrored: the 2024 bridging-visa
+press release and the ITK-to-ITAS status-conversion page.
+129 pages total (15 "daily" + 114 "weekly"), asserted below so the number
+cannot go stale in prose the way it already had.
 
 Every URL below was verified live (200, real content — not a 404) before being
 committed here (anti-hallucination discipline, CLAUDE.md §6): the v1 set on
@@ -228,6 +232,39 @@ DAILY_PAGES: list[Page] = [
         tier="daily",
         category="regional",
     ),
+    # v3 (2026-08-31): the two OFFICIAL_PORTAL urls the signed RulePack cites
+    # that this catalog did not cover. Found by auditing the pack's 18
+    # OFFICIAL_PORTAL source records against the 127 slugs actually on disk:
+    # 16 were mirrored, these 2 never were, so the engine had a freshness
+    # policy on a page nobody was watching.
+    #
+    # Both are DAILY on purpose. 14 of the 16 already-covered portal urls sit
+    # on the weekly `code-*` tier, which means a change to them is invisible
+    # for up to six days. A bridging-visa announcement and a status-conversion
+    # service page are exactly the surfaces that must not be seen once a week.
+    #
+    # Extraction-stability probed live from Mini on 2026-08-31, two fetches
+    # each, per this file's own house rule:
+    #   bridging-visa-press-2024  200, 2436 chars, sha1 d58841c0fc69b58c x2
+    #   itk-to-itas               200, 3728 chars, sha1 604ea66a793f4610 x2
+    # Both land on the real content block, not the boilerplate banner that
+    # trapped extract_text() on 2026-08-08, so `default` is correct for both.
+    Page(
+        id="bridging-visa-press-2024",
+        url=f"{BASE}/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+        slug="bridging-visa-press-2024",
+        label="Siaran pers 2024 — Izin Tinggal Peralihan (bridging visa)",
+        tier="daily",
+        category="berita",
+    ),
+    Page(
+        id="itk-to-itas",
+        url=f"{BASE}/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+        slug="itk-to-itas",
+        label="Alih status ITK -> ITAS — pagina di servizio izin tinggal",
+        tier="daily",
+        category="list",
+    ),
 ]
 
 # --- weekly tier: the ~114 per-visa-code detail pages -----------------------
@@ -245,8 +282,28 @@ WEEKLY_PAGES: list[Page] = [
 
 ALL_PAGES: list[Page] = DAILY_PAGES + WEEKLY_PAGES
 
+# Asserted, not narrated. The module docstring carried "~127 (13 daily + 114
+# weekly)" as prose and `run.py --help` still says "9 pages" from an earlier
+# era; prose drifts silently, an assert does not.
+assert len(DAILY_PAGES) == 15, f"expected 15 daily pages, got {len(DAILY_PAGES)}"
+assert len(ALL_PAGES) == 129, f"expected 129 pages, got {len(ALL_PAGES)}"
+
 _BY_ID = {p.id: p for p in ALL_PAGES}
 assert len(_BY_ID) == len(ALL_PAGES), "duplicate page id in catalog"
+
+# The slug is the snapshot FILENAME STEM (`snapshots/<date>/<slug>.txt`), and
+# until 2026-08-31 nothing checked it. Only `id` was guarded, and the two are
+# deliberately allowed to differ (`id="parent"` / `slug="voa-bvk-calling-parent"`
+# ships that way today) — so a hand-authored daily page could reuse another
+# page's slug and the two would overwrite each other's snapshot on EVERY run,
+# silently, with no error and no missing file to notice. The mirror would keep
+# reporting "no diffs" for whichever page lost the race.
+_BY_SLUG = {p.slug: p for p in ALL_PAGES}
+assert len(_BY_SLUG) == len(ALL_PAGES), (
+    "duplicate page slug in catalog — two pages would overwrite each other's "
+    "snapshot file every run: "
+    + repr(sorted({p.slug for p in ALL_PAGES if sum(q.slug == p.slug for q in ALL_PAGES) > 1}))
+)
 
 
 def pages_for_tier(tier: str) -> list[Page]:

--- a/scripts/tests/test_imigrasi_mirror_catalog.py
+++ b/scripts/tests/test_imigrasi_mirror_catalog.py
@@ -1,0 +1,182 @@
+"""The imigrasi mirror's URL catalog must cover what the signed RulePack cites,
+and must not let two pages share a snapshot filename.
+
+Why this file exists at all: until 2026-08-31 the mirror had NO test surface.
+Its only guards were two import-time asserts inside `urls.py` — one on `CODES`,
+one on page `id` — and an assert that nothing exercises deliberately is a guard
+whose innocence half was never checked. Both properties below are load-bearing
+and both were, until this file, unwatched:
+
+  * COVERAGE. The RulePack carries a freshness policy per OFFICIAL_PORTAL
+    source. A policy on a page the mirror never fetches is a promise nobody
+    can keep: the clock expires, the engine abstains, and no snapshot exists
+    to say whether anything actually changed. Two of the pack's 18 portal urls
+    were in exactly that state.
+  * SLUG UNIQUENESS. The slug is the snapshot filename stem. `id` and `slug`
+    are allowed to differ, so a hand-authored daily page can silently reuse
+    another page's slug — after which the two overwrite each other every run,
+    with no error, no missing file, and a permanent "no diffs" for whichever
+    one lost.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO / "scripts"))
+
+from imigrasi_mirror import urls as catalog  # noqa: E402
+
+_PACKS = (
+    _REPO
+    / "apps/backend-rag/backend/services/visa_engine/contracts/packs"
+)
+
+
+def _latest_pack_source() -> dict:
+    """The highest-numbered `rulepack-prod-NNN.source.json` on disk.
+
+    Read by number rather than pinned to one sequence: pinning would make this
+    test go quietly irrelevant the moment a forward pack ships, which is the
+    same "watching the wrong thing" failure it exists to prevent.
+    """
+    candidates = sorted(
+        _PACKS.glob("rulepack-prod-*.source.json"),
+        key=lambda q: int(q.name.split("-")[2].split(".")[0]),
+    )
+    if not candidates:
+        pytest.skip(f"no rulepack source files on disk under {_PACKS}")
+    return json.loads(candidates[-1].read_text())
+
+
+#: The field is `authority_type`, NOT `source_class`. Written down because the
+#: first draft of this file guessed `source_class`, which matches nothing in a
+#: real pack — so `_portal_urls` returned the empty set, the coverage test
+#: compared nothing against everything, and it passed. A green that means "I
+#: found no records to check" is indistinguishable from "every record is
+#: covered" unless something asserts the set is non-empty, which
+#: `test_the_pack_actually_has_portal_records_to_check` now does.
+_PORTAL = "OFFICIAL_PORTAL"
+
+
+def _portal_urls(pack: dict) -> set[str]:
+    return {
+        record["canonical_url"]
+        for record in pack.get("source_records", [])
+        if record.get("authority_type") == _PORTAL
+    }
+
+
+def _normalise(url: str) -> str:
+    """Compare on scheme-less host+path, no trailing slash.
+
+    The catalog and the pack are hand-maintained separately, so a mismatch on
+    `http` vs `https` or a trailing slash would read as "not covered" and send
+    someone chasing a gap that is not there.
+    """
+    parts = urlsplit(url)
+    return f"{parts.netloc}{parts.path}".rstrip("/").lower()
+
+
+def test_the_pack_actually_has_portal_records_to_check():
+    """NON-VACUITY, and it is not ceremony: without it, renaming the field or
+    the value in a future pack would silently turn every coverage assertion in
+    this file into a comparison of two empty sets, reported as a pass."""
+    portal = _portal_urls(_latest_pack_source())
+    assert portal, (
+        "no OFFICIAL_PORTAL records found — either the pack changed shape or "
+        f"the {_PORTAL!r} value moved off `authority_type`. Every coverage "
+        "check below is vacuous until this is fixed."
+    )
+    assert len(portal) >= 18, f"portal record count dropped to {len(portal)}"
+
+
+def test_every_official_portal_url_in_the_pack_is_mirrored():
+    """COVERAGE, the real thing — not a fixture."""
+    pack = _latest_pack_source()
+    mirrored = {_normalise(p.url) for p in catalog.ALL_PAGES}
+    missing = sorted(u for u in _portal_urls(pack) if _normalise(u) not in mirrored)
+    assert not missing, (
+        "the signed RulePack carries a freshness policy for these OFFICIAL_PORTAL "
+        "urls, but the mirror never fetches them, so nothing can tell a real "
+        "'unchanged' from 'never looked': " + repr(missing)
+    )
+
+
+def test_the_two_urls_this_file_was_written_for_are_daily_not_weekly():
+    """A page mirrored on the weekly tier is invisible for up to six days.
+    For a bridging-visa announcement and a status-conversion page that is not
+    coverage, it is a delay dressed as coverage."""
+    by_id = {p.id: p for p in catalog.ALL_PAGES}
+    for page_id in ("bridging-visa-press-2024", "itk-to-itas"):
+        assert page_id in by_id, f"{page_id} vanished from the catalog"
+        assert by_id[page_id].tier == "daily", (
+            f"{page_id} is on the {by_id[page_id].tier} tier"
+        )
+
+
+def test_the_coverage_check_can_actually_fail():
+    """GUILT. A coverage test that cannot go red proves nothing — and this one
+    reads real files, so its silence would be indistinguishable from success if
+    the normalisation or the source_class filter were wrong."""
+    pack = {
+        "source_records": [
+            {
+                "authority_type": "OFFICIAL_PORTAL",
+                "canonical_url": "https://www.imigrasi.go.id/wna/a-page-nobody-mirrors",
+            }
+        ]
+    }
+    mirrored = {_normalise(p.url) for p in catalog.ALL_PAGES}
+    assert [u for u in _portal_urls(pack) if _normalise(u) not in mirrored]
+
+
+def test_a_non_portal_source_is_not_demanded_of_the_mirror():
+    """INNOCENCE. Only OFFICIAL_PORTAL records are the mirror's business. A
+    pack's IMPLEMENTING_REGULATION and PRIMARY_LAW records (7 and 3 of them in
+    seq-18) cite gazettes and statutes, not crawlable portal pages, and must
+    not make this test demand the crawler fetch them."""
+    pack = {
+        "source_records": [
+            {
+                "authority_type": "IMPLEMENTING_REGULATION",
+                "canonical_url": "https://example.invalid/not-a-portal",
+            }
+        ]
+    }
+    assert _portal_urls(pack) == set()
+
+
+def test_no_two_pages_share_a_snapshot_filename():
+    """The property the catalog's own asserts did not cover."""
+    slugs = [p.slug for p in catalog.ALL_PAGES]
+    duplicates = sorted({s for s in slugs if slugs.count(s) > 1})
+    assert not duplicates, (
+        "these slugs are used by more than one page and would overwrite each "
+        "other's snapshot on every run: " + repr(duplicates)
+    )
+
+
+def test_the_slug_guard_catches_a_collision():
+    """GUILT for the slug guard. Builds the collision the guard exists to stop
+    and asserts the detection logic sees it — the import-time assert in
+    urls.py cannot be exercised from here without reimporting the module, so
+    the property is checked directly on a constructed catalog."""
+    victim = catalog.DAILY_PAGES[0]
+    clash = replace(catalog.DAILY_PAGES[1], slug=victim.slug)
+    slugs = [p.slug for p in (victim, clash)]
+    assert sorted({s for s in slugs if slugs.count(s) > 1}) == [victim.slug]
+
+
+def test_ids_and_slugs_are_allowed_to_differ():
+    """INNOCENCE. Tightening the slug guard must not accidentally impose
+    slug == id: the catalog deliberately ships pages where they differ, and
+    an over-strict guard here would be a false alarm on shipped, correct rows."""
+    assert any(p.id != p.slug for p in catalog.ALL_PAGES)


### PR DESCRIPTION
## The coverage gap

The Visa Oracle's signed RulePack carries a **per-source freshness policy**. I audited seq-18's 18 `OFFICIAL_PORTAL` records against the 127 slugs actually on disk in the Mini mirror: **16 mirrored, 2 never were.**

- `/siaran_pers/2024/04/23/izin-tinggal-peralihan-…` — the bridging-visa press release
- `/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas` — ITK→ITAS

A freshness policy on a page nobody fetches is a promise nobody can keep: the clock expires, the engine abstains, and no snapshot exists to say whether anything actually changed.

Both go on the **daily** tier deliberately. 14 of the 16 already-covered portal urls sit on the weekly `code-*` tier, so a change to them is invisible for up to six days — and a bridging-visa announcement and a status-conversion page are exactly the surfaces that must not be seen once a week.

**Extraction-stability probed live from Mini before committing**, per this file's own house rule (two fetches, identical sha):

| page | status | chars | sha1 ×2 |
|---|---|---|---|
| `bridging-visa-press-2024` | 200 | 2436 | `d58841c0fc69b58c` |
| `itk-to-itas` | 200 | 3728 | `604ea66a793f4610` |

Both land on the real content block, not the boilerplate banner that trapped `extract_text()` on 2026-08-08 — so `default` is correct for both.

## The unguarded filename

The slug is the snapshot **filename stem** (`snapshots/<date>/<slug>.txt`), and nothing checked it was unique. Only `id` was guarded, and the two are deliberately allowed to differ (`id="parent"` / `slug="voa-bvk-calling-parent"` ships that way today). A hand-authored daily page could reuse another page's slug — after which the two overwrite each other's snapshot **every run**: no error, no missing file, and a permanent "no diffs" for whichever page lost the race.

## The missing test surface

This mirror had none. Its only guards were import-time asserts, and an assert nothing exercises is a guard whose innocence half was never checked. New `scripts/tests/test_imigrasi_mirror_catalog.py`, 8 tests, both polarities on both properties.

**One of those tests earns its place by having caught me.** My first draft filtered portal records on `source_class` — a field that does not exist in a real pack; the real one is `authority_type`. So `_portal_urls()` returned the empty set, the coverage test compared nothing against everything, and **it passed**. A green meaning *"I found no records to check"* is indistinguishable from *"every record is covered"* unless something asserts the set is non-empty. `test_the_pack_actually_has_portal_records_to_check` now does, with a floor of 18, and the field name is written down beside the constant rather than left to be rediscovered.

## Counts asserted, not narrated

The module docstring carried `~127 (13 daily + 114 weekly)` as prose and `run.py --help` still claimed `9 pages` from an earlier era. Adding two pages would have put a second stale count next to the first. Both corrected, and `assert len(DAILY_PAGES) == 15` / `assert len(ALL_PAGES) == 129` make drift loud — matching the file's own existing style for `CODES`.

## Verification

| mutation | red |
|---|---|
| remove the two pages | 2 tests |
| point the filter at the wrong field | 2 tests (vacuity guard + guilt control) |
| flip one page to weekly, counts untouched | 1 test |
| duplicate a slug | import-time assert fires |

8 pass restored.

Found while grounding the re-attestation organ. **Not fixed here** (separate finding): the mirror's three LaunchAgents exist only on Mini with no tracked copy in the monorepo, and there is no `organs_registry.yaml` entry for it — HOME-fork (superscar #1) plus an unregistered organ.