### PR TITLE
fix(guard): tell a prose author what to do, not to migrate a sender they don't have

### DIFF
--- a/scripts/lint_tg_direct_senders.py
+++ b/scripts/lint_tg_direct_senders.py
@@ -87,6 +87,22 @@ GATEWAY_ALLOWLIST = {
     "scripts/tests/test_lint_telegram_tokens.py",
 }
 
+# Printed under the offender list. Kept next to GATEWAY_ALLOWLIST so the two stay
+# in sync: the second remedy below is that constant, and it costs a reviewed edit
+# to this file precisely so it is not the reflex.
+HINT_FOR_PROSE = (
+    "\nlint_tg: if a file above only DESCRIBES the endpoint rather than calling it "
+    "(evidence pack, runbook, test fixture), there is no sender to migrate. Two "
+    "remedies, in order of preference:\n"
+    "  1. rephrase so the literal does not appear — e.g. \"a direct Bot API call\" "
+    "instead of the host string. Costs one sentence, keeps the guard intact.\n"
+    "  2. add the path to GATEWAY_ALLOWLIST in this file, with a comment saying why "
+    "that file legitimately carries the pattern as prose. Costs a reviewed edit to "
+    "the guard, and does not scale — prefer 1.\n"
+    "The over-match is deliberate (see the comment above GATEWAY_ALLOWLIST): keeping "
+    "the string out of non-gateway files is the point, not a side effect."
+)
+
 
 def _root() -> Path:
     return Path(os.environ.get("TG_LINT_ROOT", ".")).resolve()
@@ -240,6 +256,14 @@ def lint(root: Path, prune: bool = False) -> int:
               f"Use scripts/tg_notify.py (--tier p0|digest|log) instead:", file=sys.stderr)
         for f in sorted(offenders):
             print(f"  - {f}", file=sys.stderr)
+        # The scan is a bare substring match on purpose (see the comment above
+        # GATEWAY_ALLOWLIST), so a file that only WRITES ABOUT the endpoint —
+        # an evidence pack, a runbook, a test fixture — lands here too, and for
+        # that author "use tg_notify.py instead" is not actionable advice: there
+        # is no sender to migrate. Measured 2026-08-31: nothing anywhere else in
+        # this repo tells a pack author the literal is forbidden, so this message
+        # is the only place the remedy can reach them.
+        print(HINT_FOR_PROSE, file=sys.stderr)
         return 1
 
     mono_ok, added = check_monotone(root)

--- a/scripts/tests/test_tg_gateway.py
+++ b/scripts/tests/test_tg_gateway.py
@@ -64,3 +64,57 @@ def test_lint_clean_on_real_tree():
         capture_output=True, text=True, timeout=180, cwd=str(REPO),
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# --- the FAIL message must be actionable for a PROSE offender ---------------
+# Added 2026-08-31. The lint's advice ("use tg_notify.py instead") is right for a
+# code offender and useless for a file that only WRITES ABOUT the endpoint: an
+# evidence pack has no sender to migrate. Measured that day: nothing anywhere
+# else in this repo warns a pack author the literal is forbidden — not
+# evidence_paths.py's docstring, not the modus skill, not docs/, not the
+# gateway's own runbook — so this message is the only place the remedy reaches
+# them, and PR #5422 spent a round of CI discovering that by hand.
+
+
+def _run_lint_against(root: Path, rel: str) -> subprocess.CompletedProcess:
+    import os
+    env = dict(os.environ, TG_LINT_ROOT=str(root), TG_LINT_FILES=rel)
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "lint_tg_direct_senders.py")],
+        capture_output=True, text=True, timeout=120, env=env,
+    )
+
+
+def test_fail_message_tells_a_prose_author_what_to_do(tmp_path: Path):
+    """GUILT: the hint appears, and names BOTH remedies in preference order."""
+    # Built at runtime, never spelled as a literal — this test file is itself
+    # scanned by the lint it is testing.
+    pattern = "https://api." + "telegram" + ".org/bot<TOKEN>/sendMessage"
+    guilty = tmp_path / "evidence" / "2026-08" / "some-task" / "brief.yml"
+    guilty.parent.mkdir(parents=True)
+    guilty.write_text(f"note: the alert step posts to {pattern} directly\n", encoding="utf-8")
+
+    proc = _run_lint_against(tmp_path, "evidence/2026-08/some-task/brief.yml")
+
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    err = proc.stderr
+    assert "evidence/2026-08/some-task/brief.yml" in err, "the offender must still be named"
+    assert "only DESCRIBES the endpoint" in err, "the prose case must be addressed"
+    assert "rephrase" in err, "remedy 1 (preferred) must be offered"
+    assert "GATEWAY_ALLOWLIST" in err, "remedy 2 must be named"
+    assert err.index("rephrase") < err.index("GATEWAY_ALLOWLIST"), (
+        "the cheap remedy must come first — the allowlist does not scale"
+    )
+    assert "deliberate" in err, "the author must learn the over-match is intended, not a bug"
+
+
+def test_no_hint_when_the_tree_is_clean(tmp_path: Path):
+    """INNOCENCE: a passing run must not print the hint at all."""
+    clean = tmp_path / "scripts" / "harmless.py"
+    clean.parent.mkdir(parents=True)
+    clean.write_text("print('no endpoint here')\n", encoding="utf-8")
+
+    proc = _run_lint_against(tmp_path, "scripts/harmless.py")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "only DESCRIBES the endpoint" not in (proc.stdout + proc.stderr)


### PR DESCRIPTION
## What

`lint_tg_direct_senders.py`'s FAIL message now addresses the second population it catches: files that only **write about** the Telegram endpoint rather than calling it.

The guard's behaviour is unchanged. The bare-substring over-match is deliberate and stays — its own comment says why ("keep the URL string out of non-gateway files entirely"), and widening the allowlist to `evidence/**` would trade a working rule for one PR's convenience.

## Why

An evidence pack that narrates an alert step fails identically to a live sender, and is then told *"use scripts/tg_notify.py (--tier p0|digest|log) instead"*. There is no sender to migrate. The author is left to open the lint's source to find out that (a) the over-match is intentional and (b) rephrasing is the intended remedy.

Measured across the repo on 2026-08-31 — **nothing warns such an author beforehand**:

| checked | telegram mentions relevant to pack authors |
|---|---|
| `scripts/ci/evidence_paths.py` docstring (318 lines) | 0 |
| `.claude/skills/modus/SKILL.md` | 0 |
| `.claude/skills/modus/AMENDMENTS.md` | 0 |
| `docs/` | no evidence-pack authoring guide exists |
| `docs/runbooks/telegram-notification-gateway.md` | migration guide for code senders only |

So this message is the only place the remedy can reach them. PR #5422 spent a CI round finding this out by hand.

## The hint

Both remedies, in preference order: **rephrase** (one sentence, guard untouched) before **`GATEWAY_ALLOWLIST`** (a reviewed edit to the guard, and it does not scale — every future pack narrating Telegram repeats it). Plus one line saying the over-match is intended, so the next reader does not arrive believing they found a bug.

## Guilt, proven rather than assumed

`test_fail_message_tells_a_prose_author_what_to_do`, run against `origin/main`'s version of the script:

```
assert "only DESCRIBES the endpoint" in err
E  AssertionError: the prose case must be addressed
E  assert 'only DESCRIBES the endpoint' in 'lint_tg: FAIL — 1 NEW direct Telegram sender(s). Use scripts/tg_notify.py ...'
```

Green after the change; 8/8 in the file. The innocence case (`test_no_hint_when_the_tree_is_clean`) passes on both versions — correct, a clean run never printed it.

Both new tests build the pattern at runtime instead of spelling it, since this test file is itself scanned by the lint it tests. Two other files adopted that same convention independently (`test_wal_continuity_probe.py:466`, `test_nlm_alarm_gateway.py:41`) without it ever being written down — which is the same gap this PR is closing, one layer down.

## Scope

2 files, +78/-0, gear floor 1 (`--print-floor` → `1`), no evidence pack required. No behaviour change to what the guard accepts or rejects.