### PR TITLE
fix(ops): let the P0 spool probe measure the machine it is standing on

### DIFF
--- a/scripts/queue_doctor.py
+++ b/scripts/queue_doctor.py
@@ -30,16 +30,21 @@ The verdict text, not the exit code, is the product.
 Env overrides (test seams + fleet variance):
   QUEUE_DOCTOR_REPO   default "Bali-Zero/Teman2"
   QUEUE_DOCTOR_LOCK   default "/tmp/nuzantara-prepush-backend-suite.lock"
-  QUEUE_DOCTOR_SSH    default "pro" (ssh alias for the spool host; "" = skip)
+  QUEUE_DOCTOR_SSH    default "pro" (ssh alias for the spool host; "" = skip).
+                      If the alias resolves back to THIS machine, the probe runs
+                      locally instead — see _spool_is_this_machine().
   QUEUE_DOCTOR_SPOOL  default "~/.organism/tg_spool" (path on the spool host)
 """
 
 from __future__ import annotations
 
 import datetime as _dt
+import getpass
 import json
 import math
 import os
+import re
+import socket
 import subprocess
 import sys
 import time
@@ -152,6 +157,72 @@ def probe_prepush_lock() -> None:
         print("  note: stale holder is self-healing by design; do NOT rm the lockdir by hand")
 
 
+_INET_RE = re.compile(r"\binet\s+([0-9]+(?:\.[0-9]+){3})")
+
+
+def _local_addresses() -> set[str]:
+    """Every name and IPv4 address this machine answers to, lowercased.
+
+    Only ever used to decide whether an ssh alias points back at us. An empty
+    or partial result is SAFE by construction: the caller treats "not proven
+    local" as remote, so a missing ifconfig/ip degrades to the ssh path — never
+    to a local read attributed to another host.
+    """
+    names: set[str] = set()
+    try:
+        host = socket.gethostname()
+        names.add(host.lower())
+        names.add(host.split(".")[0].lower())
+    except OSError:
+        pass
+    for cmd in (["ifconfig"], ["ip", "-4", "-o", "addr"]):
+        rc, out, _ = _run(cmd, timeout=8)
+        if rc == 0 and out:
+            names.update(_INET_RE.findall(out))
+            break
+    return names
+
+
+def _resolve_ssh_alias(alias: str) -> tuple[str, str]:
+    """(hostname, user) exactly as ssh itself resolves `alias`, or ("", "").
+
+    `ssh -G` is the only honest way to turn an alias into an address: it applies
+    the same config, Match blocks and defaults the real connection would.
+    """
+    rc, out, _ = _run(["ssh", "-G", alias], timeout=8)
+    if rc != 0:
+        return "", ""
+    host = user = ""
+    for line in out.splitlines():
+        key, _, value = line.partition(" ")
+        if key == "hostname" and not host:
+            host = value.strip()
+        elif key == "user" and not user:
+            user = value.strip()
+    return host, user
+
+
+def _spool_is_this_machine(alias: str) -> tuple[bool, str]:
+    """Is the spool host US? Returns (verdict, the reason to print).
+
+    The tempting shortcut — "the spool directory exists locally, so read it" —
+    is WRONG and would be a worse defect than the one this replaces: every
+    organism machine has a ~/.organism/tg_spool, so on Mini that shortcut would
+    measure MINI's spool while the report still claimed the alias's host. The
+    discriminator therefore compares resolved ADDRESSES, and abstains (=> ssh)
+    whenever identity cannot be established.
+    """
+    host, user = _resolve_ssh_alias(alias)
+    if not host:
+        return False, f"ssh -G {alias} resolved no hostname"
+    if host.lower() not in _local_addresses():
+        return False, f"{alias} resolves to {host}, not an address of this machine"
+    me = getpass.getuser()
+    if user and user != me:
+        return False, f"{alias} resolves here but as user {user!r}, not {me!r}"
+    return True, f"{alias} resolves to {host}, an address of this machine"
+
+
 def probe_p0_spool() -> None:
     print(f"== 3. P0 SPOOL ({SSH_HOST}:{SPOOL}) ==")
     if not SSH_HOST:
@@ -160,13 +231,27 @@ def probe_p0_spool() -> None:
     today = _dt.date.today().isoformat()
     # Counts only: wc/grep -c on the spool host; no message body crosses the wire.
     # Test every source before reading it. A missing archive is not the same as
-    # an archive containing zero P0 events, and a missing pending file is not an
-    # empty queue.
+    # an archive containing zero P0 events.
+    #
+    # A missing pending.jsonl, however, IS a measurement, and a healthy one --
+    # corrected 2026-08-31 against the producer rather than against intuition.
+    # tg_digest_flush.py claims the spool by RENAMING pending.jsonl to
+    # .flushing-<pid>.jsonl (line 68), archives it, unlinks the claim, and only
+    # recreates pending.jsonl if the send FAILED (_restore, line 81). So on a
+    # machine whose digest is delivering, no pending.jsonl exists between
+    # flushes: absence means DRAINED, which is strictly stronger than "zero
+    # lines". Reading it as unmeasurable made the probe red in exactly the
+    # healthy case -- an alarm that is wrong when nothing is wrong teaches its
+    # reader to skip the line.
     script = (
         f'P={SPOOL}; '
+        # The spool DIRECTORY is what must exist to measure anything. Its absence
+        # is unmeasurable; the absence of a file inside it is a state.
+        'if [ ! -d "$P" ]; then printf "spool_dir MISSING\\n"; exit 0; fi; '
+        'printf "spool_dir OK\\n"; '
         'if [ -f "$P/pending.jsonl" ]; then '
         'printf "pending %s\\n" "$(wc -l < "$P/pending.jsonl")"; '
-        'else printf "pending MISSING\\n"; fi; '
+        'else printf "pending DRAINED\\n"; fi; '
         'if [ -f "$P/last_flush.json" ]; then '
         'printf "last_flush %s\\n" "$(cat "$P/last_flush.json")"; '
         'else printf "last_flush MISSING\\n"; fi; '
@@ -174,14 +259,30 @@ def probe_p0_spool() -> None:
         f'printf "p0_today %s\\n" "$(grep -c "{today}" "$P/archive-p0.jsonl" || true)"; '
         'else printf "p0_today MISSING\\n"; fi'
     )
-    rc, out, err = _run(["ssh", "-o", "ConnectTimeout=8", SSH_HOST, script], timeout=25)
+    # One measurement, two transports: the script above is the single source of
+    # truth for WHAT is counted; this only chooses HOW to reach it. Naming the
+    # transport in the output is part of the measurement -- a reader must never
+    # have to guess which machine a number came from.
+    is_local, why = _spool_is_this_machine(SSH_HOST)
+    if is_local:
+        argv, source = ["/bin/sh", "-c", script], f"local ({why})"
+    else:
+        argv, source = ["ssh", "-o", "ConnectTimeout=8", SSH_HOST, script], f"ssh {SSH_HOST} ({why})"
+    print(f"  source: {source}")
+    rc, out, err = _run(argv, timeout=25)
     if rc != 0:
-        _cannot_verify("P0 spool", f"ssh {SSH_HOST} failed rc={rc}: {err.strip()[:160]}")
+        _cannot_verify("P0 spool", f"{source} failed rc={rc}: {err.strip()[:160]}")
         return
     fields = dict(
         line.split(None, 1) for line in out.splitlines() if " " in line
     )
+    if fields.get("spool_dir", "MISSING").strip() != "OK":
+        _cannot_verify("P0 spool", f"spool directory {SPOOL} does not exist on the measured host")
+        return
     pending = fields.get("pending", "MISSING").strip()
+    pending_drained = pending == "DRAINED"
+    if pending_drained:
+        pending = "0"
     p0_today = fields.get("p0_today", "MISSING").strip()
     last_flush_raw = fields.get("last_flush", "MISSING").strip()
     if not pending.isdigit() or not p0_today.isdigit() or last_flush_raw == "MISSING":
@@ -205,7 +306,11 @@ def probe_p0_spool() -> None:
         _cannot_verify("P0 spool", f"invalid last_flush metadata: {type(exc).__name__}")
         return
     age_min = max(0.0, (time.time() - last_flush_ts) / 60)
-    print(f"  pending (waiting for digest flush): {pending}")
+    if pending_drained:
+        print("  pending (waiting for digest flush): 0 — DRAINED (no pending.jsonl; the")
+        print("    flusher renames it away on success and recreates it only if a send fails)")
+    else:
+        print(f"  pending (waiting for digest flush): {pending}")
     print(f"  last flush age: {age_min:.0f} min")
     print(f"  P0 archived today: {p0_today}")
     if int(pending) > 50:

--- a/scripts/tests/test_queue_doctor.py
+++ b/scripts/tests/test_queue_doctor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 import stat
 import subprocess
 import sys
@@ -30,7 +31,9 @@ def _write_exe(path: Path, body: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _run_doctor(tmp: Path, *, gh_body: str, ssh_body: str, lock: Path) -> subprocess.CompletedProcess[str]:
+def _run_doctor(
+    tmp: Path, *, gh_body: str, ssh_body: str, lock: Path, spool: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     bin_dir = tmp / "bin"
     bin_dir.mkdir(exist_ok=True)
     _write_exe(bin_dir / "gh", gh_body)
@@ -43,6 +46,8 @@ def _run_doctor(tmp: Path, *, gh_body: str, ssh_body: str, lock: Path) -> subpro
         "QUEUE_DOCTOR_SSH": "fakehost",
         "QUEUE_DOCTOR_REPO": "Fake-Org/fake-repo",
     }
+    if spool is not None:
+        env["QUEUE_DOCTOR_SPOOL"] = str(spool)
     return subprocess.run(
         [sys.executable, str(DOCTOR)], capture_output=True, text=True, env=env, timeout=60
     )
@@ -76,6 +81,7 @@ _HEALTHY_GH = (
 )
 
 _HEALTHY_SSH = (
+    'printf "spool_dir OK\\n"\n'
     'printf "pending %s\\n" 4\n'
     'printf "last_flush %s\\n" \'{"ts": 1786000000}\'\n'
     'printf "p0_today %s\\n" 6\n'
@@ -109,6 +115,7 @@ def test_broken_sources_say_cannot_verify_never_zero(tmp_path: Path) -> None:
 def test_missing_spool_file_is_not_reported_as_an_empty_queue(tmp_path: Path) -> None:
     lock = tmp_path / "no-such-lock"
     missing_pending = (
+        'printf "spool_dir OK\\n"\n'
         'printf "pending MISSING\\n"\n'
         'printf "last_flush %s\\n" \'{"ts": 1786000000}\'\n'
         'printf "p0_today %s\\n" 0\n'
@@ -125,6 +132,7 @@ def test_missing_spool_file_is_not_reported_as_an_empty_queue(tmp_path: Path) ->
 def test_malformed_last_flush_metadata_is_cannot_verify(tmp_path: Path) -> None:
     lock = tmp_path / "no-such-lock"
     malformed_flush = (
+        'printf "spool_dir OK\\n"\n'
         'printf "pending %s\\n" 0\n'
         'printf "last_flush %s\\n" not-json\n'
         'printf "p0_today %s\\n" 0\n'
@@ -201,3 +209,147 @@ def test_lock_stat_failure_is_cannot_verify(tmp_path: Path) -> None:
     assert "CANNOT-VERIFY" in proc.stdout
     assert "could not stat lock directory" in proc.stdout
     assert "held for -1 min" not in proc.stdout
+
+
+# --- transport: which machine did the numbers come from? (2026-08-31) ---
+#
+# The spool host is named by an ssh ALIAS. When that alias points back at the
+# machine running the doctor, ssh is the wrong transport -- Pro cannot ssh to
+# itself, so the probe abstained on every run and the P0 spool went structurally
+# unmeasured on the one machine that owns it. The fix must not overreach the
+# other way: every organism machine HAS a ~/.organism/tg_spool, so "the path
+# exists locally" can never be the reason to read it locally.
+
+_GDASH = "-G"
+
+
+def _ssh_fake(*, resolves_to: str | None, user: str | None, remote_body: str) -> str:
+    """A fake ssh that answers `ssh -G <alias>` separately from a real call.
+
+    `resolves_to=None` => the alias cannot be resolved at all (ssh -G fails).
+    """
+    if resolves_to is None:
+        g = "exit 1\n"
+    else:
+        g = f'printf "hostname {resolves_to}\\n"; printf "user {user}\\n"; exit 0\n'
+    return (
+        f'if [ "$1" = "{_GDASH}" ]; then\n{g}fi\n'
+        + remote_body
+    )
+
+
+def _local_spool(tmp: Path, *, pending_lines: int, p0_today: int) -> Path:
+    spool = tmp / "spool"
+    spool.mkdir()
+    if pending_lines:
+        (spool / "pending.jsonl").write_text("{}\n" * pending_lines, encoding="utf-8")
+    (spool / "last_flush.json").write_text('{"ts": 1786000000}', encoding="utf-8")
+    today = __import__("datetime").date.today().isoformat()
+    (spool / "archive-p0.jsonl").write_text(f'{{"ts":"{today}"}}\n' * p0_today, encoding="utf-8")
+    return spool
+
+
+def test_alias_resolving_to_this_machine_is_read_locally_not_over_ssh(tmp_path: Path) -> None:
+    """Guilt for the original defect: if the doctor still reached for ssh here,
+    the fake's non-`-G` branch exits 9 and the probe would say CANNOT-VERIFY."""
+    spool = _local_spool(tmp_path, pending_lines=3, p0_today=2)
+    ssh = _ssh_fake(
+        resolves_to=socket.gethostname(),  # always in the local identity set
+        user=os.environ.get("USER") or "nobody",
+        remote_body="exit 9\n",  # any real ssh call is a failure of the fix
+    )
+    proc = _run_doctor(tmp_path, gh_body=_HEALTHY_GH, ssh_body=ssh,
+                       lock=tmp_path / "no-such-lock", spool=spool)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "source: local" in proc.stdout
+    assert "pending (waiting for digest flush): 3" in proc.stdout
+    assert "P0 archived today: 2" in proc.stdout
+    assert "CANNOT-VERIFY" not in proc.stdout
+
+
+def test_a_machine_that_merely_has_a_spool_dir_is_not_the_spool_host(tmp_path: Path) -> None:
+    """The overreach this fix must not commit: Mini also has a spool directory.
+    A local read there would report MINI's numbers under PRO's name."""
+    spool = _local_spool(tmp_path, pending_lines=99, p0_today=99)  # the wrong answer
+    ssh = _ssh_fake(
+        resolves_to="not-this-machine.invalid",  # RFC 2606: can never be local
+        user="someone",
+        remote_body=('printf "spool_dir OK\\n"\n'
+                     'printf "pending %s\\n" 4\n'
+                     'printf "last_flush %s\\n" \'{"ts": 1786000000}\'\n'
+                     'printf "p0_today %s\\n" 6\n'),
+    )
+    proc = _run_doctor(tmp_path, gh_body=_HEALTHY_GH, ssh_body=ssh,
+                       lock=tmp_path / "no-such-lock", spool=spool)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "source: ssh fakehost" in proc.stdout
+    assert "pending (waiting for digest flush): 4" in proc.stdout
+    for wrong in ("pending (waiting for digest flush): 99", "P0 archived today: 99"):
+        assert wrong not in proc.stdout, "the local spool was read for a REMOTE host"
+
+
+def test_an_unresolvable_alias_falls_back_to_ssh_never_to_a_local_guess(tmp_path: Path) -> None:
+    spool = _local_spool(tmp_path, pending_lines=99, p0_today=99)
+    ssh = _ssh_fake(
+        resolves_to=None,
+        user=None,
+        remote_body=('printf "spool_dir OK\\n"\n'
+                     'printf "pending %s\\n" 4\n'
+                     'printf "last_flush %s\\n" \'{"ts": 1786000000}\'\n'
+                     'printf "p0_today %s\\n" 6\n'),
+    )
+    proc = _run_doctor(tmp_path, gh_body=_HEALTHY_GH, ssh_body=ssh,
+                       lock=tmp_path / "no-such-lock", spool=spool)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "source: ssh fakehost" in proc.stdout
+    assert "resolved no hostname" in proc.stdout
+    for wrong in ("pending (waiting for digest flush): 99", "P0 archived today: 99"):
+        assert wrong not in proc.stdout, "an unresolvable alias fell through to a local read"
+
+
+def test_alias_resolving_here_but_as_another_user_stays_on_ssh(tmp_path: Path) -> None:
+    """Same host, different account = a different HOME = a different spool."""
+    spool = _local_spool(tmp_path, pending_lines=99, p0_today=99)
+    ssh = _ssh_fake(
+        resolves_to=socket.gethostname(),
+        user="somebody-else",
+        remote_body=('printf "spool_dir OK\\n"\n'
+                     'printf "pending %s\\n" 4\n'
+                     'printf "last_flush %s\\n" \'{"ts": 1786000000}\'\n'
+                     'printf "p0_today %s\\n" 6\n'),
+    )
+    proc = _run_doctor(tmp_path, gh_body=_HEALTHY_GH, ssh_body=ssh,
+                       lock=tmp_path / "no-such-lock", spool=spool)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "source: ssh fakehost" in proc.stdout
+    assert "as user 'somebody-else'" in proc.stdout
+
+
+# --- a drained spool is a measurement, not an abstention (2026-08-31) ---
+
+
+def test_absent_pending_file_reads_as_drained_not_as_unmeasurable(tmp_path: Path) -> None:
+    """tg_digest_flush.py RENAMES pending.jsonl away to claim it and recreates
+    it only when a send fails, so between flushes it is absent on a HEALTHY
+    machine. Reading that as CANNOT-VERIFY made the probe red exactly when
+    nothing was wrong."""
+    spool = _local_spool(tmp_path, pending_lines=0, p0_today=2)  # no pending.jsonl
+    ssh = _ssh_fake(resolves_to=socket.gethostname(),
+                    user=os.environ.get("USER") or "nobody", remote_body="exit 9\n")
+    proc = _run_doctor(tmp_path, gh_body=_HEALTHY_GH, ssh_body=ssh,
+                       lock=tmp_path / "no-such-lock", spool=spool)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "DRAINED" in proc.stdout
+    assert "CANNOT-VERIFY" not in proc.stdout
+
+
+def test_absent_spool_directory_is_still_unmeasurable(tmp_path: Path) -> None:
+    """The guard against over-correcting: a file missing INSIDE the spool is a
+    state; the spool itself missing is an unmeasured host."""
+    ssh = _ssh_fake(resolves_to=socket.gethostname(),
+                    user=os.environ.get("USER") or "nobody", remote_body="exit 9\n")
+    proc = _run_doctor(tmp_path, gh_body=_HEALTHY_GH, ssh_body=ssh,
+                       lock=tmp_path / "no-such-lock", spool=tmp_path / "no-spool-here")
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+    assert "CANNOT-VERIFY" in proc.stdout
+    assert "spool directory" in proc.stdout


### PR DESCRIPTION
## What was wrong

`scripts/queue_doctor.py`'s third probe reached its subject over `ssh $QUEUE_DOCTOR_SSH` unconditionally, and the default alias is `pro`. **Pro cannot ssh to itself** — measured from a Pro shell:

```
$ ssh -o BatchMode=yes pro 'echo OK'
nuzantara@100.107.22.111: Permission denied (publickey,password,keyboard-interactive)
$ ssh -o BatchMode=yes mini 'echo OK'
OK mini-pro2
```

So on the machine that owns the spool, the probe printed `CANNOT-VERIFY` and the run ended `verdict: INCOMPLETE (exit 4)` — every time. `scripts/mq.sh handoff` calls it, so that has been the outcome of every handoff. The probe abstained honestly, which is why this was never an incident; it simply never measured.

## Two causes, one symptom

Fixing only the transport would have left the probe just as silent, so the PR would have claimed a cure it did not deliver. Both are here.

**1 — Transport.** `ssh -G <alias>` resolves an alias the way the real connection would. If the resolved address is one this machine answers to *and* the resolved user is us, the same probe script runs locally.

The shortcut this deliberately refuses: *"the spool path exists locally, so read it."* Every organism machine has a `~/.organism/tg_spool`, so on Mini that shortcut would report **Mini's** numbers under **Pro's** name — a worse defect than the one being fixed. Identity is compared, never inferred; an unresolvable alias falls back to ssh rather than guessing; and the chosen transport is now printed, so no reader has to wonder which machine a number came from.

**2 — Semantics.** With the transport fixed the probe *still* abstained: there is no `pending.jsonl`. `scripts/tg_digest_flush.py` claims the spool by **renaming** that file to `.flushing-<pid>.jsonl` (line 68) and recreates it only when a send **fails** (`_restore`, line 81). Its absence is the healthy steady state — DRAINED, strictly stronger than "zero lines" — so reading it as unmeasurable made the probe red exactly when nothing was wrong. An alarm that is wrong in the healthy case teaches its reader to skip the line.

The spool **directory**'s absence stays unmeasurable, so the original principle ("a missing file is not an empty queue") survives where it is actually true.

## Proof

Live on Pro, the first `verdict: all three queues measured` this probe has produced:

```
== 3. P0 SPOOL (pro:~/.organism/tg_spool) ==
  source: local (pro resolves to 100.107.22.111, an address of this machine)
  pending (waiting for digest flush): 0 — DRAINED (no pending.jsonl; the
    flusher renames it away on success and recreates it only if a send fails)
  last flush age: 254 min
  P0 archived today: 2
verdict: all three queues measured
```

**Guilt**: the 6 new tests run against `origin/main`'s script — all 6 RED.
**Innocence**: 14/14 green on this branch.
**No silent change to the old tests**: the 8 pre-existing tests pass against *both* scripts, so updating the canned ssh fakes to the current wire shape did not alter what they assert.

The new tests cover the overreach explicitly: a machine that merely *has* a spool directory is not the spool host; an unresolvable alias never falls through to a local read; the same host under a different user stays on ssh.

## Not in scope

`archive-p0.jsonl` gets the same MISSING→CANNOT-VERIFY treatment as `pending.jsonl` did. On Pro it exists, so I have **no measurement** showing it red and did not touch it. If a machine that has never archived a P0 runs this probe, that is the next thing to look at.