### PR TITLE
fix(probe): wal-continuity-probe tries pg.sh (proven) before fly ssh console

### DIFF
--- a/scripts/tests/test_wal_continuity_probe.py
+++ b/scripts/tests/test_wal_continuity_probe.py
@@ -1335,3 +1335,68 @@ def test_classify_advertises_no_clock_it_does_not_read():
     assert not clock_reads, (
         f"classify() reads the wall clock at line(s) {clock_reads} — a pure verdict "
         "function whose answer depends on when it runs cannot be pinned by any fixture")
+
+
+# ---------------------------------------------------------------------------
+# Dual observation source (2026-08-31): `scripts/pg.sh` is the PROVEN path (measured
+# live: reaches the primary through Fly's HA-aware proxy, returned `in_recovery: false`).
+# `fly ssh console` is kept as a fallback and was never deleted — `read_archiver_state`'s
+# own docstring states the philosophy: probe both, in order, and LOG which one won.
+# ---------------------------------------------------------------------------
+
+def test_innocence_pg_sh_succeeding_means_fly_is_never_invoked(monkeypatch):
+    """pg.sh is tried FIRST. When it already produced a good observation, calling out to
+    `fly ssh console` too would be wasted latency and an unnecessary extra prod touch —
+    the dispatcher must short-circuit, not probe every source unconditionally."""
+    fly_calls: list[int] = []
+    monkeypatch.setattr(probe, "read_archiver_state_via_pg_sh",
+                        lambda timeout=60: (obs(), None))
+    monkeypatch.setattr(probe, "read_archiver_state_via_fly",
+                        lambda timeout=90: (fly_calls.append(1), (None, "must not run"))[1])
+    result, reason = probe.read_archiver_state()
+    assert reason is None
+    assert result == obs()
+    assert fly_calls == [], "fly ssh console ran even though pg.sh already succeeded"
+
+
+def test_innocence_pg_sh_failing_falls_through_to_fly_and_names_the_winner(capsys, monkeypatch):
+    """The 'add a source, never delete one' contract only means something if the
+    fallback actually runs on failure, and if a human reading the log can tell WHICH
+    source answered — the same requirement `read_archiver_state_via_fly` already
+    enforces one level down, between its two credentials."""
+    monkeypatch.setattr(probe, "read_archiver_state_via_pg_sh",
+                        lambda timeout=60: (None, "pg.sh: proxy on :15432 down"))
+    monkeypatch.setattr(probe, "read_archiver_state_via_fly",
+                        lambda timeout=90: (obs(), None))
+    result, reason = probe.read_archiver_state()
+    assert reason is None
+    assert result == obs()
+    out = capsys.readouterr().out
+    assert "fly ssh console" in out, "the log never named which source was accepted"
+
+
+def test_guilt_both_sources_failing_is_cannot_verify_never_clean(tmp_path, monkeypatch):
+    """pg.sh fails, falls through to fly, fly ALSO fails: the dispatcher must report
+    failure — never fabricate an observation — and the failure reason must preserve
+    BOTH sources' own words, not just the last one tried (a page that only shows the
+    final attempt hides the first cause from whoever reads it).
+
+    Exercised through the real CLI entry point `run()` uses when NOT --from-json, so
+    this is the guilt case for the actual code path cron drives, not only the pure
+    dispatcher in isolation.
+    """
+    monkeypatch.setattr(probe, "read_archiver_state_via_pg_sh",
+                        lambda timeout=60: (None, "pg.sh: proxy on :15432 down"))
+    monkeypatch.setattr(probe, "read_archiver_state_via_fly",
+                        lambda timeout=90: (None, "fly: no credential produced a parseable row"))
+
+    result, reason = probe.read_archiver_state()
+    assert result is None
+    assert reason is not None and "pg.sh" in reason and "fly" in reason
+    assert "proxy on :15432 down" in reason
+    assert "no credential produced a parseable row" in reason
+
+    state = tmp_path / "state.json"
+    rc = probe.main(["--dry-run", "--json", "--state-file", str(state)])
+    assert rc == EXIT_CANNOT_VERIFY
+    assert not state.exists(), "dry-run must still write no state, even on CANNOT_VERIFY"

--- a/scripts/wal_continuity_probe.py
+++ b/scripts/wal_continuity_probe.py
@@ -956,17 +956,34 @@ def _resolve_fly() -> str | None:
 
 
 def read_archiver_state_via_fly(timeout: int = 90) -> tuple[dict | None, str | None]:
-    """Query the primary. Returns `(observation, failure_reason)` — exactly one is None.
+    """Query the primary via `fly ssh console`. Returns `(observation, failure_reason)`
+    — exactly one is None.
 
     TWO credentials exist and only one of them works, and WHICH one has already inverted
     once (W106: a cure pinned to today's world becomes tomorrow's bug). So we probe both
     in the order the environment offers them and LOG which was accepted — never hardcode
     that the env token is the stale one, in either direction.
 
-    NOT EXERCISED against production from the lane that wrote it: this function is the
-    one part of the probe that mutates nothing but does reach out, and the mandate that
-    commissioned it forbade touching prod. Its contract is pinned by the fixtures the
-    tests feed to `classify`; the live path is proven by the first scheduled run.
+    NO `--machine` IS PASSED, DELIBERATELY: `fly ssh console --app X` without it lands on
+    an ARBITRARY member of the HA cluster. Measured 2026-08-31: `nuzantara-postgres` runs
+    3 machines via repmgr (1 primary + 2 replica; `fly machines list -a
+    nuzantara-postgres`). Pinning a machine ID here would be exactly the W106 shape named
+    two paragraphs up — correct the day it is written, wrong the moment repmgr promotes a
+    different machine on failover, and this function has no way to re-evidence the new
+    primary's ID from inside itself. A real fix needs a DYNAMIC lookup (ask repmgr, or
+    Fly's own API, which machine holds the role right now); that is a gap, tracked, not
+    solved here — not a guess spent on a value that will not stay true.
+
+    PROVEN BROKEN, NOT PROVEN WORKING (measured 2026-08-31, this session, `--dry-run`):
+    `fly ssh console` reached a machine with no local Postgres socket at
+    `/var/run/postgresql/.s.PGSQL.5432` and the probe correctly answered CANNOT_VERIFY —
+    so the FAILURE path is now exercised, but the SUCCESS path (a console session that
+    actually reaches a `psql` that can query `pg_stat_archiver`) still never has been.
+    `scripts/pg.sh` (tried FIRST by `read_archiver_state`, below) IS proven both ways: it
+    reaches the primary through Fly's HA-aware proxy on :15432, and the same live probe
+    returned `in_recovery: false` — proof it landed on the primary, not a replica. This
+    function is kept as the FALLBACK, per this file's own "add a source, never delete
+    one" philosophy (see `read_archiver_state`) — not proven, not removed.
     """
     fly = _resolve_fly()
     if fly is None:
@@ -1007,6 +1024,91 @@ def read_archiver_state_via_fly(timeout: int = 90) -> tuple[dict | None, str | N
         failures.append(f"{source}: rc={proc.returncode} {proc.stderr.strip()[:160]}")
 
     return None, "; ".join(failures) or "no credential produced a parseable row"
+
+
+def read_archiver_state_via_pg_sh(timeout: int = 60) -> tuple[dict | None, str | None]:
+    """Query the primary through `scripts/pg.sh` — the PROVEN path (measured 2026-08-31,
+    this session: returned a real row with `in_recovery: false`, proof it reached the
+    primary and not a replica).
+
+    `pg.sh` reaches PROD through the Fly proxy it manages on :15432, which Fly's
+    postgres-flex HA setup routes to the PRIMARY member of the cluster regardless of
+    which machine that is right now — unlike `fly ssh console --app X` above, which picks
+    an arbitrary machine of the cluster because no `--machine` is (or safely can be)
+    given. `pg.sh` also owns its own credential lookup (Keychain first, a 0600
+    credential-file fallback for non-interactive callers) — opaque to this function,
+    which only needs pg.sh's exit behaviour and stdout.
+
+    Resolved relative to `PROJECT_ROOT` — this file's OWN repo root, computed once at
+    import from `__file__` — never a hardcoded `/Users/...`. A worktree checkout carries
+    its own `scripts/pg.sh` and must run ITS copy, not the main checkout's (superscar #1,
+    HOME-fork drift, generalised to worktree-fork drift).
+
+    Returns `(observation, failure_reason)` — exactly one is None. Never touches
+    `archive_command`'s VALUE: `ARCHIVER_QUERY` (the SAME constant the fly path above
+    uses — one query, one contract, two transports) only ever asks Postgres for the
+    boolean `archive_command_set`. The secret never leaves the server, so there is
+    nothing here to scrub — `sanitize_observation` in `run()` is the belt to this
+    function's already-fastened suspenders.
+    """
+    pg_sh = PROJECT_ROOT / "scripts" / "pg.sh"
+    if not pg_sh.is_file():
+        return None, f"pg.sh not found at {pg_sh}"
+
+    cmd = ["/bin/bash", str(pg_sh), "-Atc", ARCHIVER_QUERY]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return None, f"pg.sh timed out after {timeout}s"
+    except OSError as exc:
+        return None, f"pg.sh: {exc}"
+
+    for line in reversed(proc.stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("{") and line.endswith("}"):
+            try:
+                return json.loads(line), None
+            except ValueError:
+                break
+    # stderr can carry pg.sh's own diagnostics (proxy-down, no Keychain password) — none
+    # of which embed a secret (pg.sh never echoes PGPASSWORD), so it is safe to surface.
+    return None, f"pg.sh: rc={proc.returncode} {proc.stderr.strip()[:200]}"
+
+
+def read_archiver_state(timeout: int = 90) -> tuple[dict | None, str | None]:
+    """Try every observation source in the order the environment actually proves them,
+    and LOG which one was accepted — the same philosophy `read_archiver_state_via_fly`
+    already applies one level down, between its two credentials, applied here one level
+    up, between two TRANSPORTS.
+
+    `pg.sh` first: measured working end-to-end against the primary (see its docstring).
+    `fly ssh console` second, kept as a fallback and NEVER deleted — today pg.sh works
+    and the fly path fails closed (a live, measured fact, not a promise it will always
+    hold), so this tries the proven source first without removing the other. Should
+    pg.sh's Keychain lookup ever go dark under launchd (a documented pg.sh caveat for
+    non-interactive callers — its own header names the 0600 credential-file fallback),
+    the fly path is still here to fall through to; that is the point of keeping it.
+
+    Returns `(observation, failure_reason)` — exactly one is None. On total failure the
+    reason names WHAT EACH SOURCE SAID, not just the last one tried — a CANNOT_VERIFY
+    alert that reports only the final attempt hides the first one's cause from whoever
+    reads the page.
+    """
+    failures: list[str] = []
+
+    obs, reason = read_archiver_state_via_pg_sh(timeout=timeout)
+    if obs is not None:
+        log("wal-continuity source accepted: scripts/pg.sh")
+        return obs, None
+    failures.append(f"pg.sh: {reason}")
+
+    obs, reason = read_archiver_state_via_fly(timeout=timeout)
+    if obs is not None:
+        log("wal-continuity source accepted: fly ssh console (pg.sh fell through)")
+        return obs, None
+    failures.append(f"fly ssh console: {reason}")
+
+    return None, "; ".join(failures)
 
 
 # ===========================================================================
@@ -1103,7 +1205,7 @@ def run(args: argparse.Namespace) -> int:
         except (OSError, ValueError) as exc:
             raw, reason = None, f"--from-json unreadable: {exc}"
     else:
-        raw, reason = read_archiver_state_via_fly()
+        raw, reason = read_archiver_state()
 
     # ---- CANNOT_VERIFY: read failed, or answered from recovery -------------
     cannot_verify_reason = reason


### PR DESCRIPTION
## Summary

- `read_archiver_state_via_fly()` (the probe's only production observation path) picks
  an arbitrary machine of the 3-machine `nuzantara-postgres` HA cluster (`fly ssh console
  --app X` with no `--machine`), and **measured live** it fails closed: `psql: error:
  connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such
  file or directory` → `CANNOT_VERIFY` (exit 4). The launchd job meant to prove this path
  against prod was never installed, so it has never returned a real verdict — the
  function's own docstring said as much before this PR.
- Adds `read_archiver_state_via_pg_sh()`, which runs the SAME `ARCHIVER_QUERY` through
  `scripts/pg.sh` — measured live, working end-to-end, `in_recovery: false` in the
  returned row (proof it reached the primary, not a replica). `pg.sh` reaches PROD
  through Fly's HA-aware proxy on :15432, which routes to the primary regardless of
  which machine currently holds that role.
- Adds `read_archiver_state()`, a dispatcher that tries `pg.sh` first, falls through to
  the existing `fly ssh console` path on failure, and **logs which source was accepted**
  (`log("wal-continuity source accepted: ...")`, always printed, not gated behind
  `--verbose`). `run()`'s single call site now goes through this dispatcher.
- `read_archiver_state_via_fly` is **kept, not deleted** — the file's own philosophy
  ("probe both in the order the environment offers them and log which was accepted —
  never hardcode that one is stale") now applies one level up, between two TRANSPORTS,
  not just between the fly path's two credentials.

## What was measured vs what remains unproven

**Measured this session, on Pro, live against `nuzantara-postgres`:**
- `fly ssh console` path fails closed exactly as described (socket-not-found →
  CANNOT_VERIFY, exit 4).
- `bash scripts/pg.sh -Atc "<ARCHIVER_QUERY>"` returns a complete, valid observation with
  `in_recovery: false`.
- After this change, `python3 scripts/wal_continuity_probe.py --dry-run --json` returns a
  REAL verdict (`FIRST_RUN`, exit 0 — no baseline exists yet since the launchd job was
  never armed) and the log line names `scripts/pg.sh` as the accepted source.
- `--selftest`: 22/22 checks pass (11 of them prefixed `guilt:`), 0 failures.
- Full existing test file + 3 new tests: 89/89 pass.
- `ruff check` clean on both changed files.
- `fly machines list -a nuzantara-postgres`: 3 machines, repmgr HA, 1 primary + 2
  replica — this is the evidence behind the decision below.

**Deliberately NOT done, and why:**
- **No `--machine` pin added to the fly path.** The cluster is repmgr HA and the primary
  role can migrate on failover; hardcoding today's primary machine ID would reproduce the
  exact "cure pinned to today's world becomes tomorrow's bug" shape the file already
  names for its credential-order choice (W106) — just one level up, for the transport
  choice. A real fix needs a *dynamic* lookup (ask repmgr, or Fly's API, which machine
  holds the role right now); that's a gap, tracked in the new docstring, not solved here.
- **The launchd job is NOT installed or loaded by this PR.** That's a separate, later
  arming step (per the mandate). Once armed, note that `pg.sh`'s own header documents a
  non-interactive-caller caveat: under launchd, its Keychain password lookup can come
  back empty, with a documented 0600-credential-file fallback
  (`NUZANTARA_PG_RO_CRED_FILE`) that would need to be armed too for `pg.sh` to work
  under cron — if that's not armed, the dispatcher still falls through to the existing
  fly path, so the probe degrades rather than going silently blind.
- `archive_command`'s value is still never touched — `ARCHIVER_QUERY` (shared by both
  transports) only ever asks Postgres for the boolean `archive_command_set`; the secret
  never leaves the server.

## Test plan

- [x] `python3 scripts/wal_continuity_probe.py --selftest` — 22/22 PASS
- [x] `python3 scripts/wal_continuity_probe.py --dry-run --json` — real verdict, names
      the accepted source (`scripts/pg.sh`)
- [x] `pytest scripts/tests/test_wal_continuity_probe.py -q` — 89 passed (86 existing + 3
      new: 1 guilt — both sources fail → CANNOT_VERIFY through the real `run()` CLI path
      — and 2 innocence — pg.sh success short-circuits fly, pg.sh failure falls through
      and names the winner)
- [x] `ruff check scripts/wal_continuity_probe.py scripts/tests/test_wal_continuity_probe.py`
- [x] `bash -n infra/launchagents/wrappers/wal-continuity-probe.sh` (unaffected by this
      change, re-checked per the CI workflow for this probe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)