### PR TITLE
fix(db): baseline the 25 legacy checksum rows so the gate is fail-closed again

### DIFF
--- a/apps/backend-rag/backend/db/schema_audit.py
+++ b/apps/backend-rag/backend/db/schema_audit.py
@@ -116,7 +116,6 @@ class AuditReport:
 # ---------------------------------------------------------------------------
 
 
-
 # ---------------------------------------------------------------------------
 # Checksum verification (migration 299)
 # ---------------------------------------------------------------------------
@@ -174,26 +173,26 @@ SYMBOLIC_CHECKSUM_ALLOWLIST: dict[tuple[int, str], tuple[str, str]] = {
         "legacy_fake_checksum",
         "marked applied WITHOUT executing its SQL when the runner adopts a "
         "pre-existing database (migration_manager.py:451-462); the text never ran, "
-        "so there is no honest checksum to record."
+        "so there is no honest checksum to record.",
     ),
     (107, "107_bridge_outbox"): (
         "legacy-107-bridge-outbox",
         "the ledger row is BACKFILLED by migration 194 with the literal "
         "'legacy-107-bridge-outbox'; 107 itself was promoted from a legacy Python "
         "migration, so the row records the promotion rather than an execution of "
-        "this file's text."
+        "this file's text.",
     ),
     (165, "165_reconcile_schema_migrations_duplicates"): (
         "tracked-by-migration-165",
         "this migration INSERTS ITS OWN ledger row with 'tracked-by-migration-165', "
         "and `_log_migration` then uses ON CONFLICT DO NOTHING, so the symbolic "
-        "value is never replaced by a real digest."
+        "value is never replaced by a real digest.",
     ),
     (166, "166_reconcile_client_email_duplicates"): (
         "tracked-by-migration-166",
         "same self-inserting shape as 165, with 'tracked-by-migration-166'; the "
         "ON CONFLICT DO NOTHING in `_log_migration` leaves the symbolic value in "
-        "place for the lifetime of the row."
+        "place for the lifetime of the row.",
     ),
 }
 
@@ -236,22 +235,149 @@ LEGACY_CHECKSUM_ALLOWLIST: dict[int, str] = {
 # migration, a duplicate number, a tracking divergence or a missing required
 # table still fails the deploy, because each of those describes something the
 # CURRENT deploy is about to get wrong.
+# The 25 rows production was already carrying when this verifier was armed on
+# 2026-08-30, read verbatim out of the failing `release_command` — number,
+# name, and the EXACT stored value, plus the recomputed digest for the eight
+# whose file disagrees. Not transcribed by hand: extracted from the run's own
+# `details:` JSON.
+#
+# WHY A BASELINE AND NOT A CLASS-WIDE DEMOTION. The first cure (#5376) demoted
+# the whole checksum CLASS to warning, which unblocked the fleet but also
+# disarmed the check against corruption that has not happened yet: tamper with
+# migration 300 tomorrow and the deploy would still exit 0. A cross-family
+# refuter (Codex gpt-5.6-sol, xhigh) named that as its lead finding and it was
+# right. Pinning the 25 known rows instead restores fail-closed for everything
+# else — a NEW anomaly, even on one of these same migration numbers, is an
+# error again.
+#
+# BOUND TO THE VALUES, NOT THE ROW. A sentinel entry excuses one exact stored
+# string; a mismatch entry excuses one exact (stored, recomputed) PAIR. So
+# editing one of those eight legacy .sql files turns the deploy red rather
+# than silently re-excusing a different divergence. That is deliberate and it
+# is the one real cost of this design: those eight files are effectively
+# frozen until someone re-baselines. Editing an already-applied migration is
+# precisely the event this check exists to stop, so the cost is the feature.
+LegacyFingerprint = tuple[str, str | None]
+
+LEGACY_CHECKSUM_BASELINE: dict[tuple[int, str], LegacyFingerprint] = {
+    (2, "002_portal_sync_tables.sql"): ("manual_apply", None),
+    (3, "003_portal_performance_indexes.sql"): ("manual_apply", None),
+    (4, "004_query_analytics.sql"): ("manual_apply", None),
+    (5, "005_workflow_analytics.sql"): ("manual_apply", None),
+    (6, "006_performance_indexes_advanced"): ("", None),
+    (19, "migration_019"): ("", None),
+    (22, "022_dedup_constraints"): ("manual-fix", None),
+    (23, "migration_023"): ("", None),
+    (26, "026_review_queue"): ("manual-fix", None),
+    (34, "034_company_centric_crm"): ("manual", None),
+    (40, "040_documents_drive_integrity"): ("", None),
+    (41, "041_workflow_jobs_context"): ("", None),
+    (42, "042_clients_tax_ids"): ("", None),
+    (43, "043_invoices_table"): ("", None),
+    (44, "044_cleanup_practices_invoice_jsonb"): ("", None),
+    (45, "045_visa_records_type_fk"): ("", None),
+    (182, "182_companies_tax_dept_folder"): ("031c4d196dcc3860b6ee0598d0db7853", None),
+    # --- mismatches ---
+    (127, "127_war_room_canva_url"): (
+        "ff34400ec9cd949199a00d66ce2a60601c376ebe45591fee9f95fc4a6011ca76",
+        "9a493d1f70c814bc15bcd21e613bf0fb8881505526e07761dab1d6602cff066b",
+    ),
+    (157, "157_practice_types_2026_pricing_delta"): (
+        "f602c9afefc92ff7750ca0d5c63145771756d79bdab6819bc582d2b7b6412512",
+        "4caafd4a22cb66c915425e11d5f07401960310678a90717948b39a61b14d2d43",
+    ),
+    (158, "158_practices_discount_columns"): (
+        "86cbe9765757450b42f2f075394c0f54364d89de2cd9cda86deb35893545e190",
+        "1a1c1931d2a5e48dcb813c8cb8df2adff6b0a8adf63fa556a8ff28eb0119d13a",
+    ),
+    (186, "186_crm_phone_dedup_2026_05_20"): (
+        "431e0465a0e055c36e5b51615c627da36d557845b542f5c950ba7d49ae0e1ba9",
+        "ea743cce867034bfd0600ed64903d6265891ea3caff231d1f52b3d88f25afa5c",
+    ),
+    (192, "192_bridge_outbox_jsonb_double_encoding_repair"): (
+        "6a070dbdb8c2dd9de289c5c42e45798816b9a6475af65d2e6f98c3fe773e2083",
+        "df865b0734d7e98c8ea421bb93bfddbd74c68a0a984eb797adbc8029fc045bfb",
+    ),
+    (200, "200_wa_copilot_infrastructure"): (
+        "70d0962f1d17f8bd0413b5c2160b94812d0a7e9a8a8054f505427108365b0fe8",
+        "e32d488b2c6c5a9c799159fd83be4979d3d6928181f845db0d1b62ea48658845",
+    ),
+    (207, "207_team_admin_runtime_grants"): (
+        "a101bc5f13f47357e96b59d0e1815cae8befd0e3329e9b9560e16df06623edca",
+        "280a7abc2e1209f7dee167a8fac837f9f033a4e90238f67c83760d84ff88b9c5",
+    ),
+    (217, "217_intake_commit_audit"): (
+        "4404de267c13064f25929089b227b8d269f65b52924117a2fa68094e7378540a",
+        "5522a284fbf7fb958c4b088a2ce591dccc2d5f72b44c26124bdd2a565d7daef9",
+    ),
+}
+
+
+def _baseline_covers(number: int, name: str, stored: str | None, recomputed: str | None) -> bool:
+    """True iff this exact row is one of the 25 known-legacy rows.
+
+    `recomputed is None` in the table means a sentinel entry (there is no
+    honest digest to compare); a mismatch entry pins BOTH sides.
+    """
+    entry = LEGACY_CHECKSUM_BASELINE.get((number, name))
+    if entry is None:
+        return False
+    baseline_stored, baseline_recomputed = entry
+    if stored != baseline_stored:
+        return False
+    return baseline_recomputed is None or baseline_recomputed == recomputed
+
+
 _CHECKSUM_ENFORCE_ENV = "SCHEMA_AUDIT_CHECKSUM_ENFORCE"
-_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_TRUTHY = frozenset({"1", "true", "yes", "on", "enforce"})
+_FALSY = frozenset({"0", "false", "no", "off"})
 
 
-def _checksum_severity() -> str:
-    """Severity for the checksum findings: "warning" unless explicitly armed.
+def _enforcement_armed() -> str | None:
+    """The raw flag value if enforcement is armed, else None.
 
     Read per call, never cached at import: the release_command is a fresh
-    process, but a long-lived caller must not be pinned to the value the
+    process, but a long-lived caller must not be pinned to whatever value the
     module happened to see first.
+
+    An UNRECOGNISED non-empty value raises rather than reading as "off". A
+    flag whose typo fails open is the failure this whole file is about:
+    `SCHEMA_AUDIT_CHECKSUM_ENFORCE=treu` would otherwise leave the gate
+    disarmed with no error and no log line, and the operator who typed it
+    would have every reason to believe it was on. `ENFORCE` is accepted
+    because the neighbouring `VISA_ENGINE_EVALUATE_MODE` takes that literal
+    word, and an operator carrying the habit across must not be silently
+    wrong.
     """
-    return (
-        "error"
-        if os.environ.get(_CHECKSUM_ENFORCE_ENV, "").strip().lower() in _TRUTHY
-        else "warning"
+    raw = os.environ.get(_CHECKSUM_ENFORCE_ENV, "").strip()
+    if not raw:
+        return None
+    lowered = raw.lower()
+    if lowered in _TRUTHY:
+        return raw
+    if lowered in _FALSY:
+        return None
+    raise ValueError(
+        f"{_CHECKSUM_ENFORCE_ENV}={raw!r} is not a recognised value. "
+        f"Use one of {sorted(_TRUTHY)} to arm, {sorted(_FALSY)} to disarm, or "
+        "leave it unset. Refusing to guess: a flag that reads an unknown value "
+        "as 'off' disarms the gate exactly when someone believed they armed it."
     )
+
+
+def _checksum_severity(
+    number: int, name: str, stored: str | None, recomputed: str | None = None
+) -> str:
+    """Severity for ONE checksum finding.
+
+    `error` for everything, EXCEPT the 25 fingerprints in
+    `LEGACY_CHECKSUM_BASELINE`, which are `warning` until enforcement is armed.
+    A row that is not in the baseline — or is, but with a different value — is
+    a new anomaly and fails the deploy.
+    """
+    if _enforcement_armed() is not None:
+        return "error"
+    return "warning" if _baseline_covers(number, name, stored, recomputed) else "error"
 
 
 def _migration_sql_by_number() -> dict[int, Path]:
@@ -319,7 +445,7 @@ async def _check_migration_checksums(
             findings.append(
                 Finding(
                     code="migration_checksum_unallowed_sentinel",
-                    severity=_checksum_severity(),
+                    severity=_checksum_severity(number, row["migration_name"], stored),
                     message=(
                         f"migration {number} ({row['migration_name']}) stores "
                         f"{stored!r}, which is not a sha256 digest, and the pair "
@@ -347,7 +473,7 @@ async def _check_migration_checksums(
             findings.append(
                 Finding(
                     code="migration_checksum_mismatch",
-                    severity=_checksum_severity(),
+                    severity=_checksum_severity(number, row["migration_name"], stored, actual),
                     message=(
                         f"migration {number} ({row['migration_name']}) does not match the "
                         "file on disk: the text applied to this database is not the text "
@@ -627,6 +753,12 @@ async def run_audit(
 # ---------------------------------------------------------------------------
 
 
+def _plural(count: int, noun: str) -> str:
+    """`1 error` / `2 errors` — not `1 error(s)`. A deploy log is read at 03:00
+    by someone deciding whether to scroll; `(s)` is one more thing to parse."""
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
 def _format_human(report: AuditReport) -> str:
     lines = ["=" * 70, "SCHEMA AUDIT", "=" * 70]
     lines.append(f"Checks run: {', '.join(report.checks_run)}")
@@ -635,11 +767,11 @@ def _format_human(report: AuditReport) -> str:
     # A warning-only report must never render as an empty success. The whole
     # risk of demoting a finding is that the summary line starts impersonating
     # "nothing was found" -- so the count is always stated, on both branches.
-    suffix = f" ({warnings} warning(s))" if warnings else ""
+    suffix = f" ({_plural(warnings, 'warning')})" if warnings else ""
     if report.ok:
         lines.append(f"Result: OK — no errors{suffix}")
     else:
-        lines.append(f"Result: FAIL — {errors} error(s){suffix}")
+        lines.append(f"Result: FAIL — {_plural(errors, 'error')}{suffix}")
     for f in report.findings:
         lines.append("")
         lines.append(f"[{f.severity.upper()}] {f.code}")

--- a/apps/backend-rag/backend/db/schema_audit.py
+++ b/apps/backend-rag/backend/db/schema_audit.py
@@ -276,39 +276,42 @@ LEGACY_CHECKSUM_BASELINE: dict[tuple[int, str], LegacyFingerprint] = {
     (43, "043_invoices_table"): ("", None),
     (44, "044_cleanup_practices_invoice_jsonb"): ("", None),
     (45, "045_visa_records_type_fk"): ("", None),
-    (182, "182_companies_tax_dept_folder"): ("031c4d196dcc3860b6ee0598d0db7853", None),
+    (182, "182_companies_tax_dept_folder"): (
+        "031c4d196dcc3860b6ee0598d0db7853",  # pragma: allowlist secret
+        None,
+    ),
     # --- mismatches ---
     (127, "127_war_room_canva_url"): (
-        "ff34400ec9cd949199a00d66ce2a60601c376ebe45591fee9f95fc4a6011ca76",
-        "9a493d1f70c814bc15bcd21e613bf0fb8881505526e07761dab1d6602cff066b",
+        "ff34400ec9cd949199a00d66ce2a60601c376ebe45591fee9f95fc4a6011ca76",  # pragma: allowlist secret
+        "9a493d1f70c814bc15bcd21e613bf0fb8881505526e07761dab1d6602cff066b",  # pragma: allowlist secret
     ),
     (157, "157_practice_types_2026_pricing_delta"): (
-        "f602c9afefc92ff7750ca0d5c63145771756d79bdab6819bc582d2b7b6412512",
-        "4caafd4a22cb66c915425e11d5f07401960310678a90717948b39a61b14d2d43",
+        "f602c9afefc92ff7750ca0d5c63145771756d79bdab6819bc582d2b7b6412512",  # pragma: allowlist secret
+        "4caafd4a22cb66c915425e11d5f07401960310678a90717948b39a61b14d2d43",  # pragma: allowlist secret
     ),
     (158, "158_practices_discount_columns"): (
-        "86cbe9765757450b42f2f075394c0f54364d89de2cd9cda86deb35893545e190",
-        "1a1c1931d2a5e48dcb813c8cb8df2adff6b0a8adf63fa556a8ff28eb0119d13a",
+        "86cbe9765757450b42f2f075394c0f54364d89de2cd9cda86deb35893545e190",  # pragma: allowlist secret
+        "1a1c1931d2a5e48dcb813c8cb8df2adff6b0a8adf63fa556a8ff28eb0119d13a",  # pragma: allowlist secret
     ),
     (186, "186_crm_phone_dedup_2026_05_20"): (
-        "431e0465a0e055c36e5b51615c627da36d557845b542f5c950ba7d49ae0e1ba9",
-        "ea743cce867034bfd0600ed64903d6265891ea3caff231d1f52b3d88f25afa5c",
+        "431e0465a0e055c36e5b51615c627da36d557845b542f5c950ba7d49ae0e1ba9",  # pragma: allowlist secret
+        "ea743cce867034bfd0600ed64903d6265891ea3caff231d1f52b3d88f25afa5c",  # pragma: allowlist secret
     ),
     (192, "192_bridge_outbox_jsonb_double_encoding_repair"): (
-        "6a070dbdb8c2dd9de289c5c42e45798816b9a6475af65d2e6f98c3fe773e2083",
-        "df865b0734d7e98c8ea421bb93bfddbd74c68a0a984eb797adbc8029fc045bfb",
+        "6a070dbdb8c2dd9de289c5c42e45798816b9a6475af65d2e6f98c3fe773e2083",  # pragma: allowlist secret
+        "df865b0734d7e98c8ea421bb93bfddbd74c68a0a984eb797adbc8029fc045bfb",  # pragma: allowlist secret
     ),
     (200, "200_wa_copilot_infrastructure"): (
-        "70d0962f1d17f8bd0413b5c2160b94812d0a7e9a8a8054f505427108365b0fe8",
-        "e32d488b2c6c5a9c799159fd83be4979d3d6928181f845db0d1b62ea48658845",
+        "70d0962f1d17f8bd0413b5c2160b94812d0a7e9a8a8054f505427108365b0fe8",  # pragma: allowlist secret
+        "e32d488b2c6c5a9c799159fd83be4979d3d6928181f845db0d1b62ea48658845",  # pragma: allowlist secret
     ),
     (207, "207_team_admin_runtime_grants"): (
-        "a101bc5f13f47357e96b59d0e1815cae8befd0e3329e9b9560e16df06623edca",
-        "280a7abc2e1209f7dee167a8fac837f9f033a4e90238f67c83760d84ff88b9c5",
+        "a101bc5f13f47357e96b59d0e1815cae8befd0e3329e9b9560e16df06623edca",  # pragma: allowlist secret
+        "280a7abc2e1209f7dee167a8fac837f9f033a4e90238f67c83760d84ff88b9c5",  # pragma: allowlist secret
     ),
     (217, "217_intake_commit_audit"): (
-        "4404de267c13064f25929089b227b8d269f65b52924117a2fa68094e7378540a",
-        "5522a284fbf7fb958c4b088a2ce591dccc2d5f72b44c26124bdd2a565d7daef9",
+        "4404de267c13064f25929089b227b8d269f65b52924117a2fa68094e7378540a",  # pragma: allowlist secret
+        "5522a284fbf7fb958c4b088a2ce591dccc2d5f72b44c26124bdd2a565d7daef9",  # pragma: allowlist secret
     ),
 }
 

--- a/apps/backend-rag/backend/tests/db/test_migration_checksum_verification.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_checksum_verification.py
@@ -22,10 +22,13 @@ import pytest
 from backend.db.schema_audit import (
     _SHA256_HEX,
     LEGACY_CHECKSUM_ALLOWLIST,
+    LEGACY_CHECKSUM_BASELINE,
     LEGACY_CHECKSUM_SENTINEL,
     SYMBOLIC_CHECKSUM_ALLOWLIST,
+    _baseline_covers,
     _check_migration_checksums,
     _checksum_severity,
+    _enforcement_armed,
     _migration_sql_by_number,
 )
 
@@ -211,7 +214,6 @@ async def test_an_untampered_row_passes(monkeypatch) -> None:
     """INNOCENCE. A row whose stored checksum matches the file raises nothing."""
     import asyncpg
 
-
     conn = await asyncpg.connect(TEST_DATABASE_URL)
     try:
         await _fresh_versions_table(conn, SCRATCH_TABLE)
@@ -220,9 +222,13 @@ async def test_an_untampered_row_passes(monkeypatch) -> None:
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            path.name, 299, honest,
+            path.name,
+            299,
+            honest,
         )
-        findings = await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
+        findings = await _check_migration_checksums(
+            _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
+        )
         assert findings == [], f"an honest row produced findings: {findings}"
     finally:
         await conn.execute(f"DROP TABLE IF EXISTS {SCRATCH_TABLE}")
@@ -244,17 +250,22 @@ async def test_a_tampered_row_is_caught_and_names_the_migration_number() -> None
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            path.name, 299, hashlib.sha256(b"what was actually applied").hexdigest(),
+            path.name,
+            299,
+            hashlib.sha256(b"what was actually applied").hexdigest(),
         )
-        findings = await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
+        findings = await _check_migration_checksums(
+            _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
+        )
         assert len(findings) == 1, findings
         f = findings[0]
         assert f.code == "migration_checksum_mismatch"
-        # Default stage is WARNING (see `_checksum_severity`): the finding is
-        # raised in full, it just does not abort a deploy over state that
-        # predates the check. `SCHEMA_AUDIT_CHECKSUM_ENFORCE` flips it, and
-        # `TestChecksumEnforcementStage` below owns both halves of that.
-        assert f.severity == "warning"
+        # ERROR, with no flag set: migration 299 is not in
+        # `LEGACY_CHECKSUM_BASELINE`, so it is a NEW anomaly and fails the
+        # deploy. This assertion is the whole point of the baseline — under
+        # the class-wide demotion it briefly read `warning`, which is exactly
+        # the hole the baseline closes.
+        assert f.severity == "error"
         assert "299" in f.message
         assert f.details["migration_number"] == 299
         assert f.details["stored_checksum"] != f.details["recomputed_checksum"]
@@ -285,16 +296,25 @@ async def test_the_allowlisted_sentinel_passes_but_an_unlisted_one_does_not() ->
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            f"{allowed:03d}_baseline_v2.sql", allowed, LEGACY_CHECKSUM_SENTINEL,
+            f"{allowed:03d}_baseline_v2.sql",
+            allowed,
+            LEGACY_CHECKSUM_SENTINEL,
         )
-        assert await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE) == []
+        assert (
+            await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
+            == []
+        )
 
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            on_disk[299].name, 299, LEGACY_CHECKSUM_SENTINEL,
+            on_disk[299].name,
+            299,
+            LEGACY_CHECKSUM_SENTINEL,
         )
-        findings = await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
+        findings = await _check_migration_checksums(
+            _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
+        )
         assert len(findings) == 1, findings
         assert findings[0].code == "migration_checksum_unallowed_sentinel"
         assert findings[0].details["migration_number"] == 299
@@ -317,9 +337,14 @@ async def test_a_row_whose_file_is_gone_is_left_to_the_divergence_check() -> Non
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            f"9999_never_existed_{uuid.uuid4().hex[:8]}.sql", 9999, "deadbeef" * 8,
+            f"9999_never_existed_{uuid.uuid4().hex[:8]}.sql",
+            9999,
+            "deadbeef" * 8,
         )
-        assert await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE) == []
+        assert (
+            await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
+            == []
+        )
     finally:
         await conn.execute(f"DROP TABLE IF EXISTS {SCRATCH_TABLE}")
         await conn.close()
@@ -358,9 +383,13 @@ async def test_an_UNLISTED_sentinel_with_NO_FILE_is_still_an_error() -> None:
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            "002_no_such_file.sql", unlisted, LEGACY_CHECKSUM_SENTINEL,
+            "002_no_such_file.sql",
+            unlisted,
+            LEGACY_CHECKSUM_SENTINEL,
         )
-        findings = await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
+        findings = await _check_migration_checksums(
+            _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
+        )
         assert len(findings) == 1, (
             f"an UNLISTED sentinel row was not reported: {findings}. If this is empty, "
             "the file-absent skip has been moved back above the sentinel branch and the "
@@ -463,7 +492,9 @@ async def test_THE_FOUR_REAL_SYMBOLIC_ROWS_PRODUCE_NO_FINDING() -> None:
             await conn.execute(
                 f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
                 "VALUES ($1, $2, $3)",
-                name, number, checksum,
+                name,
+                number,
+                checksum,
             )
         findings = await _check_migration_checksums(
             _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
@@ -478,7 +509,6 @@ async def test_THE_FOUR_REAL_SYMBOLIC_ROWS_PRODUCE_NO_FINDING() -> None:
     finally:
         await conn.execute(f"DROP TABLE IF EXISTS {SCRATCH_TABLE}")
         await conn.close()
-
 
 
 @_live_only
@@ -500,7 +530,9 @@ async def test_an_allowlisted_row_carrying_a_DIFFERENT_symbolic_value_still_erro
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            name, number, expected + "-tampered",
+            name,
+            number,
+            expected + "-tampered",
         )
         findings = await _check_migration_checksums(
             _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
@@ -526,84 +558,182 @@ async def test_an_allowlisted_row_carrying_a_DIFFERENT_symbolic_value_still_erro
 
 
 class TestChecksumEnforcementStage:
-    """GUILT and INNOCENCE for `_checksum_severity` and its blast radius."""
+    """GUILT and INNOCENCE for the baseline, the flag, and the blast radius."""
 
-    def test_the_default_stage_is_warning(self, monkeypatch) -> None:
-        """INNOCENCE. Unset means observe, and unset is the production state.
+    _BASELINED = next(iter(LEGACY_CHECKSUM_BASELINE.items()))
 
-        A verifier armed fail-closed against a database it was never measured
-        against is an outage, not a check -- which is what happened on
-        2026-08-30 between 19:02 UTC and this fix.
-        """
+    def test_a_baselined_row_is_a_warning_by_default(self, monkeypatch) -> None:
+        """INNOCENCE. The 25 rows production already carried do not abort a
+        deploy — no amount of waiting makes a row written in January
+        verifiable, so fail-closed on them is a permanent outage, not a
+        check."""
         monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
-        assert _checksum_severity() == "warning"
+        (number, name), (stored, recomputed) = self._BASELINED
+        assert _checksum_severity(number, name, stored, recomputed) == "warning"
 
-    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on", " True "])
+    def test_an_UNKNOWN_row_is_an_ERROR_by_default(self, monkeypatch) -> None:
+        """GUILT, and the reason this baseline exists at all. The first cure
+        demoted the whole checksum CLASS, which also disarmed the check
+        against corruption that has not happened yet. Anything outside the 25
+        fails the deploy with no flag set."""
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
+        assert _checksum_severity(9999, "9999_not_a_real_migration.sql", "manual") == "error"
+        assert _checksum_severity(9999, "9999_x.sql", "a" * 64, "b" * 64) == "error"
+
+    def test_a_baselined_row_carrying_a_DIFFERENT_value_is_an_ERROR(self, monkeypatch) -> None:
+        """The binding is to the VALUE, not the row. Keyed on (number, name)
+        alone, a baseline entry would excuse that migration forever —
+        including after its stored checksum changed into something nobody has
+        ever seen."""
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
+        (number, name), (stored, recomputed) = self._BASELINED
+        assert _checksum_severity(number, name, stored + "-drifted", recomputed) == "error"
+
+    def test_a_baselined_MISMATCH_whose_file_changed_is_an_ERROR(self, monkeypatch) -> None:
+        """A mismatch entry pins BOTH digests, so editing one of the eight
+        legacy .sql files re-raises it as an error instead of silently
+        excusing a different divergence. Those files are effectively frozen
+        until someone re-baselines, and that is the intended cost: editing an
+        already-applied migration is the event this check exists to stop."""
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
+        pair = next(
+            ((k, v) for k, v in LEGACY_CHECKSUM_BASELINE.items() if v[1] is not None),
+            None,
+        )
+        assert pair is not None, "the baseline should carry at least one mismatch entry"
+        (number, name), (stored, recomputed) = pair
+        assert _checksum_severity(number, name, stored, recomputed) == "warning"
+        assert _checksum_severity(number, name, stored, "0" * 64) == "error"
+
+    def test_the_baseline_holds_exactly_the_25_rows_production_reported(self) -> None:
+        """A count, pinned. The baseline is evidence about ONE database at ONE
+        moment; if it grows, someone has added an exemption rather than fixing
+        a row, and that must be a visible diff with a reason beside it."""
+        assert len(LEGACY_CHECKSUM_BASELINE) == 25
+        sentinels = [k for k, v in LEGACY_CHECKSUM_BASELINE.items() if v[1] is None]
+        mismatches = [k for k, v in LEGACY_CHECKSUM_BASELINE.items() if v[1] is not None]
+        assert len(sentinels) == 17, sentinels
+        assert len(mismatches) == 8, mismatches
+        for (number, name), (stored, recomputed) in LEGACY_CHECKSUM_BASELINE.items():
+            assert isinstance(number, int) and name, (number, name)
+            if recomputed is not None:
+                assert _SHA256_HEX.match(stored), f"{number}: mismatch entries pin a real digest"
+                assert _SHA256_HEX.match(recomputed), f"{number}: recomputed must be a digest"
+                assert stored != recomputed, f"{number}: a mismatch whose digests agree is not one"
+            else:
+                assert not _SHA256_HEX.match(stored or ""), (
+                    f"{number}: a sentinel entry pins a NON-digest; a real digest "
+                    "must be verified, never baselined"
+                )
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on", " True ", "ENFORCE"])
     def test_the_env_var_arms_it(self, monkeypatch, raw: str) -> None:
-        """GUILT. Arming must actually arm -- including the shapes a human
-        types into `fly secrets set`, and including stray whitespace, which is
-        how a secret set from a shell heredoc arrives."""
+        """GUILT. Including `ENFORCE`, because the neighbouring
+        `VISA_ENGINE_EVALUATE_MODE` takes that literal word and an operator
+        carrying the habit across must not be silently wrong."""
         monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raw)
-        assert _checksum_severity() == "error", f"{raw!r} failed to arm the check"
+        assert _enforcement_armed() is not None, f"{raw!r} failed to arm the check"
+        (number, name), (stored, recomputed) = self._BASELINED
+        assert _checksum_severity(number, name, stored, recomputed) == "error", (
+            "arming must revoke the baseline exemptions too, or the flag cannot "
+            "express 'no legacy excuses'"
+        )
 
-    @pytest.mark.parametrize("raw", ["", "0", "false", "no", "off", "maybe", "warning"])
-    def test_a_non_truthy_value_does_not_arm_it(self, monkeypatch, raw: str) -> None:
-        """INNOCENCE, and the half that bites: a flag whose OFF value silently
-        reads as ON turns a staged rollout into the outage it was staging
-        around. `"false"` in particular is a non-empty string, and a naive
-        truthiness test would arm on it."""
+    @pytest.mark.parametrize("raw", ["", "   ", "0", "false", "no", "off", "OFF"])
+    def test_a_recognised_falsy_value_does_not_arm_it(self, monkeypatch, raw: str) -> None:
+        """INNOCENCE. `"false"` is a non-empty string; a naive truthiness test
+        would arm on it."""
         monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raw)
-        assert _checksum_severity() == "warning", f"{raw!r} wrongly armed the check"
+        assert _enforcement_armed() is None, f"{raw!r} wrongly armed the check"
+
+    @pytest.mark.parametrize("raw", ["treu", "enforcing", "maybe", "warning", "2"])
+    def test_an_UNRECOGNISED_value_raises_instead_of_failing_open(
+        self, monkeypatch, raw: str
+    ) -> None:
+        """The failure this whole module is about, applied to its own flag: a
+        typo that reads as "off" disarms the gate at exactly the moment
+        someone believed they armed it, with no error and no log line."""
+        monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raw)
+        with pytest.raises(ValueError) as excinfo:
+            _enforcement_armed()
+        assert raw in str(excinfo.value), "the error must quote what was actually set"
 
     def test_the_stage_is_read_per_call_not_frozen_at_import(self, monkeypatch) -> None:
-        """A value cached at import time cannot be armed by a secret set after
-        the process starts, and the failure is silent: the env var is present,
-        the check stays demoted, and nobody learns why."""
+        """A value cached at import cannot be armed by a secret set after the
+        process starts, and the failure is silent."""
+        (number, name), (stored, recomputed) = self._BASELINED
         monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
-        assert _checksum_severity() == "warning"
+        assert _checksum_severity(number, name, stored, recomputed) == "warning"
         monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", "1")
-        assert _checksum_severity() == "error"
+        assert _checksum_severity(number, name, stored, recomputed) == "error"
         monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
-        assert _checksum_severity() == "warning"
+        assert _checksum_severity(number, name, stored, recomputed) == "warning"
+
+    def test_baseline_covers_is_not_fooled_by_a_missing_recomputed(self) -> None:
+        """A sentinel entry (`recomputed is None`) must not become a wildcard
+        that also excuses a real digest mismatch on the same row."""
+        sentinel = next((k for k, v in LEGACY_CHECKSUM_BASELINE.items() if v[1] is None), None)
+        assert sentinel is not None
+        number, name = sentinel
+        stored = LEGACY_CHECKSUM_BASELINE[sentinel][0]
+        assert _baseline_covers(number, name, stored, None) is True
+        assert _baseline_covers(number, name, "a" * 64, None) is False
+        assert _baseline_covers(number, name, stored, "b" * 64) is True
 
     def test_only_the_two_checksum_findings_are_staged(self) -> None:
-        """SCOPE. Everything else in this module still fails the deploy.
+        """SCOPE, by AST rather than by regex.
 
-        A pending migration, a duplicate number, a tracking divergence or a
-        missing required table each describe something the CURRENT deploy is
-        about to get wrong -- unlike a checksum row written in January, which
-        no amount of waiting makes verifiable. Read off the SOURCE rather than
-        by calling every check, because the point is that no future edit
-        quietly widens the demotion while the callers still look fine.
+        The earlier version of this test matched `code="..."` followed
+        IMMEDIATELY by `severity=...` in the source text. Two reviewers
+        independently found the same hole from different directions: reorder
+        the kwargs, or insert a `message=` line between them, and a genuinely
+        demoted third finding drops out of the match set while the assertion
+        still passes on the remainder. Parsing the AST removes the question —
+        keyword order and formatting stop mattering, and a `Finding(` call
+        this test cannot read is a failure rather than a silent omission.
         """
+        import ast
         import inspect
-        import re
 
         from backend.db import schema_audit
 
-        source = inspect.getsource(schema_audit)
-        # Pair each `code="..."` with the `severity=...` that follows it, which
-        # is how the Finding constructors are written throughout this module.
-        pairs = re.findall(
-            r'code="(?P<code>[a-z_]+)",\s*\n\s*severity=(?P<sev>[^,\n]+),', source
-        )
-        assert pairs, "no code/severity pairs found — the parse, not the module, is broken"
-        staged = {code for code, sev in pairs if sev == "_checksum_severity()"}
+        tree = ast.parse(inspect.getsource(schema_audit))
+        staged: set[str] = set()
+        hardcoded: dict[str, str] = {}
+        seen = 0
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            if not (isinstance(fn, ast.Name) and fn.id == "Finding"):
+                continue
+            seen += 1
+            kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+            code_node, sev_node = kwargs.get("code"), kwargs.get("severity")
+            assert isinstance(code_node, ast.Constant), (
+                f"a Finding() at line {node.lineno} has no literal code= this test can read"
+            )
+            assert sev_node is not None, f"Finding() at line {node.lineno} has no severity="
+            if isinstance(sev_node, ast.Call):
+                staged.add(code_node.value)
+            elif isinstance(sev_node, ast.Constant):
+                hardcoded[code_node.value] = sev_node.value
+            else:
+                raise AssertionError(f"unreadable severity= on Finding() at line {node.lineno}")
+        assert seen >= 9, f"only {seen} Finding() calls parsed — the AST walk is broken"
         assert staged == {
             "migration_checksum_unallowed_sentinel",
             "migration_checksum_mismatch",
         }, f"the set of staged findings changed: {sorted(staged)}"
-        for code, sev in pairs:
-            if code not in staged:
-                assert sev == '"error"', (
-                    f"{code} is no longer a hard error (severity={sev}); the "
-                    "demotion has leaked past the two checksum findings"
-                )
+        for code, severity in hardcoded.items():
+            assert severity == "error", (
+                f"{code} is no longer a hard error (severity={severity!r}); the "
+                "demotion has leaked past the two checksum findings"
+            )
 
     def test_a_warning_only_report_does_not_block_but_an_error_does(self) -> None:
-        """The actual deploy semantics, asserted on the object the
-        `release_command` exit code is derived from -- not on the severity
-        string, which is only a means to it."""
+        """The actual deploy semantics, on the object the release_command's
+        exit code is derived from."""
         from backend.db.schema_audit import AuditReport, Finding
 
         warn = Finding(code="c", severity="warning", message="m", details={})
@@ -612,10 +742,7 @@ class TestChecksumEnforcementStage:
         assert AuditReport(checks_run=["x"], findings=[warn, err]).ok is False
 
     def test_the_summary_line_never_hides_a_warning(self) -> None:
-        """The one thing a demotion must not buy: silence. A report carrying
-        warnings and no errors must SAY it carries warnings on its headline
-        line, because that line is what a human reads in a deploy log before
-        deciding whether to scroll."""
+        """The one thing a demotion must not buy: silence."""
         from backend.db.schema_audit import AuditReport, Finding, _format_human
 
         warn = Finding(
@@ -624,7 +751,7 @@ class TestChecksumEnforcementStage:
         text = _format_human(AuditReport(checks_run=["migration_checksums"], findings=[warn]))
         headline = next(line for line in text.splitlines() if line.startswith("Result:"))
         assert "warning" in headline, f"a warning-only report headlined as clean: {headline!r}"
-        assert "migration_checksum_mismatch" in text, "the finding itself vanished from the report"
+        assert "migration_checksum_mismatch" in text, "the finding itself vanished"
 
         clean = _format_human(AuditReport(checks_run=["migration_checksums"], findings=[]))
         clean_headline = next(line for line in clean.splitlines() if line.startswith("Result:"))
@@ -632,38 +759,88 @@ class TestChecksumEnforcementStage:
             f"a genuinely clean report claims warnings: {clean_headline!r}"
         )
 
+    def test_the_MIXED_case_reports_both_counts_separately(self) -> None:
+        """The combination a real deploy hits the moment any other check
+        fires alongside a baselined checksum row — and the one branch the
+        first version of this corpus never constructed. A miscount that only
+        shows up mixed would have passed."""
+        from backend.db.schema_audit import AuditReport, Finding, _format_human
+
+        findings = [
+            Finding(code="pending_migrations", severity="error", message="m", details={}),
+            Finding(code="required_table_missing", severity="error", message="m", details={}),
+            Finding(
+                code="migration_checksum_mismatch", severity="warning", message="m", details={}
+            ),
+        ]
+        text = _format_human(AuditReport(checks_run=["x"], findings=findings))
+        headline = next(line for line in text.splitlines() if line.startswith("Result:"))
+        assert "2 errors" in headline, headline
+        assert "1 warning" in headline, headline
+        assert "3" not in headline, (
+            f"the headline conflates errors and warnings into one total: {headline!r}"
+        )
+
+    def test_the_headline_pluralises(self) -> None:
+        """`1 error(s)` is one more thing to parse at 03:00."""
+        from backend.db.schema_audit import AuditReport, Finding, _format_human
+
+        one = [Finding(code="pending_migrations", severity="error", message="m", details={})]
+        headline = next(
+            line
+            for line in _format_human(AuditReport(checks_run=["x"], findings=one)).splitlines()
+            if line.startswith("Result:")
+        )
+        assert "1 error" in headline and "error(s)" not in headline, headline
+
 
 @_live_only
-async def test_a_staged_finding_is_still_a_complete_finding() -> None:
-    """THE test of this change. Demotion must move the severity and NOTHING
-    else -- same code, same message, same details, same count. If a demoted
-    finding were also a thinner finding, the deploy log would stop carrying
-    what an operator needs to act, and the check would be disarmed in
+async def test_a_staged_finding_is_still_a_complete_finding(monkeypatch) -> None:
+    """Demotion must move the severity and NOTHING else — same code, message,
+    details and count. A demoted finding that is also a THINNER finding would
+    stop carrying what an operator needs to act, which is disarmament in
     substance while looking staged on paper.
+
+    Driven on a REAL baselined row, so it exercises the path production takes.
+    `monkeypatch` rather than a hand-rolled try/finally: the hand-rolled
+    version left the variable UNSET rather than restoring it, so a developer
+    who had exported it to exercise the armed path lost it for the rest of the
+    pytest process.
     """
     import asyncpg
 
+    (number, name), (stored, recomputed) = next(
+        (k, v) for k, v in LEGACY_CHECKSUM_BASELINE.items() if v[1] is not None
+    )
     conn = await asyncpg.connect(TEST_DATABASE_URL)
     try:
         await _fresh_versions_table(conn, SCRATCH_TABLE)
-        path = _migration_sql_by_number()[299]
+        # The row's FILE must be the one whose digest the baseline pins, so
+        # write the recomputed digest's source: use the real file if present,
+        # else skip — a fabricated file would prove only that the fake agrees
+        # with itself.
+        on_disk = _migration_sql_by_number().get(number)
+        if on_disk is None:
+            pytest.skip(f"migration {number}'s file is not in this checkout")
+        actual = hashlib.sha256(on_disk.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+        if actual != recomputed:
+            pytest.skip(
+                f"migration {number}'s file has changed since the baseline was taken "
+                "— that is itself a finding, not a reason to fabricate one here"
+            )
         await conn.execute(
             f"INSERT INTO {SCRATCH_TABLE} (migration_name, migration_number, checksum) "
             "VALUES ($1, $2, $3)",
-            path.name, 299, hashlib.sha256(b"not what is on disk").hexdigest(),
+            name,
+            number,
+            stored,
         )
-        # Same table, same row, read twice -- the only variable is the stage.
-        os.environ.pop("SCHEMA_AUDIT_CHECKSUM_ENFORCE", None)
+        monkeypatch.delenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", raising=False)
         staged = await _check_migration_checksums(
             _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
         )
-        os.environ["SCHEMA_AUDIT_CHECKSUM_ENFORCE"] = "1"
-        try:
-            armed = await _check_migration_checksums(
-                _FakeManager(_FakePool(conn)), table=SCRATCH_TABLE
-            )
-        finally:
-            os.environ.pop("SCHEMA_AUDIT_CHECKSUM_ENFORCE", None)
+        monkeypatch.setenv("SCHEMA_AUDIT_CHECKSUM_ENFORCE", "1")
+        armed = await _check_migration_checksums(_FakeManager(_FakePool(conn)), table=SCRATCH_TABLE)
 
         assert len(staged) == len(armed) == 1, (staged, armed)
         assert staged[0].severity == "warning"


### PR DESCRIPTION
Follow-up to #5376, closing every finding both reviewers raised on it.

## What #5376 got wrong

It stopped the four-hour outage by demoting the whole checksum **class** to `warning`. That unblocked the fleet — and it also disarmed the check against corruption that has not happened yet: tamper with migration 300 tomorrow and the deploy would still exit 0. The cross-family refuter (Codex `gpt-5.6-sol`, xhigh) led with exactly that, and it was right. The corpus even demonstrated it without meaning to, by *expecting* a tampered migration 299 to be a warning.

## The exemption moves from the class to the rows

`LEGACY_CHECKSUM_BASELINE` pins the **25 fingerprints production was already carrying** when the verifier was armed — 17 symbolic sentinels and 8 file mismatches — extracted from the failing run's own `details:` JSON rather than transcribed by hand. Everything else is `error` again with no flag set.

**Bound to the values, not the row.** A sentinel entry excuses one exact stored string; a mismatch entry excuses one exact `(stored, recomputed)` **pair**. Editing one of those eight legacy `.sql` files therefore turns the deploy red instead of silently re-excusing a different divergence. Those files are effectively frozen until someone re-baselines — and that cost is the feature: editing an already-applied migration is the event this check exists to stop.

## Measured, against production's exact rows seeded with production's own stored values

```
baseline-vs-checkout drift on the 8 mismatch files: 0
STAGED (production default)  findings=25 errors= 0 warnings=25 exit=0
ARMED                        findings=25 errors=25 warnings= 0 exit=1
+ one NEW unknown bad row    findings=26 errors= 1          exit=1
```

**Zero drift** matters on its own: it proves the baseline describes the tree that actually deploys, not a stale snapshot. **The last line is the fix** — the gate is fail-closed again for anything outside the 25.

## The other findings, closed

| finding | who found it | what changed |
|---|---|---|
| flag fails open on a typo (`=treu` reads as off) | Codex | accepts `enforce` too (the neighbouring `VISA_ENGINE_EVALUATE_MODE` takes that literal word); **raises** on anything unrecognised |
| scope test bypassable | **both, independently** — one by kwarg reorder, one by inserting a `message=` line | AST census of every `Finding(` call; an unreadable call is a failure, not a silent omission |
| `1 error(s)` never pluralises | second reader | `_plural()` |
| the mixed (N errors, M warnings) branch is never constructed | second reader | test added — it fires the moment any other check trips beside a baselined row |
| live test leaves the env var unset instead of restoring it | **both** | `monkeypatch` |

Proof for the scope test specifically: reordering `pending_migrations`' kwargs now **fails** the test. Under the regex it did not — that is the exact edit Codex named.

## Mutation-proven, each killed by the test that should kill it

| mutation | killed by |
|---|---|
| baseline ignores the stored value | 2 tests |
| a sentinel entry acts as a wildcard for the whole row | mismatch-file-changed test |
| uncovered rows fall back to warning (the #5376 behaviour) | 4 tests, incl. the tampered-299 one |
| an unrecognised flag value reads as off | 5 tests |
| pluralisation reverted | 2 tests |
| kwargs reordered on a demoted third finding | AST scope test |

63 passed against a real Postgres 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)