### PR TITLE
fix(queue-unstick): a cross-family refuter broke my own message test in one line

### DIFF
--- a/scripts/queue_unstick.py
+++ b/scripts/queue_unstick.py
@@ -149,9 +149,21 @@ query($owner:String!, $repo:String!, $cursor:String) {
 
 
 def _run(cmd: list[str], timeout: int = 30) -> tuple[int, str, str]:
-    """Run a command; never raises. Returns (rc, stdout, stderr)."""
+    """Run a command; never raises. Returns (rc, stdout, stderr).
+
+    `errors="replace"` is what makes "never raises" TRUE rather than merely
+    intended. With the default strict decoding, `text=True` raises
+    UnicodeDecodeError — a ValueError, caught by neither arm of the except
+    below — the moment git prints a path whose bytes are not valid UTF-8, which
+    `git diff -z --name-only` will happily do. A cross-family refuter found this
+    by reading the contract rather than the code; the docstring had been lying
+    since it was written, and the fail-quiet argument for every caller rests on
+    it being true.
+    """
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, errors="replace", timeout=timeout
+        )
         return proc.returncode, proc.stdout, proc.stderr
     except (OSError, subprocess.TimeoutExpired) as exc:
         return 127, "", f"{type(exc).__name__}: {exc}"

--- a/scripts/tests/test_queue_unstick.py
+++ b/scripts/tests/test_queue_unstick.py
@@ -605,22 +605,70 @@ def test_a_broken_repo_returns_empty_rather_than_raising(tmp_path):
 
 # --- the MESSAGE, which is the part that was dangerous ----------------------
 
-def test_the_message_never_prescribes_hand_resolving_or_rebasing(tmp_path):
-    """The shipped message told the fleet 'the cure is a hand rebase of that
-    file'. Hand-resolving a union file silently deletes the other lane's
+#: The EXACT advice the daemon prints when it finds a permanent driver
+#: divergence, pinned character for character. This is deliberately a
+#: change-detector, not a content-guesser.
+#:
+#: The first cut of this test asserted that the message CONTAINS "hand-resolve"
+#: and "do not" and "origin/main". A cross-family refuter broke it in one line:
+#:
+#:   "Instead, reset the file to origin/main and manually re-apply your rows"
+#:
+#: — which IS hand-resolving, means the forbidden thing, and satisfies every one
+#: of those assertions. A substring test cannot decide what a sentence means, and
+#: one that pretends to is worse than none: it converts an unreviewed reword into
+#: a green tick. So the bar is lower and honest — ANY edit to this string fails
+#: here, and a human has to look at it and update this constant on purpose.
+_EXPECTED_DRIVER_ADVICE = (
+    "none locally, but this is NOT a race: {shown} — git honours that "
+    "driver, GitHub's merge machinery honours none, so the two disagree "
+    "permanently and re-probing will never clear it. DO NOT hand-resolve "
+    "the file and DO NOT rebase onto it: the first silently deletes the "
+    "other lane's appended row, the second replays the append and "
+    "duplicates it. Rebuild your addition on a branch cut from fresh "
+    "origin/main, then verify `git diff origin/main -- <file>` is +N/-0."
+)
+
+
+def test_the_driver_advice_is_exactly_what_was_reviewed(tmp_path):
+    """The shipped message once told the fleet 'the cure is a hand rebase of
+    that file'. Hand-resolving a union file silently deletes the other lane's
     appended row (the loss the driver exists to prevent, caught by
     check-ledger-no-silent-loss on #5355); `git rebase` DOES apply the union
     driver and duplicates the row instead (#4060). Both readings of that
-    sentence are documented failure modes, and it was broadcast to a fleet
-    mailbox that agents act on. This pins the replacement."""
-    import inspect
+    sentence are documented failure modes, and it is broadcast to a fleet
+    mailbox that agents act on.
+
+    So this string is security-relevant text. It is pinned exactly: any reword,
+    however well-meant, goes red here and has to be looked at by a person.
+    THIS TEST DOES NOT PROVE THE ADVICE IS SAFE — no substring test can. It
+    proves only that the advice is the one that was reviewed."""
+    import inspect, re
     src = inspect.getsource(qu.get_conflicting_files)
-    msg_start = src.index("none locally, but this is NOT a race")
-    msg = src[msg_start:src.index("return \"none (merge-tree", msg_start)]
-    lowered = msg.lower()
-    assert "hand-resolve" in lowered and "do not" in lowered, \
-        "the message must explicitly forbid hand-resolving"
-    assert "origin/main" in msg, "the message must name the rebuild-from-fresh-main cure"
-    assert "+n/-0" in lowered or "+n / -0" in lowered, \
-        "the message must name the proof that the append is additive"
-    assert "the cure is a hand rebase" not in lowered, "the forbidden prescription is back"
+    # Recover the message as source text, then undo the f-string concatenation
+    # the same way Python does, so the comparison is against the real template.
+    start = src.index('f"none locally, but this is NOT a race')
+    end = src.index("return \"none (merge-tree", start)
+    literal_src = src[start:end]
+    pieces = re.findall(r'f?"((?:[^"\\]|\\.)*)"', literal_src)
+    got = "".join(pieces)
+    assert got == _EXPECTED_DRIVER_ADVICE, (
+        "the driver-divergence advice changed. This is the string that told the "
+        "fleet to perform a data-destroying gesture once already. Read the new "
+        "wording, satisfy yourself it forbids BOTH hand-resolving and rebasing "
+        "and names the rebuild-from-fresh-main cure, then update "
+        "_EXPECTED_DRIVER_ADVICE deliberately.\n"
+        f"  got:      {got!r}\n  expected: {_EXPECTED_DRIVER_ADVICE!r}"
+    )
+
+
+def test_the_pinned_advice_still_forbids_both_gestures(tmp_path):
+    """A second, independent reading of the pinned constant — so that updating
+    the pin cannot silently drop the two prohibitions and the cure. Weak by
+    construction (see the note above), and kept only because a pin nobody
+    sanity-checks is a pin that can be updated to anything."""
+    lowered = _EXPECTED_DRIVER_ADVICE.lower()
+    assert "do not hand-resolve" in lowered
+    assert "do not rebase" in lowered
+    assert "origin/main" in lowered
+    assert "+n/-0" in lowered


### PR DESCRIPTION
Follow-up to #5393 (merged). Its branch was frozen in the merge queue when this review landed, so per the Agent PR Contract these go in a new PR cut from fresh `origin/main` rather than as a push to an armed branch.

A Kimi K3 adversarial round on #5393's diff. It **reproduced the claims that PR rested on** before attacking them, which is worth recording as much as the findings: `-merge` really does make `merge-tree` conflict (so excluding `unset` from the ordinary-values set is sound); `merge=union` with both sides changed really does return rc=0 (the disease shape); and the `-z` triple parse handles the trailing NUL correctly at n=0, 1 and 2 — checked against real byte dumps, not reasoned about.

Two findings.

## 1. The message test was decorative

It asserted the advice **contains** `hand-resolve`, `do not`, `origin/main` and `+N/-0`. The refuter defeated it with one sentence:

> `"Instead, reset the file to origin/main and manually re-apply your rows"`

That **is** hand-resolving. It means precisely the forbidden thing, and it satisfies every assertion — because presence-of-safe-words says nothing about what a sentence instructs.

**A substring test cannot decide what a sentence means, and one that pretends to is worse than no test:** it converts an unreviewed reword into a green tick, on the one string that already told this fleet to destroy data once.

Replaced with an **exact pin**. Any edit to the advice goes red, and a person has to update the constant deliberately. The bar is lower and honest, and the docstring says so outright — *this does not prove the advice is safe; it proves the advice is the one that was reviewed.*

**Mutation-verified with the refuter's own bypass sentence**: the pin fails on it, the old assertions passed it.

## 2. `_run`'s "never raises" was false

```python
def _run(cmd, timeout=30) -> tuple[int, str, str]:
    """Run a command; never raises. ..."""
    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
```

`text=True` decodes strictly, so **UnicodeDecodeError — a ValueError, caught by neither arm of its except** — escapes the moment git prints a path whose bytes are not valid UTF-8, which `git diff -z --name-only` will do. Found by reading the **contract** rather than the code.

`errors="replace"` makes the docstring true. Every caller's fail-quiet argument, #5393's included, rests on that sentence being a fact rather than an intention.

## Findings deliberately NOT acted on

`check-attr` reads attributes from the local checkout rather than from the merged trees, so `--source <ref>` goes unused. But `merge-tree` reads the working tree too, so the two move together — the refuter worked through three desynchronisation scenarios and found **no false "permanent" verdict in any of them**. Chasing it would add a flag and no behaviour.

`42/42` pass. 2 files, +77/−17.