### PR TITLE
fix(i18n): the E33 claim guard watched one spelling of each token

### DIFF
--- a/apps/mouth/src/i18n/secondhome-forbidden-claims.test.ts
+++ b/apps/mouth/src/i18n/secondhome-forbidden-claims.test.ts
@@ -34,19 +34,39 @@ import ruMessages from "./locales/ru.json";
 
 type Locale = "en" | "it" | "id" | "fr" | "ru";
 
+// ── The superseded USD 1,500 figure, in every orthography these five
+//    locales produce. ONE pattern shared by all of them, for two reasons.
+//
+//    (a) It used to be five separate patterns and they had DRIFTED apart:
+//        `en` knew only `USD 1,500` (comma, currency first), `it`/`id` only
+//        the period form, and only fr/ru knew the space separator. So
+//        `1.500 USD` written in English copy was invisible to the English
+//        ruleset while being caught in Italian — the same claim, guarded in
+//        one language and not its neighbour.
+//    (b) It was UNANCHORED. `USD 1 500 000` is a legitimate figure and
+//        `11 500 USD` a plausible one, and both matched. The digit
+//        lookarounds below are what make this fire on 1 500 and nothing
+//        else; the INNOCENCE test at the bottom pins that.
+const SEP = "[\\s\\u00a0\\u202f.,]";
+const N1500 = `(?<!\\d)1${SEP}?500(?!${SEP}?\\d)`;
+const SUPERSEDED_1500 = new RegExp(
+  `${N1500}\\s*(?:USD|\\$)|(?:USD|\\$)\\s*${N1500}`,
+  "i",
+);
+
 const RULES: Record<Locale, RegExp[]> = {
   en: [
-    /USD\s*1,500\b/i,
+    SUPERSEDED_1500,
     /\bany\s+bank\b/i,
     /\bguaranteed\b/i,
     /100%\s*approval/i,
     /\bautomatic\s+(?:ITAP|KITAP)\b/i,
     /\bsplit\s+deposit\b/i,
-    /\bLPS\b/,
-    /\bBSI\b/,
-    /\bsharia\b/i,
-    /\bE33S\b/,
-    /\bE33R\b/,
+    /\bLPS\b/i,
+    /\bBSI\b/i,
+    /\b(?:sharia|syariah)\b/i,
+    /\bE33S\b/i,
+    /\bE33R\b/i,
   ],
   it: [
     /\bqualsiasi\s+banca\b/i,
@@ -54,9 +74,16 @@ const RULES: Record<Locale, RegExp[]> = {
     /\bapprovazione\s+garantita/i,
     /\bautomatic[ao]\s+(?:ITAP|KITAP)/i,
     /\bdeposit[oi]\s+(?:frazionat|suddivis|multipl)/i,
-    /\bLPS\b/,
-    /\bBSI\b/,
-    /1\.500\s*(?:USD|\$)|USD\s*1\.500/,
+    /\bLPS\b/i,
+    /\bBSI\b/i,
+    // it/id watched neither the sharia claim nor the two fabricated codes,
+    // which en/fr/ru all did — the same claim guarded in three languages and
+    // open in two. These literals are language-independent, so there is no
+    // translation judgement in adding them.
+    /\b(?:sharia|syariah)\b/i,
+    /\bE33S\b/i,
+    /\bE33R\b/i,
+    SUPERSEDED_1500,
   ],
   id: [
     /\bbank\s+mana\s*pun\b/i,
@@ -64,42 +91,43 @@ const RULES: Record<Locale, RegExp[]> = {
     /\bjaminan\s+persetujuan/i,
     /\botomatis\s+(?:ITAP|KITAP)/i,
     /\bdeposito\s+(?:terpisah|dibagi|ganda)/i,
-    /\bLPS\b/,
-    /\bBSI\b/,
-    // Scoped to currency context — a bare "1.500"/"1,500" elsewhere in the
-    // subtree (a duration, a code) is not this claim.
-    /(?:1\.500|1,500)\s*(?:USD|\$)|(?:USD|\$)\s*(?:1\.500|1,500)/,
+    /\bLPS\b/i,
+    /\bBSI\b/i,
+    /\b(?:sharia|syariah)\b/i,
+    /\bE33S\b/i,
+    /\bE33R\b/i,
+    SUPERSEDED_1500,
   ],
   // fr/ru added 2026-08-31 with the secondHome dictionaries themselves. Two
   // things are different about these two languages and both are load-bearing:
   //
   // (a) THE SEPARATOR. French and Russian both use a SPACE for thousands
   //     (the copy reads `USD 130 000`, not `USD 130,000`), because a comma is
-  //     their DECIMAL marker. So a superseded `USD 1,500` would land here as
-  //     `USD 1 500` — and the en/it/id patterns, which only know `,` and `.`,
-  //     would sail straight past it. The character class below therefore
-  //     covers the plain space, NBSP (U+00A0) and the narrow no-break space
-  //     (U+202F) that French typography actually produces, alongside `.`/`,`.
-  //     This is the W82 under-match shape exactly: same claim, different
-  //     orthography, guard blind.
+  //     their DECIMAL marker, so a superseded `USD 1,500` lands here as
+  //     `USD 1 500`. That is why SUPERSEDED_1500 above covers the plain
+  //     space, NBSP (U+00A0) and the narrow no-break space (U+202F) that
+  //     French typography actually produces, alongside `.`/`,` — and why it
+  //     is now shared with en/it/id rather than living only here: the same
+  //     claim in a different orthography is the W82 under-match shape, and it
+  //     does not stop being one when it is written in English.
   //
   // (b) THE APOSTROPHE. The French copy uses the straight `'` (47 occurrences,
   //     measured), but a later translator or a CMS paste can produce the
   //     typographic `\u2019`. Any pattern spanning an elision accepts both, or
   //     it silently stops matching the day the copy is retyped.
   fr: [
-    /(?:1[\s\u00a0\u202f.,]?500)\s*(?:USD|\$)|(?:USD|\$)\s*(?:1[\s\u00a0\u202f.,]?500)/,
+    SUPERSEDED_1500,
     /\b(?:n['\u2019]importe\s+quelle|une\s+quelconque|toute)\s+banque\b/i,
     /\bgaranti(?:e|s|es)?\b/i,
     /\bnous\s+garantissons\b/i,
     /\b(?:ITAP|KITAP)\s+automatique\b/i,
     /\bautomatiquement\s+(?:un\s+|une\s+)?(?:ITAP|KITAP)\b/i,
     /\bd[ée]p[ôo]ts?\s+(?:fractionn|divis|multipl|r[ée]parti)/i,
-    /\bLPS\b/,
-    /\bBSI\b/,
-    /\b(?:charia|sharia)\b/i,
-    /\bE33S\b/,
-    /\bE33R\b/,
+    /\bLPS\b/i,
+    /\bBSI\b/i,
+    /\b(?:charia|sharia|syariah)\b/i,
+    /\bE33S\b/i,
+    /\bE33R\b/i,
   ],
   // (c) THE WORD BOUNDARY. `\b` and `\w` in JavaScript are ASCII-only: `\w`
   //     is `[A-Za-z0-9_]`, so `\bдепозит` can NEVER match — there is no
@@ -111,18 +139,22 @@ const RULES: Record<Locale, RegExp[]> = {
   //     test, not by review. The cure is a Unicode-aware boundary
   //     (`(?<![\p{L}])` with the `u` flag) and `\p{L}` in place of `\w`.
   ru: [
-    /(?:1[\s\u00a0\u202f.,]?500)\s*(?:USD|\$)|(?:USD|\$)\s*(?:1[\s\u00a0\u202f.,]?500)/,
+    SUPERSEDED_1500,
     /(?<![\p{L}])люб(?:ой|ом|ого|ые|ых)\s+банк/iu,
     /(?<![\p{L}])гарантир\p{L}*/iu,
     /(?<![\p{L}])гаранти(?:я|ю|и)\s+одобрения/iu,
     /(?<![\p{L}])автоматическ\p{L}*\s+(?:ITAP|KITAP)(?![\p{L}])/iu,
     /(?<![\p{L}])(?:раздел[её]нн\p{L}*|разбит\p{L}*)\s+депозит/iu,
     /(?<![\p{L}])депозит\p{L}*\s+(?:раздел|разбит|в\s+нескольких)/iu,
-    /\bLPS\b/,
-    /\bBSI\b/,
-    /(?<![\p{L}])(?:шариат\p{L}*|sharia)(?![\p{L}])/iu,
-    /\bE33S\b/,
-    /\bE33R\b/,
+    /\bLPS\b/i,
+    /\bBSI\b/i,
+    // Russian copy routinely transliterates a foreign acronym rather than
+    // keeping it in Latin script. `\bLPS\b` cannot see ЛПС at all — it is a
+    // script-level miss, not a case one, so /i does not reach it.
+    /(?<![\p{L}])(?:ЛПС|БСИ)(?![\p{L}])/iu,
+    /(?<![\p{L}])(?:шариат\p{L}*|sharia|syariah)(?![\p{L}])/iu,
+    /\bE33S\b/i,
+    /\bE33R\b/i,
   ],
 };
 
@@ -218,6 +250,9 @@ describe("secondHome dictionaries — W82 locale-aware forbidden-claims sweep", 
         p6: "Coperto da LPS.",
         p7: "Accettiamo BSI sharia.",
         p8: "USD 1.500 di anticipo.",
+        p9: "Conto conforme alla syariah.",
+        p10: "Richiedi l'E33S oggi stesso.",
+        p11: "Richiedi l'E33R oggi stesso.",
       },
     };
     const hits = sweep(fixture, RULES.it);
@@ -306,6 +341,7 @@ describe("secondHome dictionaries — W82 locale-aware forbidden-claims sweep", 
         p10: "Счёт соответствует шариату.",
         p11: "Подайте на E33S сегодня.",
         p12: "Подайте на E33R сегодня.",
+        p13: "Депозит покрывается по программе ЛПС.",
       },
     };
     const hits = sweep(fixture, RULES.ru);
@@ -314,38 +350,57 @@ describe("secondHome dictionaries — W82 locale-aware forbidden-claims sweep", 
     }
   });
 
-  it("GUILT (fr+ru): the space-separated superseded figure is caught in BOTH", () => {
-    // The whole reason these two rulesets are not copies of the en one.
-    for (const locale of ["fr", "ru"] as const) {
-      for (const spaced of [
+  it("GUILT (all locales): the superseded figure is caught in every orthography", () => {
+    // One table, five rulesets. Before SUPERSEDED_1500 was shared, this
+    // table could not have been written: each locale caught its own
+    // separator and was blind to the others, so `1.500 USD` in English copy
+    // and `USD 1,500` in French copy both walked through.
+    for (const locale of Object.keys(RULES) as Locale[]) {
+      for (const spelled of [
+        "USD 1,500",
+        "USD 1.500",
         "USD 1 500",
         "USD 1\u00a0500",
         "USD 1\u202f500",
         "1 500 USD",
+        "1.500 USD",
+        "1,500 USD",
+        // lowercase ticker — the /i flag, not the separator, is what
+        // catches this one.
+        "usd 1 500",
+        "$1,500",
+        "1 500 $",
       ]) {
-        const hits = sweep({ p: `Le montant est ${spaced}.` }, RULES[locale]);
-        expect({ locale, spaced, caught: hits.length > 0 }).toEqual({
+        const hits = sweep({ p: `Total: ${spelled}.` }, RULES[locale]);
+        expect({ locale, spelled, caught: hits.length > 0 }).toEqual({
           locale,
-          spaced,
+          spelled,
           caught: true,
         });
       }
     }
   });
 
-  it("INNOCENCE (fr+ru): the LEGITIMATE figures are not mistaken for the superseded one", () => {
+  it("INNOCENCE (all locales): the legitimate figures are not mistaken for it", () => {
     // The money pattern must fire on 1 500 and nothing else. USD 130 000,
-    // USD 1 000 000, USD 50 000 and USD 3 000 all appear in the live copy
-    // with the same space separator; a pattern anchored loosely on "1" and
-    // a space would swallow USD 1 000 000 and turn the guard into noise.
-    for (const locale of ["fr", "ru"] as const) {
+    // USD 1 000 000, USD 50 000 and USD 3 000 all appear in the live copy.
+    // The last two rows are the ones the UNANCHORED pattern got wrong:
+    // `USD 1 500 000` and `11 500 USD` both contain the digits 1-500 and
+    // are not the superseded figure.
+    for (const locale of Object.keys(RULES) as Locale[]) {
       for (const ok of [
+        "USD 130,000",
+        "USD 130.000",
         "USD 130 000",
+        "USD 1,000,000",
+        "USD 1.000.000",
         "USD 1 000 000",
         "USD 50 000",
         "USD 3 000",
+        "USD 1 500 000",
+        "11 500 USD",
       ]) {
-        const hits = sweep({ p: `Le montant est ${ok}.` }, RULES[locale]);
+        const hits = sweep({ p: `Total: ${ok}.` }, RULES[locale]);
         expect({ locale, figure: ok, hits }).toEqual({
           locale,
           figure: ok,
@@ -353,6 +408,71 @@ describe("secondHome dictionaries — W82 locale-aware forbidden-claims sweep", 
         });
       }
     }
+  });
+
+  it("STRUCTURAL: every pattern in every ruleset is case-insensitive", () => {
+    // `/\bLPS\b/` without the flag is a guard a translator disarms by
+    // writing `lps`. Twenty patterns across the five locales were missing
+    // it — including all four brand/code literals in all five, and three of
+    // the five money patterns — so a claim written in lower case was
+    // invisible everywhere at once. Asserted over the whole ruleset rather
+    // than the twenty known cases, so a pattern added later inherits it.
+    const caseSensitive: string[] = [];
+    for (const locale of Object.keys(RULES) as Locale[]) {
+      for (const pattern of RULES[locale]) {
+        if (!pattern.flags.includes("i")) {
+          caseSensitive.push(`${locale}: ${String(pattern)}`);
+        }
+      }
+    }
+    expect(caseSensitive).toEqual([]);
+  });
+
+  // ── STRUCTURAL: the language-INDEPENDENT tokens are watched everywhere.
+  //    LPS, BSI, E33S, E33R and sharia/syariah read the same in all five
+  //    languages, so there is no translation judgement involved in watching
+  //    them — yet it/id watched neither the codes nor the sharia claim,
+  //    which is how a ruleset drifts: nobody diffs five arrays by eye. This
+  //    test is the diff.
+  const UNIVERSAL_TOKENS = [
+    "LPS",
+    "lps",
+    "BSI",
+    "bsi",
+    "E33S",
+    "e33s",
+    "E33R",
+    "e33r",
+    "sharia",
+    "Sharia",
+    "syariah",
+    "Syariah",
+  ];
+  it("STRUCTURAL (ru): the transliterated acronyms are watched too", () => {
+    // Kept separate from UNIVERSAL_TOKENS because ЛПС/БСИ are a RUSSIAN
+    // spelling of a Latin acronym, not a language-independent literal.
+    // It also needs to be its own assertion: the GUILT test above cannot
+    // catch a pattern being DELETED — it iterates over the patterns that
+    // exist, so removing one removes its own obligation to fire, and the
+    // planted phrase for it becomes inert copy nobody checks. Measured:
+    // deleting this rule left all 21 tests green until this test existed.
+    for (const token of ["ЛПС", "лпс", "БСИ", "бси"]) {
+      const hits = sweep({ p: `Депозит и ${token} здесь.` }, RULES.ru);
+      expect({ token, caught: hits.length > 0 }).toEqual({
+        token,
+        caught: true,
+      });
+    }
+  });
+
+  (Object.keys(RULES) as Locale[]).forEach((locale) => {
+    it(`STRUCTURAL (${locale}): every language-independent token is watched, in either case`, () => {
+      const missed = UNIVERSAL_TOKENS.filter(
+        (token) =>
+          sweep({ p: `Note: ${token} here.` }, RULES[locale]).length === 0,
+      );
+      expect({ locale, missed }).toEqual({ locale, missed: [] });
+    });
   });
 
   it("GUILT (id): each forbidden pattern fires on a planted phrase", () => {
@@ -366,6 +486,8 @@ describe("secondHome dictionaries — W82 locale-aware forbidden-claims sweep", 
         p6: "Dilindungi LPS.",
         p7: "BSI syariah diterima.",
         p8: "USD 1.500 saja.",
+        p9: "Ajukan E33S sekarang.",
+        p10: "Ajukan E33R sekarang.",
       },
     };
     const hits = sweep(fixture, RULES.id);


### PR DESCRIPTION
## What

An adversarial pass against `secondhome-forbidden-claims.test.ts` — the guard that
stops a superseded or forbidden E33 claim reaching the live landing copy in any of
the five locales. Three defects, all the same shape: **the guard watches a token in
exactly one spelling and is blind to the others.**

### 1. Case

Twenty patterns carried no `i` flag — `\bLPS\b`, `\bBSI\b`, `\bE33S\b`, `\bE33R\b`
in every locale that had them, plus three of the five money patterns. A translator
writing `lps`, `bsi`, `e33s` or `usd 1,500` disarmed them. None of these has a
reason to be case-sensitive, so the invariant is asserted over the **whole**
ruleset rather than the twenty known cases — a pattern added later inherits it.

### 2. Drift between locales

`it` and `id` watched neither the sharia claim nor the two fabricated codes
E33S/E33R, which `en`/`fr`/`ru` all did. The same claim, guarded in three
languages and open in two. Nobody diffs five regex arrays by eye, so a test does
it: a floor of language-independent tokens (`LPS`, `BSI`, `E33S`, `E33R`,
`sharia`/`syariah`) that every ruleset must catch, in either case.

### 3. The money pattern

It was five patterns that had drifted apart — `en` knew only `USD 1,500` (comma,
currency-first), `it`/`id` only the period form, and only `fr`/`ru` the space
separator — so `1.500 USD` written in English copy was invisible to the English
ruleset while being caught in Italian. It was also **unanchored**: `USD 1 500 000`
(a legitimate figure that appears in the live copy in exactly that orthography)
and `11 500 USD` both matched. Now one shared, anchored pattern; the INNOCENCE
table pins both.

Also from the same pass: `syariah` — the bank's real Indonesian spelling, so copy
naming "Bank Syariah Indonesia" verbatim is no longer invisible — and `ЛПС`/`БСИ`
for `ru`, since transliterating a Latin acronym is a *script*-level miss that `i`
cannot reach.

## Why it is safe on the current copy

Measured before adding anything: none of `syariah`, `LPS`, `BSI`, `ЛПС`, `БСИ` or
`sharia` occurs anywhere in any of the five `secondHome` subtrees. Every addition
is innocent on the live dictionaries, and INNOCENCE stays green in all five.

## Proof

- 22 tests in this file, 62 across `src/i18n/` — green. `tsc --noEmit` clean,
  Prettier clean.
- **Seven mutations, seven killed** — drop `/i` from an `en` pattern; delete
  `E33S`/`E33R` from `it`; un-anchor the money pattern; revert `en` to the old
  comma-only one; delete the `ru` Cyrillic rule; drop `syariah` from `en`; drop
  the whole sharia rule from `id`.
- The `ru` Cyrillic rule needed a test of its own. The GUILT tests iterate over
  the patterns that **exist**, so deleting a rule deletes its own obligation to
  fire and its planted phrase becomes inert copy nobody checks — deleting that
  rule left all 21 tests green until the dedicated test existed.

## Deliberately not in this PR

The same pass found two things that are a vocabulary **redesign**, not a spelling
fix, and they are filed rather than rushed:

- **Unwatched phrasings.** "banque de votre choix" / "банк на ваш выбор" for *any
  bank*; "nous promettons" / "обещаем" for *garanti*; "d'office" / "по умолчанию"
  for *automatique*; "ventilé" / "делить" for *fractionné*.
- **No negation awareness.** Honest copy stating "le passage à l'ITAP **n'est
  pas** automatique" trips the guard today. An over-match is fail-safe where an
  under-match is not, but it will go red on compliant copy someone writes later.