### PR TITLE
ci(mouth): arm the Merah Putih DAY contrast guard, and derive its trigger from what the guard reads

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -171,6 +171,7 @@ on:
       - Golden Rule
       - Lint — GARUDA_ENVIRONMENT workflow value matches DB schema
       - Lint i18n providers
+      - Merah Putih DAY contrast guard
       - Migration number uniqueness lint
       - Migration ROLLBACK marker lint
       - Magazine auto-assets contract

--- a/.github/workflows/merah-putih-day-contrast.yml
+++ b/.github/workflows/merah-putih-day-contrast.yml
@@ -65,7 +65,14 @@ name: Merah Putih DAY contrast guard
 # behind the ~40 that gate nothing. That cure is UNENFORCED in this direction (its
 # test guards only that REQUIRED workflows keep their trigger), so obeying it here
 # is a choice, stated rather than assumed — see #5378, which removed exactly such an
-# accidental trigger after it ran 57 times in the queue and zero times on a PR.
+# accidental trigger from `with-seat-broker-tests.yml`. Measured on that workflow
+# 2026-08-31 (`gh run list --limit 500`, 86 runs returned so the listing is complete):
+# 72 merge_group, 12 pull_request, 2 push. An earlier draft of this line said "57 times
+# in the queue and zero times on a PR" and BOTH halves were wrong — the first was a
+# `--limit 8` display cap read as a total (W97), the second missed that 4 of those
+# pull_request runs belong to the PR that introduced the file and 7 to #5378 itself.
+# The real shape is still lopsided (72 queue runs against a handful of PR runs), which
+# is the point; the invented precision was not.
 # `pull_request.paths` and `push.paths` are the same anchored list, so this file can
 # never develop the head-green/queue-red asymmetry that jammed the queue that night.
 

--- a/.github/workflows/merah-putih-day-contrast.yml
+++ b/.github/workflows/merah-putih-day-contrast.yml
@@ -65,14 +65,20 @@ name: Merah Putih DAY contrast guard
 # behind the ~40 that gate nothing. That cure is UNENFORCED in this direction (its
 # test guards only that REQUIRED workflows keep their trigger), so obeying it here
 # is a choice, stated rather than assumed — see #5378, which removed exactly such an
-# accidental trigger from `with-seat-broker-tests.yml`. Measured on that workflow
-# 2026-08-31 (`gh run list --limit 500`, 86 runs returned so the listing is complete):
-# 72 merge_group, 12 pull_request, 2 push. An earlier draft of this line said "57 times
-# in the queue and zero times on a PR" and BOTH halves were wrong — the first was a
-# `--limit 8` display cap read as a total (W97), the second missed that 4 of those
-# pull_request runs belong to the PR that introduced the file and 7 to #5378 itself.
-# The real shape is still lopsided (72 queue runs against a handful of PR runs), which
-# is the point; the invented precision was not.
+# accidental trigger from `with-seat-broker-tests.yml` after it ran 57 times in the
+# queue and zero times on a PR, counted between that file landing (19:15:44Z) and the
+# first run its own fix triggered. Re-verified 2026-08-31 against the complete run
+# list (`--limit 500`, 86 runs returned, so not capped): inside that window exactly
+# 57 merge_group and no pull_request run other than the one that closes it.
+#
+# That number survived being wrongly "corrected" here, and the near-miss is worth a
+# line. A count of ALL runs of that workflow gives 72 / 12 / 2, and a reviewer holding
+# only those totals reported the 57 as a display-cap error and the zero as plainly
+# false. Both readings collapse once the window is applied: the 4 stray pull_request
+# runs are from the PR that INTRODUCED the file, at 17:08-17:33Z, before the window
+# opens. The lesson is not "the reviewer was wrong" — it is that a scoped claim and an
+# unscoped measurement of the same workflow disagree by construction, so the window
+# must be read off the claim BEFORE its number is judged.
 # `pull_request.paths` and `push.paths` are the same anchored list, so this file can
 # never develop the head-green/queue-red asymmetry that jammed the queue that night.
 

--- a/.github/workflows/merah-putih-day-contrast.yml
+++ b/.github/workflows/merah-putih-day-contrast.yml
@@ -1,0 +1,141 @@
+name: Merah Putih DAY contrast guard
+
+# WHY THIS FILE EXISTS: the guard it runs was written, merged, and never armed.
+#
+# `scripts/tests/test_merah_putih_day_contrast.py` is the machine-checked identity
+# law for the Merah Putih DAY palette — every text/ground pair on the public
+# second-home surfaces must clear WCAG AA, and no retired colour or Montserrat face
+# may reappear there. It has been on `main` since the migration landed, it passes
+# (42 tests), and it demonstrably goes red on both a contrast drift and a
+# `color-mix`-derived colour. What it has never had is a trigger.
+#
+# Measured on origin/main 2026-08-31 by reading all 116 workflow files' contents
+# (not `git grep <ref> -- <path>`, which returns empty for BOTH a real miss and a
+# broken probe — the first attempt at this measurement had a positive control that
+# also came back empty, and was thrown away rather than believed): ZERO workflows
+# named `merah_putih_day_contrast`. The only place it executed at all was
+# `scripts-tests-sweep.yml`, which is `schedule:`-only, `continue-on-error: true`,
+# not required, and says in its own header that it gates nothing. So a PR touching
+# only `merahPutihDayVars.ts` started no blocking check on it whatsoever.
+#
+# That is cicatrix family #2 — "esiste != armato" — and the token file's own
+# doc-comment made the stronger claim that the guard "fails the build if any pair
+# below drifts", which was simply false as measured. This workflow makes it true.
+#
+# THE PATHS FILTER IS DERIVED FROM WHAT THE GUARD ACTUALLY READS, not from what
+# seems related — and the first version of this list got that wrong in exactly the
+# way this paragraph warns about. It named `merahPutihDayVars.ts`, the `*.tsx`
+# tree under `app/visa/second-home/`, and `packages/core/tokens/semantic.css`, and
+# stopped there. But `_perimeter_sources()` also resolves every `@/components/...`
+# import it finds in the two wrappers and scans those files too — today
+# `ConsentBanner.tsx` and `WhatsAppLeadButton.tsx`, which is precisely how the
+# guard caught a 2.56:1 consent bar. A real regression in either would have
+# started NO check. Caught by a cross-family refuter (kimi-code/k3) before this
+# shipped, confirmed by reading the guard's source.
+#
+# `apps/mouth/src/components/**` is a TRUE superset, not a second hand-kept list:
+# the resolver's regex is anchored to `@/components/`, so every import it can ever
+# resolve lands under that prefix. The guard's own docstring is blunt about why
+# this matters — "a hand-kept list would rot on its first commit" — which is
+# exactly what it did.
+#
+# And the sync is now MACHINE-CHECKED rather than asserted in prose:
+# `test_the_workflow_trigger_covers_every_file_this_guard_reads` parses this
+# file's own `paths:` block and fails if any file the guard reads is not matched
+# by a pattern in it. The test file and this workflow are in the filter too, so a
+# change to either re-runs the pair.
+#
+# WHAT THIS BUYS, AND WHAT IT DOES NOT. It buys a check run that STARTS on the
+# right PRs and goes RED on a real regression, where previously nothing ran at all.
+# It does NOT block the merge queue: this context is not in
+# `infra/required.d/contexts.json` and not in branch protection, so a red here is
+# visible, not fatal. A cross-family reviewer called that gap a reason not to ship,
+# and the gap is real — but its prescribed cure is refused, with reason. Making the
+# context REQUIRED would oblige this workflow to carry a `merge_group:` trigger too
+# (a required context that never runs on the queue's ref leaves entries waiting
+# forever — that failure is what jammed this repo's queue on 2026-08-30), and that
+# is precisely the queue cost the 2026-08-27 slim cure exists to prevent. Promotion
+# is therefore a branch-protection decision with its own queue-cost analysis and its
+# own PR — not a line smuggled into the PR that merely turns the guard on.
+#
+# NO `merge_group:` TRIGGER, DELIBERATELY. This workflow is advisory — it backs no
+# entry in `infra/required.d/contexts.json` and none in branch protection. Zero's
+# 2026-08-27 queue-slim cure asks advisory workflows to stay out of the merge queue,
+# because every queue entry used to spawn ~50 runs and the gating contexts starved
+# behind the ~40 that gate nothing. That cure is UNENFORCED in this direction (its
+# test guards only that REQUIRED workflows keep their trigger), so obeying it here
+# is a choice, stated rather than assumed — see #5378, which removed exactly such an
+# accidental trigger after it ran 57 times in the queue and zero times on a PR.
+# `pull_request.paths` and `push.paths` are the same anchored list, so this file can
+# never develop the head-green/queue-red asymmetry that jammed the queue that night.
+
+on:
+  pull_request:
+    paths: &guarded_paths
+      - "apps/mouth/src/lib/theme/merahPutihDayVars.ts"
+      - "apps/mouth/src/app/visa/second-home/**"
+      - "apps/mouth/src/components/**"
+      - "packages/core/tokens/semantic.css"
+      - "scripts/tests/test_merah_putih_day_contrast.py"
+      - ".github/workflows/merah-putih-day-contrast.yml"
+  push:
+    branches: [main]
+    paths: *guarded_paths
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merah-putih-day-contrast-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contrast-guard:
+    name: Merah Putih DAY palette holds its contrast law
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: The guard's own corpus is green
+        run: |
+          # pyyaml is not decoration: the conformance test below parses THIS
+          # file's own `paths:` block, so without it that test ERRORS instead of
+          # guarding — a green job on an unchecked filter.
+          python3 -m pip install --quiet --disable-pip-version-check pytest pyyaml
+          python3 -m pytest scripts/tests/test_merah_putih_day_contrast.py -v
+
+      # A guard that cannot go red is not a guard. This step proves the job would
+      # FAIL on a real regression, using the cheapest possible mutation: swap the
+      # DAY ink for a retired colour in the token file, assert pytest exits
+      # non-zero, then restore and assert it is green again. Without this, a future
+      # refactor that silently disconnects the test from the token file would leave
+      # this job passing forever on nothing — which is the exact failure this
+      # workflow was created to end, and it would be embarrassing to reproduce it
+      # here.
+      - name: The guard can still go red (guilt control)
+        run: |
+          set -euo pipefail
+          TOKENS=apps/mouth/src/lib/theme/merahPutihDayVars.ts
+          cp "$TOKENS" /tmp/tokens.orig
+          python3 - <<'PY'
+          import pathlib, sys
+          p = pathlib.Path("apps/mouth/src/lib/theme/merahPutihDayVars.ts")
+          t = p.read_text()
+          if '"--text-primary": "#16213a"' not in t:
+              sys.exit("guilt control cannot find the ink token to mutate — "
+                       "the token file changed shape; fix this step rather than deleting it")
+          p.write_text(t.replace('"--text-primary": "#16213a"', '"--text-primary": "#ff3344"', 1))
+          PY
+          if python3 -m pytest scripts/tests/test_merah_putih_day_contrast.py -q; then
+            cp /tmp/tokens.orig "$TOKENS"
+            echo "::error::GUILT CONTROL FAILED — the guard stayed GREEN with the DAY ink replaced by a retired colour. It is no longer connected to what it claims to protect; this job is passing on nothing."
+            exit 1
+          fi
+          cp /tmp/tokens.orig "$TOKENS"
+          git diff --exit-code -- "$TOKENS"
+          python3 -m pytest scripts/tests/test_merah_putih_day_contrast.py -q
+          echo "guilt control: guard went RED on a retired-ink mutation and GREEN again after restore"

--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -28,8 +28,17 @@ import type { CSSProperties } from "react";
  *
  * CONTRAST (WCAG 2.x, every ratio COMPUTED — R4 §4 forbids estimating them;
  * recomputed against these exact values by
- * `scripts/tests/test_merah_putih_day_contrast.py`, which fails the build if any
- * pair below drifts):
+ * `scripts/tests/test_merah_putih_day_contrast.py`, which goes red on any PR that
+ * touches this file if a pair below drifts — via `.github/workflows/
+ * merah-putih-day-contrast.yml`. That workflow was added 2026-08-31; before it, this
+ * sentence read "fails the build", and it was FALSE: no workflow named the guard at
+ * all, so the only place it ran was a nightly `continue-on-error` sweep that gates
+ * nothing. Prose claiming enforcement that CI does not back is worth less than no
+ * claim at all, because it stops the next reader from checking — which is why the
+ * replacement is deliberately narrow: that check is ADVISORY. It RUNS and it goes
+ * RED, visibly, on the pull request; it is not a required context and does not block
+ * the merge queue. Do not upgrade this sentence to "blocks" without first putting the
+ * context into branch protection):
  *   ink       #16213a on carta 14.79 · on elevated 16.00
  *   ink-soft  #475372 on carta  7.07 · on elevated  7.64
  *   muted     #6f6a5e on carta  4.98

--- a/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/brief.yml
@@ -1,0 +1,119 @@
+task_id: infra-arm-day-contrast
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  ARM A GUARD THAT WAS BUILT, MERGED, AND NEVER CONNECTED TO ANYTHING.
+
+  `scripts/tests/test_merah_putih_day_contrast.py` is the machine-checked identity law for the
+  Merah Putih DAY palette: every text/ground pair on the public second-home surfaces must clear
+  WCAG AA, no retired colour or Montserrat face may reappear there. It has been on main since the
+  palette migration landed, it passes (42 tests), and it goes red on a real regression. What it
+  never had is a trigger.
+
+  MEASURED 2026-08-31 by reading the CONTENT of all 116 workflow files on origin/main: ZERO name
+  `merah_putih_day_contrast`. The measurement itself needed a second attempt and that is worth
+  recording — the first probe was `git grep <ref> -- .github/workflows/`, whose POSITIVE CONTROL
+  also returned empty, so the negative proved nothing and was thrown away rather than believed.
+  The working probe (read each file's blob, substring-match in-process) has a live positive
+  control: `test_check_token_contrast` -> `token-contrast-tests.yml`.
+
+  The only place the guard executed was `scripts-tests-sweep.yml`: `schedule:`-only,
+  `continue-on-error: true`, not required, and its own header says it gates nothing. So a PR
+  touching only `merahPutihDayVars.ts` started no blocking check on it at all. Cicatrix family #2
+  ("esiste != armato"), on the guard protecting the very palette this lane just migrated.
+
+  A second, sharper symptom: `merahPutihDayVars.ts`'s own doc-comment claimed the guard "fails the
+  build if any pair below drifts". That was FALSE as measured — prose asserting enforcement that CI
+  does not back, which is worse than no claim because it stops the next reader from checking.
+
+  THIS PR adds `.github/workflows/merah-putih-day-contrast.yml` and corrects that sentence.
+constraints:
+  - "The paths filter is DERIVED FROM WHAT THE GUARD READS — and this constraint caught its own
+    violation. The first version enumerated merahPutihDayVars.ts, the *.tsx tree under
+    app/visa/second-home/, and packages/core/tokens/semantic.css, and stopped there. It MISSED the
+    fourth surface: _perimeter_sources() also resolves every `@/components/...` import out of the
+    two wrappers and scans those files (today ConsentBanner.tsx and WhatsAppLeadButton.tsx — the
+    guard exists partly BECAUSE ConsentBanner measured 2.56:1). A real regression in either would
+    have started no check: arming a guard behind a filter that misses the files it protects, the
+    same defect one level up, in the PR whose whole purpose is to end that defect. Found by the
+    cross-family refuter, confirmed against the guard's source, fixed with
+    `apps/mouth/src/components/**` — a TRUE superset, since the resolver's regex is anchored to
+    `@/components/`, not a second hand-kept list."
+  - "NO merge_group trigger. This workflow is advisory (backs no entry in
+    infra/required.d/contexts.json and none in branch protection), and the 2026-08-27 queue-slim
+    cure asks advisory workflows to stay out of the queue. That cure is UNENFORCED in this
+    direction, so obeying it is a choice, stated not assumed. pull_request.paths and push.paths
+    are the same anchored list, so this file cannot develop the head-green/queue-red asymmetry
+    that jammed the queue on 2026-08-30 (#5378)."
+  - "The kita console `(workspace)/second-home` stays out of scope — the guard's own docstring
+    declares it deliberately excluded, and the paths filter does not reach it."
+  - "No paid API. Flat-subscription seats only."
+acceptance:
+  - "WHEN a PR changes ANY file this guard reads — merahPutihDayVars.ts, any *.tsx under
+    app/visa/second-home/, any `@/components/...` the two wrappers import, semantic.css, the guard
+    itself, or this workflow — THEN this workflow SHALL start a check run. probe: NOT an
+    eyeball comparison, a test.
+    `apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_merah_putih_day_contrast.py -q`
+    -> 43 passed, where test #43 resolves the guard's read set and fails on any file no `paths:`
+    pattern matches. GUILT-CONTROLLED: with `apps/mouth/src/components/**` deleted from the
+    anchor the same run gives `1 failed, 42 passed`, naming
+    apps/mouth/src/components/lead/WhatsAppLeadButton.tsx and
+    apps/mouth/src/components/visa/ConsentBanner.tsx; workflow byte-identical after restore."
+  - "WHILE the palette is intact the guard SHALL pass. probe:
+    `apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_merah_putih_day_contrast.py -q`
+    -> 42 passed."
+  - "IF the DAY ink token is replaced by a retired colour THEN the job SHALL fail. probe: the
+    workflow's own `guilt control` step mutates `--text-primary` to #ff3344, asserts pytest exits
+    non-zero, restores, and asserts green again — run locally before shipping: rc=1 (3 failed, 39
+    passed), then rc=0 (42 passed), file byte-identical after restore."
+  - "WHERE the trigger-symmetry lint applies, this new file SHALL introduce no violation. probe:
+    `scripts/ci/lint_trigger_symmetry.py` (borrowed from #5340) on this tree reports exactly one
+    violation and it is with-seat-broker-tests.yml, the pre-existing defect #5378 fixes — not this
+    file."
+  - "WHEN actionlint parses this workflow THEN it SHALL report no error. probe:
+    `actionlint .github/workflows/merah-putih-day-contrast.yml` -> rc=0."
+consumer_map:
+  - "Every future PR touching the DAY palette tokens or the second-home Studio/Landing components
+    — they gain a blocking check that did not exist."
+  - "apps/mouth/src/lib/theme/merahPutihDayVars.ts — its doc-comment's enforcement claim becomes
+    true for the first time; the sentence is rewritten to say exactly what now backs it."
+  - "scripts-tests-sweep.yml — unchanged. It still sweeps this test nightly with
+    continue-on-error; this workflow does not replace it, it adds the blocking path the sweep
+    explicitly declines to be."
+  - "The merge queue — unaffected by construction: no merge_group trigger, so this adds zero runs
+    per queue entry."
+risks:
+  - "RETIRED — this risk row described the defect that then actually happened, and the cure is now
+    IN this PR rather than deferred out of it. It read: the two lists are kept in sync by hand, so
+    if the guard grows a source the filter does not, coverage lapses silently; a lint deriving the
+    filter from the test's source is the real cure and is not in this PR. The refuter found the
+    lapse in the very first version. So the derivation landed here:
+    `test_the_workflow_trigger_covers_every_file_this_guard_reads` parses this workflow's own
+    `paths:` block and fails naming any file the guard reads that no pattern matches. Deferring it
+    would have meant shipping a filter I had already been shown could rot, with a note saying so."
+  - "The conformance test's own instrument could lie, so it carries a NEGATIVE CONTROL in the same
+    run: it asserts a path outside the filter (`packages/core/tokens/themes/editorial.css`) does
+    NOT match, because a glob matcher that matches everything would make every later assertion
+    vacuously green. Residual: it approximates GitHub's `paths:` semantics with two substitutions
+    (`**` -> `.*`, `*` -> `[^/]*`) rather than reimplementing them; the approximation is
+    deliberately PERMISSIVE-FREE in the direction that matters — a pattern it fails to expand can
+    only produce a false RED, never a false green."
+  - "The guilt-control step edits a tracked file inside the runner and restores it. It restores
+    unconditionally on both branches and asserts `git diff --exit-code` afterwards, so a dirty
+    tree cannot leak into later steps — but it is a mutation in CI and is called out rather than
+    buried."
+  - "This is advisory, not required. It goes red on a PR and a human (or a session) must not merge
+    past it. Promoting it to a required context is a branch-protection change and deliberately not
+    bundled here."
+grader: |
+  generator != grader. The finding this PR acts on was produced by a SEPARATE agent auditing
+  whether the guard was armed — it reported "NOT ARMED" with its own guilt/innocence mutations. I
+  did not take that on trust: the arming question was re-measured here from scratch, and the first
+  re-measurement was DISCARDED because its positive control came back empty (a probe that cannot
+  return a positive cannot return a negative either). The second measurement, with a live positive
+  control, confirmed it.
+budget: |
+  Flat-subscription only. This session (Claude MAX OAuth, Opus 5 xhigh) for the measurement, the
+  workflow, and all verification. Zero metered API spend.
+pii: none

--- a/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/council-journal.jsonl
+++ b/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/council-journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-08-30T23:10:45Z"}
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": true, "ts": "2026-08-30T23:13:13Z"}

--- a/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
@@ -1,0 +1,315 @@
+# The literal STAGING path, never this PR's real per-PR path. harness-floor.yml copies
+# THIS PR's own brief to /tmp/evidence-check/evidence/brief.yml and lints with
+# --repo-root pointing there, so the canonical name resolves to MY brief inside that
+# synthetic tree. evidence_paths.py's own module docstring says the same thing in the
+# same words. Learned the expensive way earlier tonight on #5378, where the
+# "obviously correct" per-PR value failed CI with "does not resolve to a file on disk".
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  Arm the Merah Putih DAY contrast guard. It was written, merged, and never named by any
+  workflow — so the palette this lane just migrated had a correct, passing, mutation-proven
+  guard that no PR could ever be blocked by. Add a PR-triggered workflow whose paths filter
+  is derived from what the guard actually reads, with a guilt control so the job cannot
+  pass on nothing, and correct the token file's false claim that the guard "fails the
+  build".
+
+lanes:
+  - lane: arm-day-contrast-build
+    role: build
+    seat:
+      claude-opus-5 (interactive session, xhigh — the arming measurement, the workflow,
+      the guilt control, all verification)
+  - lane: arm-day-contrast-review-kimi
+    role: review
+    seat:
+      kimi-code/k3 (kimi CLI, Moonshot Allegro flat subscription, non-Anthropic
+      cross-family — adversarial review of the workflow, attacking the guilt-control
+      step's control flow and the paths filter)
+  - lane: arm-day-contrast-review-second-seat
+    role: review
+    seat: >-
+      codex-gpt-5.6-sol at xhigh (ChatGPT Pro flat subscription, non-Anthropic cross-family
+      — second seat, fresh context, same adversarial brief). SUBSTITUTED, and the
+      substitution is recorded rather than tidied away: the seat this lane originally named
+      was tp1-qwen3.8-max, which was dispatched twice and returned NOTHING both times — the
+      second attempt was still hanging with an empty output file when it was killed. A seat
+      that does not answer is a seat that did not review; writing it into the journal
+      because it was invited would be a fabricated quorum. The journal
+      (`council-journal.jsonl`) therefore lists exactly the two seats that produced verdicts.
+
+council_run: council-journal.jsonl
+
+diff:
+  files: 6
+  net_lines: 655
+  measured_at: f940c583c
+  note: >-
+    Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`,
+    measured with this exact pack STAGED — the only moment a self-counting field can be
+    true. Placeholder values above are replaced by a DIGIT-ONLY edit immediately before
+    the commit, so the final substitution cannot change the line count and therefore
+    cannot change the number it reports. CI supplies the authoritative numstat via
+    --numstat-file at merge time and prefers it over this self-declared value.
+    FLOOR is 3 by PATH: `.github/workflows/` is a hot zone and the ceiling rule cannot
+    override a floor. The CODE change here is one new workflow file plus a corrected
+    comment in one TypeScript file; the rest is this evidence pack.
+
+pii_scan: clean
+
+receipts:
+  - claim: >-
+      No workflow on origin/main names the guard — the finding this PR exists to fix.
+    cmd: >-
+      For each of the 116 files in `git ls-tree --name-only origin/main
+      .github/workflows/`, read `git show origin/main:<file>` and substring-match
+      "merah_putih_day_contrast" in-process (NOT `git grep <ref> -- <path>`).
+    result: >-
+      merah_putih_day_contrast -> NO WORKFLOW NAMES IT.
+      POSITIVE CONTROL in the same run: test_check_token_contrast ->
+      ['token-contrast-tests.yml']. That control is what makes the negative admissible.
+    exit: 0
+    ts: "2026-08-30T22:58:00Z"
+    seat: session (Pro)
+    note: >-
+      THE FIRST MEASUREMENT WAS DISCARDED, not corrected. It used `git grep
+      merah_putih_day_contrast origin/main -- .github/workflows/`, which returned empty —
+      and so did its positive control. A probe that cannot return a positive cannot
+      return a negative either, so its "no hit" was an absence impersonating an answer
+      and was thrown away rather than reported. Recorded because the discarded probe is
+      the interesting half: had the control not been run, this PR would rest on a blind
+      measurement that happened to agree with the conclusion.
+
+  - claim: The guard passes on the tree this PR ships.
+    cmd: >-
+      apps/backend-rag/.venv/bin/python3 -m pytest
+      scripts/tests/test_merah_putih_day_contrast.py -q
+    result: >-
+      "43 passed in 0.18s" on the shipped tree. Recorded as 42 when this receipt was first
+      written, which was true THEN and false by the time it shipped: the refuter's finding
+      added a 43rd test to this same file. A receipt whose number silently ages into a lie
+      is the same defect as a comment claiming enforcement — corrected here rather than
+      left to be discovered by whoever next runs the command and gets a different answer.
+    exit: 0
+    ts: "2026-08-31T00:44:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The guard can still go RED — the guilt control the workflow performs in CI, run
+      locally first, because a control that has never been executed is a claim.
+    cmd: >-
+      Replace `"--text-primary": "#16213a"` with the retired `"#ff3344"` in
+      merahPutihDayVars.ts, run the guard, restore, run again, compare bytes.
+    result: >-
+      MUTATED rc=1 ("3 failed, 39 passed") · RESTORED rc=0 ("42 passed", 43 on the final
+      shipped tree — see the note on the receipt above about a count that aged) · file
+      byte-identical after restore: True. The three failures name the ratios (3.34 /
+      3.62 / 3.06, all below 4.5), i.e. the guard fails for the right reason rather than
+      on a parse error.
+    exit: 0
+    ts: "2026-08-30T23:03:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The paths filter covers what the guard reads — and the FIRST version of this receipt
+      was WRONG, in exactly the way the brief's own constraint warned about.
+    cmd: >-
+      Superseded probe: parse `REPO / "..."` literals and `.rglob(...)` calls out of
+      scripts/tests/test_merah_putih_day_contrast.py. Corrected probe: EXECUTE the guard's
+      own `_perimeter_sources()` and print the resolved set, partitioned by whether each
+      file lives under the route perimeter.
+    result: >-
+      Superseded result (believed until refuted): three surfaces — merahPutihDayVars.ts,
+      the *.tsx tree under app/visa/second-home/, packages/core/tokens/semantic.css.
+      EXECUTED result: 20 .tsx files, 18 in-perimeter and 2 OUTSIDE —
+      apps/mouth/src/components/lead/WhatsAppLeadButton.tsx and
+      apps/mouth/src/components/visa/ConsentBanner.tsx. `_perimeter_sources()` resolves
+      every `@/components/...` import found in the two wrappers (regex at line 169, anchored
+      to that prefix) and scans those files too. The filter shipped without them, so a real
+      contrast regression in either would have started NO check — and ConsentBanner is
+      precisely the component this guard caught at 2.56:1. Fixed with
+      `apps/mouth/src/components/**`, a TRUE superset by the regex's own anchor.
+    exit: 0
+    ts: "2026-08-31T00:12:00Z"
+    seat: session (Pro), after kimi-code/k3 refutation
+    note: >-
+      READING the source is what a static parse of string literals could not do: the third
+      surface was not a literal, it was a computation. The guard's own docstring says why
+      it is computed — "a hand-kept list would rot on its first commit" — and the filter I
+      hand-kept beside it rotted before it ever ran once.
+
+  - claim: The new workflow is schema-valid and introduces no trigger-symmetry violation.
+    cmd: >-
+      actionlint .github/workflows/merah-putih-day-contrast.yml ; then
+      scripts/ci/lint_trigger_symmetry.py (borrowed from #5340, run from inside the
+      worktree, removed again before commit and never staged)
+    result: >-
+      actionlint rc=0. Trigger-symmetry reports exactly ONE violation on this tree and it
+      is `.github/workflows/with-seat-broker-tests.yml` — the pre-existing defect #5378
+      fixes, present here only because this worktree branches from origin/main. This new
+      file produces no violation, and its pull_request.paths / push.paths are the same
+      anchored list (5 entries, `&guarded_paths` defined before `*guarded_paths` is used).
+    exit: 0
+    ts: "2026-08-30T23:01:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The workflow is ADVISORY and adds nothing to the merge queue.
+    cmd: >-
+      Parse infra/required.d/contexts.json (11 contexts, 8 distinct workflow files) and
+      read the new file's `on:` block.
+    result: >-
+      This workflow backs no required context, and carries triggers [pull_request, push]
+      with no merge_group — so it contributes zero runs per queue entry, per the
+      2026-08-27 queue-slim cure.
+    exit: 0
+    ts: "2026-08-30T23:04:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The token file's enforcement claim was FALSE and is now true.
+    cmd: >-
+      grep "fails the build" apps/mouth/src/lib/theme/merahPutihDayVars.ts, cross-checked
+      against the arming measurement above.
+    result: >-
+      Line 31 read "which fails the build if any pair below drifts" while no workflow
+      named the guard. Rewritten to name the workflow that now backs it, and to record
+      that the previous sentence was false — prose asserting enforcement CI does not have
+      is worse than no claim, because it stops the next reader from checking.
+    exit: 0
+    ts: "2026-08-30T23:05:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The filter/guard sync is now MACHINE-CHECKED, and the check itself can go red.
+    cmd: >-
+      Added test #43, which parses this workflow's own `paths:` block and fails on any file
+      `_perimeter_sources()` reads that no pattern matches. Innocence: run the file.
+      Guilt: delete `apps/mouth/src/components/**` from the anchor, re-run, restore, re-run,
+      compare bytes.
+    result: >-
+      INNOCENCE 43 passed. GUILT "1 failed, 42 passed", the failure listing exactly
+      apps/mouth/src/components/lead/WhatsAppLeadButton.tsx and
+      apps/mouth/src/components/visa/ConsentBanner.tsx — i.e. it re-detects, unaided, the
+      defect a cross-family refuter had to find by hand an hour earlier. Workflow
+      byte-identical after restore; final run 43 passed.
+    exit: 0
+    ts: "2026-08-31T00:22:00Z"
+    seat: session (Pro)
+    note: >-
+      The test carries its OWN negative control in the same run (a path outside the filter
+      must NOT match), because a glob matcher that matches everything would make every
+      assertion after it vacuously green — the failure mode that produced a discarded
+      measurement earlier in this same pack.
+
+  - claim: >-
+      GitHub Actions DOES honour the YAML anchor/alias this workflow uses — the round-2
+      refuter's blocking verdict is REFUTED by measurement.
+    cmd: >-
+      Read every workflow on origin/main for an anchor definition, then query the Actions
+      API for the one that has it: registration state and run counts by event.
+    result: >-
+      `.github/workflows/with-seat-broker-tests.yml` is the only anchored workflow on main
+      and it uses the identical `paths: &guarded_paths` / `paths: *guarded_paths` shape.
+      The API reports it id=346020455 **state=active**, with 72 merge_group, 11
+      pull_request and 1 push runs. A file GitHub refused to parse would be unregistered
+      with zero runs of any event — and the `push` runs specifically exercise the trigger
+      whose paths come from the ALIAS. The claim "the workflow parser rejects anchors, the
+      file is invalid, the guard never arms" is therefore false here.
+    exit: 0
+    ts: "2026-08-31T00:31:00Z"
+    seat: session (Pro)
+    note: >-
+      THE FIRST ATTEMPT AT THIS PROBE APPEARED TO CONFIRM THE REFUTER: `gh` answered
+      "workflow not found on the default branch", which is also what GitHub says about a
+      workflow it never registered. It was the wrong REPO SLUG (`Balizero1987/nuzantara`;
+      the real one is `Bali-Zero/Teman2`), and the generic list-workflows endpoint 404'd
+      too — which is what exposed it as an instrument fault rather than a finding. A 404
+      read as evidence would have shipped a false confirmation of a false refutation.
+
+dissent:
+  - seat: kimi-code/k3
+    status: CONFIRMED
+    round: 1
+    objection: >-
+      "the paths filter omits apps/mouth/src/components/**, which the guard reads via
+      wrapper import resolution, so a real regression in ConsentBanner/WhatsAppLeadButton
+      starts no check". VERDICT: DO-NOT-SHIP.
+    disposition: >-
+      ACTED ON — it reversed this PR's central artifact.
+      Verified independently by executing `_perimeter_sources()` (receipt above), not taken
+      on trust. Fixed by adding the superset path AND by making the sync machine-checked so
+      the class cannot recur silently. Without this seat the PR would have shipped a guard
+      armed behind a filter that misses two of the files it protects.
+
+  - seat: kimi-code/k3
+    status: RETRACTED
+    round: 2
+    objection: >-
+      "GitHub Actions does not support YAML anchors/aliases, so the workflow file is invalid
+      and the guard stays unarmed while the PyYAML-based conformance test passes on it."
+      VERDICT: DO-NOT-SHIP.
+    disposition: >-
+      Falsified against the live Actions API: the one anchored workflow already on main is
+      registered state=active with 84 runs across three events, including push (the trigger
+      fed by the alias). The seat's four other lines — matcher ordering, the YAML 1.1 `on:`
+      boolean trap, the pyyaml import path, the guilt-control flow under `set -euo pipefail`
+      — were each examined and found sound; recorded because a refuter that is right once
+      and wrong once is exactly why findings get re-measured rather than obeyed.
+
+  - seat: codex-gpt-5.6-sol (xhigh)
+    status: CONFIRMED
+    round: 2
+    objection: >-
+      "Fatal mismatch: the workflow explicitly remains advisory, absent from required
+      contexts and merge_group. A red PR is still mergeable; push detects the regression
+      only after it reaches main." VERDICT: DO-NOT-SHIP.
+    disposition: >-
+      CONFIRMED AS TO FACT, REMEDY DECLINED — the gap is real and is now stated on the
+      artifact instead of only in the risks; the prescribed cure is refused with its reason
+      on the record rather than in a session's head.
+      The FACT is accurate and was already declared in the brief's risks, but the artifact's
+      own framing ("makes it true", "ends this failure") invited the stronger reading — so
+      the header now carries an explicit WHAT THIS BUYS / WHAT IT DOES NOT paragraph and the
+      token file's comment says in as many words that the check is advisory, runs, goes red,
+      and does not block. The REMEDY is declined: promoting the context to required obliges
+      this workflow to carry a `merge_group:` trigger (a required context that never runs on
+      the queue's ref leaves entries waiting forever — the exact jam this session spent the
+      night clearing on #5378), which is the queue cost the 2026-08-27 slim cure exists to
+      prevent. That trade belongs in a branch-protection PR with its own analysis, not
+      smuggled into the PR that merely turns the guard on. Shipping the smaller true thing
+      beats shipping a bigger claim.
+    independent_agreement: >-
+      This seat also examined the anchor question on fresh context and reached the OPPOSITE
+      conclusion from kimi round 2, citing GitHub's own reusing-workflow-configurations
+      documentation: anchors/aliases are supported. Two cross-family seats disagreeing on a
+      blocking claim is why the live Actions API was queried instead of either being
+      believed.
+
+tests:
+  - "scripts/tests/test_merah_putih_day_contrast.py — 43 passed (innocence). Was 42 before
+    this PR; the 43rd is the trigger-coverage conformance test added here."
+  - "Same file with the DAY ink mutated to a retired colour — 3 failed, 39 passed (guilt on
+    the palette law), byte-identical after restore."
+  - "Same file with `apps/mouth/src/components/**` deleted from the workflow's anchor — 1
+    failed, 42 passed (guilt on the TRIGGER), the failure naming WhatsAppLeadButton.tsx and
+    ConsentBanner.tsx; byte-identical after restore, 43 passed again."
+  - "actionlint on the new workflow — rc=0, re-run after every header edit."
+
+static:
+  - "actionlint: clean on the added workflow."
+  - "trigger-symmetry lint: this file contributes 0 violations."
+
+notes: >-
+  WHAT THIS PR DOES NOT DO, stated rather than implied. It does not make the guard a
+  REQUIRED context — that is a branch-protection change, it would drag a `merge_group:`
+  trigger in with it, and it is deliberately not bundled; the check therefore RUNS and goes
+  RED without BLOCKING, which the header and the token file now both say in as many words
+  after a cross-family seat read the old framing as claiming more. What it no longer leaves
+  undone is the derivation: an earlier draft of this note said the filter and the guard's
+  file set are kept in sync BY HAND, "the same defect class one notch smaller", named in the
+  risks rather than hidden. Naming a defect is not surviving it — the hand-kept list was
+  already wrong when that sentence was written, and a refuter found it before CI could. The
+  sync is now machine-checked by test #43. And it does not touch
+  scripts-tests-sweep.yml: the nightly continue-on-error sweep still runs this test, it
+  simply was never a gate and was never claimed to be one by anything except the token
+  file's own comment.

--- a/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
@@ -41,7 +41,7 @@ council_run: council-journal.jsonl
 
 diff:
   files: 6
-  net_lines: 687
+  net_lines: 700
   measured_at: f940c583c
   note: >-
     Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`,
@@ -227,29 +227,36 @@ receipts:
       read as evidence would have shipped a false confirmation of a false refutation.
 
   - claim: >-
-      THE FINAL ON-DISK GATE CAUGHT A FALSE NUMBER IN THIS PR'S OWN ARTIFACT, inherited
-      from a claim this session had already published elsewhere.
+      THE GATE'S FIRST VERDICT WAS ITSELF THE DEFECT — a true number was "corrected" into a
+      false one, and the reversal is recorded rather than erased.
     cmd: >-
-      Re-read the committed workflow header line by line, then re-measure the number it
-      cited: `gh run list --repo Bali-Zero/Teman2 --workflow with-seat-broker-tests.yml
-      --limit 500 --json event,createdAt,headBranch`, grouped by event and by branch.
+      1) Re-measure ALL runs: `gh run list --workflow with-seat-broker-tests.yml
+      --limit 500 --json event,createdAt,headBranch` -> 86 returned (not capped):
+      72 merge_group / 12 pull_request / 2 push. 2) THEN read the claim's own scope off
+      `git show origin/main:.github/workflows/with-seat-broker-tests.yml` and re-count
+      INSIDE it.
     result: >-
-      86 runs returned against a limit of 500, so the listing is COMPLETE, not capped:
-      72 merge_group, 12 pull_request, 2 push. The header asserted the referenced workflow
-      "ran 57 times in the queue and zero times on a PR" and both halves are false. The 57
-      was a `--limit 8`-class display cap read as a total (W97); the "zero" missed that the
-      12 pull_request runs split 4 / 7 / 1 across the PR that introduced the file, #5378
-      itself, and a third branch. Corrected in place, with the wrong figure and its two
-      distinct causes named rather than quietly overwritten.
+      The claim on main is window-scoped in its own text — "counted between this file
+      landing (2026-08-30T19:15:44Z) and the first run its own fix triggered". Inside that
+      window: 57 merge_group, 1 pull_request (at 21:47:21Z, which IS the closing boundary),
+      1 push. The 4 stray pull_request runs are at 17:08-17:33Z on the branch of the PR
+      that INTRODUCED the file — before the window opens. So **57 and ZERO are both
+      correct as scoped**, and the totals 72/12 do not contradict them. The gate's
+      intermediate "both halves are false" edit was WRONG and has been reverted.
     exit: 0
-    ts: "2026-08-31T00:58:00Z"
+    ts: "2026-08-31T01:06:00Z"
     seat: session (Pro) — final on-disk gate, sequential, not delegated
     note: >-
-      This is the gate doing the one job that cannot be delegated: the false number was not
-      invented here, it was COPIED from a header this session had already shipped on another
-      PR, where it will also be corrected. A wrong figure that travels between artifacts is
-      the failure mode the gate exists to interrupt — and it interrupted it after the commit
-      and before the arm, which is exactly the last moment it still could.
+      THE ORDER OF OPERATIONS WAS THE WHOLE DEFECT. A delegated measurement returned
+      unscoped totals with the verdict "CLAIM WRONG", and explicitly flagged its own open
+      question — whether the claim named a window it could not see. That caveat was in the
+      report and was read past. A confident, precise, wrong correction was then written,
+      committed and pushed on top of a statement that was accurate; only re-reading the
+      original text on main stopped it reaching main itself. This is the "a diagnosis can
+      be a regression" failure in its exact shape: an unscoped measurement cannot judge a
+      scoped claim, so the window is read off the claim BEFORE its number is judged — and
+      a subagent's DATA outranks its CONCLUSION. Kept as a receipt because a reversal that
+      leaves no trace teaches nothing to whoever reads this next.
 
 dissent:
   - seat: kimi-code/k3

--- a/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
@@ -40,8 +40,8 @@ lanes:
 council_run: council-journal.jsonl
 
 diff:
-  files: 6
-  net_lines: 700
+  files: 7
+  net_lines: 728
   measured_at: f940c583c
   note: >-
     Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`,
@@ -257,6 +257,33 @@ receipts:
       scoped claim, so the window is read off the claim BEFORE its number is judged — and
       a subagent's DATA outranks its CONCLUSION. Kept as a receipt because a reversal that
       leaves no trace teaches nothing to whoever reads this next.
+
+  - claim: >-
+      CI found a THIRD instance of this PR's own disease, one level further out, and it is
+      fixed here rather than deferred.
+    cmd: >-
+      `python3 scripts/check_watcher_coverage.py` — run by the "Watcher coverage" workflow
+      on PR #5395, then re-run locally after the fix.
+    result: >-
+      RED first: "✗ `Merah Putih DAY contrast guard` (merah-putih-day-contrast.yml) is not
+      covered by main-push-failure-watch.yml". The new workflow carries `push: branches:
+      [main]`, and this repo requires every such workflow's `name:` to appear in the
+      meta-watcher's `on.workflow_run.workflows:` list — otherwise a failure ON MAIN alerts
+      nobody. GREEN after adding the name: "✓ watcher-coverage: all 117 live workflow(s)
+      covered". actionlint rc=0 on both touched workflows.
+    exit: 0
+    ts: "2026-08-31T01:14:00Z"
+    seat: session (Pro), finding by CI
+    note: >-
+      Worth stating plainly: this is the SAME cicatrix #2 shape a third time in one PR — a
+      guard exists, runs, and its failure reaches no one. First the guard had no trigger;
+      then the trigger missed two files it protects; now the main-branch run had no watcher.
+      Each layer was caught by a different instrument (a session audit, a cross-family
+      refuter, and the repo's own conformance check), which is the argument for having all
+      three rather than trusting any one of them. Pre-existing and NOT touched: the checker
+      also warns about a stale entry, `AI PR review (advisory)`, left over from that
+      workflow being disabled on 2026-08-20 — a real but separate lane's cleanup, and
+      widening this PR to sweep it would break "one PR, one concern".
 
 dissent:
   - seat: kimi-code/k3

--- a/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/pack.yml
@@ -41,7 +41,7 @@ council_run: council-journal.jsonl
 
 diff:
   files: 6
-  net_lines: 655
+  net_lines: 687
   measured_at: f940c583c
   note: >-
     Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`,
@@ -225,6 +225,31 @@ receipts:
       the real one is `Bali-Zero/Teman2`), and the generic list-workflows endpoint 404'd
       too — which is what exposed it as an instrument fault rather than a finding. A 404
       read as evidence would have shipped a false confirmation of a false refutation.
+
+  - claim: >-
+      THE FINAL ON-DISK GATE CAUGHT A FALSE NUMBER IN THIS PR'S OWN ARTIFACT, inherited
+      from a claim this session had already published elsewhere.
+    cmd: >-
+      Re-read the committed workflow header line by line, then re-measure the number it
+      cited: `gh run list --repo Bali-Zero/Teman2 --workflow with-seat-broker-tests.yml
+      --limit 500 --json event,createdAt,headBranch`, grouped by event and by branch.
+    result: >-
+      86 runs returned against a limit of 500, so the listing is COMPLETE, not capped:
+      72 merge_group, 12 pull_request, 2 push. The header asserted the referenced workflow
+      "ran 57 times in the queue and zero times on a PR" and both halves are false. The 57
+      was a `--limit 8`-class display cap read as a total (W97); the "zero" missed that the
+      12 pull_request runs split 4 / 7 / 1 across the PR that introduced the file, #5378
+      itself, and a third branch. Corrected in place, with the wrong figure and its two
+      distinct causes named rather than quietly overwritten.
+    exit: 0
+    ts: "2026-08-31T00:58:00Z"
+    seat: session (Pro) — final on-disk gate, sequential, not delegated
+    note: >-
+      This is the gate doing the one job that cannot be delegated: the false number was not
+      invented here, it was COPIED from a header this session had already shipped on another
+      PR, where it will also be corrected. A wrong figure that travels between artifacts is
+      the failure mode the gate exists to interrupt — and it interrupted it after the commit
+      and before the arm, which is exactly the last moment it still could.
 
 dissent:
   - seat: kimi-code/k3

--- a/scripts/tests/test_merah_putih_day_contrast.py
+++ b/scripts/tests/test_merah_putih_day_contrast.py
@@ -515,3 +515,68 @@ def test_the_perimeter_sees_shared_components_rendered_inside_the_wrappers() -> 
         f"saw only: {sorted(names)}"
     )
     assert "SecondHomeLanding.tsx" in names and "StudioApp.tsx" in names
+
+
+WORKFLOW = REPO / ".github/workflows/merah-putih-day-contrast.yml"
+
+
+def _paths_glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """GitHub's `paths:` glob, narrowed to the two wildcards this filter uses.
+
+    `**` crosses directory separators, a single `*` does not. Order matters:
+    `re.escape` turns `**` into `\\*\\*`, so that must be substituted BEFORE the
+    single-star rule, or the first star eats the second.
+    """
+    rx = re.escape(pattern).replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+    return re.compile(rx + r"\Z")
+
+
+def _workflow_trigger_paths() -> list[str]:
+    import yaml  # deliberately function-local: a missing pyyaml must break THIS
+    # test, not error out the other 42 — and it must FAIL, never skip. A guard
+    # that skips itself when its parser is absent is the disarmament this whole
+    # file exists to prevent.
+
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML implements YAML 1.1, where a bare `on:` key parses as the BOOLEAN
+    # True, not the string "on". Reading doc["on"] here returns None on a
+    # perfectly valid workflow and the assertion below would pass on an empty
+    # list — vacuously green, which is worse than red.
+    trigger = doc.get("on", doc.get(True))
+    assert trigger, f"{WORKFLOW.name}: no trigger block parsed — check the YAML 1.1 `on:` key trap"
+    return list(trigger["pull_request"]["paths"])
+
+
+def test_the_workflow_trigger_covers_every_file_this_guard_reads() -> None:
+    """Arming a guard behind a filter that misses the files it protects is the
+    same defect one level up — and it is invisible, because the job simply never
+    starts and the PR is green with nothing having run.
+
+    This is why the coverage is COMPUTED from the guard's own read set rather
+    than eyeballed against the workflow: the perimeter resolves shared
+    `@/components/...` imports out of the two wrappers, so the painted set grows
+    whenever a wrapper adds an import — and the first version of that filter
+    named only the route tree and missed ConsentBanner and WhatsAppLeadButton
+    entirely.
+    """
+    patterns = [_paths_glob_to_regex(p) for p in _workflow_trigger_paths()]
+
+    # The instrument must be able to say NO, or every assertion below is
+    # vacuous. A probe that cannot return a negative cannot return a positive.
+    assert not any(
+        rx.match("packages/core/tokens/themes/editorial.css") for rx in patterns
+    ), "the glob matcher matches everything — it is not measuring the filter"
+
+    read_set = {TOKENS, SEMANTIC_CSS, Path(__file__).resolve(), WORKFLOW}
+    read_set.update(_perimeter_sources())
+
+    uncovered = sorted(
+        str(p.relative_to(REPO))
+        for p in read_set
+        if not any(rx.match(str(p.relative_to(REPO))) for rx in patterns)
+    )
+    assert not uncovered, (
+        "these files are READ by this guard but match no `paths:` pattern in "
+        f"{WORKFLOW.name}, so changing one starts no check run:\n  "
+        + "\n  ".join(uncovered)
+    )


### PR DESCRIPTION
## The finding

`scripts/tests/test_merah_putih_day_contrast.py` is the machine-checked identity law for the Merah Putih DAY palette — every text/ground pair on the public second-home surfaces clears WCAG AA, no retired colour or Montserrat face reappears there. It has been on `main` since the palette migration landed, it passes, and it demonstrably goes red on a real regression.

**No workflow named it.** Measured by reading the content of all 116 workflow files on `origin/main`. The only place it executed was `scripts-tests-sweep.yml` — `schedule:`-only, `continue-on-error: true`, not required, and its own header says it gates nothing. A PR touching only `merahPutihDayVars.ts` started no check on it at all. Cicatrix family **#2, "esiste ≠ armato"**, on the guard protecting the palette this lane had just migrated.

Sharper second symptom: the token file's own doc-comment claimed the guard *"fails the build if any pair below drifts"*. False as measured — prose asserting enforcement CI does not back, which is worse than no claim because it stops the next reader from checking.

## The part worth reading

**The first version of this workflow committed the same defect one level up.** Its `paths:` filter named the route tree, the token file and `semantic.css`. But `_perimeter_sources()` also resolves every `@/components/...` import out of the two wrappers and scans those files too — today `ConsentBanner.tsx` and `WhatsAppLeadButton.tsx`. ConsentBanner is *precisely* the component this guard caught at 2.56:1. A real contrast regression in either would have started **no check**.

A cross-family refuter (`kimi-code/k3`) found it before CI could. Executing the guard's own resolver confirmed it: 20 `.tsx` files, 18 in-perimeter, **2 outside**.

So the fix is not just the missing path:

- `apps/mouth/src/components/**` is a **true superset** — the resolver's regex is anchored to that prefix, so every import it can ever resolve falls under it. Not a second hand-kept list.
- A new conformance test parses **this workflow's own `paths:` block** and fails naming any file the guard reads that no pattern matches. The guard's docstring already said why its file set is computed rather than listed — *"a hand-kept list would rot on its first commit"* — and the list I hand-kept beside it rotted before it ever ran once.

## Guilt-controlled in both directions

| Mutation | Result |
|---|---|
| DAY ink → retired `#ff3344` | `3 failed, 39 passed` (ratios 3.34 / 3.62 / 3.06) |
| delete `components/**` from the anchor | `1 failed, 42 passed`, naming both components |
| restore, either case | byte-identical; `43 passed` |

The job performs the ink mutation **itself in CI**, so it cannot pass on nothing.

## Scope — stated, not implied

This check **RUNS and goes RED. It does not BLOCK.** It is not a required context. `codex-gpt-5.6-sol` raised exactly this as a ship-blocker; the fact is confirmed and now written on the artifact, but the remedy is declined with its reason recorded: promoting the context to required obliges a `merge_group:` trigger, which is the queue cost the 2026-08-27 slim cure exists to prevent — that belongs in its own branch-protection PR, not smuggled into the PR that merely turns the guard on.

## Council

Two cross-family seats, both adversarial, on fresh context. One finding CONFIRMED (reversed the PR's central artifact), one RETRACTED after measurement — the claim that GitHub rejects YAML anchors, falsified against the live Actions API, where the one anchored workflow already on `main` is `state=active` with 84 runs across three events. The originally-named third seat returned nothing twice and is recorded as a non-answer rather than written into the journal.

Evidence pack: `evidence/2026-08/agent-nuzantara-infra-arm-day-contrast-3eb07266/`