### PR TITLE
fix(governance): the contract's own staleness check has not worked since June

### DIFF
--- a/AUTONOMOUS_OPS.md
+++ b/AUTONOMOUS_OPS.md
@@ -16,10 +16,24 @@
 
 **Level 2 — active since 2026-06-11**
 (Level 1 was active earlier same day; promoted to L2 once all activation gates closed.)
-(re-certified 2026-06-11 by Antonello after the Fable-5 system audit F04;
-the SessionStart staleness hook was fixed the same day to read this declared
-date — not the file mtime, which any edit silently reset, masking the lapse.)
-(re-certified 2026-07-19 by Antonello — routine 30-day refresh; Level 2 unchanged.)
+(re-certified 2026-06-11 by Antonello after the Fable-5 system audit F04.
+That same day the SessionStart staleness hook was fixed to read this declared
+date rather than the file mtime — see `2d26dea7d`, which records the fix and its
+verification. **Corrected 2026-08-31: that fix is gone.** Measured on Pro, the
+live hook in `~/.claude/settings.json` computes `AGE_DAYS` from `date -r "$F"`
+again, i.e. the mtime; Mini and M5 carry no such hook at all. So the mechanism
+that announces this contract's own expiry works on zero of three machines. The
+cure was real and it was lost, because it lived only in a file no repository
+tracks — scar family #1 in its purest form. Do not re-apply it there a third
+time: `scripts/check_autonomous_ops_staleness.py` now does the arithmetic in the
+repo, where it is version-controlled and tested, and the hook should call it.
+Two traps that script exists to avoid: the old hook's grep matches only the
+`**Level N — active since**` line, so a naive "parse the declared date" fix reads
+2026-06-11 and not the later re-certification below; and this file carries two
+dozen unrelated ISO dates that must never govern.)
+(re-certified 2026-07-19 by Antonello — routine 30-day refresh; Level 2 unchanged.
+As of 2026-08-31 that is 43 days: this contract is LAPSED by its own rule below,
+and no session was told, because of the defect described above.)
 
 If today's date is >30 days after "active since" without a refresh commit,
 Claude falls back to conservative mode and pings the user to re-certify.

--- a/scripts/check_autonomous_ops_staleness.py
+++ b/scripts/check_autonomous_ops_staleness.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Report whether the Autonomous Ops contract has lapsed, from its DECLARED date.
+
+WHY THIS LIVES IN THE REPO, AND NOT IN THE HOOK
+================================================
+`AUTONOMOUS_OPS.md` promises that a contract older than 30 days drops the session
+into conservative mode. The thing that was supposed to enforce that promise is a
+SessionStart hook in `~/.claude/settings.json`, and it computes the age with
+`date -r "$F"` — the file's MTIME.
+
+That exact defect was already found and already fixed once. Commit `2d26dea7d`
+(2026-06-11, PR #1269, audit finding F04) says so verbatim:
+
+    the SessionStart staleness hook measured the wrong thing — it computed file
+    age from `date -r` (mtime), which any unrelated edit reset, so it would never
+    fire the >30d warning the contract itself promises.
+    ...
+    ~/.claude/settings.json (out-of-repo, local-only): hook now extracts the
+    declared YYYY-MM-DD from the "active since" line and computes the real age
+    from it. Verified: reports "declared age 51d STALE" against the old date
+
+Measured on Pro 2026-08-31, eighty-one days later: that hook computes from mtime
+again. The cure was real, it was verified, and it was LOST — because it lived in
+a file that no repository tracks, no CI reads, and no review protects. Scar
+family #1 (HOME-fork drift), in its purest form: not "the repo fix never reached
+the live copy", but "the fix only ever existed in the live copy".
+
+Measured the same day on all three machines: Pro has the hook and it is wrong;
+Mini and M5 do not have it at all. So the mechanism that announces the contract's
+own expiry works on zero of three machines.
+
+Re-doing that fix in the same non-durable place would be the third attempt at the
+same repair in the same losable location. This script is the durable half: it
+lives in the repo, it is version-controlled, it is covered by tests, and it reads
+the same bytes on every machine. Whoever repairs the hook should make the hook
+call THIS, rather than re-implement the date arithmetic a third time.
+
+TWO TRAPS A NAIVE FIX FALLS INTO
+=================================
+1. The hook's own grep is `^\\*\\*Level [12] — active since`, which matches ONLY
+   the first line of the block. The latest re-certification does not live there —
+   it lives in a `(re-certified YYYY-MM-DD ...)` parenthetical below it. A fix
+   that "parses the declared date" but keeps that grep reads 2026-06-11 (81 days)
+   instead of 2026-07-19 (43 days): still wrong, just wrong differently. This
+   script therefore takes the MAXIMUM of every declared date in the block.
+2. The file carries 24 ISO dates in total — changelog entries, audit stamps,
+   unrelated corrections. Only the ones inside the `## Active level` section, on
+   a line that actually declares activation or re-certification, may count.
+
+EXIT CODES
+==========
+0 by default, ALWAYS — this reports, it does not block. Zero's standing constraint
+on the merge queue ("non voglio regressioni") means a lapsed contract must not
+turn every open PR red; a lapse is a message for the owner, not a gate. Pass
+`--strict` to exit 1 on a lapse, for a caller that has decided it wants that.
+2 is reserved for the script failing to answer at all (file missing, no declared
+date found) — an unanswerable probe must never read as "fresh".
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_CONTRACT = REPO_ROOT / "AUTONOMOUS_OPS.md"
+
+# The contract's own rule, quoted from AUTONOMOUS_OPS.md:
+#   "If today's date is >30 days after 'active since' without a refresh commit,
+#    Claude falls back to conservative mode and pings the user to re-certify."
+STALE_AFTER_DAYS = 30
+
+SECTION_HEADING = re.compile(r"^##\s+Active level\s*$", re.IGNORECASE)
+SECTION_END = re.compile(r"^(---\s*$|##\s+)")
+ISO_DATE = re.compile(r"(20\d{2})-(\d{2})-(\d{2})")
+# A date only counts when its own line declares activation or re-certification.
+DECLARING_LINE = re.compile(r"active since|re-certified", re.IGNORECASE)
+
+
+class ContractUnreadable(Exception):
+    """The probe could not answer. Never silently degrades to 'fresh'."""
+
+
+def active_level_block(text: str) -> list[str]:
+    """Return the lines of the '## Active level' section, heading excluded.
+
+    Bounded deliberately: the file carries two dozen ISO dates elsewhere
+    (changelog, audit stamps), and none of them govern the contract.
+    """
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if SECTION_HEADING.match(line):
+            start = i + 1
+            break
+    if start is None:
+        raise ContractUnreadable("no '## Active level' section in the contract")
+
+    block: list[str] = []
+    for line in lines[start:]:
+        if SECTION_END.match(line) and block:
+            break
+        block.append(line)
+    return block
+
+
+def declared_dates(text: str) -> list[datetime.date]:
+    """Every activation/re-certification date declared in the Active level block.
+
+    Order is irrelevant on purpose — the caller takes the max. The first match is
+    NOT the governing one (see trap 1 in the module docstring).
+    """
+    found: list[datetime.date] = []
+    for line in active_level_block(text):
+        if not DECLARING_LINE.search(line):
+            continue
+        for match in ISO_DATE.finditer(line):
+            year, month, day = (int(part) for part in match.groups())
+            try:
+                found.append(datetime.date(year, month, day))
+            except ValueError:
+                # A malformed stamp is not a date; skip it rather than crash,
+                # but never let it become the governing one.
+                continue
+    return found
+
+
+def evaluate(text: str, today: datetime.date) -> tuple[datetime.date, int, bool]:
+    """Return (governing date, age in days, is_stale)."""
+    dates = declared_dates(text)
+    if not dates:
+        raise ContractUnreadable(
+            "no 'active since' / 're-certified' date found in the Active level block"
+        )
+    governing = max(dates)
+    age = (today - governing).days
+    return governing, age, age > STALE_AFTER_DAYS
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--contract",
+        type=pathlib.Path,
+        default=DEFAULT_CONTRACT,
+        help="path to AUTONOMOUS_OPS.md (default: repo root)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when the contract has lapsed (default: report only, exit 0)",
+    )
+    parser.add_argument(
+        "--today",
+        help="ISO date to evaluate against, for tests (default: today, UTC)",
+    )
+    args = parser.parse_args(argv)
+
+    today = (
+        datetime.date.fromisoformat(args.today)
+        if args.today
+        else datetime.datetime.now(datetime.timezone.utc).date()
+    )
+
+    try:
+        text = args.contract.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"UNREADABLE: {args.contract}: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        governing, age, stale = evaluate(text, today)
+    except ContractUnreadable as exc:
+        print(f"UNREADABLE: {exc}", file=sys.stderr)
+        return 2
+
+    all_dates = ", ".join(d.isoformat() for d in sorted(set(declared_dates(text))))
+    if stale:
+        print(
+            f"LAPSED: Autonomous Ops contract certified {governing.isoformat()} "
+            f"is {age} days old (limit {STALE_AFTER_DAYS}). "
+            f"Fall back to conservative mode and ask the owner to re-certify."
+        )
+    else:
+        print(
+            f"CURRENT: Autonomous Ops contract certified {governing.isoformat()}, "
+            f"{age} days old (limit {STALE_AFTER_DAYS})."
+        )
+    print(f"  declared dates in the Active level block: {all_dates}")
+    print("  measured from the DECLARED date, never the file mtime — see module docstring")
+
+    return 1 if (stale and args.strict) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_autonomous_ops_staleness.py
+++ b/scripts/tests/test_autonomous_ops_staleness.py
@@ -1,0 +1,162 @@
+"""Guilt and innocence for the Autonomous-Ops staleness probe.
+
+The defect this probe replaces was not "no check existed" — a check existed and
+reported CURRENT for a contract 43 days past its own limit, because it measured
+the file's mtime. So the tests that matter here are the ones that would have gone
+RED against that behaviour, and against the naive re-implementation of it:
+
+  * test_lapsed_contract_is_reported            — guilt: an old contract says LAPSED
+  * test_mtime_cannot_rescue_a_lapsed_contract  — guilt: touching the file changes nothing
+  * test_latest_recertification_wins            — the trap: the FIRST date is not the governing one
+  * test_dates_outside_the_active_block_are_ignored — the other trap: 24 other dates in the file
+  * test_no_declared_date_is_unreadable_not_fresh   — an unanswerable probe must not read as healthy
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+MODULE_PATH = REPO_ROOT / "scripts" / "check_autonomous_ops_staleness.py"
+
+_spec = importlib.util.spec_from_file_location("check_autonomous_ops_staleness", MODULE_PATH)
+assert _spec and _spec.loader
+staleness = importlib.util.module_from_spec(_spec)
+sys.modules["check_autonomous_ops_staleness"] = staleness
+_spec.loader.exec_module(staleness)
+
+
+def contract(body: str) -> str:
+    """A minimal contract file with the same shape as the real one."""
+    return (
+        "# AUTONOMOUS OPS CONTRACT\n\n"
+        "> preamble that also mentions 2019-01-01 for good measure\n\n"
+        "---\n\n"
+        "## Active level\n\n"
+        f"{body}\n\n"
+        "---\n\n"
+        "## Level 1 — something else\n\n"
+        "changelog stamp 2026-12-31 that must never govern anything\n"
+    )
+
+
+TODAY = datetime.date(2026, 8, 31)
+
+
+def test_lapsed_contract_is_reported() -> None:
+    """GUILT. 43 days against a 30-day limit is a lapse, and must be named one."""
+    text = contract("**Level 2 — active since 2026-07-19**")
+    governing, age, stale = staleness.evaluate(text, TODAY)
+    assert governing == datetime.date(2026, 7, 19)
+    assert age == 43
+    assert stale is True
+
+
+def test_fresh_contract_is_not_reported() -> None:
+    """INNOCENCE. A contract inside its window must not cry wolf."""
+    text = contract("**Level 2 — active since 2026-08-20**")
+    governing, age, stale = staleness.evaluate(text, TODAY)
+    assert governing == datetime.date(2026, 8, 20)
+    assert age == 11
+    assert stale is False
+
+
+def test_boundary_is_strictly_greater_than_thirty() -> None:
+    """The contract says '>30 days', so exactly 30 is still current."""
+    at_30 = TODAY - datetime.timedelta(days=30)
+    at_31 = TODAY - datetime.timedelta(days=31)
+    assert staleness.evaluate(contract(f"active since {at_30.isoformat()}"), TODAY)[2] is False
+    assert staleness.evaluate(contract(f"active since {at_31.isoformat()}"), TODAY)[2] is True
+
+
+def test_mtime_cannot_rescue_a_lapsed_contract(tmp_path: pathlib.Path) -> None:
+    """GUILT, against the exact defect being replaced.
+
+    The old hook read the file's mtime, so a freshly written file always looked
+    0 days old. Here the file is written milliseconds before the probe runs — the
+    most favourable possible mtime — and the verdict must still be LAPSED.
+    """
+    path = tmp_path / "AUTONOMOUS_OPS.md"
+    path.write_text(contract("**Level 2 — active since 2026-07-19**"), encoding="utf-8")
+    age_by_mtime = (datetime.datetime.now().timestamp() - path.stat().st_mtime) / 86400
+    assert age_by_mtime < 1, "precondition: the file is freshly written"
+
+    rc = staleness.main(["--contract", str(path), "--today", TODAY.isoformat()])
+    assert rc == 0, "default mode reports, it does not block"
+    rc_strict = staleness.main(
+        ["--contract", str(path), "--today", TODAY.isoformat(), "--strict"]
+    )
+    assert rc_strict == 1, "--strict must fail on a lapse the mtime would have hidden"
+
+
+def test_latest_recertification_wins() -> None:
+    """THE TRAP. The first declared date is not the governing one.
+
+    The real file opens with 'active since 2026-06-11' and re-certifies to
+    2026-07-19 two lines below. A probe that greps the first line reads 81 days
+    where the truth is 43 — and, on a contract re-certified yesterday, would
+    report a lapse that does not exist.
+    """
+    yesterday = TODAY - datetime.timedelta(days=1)
+    text = contract(
+        "**Level 2 — active since 2026-01-01**\n"
+        "(Level 1 was active earlier same day.)\n"
+        f"(re-certified {yesterday.isoformat()} by the owner — routine refresh.)"
+    )
+    governing, age, stale = staleness.evaluate(text, TODAY)
+    assert governing == yesterday, "must take the maximum, not the first match"
+    assert age == 1
+    assert stale is False
+
+
+def test_dates_outside_the_active_block_are_ignored() -> None:
+    """THE OTHER TRAP. The real file carries two dozen unrelated ISO dates."""
+    text = contract("**Level 2 — active since 2026-07-19**")
+    assert datetime.date(2026, 12, 31) not in staleness.declared_dates(text)
+    assert datetime.date(2019, 1, 1) not in staleness.declared_dates(text)
+    assert staleness.declared_dates(text) == [datetime.date(2026, 7, 19)]
+
+
+def test_a_date_on_a_non_declaring_line_does_not_count() -> None:
+    """A date inside the block still needs a line that declares something."""
+    text = contract(
+        "**Level 2 — active since 2026-07-19**\n"
+        "(an unrelated note mentioning 2026-08-30, which certifies nothing.)"
+    )
+    assert staleness.declared_dates(text) == [datetime.date(2026, 7, 19)]
+
+
+def test_no_declared_date_is_unreadable_not_fresh() -> None:
+    """An unanswerable probe must never read as healthy."""
+    with pytest.raises(staleness.ContractUnreadable):
+        staleness.evaluate(contract("**Level 2 — active**, no date at all"), TODAY)
+
+
+def test_missing_section_is_unreadable_not_fresh() -> None:
+    with pytest.raises(staleness.ContractUnreadable):
+        staleness.evaluate("# nothing here\n\nactive since 2026-07-19\n", TODAY)
+
+
+def test_missing_file_exits_two_not_zero(tmp_path: pathlib.Path) -> None:
+    rc = staleness.main(["--contract", str(tmp_path / "absent.md"), "--strict"])
+    assert rc == 2
+
+
+def test_reads_the_real_contract_and_finds_the_recertification() -> None:
+    """Against the file actually in this repo, not a fixture.
+
+    Pins the governing date to the re-certification rather than the opening
+    'active since' — the whole point of the max().
+    """
+    real = REPO_ROOT / "AUTONOMOUS_OPS.md"
+    assert real.exists()
+    dates = staleness.declared_dates(real.read_text(encoding="utf-8"))
+    assert dates, "the real contract must declare at least one date"
+    assert max(dates) >= datetime.date(2026, 7, 19)
+    assert datetime.date(2026, 6, 11) in dates, "the opening date is still parsed…"
+    assert max(dates) != datetime.date(2026, 6, 11), "…but it does not govern"


### PR DESCRIPTION
`AUTONOMOUS_OPS.md` promises that a contract older than 30 days drops the session into conservative mode. **Measured on Pro today: it does not, and it has not since June.**

## What is actually happening

The SessionStart hook in `~/.claude/settings.json` computes the age with `date -r "$F"` — the file's **mtime**. `AUTONOMOUS_OPS.md` was touched yesterday by #5341, a citation-integrity lint that has nothing to do with autonomy, so the hook prints `(file age 0d)` and takes its healthy branch. The declared certification date is **2026-07-19 — 43 days**, past the file's own limit.

Measured on all three machines the same day: **Pro** has the hook and it is wrong; **Mini** and **M5** have no such hook at all. The mechanism that announces this contract's expiry works on **zero of three machines**.

An adversarial pass on fresh context tried to falsify all of this and could not — and added something worse than I had: every agent session runs in a **worktree** by this repo's own mandate, and `git worktree add` stamps a fresh mtime on every file it checks out. So for the dominant case the false-healthy reading is not an accident of one recent PR — it is **structurally guaranteed, every time**.

## Why this is the second time, and why the fix goes in the repo

Commit `2d26dea7d` (2026-06-11, PR #1269, audit finding F04) found this exact defect and describes it verbatim:

> it computed file age from `date -r` (mtime), which any unrelated edit reset, so it would never fire the >30d warning the contract itself promises

It then fixed it and recorded the verification. Eighty-one days later the file computes from mtime again. **The cure was real, it was verified, and it was lost** — because, by its own commit message, it lived only in *"`~/.claude/settings.json` (out-of-repo, local-only)"*: a file no repository tracks, no CI reads and no review protects. Scar family #1 in its purest form — not "the repo fix never reached the live copy", but "the fix only ever existed in the live copy".

Re-applying it there would be the third attempt in the same losable place. So this PR puts the durable half where it survives.

## What ships

- **`scripts/check_autonomous_ops_staleness.py`** — reads the *declared* dates and reports the lapse. **Exit 0 always by default**: a lapsed contract must not turn every open PR red (Zero's standing constraint on the merge queue), so this reports rather than gates; `--strict` opts in. Exit 2 when it cannot answer, so an unreadable probe never reads as fresh.
- **11 tests**, built around the two traps a naive fix falls into:
  - the old hook's grep matches only the `**Level N — active since**` line, so "just parse the declared date" still reads **2026-06-11 (81d)** instead of the **2026-07-19** re-certification two lines below. The script takes the max.
  - the file carries **24 ISO dates**; only those inside `## Active level`, on a line that actually declares activation, may count.
- **Mutation-checked, not just green**: reverting to `dates[0]` reddens exactly one test — the one named for that trap. Reverting to an mtime-based age reddens five, including `test_mtime_cannot_rescue_a_lapsed_contract`, which writes the file milliseconds before asserting.
- **`AUTONOMOUS_OPS.md` lines 19-21** asserted the hook "was fixed to read this declared date". That is false about the hook that runs. A doctrine that lies is worse than one that is silent, because the next session builds on it — corrected in place with the measurement and the reason.

The hook itself lives under `~/.claude/` and is operator control-plane; **not touched here**. When it is repaired it should *call* this script rather than re-implement the arithmetic a third time.

## What this PR does not do

It does not re-certify the contract. That is the owner's call, and it is now 43 days overdue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
