### PR TITLE
chore(regulatory): three stranded watcher deltas, one carrying a real finding

### DIFF
--- a/research/regulatory/2026-08-28-delta.json
+++ b/research/regulatory/2026-08-28-delta.json
@@ -1,0 +1,81 @@
+{
+  "run_at": "2026-08-28T07:17:33+08:00",
+  "today": "2026-08-28",
+  "new_today_count": 1,
+  "partial": false,
+  "unreachable_sources": [],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "checked_no_new",
+      "note": "The in-window result concerned an RUU, not an enacted instrument in the permitted regulation types."
+    },
+    {
+      "url": "https://ortax.org/",
+      "reason": "checked_no_new",
+      "note": "No in-window permitted regulation type was found."
+    },
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window permitted regulation type was found."
+    },
+    {
+      "url": "https://muc.co.id/id/article",
+      "reason": "checked_no_new",
+      "note": "The latest located regulation updates predated the 48-hour window."
+    },
+    {
+      "url": "https://ikpi.or.id/berita/",
+      "reason": "checked_no_new",
+      "note": "The latest located regulation-related items predated the 48-hour window."
+    },
+    {
+      "url": "https://jdih.kemenkum.go.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window Permenkumham was found."
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window PMK was found."
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/",
+      "reason": "checked_no_new",
+      "note": "No additional qualifying instrument was found beyond the delta captured from this source."
+    },
+    {
+      "url": "https://peraturan.go.id/",
+      "reason": "checked_no_new",
+      "note": "No additional in-window permitted regulation type affecting the scoped service lines was found."
+    },
+    {
+      "url": "https://www.pajak.go.id/",
+      "reason": "checked_no_new",
+      "note": "The current regulation catalogue exposed no in-window PMK, PP, Perpres, or UU."
+    },
+    {
+      "url": "https://jdih.kemkes.go.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window Permenkes was found."
+    }
+  ],
+  "nb_query_errors": [
+    "Telegram sendMessage failed: curl could not resolve host api.telegram.org."
+  ],
+  "deltas": [
+    {
+      "citation": "Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+      "title_id": "Peraturan Menteri Ketenagakerjaan Nomor 12 Tahun 2026 tentang Perubahan Ketiga atas Peraturan Menteri Ketenagakerjaan Nomor 8 Tahun 2025 tentang Pedoman Pemberian Bantuan Pemerintah Program Pemagangan Lulusan Perguruan Tinggi",
+      "title_en": "Peraturan Menteri Ketenagakerjaan Nomor 12 Tahun 2026 tentang Perubahan Ketiga atas Peraturan Menteri Ketenagakerjaan Nomor 8 Tahun 2025 tentang Pedoman Pemberian Bantuan Pemerintah Program Pemagangan Lulusan Perguruan Tinggi",
+      "service_line": "regulatory/HR",
+      "summary": "Subjek | BANPEM - PEMAGANGAN; Bidang Hukum | Hukum Ketenagakerjaan; Status | Berlaku",
+      "source": "https://jdih.kemnaker.go.id/peraturan/detail/3084/peraturan-menteri-ketenagakerjaan-nomor-12-tahun-2026",
+      "verbatim_excerpt": "Tanggal Penetapan | 24 Agustus 2026\nTanggal Pengundangan | 27 Agustus 2026\nSumber | BN 2026 (598): 4 hlm\nSubjek | BANPEM - PEMAGANGAN\nBidang Hukum | Hukum Ketenagakerjaan\nStatus | Berlaku"
+    }
+  ],
+  "seen_citations": [
+    "Permenaker No. 12 Tahun 2026; BN 2026 (598)"
+  ]
+}

--- a/research/regulatory/2026-08-29-delta.json
+++ b/research/regulatory/2026-08-29-delta.json
@@ -1,0 +1,92 @@
+{
+  "run_at": "2026-08-29T07:14:50+08:00",
+  "today": "2026-08-29",
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "http_403",
+      "note": "WAF/Cloudflare block (HTTP 403), persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ikpi.or.id/berita/",
+      "reason": "http_404",
+      "note": "HTTP 404 Not Found, persisted after 1 retry"
+    }
+  ],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://ortax.org/",
+      "reason": "checked_no_new",
+      "note": "No in-window permitted regulation type (PMK, PP, Perpres, UU) found in news/updates."
+    },
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window permitted regulation type found; KMK 39/2026 (kurs) and PENG-4/PJ/2026 (pengumuman) fall outside scoped reg-types."
+    },
+    {
+      "url": "https://muc.co.id/id/article",
+      "reason": "checked_no_new",
+      "note": "Latest update discusses DJP Pengumuman No. PENG-4/PJ/2026 on CRS self-certification, which is outside the scoped regulation types."
+    },
+    {
+      "url": "https://jdih.kemenkum.go.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window Permenkumham found (latest listed entries are Permenkum No. 10/2026, 7/2026, 6/2026)."
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/",
+      "reason": "checked_no_new",
+      "note": "No new PMK found within the 48h window (latest listed are PMK 62/2026 and PMK 63/2026 from 21 August 2026)."
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/",
+      "reason": "checked_no_new",
+      "note": "No additional qualifying instrument found beyond Permenaker No. 12 Tahun 2026 already captured in previous run."
+    },
+    {
+      "url": "https://peraturan.go.id/",
+      "reason": "outside_window",
+      "note": "Latest national regulations listed (PP No. 30/2026, PP No. 31/2026, PP No. 27/2026) predate the 48-hour window."
+    },
+    {
+      "url": "https://www.pajak.go.id/",
+      "reason": "outside_window",
+      "note": "Latest regulatory entry in catalogue remains PER-8/PJ/2026 dated 2026-07-28; no in-window PMK, PP, Perpres, or UU found."
+    },
+    {
+      "url": "https://jdih.kemkes.go.id/",
+      "reason": "checked_no_new",
+      "note": "No in-window Permenkes found (latest listed is Permenkes No. 6 Tahun 2026)."
+    }
+  ],
+  "nb_query_errors": [],
+  "deltas": [],
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 44 Tahun 2026",
+    "PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026",
+    "Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026"
+  ]
+}

--- a/research/regulatory/2026-08-31-delta.json
+++ b/research/regulatory/2026-08-31-delta.json
@@ -1,0 +1,108 @@
+{
+  "run_at": "2026-08-31T07:11:35+08:00",
+  "today": "2026-08-31",
+  "yesterday_seen_count": 23,
+  "new_today_count": 0,
+  "partial": false,
+  "unreachable_sources": [
+    {
+      "url": "https://www.hukumonline.com/berita/",
+      "reason": "http_403",
+      "note": "WAF/Cloudflare challenge (HTTP 403), persisted after 1 retry with Mozilla UA"
+    },
+    {
+      "url": "https://ortax.org/news",
+      "reason": "empty_shell",
+      "note": "HTTP 200 but body is \"Artikel tidak ditemukan\" (soft-404 path); root https://ortax.org/ and /berita checked separately"
+    },
+    {
+      "url": "https://ikpi.or.id/berita/",
+      "reason": "http_404",
+      "note": "Cloudflare 404 confirmed via header check, persisted after 1 retry"
+    },
+    {
+      "url": "https://www.pajak.go.id/peraturan",
+      "reason": "empty_shell",
+      "note": "Search-form landing page, no dated peraturan list rendered in static HTML (requires dynamic JS/query submit)"
+    },
+    {
+      "url": "https://jdih.kemenkeu.go.id/peraturan",
+      "reason": "empty_shell",
+      "note": "Next.js client-side SPA shell with no pre-rendered regulation entries in static HTML"
+    }
+  ],
+  "sources_checked_no_delta": [
+    {
+      "url": "https://ortax.org/",
+      "reason": "outside_window",
+      "note": "Latest entries dated 28 Agustus 2026 (predates 48h window); no qualifying PMK/PP/Perpres/UU/BKPM regulations"
+    },
+    {
+      "url": "https://news.ddtc.co.id/",
+      "reason": "checked_no_new",
+      "note": "Only SE-6/PJ/2026 (Surat Edaran, out of scope reg-type) and general tax news; no new in-scope regulation types"
+    },
+    {
+      "url": "https://muc.co.id/id/article",
+      "reason": "outside_window",
+      "note": "Latest regulation article cites PMK 108/2025, predating the 48h window"
+    },
+    {
+      "url": "https://peraturan.go.id",
+      "reason": "outside_window",
+      "note": "Latest promulgated items dated 18 August 2026 or earlier, predating the 48h window"
+    },
+    {
+      "url": "https://jdih.kemenkum.go.id/",
+      "reason": "outside_window",
+      "note": "Latest indexed regulations predate the 48h freshness window; no new Permenkumham/Permenkum in window"
+    },
+    {
+      "url": "https://jdih.kemnaker.go.id/peraturan",
+      "reason": "checked_no_new",
+      "note": "Permenaker 12/2026 already captured in seen_citations; no new in-window Permenaker promulgated"
+    },
+    {
+      "url": "https://jdih.kemkes.go.id/",
+      "reason": "checked_no_new",
+      "note": "Only Kepmen/Kepdirjen dated 13 Aug 2026 or earlier; no promulgated Permenkes in 48h window"
+    },
+    {
+      "url": "https://www.imigrasi.go.id",
+      "reason": "checked_no_new",
+      "note": "Only enforcement/operational news; no new visa/immigration regulation citations"
+    },
+    {
+      "url": "https://jdih.bkpm.go.id/",
+      "reason": "outside_window",
+      "note": "Latest regulation is Peraturan Menteri Investasi/Kepala BKPM No. 6 Tahun 2026 (promulgated 2026-07-16), predating 48h window"
+    }
+  ],
+  "nb_query_errors": [],
+  "deltas": [],
+  "seen_citations": [
+    "PMK Nomor 28 Tahun 2026",
+    "PMK Nomor 40 Tahun 2026",
+    "PMK Nomor 41 Tahun 2026",
+    "PMK Nomor 42 Tahun 2026",
+    "PMK Nomor 43 Tahun 2026",
+    "PMK Nomor 44 Tahun 2026",
+    "PMK Nomor 57 Tahun 2026",
+    "PMK Nomor 61 Tahun 2026",
+    "PP Nomor 20 Tahun 2026",
+    "PP Nomor 24 Tahun 2026",
+    "Peraturan Direktur Jenderal Pajak Nomor PER-8/PJ/2026",
+    "Peraturan Menteri Hukum Nomor 13 Tahun 2026",
+    "Permen PMK/Badan PMI Nomor 5 Tahun 2026",
+    "Permenaker No. 12 Tahun 2026; BN 2026 (598)",
+    "Permenaker Nomor 7 Tahun 2026",
+    "Permenaker Nomor 8 Tahun 2026",
+    "Permenaker Nomor 9 Tahun 2026",
+    "Permenkes Nomor 6 Tahun 2026",
+    "Perpres Nomor 26 Tahun 2026",
+    "Perpres Nomor 27 Tahun 2026",
+    "Perpres Nomor 3 Tahun 2026",
+    "UU Nomor 4 Tahun 2026",
+    "UU Nomor 5 Tahun 2026"
+  ]
+}


### PR DESCRIPTION
The regulatory watcher runs daily and writes `research/regulatory/<date>-delta.json`. **Three of its outputs never reached main**: 2026-08-28, 2026-08-29 and 2026-08-31. 2026-08-30 did — so the cron is alive; its results simply arrive on main by luck.

## The 08-28 file is not empty

It carries one real finding, sitting outside the repository for three days:

> **Permenaker No. 12 Tahun 2026** (BN 2026/598) — the third amendment to Permenaker 8/2025 on internship (*pemagangan*) guidelines. Status *Berlaku*. `service_line: regulatory/HR`, with source URL and verbatim excerpt.

That is precisely the class of thing this watcher exists to catch.

The 08-29 and 08-31 files carry zero deltas, which is not nothing either: they are the **evidence that the check ran** and found no change on those days. Without them the record reads as though the watcher had been silent, which is a different and worse claim.

## It is not a one-off, and this PR does not fix that

An independent read-only sweep this session checked three historical siblings of tonight's watcher branch — `agent/nuzantara/intel/regwatch-*` for 2026-08-26, -28 and -29 — and **none of them has ever had a PR**. The lane pushes a branch and stops; whether the delta reaches main afterwards depends on something else picking it up, and on three days out of the last four it did not.

This PR lands the three stranded files. It does **not** arm the lane. That gap deserves its own ledger row and its own fix, and conflating the two would let the lane read as repaired when only its backlog was cleared.

## Provenance and safety

Files copied byte-identical from the main checkout (`cmp` clean on all three). No PII — these are public Indonesian regulations; scanned for client email domains, Indonesian phone numbers and passport/KTP/NPWP patterns with **zero hits**, and a positive control confirmed the scanner fires on a planted address rather than being silently broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
