### PR TITLE
fix(kbli): the JSON-LD still shipped the risk tier in raw Bahasa

### DIFF
--- a/apps/mouth/src/components/kbli/KBLIStructuredData.test.tsx
+++ b/apps/mouth/src/components/kbli/KBLIStructuredData.test.tsx
@@ -141,3 +141,56 @@ describe("structured data — whole-verdict PMA gate", () => {
     );
   });
 });
+
+// =============================================================================
+// The rendered page translates the risk tier (PR #4776) and the JSON-LD did
+// not, so a block declaring `"inLanguage": "en"` shipped `Risk: Menengah
+// Rendah` into the description, keywords and GovernmentService that search
+// engines read. Measured live on 2026-08-31 at kbli/56101: 22 "Medium-Low" in
+// the rendered body, 6 "Menengah Rendah" — every one of them inside JSON-LD.
+// =============================================================================
+describe("KBLICodeJsonLd — the risk tier is translated in the JSON-LD too", () => {
+  it("guilt: a Bahasa tier reaches the JSON-LD in English, not raw", () => {
+    const code = getAllCodes().find((c) =>
+      /menengah\s+rendah/i.test(c.licensing[0]?.riskCategory ?? ""),
+    ) as KBLICode;
+    expect(code).toBeDefined();
+
+    const payload = JSON.stringify(jsonLdOf(code));
+    expect(payload).toContain("Medium-Low");
+    expect(payload).not.toMatch(/Menengah\s+Rendah/i);
+  });
+
+  it("innocence: a tier the translator does not recognise is kept verbatim, never dropped", () => {
+    const base = getAllCodes().find(
+      (c) => !!c.licensing[0]?.riskCategory,
+    ) as KBLICode;
+    expect(base).toBeDefined();
+    const exotic = {
+      ...base,
+      licensing: [
+        { ...base.licensing[0], riskCategory: "Kategori Baru 2027" },
+        ...base.licensing.slice(1),
+      ],
+    } as KBLICode;
+
+    const payload = JSON.stringify(jsonLdOf(exotic));
+    expect(payload).toContain("Kategori Baru 2027");
+    expect(payload).not.toContain("Unknown");
+  });
+
+  it("innocence: a code with no risk tier at all still falls back to Unknown", () => {
+    const base = getAllCodes().find(
+      (c) => !!c.licensing[0]?.riskCategory,
+    ) as KBLICode;
+    const bare = {
+      ...base,
+      licensing: [
+        { ...base.licensing[0], riskCategory: undefined },
+        ...base.licensing.slice(1),
+      ],
+    } as unknown as KBLICode;
+
+    expect(JSON.stringify(jsonLdOf(bare))).toContain("Unknown");
+  });
+});

--- a/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
+++ b/apps/mouth/src/components/kbli/KBLIStructuredData.tsx
@@ -8,6 +8,7 @@ import {
   formatPmaOwnership,
   hasPublishablePmaCap,
 } from "@/lib/kbli-pma-disclosure";
+import { riskLabelEn } from "@/lib/kbli-derive";
 import { pmaCapShape } from "@/lib/kbli-pma-shape";
 import { pmaSourceAttributionStructured } from "@/lib/kbli-pma-source";
 
@@ -100,7 +101,14 @@ export function KBLICodeJsonLd({
         }`
   }${pmaAttribution}`;
 
-  const riskLevel: string = code.licensing[0]?.riskCategory ?? "Unknown";
+  // The rendered page translates this tier (PR #4776); the JSON-LD did not, so a
+  // block that declares `"inLanguage": "en"` was emitting `Risk: Menengah Rendah`
+  // into the description, keywords and GovernmentService that search engines read.
+  // `riskLabelEn` returns null for a tier it does not recognise, so the raw value is
+  // kept as the fallback -- this translates what it knows and never drops information.
+  const rawRiskCategory = code.licensing[0]?.riskCategory;
+  const riskLevel: string =
+    riskLabelEn(rawRiskCategory) ?? rawRiskCategory ?? "Unknown";
   const licenseType = code.licensing[0]?.licenseType ?? "NIB";
   // Rows not verified against a KBLI-2025-native OSS source must not reach
   // Google/AI answers as unqualified fact (Codex gate round 4).


### PR DESCRIPTION
PR #4776 translated the KBLI risk category on the rendered page. The structured data did not follow.

**Measured live today on `https://kita.balizero.com/kbli/56101`** (200, 161 KB body, redirects followed — a positive control confirms the page really is the KBLI page):

| where | occurrences |
|---|---|
| rendered body, English (`Medium-Low`) | 22 |
| raw Bahasa (`Menengah Rendah`) | 6 |

**All six are inside JSON-LD** — and that block declares `"inLanguage": "en"` while its `description`, `keywords` and `GovernmentService` description read `Risk: Menengah Rendah`. That is the untranslated tier going into what search engines and AI answers read.

`KBLIStructuredData.tsx:103` took `code.licensing[0]?.riskCategory` raw and interpolated it at three sites; the file never imported `riskLabelEn`. This adds the import and the same idiom the two existing call sites already use (`apps/mouth/src/app/kbli/[code]/page.tsx:883`, `apps/mouth/src/lib/kbli-faq.ts:325`):

```ts
riskLabelEn(rawRiskCategory) ?? rawRiskCategory ?? "Unknown"
```

`riskLabelEn` returns `null` for a tier it does not recognise, so the raw value stays as the fallback — this translates what it knows and **never drops information**.

## Proof

Three tests added, and the guilt one was proven to fail without the cure — with the source reverted to `origin/main` and the tests left in place:

```
× guilt: a Bahasa tier reaches the JSON-LD in English, not raw
Tests  1 failed | 10 passed (11)
```

With the cure: `Tests 11 passed (11)`. The two innocence tests pass in **both** states, so they pin the fallback rather than riding on the fix:
- an unrecognised tier (`Kategori Baru 2027`) is kept verbatim and does not become `Unknown`
- a code with no tier at all still falls back to `Unknown`

Typecheck green through the pre-commit hook. Re-ran the suite after Prettier rewrote the test file.

## Scope

Deliberately narrow: this is the surface #4776 missed, not a widening. `kbli-explorer/page.tsx:689` builds a separate share-text `Risk:` string from `getRiskBadge` — a different code path with a different helper, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)