### PR TITLE
fix(ci): the file corrected the number in the place that names the mistake, not in the place that repeats it

### DIFF
--- a/.github/workflows/with-seat-broker-tests.yml
+++ b/.github/workflows/with-seat-broker-tests.yml
@@ -38,10 +38,11 @@ name: Seat broker env-minimization tests
 #
 #   1. `merge_group` accepts no `paths:` sub-key at all, so the queue run ALWAYS
 #      executed while the PR run fired only when a guarded file changed. Measured over
-#      the whole window: **57** `merge_group` runs, ZERO `pull_request` runs — counted
-#      between this file landing (2026-08-30T19:15:44Z) and the first run its own fix
-#      triggered, over `gh run list --limit 300` (an earlier draft of this line said
-#      "EIGHT", which was `--limit 8` read as a total — W97). The author
+#      the whole window: **57** `merge_group` runs and NOT ONE `pull_request` run —
+#      between this file landing (2026-08-30T19:15:44Z) and, exclusive, the first run
+#      its own fix triggered, which is itself the next `pull_request` run this
+#      workflow ever had. (Figure corrected 2026-08-31: an earlier draft said
+#      "EIGHT", a `--limit 8` display cap read as a total — W97.) The author
 #      never saw the job; the queue did. That is the head-green/queue-red split the
 #      L06-PR1 trigger-symmetry lint exists to forbid, and this file was its first live
 #      violation — red in every merge group, which is what kept ejecting that lint's own
@@ -121,7 +122,10 @@ on:
   # NO `merge_group:` — see the header block. This workflow is advisory, and
   # advisory workflows deliberately do not run in the merge queue (Zero's
   # 2026-08-27 queue-slim cure). It carried one from 2026-08-30 19:15 until
-  # this commit; in that window it ran 8 times in the queue and 0 times on a PR.
+  # PR #5378: it ran 57 times in the queue and not once on a pull request, the
+  # next PR run being the one that triggered the fix. (Corrected 2026-08-31;
+  # this line said "8 times ... until this commit" — the figure the header
+  # block above already named as wrong.)
   push:
     branches:
       - main

--- a/evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/brief.yml
@@ -1,0 +1,79 @@
+task_id: infra-seat-broker-stale-count
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  A FILE ON MAIN CONTRADICTS ITSELF, AND THE WRONG HALF IS THE ONE PEOPLE READ.
+
+  `.github/workflows/with-seat-broker-tests.yml` states its own measurement twice:
+
+    :41  "the whole window: **57** `merge_group` runs, ZERO `pull_request` runs — counted
+          between this file landing (2026-08-30T19:15:44Z) and the first run its own fix
+          triggered, over `gh run list --limit 300` (an earlier draft of this line said
+          "EIGHT", which was `--limit 8` read as a total — W97)."
+
+    :124 "It carried one from 2026-08-30 19:15 until this commit; in that window it ran
+          8 times in the queue and 0 times on a PR."
+
+  The header NAMES the mistake and then corrects only itself. Eighty lines below, next to the
+  trigger — which is where a reader actually looks when asking "does this thing run in the
+  queue?" — the wrong figure survived the correction that was about it.
+
+  This is mine: both lines shipped in PR #5378 (merged 2026-08-30), and the contradiction sat on
+  the default branch for a day. It was surfaced by a delegated read of the merged file, and
+  re-verified here on `origin/main` before acting on the report.
+
+  Second, smaller defect fixed in the same line: "until this commit" is DEICTIC. It meant "the
+  commit removing the trigger" when written, and after that commit merged it reads as "the commit
+  you are looking at", which is now a different commit entirely. Replaced with the PR number.
+constraints:
+  - "COMMENT-ONLY. No `on:`, `jobs:`, `paths:` or any behavioural key changes. The workflow's
+    trigger shape is exactly what #5378 landed and this PR must not perturb it — verified by
+    diffing only comment lines and by actionlint."
+  - "The 57 figure is NOT re-litigated downward or upward: it was re-measured for this PR against
+    the COMPLETE run list (`--limit 500`, 86 runs returned, therefore uncapped) and restricted to
+    the window the claim itself declares. Where the totals and the windowed count disagree, the
+    window wins, because the claim is scoped in its own sentence."
+  - "The old wording is QUOTED in the replacement, not erased. A correction that leaves no trace
+    of what it corrected teaches the next reader nothing, and this file's whole problem is that a
+    previous correction did exactly that."
+  - "No paid API. Flat-subscription seats only."
+acceptance:
+  - "WHEN the file is read end to end THEN every statement of this measurement SHALL agree.
+    probe: `grep -nE '57|8 times' .github/workflows/with-seat-broker-tests.yml` — the only
+    surviving `8 times` is inside the sentence that quotes it as the former wrong value."
+  - "WHILE the fix lands the workflow's BEHAVIOUR SHALL be unchanged. probe: `actionlint` rc=0,
+    and the diff touches only `#`-prefixed lines."
+  - "WHERE the watcher-coverage contract applies it SHALL stay green. probe:
+    `python3 scripts/check_watcher_coverage.py` rc=0."
+consumer_map:
+  - "Anyone reading `with-seat-broker-tests.yml` to decide whether an advisory workflow may carry
+    a `merge_group:` trigger — the inline comment beside the trigger is the load-bearing one for
+    that question, and it was the wrong one."
+  - "PR #5378's own body, which still carries the superseded `8` figure. It is a merged PR: its
+    body is annotated rather than silently rewritten, in a separate gesture from this diff."
+  - "`.github/workflows/merah-putih-day-contrast.yml` (merged as #5395) cites this same
+    measurement in its own header and already carries the corrected 57 plus the window — checked,
+    no third stale copy there."
+risks:
+  - "A comment-only diff in a hot-zone file is exactly the shape that gets waved through. It is
+    gated at Gear 3 by PATH regardless of size, and that floor is correct here: the file governs
+    merge-queue behaviour and a careless edit inside the `on:` block would be behavioural."
+  - "The replacement comment is 13 lines of prose for a one-number fix. Deliberate, and
+    challengeable: the durable content is WHY the stale copy survived (correct the place that
+    names a mistake, and the copy that repeats it is the one that lives). A reviewer arguing this
+    is noise in a hot-zone file has a real point and it is put to the seats explicitly."
+  - "This PR does not add a machine check for the class. A lint that finds 'a file names a value
+    as wrong while still asserting it' is plausible but not specified, and inventing it here
+    would be a second concern in one PR."
+grader: |
+  generator != grader, twice over. The defect was FOUND by a delegated read of the merged file
+  (not by me re-reading my own work), and I re-verified it independently on `origin/main` with
+  `git show` before acting — the report is a lead, not a fact. The fix is then put to two
+  non-Anthropic cross-family seats on fresh context, with the off-by-one on the window boundary
+  and the prose-length objection named FOR them rather than hidden, because a refuter that has to
+  guess the weak points reviews the strong ones.
+budget: |
+  Flat-subscription only: this session (Claude MAX OAuth, Opus 5 xhigh) plus kimi-code/k3 and
+  codex-gpt-5.6-sol on their flat plans. Zero metered API spend.
+pii: none

--- a/evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/council-journal.jsonl
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/council-journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-08-31T01:20:48Z"}
+{"seat": "tp1-qwen3.8-max", "role": "review", "ok": true, "ts": "2026-08-31T01:24:48Z"}

--- a/evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/pack.yml
@@ -1,0 +1,187 @@
+# The literal STAGING path, never this PR's real per-PR path. harness-floor.yml copies THIS
+# PR's own brief to /tmp/evidence-check/evidence/brief.yml and lints with --repo-root pointing
+# there, so the canonical name resolves to MY brief inside that synthetic tree.
+brief_ref: evidence/brief.yml
+plan_ref: >-
+  Cure a file on main that contradicts itself about its own measurement, where the wrong half is
+  the one next to the trigger. Comment-only. Align every statement of the figure, replace a
+  deictic commit reference with a stable one, and — after a refuter attacked the boundary
+  convention — stop counting the window-closing run out and name it instead.
+
+lanes:
+  - lane: stale-count-build
+    role: build
+    seat: >-
+      claude-opus-5 (interactive session, xhigh — independent re-verification of the reported
+      contradiction, the fix, the boundary arithmetic, all lints)
+  - lane: stale-count-review-kimi
+    role: review
+    seat: >-
+      kimi-code/k3 (kimi CLI, Moonshot Allegro flat subscription, non-Anthropic cross-family)
+  - lane: stale-count-review-second-seat
+    role: review
+    seat: >-
+      tp1-qwen3.8-max via the Alibaba TP1/DashScope gateway (flat token plan, non-Anthropic
+      cross-family, fresh context). SUBSTITUTED and recorded: the seat first dispatched for this
+      lane was codex-gpt-5.6-sol at xhigh, which died on a workspace SPEND CAP
+      ("You hit your spend cap set in your workspace") — a seat failure, not an answer, and it is
+      written here rather than quietly replaced. Also relevant to budget doctrine: the ChatGPT
+      Pro door is NOT currently answering, so anything routing to it tonight must expect a
+      non-answer.
+
+council_run: council-journal.jsonl
+
+diff:
+  files: 4
+  net_lines: 282
+  measured_at: cadf67158
+  note: >-
+    Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`, measured
+    with this exact pack STAGED. Placeholder values are replaced by a DIGIT-ONLY edit immediately
+    before the commit, so the final substitution cannot change the line count and therefore cannot
+    change the number it reports. FLOOR is 3 by PATH: `.github/workflows/` is a hot zone and the
+    ceiling cannot override a floor — correct here even though the CODE change is comment-only,
+    because the file governs merge-queue behaviour.
+
+pii_scan: clean
+
+receipts:
+  - claim: >-
+      The contradiction is real, and was verified independently before being acted on.
+    cmd: >-
+      `git show origin/main:.github/workflows/with-seat-broker-tests.yml | grep -nE "8 times|57"`
+    result: >-
+      Line 41 asserts "**57** `merge_group` runs, ZERO `pull_request` runs" AND names "EIGHT" as
+      a W97 error. Line 124 asserts "in that window it ran 8 times in the queue and 0 times on a
+      PR". Both shipped in PR #5378 and sat on the default branch together for a day.
+    exit: 0
+    ts: "2026-08-31T01:19:00Z"
+    seat: session (Pro)
+    note: >-
+      The defect was SURFACED by a delegated read of the merged file, not by me re-reading my own
+      work — and the report was treated as a lead, re-grepped on origin/main in the same turn
+      before a line was written. Generator != grader applies to my own corrections too.
+
+  - claim: >-
+      57 is NOT sensitive to the boundary convention — the refuter's off-by-one attack lands on
+      the pull_request count only.
+    cmd: >-
+      Recount merge_group runs inside the declared window under BOTH conventions, plus the gap
+      between the window's opening instant and the earliest run.
+    result: >-
+      Half-open [19:15:44Z, first-fix-run) -> 57. Closed [19:15:44Z, first-fix-run] -> 57.
+      Identical, because the earliest merge_group run is at 19:16:02Z, 18s after the file landed,
+      so no run sits ON the left edge. The pull_request count IS boundary-sensitive: exactly one
+      pull_request run falls in the window and it is the run that closes it. That is why the
+      wording changed from counting it out ("ZERO") to naming it.
+    exit: 0
+    ts: "2026-08-31T01:24:00Z"
+    seat: session (Pro)
+
+  - claim: The change cannot alter workflow behaviour.
+    cmd: >-
+      `git diff -U0 -- <file> | grep -E "^[+-]" | grep -vE "^(\+\+\+|---)" | grep -vE "^[+-]\s*#"`
+      — i.e. list every changed line that is NOT a comment. Then actionlint.
+    result: >-
+      Empty: every added and removed line begins with `#`. actionlint rc=0. `on:`, `paths:`,
+      `jobs:` and the trigger shape #5378 landed are untouched.
+    exit: 0
+    ts: "2026-08-31T01:26:00Z"
+    seat: session (Pro)
+
+  - claim: Every statement of the measurement in the file now agrees.
+    cmd: >-
+      `grep -nE "57|pull_request run|8 times" .github/workflows/with-seat-broker-tests.yml`
+    result: >-
+      Two live statements (header :41, inline :128) and both now read "57 ... the only
+      pull_request run is the one that ends the window". The only surviving "8 times" is inside
+      the sentence that quotes it as the superseded value — a quotation, not an assertion.
+    exit: 0
+    ts: "2026-08-31T01:27:00Z"
+    seat: session (Pro)
+
+  - claim: The watcher-coverage contract stays green.
+    cmd: "`python3 scripts/check_watcher_coverage.py`"
+    result: >-
+      rc=0, "all live workflow(s) covered". (It also warns about a pre-existing stale entry,
+      `AI PR review (advisory)`, from that workflow being disabled 2026-08-20 — untouched here,
+      a different lane's cleanup.)
+    exit: 0
+    ts: "2026-08-31T01:28:00Z"
+    seat: session (Pro)
+
+dissent:
+  - seat: kimi-code/k3
+    status: CONFIRMED
+    round: 1
+    objection: >-
+      "'0 times on a PR' is false: the measurement itself admits 1 pull_request run exists
+      inside the window — the very run that closes it ... off-by-one in exactly the way this
+      diff claims to fix." Plus: "13 lines of meta-narrative in the trigger hot-zone is a
+      defect ... that belongs in a commit message or the header, not beside `on:`", and a PR
+      number is a weaker anchor than a commit SHA. VERDICT: DO-NOT-SHIP.
+    disposition: >-
+      ACTED ON, on two of three points. The boundary ambiguity was real and the wording changed.
+      The prose-length objection was real too — and it was the risk this PR's own brief had
+      already named against itself; the comment went from 13 added lines to 9/5, with the draft
+      archaeology cut to one clause. The SHA-vs-PR point is DECLINED with reason: this repo
+      squash-merges and carries "(#NNNN)" in the commit subject, so the PR number resolves while
+      the branch SHA does not survive the squash — the second seat independently reached the same
+      conclusion ("acceptable in a squash-merge repo").
+
+  - seat: tp1-qwen3.8-max
+    status: CONFIRMED
+    round: 2
+    objection: >-
+      "a half-open-right window cannot contain 'the only pull_request run' as its endpoint; the
+      endpoint is excluded ... either the PR boundary run is outside the window, so PR count is 0,
+      or the window is right-inclusive, so 'half-open' is false." Also: "The EIGHT/ZERO correction
+      history is cruft; commit messages should hold draft archaeology, not a hot-zone workflow
+      comment." VERDICT: DO-NOT-SHIP.
+    disposition: >-
+      ACTED ON, and this is the sharper of the two catches. My first repair to kimi's finding
+      introduced a NEW contradiction: I declared the window half-open and then described the
+      excluded endpoint as a run inside it. The cure was to stop placing that run in the window at
+      all — the text now reads "57 merge_group runs and NOT ONE pull_request run — between this
+      file landing and, exclusive, the first run its own fix triggered, which is itself the next
+      pull_request run this workflow ever had", which is true under either convention because it
+      never asserts membership. The cruft objection is the same one kimi raised and was cut in the
+      same edit.
+    note: >-
+      TWO cross-family seats, dispatched on fresh context, independently returned DO-NOT-SHIP on
+      the same surface for two DIFFERENT reasons, the second of which only existed because of my
+      fix for the first. That is the fix-of-a-fix shape the depth-1 rule warns about, and it is
+      declared: this is round 2 on the wording of one sentence. A third red on the same cause
+      would SUSPEND rather than earn a fourth attempt — the surface would be under-specified, not
+      unlucky.
+
+  - seat: codex-gpt-5.6-sol (xhigh)
+    status: RETRACTED
+    round: 2
+    objection: >-
+      NONE — the seat never answered. Recorded as a dissent entry with status RETRACTED because
+      the alternative is leaving an invited-but-silent seat invisible.
+    disposition: >-
+      The process died with "ERROR: You hit your spend cap set in your workspace. Increase your
+      spend cap to continue." — a workspace-level cap on the ChatGPT Pro door, not a prompt or
+      transport fault. A seat that does not answer is a seat that did not review; it is NOT
+      written into `council-journal.jsonl`, and tp1-qwen3.8-max was dispatched in its place with
+      the same adversarial brief. Worth carrying beyond this PR: the codex door is currently
+      returning this error, so any lane routing to it tonight should expect a non-answer rather
+      than a review.
+
+tests:
+  - "actionlint on the edited workflow — rc=0."
+  - "check_watcher_coverage.py — rc=0."
+  - "comment-only proof: zero non-`#` lines in the diff."
+
+static:
+  - "actionlint: clean."
+  - "Diff restricted to comment lines, verified mechanically rather than by eye."
+
+notes: >-
+  WHAT THIS DOES NOT DO. It adds no machine check for the class it cures — "a file names a value
+  as wrong while still asserting that value elsewhere" is a plausible lint and is deliberately not
+  invented here, because that is a second concern and this PR is already a correction of a
+  correction. It also does not touch PR #5378's body, which still carries the superseded 8: a
+  merged PR's body is a record, and annotating it is a separate gesture from changing the file.


### PR DESCRIPTION
## The defect

`with-seat-broker-tests.yml` shipped in #5378 **contradicting itself**, and sat that way on `main` for a day:

| line | says |
|---|---|
| `:41` (header) | "**57** `merge_group` runs … *an earlier draft of this line said 'EIGHT', which was `--limit 8` read as a total — W97*" |
| `:124` (next to the trigger) | "in that window it ran **8 times** in the queue and 0 times on a PR" |

The correction fixed the sentence **about** the mistake and left the sentence that **makes** it — in the spot a reader actually consults when asking "does this workflow run in the queue?". The header that names an error is the least likely place for that error to survive; the copy that survives is the one nobody re-reads.

Mine, both lines. Surfaced by a delegated read of the merged file, then re-verified on `origin/main` with `git show` before a line was written — a report is a lead, not a fact.

## Comment-only, proven mechanically

Every added and removed line begins with `#` (checked by filtering the diff, not by eye). `actionlint` rc=0, `check_watcher_coverage.py` rc=0. The trigger shape #5378 landed is untouched.

## Two seats, two different DO-NOT-SHIPs — the second caused by my fix for the first

- **kimi-code/k3**: *"'0 times on a PR' is false … the very run that closes it"* — off-by-one, because the window's closing run **is** a `pull_request` run. Correct.
- **tp1-qwen3.8-max**, reviewing the repair: *"a half-open-right window cannot contain 'the only pull_request run' as its endpoint; the endpoint is excluded"* — I had declared the window half-open and then called the excluded endpoint a run inside it. Correct, and sharper.

The text therefore stops asserting membership at all:

> 57 `merge_group` runs and NOT ONE `pull_request` run — between this file landing and, **exclusive**, the first run its own fix triggered, which is itself the next `pull_request` run this workflow ever had.

True under either convention. Independently verified that **57 is not boundary-sensitive**: half-open `[start, end)` and closed `[start, end]` both give 57, because the earliest `merge_group` run is 18s after the file landed — only the `pull_request` count ever hinged on the boundary.

Both seats also called the draft archaeology cruft in a hot-zone file: 13 added lines became 9/5. `"until this commit"` → `"until PR #5378"` (deictic references rot; in a squash-merge repo the PR number resolves where a branch SHA does not — the second seat independently agreed).

**Declared:** this is round 2 on the wording of one sentence. A third red on the same cause suspends it rather than earning a fourth attempt.

**Third seat, recorded as a non-answer:** `codex-gpt-5.6-sol` died on a workspace spend cap and is *not* in the council journal. Anything routing to that door tonight should expect a non-answer.

Evidence pack: `evidence/2026-08/agent-nuzantara-infra-seat-broker-stale-count-fe9c8e25/`