### PR TITLE
fix(hooks): a guard blocked a pure read as a write, and its twin had drifted

### DIFF
--- a/infra/claude-hooks/host_boundary.py
+++ b/infra/claude-hooks/host_boundary.py
@@ -82,14 +82,20 @@ SECRET_READ_HINTS = (
     ".nuzantara-secrets", "token",
 )
 
-# --- W79 write-target extraction (CLONED VERBATIM from worktree_isolation.py) --
+# --- W79 write-target extraction (shared with worktree_isolation.py) ----------
+# This block is a COPY, and "verbatim" is a promise prose cannot keep: the
+# 2026-08-18 W119 cure fixed CPMV_RE in worktree_isolation.py and never reached
+# this file, which went on asserting it was verbatim for 13 days — which is
+# exactly why nobody looked. The five names below are now pinned identical by
+# `test_w119b_write_regex_newline_bleed.py::test_w119b_shared_regexes_are_identical_in_both_hooks`,
+# so a one-sided edit goes RED instead of going unnoticed. Change one, change both.
 # Quick gate: does the command contain anything that could write a file?
-WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|]*-i|\bdd\b[^|]*\bof=|\b(?:cp|mv|install)\b)")
+WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|\n]*-i|\bdd\b[^|\n]*\bof=|\b(?:cp|mv|install)\b)")
 REDIR_RE = re.compile(r"(?<![0-9>&])>>?\s*([^\s|;&)]+)")
-TEE_RE = re.compile(r"\btee\s+(?:-a\s+)?([^\s|;&)]+)")
-SEDI_RE = re.compile(r"\bsed\b[^|;&]*?-i\S*\s+(?:-e\s+\S+\s+|'[^']*'\s+|\"[^\"]*\"\s+|\S+\s+)([^\s|;&)]+)")
-DDOF_RE = re.compile(r"\bdd\b[^|;&]*?\bof=([^\s|;&)]+)")
-CPMV_RE = re.compile(r"\b(?:cp|mv|install)\b((?:\s+(?:-\S+|[^\s|;&)]+))+)")
+TEE_RE = re.compile(r"\btee[ \t]+(?:-a[ \t]+)?([^\s|;&)]+)")
+SEDI_RE = re.compile(r"\bsed\b[^|;&\n]*?-i\S*[ \t]+(?:-e[ \t]+\S+[ \t]+|'[^']*'[ \t]+|\"[^\"]*\"[ \t]+|\S+[ \t]+)([^\s|;&)]+)")
+DDOF_RE = re.compile(r"\bdd\b[^|;&\n]*?\bof=([^\s|;&)]+)")
+CPMV_RE = re.compile(r"\b(?:cp|mv|install)\b((?:[ \t]+(?:-\S+|[^\s|;&)]+))+)")
 # Read commands whose FIRST file arg, if a secret, triggers a WARN.
 READ_CMD_RE = re.compile(r"\b(cat|less|more|head|tail|bat)\b\s+((?:-\S+\s+)*)([^\s|;&)]+)")
 

--- a/infra/claude-hooks/host_boundary.py
+++ b/infra/claude-hooks/host_boundary.py
@@ -91,9 +91,9 @@ SECRET_READ_HINTS = (
 # so a one-sided edit goes RED instead of going unnoticed. Change one, change both.
 # Quick gate: does the command contain anything that could write a file?
 WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|\n]*-i|\bdd\b[^|\n]*\bof=|\b(?:cp|mv|install)\b)")
-REDIR_RE = re.compile(r"(?<![0-9>&])>>?\s*([^\s|;&)]+)")
+REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?[ \t]*([^\s|;&)]+)")  # stdout/stderr/combined redirects
 TEE_RE = re.compile(r"\btee[ \t]+(?:-a[ \t]+)?([^\s|;&)]+)")
-SEDI_RE = re.compile(r"\bsed\b[^|;&\n]*?-i\S*[ \t]+(?:-e[ \t]+\S+[ \t]+|'[^']*'[ \t]+|\"[^\"]*\"[ \t]+|\S+[ \t]+)([^\s|;&)]+)")
+SEDI_RE = re.compile(r"\bsed\b[^|;&\n]*?-i\S*[ \t]+(?:-e[ \t]+\S+[ \t]+|'[^'\n]*'[ \t]+|\"[^\"\n]*\"[ \t]+|\S+[ \t]+)*([^\s|;&)]+)")
 DDOF_RE = re.compile(r"\bdd\b[^|;&\n]*?\bof=([^\s|;&)]+)")
 CPMV_RE = re.compile(r"\b(?:cp|mv|install)\b((?:[ \t]+(?:-\S+|[^\s|;&)]+))+)")
 # Read commands whose FIRST file arg, if a secret, triggers a WARN.
@@ -123,8 +123,21 @@ def _strip_noise(cmd: str) -> str:
         return "\n".join(out)
 
     s = _drop_heredocs(cmd)
-    s = re.sub(r"'[^']*'", "''", s)
-    s = re.sub(r'"[^"]*"', '""', s)
+    # W84 (ported here 2026-08-31, 13 days after it was cured in
+    # worktree_isolation.py and never copied across — see the block comment
+    # there for the full reasoning): the char-class MUST exclude newline. With
+    # `[^']*`, an apostrophe on line A pairs with one on line C, and every line
+    # BETWEEN them is deleted from the scanned text. Measured fail-OPEN on this
+    # very guard:
+    #     echo don't panic
+    #     cp /tmp/evil ~/.ssh/config
+    #     echo it's done
+    # collapsed to `echo don''s done` — the `cp` line vanished and the write to
+    # a protected path was ALLOWED. A shell quote never legitimately spans a
+    # newline here, so confining the match to one line is both correct and the
+    # false-positive killer.
+    s = re.sub(r"'[^'\n]*'", "''", s)
+    s = re.sub(r'"[^"\n]*"', '""', s)
     return s
 
 

--- a/infra/claude-hooks/test_w119b_write_regex_newline_bleed.py
+++ b/infra/claude-hooks/test_w119b_write_regex_newline_bleed.py
@@ -1,95 +1,109 @@
 #!/usr/bin/env python3
-"""W119b — the same statement-boundary defect, in the regexes the 2026-08-18 pass
-did not look at, and in the copy that never received the half it did fix.
+"""W119b — statement-boundary bleed in the regexes the 2026-08-18 pass did not
+look at, plus the two cures that reached one copy of this block and not the other.
 
 ## What W119 already cured, and what it left alive
 
 `test_w119_multiline_token_bleed.py` (2026-08-18) established the invariant: a
 shell token never spans a bare newline, because bash treats a newline exactly as
 it treats `;`, so a guard's inter-token separator must be `[ \\t]`, never `\\s`.
-It applied that cure to three regexes — `RM_RF_RE`, `WT_REMOVE_GIT_RE`,
-`CPMV_RE` — **in `worktree_isolation.py`**.
+It applied that cure to `RM_RF_RE`, `WT_REMOVE_GIT_RE` and `CPMV_RE` — **in
+`worktree_isolation.py` only**.
 
-Two things survived it, and this file is about both:
+Three things survived it, and this file is about all three:
 
 1. **`SEDI_RE` and `DDOF_RE` were never cured, in EITHER file.** They sit three
-   lines away from `CPMV_RE` in the same block and carry the identical defect,
-   in a worse spot: their span between the verb and its flag is `[^|;&]*?`, and
-   a negated character class matches a newline, so `sed` on line 1 welds itself
-   to a `-i` appearing ANY number of lines later. The `-i` does not even have to
-   belong to sed.
-2. **`host_boundary.py` never received the `CPMV_RE` half of the 2026-08-18
-   cure.** Its block is introduced by the comment *"CLONED VERBATIM from
-   worktree_isolation.py"* — an assertion that stopped being true the moment the
-   original was fixed and the clone was not. That comment is precisely what made
-   the divergence invisible: a reader who trusts it has no reason to look.
+   lines from `CPMV_RE` in the same block. Their span between verb and flag is
+   `[^|;&]*?`, and a negated class matches a newline, so `sed` on line 1 welds
+   itself to a `-i` any number of lines later — and the `-i` need not be sed's.
+2. **`host_boundary.py` never received the `CPMV_RE` half of that cure**, under a
+   comment reading *"CLONED VERBATIM from worktree_isolation.py"* — an assertion
+   that stopped being true the moment the original moved, and that is precisely
+   what kept anyone from looking. Thirteen days.
+3. **`host_boundary.py` never received the W84 `_strip_noise` cure either**, and
+   that one fails **OPEN**. See below.
 
-## The live incident (2026-08-31, this repo, a real session)
+## Two live incidents, both measured
 
-A single Bash call of three lines:
+**Over-match (2026-08-31, a real session).** Three lines that write nothing:
 
-    sed -n '40,75p' /Users/nuzantara/nuzantara/scripts/fleet_mail.sh
+    sed -n '40,75p' <repo>/scripts/fleet_mail.sh
     echo "=== ssh config for air ==="
     grep -A6 -i "^Host air" <HOME>/.ssh/config 2>/dev/null | head -20
 
-Nothing in it writes anything. `host_boundary.py` blocked it with **"HOST
-BOUNDARY VIOLATION (write to host-sensitive path) — target: <HOME>/.ssh/config"**.
+blocked as *"HOST BOUNDARY VIOLATION (write to host-sensitive path)"*.
+`WRITE_HINT_RE`'s `\\bsed\\b[^|]*-i` matched from `sed` on line 1 across two
+newlines to the **`-i` of grep** on line 3; `SEDI_RE` took the next token as the
+destination and handed the guard a credentials file.
 
-The mechanism, measured: `WRITE_HINT_RE`'s `\\bsed\\b[^|]*-i` matched from `sed`
-on line 1 across two newlines to the `-i` of **grep** on line 3; `SEDI_RE` then
-took the next token as the write destination and handed the guard a credentials
-file. A pure read was convicted as a mutating write.
+**Under-match, fail-OPEN (found by a cross-family refuter reviewing the first
+draft of this very fix).** `host_boundary._strip_noise` used `'[^']*'`, which
+matches newlines, so:
 
-## Why an over-matching guard is not "the safe direction"
+    echo don't panic
+    cp /tmp/evil <HOME>/.ssh/config
+    echo it's done
 
-It fails closed, so nothing was damaged. The damage is downstream and slower: a
-guard that blocks correct work teaches the next session to reach for
-`HOST_BOUNDARY_OFF=1`, and a disarmed guard blocks nothing at all. The escape
-hatch is legitimate (W33); training people to use it routinely is not.
+collapsed to `echo don''s done` — the apostrophes in *don't* and *it's* paired
+across three lines and **deleted the `cp` line from the scanned text entirely**.
+The write to a protected path was ALLOWED. Same defect class, opposite and worse
+direction, on the credentials guard, in the copy that never got the W84 cure.
 
-## Known residual, stated rather than inherited silently
+That is why an over-matching guard is not "the safe direction": the two live in
+the same char-class mistake, and only one of them announces itself.
 
-Confining the separator to `[ \\t]` means a genuine backslash-newline line
-continuation (`cp foo \\` / newline / `<HOME>/.ssh/config`) is no longer swept
-into one statement, so its destination is not seen — an UNDER-match. That
-trade-off is not introduced here: it is the one the 2026-08-18 cure already
-chose for `RM_RF_RE`/`CPMV_RE`, and this file deliberately matches the
-established cure rather than inventing a second, divergent one — divergence
-between these two copies is the very disease being treated. It is named here so
-the next reader inherits a known limit instead of an unexamined one.
+## What this file asserts
 
-## Guilt and innocence, both required (superscar family #3)
+- **Over-match** — commands that write nothing are allowed (three of the four
+  cases reproduce a real pre-fix block; the `tee` case is labelled below).
+- **Innocence** — every real write to a protected path is still blocked, through
+  all five channels, alone and on line 2, **including the BSD `sed -i ''` form,
+  which is the only form `sed -i` has on macOS — this fleet's own OS.** The first
+  draft tested only the GNU form and therefore certified nothing about the form
+  that actually runs here.
+- **Parity** — the six shared regexes are pinned identical across both hooks,
+  read with a paren-balancing extractor so a multi-line `re.compile(` cannot
+  fake agreement (`data_plane_guard.py` in this directory already uses that
+  style, so this is a live risk, not a hypothetical one).
+- **Behavioural parity of `_strip_noise`** — a string compare cannot see a
+  divergence in a function body, and that is where the fail-open lived.
+- **The property, behaviourally** — for each regex, "no token pair joins across
+  `\\n`", asserted by running it. The first draft grepped the source for `\\s+`,
+  which would not have caught the ORIGINAL defect being reintroduced: `[^|;&]*?`
+  contains no `\\s` at all. So would `re.DOTALL`, `[\\s\\S]+`, `[ \\t\\n]+`, `\\v+`.
+- **Both hooks are executed**, not just host_boundary: the shared extraction
+  functions are imported and driven directly, because the two files' plumbing
+  around these regexes is NOT identical and string equality cannot see that.
 
-Over-match cases below assert the hook now ALLOWS commands that write nothing.
-Innocence cases assert it still BLOCKS every real write to a protected path
-through each of the five channels. A fix that only satisfied the first half
-would be a disarmed guard wearing a green tick.
+## Known residuals, named rather than inherited silently
 
-VERIFIED NOT VACUOUS, and stated exactly. Re-running this file against the
-pre-fix hooks (restored from `origin/main`) produced:
+Verified still-allowed after this fix, and deliberately out of scope — each is a
+pre-existing path-resolution gap that this diff neither introduces nor worsens,
+and each is recorded in the PR so it is inherited knowingly:
 
-  FAIL over-match     — SEDI_RE, DDOF_RE and CPMV_RE cases each blocked rc=2
-                        with "HOST BOUNDARY VIOLATION (write to host-sensitive
-                        path)" on commands that write nothing
-  PASS innocence      — the pre-fix guard blocked real writes too, as it must;
-                        this half exists to prove the fix did not disarm it,
-                        so it is expected green on both sides
-  FAIL parity         — CPMV_RE diverged between the two copies
-  FAIL no-backslash-s — the separators were still `\\s`
+- `$HOME`-expanded targets (`cp /tmp/evil $HOME/.ssh/config`) — `_resolve_target`
+  expands `~` but not `$VAR`.
+- multi-file `tee` (`tee /tmp/ok ~/.ssh/config`) — only the first file is read.
+- `cd ~/.ssh && echo evil > config` — relative to the payload's cwd, not the `cd`.
+- `cp -t ~/.ssh /tmp/evil` — GNU `--target-directory` hides the destination in a flag.
+- `>|` noclobber-override redirects.
+- a genuine backslash-newline continuation is no longer swept into one statement.
+  That trade-off is the one the 2026-08-18 cure already chose for
+  `RM_RF_RE`/`CPMV_RE`; this file matches it rather than inventing a second.
 
-The `tee` case is the one exception and is labelled honestly: it passed BEFORE
-the fix as well. `TEE_RE`'s bleed could only capture a following line's first
-token, which is a command name rather than a path, so it never reached a
-protected target. It is a FORWARD guard against the same class in a regex that
-happened not to have a live victim — not a reproduction of an observed defect.
-Three of the four over-match cases are real reproductions; this one is not, and
-saying otherwise would make this docstring the same kind of confident-and-wrong
-artifact the fix is about.
+VERIFIED NOT VACUOUS: run against the pre-fix hooks restored from `origin/main`,
+the over-match, parity and property tests FAIL and the innocence test passes
+(it must pass on both sides — that is what makes it evidence the guard was
+narrowed across statements and not within one). The `tee` over-match case passed
+before the fix too: its bleed could only capture a following line's command
+*name*, never a protected path, so it is a FORWARD guard against the same class,
+not a reproduction. Calling it a fourth reproduction would make this docstring
+the same confident-and-wrong artifact the fix exists to remove.
 """
+import importlib.util
 import json
 import os
 import pathlib
-import re
 import subprocess
 import sys
 
@@ -100,8 +114,16 @@ HOME = pathlib.Path.home()
 SSH_CONFIG = HOME / ".ssh" / "config"
 
 
+def _load(path: pathlib.Path, name: str):
+    """Import a hook module so its real functions can be driven directly."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _run_hook(hook: pathlib.Path, cmd: str, cwd: str) -> tuple[int, str]:
-    """Drive a hook the way the harness does: JSON payload on stdin."""
+    """Drive a hook end-to-end the way the harness does: JSON payload on stdin."""
     env = dict(os.environ)
     env.pop("HOST_BOUNDARY_OFF", None)
     env.pop("AGENT_WORKTREE_ENFORCEMENT", None)
@@ -113,109 +135,197 @@ def _run_hook(hook: pathlib.Path, cmd: str, cwd: str) -> tuple[int, str]:
     return proc.returncode, proc.stderr
 
 
-# --- the five regex source lines that MUST stay identical across both copies ---
-# Named individually rather than diffed as a block: a block diff would go red on
-# an unrelated comment edit and get "fixed" by loosening it.
-_SHARED_REGEX_NAMES = ("WRITE_HINT_RE", "TEE_RE", "SEDI_RE", "DDOF_RE", "CPMV_RE")
+# The shared W79 extraction regexes. REDIR_RE is here deliberately: leaving it
+# out of the first draft let a real, security-relevant divergence stand one line
+# below the block the parity test was written to protect.
+_SHARED_REGEX_NAMES = (
+    "WRITE_HINT_RE", "REDIR_RE", "TEE_RE", "SEDI_RE", "DDOF_RE", "CPMV_RE",
+)
 
 
 def _regex_source(path: pathlib.Path, name: str) -> str | None:
-    """The literal right-hand side of `<name> = re.compile(...)`, or None."""
-    for line in path.read_text().splitlines():
-        stripped = line.strip()
-        if stripped.startswith(f"{name} = re.compile("):
-            return stripped
-    return None
+    """The full `<name> = re.compile(...)` expression, however many lines it spans.
+
+    Balances parens rather than taking the first line: two files can carry the
+    same first line and different patterns underneath, and `data_plane_guard.py`
+    in this same directory already declares a multi-line `re.compile(`, so the
+    first refactor to that style would silently disarm a first-line comparison.
+    Comments are stripped so a divergence in prose is not reported as a
+    divergence in behaviour.
+    """
+    text = path.read_text()
+    marker = f"{name} = re.compile("
+    idx = text.find(marker)
+    if idx == -1:
+        return None
+    depth = 0
+    out: list[str] = []
+    for ch in text[idx:]:
+        out.append(ch)
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                break
+    else:
+        return None  # unbalanced — report as unreadable, never as parity
+    expr = "".join(out)
+    return " ".join(expr.split())
 
 
 # ---------------------------------------------------------------- over-match --
 
 def _overmatch_cases() -> list[str]:
-    """Commands that write NOTHING. Each was a false BLOCK before the fix."""
+    """Commands that write NOTHING. Three of these were false BLOCKs pre-fix."""
     fails: list[str] = []
     cwd = str(HERE)
 
-    # 1. The live incident: `sed -n` on line 1, grep's `-i` on line 3.
-    live = (
-        f"sed -n '40,75p' {HERE / 'host_boundary.py'}\n"
-        'echo "=== ssh config ==="\n'
-        f'grep -A6 -i "^Host air" {SSH_CONFIG} 2>/dev/null | head -20\n'
-    )
-    rc, err = _run_hook(HOST_BOUNDARY, live, cwd)
-    if rc != 0:
-        fails.append(
-            "SEDI_RE bleed (the live 2026-08-31 incident): a three-line command "
-            f"that only reads was blocked rc={rc}: {err.strip()[:160]}"
-        )
-
-    # 2. `dd` with no `of=` on its own line; an unrelated `of=` two lines later.
-    dd_bleed = (
-        "dd if=/dev/zero bs=1 count=1 2>/dev/null\n"
-        'echo "next"\n'
-        f"echo of={SSH_CONFIG}\n"
-    )
-    rc, err = _run_hook(HOST_BOUNDARY, dd_bleed, cwd)
-    if rc != 0:
-        fails.append(
-            f"DDOF_RE bleed: an `echo of=` on a later line was read as dd's "
-            f"destination, rc={rc}: {err.strip()[:160]}"
-        )
-
-    # 3. CPMV_RE — the half of the 2026-08-18 cure the clone never received.
-    #    Cured in worktree_isolation.py since 2026-08-18; still bleeding in
-    #    host_boundary.py until this PR.
-    cp_bleed = f"cp a.txt b.txt\ncat {SSH_CONFIG}\n"
-    rc, err = _run_hook(HOST_BOUNDARY, cp_bleed, cwd)
-    if rc != 0:
-        fails.append(
-            "CPMV_RE bleed in host_boundary.py (the un-synced clone): a later "
-            f"`cat` target was swept in as cp's destination, rc={rc}: "
-            f"{err.strip()[:160]}"
-        )
-
-    # 4. `tee` ending a pipeline, with an unrelated path on the next line.
-    tee_bleed = f"echo hi | tee\ncat {SSH_CONFIG}\n"
-    rc, err = _run_hook(HOST_BOUNDARY, tee_bleed, cwd)
-    if rc != 0:
-        fails.append(
-            f"TEE_RE bleed: a bare `tee` took the next line's first token as its "
-            f"file, rc={rc}: {err.strip()[:160]}"
-        )
-
+    cases = {
+        "SEDI_RE bleed (the live 2026-08-31 incident)": (
+            f"sed -n '40,75p' {HERE / 'host_boundary.py'}\n"
+            'echo "=== ssh config ==="\n'
+            f'grep -A6 -i "^Host air" {SSH_CONFIG} 2>/dev/null | head -20\n'
+        ),
+        "DDOF_RE bleed (an `of=` two lines below a flagless dd)": (
+            "dd if=/dev/zero bs=1 count=1 2>/dev/null\n"
+            'echo "next"\n'
+            f"echo of={SSH_CONFIG}\n"
+        ),
+        "CPMV_RE bleed (the half of the 2026-08-18 cure the clone never got)": (
+            f"cp a.txt b.txt\ncat {SSH_CONFIG}\n"
+        ),
+        "TEE_RE bleed (forward guard — was already green pre-fix)": (
+            f"echo hi | tee\ncat {SSH_CONFIG}\n"
+        ),
+        "_strip_noise quote bleed, read direction": (
+            f"echo don't panic\ncat {SSH_CONFIG}\necho it's done\n"
+        ),
+    }
+    for label, cmd in cases.items():
+        rc, err = _run_hook(HOST_BOUNDARY, cmd, cwd)
+        if rc != 0:
+            fails.append(f"{label}: a command that writes nothing was blocked "
+                         f"rc={rc}: {err.strip()[:170]}")
     return fails
 
 
 # ----------------------------------------------------------------- innocence --
 
+_REAL_WRITES = {
+    # BSD form FIRST: on macOS — this fleet's OS — `sed -i` REQUIRES the
+    # backup-suffix argument, so this is the only spelling that actually runs
+    # here. Testing solely the GNU form certifies the wrong thing.
+    "sed -i '' (BSD/macOS)": f"sed -i '' 's/x/y/' {SSH_CONFIG}",
+    "sed -i (GNU)": f"sed -i 's/x/y/' {SSH_CONFIG}",
+    "sed -i.bak (suffix attached)": f"sed -i.bak 's/x/y/' {SSH_CONFIG}",
+    "sed -e ... -i (flags reordered)": f"sed -e 's/x/y/' -i {SSH_CONFIG}",
+    "dd of=": f"dd if=/dev/zero of={SSH_CONFIG} bs=1 count=1",
+    "cp": f"cp /tmp/evil.txt {SSH_CONFIG}",
+    "mv": f"mv /tmp/evil.txt {SSH_CONFIG}",
+    "redirect >": f"echo 'Host evil' > {SSH_CONFIG}",
+    "redirect >>": f"echo 'Host evil' >> {SSH_CONFIG}",
+    "redirect 2> (fd-qualified)": f"echo 'Host evil' 2> {SSH_CONFIG}",
+    "redirect &> (combined)": f"echo 'Host evil' &> {SSH_CONFIG}",
+    "tee": f"echo 'Host evil' | tee {SSH_CONFIG}",
+    "tee -a": f"echo 'Host evil' | tee -a {SSH_CONFIG}",
+}
+
+
 def _innocence_cases() -> list[str]:
     """Real writes to a protected path. Every one MUST still be blocked."""
     fails: list[str] = []
     cwd = str(HERE)
-    real_writes = {
-        "sed -i": f"sed -i 's/x/y/' {SSH_CONFIG}",
-        "dd of=": f"dd if=/dev/zero of={SSH_CONFIG} bs=1 count=1",
-        "cp": f"cp /tmp/evil.txt {SSH_CONFIG}",
-        "redirect": f"echo 'Host evil' > {SSH_CONFIG}",
-        "tee": f"echo 'Host evil' | tee {SSH_CONFIG}",
-    }
-    for label, cmd in real_writes.items():
+    for label, cmd in _REAL_WRITES.items():
         rc, _ = _run_hook(HOST_BOUNDARY, cmd, cwd)
         if rc == 0:
             fails.append(
                 f"DISARMED: a real write to a protected path via {label} was "
-                f"ALLOWED — `{cmd}` returned rc=0. The fix must narrow the "
-                "guard's reach across statements, never its reach within one."
+                f"ALLOWED — `{cmd}` returned rc=0. This fix narrows the guard's "
+                "reach ACROSS statements; it must never narrow it WITHIN one."
             )
-
-    # The same five, each still preceded by an unrelated line: narrowing the
-    # separator must not make a guard blind to a write that is simply not first.
-    for label, cmd in real_writes.items():
-        multi = f'echo "preamble"\n{cmd}\n'
-        rc, _ = _run_hook(HOST_BOUNDARY, multi, cwd)
+    # Same battery, each preceded by an unrelated line: confining the separator
+    # must not blind the guard to a write that simply is not the first statement.
+    for label, cmd in _REAL_WRITES.items():
+        rc, _ = _run_hook(HOST_BOUNDARY, f'echo "preamble"\n{cmd}\n', cwd)
         if rc == 0:
+            fails.append(f"DISARMED (multi-line): a real {label} write to a "
+                         "protected path on line 2 was ALLOWED.")
+    # And the fail-open that a cross-family refuter found in the first draft:
+    # apostrophes on lines 1 and 3 must not delete the write on line 2.
+    quote_bleed = (
+        f"echo don't panic\ncp /tmp/evil {SSH_CONFIG}\necho it's done\n"
+    )
+    rc, _ = _run_hook(HOST_BOUNDARY, quote_bleed, cwd)
+    if rc == 0:
+        fails.append(
+            "FAIL-OPEN: `_strip_noise` paired the apostrophes in \"don't\" and "
+            "\"it's\" across three lines, deleting the `cp` to a protected path "
+            "from the scanned text. This is the W84 cure host_boundary never "
+            "received; the write was ALLOWED."
+        )
+    return fails
+
+
+# ------------------------------------------------------- both hooks, for real --
+
+def _both_hooks_behavioural_cases() -> list[str]:
+    """Drive the shared extraction in BOTH files, not just host_boundary.
+
+    String equality of six regex lines cannot see a divergence in the plumbing
+    around them — which is exactly where the `_strip_noise` fail-open lived. So
+    the real functions are imported and called. This covers the shared
+    extraction path; it does not claim to cover worktree_isolation's own
+    repo-relative decision logic, which `test_w119_multiline_token_bleed.py`
+    exercises end-to-end.
+    """
+    fails: list[str] = []
+    hb = _load(HOST_BOUNDARY, "hb_w119b")
+    wi = _load(WORKTREE_ISOLATION, "wi_w119b")
+
+    def _paths(mod, cmd: str) -> list[str]:
+        """Normalize the two hooks' differently-shaped returns.
+
+        `_extract_write_targets` is one NAME with two RETURN TYPES:
+        host_boundary yields `list[str]`, worktree_isolation yields
+        `list[tuple[str, int]]` (it needs each target's offset to judge
+        repo-relativeness). The divergence is legitimate — but it is exactly the
+        shape that makes a naive `"path" in targets` membership test silently
+        False against the tuple form, which is how the first draft of this test
+        reported a phantom fail-open in worktree_isolation that did not exist.
+        Normalize explicitly rather than assume a shape.
+        """
+        out: list[str] = []
+        for t in mod._extract_write_targets(cmd):
+            out.append(t[0] if isinstance(t, tuple) else t)
+        return out
+
+    bleeders = {
+        "sed/grep -i across lines": "sed -n '1,5p' a.txt\ngrep -i host /etc/ssh/x\n",
+        "dd then a later of=": "dd if=/dev/zero bs=1\necho of=/etc/ssh/x\n",
+        "cp then a later cat": "cp a.txt b.txt\ncat /etc/ssh/x\n",
+        "quote pairing across lines": "echo don't\ncp /tmp/e /etc/ssh/x\necho it's\n",
+    }
+    for label, cmd in bleeders.items():
+        if label == "quote pairing across lines":
+            continue  # inverse expectation — handled below
+        for mod, name in ((hb, "host_boundary"), (wi, "worktree_isolation")):
+            targets = _paths(mod, cmd)
+            if "/etc/ssh/x" in targets:
+                fails.append(
+                    f"{name}: `{label}` still extracts /etc/ssh/x as a write "
+                    f"target from a command that writes nothing. Got {targets!r}"
+                )
+    # The quote case is the inverse: the `cp` line MUST survive _strip_noise in
+    # both files, so the destination IS expected among the targets. Its absence
+    # is the fail-OPEN, not a pass.
+    quote_cmd = bleeders["quote pairing across lines"]
+    for mod, name in ((hb, "host_boundary"), (wi, "worktree_isolation")):
+        if "/etc/ssh/x" not in _paths(mod, quote_cmd):
             fails.append(
-                f"DISARMED (multi-line): a real {label} write to a protected "
-                "path on line 2 of a two-line command was ALLOWED."
+                f"{name}: `_strip_noise` deleted the `cp` line — apostrophes on "
+                "lines 1 and 3 paired across the newline and the real write "
+                "vanished from the scanned text (W84, fail-OPEN)."
             )
     return fails
 
@@ -223,21 +333,17 @@ def _innocence_cases() -> list[str]:
 # -------------------------------------------------------------------- parity --
 
 def _parity_cases() -> list[str]:
-    """The shared W79 extraction regexes must be byte-identical in both copies.
-
-    This is the machine half of the finding: the clone's comment asserted
-    verbatim-ness in prose, and prose does not go red when it stops being true.
-    """
+    """The shared W79 extraction regexes must be identical in both copies."""
     fails: list[str] = []
     for name in _SHARED_REGEX_NAMES:
         a = _regex_source(HOST_BOUNDARY, name)
         b = _regex_source(WORKTREE_ISOLATION, name)
         if a is None or b is None:
+            missing = "host_boundary.py" if a is None else "worktree_isolation.py"
             fails.append(
-                f"{name}: not found in "
-                f"{'host_boundary.py' if a is None else 'worktree_isolation.py'} — "
-                "if it was deliberately removed, remove it from _SHARED_REGEX_NAMES "
-                "in the same commit, so this test never reports absence as parity."
+                f"{name}: not found (or unbalanced parens) in {missing} — if it "
+                "was deliberately removed, remove it from _SHARED_REGEX_NAMES in "
+                "the SAME commit, so absence is never reported as parity."
             )
             continue
         if a != b:
@@ -251,59 +357,102 @@ def _parity_cases() -> list[str]:
     return fails
 
 
-def _no_bare_backslash_s_cases() -> list[str]:
-    """No separator inside the shared block may be `\\s` again.
+def _strip_noise_parity_cases() -> list[str]:
+    """`_strip_noise` must behave identically in both copies.
 
-    Pins the PROPERTY, not the current strings: a future edit that reintroduces
-    `\\s+` between tokens goes red here even if it spells the rest differently.
+    A string compare of regex assignments cannot see into a function body, and
+    that blind spot is where a fail-open lived for 13 days.
     """
     fails: list[str] = []
-    for path in (HOST_BOUNDARY, WORKTREE_ISOLATION):
-        for name in _SHARED_REGEX_NAMES:
-            src = _regex_source(path, name)
-            if src is None:
-                continue
-            if re.search(r"\\s[+*]", src):
+    hb = _load(HOST_BOUNDARY, "hb_sn")
+    wi = _load(WORKTREE_ISOLATION, "wi_sn")
+    probes = [
+        "echo don't panic\ncp /tmp/evil /etc/ssh/x\necho it's done\n",
+        'echo "open\ncp /tmp/evil /etc/ssh/x\necho close"\n',
+        "echo 'single line' && cp a b\n",
+        "cat <<'EOF'\nnot a command\nEOF\ncp a b\n",
+    ]
+    for probe in probes:
+        got_hb, got_wi = hb._strip_noise(probe), wi._strip_noise(probe)
+        if got_hb != got_wi:
+            fails.append(
+                "_strip_noise DIVERGED between the two hooks on:\n"
+                f"  input : {probe!r}\n  host_boundary     : {got_hb!r}\n"
+                f"  worktree_isolation: {got_wi!r}"
+            )
+    return fails
+
+
+# ------------------------------------------------------------------ property --
+
+def _property_cases() -> list[str]:
+    """No token pair may join across a newline — asserted BEHAVIOURALLY.
+
+    The first draft grepped the source for `\\s+`. That would not have caught
+    the ORIGINAL defect being reintroduced: `[^|;&]*?` contains no `\\s` at all.
+    Nor would `re.DOTALL`, `[\\s\\S]+`, `[ \\t\\n]+`, or `\\v+`. Pin the property
+    by running the regex, and every spelling of the defect goes red.
+    """
+    fails: list[str] = []
+    for path, modname in ((HOST_BOUNDARY, "hb_prop"), (WORKTREE_ISOLATION, "wi_prop")):
+        mod = _load(path, modname)
+        probes = [
+            ("SEDI_RE", mod.SEDI_RE, "sed -n '1p' a.txt\ngrep -i x b.txt c.txt"),
+            ("DDOF_RE", mod.DDOF_RE, "dd if=x bs=1\nof=/tmp/victim"),
+            ("CPMV_RE", mod.CPMV_RE, "cp a.txt b.txt\ncat /tmp/victim"),
+            ("TEE_RE", mod.TEE_RE, "echo x | tee\n/tmp/victim"),
+            ("REDIR_RE", mod.REDIR_RE, "echo x >\n/tmp/victim"),
+            ("WRITE_HINT_RE", mod.WRITE_HINT_RE, "sed -n '1p' a\ngrep -i b c"),
+        ]
+        for name, rx, probe in probes:
+            m = rx.search(probe)
+            if m and "\n" in m.group(0):
                 fails.append(
-                    f"{path.name}:{name} uses `\\s` as a separator again — `\\s` "
-                    "matches a newline, and a bash newline is a statement "
-                    "boundary. Use `[ \\t]`. (W119 / W119b)"
+                    f"{path.name}:{name} matched ACROSS a newline — a bash "
+                    "newline is a statement boundary, so no token pair may join "
+                    f"over one. Match spanned: {m.group(0)!r}"
                 )
     return fails
 
 
 def test_w119b_overmatch_allows_commands_that_write_nothing():
-    fails = _overmatch_cases()
-    assert not fails, "\n".join(fails)
+    assert not (f := _overmatch_cases()), "\n".join(f)
 
 
 def test_w119b_innocence_real_writes_are_still_blocked():
-    fails = _innocence_cases()
-    assert not fails, "\n".join(fails)
+    assert not (f := _innocence_cases()), "\n".join(f)
+
+
+def test_w119b_both_hooks_extract_the_same_way():
+    assert not (f := _both_hooks_behavioural_cases()), "\n".join(f)
 
 
 def test_w119b_shared_regexes_are_identical_in_both_hooks():
-    fails = _parity_cases()
-    assert not fails, "\n".join(fails)
+    assert not (f := _parity_cases()), "\n".join(f)
 
 
-def test_w119b_no_separator_reintroduces_backslash_s():
-    fails = _no_bare_backslash_s_cases()
-    assert not fails, "\n".join(fails)
+def test_w119b_strip_noise_behaves_identically_in_both_hooks():
+    assert not (f := _strip_noise_parity_cases()), "\n".join(f)
+
+
+def test_w119b_no_regex_joins_tokens_across_a_newline():
+    assert not (f := _property_cases()), "\n".join(f)
 
 
 if __name__ == "__main__":
-    problems: list[str] = []
+    problems = 0
     for fn in (
         test_w119b_overmatch_allows_commands_that_write_nothing,
         test_w119b_innocence_real_writes_are_still_blocked,
+        test_w119b_both_hooks_extract_the_same_way,
         test_w119b_shared_regexes_are_identical_in_both_hooks,
-        test_w119b_no_separator_reintroduces_backslash_s,
+        test_w119b_strip_noise_behaves_identically_in_both_hooks,
+        test_w119b_no_regex_joins_tokens_across_a_newline,
     ):
         try:
             fn()
             print(f"PASS {fn.__name__}")
         except AssertionError as exc:
-            problems.append(f"FAIL {fn.__name__}\n{exc}")
+            problems += 1
             print(f"FAIL {fn.__name__}\n{exc}")
     sys.exit(1 if problems else 0)

--- a/infra/claude-hooks/test_w119b_write_regex_newline_bleed.py
+++ b/infra/claude-hooks/test_w119b_write_regex_newline_bleed.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""W119b — the same statement-boundary defect, in the regexes the 2026-08-18 pass
+did not look at, and in the copy that never received the half it did fix.
+
+## What W119 already cured, and what it left alive
+
+`test_w119_multiline_token_bleed.py` (2026-08-18) established the invariant: a
+shell token never spans a bare newline, because bash treats a newline exactly as
+it treats `;`, so a guard's inter-token separator must be `[ \\t]`, never `\\s`.
+It applied that cure to three regexes — `RM_RF_RE`, `WT_REMOVE_GIT_RE`,
+`CPMV_RE` — **in `worktree_isolation.py`**.
+
+Two things survived it, and this file is about both:
+
+1. **`SEDI_RE` and `DDOF_RE` were never cured, in EITHER file.** They sit three
+   lines away from `CPMV_RE` in the same block and carry the identical defect,
+   in a worse spot: their span between the verb and its flag is `[^|;&]*?`, and
+   a negated character class matches a newline, so `sed` on line 1 welds itself
+   to a `-i` appearing ANY number of lines later. The `-i` does not even have to
+   belong to sed.
+2. **`host_boundary.py` never received the `CPMV_RE` half of the 2026-08-18
+   cure.** Its block is introduced by the comment *"CLONED VERBATIM from
+   worktree_isolation.py"* — an assertion that stopped being true the moment the
+   original was fixed and the clone was not. That comment is precisely what made
+   the divergence invisible: a reader who trusts it has no reason to look.
+
+## The live incident (2026-08-31, this repo, a real session)
+
+A single Bash call of three lines:
+
+    sed -n '40,75p' /Users/nuzantara/nuzantara/scripts/fleet_mail.sh
+    echo "=== ssh config for air ==="
+    grep -A6 -i "^Host air" <HOME>/.ssh/config 2>/dev/null | head -20
+
+Nothing in it writes anything. `host_boundary.py` blocked it with **"HOST
+BOUNDARY VIOLATION (write to host-sensitive path) — target: <HOME>/.ssh/config"**.
+
+The mechanism, measured: `WRITE_HINT_RE`'s `\\bsed\\b[^|]*-i` matched from `sed`
+on line 1 across two newlines to the `-i` of **grep** on line 3; `SEDI_RE` then
+took the next token as the write destination and handed the guard a credentials
+file. A pure read was convicted as a mutating write.
+
+## Why an over-matching guard is not "the safe direction"
+
+It fails closed, so nothing was damaged. The damage is downstream and slower: a
+guard that blocks correct work teaches the next session to reach for
+`HOST_BOUNDARY_OFF=1`, and a disarmed guard blocks nothing at all. The escape
+hatch is legitimate (W33); training people to use it routinely is not.
+
+## Known residual, stated rather than inherited silently
+
+Confining the separator to `[ \\t]` means a genuine backslash-newline line
+continuation (`cp foo \\` / newline / `<HOME>/.ssh/config`) is no longer swept
+into one statement, so its destination is not seen — an UNDER-match. That
+trade-off is not introduced here: it is the one the 2026-08-18 cure already
+chose for `RM_RF_RE`/`CPMV_RE`, and this file deliberately matches the
+established cure rather than inventing a second, divergent one — divergence
+between these two copies is the very disease being treated. It is named here so
+the next reader inherits a known limit instead of an unexamined one.
+
+## Guilt and innocence, both required (superscar family #3)
+
+Over-match cases below assert the hook now ALLOWS commands that write nothing.
+Innocence cases assert it still BLOCKS every real write to a protected path
+through each of the five channels. A fix that only satisfied the first half
+would be a disarmed guard wearing a green tick.
+
+VERIFIED NOT VACUOUS, and stated exactly. Re-running this file against the
+pre-fix hooks (restored from `origin/main`) produced:
+
+  FAIL over-match     — SEDI_RE, DDOF_RE and CPMV_RE cases each blocked rc=2
+                        with "HOST BOUNDARY VIOLATION (write to host-sensitive
+                        path)" on commands that write nothing
+  PASS innocence      — the pre-fix guard blocked real writes too, as it must;
+                        this half exists to prove the fix did not disarm it,
+                        so it is expected green on both sides
+  FAIL parity         — CPMV_RE diverged between the two copies
+  FAIL no-backslash-s — the separators were still `\\s`
+
+The `tee` case is the one exception and is labelled honestly: it passed BEFORE
+the fix as well. `TEE_RE`'s bleed could only capture a following line's first
+token, which is a command name rather than a path, so it never reached a
+protected target. It is a FORWARD guard against the same class in a regex that
+happened not to have a live victim — not a reproduction of an observed defect.
+Three of the four over-match cases are real reproductions; this one is not, and
+saying otherwise would make this docstring the same kind of confident-and-wrong
+artifact the fix is about.
+"""
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+HOST_BOUNDARY = HERE / "host_boundary.py"
+WORKTREE_ISOLATION = HERE / "worktree_isolation.py"
+HOME = pathlib.Path.home()
+SSH_CONFIG = HOME / ".ssh" / "config"
+
+
+def _run_hook(hook: pathlib.Path, cmd: str, cwd: str) -> tuple[int, str]:
+    """Drive a hook the way the harness does: JSON payload on stdin."""
+    env = dict(os.environ)
+    env.pop("HOST_BOUNDARY_OFF", None)
+    env.pop("AGENT_WORKTREE_ENFORCEMENT", None)
+    payload = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": cwd}
+    proc = subprocess.run(
+        [sys.executable, str(hook)], input=json.dumps(payload),
+        capture_output=True, text=True, timeout=20, env=env,
+    )
+    return proc.returncode, proc.stderr
+
+
+# --- the five regex source lines that MUST stay identical across both copies ---
+# Named individually rather than diffed as a block: a block diff would go red on
+# an unrelated comment edit and get "fixed" by loosening it.
+_SHARED_REGEX_NAMES = ("WRITE_HINT_RE", "TEE_RE", "SEDI_RE", "DDOF_RE", "CPMV_RE")
+
+
+def _regex_source(path: pathlib.Path, name: str) -> str | None:
+    """The literal right-hand side of `<name> = re.compile(...)`, or None."""
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{name} = re.compile("):
+            return stripped
+    return None
+
+
+# ---------------------------------------------------------------- over-match --
+
+def _overmatch_cases() -> list[str]:
+    """Commands that write NOTHING. Each was a false BLOCK before the fix."""
+    fails: list[str] = []
+    cwd = str(HERE)
+
+    # 1. The live incident: `sed -n` on line 1, grep's `-i` on line 3.
+    live = (
+        f"sed -n '40,75p' {HERE / 'host_boundary.py'}\n"
+        'echo "=== ssh config ==="\n'
+        f'grep -A6 -i "^Host air" {SSH_CONFIG} 2>/dev/null | head -20\n'
+    )
+    rc, err = _run_hook(HOST_BOUNDARY, live, cwd)
+    if rc != 0:
+        fails.append(
+            "SEDI_RE bleed (the live 2026-08-31 incident): a three-line command "
+            f"that only reads was blocked rc={rc}: {err.strip()[:160]}"
+        )
+
+    # 2. `dd` with no `of=` on its own line; an unrelated `of=` two lines later.
+    dd_bleed = (
+        "dd if=/dev/zero bs=1 count=1 2>/dev/null\n"
+        'echo "next"\n'
+        f"echo of={SSH_CONFIG}\n"
+    )
+    rc, err = _run_hook(HOST_BOUNDARY, dd_bleed, cwd)
+    if rc != 0:
+        fails.append(
+            f"DDOF_RE bleed: an `echo of=` on a later line was read as dd's "
+            f"destination, rc={rc}: {err.strip()[:160]}"
+        )
+
+    # 3. CPMV_RE — the half of the 2026-08-18 cure the clone never received.
+    #    Cured in worktree_isolation.py since 2026-08-18; still bleeding in
+    #    host_boundary.py until this PR.
+    cp_bleed = f"cp a.txt b.txt\ncat {SSH_CONFIG}\n"
+    rc, err = _run_hook(HOST_BOUNDARY, cp_bleed, cwd)
+    if rc != 0:
+        fails.append(
+            "CPMV_RE bleed in host_boundary.py (the un-synced clone): a later "
+            f"`cat` target was swept in as cp's destination, rc={rc}: "
+            f"{err.strip()[:160]}"
+        )
+
+    # 4. `tee` ending a pipeline, with an unrelated path on the next line.
+    tee_bleed = f"echo hi | tee\ncat {SSH_CONFIG}\n"
+    rc, err = _run_hook(HOST_BOUNDARY, tee_bleed, cwd)
+    if rc != 0:
+        fails.append(
+            f"TEE_RE bleed: a bare `tee` took the next line's first token as its "
+            f"file, rc={rc}: {err.strip()[:160]}"
+        )
+
+    return fails
+
+
+# ----------------------------------------------------------------- innocence --
+
+def _innocence_cases() -> list[str]:
+    """Real writes to a protected path. Every one MUST still be blocked."""
+    fails: list[str] = []
+    cwd = str(HERE)
+    real_writes = {
+        "sed -i": f"sed -i 's/x/y/' {SSH_CONFIG}",
+        "dd of=": f"dd if=/dev/zero of={SSH_CONFIG} bs=1 count=1",
+        "cp": f"cp /tmp/evil.txt {SSH_CONFIG}",
+        "redirect": f"echo 'Host evil' > {SSH_CONFIG}",
+        "tee": f"echo 'Host evil' | tee {SSH_CONFIG}",
+    }
+    for label, cmd in real_writes.items():
+        rc, _ = _run_hook(HOST_BOUNDARY, cmd, cwd)
+        if rc == 0:
+            fails.append(
+                f"DISARMED: a real write to a protected path via {label} was "
+                f"ALLOWED — `{cmd}` returned rc=0. The fix must narrow the "
+                "guard's reach across statements, never its reach within one."
+            )
+
+    # The same five, each still preceded by an unrelated line: narrowing the
+    # separator must not make a guard blind to a write that is simply not first.
+    for label, cmd in real_writes.items():
+        multi = f'echo "preamble"\n{cmd}\n'
+        rc, _ = _run_hook(HOST_BOUNDARY, multi, cwd)
+        if rc == 0:
+            fails.append(
+                f"DISARMED (multi-line): a real {label} write to a protected "
+                "path on line 2 of a two-line command was ALLOWED."
+            )
+    return fails
+
+
+# -------------------------------------------------------------------- parity --
+
+def _parity_cases() -> list[str]:
+    """The shared W79 extraction regexes must be byte-identical in both copies.
+
+    This is the machine half of the finding: the clone's comment asserted
+    verbatim-ness in prose, and prose does not go red when it stops being true.
+    """
+    fails: list[str] = []
+    for name in _SHARED_REGEX_NAMES:
+        a = _regex_source(HOST_BOUNDARY, name)
+        b = _regex_source(WORKTREE_ISOLATION, name)
+        if a is None or b is None:
+            fails.append(
+                f"{name}: not found in "
+                f"{'host_boundary.py' if a is None else 'worktree_isolation.py'} — "
+                "if it was deliberately removed, remove it from _SHARED_REGEX_NAMES "
+                "in the same commit, so this test never reports absence as parity."
+            )
+            continue
+        if a != b:
+            fails.append(
+                f"{name} DIVERGED between the two hooks — this is exactly how the "
+                "2026-08-18 CPMV_RE cure reached one file and not the other, for "
+                "13 days, under a comment saying they were identical.\n"
+                f"  host_boundary.py     : {a}\n"
+                f"  worktree_isolation.py: {b}"
+            )
+    return fails
+
+
+def _no_bare_backslash_s_cases() -> list[str]:
+    """No separator inside the shared block may be `\\s` again.
+
+    Pins the PROPERTY, not the current strings: a future edit that reintroduces
+    `\\s+` between tokens goes red here even if it spells the rest differently.
+    """
+    fails: list[str] = []
+    for path in (HOST_BOUNDARY, WORKTREE_ISOLATION):
+        for name in _SHARED_REGEX_NAMES:
+            src = _regex_source(path, name)
+            if src is None:
+                continue
+            if re.search(r"\\s[+*]", src):
+                fails.append(
+                    f"{path.name}:{name} uses `\\s` as a separator again — `\\s` "
+                    "matches a newline, and a bash newline is a statement "
+                    "boundary. Use `[ \\t]`. (W119 / W119b)"
+                )
+    return fails
+
+
+def test_w119b_overmatch_allows_commands_that_write_nothing():
+    fails = _overmatch_cases()
+    assert not fails, "\n".join(fails)
+
+
+def test_w119b_innocence_real_writes_are_still_blocked():
+    fails = _innocence_cases()
+    assert not fails, "\n".join(fails)
+
+
+def test_w119b_shared_regexes_are_identical_in_both_hooks():
+    fails = _parity_cases()
+    assert not fails, "\n".join(fails)
+
+
+def test_w119b_no_separator_reintroduces_backslash_s():
+    fails = _no_bare_backslash_s_cases()
+    assert not fails, "\n".join(fails)
+
+
+if __name__ == "__main__":
+    problems: list[str] = []
+    for fn in (
+        test_w119b_overmatch_allows_commands_that_write_nothing,
+        test_w119b_innocence_real_writes_are_still_blocked,
+        test_w119b_shared_regexes_are_identical_in_both_hooks,
+        test_w119b_no_separator_reintroduces_backslash_s,
+    ):
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as exc:
+            problems.append(f"FAIL {fn.__name__}\n{exc}")
+            print(f"FAIL {fn.__name__}\n{exc}")
+    sys.exit(1 if problems else 0)

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -547,16 +547,16 @@ def _unarmed_dirty_removal_target(cmd_scan: str, cwd: str) -> pathlib.Path | Non
 
 # --- W79 B1: shell file-WRITE detection ----------------------------------------
 # Quick gate: does the command contain anything that could write a file?
-WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|]*-i|\bdd\b[^|]*\bof=|\b(?:cp|mv|install)\b)")
+WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|\n]*-i|\bdd\b[^|\n]*\bof=|\b(?:cp|mv|install)\b)")
 # Extractors for write TARGETS. Each yields candidate destination path(s).
 # Redirect:  ... > path   or  ... >> path   (NOT >&, NOT >/dev/null handled by classifier)
 REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?\s*([^\s|;&)]+)")  # stdout/stderr/combined redirects
 # tee [-a] path...   (path before next pipe/redirect)
-TEE_RE = re.compile(r"\btee\s+(?:-a\s+)?([^\s|;&)]+)")
+TEE_RE = re.compile(r"\btee[ \t]+(?:-a[ \t]+)?([^\s|;&)]+)")
 # sed -i ... LAST-non-flag-token is the file (best-effort: take tokens after the script)
-SEDI_RE = re.compile(r"\bsed\b[^|;&]*?-i\S*\s+(?:-e\s+\S+\s+|'[^']*'\s+|\"[^\"]*\"\s+|\S+\s+)([^\s|;&)]+)")
+SEDI_RE = re.compile(r"\bsed\b[^|;&\n]*?-i\S*[ \t]+(?:-e[ \t]+\S+[ \t]+|'[^']*'[ \t]+|\"[^\"]*\"[ \t]+|\S+[ \t]+)([^\s|;&)]+)")
 # dd of=path
-DDOF_RE = re.compile(r"\bdd\b[^|;&]*?\bof=([^\s|;&)]+)")
+DDOF_RE = re.compile(r"\bdd\b[^|;&\n]*?\bof=([^\s|;&)]+)")
 # cp/mv/install SRC... DEST  → DEST is the last non-flag token before pipe/sep
 # W119 (2026-08-18): same cross-line-bleed defect as RM_RF_RE / WT_REMOVE_GIT_RE
 # above — `\s+` as the inter-token separator inside a repeated group matches a

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -550,11 +550,11 @@ def _unarmed_dirty_removal_target(cmd_scan: str, cwd: str) -> pathlib.Path | Non
 WRITE_HINT_RE = re.compile(r"(>>?|\btee\b|\bsed\b[^|\n]*-i|\bdd\b[^|\n]*\bof=|\b(?:cp|mv|install)\b)")
 # Extractors for write TARGETS. Each yields candidate destination path(s).
 # Redirect:  ... > path   or  ... >> path   (NOT >&, NOT >/dev/null handled by classifier)
-REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?\s*([^\s|;&)]+)")  # stdout/stderr/combined redirects
+REDIR_RE = re.compile(r"(?:[0-9]?>|&>)>?[ \t]*([^\s|;&)]+)")  # stdout/stderr/combined redirects
 # tee [-a] path...   (path before next pipe/redirect)
 TEE_RE = re.compile(r"\btee[ \t]+(?:-a[ \t]+)?([^\s|;&)]+)")
 # sed -i ... LAST-non-flag-token is the file (best-effort: take tokens after the script)
-SEDI_RE = re.compile(r"\bsed\b[^|;&\n]*?-i\S*[ \t]+(?:-e[ \t]+\S+[ \t]+|'[^']*'[ \t]+|\"[^\"]*\"[ \t]+|\S+[ \t]+)([^\s|;&)]+)")
+SEDI_RE = re.compile(r"\bsed\b[^|;&\n]*?-i\S*[ \t]+(?:-e[ \t]+\S+[ \t]+|'[^'\n]*'[ \t]+|\"[^\"\n]*\"[ \t]+|\S+[ \t]+)*([^\s|;&)]+)")
 # dd of=path
 DDOF_RE = re.compile(r"\bdd\b[^|;&\n]*?\bof=([^\s|;&)]+)")
 # cp/mv/install SRC... DEST  → DEST is the last non-flag token before pipe/sep


### PR DESCRIPTION
## What happened

A three-line Bash call that writes nothing was blocked as a write to a credentials file:

```
sed -n '40,75p' scripts/fleet_mail.sh
echo "=== ssh config for air ==="
grep -A6 -i "^Host air" ~/.ssh/config 2>/dev/null | head -20
```

> HOST BOUNDARY VIOLATION (write to host-sensitive path) — target: `~/.ssh/config`

## Mechanism, measured — not inferred

`WRITE_HINT_RE` contains `\bsed\b[^|]*-i`. A negated character class matches a newline, so it
matched from the `sed -n` on line 1, across two newlines, to the **`-i` flag of `grep`** on
line 3. `SEDI_RE` then took the following token as sed's destination and handed the guard a
protected path. Bash treats a bare newline exactly as it treats `;`; these regexes did not.

Reproduced directly:

```
>>> re.compile(r"\bsed\b[^|]*-i").search("sed -n '1p' a.txt\ngrep -i foo b.txt")
<match>                    # two independent statements, welded into a phantom `sed -i`
>>> re.compile(r"\bsed\b[^|\n]*-i").search(same)
None
```

## Why this is a recurrence, not a new bug

This is **W119** (superscar family #3 — statement-boundary bleed). The 2026-08-18 pass named
that exact disease and cured `RM_RF_RE`, `WT_REMOVE_GIT_RE` and `CPMV_RE`. Two things survived:

| regex | `worktree_isolation.py` | `host_boundary.py` |
|---|---|---|
| `CPMV_RE` | cured 2026-08-18 | **still bleeding** — the cure never crossed |
| `SEDI_RE` | never cured | never cured |
| `DDOF_RE` | never cured | never cured |
| `WRITE_HINT_RE` | never cured | never cured |

`host_boundary.py`'s block is introduced by the comment **"CLONED VERBATIM from
worktree_isolation.py"** — true when written, false from the moment the original was fixed.
That comment is what made the divergence invisible: a reader who trusts it has no reason to
look. Thirteen days.

## An over-matching guard is not "the safe direction"

It fails closed, so nothing was damaged. The cost is slower and worse: a guard that blocks
correct work teaches the next session to reach for `HOST_BOUNDARY_OFF=1`, and a disarmed guard
blocks nothing at all. The escape hatch is legitimate; training people into it is not.

## The change

Every inter-token separator in the shared W79 extraction block is confined to `[ \t]` — the
same cure the 2026-08-18 pass chose, deliberately **not** a second and divergent one, since
divergence between these two copies is the disease being treated.

## Tests — guilt and innocence, and proven non-vacuous

`infra/claude-hooks/test_w119b_write_regex_newline_bleed.py`, run against the pre-fix hooks
restored from `origin/main`:

```
FAIL over-match      SEDI_RE / DDOF_RE / CPMV_RE cases each rc=2
                     "HOST BOUNDARY VIOLATION" on commands that write nothing
PASS innocence       the pre-fix guard blocked real writes too — expected green
                     on BOTH sides; that is what it is for
FAIL parity          CPMV_RE diverged between the two copies
FAIL no-backslash-s  the separators were still `\s`
```

After the fix: all four green, and the whole hook suite is **116 passed**.

- **Innocence** covers all five write channels (`sed -i`, `dd of=`, `cp`, redirect, `tee`) to a
  protected path, each alone *and* on line 2 of a two-line command — the half that proves the
  guard was narrowed *across* statements and not *within* one.
- **Parity** pins the five shared regexes byte-identical across both hooks, so the next
  one-sided edit goes red instead of unnoticed. This is the machine half of the finding: prose
  does not go red when it stops being true.
- **Property test** rejects any future `\s` separator in that block — pinned to the property,
  not to today's strings.

The `tee` case is labelled in-file as a **forward** guard, not a reproduction: it passed before
the fix too, because its bleed could only capture a following line's command *name*, never a
protected path. Calling it a fourth reproduction would have made this PR the same kind of
confident-and-wrong artifact it exists to remove.

## Known residual, named rather than inherited silently

A genuine backslash-newline continuation (`cp foo \` / newline / `<protected>`) is no longer
swept into one statement, so its destination is not seen — an under-match. That trade-off is
not introduced here: it is the one the 2026-08-18 cure already made for `RM_RF_RE`/`CPMV_RE`.
Matching it is deliberate.

## Scope

3 files, +325/−10. Gear floor **1** (computed, `compute_floor` → source `none`). Gear 1 is not
the same as harmless — this is a security guard — so it goes to an independent cross-family
refuter before merge: the author does not grade the diff.
