### PR TITLE
docs(spec): the postscript said PUT 404s; the runbook above it still told you to run PUT

### DIFF
--- a/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
+++ b/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
@@ -7,6 +7,18 @@ sources:
   - gh api repos/Balizero1987/Teman2/branches/main/protection/required_status_checks (live read 2026-06-09)
   - .github/workflows/verify-the-verifiers.yml, p1s2-mutation-incremental.yml
   - .github/CODEOWNERS
+adversarial_review: >-
+  kimi-code/k3 (Moonshot, non-Anthropic cross-family, flat subscription) reviewed the
+  2026-08-31 PUT->PATCH correction on 2026-08-31 and returned SHIP. Substantive, not a
+  rubber stamp: it independently confirmed that GitHub documents only PATCH on
+  `.../protection/required_status_checks` (PUT exists solely on the parent
+  `branches/{branch}/protection` endpoint, which is why PUT 404s here); it refuted an
+  attack line put TO it about the rollback verb, establishing that this endpoint replaces
+  the whole `required_status_checks` object rather than JSON-merging, so replaying the
+  9-context snapshot restores the prior state exactly; and it opened by checking the file
+  on disk to test the correction note's own claim that every surviving "PUT" is
+  historical, rather than accepting it. The original 2026-06-09 spec body was authored by
+  a different session; this reviewer is not its author.
 ---
 
 # FASE-0 BUCO #1 — make the P* workflows required-status-checks (sequenced, NOT executed)

--- a/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
+++ b/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
@@ -7,18 +7,7 @@ sources:
   - gh api repos/Balizero1987/Teman2/branches/main/protection/required_status_checks (live read 2026-06-09)
   - .github/workflows/verify-the-verifiers.yml, p1s2-mutation-incremental.yml
   - .github/CODEOWNERS
-adversarial_review: >-
-  kimi-code/k3 (Moonshot, non-Anthropic cross-family, flat subscription) reviewed the
-  2026-08-31 PUT->PATCH correction on 2026-08-31 and returned SHIP. Substantive, not a
-  rubber stamp: it independently confirmed that GitHub documents only PATCH on
-  `.../protection/required_status_checks` (PUT exists solely on the parent
-  `branches/{branch}/protection` endpoint, which is why PUT 404s here); it refuted an
-  attack line put TO it about the rollback verb, establishing that this endpoint replaces
-  the whole `required_status_checks` object rather than JSON-merging, so replaying the
-  9-context snapshot restores the prior state exactly; and it opened by checking the file
-  on disk to test the correction note's own claim that every surviving "PUT" is
-  historical, rather than accepting it. The original 2026-06-09 spec body was authored by
-  a different session; this reviewer is not its author.
+adversarial_review: kimi-k3
 ---
 
 # FASE-0 BUCO #1 — make the P* workflows required-status-checks (sequenced, NOT executed)
@@ -177,3 +166,33 @@ each only after it is green-stable on main with its own sentinel.
 - `required_status_checks` updated via **PATCH** (NOT PUT — PUT 404s on this sub-resource; the original spec verb was wrong) to 11 contexts: the original 9 + `verify-the-verifiers` + `Canary self-test + incremental mutation`. strict=true preserved.
 - This markdown-only PR is the falsifiable canary: it MUST merge (path-miss → sentinel SUCCESS), proving the new required checks do NOT pending-forever-block doc PRs.
 - Rollback (if ever needed): `gh api -X PATCH .../required_status_checks --input <original-9-snapshot>`.
+## Adversarial review
+
+**Seat:** `kimi-code/k3` (Moonshot, non-Anthropic cross-family, flat subscription), fresh
+context, 2026-08-31. Reviewing the PUT→PATCH correction above. The seat is not the author
+of either the 2026-06-09 spec or the 2026-08-31 correction.
+
+**Surviving objections: none. Five attack lines raised, all resolved:**
+
+1. *"Is PATCH actually correct, or does this diff make the runbook worse?"* — RESOLVED,
+   and this was the one that mattered. Confirmed independently: GitHub documents only
+   `PATCH` for updating `.../protection/required_status_checks`; `PUT` exists solely on the
+   parent `branches/{branch}/protection` endpoint, which is exactly why PUT 404s on the
+   sub-resource.
+2. *Does changing "the PUT" to "the PATCH"/"write" break any meaning, particularly
+   "fully reversible in one command" and "PRESERVE ALL 9"?* — RESOLVED, meaning preserved.
+3. *Is PATCH right for the ROLLBACK too? PATCH merges, PUT replaces — could a rollback
+   leave extra contexts behind?* — RESOLVED, and the seat refuted the attack rather than
+   conceding it: this endpoint replaces the whole `required_status_checks` object
+   (`strict` + the full `contexts` array) rather than JSON-merging, so replaying the
+   9-context snapshot restores the prior state exactly.
+4. *Does the correction note overstate its own edit by claiming every surviving "PUT" is
+   historical?* — RESOLVED. The seat opened by reading the file on disk to test that claim
+   instead of accepting it, and found it true (noting that two apparent hits are
+   `GITHUB_OUTPUT` substring false positives).
+5. *Should a CLOSED historical spec be edited in place, or left with an erratum?* —
+   RESOLVED in favour of editing: an erratum at the bottom already existed since
+   2026-06-09 and demonstrably failed to stop readers executing the body's PUT. The dated
+   note preserves the record.
+
+**Verdict: SHIP.**

--- a/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
+++ b/research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md
@@ -25,12 +25,12 @@ sources:
    by an agent, by design. `verify-the-verifiers.yml` is additionally
    tamper-evident (sha256 `.github/verify-the-verifiers.sha256` + the workflow
    lists itself in its own `paths:`).
-2. **The PUT must come AFTER the sentinel is on `main` + green-stable** (W69
+2. **The PATCH must come AFTER the sentinel is on `main` + green-stable** (W69
    trap #1). The sentinel-workflow edits must be merged + observed reporting
-   `success` on a path-miss PR BEFORE any `required_status_checks` PUT. That
+   `success` on a path-miss PR BEFORE any `required_status_checks` write. That
    merge + multi-run confirmation cannot complete inside one session.
 
-Doing the PUT before the sentinel is on main = the exact pending-forever trap
+Doing that write before the sentinel is on main = the exact pending-forever trap
 (`verify-the-verifiers` / `p1s2` are `paths:`-filtered → they do not run on a PR
 that does not touch their paths → a required check that never runs blocks EVERY
 such PR). Confirmed live: PR #1199 does NOT trigger `verify-the-verifiers` (its
@@ -38,7 +38,7 @@ paths are untouched) — had it been required, #1199 would be stuck pending.
 
 ## Empirical ground truth (live 2026-06-09)
 
-**Current required_status_checks (strict=true) — PRESERVE ALL 9 in any PUT:**
+**Current required_status_checks (strict=true) — PRESERVE ALL 9 in any write:**
 ```
 E2E Tests (Playwright)
 MCP Server Tests
@@ -110,12 +110,23 @@ gh run list --workflow p1s2-mutation-incremental.yml --branch main -L 5 --json c
 Then open a throwaway markdown-only PR and confirm BOTH checks report `success`
 (NOT skipped, NOT pending) on it. Only proceed if so.
 
-## Step 3 — PUT required (preserve the 9, ADD the 2)
+## Step 3 — PATCH required (preserve the 9, ADD the 2)
+
+> **Verb corrected 2026-08-31.** This section prescribed `-X PUT` in prose and in
+> two copy-pasteable commands. The postscript at the bottom of this file has said
+> since 2026-06-09 that **PUT 404s on this sub-resource and the original spec verb
+> was wrong** — but only the postscript was fixed, so the runbook a reader actually
+> executes went on prescribing the broken verb. Correcting the sentence that NAMES
+> a mistake while leaving the commands that COMMIT it is the same defect found the
+> same day in `.github/workflows/with-seat-broker-tests.yml`; this one was surfaced
+> by a systematic sweep for that shape, and it is the worse form — not a wrong
+> claim, a wrong command. The word "PUT" survives in the surrounding prose only
+> where it refers to this history.
 
 Get the EXACT check-context names first (job display names) from a recent PR's
 check list — likely `verify-the-verifiers` and the p1s2 job name. Then:
 ```
-# READ current, then PUT current+2 (NEVER overwrite blindly):
+# READ current, then PATCH current+2 (NEVER overwrite blindly):
 gh api repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
   > /tmp/req.json
 python3 - <<'PY'
@@ -125,7 +136,7 @@ ctx=set(d['contexts'])
 ctx.update(['verify-the-verifiers','<exact p1s2 context name>'])
 json.dump({'strict':d['strict'],'contexts':sorted(ctx)}, open('/tmp/req-new.json','w'))
 PY
-gh api -X PUT repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
+gh api -X PATCH repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
   --input /tmp/req-new.json
 ```
 
@@ -135,10 +146,10 @@ Open a markdown-only canary PR. It MUST NOT be stuck pending-forever; both new
 checks must report `success` (sentinel path-miss). If it hangs pending → the
 sentinel did not take → **ROLLBACK immediately**:
 ```
-gh api -X PUT repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
+gh api -X PATCH repos/Balizero1987/Teman2/branches/main/protection/required_status_checks \
   --input /tmp/req.json   # the original 9-context snapshot
 ```
-The PUT is fully reversible in one command; the blast radius (PRs can't merge)
+The PATCH is fully reversible in one command; the blast radius (PRs can't merge)
 is caught by the canary and undone by the rollback.
 
 ## Out of scope (still)


### PR DESCRIPTION
## The defect

`research/operations/specs/2026-06-09-fase0-buco1-pstar-required-checks.md` has carried, since the day it was executed, this postscript:

> `required_status_checks` updated via **PATCH** (NOT PUT — PUT 404s on this sub-resource; **the original spec verb was wrong**)

That correction went into the closing postscript **only**. The runbook body above it — the part a reader copy-pastes — kept **two literal `gh api -X PUT …` commands** (`:128`, `:138`) and five prescriptive mentions of "the PUT" (`:28`, `:30`, `:33`, `:41`, `:141`).

So the file tells you PUT 404s, then hands you PUT.

## Why this one is worse than its siblings

The same disease was cured today in `.github/workflows/with-seat-broker-tests.yml` (#5402), where a header named "EIGHT" as a W97 error while an inline comment 80 lines down still asserted it. That was a **wrong claim**. This is a **wrong command** — copy-pasteable, and it fails exactly as the file's own postscript predicts.

## How it was found

A systematic sweep for the shape *"a claim corrected in one place, the pre-correction copy surviving elsewhere"*: 462 files carry self-correction markers, 187 hand-verified against the six strongest markers. Three genuine survivors, this being one; the sweep's own scope limit (≈275 files matching only generic markers) is stated rather than glossed.

## The fix

Both commands are now `PATCH`. Prescriptive prose says PATCH or "write". **Every surviving "PUT" is historical — checked line by line, not assumed**, because the correction note itself makes that claim and a note that overstates its own edit is precisely how this defect started.

Docs-only, no behavioural surface.