### PR TITLE
fix(response): a marker-stripping rule deleted the line after its own marker

### DIFF
--- a/apps/backend-rag/backend/channels/format.py
+++ b/apps/backend-rag/backend/channels/format.py
@@ -136,7 +136,10 @@ def format_rich_text(text: str, channel: str) -> str:
         # Convert **bold** → *bold* (WA uses single asterisks)
         text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
         # Convert headers (#{1,6} Header) → *Header*
-        text = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", text, flags=re.MULTILINE)
+        # W119c (2026-08-31): same-line separator. With `\s+` a bare `###` on its own
+        # line paired with the NEXT paragraph, delivered bold as if it were a heading.
+        # A heading and its text are on one line by definition.
+        text = re.sub(r"^#{1,6}[^\S\n]+(.+)$", r"*\1*", text, flags=re.MULTILINE)
         # Strip code blocks (WA doesn't render them well)
         text = re.sub(r"```[\s\S]*?```", lambda m: m.group(0).strip("`"), text)
         # Strip inline code backticks

--- a/apps/backend-rag/backend/services/response/cleaner.py
+++ b/apps/backend-rag/backend/services/response/cleaner.py
@@ -423,7 +423,9 @@ _MARKER_PATTERNS: tuple[str, ...] = (
     r"^ACTION:\s*[a-z_]+\([^)]*\)\.?\s*",
     r"^ACTION:\s*No tool call needed[^.]*\.\s*",
     r"^vector_search\([^)]*\)\s*",
-    r"^User Query:\s*[^\n]*\n*",
+    # W119c (2026-08-31): same-line separator. `\s*` crossed the newline on an
+    # EMPTY marker, so the client received the answer with its first line gone.
+    r"^User Query:[^\S\n]*[^\n]*\n*",
     # `internal_monologue` — the model emitting the name of the section the
     # system prompt tells it to run SILENTLY (`<internal_monologue_instructions>`
     # in zantara_core.py). Measured live 2026-08-11: 2 of 16 cold answers opened

--- a/apps/backend-rag/backend/tests/unit/response/test_w119c_outbound_marker_newline_bleed.py
+++ b/apps/backend-rag/backend/tests/unit/response/test_w119c_outbound_marker_newline_bleed.py
@@ -1,0 +1,99 @@
+r"""W119c — a marker-stripping rule must never eat the line after its marker.
+
+Three rules on the bot's OUTBOUND path used `\s` as the separator between a
+marker and its own text. `\s` matches a newline, so when the marker line was
+EMPTY the separator swallowed its own newline and the rule went on to consume
+the FOLLOWING line — which is the client's answer.
+
+    THOUGHT:                          ->  (marker line removed, correct)
+    Here is the real answer.              Here is the real answer.   <- DELETED
+
+The trigger is narrower than "any leaked scratchpad": it needs the marker line
+to be empty. That is stated plainly because the fix should be judged on what it
+actually prevents. But the direction is the unsafe one — content the client was
+meant to read is deleted silently, on every channel — so it is worth a character.
+
+`[^\S\n]` here, NOT `[ \t]`. These rules run on natural-language text, where a
+non-breaking space or other exotic separator is legitimate and matching it is
+the CORRECT behaviour; the repo learned that in
+`test_redos_anchor_patterns.py`, where a first-draft `[ \t\r]` silently dropped
+NBSP and form-feed out of OCR'd legal PDFs. Note the opposite choice is right
+for the command guards in `infra/claude-hooks/` (`[ \t]`, W119b/W119c there):
+matching LESS is safe when a miss falls through to a block, and matching MORE is
+safe when a miss deletes a customer's answer. The direction of the failure picks
+the character, not house style.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from backend.channels.format import format_rich_text
+from backend.utils.response_sanitizer import sanitize_zantara_response
+
+REAL = "The capital gains rate for a PT PMA depends on your KBLI sector."
+
+
+# --- guilt: the content loss each rule caused ---------------------------------
+
+
+@pytest.mark.parametrize("marker", ["THOUGHT", "ACTION", "OBSERVATION"])
+def test_w119c_an_empty_agentic_marker_does_not_delete_the_answer(marker):
+    out = sanitize_zantara_response(f"{marker}:\n{REAL}\nSecond line.\n")
+    assert REAL in out, f"{marker}: ate the answer -> {out!r}"
+
+
+@pytest.mark.parametrize("marker", ["THOUGHT", "ACTION", "OBSERVATION"])
+def test_w119c_a_populated_agentic_marker_line_is_still_removed(marker):
+    """Innocence: the rule must keep doing the job it exists for."""
+    out = sanitize_zantara_response(f"{marker}: I should look up the KBLI table.\n{REAL}\n")
+    assert marker.lower() not in out.lower(), out
+    assert REAL in out, out
+
+
+def test_w119c_an_empty_user_query_marker_does_not_delete_the_answer():
+    from backend.services.response.cleaner import _MARKER_PATTERNS
+
+    pat = next(p for p in _MARKER_PATTERNS if "User Query" in getattr(p, "pattern", str(p)))
+    rx = pat if isinstance(pat, re.Pattern) else re.compile(pat, re.MULTILINE)
+    out = rx.sub("", f"User Query:\n{REAL}\nMore of the real answer.\n")
+    assert REAL in out, out
+
+
+# --- guilt + innocence: the WhatsApp/Telegram heading conversion ---------------
+
+
+def test_w119c_a_bare_hash_does_not_bold_the_next_paragraph_as_a_heading():
+    out = format_rich_text("###\n" + REAL + "\nAnd more.\n", "whatsapp")
+    assert f"*{REAL}*" not in out, out
+
+
+def test_w119c_a_real_heading_is_still_converted():
+    out = format_rich_text("## Pajak Penghasilan\nbody text\n", "whatsapp")
+    assert "*Pajak Penghasilan*" in out, out
+
+
+def test_w119c_a_heading_separated_by_a_non_breaking_space_is_still_converted():
+    """Why `[^\\S\n]` and not `[ \t]` on this path: NBSP is real text, not an attack."""
+    out = format_rich_text("## Pajak Penghasilan\nbody\n", "whatsapp")
+    assert "*Pajak Penghasilan*" in out, out
+
+
+# --- the class ----------------------------------------------------------------
+
+
+def test_w119c_no_outbound_marker_rule_matches_across_a_newline():
+    r"""Behavioural, not a source grep: assert on spans, so reintroducing the
+    defect with `[^|]`, `[\s\S]` or `.` under DOTALL is caught too."""
+    from backend.services.response.cleaner import _MARKER_PATTERNS
+
+    probe = "THOUGHT:\n" + REAL + "\nUser Query:\nAnother real line.\n"
+    for pat in _MARKER_PATTERNS:
+        rx = pat if isinstance(pat, re.Pattern) else re.compile(pat, re.MULTILINE)
+        for m in rx.finditer(probe):
+            span = m.group(0)
+            # a rule may legitimately END on its own newline; it may not contain
+            # a newline with non-whitespace after it (that is the next line).
+            assert not re.search(r"\n\s*\S", span), f"{rx.pattern!r} spanned: {span!r}"

--- a/apps/backend-rag/backend/utils/response_sanitizer.py
+++ b/apps/backend-rag/backend/utils/response_sanitizer.py
@@ -64,9 +64,16 @@ def sanitize_zantara_response(response: str) -> str:
 
     # CRITICAL: Remove agentic reasoning artifacts (THOUGHT:, ACTION:, etc.)
     # These should NEVER appear in user-facing responses
-    cleaned = re.sub(r"^THOUGHT:\s*.*?\n", "", cleaned, flags=re.MULTILINE | re.IGNORECASE)
-    cleaned = re.sub(r"^ACTION:\s*.*?\n", "", cleaned, flags=re.MULTILINE | re.IGNORECASE)
-    cleaned = re.sub(r"^OBSERVATION:\s*.*?\n", "", cleaned, flags=re.MULTILINE | re.IGNORECASE)
+    # W119c (2026-08-31): the separator is SAME-LINE (`[^\S\n]`), never `\s`. With
+    # `\s*` an EMPTY marker line let the separator swallow its own newline, after
+    # which `.*?\n` consumed the FOLLOWING line — so `"THOUGHT:\n<the real answer>"`
+    # reached the client with the answer deleted. Each rule removes its own marker
+    # LINE; binding to same-line whitespace is what makes it do exactly that.
+    cleaned = re.sub(r"^THOUGHT:[^\S\n]*.*?\n", "", cleaned, flags=re.MULTILINE | re.IGNORECASE)
+    cleaned = re.sub(r"^ACTION:[^\S\n]*.*?\n", "", cleaned, flags=re.MULTILINE | re.IGNORECASE)
+    cleaned = re.sub(
+        r"^OBSERVATION:[^\S\n]*.*?\n", "", cleaned, flags=re.MULTILINE | re.IGNORECASE
+    )
     cleaned = re.sub(r"^Final Answer:\s*", "", cleaned, flags=re.MULTILINE | re.IGNORECASE)
 
     # Remove placeholder markers


### PR DESCRIPTION
## What the client got

Three rules on the bot's **outbound** path used `\s` between a marker and its text. `\s` matches a
newline, so when the marker line was EMPTY the separator swallowed its own newline and the rule went
on to eat the FOLLOWING line — the answer.

```
in : "THOUGHT:\nThe capital gains rate for a PT PMA depends on your KBLI sector.\nSecond line.\n"
out: "Second line.\n"
```

WhatsApp, Telegram, Instagram and web chat alike — these run before every outbound message. Same
shape for `ACTION:`, `OBSERVATION:`, and `cleaner.py`'s `User Query:`. `format.py`'s heading rule is
the milder sibling: a bare `###` on its own line made the NEXT paragraph render **bold**, as if it
were a heading.

## What this is NOT

**The trigger is narrower than "any leaked scratchpad": it needs the marker line to be empty.** That
is written into the test docstrings rather than glossed over, so the fix is judged on what it
actually prevents. I am not claiming this was firing constantly.

But the direction is the unsafe one — content the client was meant to read disappears silently, with
no error and no test noticing — so it is worth a character.

## Why `[^\S\n]` here and `[ \t]` in the hooks

Not house style. **The direction of the failure picks the character.**

- These rules run on natural-language text, where a non-breaking space is legitimate and matching it
  is the CORRECT behaviour. A first-draft `[ \t\r]` elsewhere in this repo silently dropped NBSP and
  form-feed out of OCR'd legal PDFs and truncated a law from 2 articles to 0
  (`test_redos_anchor_patterns.py` documents it). Matching **more** is safe here.
- The command guards in `infra/claude-hooks/` take `[ \t]`, because a separator the guard fails to
  see there falls through to the real cwd and the operation gets judged against the main checkout —
  i.e. blocked. Matching **less** is safe there.

Writing this down as "always bind with X" would produce the opposite defect half the time.

## Evidence

- **6 of the 11 new tests fail against `origin/main`** and pass here. The other 5 are innocence
  checks — a populated marker line is still removed, a real `## Heading` is still converted.
- One innocence test carries a **real U+00A0**, so it actually pins the reason the wider class was
  chosen instead of just asserting it in a comment.
- The class-level test is **behavioural** — it asserts no match's span contains a newline followed by
  non-whitespace. A source grep for `\s` would go green the moment someone reintroduced the defect
  with `[^|]`, `[\s\S]` or `.` under `DOTALL`.
- 199 response + channel tests green. **1650 green** across everything touching these three modules.

Sibling of #5396 and #5405 — same class (a regex applied to whole multi-line text), found by the
repo-wide sweep those two triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)