### PR TITLE
fix(pricing): the contact block's two halves named different numbers, and the guard could not see it

### DIFF
--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -6,7 +6,7 @@
     "contact": {
       "email": "zero@balizero.com",
       "whatsapp": "+62 821 3465 159",
-      "wa_link": "https://wa.me/628213454721",
+      "wa_link": "https://wa.me/628213465159",
       "location": "Kerobokan, Bali, Indonesia",
       "website": "balizero.com"
     },

--- a/scripts/pricelist_2026/schema.py
+++ b/scripts/pricelist_2026/schema.py
@@ -8,10 +8,23 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+# Single source of truth for the digits — matches SUPPORT_WHATSAPP in
+# apps/backend-rag/backend/app/core/config.py and CANONICAL_WHATSAPP in
+# scripts/patch_pricing_contact_block.py (Meta-verified Bali Zero number).
+# `whatsapp` (human-readable) and `wa_link` (wa.me href) are both derived
+# from these digits below so they cannot disagree — a prior hand-typed
+# duplication let `wa_link` drift to a different number's digits while
+# `whatsapp` was updated (see docs/pricing/Bali_Zero_Price_List_2026.md
+# WhatsApp link mismatch, fixed 2026-08-31).
+_CANONICAL_WHATSAPP_DIGITS = "628213465159"
+
 CANONICAL_CONTACT = {
     "email": "zero@balizero.com",
-    "whatsapp": "+62 821 3465 159",
-    "wa_link": "https://wa.me/628213454721",
+    "whatsapp": (
+        f"+{_CANONICAL_WHATSAPP_DIGITS[:2]} {_CANONICAL_WHATSAPP_DIGITS[2:5]} "
+        f"{_CANONICAL_WHATSAPP_DIGITS[5:9]} {_CANONICAL_WHATSAPP_DIGITS[9:]}"
+    ),
+    "wa_link": f"https://wa.me/{_CANONICAL_WHATSAPP_DIGITS}",
     "location": "Kerobokan, Bali, Indonesia",
     "website": "balizero.com",
 }

--- a/scripts/pricelist_2026/tests/fixtures/minimal_prices.json
+++ b/scripts/pricelist_2026/tests/fixtures/minimal_prices.json
@@ -6,7 +6,7 @@
     "contact": {
       "email": "zero@balizero.com",
       "whatsapp": "+62 821 3465 159",
-      "wa_link": "https://wa.me/628213454721",
+      "wa_link": "https://wa.me/628213465159",
       "location": "Kerobokan, Bali, Indonesia",
       "website": "balizero.com"
     },

--- a/scripts/pricelist_2026/tests/test_generate.py
+++ b/scripts/pricelist_2026/tests/test_generate.py
@@ -74,7 +74,7 @@ def test_generate_markdown_smoke(fixture_data, tmp_path):
     assert "# Bali Zero — Price List 2026" in md
     assert "C1 Tourism" in md
     assert "1.800.000 IDR – 2.000.000 IDR" in md
-    assert "wa.me/628213454721" in md
+    assert "wa.me/628213465159" in md
 
 
 def test_generate_rejects_invalid_json(stub_assets, tmp_path):

--- a/scripts/pricelist_2026/tests/test_schema.py
+++ b/scripts/pricelist_2026/tests/test_schema.py
@@ -1,5 +1,6 @@
 """Tests for the 2026 price list JSON schema validator."""
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,10 @@ FIXTURE = Path(__file__).parent / "fixtures" / "minimal_prices.json"
 
 def _load_fixture():
     return json.loads(FIXTURE.read_text())
+
+
+def _digits(value: str) -> str:
+    return re.sub(r"\D", "", value)
 
 
 def test_valid_fixture_passes():
@@ -76,6 +81,54 @@ def test_tier_range_must_be_two_strings():
     result = schema.validate(data)
     assert not result.ok
     assert any("tier_range" in e for e in result.errors)
+
+
+def test_canonical_contact_whatsapp_and_wa_link_share_the_same_digits():
+    """Regression guard for the 2026-08-31 scar: `wa_link` drifted to a
+    different phone number's digits (a team member's personal wa-mirror
+    number) while `whatsapp` (the display text) was updated to the
+    Meta-verified Bali Zero number. Because `schema.validate` only checks
+    each field against `CANONICAL_CONTACT` by exact string match, a
+    mismatch baked into `CANONICAL_CONTACT` itself was invisible to
+    validation — both the dict and the shipped JSON agreed on the WRONG
+    wa_link. This test checks the underlying invariant directly: the
+    digits inside `whatsapp` (human-readable) and `wa_link` (wa.me href)
+    must be the same phone number, independent of what either string is
+    hand-typed to say.
+    """
+    contact = schema.CANONICAL_CONTACT
+    assert _digits(contact["whatsapp"]) == _digits(contact["wa_link"]), (
+        f"whatsapp digits {_digits(contact['whatsapp'])!r} != "
+        f"wa_link digits {_digits(contact['wa_link'])!r}"
+    )
+
+
+def test_contact_wa_link_must_match_canonical():
+    data = _load_fixture()
+    data["metadata"]["contact"]["wa_link"] = "https://wa.me/628213454721"
+    result = schema.validate(data)
+    assert not result.ok
+    assert any("wa_link" in e for e in result.errors)
+
+
+def test_real_2026_json_whatsapp_and_wa_link_share_the_same_digits():
+    """Same guard as above, run against the actual shipped JSON — the file
+    `scripts/pricelist_2026/generate.py` reads by default and the one
+    `docs/pricing/Bali_Zero_Price_List_2026.md` is rendered from. Catches
+    a future edit that updates `whatsapp` without updating `wa_link` (or
+    vice versa) directly in the JSON, bypassing `CANONICAL_CONTACT`
+    entirely.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    real = repo_root / "apps/backend-rag/backend/data/bali_zero_official_prices_2026.json"
+    if not real.exists():
+        pytest.skip(f"real JSON not yet authored at {real}")
+    data = json.loads(real.read_text())
+    contact = data["metadata"]["contact"]
+    assert _digits(contact["whatsapp"]) == _digits(contact["wa_link"]), (
+        f"whatsapp digits {_digits(contact['whatsapp'])!r} != "
+        f"wa_link digits {_digits(contact['wa_link'])!r}"
+    )
 
 
 def test_real_2026_json_validates():


### PR DESCRIPTION
## What

`CANONICAL_CONTACT` carried the phone number twice, hand-typed, in two formats. `whatsapp` had been updated to the number `config.py:28` `SUPPORT_WHATSAPP` and `patch_pricing_contact_block.py` both declare canonical and Meta-verified. `wa_link` had not, and still resolved to a different real number.

The same mismatch was live in `apps/backend-rag/backend/data/bali_zero_official_prices_2026.json` — the sheet the **running PricingService loads**, so this was never confined to a generated document. `generate.py:110/188` also feeds that `wa_link` to `_make_qr_data_uri`, so the QR rendered into the price list encoded the wrong number.

## Why the guard missed it

`schema.validate()` checks each contact field for exact-string equality against `CANONICAL_CONTACT`. Since `CANONICAL_CONTACT`'s own `wa_link` was equally wrong, the JSON matched it and validation passed. And `test_generate.py:77` asserted `"wa.me/628213454721" in md` — a passing test that encoded the defect. Both failures have the same shape as the thing they guarded: a value duplicated by hand, agreement assumed rather than derived.

## Cure

One `_CANONICAL_WHATSAPP_DIGITS` constant; display text and `wa.me` href both derived from it, so they cannot disagree again.

Three tests added: the two fields' digits must match in `CANONICAL_CONTACT`; `validate()` must reject a divergent `wa_link` (symmetry with the existing `whatsapp` test); the shipped JSON must satisfy the same check directly. One pre-existing test corrected.

**Mutation-verified**: reintroducing the old `wa_link` turns 8 tests red including the new regression; restored, 17 pass.

## Deliberately NOT changed

`docs/pricing/Bali_Zero_Price_List_2026.md` still publishes the other number — consistently, in both display text and href. **Which number Bali Zero publishes is a business decision, not a consistency defect.** The `kimi-code/k3` seat found that other number still published across roughly thirty balizero.com articles, so either those are stale or the declared canonical is. That question is for the owner; this PR only stops the two halves of one record from contradicting each other.

Gear 1 (`--print-floor` = 1 on this file set). Split out of #5407 to keep that PR to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142VSuDn5fqCvckyb4JMeYz