### PR TITLE
fix(ci): name the correct stage when run-migrations is cancelled

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -660,10 +660,27 @@ jobs:
       - name: Determine failing stage
         id: stage
         run: |
+          # This job's `if:` (above) fires on BOTH `failure` and `cancelled` for each upstream
+          # job (widened 2026-08-31 so a timeout-minutes kill — which concludes `cancelled`, not
+          # `failure` — no longer goes silent). This step used to test only for the literal
+          # string "failure", so a cancelled run-migrations fell through to the `else` branch and
+          # was reported as "deploy crashed" -- wrong stage AND wrong narrative, since deploy
+          # never even started (needs: run-migrations, no override `if:`, so deploy.result is
+          # `skipped` whenever run-migrations didn't succeed). `deploy` and `run-migrations` can
+          # never both be in a bad state in the same run -- whichever branch below matches is the
+          # one that actually broke.
           if [ "${{ needs.run-migrations.result }}" = "failure" ]; then
             echo "stage=run-migrations" >> $GITHUB_OUTPUT
             echo "icon=🧬" >> $GITHUB_OUTPUT
             echo "detail=DB migration failed before deploy. No new release shipped; previous release still live." >> $GITHUB_OUTPUT
+          elif [ "${{ needs.run-migrations.result }}" = "cancelled" ]; then
+            echo "stage=run-migrations" >> $GITHUB_OUTPUT
+            echo "icon=🧬" >> $GITHUB_OUTPUT
+            echo "detail=DB migration job was cancelled (its own timeout, or the workflow run was cancelled) before deploy. No new release shipped; previous release still live." >> $GITHUB_OUTPUT
+          elif [ "${{ needs.deploy.result }}" = "cancelled" ]; then
+            echo "stage=deploy" >> $GITHUB_OUTPUT
+            echo "icon=🚨" >> $GITHUB_OUTPUT
+            echo "detail=flyctl deploy was cancelled (its own timeout, or the workflow run was cancelled) before the rolling swap reached health check. Previous release still live." >> $GITHUB_OUTPUT
           else
             echo "stage=deploy" >> $GITHUB_OUTPUT
             echo "icon=🚨" >> $GITHUB_OUTPUT

--- a/evidence/2026-08/agent-nuzantara-infra-alert-stage-f9200d8d/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-alert-stage-f9200d8d/brief.yml
@@ -1,0 +1,130 @@
+task_id: alert-stage-0831
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Fix a caveat a Gear-3 gate raised on PR #5422 ("ci(deploy): fall back off the depot builder, on
+  the one string that means depot", branch agent/nuzantara/infra/fly-depot-retry, ARMED/FROZEN,
+  not yet merged): "alert names wrong stage when run-migrations cancelled".
+
+  PR #5422 widens `deploy-failure-alert`'s job-level `if:` in
+  `.github/workflows/fly-deploy.yml` so it fires on `needs.<job>.result == 'cancelled'` as well as
+  `'failure'`, for both `run-migrations` and `deploy`. It does NOT touch the step that follows,
+  "Determine failing stage" (unchanged lines 660-671 on origin/main
+  80b460bc4d715f47fd30062f02dad8d5fa4b9585, which this branch is cut from) — that step still tests
+  only the literal string `"failure"`:
+
+    if [ "${{ needs.run-migrations.result }}" = "failure" ]; then
+      stage=run-migrations ...
+    else
+      stage=deploy ...
+    fi
+
+  CONFIRMED REAL (read, not assumed): with #5422's widened `if:` live, a `run-migrations` job that
+  is `cancelled` (its own 10-minute step timeout, or a whole-workflow cancellation while it runs)
+  now reaches this alert job — but the literal-string test above only matches `"failure"`, so
+  `"cancelled"` falls through to the `else` branch and the alert reports `stage=deploy`,
+  `"flyctl deploy crashed before the rolling swap reached health check"`. That is doubly wrong:
+  wrong STAGE (deploy never ran — `deploy`'s only gate is `needs: run-migrations` with no override
+  `if:`, verified on disk, so `deploy.result` is `skipped` whenever `run-migrations` did not
+  succeed) and wrong NARRATIVE ("crashed" for a cancellation/timeout). A human paged by this alert
+  would open flyctl deploy logs for a job that never ran, while the real evidence sits in the
+  run-migrations job they were never pointed at — "the wrong logs at the worst possible moment"
+  (dispatching team lead's framing). This is exactly the family-#3 UNDER-match shape in
+  `.claude/rules/cicatrix-superscar.md` (W82 sibling): a guard keyed on one literal string, blind
+  to a synonymous state the surrounding condition was just widened to admit.
+
+  Matches cicatrix family #9 (State-schema mutation drift) in shape too: PR #5422 changed what
+  STATES can reach this job (the job-level `if:`) without updating the downstream reader (the
+  step body) that interprets those states — a producer/consumer drift inside one file.
+
+  FIX (this PR, applied on a FRESH origin/main — #5422's branch is frozen, not touched): replace
+  the 2-branch if/else with a 4-branch if/elif/elif/else that tests both `"failure"` and
+  `"cancelled"` for `run-migrations`, then both for `deploy` (`deploy`'s `"failure"` case stays the
+  final `else`, unchanged text). Full truth table and reachability argument in pack.yml `diff:`
+  and receipts. Does not touch #5422's own diff (job-level `if:`, deploy timeout/retry logic) —
+  no line overlap, composes cleanly with #5422 landing either before or after this PR.
+
+  Gear is 3, DETERMINISTICALLY, by PATH: `.github/workflows/*` is a HOTZONE_PATTERNS entry in
+  `scripts/evidence_pack_lint.py`, reconfirmed by reading that module this session (not merely
+  cited) — `compute_floor()` returns 3 on any hot-zone path hit regardless of diff size. The actual
+  diff is small (1 file, +17/-0, all inside one step's `run:` block) — a Gear-1-shaped diff by the
+  SIZE term, but the ceiling check's own contract is explicit: "FLOOR ALWAYS WINS: if changed_paths
+  hits the hot-zone ... this function returns (3, []) immediately" (compute_ceiling docstring,
+  read this session) — so there is no ceiling conflict and no `gear_override` is needed.
+
+constraints:
+  - "Do not touch PR #5422's branch (agent/nuzantara/infra/fly-depot-retry) or its diff — it is
+    ARMED and FROZEN. This PR is cut from fresh origin/main and does not depend on #5422 having
+    merged first: its new `elif` branches are simply unreachable dead code on pre-#5422 main
+    (the job-level `if:` there still only admits `failure`), and become live automatically the
+    moment #5422 lands — no coordination step required."
+  - "Cure only what the caveat names: the stage-attribution logic in the 'Determine failing stage'
+    step. Do not touch #5422's own lines (job-level `if:`, deploy timeout/retry loop) — verified
+    no line-range overlap between the two diffs (Regola 8: cure what THIS diff introduces / what
+    the caveat named, do not re-litigate #5422's own content)."
+  - "Every new branch must name a REAL, reachable (upstream-result, deploy-result) state — no
+    branch may be dead code under the alert job's own `if:` gate. Verified via the full truth
+    table in pack.yml `diff:`."
+  - "Preserve the two pre-existing, verified-correct branches byte-for-byte in behavior: `deploy`
+    ended `failure` (with `run-migrations` `success`) keeps stage=deploy/icon=🚨/'crashed' text
+    unchanged; `run-migrations` ended `failure` keeps stage=run-migrations/icon=🧬/'failed' text
+    unchanged."
+
+acceptance:
+  - text: >
+      WHEN `run-migrations` concludes `failure`, the step SHALL set stage=run-migrations with the
+      unchanged "DB migration failed" detail (pre-existing behavior, must not regress).
+    probe: "needs.run-migrations.result == 'failure' -> stage=run-migrations"
+  - text: >
+      WHEN `run-migrations` concludes `cancelled`, the step SHALL set stage=run-migrations (NOT
+      deploy) with detail text that says "cancelled", not "crashed" or "failed". THIS IS THE BUG
+      BEING FIXED — before this PR, this case fell to the `else` branch and reported stage=deploy.
+    probe: "needs.run-migrations.result == 'cancelled' -> stage=run-migrations, detail mentions cancelled"
+  - text: >
+      WHILE `run-migrations` is `success` AND `deploy` concludes `cancelled`, the step SHALL set
+      stage=deploy with detail text that says "cancelled", not "crashed" (secondary imprecision
+      fixed alongside the primary bug — same root cause, same fix shape).
+    probe: "needs.deploy.result == 'cancelled' (run-migrations success) -> stage=deploy, detail mentions cancelled"
+  - text: >
+      WHILE `run-migrations` is `success` AND `deploy` concludes `failure`, the step SHALL set
+      stage=deploy with the unchanged "flyctl deploy crashed" detail (pre-existing behavior, must
+      not regress).
+    probe: "needs.deploy.result == 'failure' (run-migrations success) -> stage=deploy, unchanged crashed text"
+  - text: >
+      WHERE `actionlint -shellcheck=` (the exact invocation `.github/workflows/actionlint.yml`'s
+      REQUIRED gate runs) is applied to the fixed file, the finding count SHALL be 0, matching
+      origin/main exactly — this gate does not run shellcheck at all (schema + expression syntax
+      only), so it is unaffected by this diff either way.
+    probe: "actionlint -shellcheck= .github/workflows/fly-deploy.yml"
+
+consumer_map:
+  - "`.github/workflows/fly-deploy.yml`, job `deploy-failure-alert`, step 'Determine failing
+    stage' — the only step this diff touches. Its outputs (`stage`, `icon`, `detail`) feed
+    directly into the next step's Telegram message text; that next step (`Telegram alert (deploy
+    crash before health)`) is UNCHANGED by this diff."
+  - "The Telegram alert channel itself (Bot API call, secrets TELEGRAM_BOT_TOKEN /
+    TELEGRAM_OWNER_CHAT_ID) — unchanged mechanism, only the upstream text it relays is corrected."
+  - "PR #5422 (separate, frozen, not touched) — this PR's new branches are inert until #5422's
+    job-level `if:` widening lands; no shared state, no file-line overlap, composes cleanly
+    landing in either order (verified: #5422's diff ends at the `steps:` line, this diff starts
+    at the first step's `run:` body, several unchanged context lines apart)."
+  - "No PENDING-ARMS row needed — a merged GitHub Actions workflow file is armed by construction
+    (GitHub picks it up on the next matching push), same reasoning #5422's own pack recorded for
+    the same file."
+
+risks:
+  - "Residual, LOW severity: this brief and its review (see pack.yml dissent) could not find a
+    documented GitHub Actions mechanism that leaves `deploy.result == 'skipped'` while
+    `run-migrations.result == 'success'` (deploy's only gate is `needs: run-migrations`, no
+    override `if:`, verified on disk) — so that combination is treated as unreachable and gets no
+    dedicated branch. If it is somehow reachable after all, the WORST case is not a wrong-stage
+    alert: the job-level `if:` (from #5422) requires `run-migrations` OR `deploy` to be in
+    {failure, cancelled} to fire at all, so a `(success, skipped)` state simply does not trigger
+    the alert job — silence, not misattribution. This is the SAME failure mode that combination
+    already has today (pre-this-PR), so this diff introduces no regression on it either way."
+  - "This fix does not, and does not need to, distinguish WHY a job shows `cancelled` (its own
+    `timeout-minutes` kill vs. an external whole-workflow cancellation) — both branches' wording
+    ('its own timeout, or the workflow run was cancelled') covers either cause without asserting
+    which one happened, so this residual is deliberately absorbed by wording, not left as an
+    open question requiring a probe."

--- a/evidence/2026-08/agent-nuzantara-infra-alert-stage-f9200d8d/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-alert-stage-f9200d8d/pack.yml
@@ -1,0 +1,204 @@
+brief_ref: evidence/brief.yml
+plan_ref:
+  "Team-lead dispatch (teammate message, this session, 2026-08-31): cure the Gear-3 gate caveat on
+  PR #5422 ('alert names wrong stage when run-migrations cancelled') in its own PR, from fresh
+  origin/main, without touching #5422's frozen branch. No separate governing mandate doc — a
+  direct, narrowly-scoped infra fix dispatched ad hoc off that caveat."
+lanes:
+  - lane: alert-stage-build
+    role: build
+    seat: >
+      claude (this session, conducting agent — diagnosed the defect by reading PR 5422's diff plus
+      the unchanged step body on origin/main, wrote the truth table, wrote the 4-branch fix, wrote
+      this pack). Per current CLAUDE.md Gear-3 routing doctrine the model is Opus 5; not
+      independently introspectable from inside the session, stated as doctrine rather than a
+      verified runtime fact.
+  - lane: alert-stage-review-gemini
+    role: review
+    seat: >
+      gemini-3.1-pro (agy CLI v1.1.22, cross-family, read-only sandbox implied by prompt scope —
+      dispatched WITH the full truth table and 4 explicit adversarial probes, labeled a through d:
+      reachability of the success/skipped pair; simultaneous-bad-state branch ordering; bash/YAML
+      mechanics; GHA cancelled semantics. Verdict CONFIRMED, all 4 probes addressed individually —
+      see receipts and dissent (each probed concern recorded as a RETRACTED objection, not
+      silently dropped).
+seat_diversity_note:
+  "One build lane only (claude) -> D3's non-Anthropic build-seat-diversity floor does not apply
+  (needs >=2 build lanes to trigger). Cross-family review WAS sought regardless, on the repo's own
+  generator!=grader default: Codex (gpt-5.6-sol, cross-family) was tried FIRST and failed with
+  'ERROR: Your workspace is out of credits' (real cascade exhaustion, not a health-check skip —
+  see receipts); Kimi K3 was tried SECOND and failed with a 403 weekly-quota-limit error (same);
+  Gemini 3.1 Pro via agy succeeded THIRD and delivered the real review this pack's dissent is
+  built from. This is the CLAUDE.md multi-LLM cascade working as designed, not a shortcut — two
+  real quota-exhaustion failures are recorded as receipts rather than silently omitted."
+diff:
+  net_lines: |
+    3 files, +351/-0, 1 commits (evidence_pack_lint.py --print-measured --commit-count 1, run
+    against this pack's own final staged content — the canonical sentence, pasted verbatim rather
+    than hand-computed, per this script's own documented anti-self-reference guidance). Of that
+    total, the actual behavior change is the .github/workflows/fly-deploy.yml edit alone: 17
+    inserted lines, zero deleted, confirmed via `git diff --numstat` scoped to that one path
+    against this branch's merge-base with origin/main, 80b460bc4d715f47fd30062f02dad8d5fa4b9585.
+    The rest of the measured total is this evidence pack itself (brief.yml and pack.yml), both
+    pure additions, same commit.
+  behaviour_change: |
+    One file changed, one step's shell logic only: `.github/workflows/fly-deploy.yml`, job
+    `deploy-failure-alert`, step "Determine failing stage". The pre-existing 2-branch if/else
+    (tests only the literal string "failure" against `needs.run-migrations.result`) becomes a
+    4-branch if/elif/elif/else that also tests "cancelled" for `run-migrations`, then both
+    "cancelled" and (the pre-existing, unchanged) "failure" fallback for `deploy`. No other job,
+    step, condition, secret, or trigger in the file is touched. No line-range overlap with PR
+    #5422's own diff (job-level `if:` widening, deploy timeout/retry loop) — verified: #5422's
+    hunk ends at the `steps:` context line; this diff's first changed line is the next step's
+    `run:` body, several unchanged lines later.
+
+    FULL TRUTH TABLE (reachable (run-migrations.result, deploy.result) pairs — deploy's ONLY gate
+    is `needs: run-migrations`, no override `if:`, confirmed by reading the file, R6 receipt):
+
+      run-migrations | deploy   | alert if: fires? | stage named        | detail says          | verdict
+      ---------------|----------|-------------------|---------------------|-----------------------|--------
+      success         success   no (neither term)  -                    -                       N/A, post-deploy-health takes over
+      success         failure   yes (deploy=fail)   deploy               "crashed"               correct, UNCHANGED behavior
+      success         cancelled yes (deploy=cancel) deploy               "was cancelled"         FIXED (was "crashed" pre-this-PR)
+      success         skipped   not reachable       -                    -                       deploy has no if beyond needs — see brief risks
+      failure         skipped   yes (rm=failure)    run-migrations       "failed"                correct, UNCHANGED behavior
+      cancelled       skipped   yes (rm=cancelled)  run-migrations       "was cancelled"          FIXED — THE BUG (was stage=deploy/"crashed" pre-this-PR)
+      skipped         skipped   no (neither term)   -                    -                       pre-deploy-gate failed upstream; out of scope, pre-existing, not touched by #5422 or this PR
+
+    run-migrations and deploy can never BOTH be in {failure, cancelled} simultaneously (deploy
+    only runs at all when run-migrations succeeded), so checking run-migrations first and falling
+    through to deploy's cases is not an ordering risk — whichever branch matches IS the one that
+    broke, by construction.
+receipts:
+  - claim: "actionlint baseline (bare, includes shellcheck) on origin/main is 14 findings, matching the dispatching team lead's stated baseline exactly."
+    cmd: "cd /Users/nuzantara/nuzantara && actionlint .github/workflows/fly-deploy.yml; grep -c '^\\.github' <output>"
+    result: "exit=1, 14 findings, all [shellcheck] SC2086 (info, unquoted $GITHUB_OUTPUT) or SC2129 (style, group redirects)"
+    exit: 1
+    ts: "2026-08-31T06:48:40Z"
+    seat: claude (this session)
+  - claim: "actionlint with the EXACT flags .github/workflows/actionlint.yml's REQUIRED gate uses (-shellcheck=, disabling shellcheck entirely) shows ZERO findings on origin/main."
+    cmd: "cd /Users/nuzantara/nuzantara && actionlint -shellcheck= .github/workflows/fly-deploy.yml"
+    result: "exit=0, 0 lines of output"
+    exit: 0
+    ts: "2026-08-31T06:48:40Z"
+    seat: claude (this session)
+  - claim: "After the fix, bare actionlint (incl. shellcheck) rises 14 -> 22 findings — all 8 new findings are the SAME two pre-existing categories (SC2086 unquoted $GITHUB_OUTPUT, SC2129 group-your-redirects), proportionally more because the step gained 2 more branches (2 -> 4) each replicating the file's own pre-existing style, not a new category of complaint. This file's own actionlint.yml explicitly disables shellcheck for the required gate because 'the corpus is not shellcheck-clean' — a declared, accepted, deferred style debt, not a bar this PR is expected to clear."
+    cmd: "cd /Users/nuzantara/nuzantara/.worktrees/infra-alert-stage && actionlint .github/workflows/fly-deploy.yml; grep -c '^\\.github' <output>; diff <(actionlint main-copy) <(actionlint fixed-copy) to classify SC-codes"
+    result: "exit=1, 22 findings — 6 unrelated to this step (unchanged from baseline) + 12 SC2086 + 4 SC2129 all within the fixed step's script block, vs. 6 SC2086 + 2 SC2129 there on baseline"
+    exit: 1
+    ts: "2026-08-31T06:48:43Z"
+    seat: claude (this session)
+  - claim: "After the fix, actionlint with the REQUIRED gate's exact flags (-shellcheck=) is still ZERO findings — this PR does not affect the check that actually gates merges."
+    cmd: "cd /Users/nuzantara/nuzantara/.worktrees/infra-alert-stage && actionlint -shellcheck= .github/workflows/fly-deploy.yml"
+    result: "exit=0, 0 lines of output"
+    exit: 0
+    ts: "2026-08-31T06:48:43Z"
+    seat: claude (this session)
+  - claim: "The workflow-fix diff (before adding this pack) is exactly 1 file, +17/-0."
+    cmd: "cd /Users/nuzantara/nuzantara/.worktrees/infra-alert-stage && git diff --numstat"
+    result: "17\\t0\\t.github/workflows/fly-deploy.yml"
+    exit: 0
+    ts: "2026-08-31T06:48:43Z"
+    seat: claude (this session)
+  - claim: "deploy job's ONLY gate is `needs: run-migrations` — no override `if:` exists anywhere in that job — confirmed by reading the job header directly, not inferred."
+    cmd: "sed -n '160,163p' .github/workflows/fly-deploy.yml"
+    result: "'deploy:' / 'name: Fly.io rolling deploy' / 'needs: run-migrations # BLOCCATO se migration fallisce' / 'runs-on: ubuntu-latest' -- no if: line present"
+    exit: 0
+    ts: "2026-08-31T06:48:43Z"
+    seat: claude (this session)
+  - claim: "PR #5422 is still OPEN, mergeStateStatus CLEAN, has not merged out from under this PR's base assumption; origin/main HEAD is unchanged (80b460bc4d715f47fd30062f02dad8d5fa4b9585) since this worktree was created — no rebase needed."
+    cmd: "gh pr view 5422 --json number,state,mergeStateStatus,autoMergeRequest ; git fetch origin --quiet && git rev-parse origin/main"
+    result: '{"autoMergeRequest":null,"mergeStateStatus":"CLEAN","number":5422,"state":"OPEN"} / 80b460bc4d715f47fd30062f02dad8d5fa4b9585 (unchanged)'
+    exit: 0
+    ts: "2026-08-31T06:48:53Z"
+    seat: claude (this session)
+    note:
+      "autoMergeRequest:null is NOT read as 'not armed' — per this repo's own cicatrix-scars.md
+      family #9 PR-1 landing note, that field does not prove armed/disarmed either way
+      (mergeQueueEntry is the real signal). Not re-litigated further: PR #5422's arm state is the
+      dispatching team lead's stated fact and out of this PR's scope to verify or dispute."
+  - claim: "Codex (gpt-5.6-sol, cross-family) was dispatched FIRST for adversarial review and failed with real quota exhaustion, not a health-check skip — the CLI itself passed a prior 1-token health-check ('ping'->'OK', exit 0) moments earlier, so this is a genuine mid-session exhaustion, matching the CLAUDE.md cascade-detection pattern."
+    cmd: 'codex exec --sandbox read-only --skip-git-repo-check -m gpt-5.6-sol -c model_reasoning_effort="high" "<truth-table + 4 probes prompt>" < /dev/null'
+    result: "ERROR: Your workspace is out of credits. Add credits to continue. (printed twice, session aborted before producing a review)"
+    exit: 1
+    ts: "2026-08-31, this session"
+    seat: claude (this session, dispatching)
+  - claim: "Kimi K3 was dispatched SECOND (same prompt) after Codex's exhaustion and also failed, on its own distinct quota class (weekly, not workspace-credits)."
+    cmd: 'kimi -p "<same prompt>" -m kimi-code/k3'
+    result: "error: failed to run prompt: provider.auth_error: 403 You've reached your weekly (7-day) usage limit."
+    exit: 1
+    ts: "2026-08-31, this session"
+    seat: claude (this session, dispatching)
+  - claim: "Gemini 3.1 Pro via agy was dispatched THIRD (same prompt, passed as an actual -p argument per this repo's own documented agy stdin gotcha, never piped) and returned a real, content-bearing review addressing all 4 named probes individually, verdict CONFIRMED."
+    cmd: 'agy -p "<same prompt>" --print-timeout 4m'
+    result:
+      "Full text in this pack's dissent[0..2] below. Summary: (a) (success,skipped) unreachable,
+      and even if it occurred the alert's own if: would not fire (no false alarm) — same
+      conclusion as this pack's brief; (b) run-migrations/deploy can never both be bad
+      simultaneously, run-migrations-first ordering is correct; (c) no bash/YAML mechanical
+      defect found (quoting, icon/detail pairing, elif chain all checked); (d) needs.<job>.result
+      is strictly one of {success,failure,cancelled,skipped}, all 4 covered."
+    exit: 0
+    ts: "2026-08-31, this session"
+    seat: gemini-3.1-pro (agy, review lane)
+pii_scan: clean
+pii_scan_note:
+  "Entire diff is CI workflow YAML/bash text (job names, GH Actions expressions, Telegram alert
+  copy). No client, employee, or regulated-individual data anywhere in the diff, this pack, or the
+  review transcripts consulted."
+dissent:
+  - seat: gemini-3.1-pro (agy, cross-family adversarial review)
+    objection:
+      "Probe (a): could `deploy.result == 'skipped'` be reachable even when `run-migrations.result
+      == 'success'`, through some GHA mechanism other than a custom `if:` (concurrency
+      cancellation, workflow_dispatch cancel, matrix quirks) — which would make this pack's 'not
+      reachable' truth-table row wrong?"
+    status: RETRACTED
+    resolution:
+      "No — reviewer concluded: 'If a workflow-level cancellation occurs while deploy is queued or
+      running, GHA marks deploy as cancelled, not skipped.' Additionally: even in the hypothetical
+      that it did occur, the alert job's own `if:` (from #5422) requires >=1 of {run-migrations,
+      deploy} in {failure, cancelled} — a (success, skipped) pair would simply not fire the alert
+      at all, so the failure mode this pack would need to worry about (a WRONG stage attributed)
+      cannot happen even under the hypothetical."
+  - seat: gemini-3.1-pro (agy, cross-family adversarial review)
+    objection:
+      "Probe (b): could run-migrations and deploy ever BOTH be simultaneously bad
+      (failure/cancelled), and if so does checking run-migrations first in the if/elif chain
+      produce a wrong verdict in that case rather than just an arbitrary-but-harmless one?"
+    status: RETRACTED
+    resolution:
+      "No — reviewer confirmed the same reachability argument this pack's brief makes: 'deploy
+      requires run-migrations to succeed [so] any failure or cancelled result in run-migrations
+      forces deploy into skipped. deploy never executes.' Checking run-migrations first is
+      therefore not an arbitrary tie-break, it is 'strictly correct because it is the causal
+      upstream failure' (reviewer's own words) — there is no tie to break."
+  - seat: gemini-3.1-pro (agy, cross-family adversarial review)
+    objection:
+      "Probes (c)+(d): possible bash/YAML mechanical defect in the diff (GHA expression quoting
+      inside `[ ... ]`, icon/detail pairing, elif-chain logic, a copy-paste wording slip), and
+      whether GHA's `cancelled`/`failure`/`success`/`skipped` enum could ever produce a value this
+      4-branch chain does not account for."
+    status: RETRACTED
+    resolution:
+      "None found on either count. Quoting 'handles any expansion cleanly'; 'details contain no
+      unescaped double quotes, backticks, or variable interpolations that could break downstream
+      bash'; 'stage names and icons are 100% consistently paired'; and `needs.<job>.result` is
+      'strictly restricted to {success, failure, cancelled, skipped}' with 'all 4 possible result
+      values across both jobs map deterministically to either a skipped alert job or the correct
+      stage diagnostic.'"
+  - seat: "claude (this session, self-review while sequencing this PR against PR 5422)"
+    objection:
+      "Could this PR's diff conflict with, or need to be sequenced relative to, PR #5422's own
+      diff — since both touch the same job (deploy-failure-alert) in the same file, and #5422 is
+      frozen so this PR cannot rebase onto it?"
+    status: RETRACTED
+    resolution:
+      "No conflict either order: #5422's hunk (job-level `if:`, lines ~654-656 on its branch)
+      ends at the unchanged `steps:` context line; this PR's hunk starts at the next step's `run:`
+      body (line 662 on origin/main), several unchanged lines later. A 3-way git merge does not
+      conflict on non-overlapping hunks separated by unchanged context, regardless of merge
+      order. Functionally: on pre-#5422 main, this PR's new `cancelled`-testing elif branches are
+      simply unreachable (the job-level if: does not yet admit cancelled), not wrong — they
+      activate automatically the instant #5422 lands, with no further change needed on either
+      side."


### PR DESCRIPTION
## Summary

Follow-up to the Gear-3 gate caveat on PR #5422 ("alert names wrong stage when run-migrations cancelled") — **verdict: real, fixed here.**

PR #5422 (ARMED/FROZEN, not touched by this PR) widens `deploy-failure-alert`'s job-level `if:` in `.github/workflows/fly-deploy.yml` to fire on `cancelled` as well as `failure`, for both `run-migrations` and `deploy`. It does **not** touch the next step, "Determine failing stage", which still tests only the literal string `"failure"` against `needs.run-migrations.result`. So once #5422 lands, a `cancelled` `run-migrations` (its own 10-minute timeout, or a whole-workflow cancel) falls through to the `else` branch and gets reported as **`stage=deploy`, "flyctl deploy crashed"** — even though `deploy` never ran (`deploy`'s only gate is `needs: run-migrations`, no override `if:`, so `deploy.result` is `skipped` whenever `run-migrations` didn't succeed). Wrong stage, wrong narrative — a human alerted this way opens deploy logs for a job that never ran, while the real evidence is in run-migrations.

This PR replaces the 2-branch `if/else` with a 4-branch `if/elif/elif/else` that tests both `"failure"` and `"cancelled"` for `run-migrations`, then both for `deploy` (deploy's pre-existing `"failure"` text is unchanged).

## Truth table

Reachable `(run-migrations.result, deploy.result)` pairs — `deploy`'s ONLY gate is `needs: run-migrations`, no override `if:`, confirmed by reading the file:

| run-migrations | deploy | alert `if:` fires? | stage named | detail says | verdict |
|---|---|---|---|---|---|
| success | success | no | — | — | N/A, post-deploy-health takes over |
| success | failure | yes | deploy | "crashed" | correct, **unchanged** |
| success | cancelled | yes | deploy | "was cancelled" | **fixed** (was "crashed") |
| success | skipped | not reachable | — | — | deploy has no `if:` beyond `needs:` |
| failure | skipped | yes | run-migrations | "failed" | correct, **unchanged** |
| cancelled | skipped | yes | run-migrations | "was cancelled" | **fixed — the bug** (was stage=deploy/"crashed") |
| skipped | skipped | no | — | — | pre-deploy-gate failed upstream; out of scope, pre-existing |

`run-migrations` and `deploy` can never both be in `{failure, cancelled}` simultaneously (`deploy` only runs when `run-migrations` succeeded), so checking `run-migrations` first and falling through to `deploy`'s cases is not an ordering risk — whichever branch matches IS the one that broke, by construction.

## Verification

- **actionlint**, exact flags `.github/workflows/actionlint.yml`'s REQUIRED gate uses (`-shellcheck=`): **0 findings, both before and after** — this PR does not affect the check that actually gates merges.
- **actionlint**, bare (incl. shellcheck, not part of the required gate — that gate explicitly disables shellcheck because "the corpus is not shellcheck-clean"): 14 → 22 findings, all 8 new ones are the same two pre-existing categories (`SC2086` unquoted `$GITHUB_OUTPUT`, `SC2129` group-your-redirects) proportionally more because the step gained 2 more branches replicating the file's own pre-existing style — not a new category of complaint.
- Independent cross-family adversarial review (Gemini 3.1 Pro via `agy`, after Codex and Kimi K3 both hit real quota exhaustion first — full cascade recorded in the evidence pack's receipts): verdict **CONFIRMED**, all 4 probed failure modes (unreachable-state reachability, simultaneous-bad-state ordering, bash/YAML mechanics, GHA `cancelled` semantics) ruled out.
- No line-range overlap with #5422's own diff (its hunk ends at the `steps:` context line; this diff's first changed line is the next step's `run:` body, several unchanged lines later) — composes cleanly landing before or after #5422, and this PR's new branches are simply unreachable dead code until #5422's job-level `if:` widening lands.

Full evidence pack (Gear 3, floored by the `.github/workflows/*` hot-zone path — deterministically re-verified via `evidence_pack_lint.py --print-floor`): `evidence/2026-08/agent-nuzantara-infra-alert-stage-f9200d8d/`.

## Test plan

- [x] `actionlint -shellcheck= .github/workflows/fly-deploy.yml` — 0 findings (matches the required gate exactly)
- [x] Truth table walked mechanically against the file's actual `needs:`/`if:` structure, not by eye
- [x] Independent cross-family adversarial review (Gemini 3.1 Pro), verdict CONFIRMED
- [x] Local Gear-3 evidence-pack validation replicating `harness-floor.yml` Step 7b exactly — clean, exit 0
- [ ] CI required checks (post-open)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## Addendum (2026-08-31, post-open): one assumption checked further, now sourced

An independent judge's diagnosis (relayed by the dispatching team lead after this PR opened)
flagged one assumption that neither that judge nor this PR's own evidence pack had verified:
**whether a `timeout-minutes` kill is reported by GitHub Actions as job conclusion `cancelled`
or `failure`.** This PR's design (and its truth table above) assumes `cancelled` — if that
assumption were wrong, a `run-migrations` timeout would still be silently mis-stage'd, just via
the `failure` branch this PR left unchanged instead of the `cancelled` branch it added.

Re-verified this session, independently, in two steps:

**1. Local repo history** — last 100 `fly-deploy.yml` runs: conclusions
`{success: 82, failure: 14, cancelled: 4}`, **zero** `timed_out`. Job-level: of the 4
run-level-`cancelled` runs, 3 spawned no jobs at all (cancelled before any job started — out of
scope). The 4th (run `32977506629`, job `98207204249`, "Fly.io rolling deploy") DID conclude
`cancelled` at the job level (~20m19s runtime) with log tail `##[error]The operation was
canceled.` — but critically, **without** a `Timeout exceeded: N minutes` suffix (see step 2) —
so this specific instance looks like a manual or concurrency-triggered cancel, not a
`timeout-minutes` kill. Locally, this repo has **no confirmed historical example** of a
`timeout-minutes` kill on this workflow either way.

**2. GitHub's documented platform behavior** (web search this session, sourced): when a job
timeout fires, the job conclusion is reported as `cancelled` (confirmed via
`gh run view <run-id> --json conclusion` returning `"conclusion": "cancelled"` for a timed-out
job), and the job log carries the more specific message `Error: The operation was canceled.
Timeout exceeded: <N> minutes` — a strict superset of the generic `The operation was canceled.`
this PR's one sampled job showed. Sources:
[GitHub Actions Job Timeout — Every Fix (2026)](https://devopsboys.com/blog/github-actions-job-timeout-fix-2026),
[How to Debug 'Action timed out' Issues in GitHub Actions](https://oneuptime.com/blog/post/2025-12-20-debug-action-timed-out-github-actions/view).

**Net**: this repo has no *locally observed* timeout-kill to point at, but GitHub's own
documented behavior (now sourced, not merely assumed) confirms `timeout-minutes` → job
conclusion `cancelled`, distinguishable from other cancels only by the extra
`Timeout exceeded: N minutes` log phrase — which this PR's `if:` logic never needed to read,
since `needs.<job>.result` collapses both to the same `cancelled` string regardless of cause.

**This does not change the fix or the truth table above.** Both branches this PR added
(`run-migrations` = `cancelled`, `deploy` = `cancelled`) use wording that covers either cause
without asserting which one happened ("its own timeout, or the workflow run was cancelled") —
`pack.yml`'s `risks:` section already recorded this as deliberately absorbed by wording, before
this addendum. Flagged explicitly per the dispatching team lead's instruction not to silently
assume an unverified platform detail — now backed by a source rather than left as a bare claim.
