### PR TITLE
fix(queue-unstick): the message shipped 90 minutes ago prescribes the one gesture the ledger forbids

### DIFF
--- a/scripts/queue_unstick.py
+++ b/scripts/queue_unstick.py
@@ -429,44 +429,74 @@ def do_update_branch(
     return "ok", f"update-branch OK PR #{number}: {out.strip() or 'requested'}"
 
 
-def _union_merged_changed_paths(
+#: How many changed paths `check-attr` is asked about PER CALL. This is a batch
+#: size, NOT a limit: every path is examined, in successive calls. The first cut
+#: of this function truncated at 200 and examined nothing beyond, so a large PR
+#: whose union path sorted late was reported as a race — "0 found" and "not
+#: looked at" producing the same answer, which is the failure this whole probe
+#: exists to stop making.
+_ATTR_BATCH = 200
+
+#: `check-attr` values that mean "git merges this file the ordinary way", i.e. the
+#: same way GitHub's merge machinery does. Anything ELSE is a declared driver, and
+#: GitHub honours no merge driver at all — so the two disagree by construction.
+#: Keyed on the complement rather than on the literal "union" because `merge=ours`
+#: diverges identically and would have silently regressed to the race wording
+#: (superscar #3's under-match twin, W82: a guard watching one literal string).
+#: `unset` (`-merge`) is excluded deliberately: it makes git ALWAYS conflict, so a
+#: file carrying it cannot reach this code path, which only runs when git said clean.
+_ORDINARY_MERGE_VALUES = frozenset({"unspecified", "unset", "set", "text"})
+
+
+def _driver_merged_changed_paths(
     *, repo_root: Path, base_ref: str, pr_ref: str, timeout: int = 25
-) -> list[str]:
-    """Paths this PR changes that `.gitattributes` marks `merge=union`.
+) -> list[tuple[str, str]]:
+    """`(path, driver)` for each changed path `.gitattributes` gives a merge driver.
 
     Read-only, and deliberately fail-quiet: every failure returns `[]`, which
     makes the caller fall back to its pre-existing "race" wording. An empty
-    list therefore means "no union path FOUND", never "no union path EXISTS" —
+    list therefore means "no driver path FOUND", never "no driver path EXISTS" —
     so this can only ever add a diagnosis, never suppress one.
+
+    Both git calls use `-z`. That is not a style choice: `core.quotePath` defaults
+    to true, so `git diff --name-only` emits a NON-ASCII path as the C-quoted
+    literal `"caf\303\251.md"`, which `check-attr` then fails to match, returning
+    `unspecified` for a file that is in fact union-merged. Measured against the
+    first cut of this function in a real repo: it returned [] where the truth was
+    ['café.md']. `-z` also removes the `<path>: merge: <value>` parse entirely,
+    and with it the class of bug where a path containing ": " is truncated.
     """
     rc, out, _err = _run(
-        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...{pr_ref}"],
+        ["git", "-C", str(repo_root), "diff", "-z", "--name-only", f"{base_ref}...{pr_ref}"],
         timeout=timeout,
     )
     if rc != 0:
         return []
-    paths = [p for p in out.splitlines() if p.strip()]
+    paths = [p for p in out.split("\0") if p]
     if not paths:
         return []
-    # `check-attr` is given the paths after `--`, so a leading-dash filename is
-    # not read as a flag. Capped because a huge PR would otherwise blow argv.
-    rc, out, _err = _run(
-        ["git", "-C", str(repo_root), "check-attr", "merge", "--", *paths[:200]],
-        timeout=timeout,
-    )
-    if rc != 0:
-        return []
-    union: list[str] = []
-    for line in out.splitlines():
-        # Format is `<path>: merge: <value>`. Split from the RIGHT: a path may
-        # legitimately contain ": " and a left split would truncate it.
-        head, sep, value = line.rpartition(": ")
-        if not sep or value.strip() != "union":
-            continue
-        path = head[: -len(": merge")] if head.endswith(": merge") else None
-        if path:
-            union.append(path)
-    return union
+    # Paths go after `--` so a leading-dash filename is not read as a flag.
+    # Capped because a huge PR would otherwise blow argv; the cap is reported by
+    # the caller rather than silently swallowed.
+    found: list[tuple[str, str]] = []
+    for start in range(0, len(paths), _ATTR_BATCH):
+        batch = paths[start:start + _ATTR_BATCH]
+        rc, out, _err = _run(
+            ["git", "-C", str(repo_root), "check-attr", "-z", "merge", "--", *batch],
+            timeout=timeout,
+        )
+        if rc != 0:
+            return []
+        # -z output is a flat NUL-separated stream of (path, attr, value) triples.
+        fields = out.split("\0")
+        for i in range(0, len(fields) - 2, 3):
+            path, attr, value = fields[i], fields[i + 1], fields[i + 2]
+            if attr != "merge" or not path:
+                continue
+            if value in _ORDINARY_MERGE_VALUES:
+                continue
+            found.append((path, value))
+    return found
 
 
 def get_conflicting_files(pr: dict, *, repo_root: Path = REPO_ROOT, timeout: int = 25) -> str:
@@ -510,26 +540,41 @@ def get_conflicting_files(pr: dict, *, repo_root: Path = REPO_ROOT, timeout: int
             #
             #   1. A race: the PR moved between the GraphQL read and this probe.
             #      Transient — the next tick reports it correctly.
-            #   2. A `merge=union` path. git's merge driver resolves the file by
-            #      concatenating both sides and exits 0; GitHub's merge queue
-            #      does NOT honour `.gitattributes` merge drivers and reports a
-            #      real conflict. PERMANENT — re-probing can never clear it, and
-            #      only a hand rebase of that file will.
+            #   2. A declared merge driver (`merge=union`, `merge=ours`, ...).
+            #      git honours it and exits 0; GitHub's merge machinery honours
+            #      NO driver and reports a real conflict. PERMANENT — re-probing
+            #      can never clear it.
             #
-            # Measured 2026-08-31 on PRs #5331 and #5373: both were DIRTY on
-            # GitHub with `merge-tree` rc=0, and both touched the repo's single
-            # union-merged path, `.claude/skills/modus/PENDING-ARMS.md`. Reported
-            # as a race, that is a permanent condition wearing a transient label.
-            union = _union_merged_changed_paths(
+            # Measured 2026-08-31 on PRs #5331 and #5373: both DIRTY on GitHub
+            # with `merge-tree` rc=0, both touching the repo's one union path,
+            # `.claude/skills/modus/PENDING-ARMS.md`. Reported as a race, that is
+            # a permanent condition wearing a transient label.
+            #
+            # WHAT THIS MESSAGE MUST NEVER SAY, and briefly did (2026-08-31):
+            # "hand rebase that file". Hand-resolving a union file is precisely
+            # how the other lane's appended row gets deleted in silence — the
+            # loss the driver exists to prevent, which `check-ledger-no-silent-loss`
+            # then catches in CI (seen live on #5355). And `git rebase` is no
+            # safer in the other reading: rebase DOES apply the union driver, so
+            # replaying an append over a base that already carries it duplicates
+            # the row (measured on #4060), which a set-based gate cannot see.
+            # The cure is neither. It is to rebuild the append on a branch cut
+            # from fresh origin/main and prove the file's diff is +N/-0.
+            drivers = _driver_merged_changed_paths(
                 repo_root=repo_root, base_ref=base_ref, pr_ref=pr_ref, timeout=timeout
             )
-            if union:
-                shown = ", ".join(union[:5]) + (" (+more)" if len(union) > 5 else "")
+            if drivers:
+                shown = ", ".join(
+                    f"{path} (merge={driver})" for path, driver in drivers[:5]
+                ) + (" (+more)" if len(drivers) > 5 else "")
                 return (
-                    f"none locally, but this is NOT a race: {shown} carries "
-                    "`merge=union` in .gitattributes, which git's merge-tree honours "
-                    "and GitHub's merge queue does not. Re-probing will never clear "
-                    "it — the cure is a hand rebase of that file."
+                    f"none locally, but this is NOT a race: {shown} — git honours that "
+                    "driver, GitHub's merge machinery honours none, so the two disagree "
+                    "permanently and re-probing will never clear it. DO NOT hand-resolve "
+                    "the file and DO NOT rebase onto it: the first silently deletes the "
+                    "other lane's appended row, the second replays the append and "
+                    "duplicates it. Rebuild your addition on a branch cut from fresh "
+                    "origin/main, then verify `git diff origin/main -- <file>` is +N/-0."
                 )
             return "none (merge-tree found no conflict at probe time)"
         # First line is the (conflicted) tree OID; the rest, with

--- a/scripts/tests/test_queue_unstick.py
+++ b/scripts/tests/test_queue_unstick.py
@@ -452,13 +452,18 @@ def test_hold_labels_are_case_insensitive():
     assert plan["skipped"][50] == "hold_label"
 
 
+
+
 # ---------------------------------------------------------------------------
-# _union_merged_changed_paths — guilt + innocence against a REAL git repo.
+# _driver_merged_changed_paths — guilt + innocence against a REAL git repo.
 #
 # These build an actual repository rather than stubbing `_run`, because the
-# behaviour under test is entirely `git check-attr`'s: a fake would encode my
-# belief about its output format and agree with itself (superscar #9 / W114 —
-# a fake and the code it checks share the same imagination).
+# behaviour under test is entirely `git check-attr`'s and `git diff`'s output
+# encoding — a fake would encode my belief about those formats and then agree
+# with itself (superscar #9 / W114: a fake and the code it checks share the
+# same imagination). Three of the cases below were written FROM defects an
+# adversarial reviewer found in the first shipped cut, and each is pinned here
+# because it was live in production for ~90 minutes.
 # ---------------------------------------------------------------------------
 
 import subprocess as _sp  # noqa: E402
@@ -469,7 +474,7 @@ def _git(repo, *args):
             capture_output=True, text=True)
 
 
-def _repo_with(tmp_path, gitattributes: str | None):
+def _repo_with(tmp_path, gitattributes: str | None, extra: str | None = None):
     repo = tmp_path / "r"
     repo.mkdir()
     _git(repo, "init", "-q", "-b", "main")
@@ -479,27 +484,65 @@ def _repo_with(tmp_path, gitattributes: str | None):
         (repo / ".gitattributes").write_text(gitattributes)
     (repo / "ledger.md").write_text("base\n")
     (repo / "plain.txt").write_text("base\n")
+    if extra:
+        (repo / extra).write_text("base\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "base")
     _git(repo, "branch", "base-ref")
     (repo / "ledger.md").write_text("base\npr row\n")
     (repo / "plain.txt").write_text("base\npr line\n")
+    if extra:
+        (repo / extra).write_text("base\npr\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "pr")
     _git(repo, "branch", "pr-ref")
     return repo
 
 
-def test_union_path_is_named_when_the_pr_touches_one(tmp_path):
-    """GUILT: the changed file carries merge=union -> it is reported."""
-    repo = _repo_with(tmp_path, "ledger.md merge=union\n")
-    found = qu._union_merged_changed_paths(
-        repo_root=repo, base_ref="base-ref", pr_ref="pr-ref"
+def _probe(repo, base="base-ref", head="pr-ref"):
+    return qu._driver_merged_changed_paths(
+        repo_root=repo, base_ref=base, pr_ref=head
     )
-    assert found == ["ledger.md"]
 
 
-def test_non_union_paths_are_not_named(tmp_path):
+def test_a_union_path_is_named_with_its_driver(tmp_path):
+    """GUILT: the changed file carries merge=union -> reported, with the driver."""
+    repo = _repo_with(tmp_path, "ledger.md merge=union\n")
+    assert _probe(repo) == [("ledger.md", "union")]
+
+
+def test_a_non_union_driver_is_also_caught(tmp_path):
+    """GUILT, and the reason this keys on the COMPLEMENT of ordinary values:
+    GitHub honours no driver at all, so `merge=ours` diverges exactly as
+    `merge=union` does. The first shipped cut compared against the literal
+    string "union" and returned [] here — a silent regression to the race
+    wording on a file that is permanently, not transiently, DIRTY."""
+    repo = _repo_with(tmp_path, "ledger.md merge=ours\n")
+    assert _probe(repo) == [("ledger.md", "ours")]
+
+
+def test_a_non_ascii_path_is_not_lost_to_quotepath(tmp_path):
+    """GUILT. `core.quotePath` defaults to true, so `git diff --name-only`
+    emits a non-ASCII path as the C-quoted literal "caf\\303\\251.md", which
+    check-attr then does not match -> `unspecified` -> a real detection lost
+    with no error. Measured against the first shipped cut: it returned []
+    where the truth was [('café.md', 'union')]. `-z` is the cure."""
+    name = "café.md"
+    repo = _repo_with(tmp_path, f"{name} merge=union\n", extra=name)
+    assert _probe(repo) == [(name, "union")]
+
+
+def test_explicit_ordinary_values_are_not_reported(tmp_path):
+    """INNOCENCE: `merge=text` and a bare `merge` are the ORDINARY merge, which
+    GitHub performs identically. Reporting them would invent a permanent
+    divergence where none exists."""
+    for i, attrs in enumerate(("ledger.md merge=text\n", "ledger.md merge\n")):
+        sub = tmp_path / f"case{i}"
+        sub.mkdir()
+        assert _probe(_repo_with(sub, attrs)) == [], attrs
+
+
+def test_non_driver_paths_are_not_named(tmp_path):
     """INNOCENCE: a PR touching only ordinary files reports nothing, so the
     caller keeps its pre-existing 'race' wording."""
     repo = _repo_with(tmp_path, "ledger.md merge=union\n")
@@ -507,36 +550,47 @@ def test_non_union_paths_are_not_named(tmp_path):
     (repo / "plain.txt").write_text("base\nonly this\n")
     _git(repo, "add", "-A")
     _git(repo, "commit", "-qm", "plain only")
-    found = qu._union_merged_changed_paths(
-        repo_root=repo, base_ref="base-ref", pr_ref="plain-only"
-    )
-    assert found == []
+    assert _probe(repo, head="plain-only") == []
 
 
 def test_no_gitattributes_at_all_reports_nothing(tmp_path):
-    """INNOCENCE: the same diff, with no merge driver declared anywhere."""
-    repo = _repo_with(tmp_path, None)
-    found = qu._union_merged_changed_paths(
-        repo_root=repo, base_ref="base-ref", pr_ref="pr-ref"
-    )
-    assert found == []
+    """INNOCENCE: the same diff with no merge driver declared anywhere."""
+    assert _probe(_repo_with(tmp_path, None)) == []
 
 
-def test_a_path_containing_a_colon_survives_the_parse(tmp_path):
-    """`check-attr` prints `<path>: merge: <value>`; splitting from the LEFT
-    would truncate a path that legitimately contains ': '."""
-    # DOUBLE quotes: `.gitattributes` rejects a single-quoted pattern outright
-    # ("name.md' is not a valid attribute name"), which silently yields
-    # `merge: unspecified` and would make this test pass for the wrong reason.
-    repo = _repo_with(tmp_path, '"weird: name.md" merge=union\n')
-    _git(repo, "checkout", "-q", "-b", "colon", "base-ref")
-    (repo / "weird: name.md").write_text("x\n")
+def test_a_path_containing_a_colon_survives(tmp_path):
+    """The old parse read `<path>: merge: <value>` and split on ': '. -z removes
+    that parse entirely; this pins that the removal actually holds.
+
+    NOTE the DOUBLE quotes: `.gitattributes` rejects a single-quoted pattern
+    ("name.md' is not a valid attribute name"), silently yielding `unspecified`,
+    which would make this test pass for the wrong reason."""
+    name = "weird: name.md"
+    repo = _repo_with(tmp_path, f'"{name}" merge=union\n', extra=name)
+    assert _probe(repo) == [(name, "union")]
+
+
+def test_every_path_is_examined_not_just_the_first_batch(tmp_path):
+    """GUILT for the silent-truncation bug: the first cut passed `paths[:200]`
+    and examined nothing beyond, so a large PR whose driver path sorted late
+    read as a race. The union file here is named `zz-...` so it sorts last
+    among 250 changed files."""
+    repo = tmp_path / "big"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+    (repo / ".gitattributes").write_text("zz-ledger.md merge=union\n")
     _git(repo, "add", "-A")
-    _git(repo, "commit", "-qm", "colon path")
-    found = qu._union_merged_changed_paths(
-        repo_root=repo, base_ref="base-ref", pr_ref="colon"
-    )
-    assert found == ["weird: name.md"]
+    _git(repo, "commit", "-qm", "attrs")
+    _git(repo, "branch", "base-ref")
+    for i in range(250):
+        (repo / f"f{i:04d}.txt").write_text("x\n")
+    (repo / "zz-ledger.md").write_text("row\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "many")
+    _git(repo, "branch", "pr-ref")
+    assert _probe(repo) == [("zz-ledger.md", "union")]
 
 
 def test_a_broken_repo_returns_empty_rather_than_raising(tmp_path):
@@ -544,6 +598,29 @@ def test_a_broken_repo_returns_empty_rather_than_raising(tmp_path):
     caller's existing wording, never crash the daemon's tick."""
     empty = tmp_path / "not-a-repo"
     empty.mkdir()
-    assert qu._union_merged_changed_paths(
+    assert qu._driver_merged_changed_paths(
         repo_root=empty, base_ref="base-ref", pr_ref="pr-ref"
     ) == []
+
+
+# --- the MESSAGE, which is the part that was dangerous ----------------------
+
+def test_the_message_never_prescribes_hand_resolving_or_rebasing(tmp_path):
+    """The shipped message told the fleet 'the cure is a hand rebase of that
+    file'. Hand-resolving a union file silently deletes the other lane's
+    appended row (the loss the driver exists to prevent, caught by
+    check-ledger-no-silent-loss on #5355); `git rebase` DOES apply the union
+    driver and duplicates the row instead (#4060). Both readings of that
+    sentence are documented failure modes, and it was broadcast to a fleet
+    mailbox that agents act on. This pins the replacement."""
+    import inspect
+    src = inspect.getsource(qu.get_conflicting_files)
+    msg_start = src.index("none locally, but this is NOT a race")
+    msg = src[msg_start:src.index("return \"none (merge-tree", msg_start)]
+    lowered = msg.lower()
+    assert "hand-resolve" in lowered and "do not" in lowered, \
+        "the message must explicitly forbid hand-resolving"
+    assert "origin/main" in msg, "the message must name the rebuild-from-fresh-main cure"
+    assert "+n/-0" in lowered or "+n / -0" in lowered, \
+        "the message must name the proof that the append is additive"
+    assert "the cure is a hand rebase" not in lowered, "the forbidden prescription is back"


### PR DESCRIPTION
## The defect, in one line

PR #5379 (merged 22:26Z) taught the fleet daemon to tell a **permanent** `merge=union` divergence from a **transient** race. The diagnosis was right. The prescription was dangerous, and it has been broadcasting to the fleet mailbox ever since:

> `Re-probing will never clear it — the cure is a hand rebase of that file.`

**Both readings of that sentence are documented failure modes of this repo.**

| reading | what actually happens | evidence |
|---|---|---|
| hand-**resolve** the union file | silently **deletes** the other lane's appended row — the exact loss the driver exists to prevent | caught by `check-ledger-no-silent-loss` live on #5355 |
| `git rebase` onto it | rebase **does** apply the union driver, so replaying an append over a base that already carries it **duplicates** the row | measured on #4060; a set-based gate cannot see it |

The documented cure is neither: **rebuild the addition on a branch cut from fresh `origin/main`, then prove `git diff origin/main -- <file>` is `+N/-0`.** The new message says exactly that and names both traps, because this string is read by agents that act on it.

## Why this happened, stated plainly

The memory carrying that warning was updated at **20:27Z**. I armed #5379 at **21:55Z** — 88 minutes later — having grepped its index line and never opened the body that contained the cure.

And the fail-quiet argument I made for #5379 does not cover this. It was true of the **return value** (`[]` on every failure, so the caller falls back to the old wording) and false of the **emitted message**: the old text was vague and inert, the new one confident, actionable and wrong. **A diagnosis can be a regression.** That is the finding worth keeping from this, more than the string itself.

## Two more defects in the same function

Both from the same adversarial review, both **reproduced against the code as actually shipped on `origin/main`** before being trusted:

**`core.quotePath` silently loses detections.** It defaults to true, so `git diff --name-only` emits a non-ASCII path as the C-quoted literal `"caf\303\251.md"`, which `check-attr` then fails to match → `unspecified` → a real detection lost with no error.

```
shipped code, café.md carrying merge=union  ->  []        (truth: ['café.md'])
```

Both git calls now use `-z`. That also deletes the `<path>: merge: <value>` parse outright, and with it the colon-truncation bug the old code needed a special case for.

**The predicate keyed on the literal `"union"`.** GitHub honours **no** merge driver, so `merge=ours` diverges identically:

```
shipped code, ledger.md carrying merge=ours  ->  []        (silently regresses to the race wording)
```

Now keyed on the complement of the ordinary values (`unspecified`/`unset`/`set`/`text`) — superscar #3's under-match twin, **W82**: a guard watching one literal string. `unset` (`-merge`) is excluded deliberately: it makes git *always* conflict, so such a file cannot reach a branch that only runs when git said clean.

**And the 200-path cap was a silent truncation.** A PR whose driver path sorted past position 200 read as a race — *"0 found"* and *"not looked at"* producing the same answer, which is precisely the failure this probe exists to stop making. It is now a batch size, not a limit; every path is examined.

## Verification

`41/41 pass`. The two guilt cases were verified to **FAIL against the shipped code** (both returned `[]`), not merely to pass here — **a guilt test that passes on the broken version proves nothing.** The truncation case is guilt-by-construction: 251 changed files with the driver path sorting last, against a literal `paths[:200]`.

One test asserts on the **message** itself — that it forbids hand-resolving, names `origin/main` as the rebuild base, and names the `+N/-0` proof. The wording is the part that was dangerous, so the wording is what is pinned.

## Scope

One concern: curing the probe I shipped in #5379. Per Rule 8, everything here is a defect **this** change introduced — none of it is inherited. 2 files.