### PR TITLE
fix(organism): repoint infra.ollama_pro at the live com.nuzantara.ollama label

### DIFF
--- a/scripts/launchagent-state-bridge.py
+++ b/scripts/launchagent-state-bridge.py
@@ -539,8 +539,21 @@ BRIDGED_LABELS: tuple[BridgedLaunchAgent, ...] = (
         organ_id="infra.syncthing_pro",
         daemon=True,
     ),
+    # infra.ollama_pro REPOINTED 2026-08-31: "homebrew.mxcl.ollama" is not
+    # loaded on Pro (verified: `launchctl list "homebrew.mxcl.ollama"` ->
+    # "Could not find service"). The live daemon runs under a different
+    # label, "com.nuzantara.ollama" (ProgramArguments:
+    # /Users/nuzantara/scripts/ollama-single-manager.sh), which exists to own
+    # the port-collision/two-program-paths problem the 2026-06-28 triage in
+    # organism_stale_detector.py:220-222 describes ("the real `ollama serve`
+    # already owns :11434 ... two program paths"). Bridging the retired
+    # Homebrew label made this organ report "failed" forever (false alarm)
+    # while the actual serving daemon had zero organism coverage under any
+    # name — pro.ollama_warm_pin tracks a different job
+    # (com.nuzantara.ollama-warm-pin, keeps a model warm) and does not cover
+    # this one. This changes the alarm's TARGET, not the daemon.
     BridgedLaunchAgent(
-        label="homebrew.mxcl.ollama",
+        label="com.nuzantara.ollama",
         organ_id="infra.ollama_pro",
         daemon=True,
     ),

--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -217,12 +217,19 @@ WARNING_STATUSES: frozenset[str] = frozenset({"warning", "warn"})
 #   - wr2.carousel_dispatcher: decommissioned 2026-06-11 (.removed-*), genome not pruned
 #   - pro.agent_library_evolver_* : intentionally disabled (deploy-drift quarantine)
 #   - pro.audit_launchd_daily : exit 1 BY DESIGN = "N unhealthy jobs found" (a true report)
-#   - infra.ollama_pro : launchd job exits 1 because the real `ollama serve` already
-#       owns :11434 (port collision, two program paths) — the daemon is ALIVE and serving
-#       (6 models on :11434). The bridge reads the launchd exit code, not the live socket.
-#       (Live triage 2026-06-28. NOTE: pro.curiosity_weekly was triaged the same day as a
-#       REAL failure — W84 TCC-dead on ~/Desktop — and is deliberately NOT suppressed here:
-#       it must stay visible as an operator-boundary finding, not be hidden.)
+#   - infra.ollama_pro : REMOVED 2026-08-31 — this was suppressing a label mismatch,
+#       not a real failure. The bridge was watching the retired Homebrew label
+#       "homebrew.mxcl.ollama" (not loaded on Pro) while the live daemon runs under
+#       "com.nuzantara.ollama"; launchagent-state-bridge.py now points infra.ollama_pro
+#       at the live label, so the organ reports its real status. Keeping it suppressed
+#       here would hide a genuine future failure of the live daemon — that is the whole
+#       point of the repoint. (Original 2026-06-28 finding, now moot: launchd exited 1
+#       because the real `ollama serve` already owned :11434 — port collision, two
+#       program paths — while the daemon was ALIVE and serving 6 models; the bridge read
+#       the launchd exit code, not the live socket. NOTE: pro.curiosity_weekly was
+#       triaged the same day as a REAL failure — W84 TCC-dead on ~/Desktop — and is
+#       deliberately NOT suppressed here: it must stay visible as an operator-boundary
+#       finding, not be hidden.)
 # The bridge tags all of these "failed" because it has no `disabled`/`expected_exit`
 # concept (HEALTHY_EXIT_CODES={0}). Curing the bridge is a separate hot-zone PR;
 # this allow-list is the safe downstream filter. Audit this list when an organ is
@@ -240,7 +247,12 @@ KNOWN_BENIGN_FAILED: frozenset[str] = frozenset({
     "pro.agent_library_evolver_daily",
     "pro.agent_library_evolver_weekly",
     "pro.audit_launchd_daily",
-    "infra.ollama_pro",
+    # "infra.ollama_pro" REMOVED 2026-08-31: was suppressing a label mismatch
+    # (bridge watched the retired "homebrew.mxcl.ollama", not the live
+    # "com.nuzantara.ollama"), not a genuinely benign failure — see the
+    # reason-list note above. Repointed in launchagent-state-bridge.py so the
+    # organ now reports real status. Per the audit rule above, do NOT re-add
+    # this entry unless a NEW, genuinely-benign failure mode is documented.
 })
 
 

--- a/scripts/tests/test_launchagent_state_bridge_ollama_label.py
+++ b/scripts/tests/test_launchagent_state_bridge_ollama_label.py
@@ -1,0 +1,80 @@
+"""Tests for launchagent-state-bridge's infra.ollama_pro label (2026-08-31).
+
+Root cause this pins shut: BRIDGED_LABELS mapped organ_id="infra.ollama_pro"
+to label="homebrew.mxcl.ollama" — a launchd job that was NOT loaded on Pro.
+The live Ollama daemon actually runs under a different label,
+"com.nuzantara.ollama" (ProgramArguments: ollama-single-manager.sh), which
+exists to own the port-collision/two-program-paths problem the 2026-06-28
+triage in organism_stale_detector.py describes. Verified live 2026-08-31:
+`launchctl list "homebrew.mxcl.ollama"` -> "Could not find service", while
+`launchctl list | grep -i ollama` showed only "com.nuzantara.ollama" running,
+and `curl :11434/api/tags` answered 200 with a live model list.
+
+Consequence of the stale mapping: infra.ollama_pro reported "failed" forever
+(a false alarm, allow-listed in organism_stale_detector.KNOWN_BENIGN_FAILED
+to suppress the noise) AND the actually-live daemon had zero organism
+coverage under any name — a real future death of com.nuzantara.ollama would
+have gone unreported. Repoint fixes both; this test pins the mapping so a
+future edit cannot silently point it back at the retired label.
+
+Reads the bridge's own declared BRIDGED_LABELS tuple rather than grepping
+source text, so it fails if the mapping regresses regardless of how the
+source line is formatted.
+
+The module name is loaded via importlib (hyphenated filename), mirroring
+test_launchagent_state_bridge_host_guard.py / _tcp_retry.py.
+"""
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+RETIRED_HOMEBREW_LABEL = "homebrew.mxcl.ollama"
+LIVE_LABEL = "com.nuzantara.ollama"
+ORGAN_ID = "infra.ollama_pro"
+
+
+@pytest.fixture()
+def bridge():
+    if _SCRIPTS_DIR not in sys.path:
+        sys.path.insert(0, _SCRIPTS_DIR)
+    spec = importlib.util.spec_from_file_location(
+        "launchagent_state_bridge_ollama_label",
+        os.path.join(_SCRIPTS_DIR, "launchagent-state-bridge.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # dataclasses + `from __future__ import annotations` resolves string
+    # annotations via sys.modules[cls.__module__] — the module must be
+    # registered there before exec_module() runs the class bodies.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestOllamaProLabel:
+    def test_infra_ollama_pro_entry_exists(self, bridge):
+        matches = [e for e in bridge.BRIDGED_LABELS if e.organ_id == ORGAN_ID]
+        assert len(matches) == 1, (
+            f"expected exactly one BRIDGED_LABELS entry for {ORGAN_ID!r}, "
+            f"found {len(matches)}"
+        )
+
+    def test_infra_ollama_pro_does_not_watch_the_retired_homebrew_label(self, bridge):
+        """The regression this test exists for: BRIDGED_LABELS pointing
+        infra.ollama_pro at a launchd label that is never loaded on Pro."""
+        entry = next(e for e in bridge.BRIDGED_LABELS if e.organ_id == ORGAN_ID)
+        assert entry.label != RETIRED_HOMEBREW_LABEL
+
+    def test_infra_ollama_pro_watches_the_live_label(self, bridge):
+        entry = next(e for e in bridge.BRIDGED_LABELS if e.organ_id == ORGAN_ID)
+        assert entry.label == LIVE_LABEL
+
+    def test_no_duplicate_coverage_of_the_live_label(self, bridge):
+        """Only one BRIDGED_LABELS entry should watch the live ollama label —
+        a second entry would mean this repoint created duplicate coverage
+        instead of fixing the existing one."""
+        matches = [e for e in bridge.BRIDGED_LABELS if e.label == LIVE_LABEL]
+        assert len(matches) == 1

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -314,13 +314,22 @@ def test_allow_list_is_documented_not_empty():
     assert "codex.spark_loop" in KNOWN_BENIGN_FAILED
 
 
-def test_ollama_pro_program_path_collision_suppressed(tmp_path):
-    """INNOCENCE: infra.ollama_pro reports failed (launchd exit 1) while the daemon
-    is actually alive — the launchd job binds the same :11434 the real `ollama serve`
-    already owns, so it exits 1 and keepalive re-spawns forever. The bridge tags it
-    'failed' from the launchd exit code, but the organ breathes (6 models served on
-    :11434). This is the same family as the other bridge false-positives: a non-zero
-    launchd exit that does NOT mean the organ is dead. (Live triage 2026-06-28.)
+def test_ollama_pro_failure_now_surfaces(tmp_path):
+    """GUILT (2026-08-31 — supersedes the old suppression contract below):
+    infra.ollama_pro reporting failed is now flagged, not swallowed.
+
+    Until 2026-08-31 this test asserted the OPPOSITE (INNOCENCE: suppressed) on the
+    theory that a non-zero launchd exit here was a benign port-collision artifact —
+    the real `ollama serve` already owned :11434 so the launchd job exited 1 forever
+    while the daemon stayed alive (Live triage 2026-06-28). That theory was built on
+    a label mismatch: launchagent-state-bridge.py's BRIDGED_LABELS entry for
+    infra.ollama_pro watched "homebrew.mxcl.ollama", a launchd label that was RETIRED
+    2026-08-18 and is not loaded on Pro at all — so every exit code it ever read was
+    stale noise, not evidence about the live daemon (which runs under a different
+    label, "com.nuzantara.ollama"). The bridge now watches the live label and the
+    KNOWN_BENIGN_FAILED entry was removed to match (see its removal comment) — a
+    failed status here means the live daemon is actually down, so it must surface
+    like any other real failure, or a genuine future death goes unreported again.
     """
     d = str(tmp_path)
     _write(
@@ -328,11 +337,11 @@ def test_ollama_pro_program_path_collision_suppressed(tmp_path):
         "infra.ollama_pro",
         {"ts": time.time(), "status": "failed", "last_error": "daemon not running"},
     )
-    # host pinned: `infra.` maps to Pro, so unpinned this suppression test is
-    # satisfied by jurisdiction on every other host.
+    # host pinned: `infra.` maps to Pro, so unpinned this test would be satisfied
+    # by jurisdiction (organ dropped as foreign) on every other host.
     findings = scan_sidecars_status(d, now=time.time(), host="nuzantara")
     flagged = {f.organ_id for f in findings if f.kind == "unhealthy"}
-    assert "infra.ollama_pro" not in flagged, f"ollama false-positive not suppressed: {flagged}"
+    assert "infra.ollama_pro" in flagged, f"real ollama failure no longer surfaces: {flagged}"
 
 
 # --- cross-host sidecar sync (2026-07-17, PENDING-ARMS "infra.eventbus_redis_mini


### PR DESCRIPTION
## Summary
- `launchagent-state-bridge.py`'s `BRIDGED_LABELS` entry for `infra.ollama_pro` watched launchd label `homebrew.mxcl.ollama`, which was retired 2026-08-18 when Pro moved to the single-manager `com.nuzantara.ollama` (`ollama-single-manager.sh`) — it is **not loaded**, so this organ has been reading a dead label's exit code forever (a false "failed" alarm, papered over by `organism_stale_detector.KNOWN_BENIGN_FAILED`).
- The bigger problem: the **live** daemon, running under `com.nuzantara.ollama`, had **zero organism coverage under any name**. `pro.ollama_warm_pin` is a sibling cron job (keeps a model warm), not the serving daemon — confirmed no duplicate coverage exists.
- Repoints the bridge to the live label, removes the now-obsolete `KNOWN_BENIGN_FAILED` suppression (keeping it would hide a real future death of the daemon — the whole point of this fix), and updates/adds tests to pin the new contract.

## Measured before/after (verified live on Pro before editing anything)
```
$ launchctl list | grep -i ollama
65924	0	com.nuzantara.ollama

$ launchctl list "homebrew.mxcl.ollama"
Could not find service "homebrew.mxcl.ollama" in domain for port
(exit 113)

$ curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://localhost:11434/api/tags
{"models":[...5 models: muse-glimmer:30b-mlx, qwen3.8:27b-mlx, qwen3.5:9b, qwen2.5vl:7b, bge-m3:latest...]}
HTTP_STATUS:200
```
So: `homebrew.mxcl.ollama` is confirmed absent, `com.nuzantara.ollama` is confirmed loaded and running, and the daemon it manages is confirmed healthy and serving. **This PR changes which label the alarm watches — it does not touch the Ollama daemon itself in any way.**

`apps/organism/organism/organs_registry.yaml` has no entry referencing `com.nuzantara.ollama` other than the unrelated `pro.ollama_warm_pin` job, so repointing `infra.ollama_pro` does not create duplicate coverage.

## Changes
- `scripts/launchagent-state-bridge.py`: `label="homebrew.mxcl.ollama"` → `label="com.nuzantara.ollama"` for the `infra.ollama_pro` entry (organ_id, daemon= unchanged); comment records why, in the file's established style.
- `scripts/organism_stale_detector.py`: removed `infra.ollama_pro` from `KNOWN_BENIGN_FAILED` (it was suppressing a label mismatch, not a genuinely benign failure), following the existing `wr3.reflexion_weekly` removal-comment precedent already in that frozenset.
- `scripts/tests/test_organism_stale_detector.py`: the one existing test that pinned the old suppression contract (`test_ollama_pro_program_path_collision_suppressed`) now asserts the opposite — a failed status must surface, not be swallowed — renamed to `test_ollama_pro_failure_now_surfaces` with a docstring explaining the history.
- `scripts/tests/test_launchagent_state_bridge_ollama_label.py` (new): reads `BRIDGED_LABELS` directly (not a source grep) and asserts the `infra.ollama_pro` entry does not name the retired Homebrew label, names the live one, and that no other entry duplicates coverage of the live label.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_launchagent_state_bridge_ollama_label.py scripts/tests/test_organism_stale_detector.py scripts/tests/test_launchagent_state_bridge_host_guard.py scripts/tests/test_launchagent_state_bridge_tcp_retry.py -q` → **81 passed**
- [x] Safety sweep of every other test file importing either touched module (`test_check_flowkit_tunnel.py`, `test_dlq_corpse_sweep_organism.py`, `test_launchd_liveness_expected_nonzero.py`, `test_proprioception_executed_code_currency.py`, `test_wr2_pipeline_consolidation.py`) → **70 passed**
- [x] `python3 infra/organ-conformance/check_organ_conformance.py` → `0 regressions, 0 non-conformant births`
- [x] `ast.parse()` syntax check on both edited modules

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>