### PR TITLE
feat(ci): rule 12 — deprecate the ROOT evidence/brief.yml write, the half rule 9 cannot see

### DIFF
--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -836,6 +836,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           PACK_PATH: ${{ steps.evpaths.outputs.pack }}
+          # Rule 12's input. Step 2b already resolved this and Step 4 already
+          # reads it (to attribute the `gear:` declaration to THIS PR's brief),
+          # so nothing new is being computed here — the value was simply never
+          # handed to the lint, which is precisely why the BRIEF half of the
+          # root-path deprecation stayed unenforced while the PACK half
+          # shipped. Same resolution, same failure modes, passed one step
+          # further.
+          BRIEF_PATH: ${{ steps.evpaths.outputs.brief }}
         run: |
           set -u
           # Same corrected reasoning as Step 3 (Kimi K3 finding #3):
@@ -983,6 +991,22 @@ jobs:
             EXTRA_ARGS+=(--source-path "$PACK_PATH")
           else
             echo "::notice::the evidence_pack_lint.py copy in use (checked out from base) does not support --source-path yet — Rule 9 (evidence root deprecation) will judge the staged canonical path instead of this PR's real per-PR path this run; self-consistent once this PR merges and base's copy is updated"
+          fi
+          # Rule 12 (the BRIEF half). Same capability-probe shape as the pack
+          # flag above and for the same reason: this job checks out BASE, so
+          # the copy running here is the one on main, not the one this PR adds
+          # — the flag only exists after this PR merges. Probed with the exact
+          # flag string rather than a version number, because a version is a
+          # proxy for a capability and this is the capability itself.
+          # Deliberately NOT defaulted to the staged canonical path when the
+          # flag is missing: staging always names the file evidence/brief.yml,
+          # so falling back would make EVERY pack look guilty of the very
+          # thing this rule forbids — a false positive on the whole fleet.
+          # Absent flag => rule inert, stated in the notice.
+          if python3 scripts/evidence_pack_lint.py --help 2>&1 | grep -q -- '--brief-source-path'; then
+            EXTRA_ARGS+=(--brief-source-path "$BRIEF_PATH")
+          else
+            echo "::notice::the evidence_pack_lint.py copy in use (checked out from base) does not support --brief-source-path yet — Rule 12 (root BRIEF deprecation) is inert this run rather than judging the staged canonical name, which would falsely accuse every pack; self-consistent once this PR merges and base's copy is updated"
           fi
           python3 scripts/evidence_pack_lint.py \
             /tmp/evidence-check/evidence/pack.yml \

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/brief.yml
@@ -48,7 +48,7 @@ acceptance:
     only NOTICE. probe: a test asserting the two constants are distinct and that the brief rule
     returns no violation on the pack's date."
   - "WHILE this change lands the existing corpus SHALL be unchanged. probe: the full
-    test_evidence_pack_lint.py file green (275 pre-existing + 25 new), actionlint rc=0 on the
+    test_evidence_pack_lint.py file green (288 pre-existing + 12 new), actionlint rc=0 on the
     edited workflow, ruff clean."
 
 risks:

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/brief.yml
@@ -1,0 +1,65 @@
+task_id: infra-evidence-root-path-guard
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Close the half of the evidence root-path deprecation that was never enforced.
+
+  Rule 9 (`check_pack_not_at_deprecated_root`, `EVIDENCE_ROOT_DEPRECATION_DATE` = 2026-09-05)
+  deprecates writing the evidence PACK to the fixed repo-root `evidence/pack.yml`, because a
+  fixed shared path makes any two Gear>=2 PRs mutually exclusive in the merge queue by
+  construction — `scripts/ci/evidence_paths.py`'s module docstring measures the original harm
+  (those two root files rewritten 4 times in 8 hours, each rewrite dirtying every open Gear>=2 PR).
+
+  MEASURED 2026-08-31 by executing the function from origin/main with `today` past the flip date:
+  it compares only the resolved PACK path against EVIDENCE_ROOT_PACK_PATH and returns clean
+  otherwise. It takes no brief argument at all, so it is structurally blind to where the BRIEF
+  lives. A PR whose pack is correctly migrated to `evidence/<YYYY-MM>/<slug>/pack.yml` but whose
+  diff still MODIFIES the repo-root `evidence/brief.yml` is therefore clean under Rule 9 at ANY
+  date, while still colliding with every other PR that writes that file.
+
+  Not hypothetical. Of the 31 open PRs that day, SIX modify the root brief (#5158 #5072 #5037
+  #4645 #4644 #4640). Five have pack AND brief at root, so Rule 9 already sees them. #5158 has
+  the invisible shape exactly: pack at `evidence/2026-08/agent-air-m5-ops-watcher-coverage-
+  0828-2dd63838/pack.yml` (ADDED), brief at the root (MODIFIED), Rule 9 green, collision live.
+  That PR is one of the DIRTY PRs the fleet-watch mailbox reported this session.
+
+  HOW THIS SURFACED, because the provenance matters for how much to trust it: not from reading
+  the code. Three `queue_unstick` messages from mini-pro2 named `evidence/brief.yml` as the
+  conflicting file on different PRs. Counting how many open PRs touch that path gave 6; the
+  readiness report written the same morning named 3. Chasing that discrepancy — not the code —
+  is what exposed the asymmetry.
+
+acceptance:
+  - "WHEN a PR's own diff writes the repo-root evidence/brief.yml AND the date is on/after the
+    declared flip THEN evidence_pack_lint exits 1 with an `evidence_root_brief_deprecated`
+    violation. probe: the direct-call guilt tests pin `today` on the flip date; they must FAIL
+    if the rule's path comparison is neutered (mutation control required, not optional)."
+  - "WHILE the mandatory `brief_ref: evidence/brief.yml` staging contract is unchanged, a
+    conformant pack declaring that literal string SHALL never trip the new rule. probe: the
+    tmp_repo fixture's write_pack() emits exactly that string; lint() with no brief path supplied
+    must stay silent. This is the failure that would break the entire fleet, so it is pinned
+    twice — once with no brief path, once with a per-task brief path alongside the root string."
+  - "WHILE the flag is absent from the copy of the lint that CI actually runs (this job checks
+    out BASE, so the flag only exists after this PR merges) THEN the rule SHALL be inert and say
+    so, never fall back to the staged canonical name. probe: read the workflow's else-branch —
+    staging always names the file evidence/brief.yml, so a fallback would accuse every pack."
+  - "WHEN the pack's own deprecation date arrives (2026-09-05) THEN the brief rule SHALL still
+    only NOTICE. probe: a test asserting the two constants are distinct and that the brief rule
+    returns no violation on the pack's date."
+  - "WHILE this change lands the existing corpus SHALL be unchanged. probe: the full
+    test_evidence_pack_lint.py file green (275 pre-existing + 25 new), actionlint rc=0 on the
+    edited workflow, ruff clean."
+
+risks:
+  - "A false positive here blocks a hot-zone CI gate for the whole fleet. The single highest-risk
+    shape is confusing the mandatory brief_ref STRING with a root brief FILE write; it is the
+    first thing both cross-family reviewers were pointed at."
+  - "The date is deliberately NOT the pack's 2026-09-05. Riding it would silently re-price a
+    measurement taken the same morning (research/operations/2026-08-31-two-nine-enforcement-
+    readiness.md priced '3 newly RED' for EVIDENCE_ROOT), turning 3 into 6 with nobody
+    re-measuring. Zero's standing instruction in that report is to move dates only 'if we are
+    ready'. This rule therefore arrives with its own constant and its own window."
+  - "This PR does NOT migrate the six in-flight PRs. They are other lanes' branches; pushing to
+    them is sibling territory. They are already blocked by DIRTY today, so the new rule does not
+    break working PRs — it explains why already-broken ones are broken, and prevents the seventh."

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/council-journal.jsonl
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/council-journal.jsonl
@@ -1,0 +1,5 @@
+{"seat": "claude-opus-5", "role": "build", "ok": true, "ts": "2026-08-31T06:40:00Z"}
+{"seat": "tp1-glm-5.2", "role": "review", "ok": true, "ts": "2026-08-31T07:12:00Z"}
+{"seat": "kimi-code/k3", "role": "review", "ok": false, "ts": "2026-08-31T06:52:00Z"}
+{"seat": "tp1-qwen3.8-max", "role": "review", "ok": false, "ts": "2026-08-31T06:58:00Z"}
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": false, "ts": "2026-08-31T07:02:00Z"}

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
@@ -34,8 +34,8 @@ lanes:
 council_run: council-journal.jsonl
 
 diff:
-  files: 6
-  net_lines: 694
+  files: 7
+  net_lines: 734
   measured_at: 494583042
   note: >-
     Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`, measured
@@ -106,6 +106,22 @@ receipts:
     result: "actionlint rc=0, YAML parses, ruff clean on both Python files."
     exit: 0
     ts: "2026-08-31T07:22:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The new guard is REGISTERED in the #3 census, and that registration is measured rather
+      than assumed — the census actually reads this entry.
+    cmd: >-
+      `check_guard_conformance.py` before the entry, after the entry, and under two mutations OF
+      THE ENTRY (a phantom guilt ref; an emptied innocence list), then restored from a byte copy.
+    result: >-
+      Before: 1 violation, `C1 ... exists in code but is NOT registered`, rc=1 (16 checks).
+      After: 0 violations, rc=0 (17 checks). Mutation A -> `C3 ... phantom reference (W65)`, rc=1.
+      Mutation B -> `C2 ... has NO innocence test`, rc=1. Restored -> rc=0, `git diff --stat`
+      shows only the 20 added lines, no reformat. A green that cannot go red measures nothing;
+      this one goes red on both faces of the entry.
+    exit: 0
+    ts: "2026-08-31T08:05:00Z"
     seat: session (Pro)
 
 dissent:

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
@@ -35,7 +35,7 @@ council_run: council-journal.jsonl
 
 diff:
   files: 7
-  net_lines: 734
+  net_lines: 764
   measured_at: 494583042
   note: >-
     Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`, measured
@@ -162,7 +162,27 @@ dissent:
       actually appears, and dies under over-match. The same insensitivity was found and fixed in
       two neighbouring tests by the same measurement.
 
-  - seat: kimi-code/k3
+  - seat: claude-opus-5 (final on-disk gate, fresh context, generator != grader)
+    status: CONFIRMED
+    round: 2
+    objection: >-
+      VERDICT: PASS-WITH-CONDITIONS. "The one defect is honesty, not safety: the pack's `tests:`
+      block and the brief's fifth acceptance criterion both claim '275 pre-existing, 25 new'; the
+      real split is 288 pre-existing, 12 new. The total (300) is right and the substantive claim
+      (whole corpus green) is true, so nothing behavioural rests on it — but this repo lints for
+      exactly this class of countable claim, the wrong split is internally consistent (275+25=300)
+      and would survive a naive check." It also asked the notes to name a limitation they did not:
+      a diff writing a per-task brief AND the root brief escapes the rule entirely.
+    disposition: >-
+      BOTH ADOPTED, and the first one is the sharper finding of the two rounds. RE-MEASURED before
+      believing it (the refuter hallucinates too, W65): `pytest -k brief_root` reports
+      `12 passed, 288 deselected` — 12 new, 288 pre-existing, exactly as the gate said, and my
+      figure was simply wrong. It is the same disease this PR's own Rule 13 neighbour exists to
+      catch, committed in the artifact that is supposed to BE the measured record, and it survived
+      an earlier reviewer because 275+25 sums to the right total. The split correction itself is
+      digit-only in both files; `diff.net_lines` below is nevertheless re-measured, because this
+      same commit also adds note (4) and this very entry. Limitation named as note (4), uncured:
+      it is inherited from the resolver's single-path contract and Rule 9 has it identically.
     status: RETRACTED
     round: 1
     objection: >-
@@ -194,7 +214,7 @@ dissent:
       in an unrelated lane). Recorded, not replaced silently.
 
 tests:
-  - "scripts/tests/test_evidence_pack_lint.py — 300 passed (275 pre-existing, 25 new)."
+  - "scripts/tests/test_evidence_pack_lint.py — 300 passed (288 pre-existing, 12 new)."
   - "Mutation control, both directions: neutered kills 6, over-match kills 4, seam test dies under both."
   - "actionlint on the edited workflow — rc=0. ruff — clean."
 
@@ -224,3 +244,13 @@ notes: >-
   describes". Rule 9 and Rule 12 are now symmetric by hand, not by construction, and a third
   root-path artifact would need a third rule. That is a real gap and deliberately not invented
   here — it is a second concern, and this PR is already a correction of an under-enforced cure.
+
+  (4) ONE SHAPE STILL ESCAPES, named by the final gate and left uncured on purpose. A diff that
+  writes BOTH a per-task brief AND the root brief resolves to the per-task path and is clean:
+  `resolve_evidence_path` returns the FIRST match, and the rule judges one resolved path, not the
+  changed-files list. Rule 9 has the identical hole for packs, so this is INHERITED from the
+  resolver's single-path contract, not introduced here — curing it means changing that contract
+  for both rules, which is a spec, not a patch (Regola 8: cure what the change introduces, send
+  to spec what it inherits). Consolation, measured not assumed: that shape still collides in the
+  queue exactly as before, so it is no worse off than today — it simply is not yet explained by
+  a lint.

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
@@ -1,0 +1,210 @@
+# The literal STAGING path, never this PR's real per-PR path — harness-floor.yml copies this
+# PR's own brief to /tmp/evidence-check/evidence/brief.yml and lints with --repo-root pointing
+# there, so the canonical name resolves to MY brief inside that synthetic tree. Writing the real
+# per-task path here would fail `brief_ref does not resolve to a file on disk`. This PR is about
+# that very distinction, so getting it wrong here would be its own refutation.
+brief_ref: evidence/brief.yml
+
+plan_ref: >-
+  Close the BRIEF half of the evidence root-path deprecation. Rule 9 judges only the pack's path
+  and takes no brief argument, so a PR with a migrated pack and a root brief is clean at any date
+  while still colliding. Add Rule 12 mirroring Rule 9's shape, a --brief-source-path flag with no
+  positional fallback, and pass the value harness-floor.yml already resolves. Its own flip date,
+  deliberately later than the pack's, so today's readiness measurement is not silently re-priced.
+
+lanes:
+  - lane: rule12-build
+    role: build
+    seat: >-
+      claude-opus-5 (interactive session, xhigh) — found the gap, wrote the rule, ran every
+      verification below.
+  - lane: rule12-review-crossfamily
+    role: review
+    seat: >-
+      tp1-glm-5.2 (Zhipu GLM via the Alibaba TP1/DashScope gateway, flat token plan,
+      non-Anthropic cross-family, fresh context). The ONLY cross-family seat that answered
+      tonight — see `notes` for the three that did not.
+  - lane: rule12-review-independent
+    role: review
+    seat: >-
+      claude-sonnet-5 subagent on fresh context, given the diff and told to find vacuous tests.
+      In-family, so it does NOT satisfy cross-family review — recorded because it found the
+      single realest defect in this PR (a vacuous test), not to pad the seat count.
+
+council_run: council-journal.jsonl
+
+diff:
+  files: 6
+  net_lines: 694
+  measured_at: 494583042
+  note: >-
+    Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`, measured
+    with this exact pack STAGED, so the pack counts itself; the final substitution is DIGIT-ONLY
+    and therefore cannot change the line count it reports. FLOOR is 3 by PATH — `.github/workflows/`
+    is a hot zone and the ceiling never overrides a floor.
+
+pii_scan: clean
+
+receipts:
+  - claim: >-
+      Rule 9 is structurally blind to the brief — the gap is real, not inferred from reading.
+    cmd: >-
+      Executed `check_pack_not_at_deprecated_root` from origin/main's copy with today=2026-09-10,
+      once with source_path="evidence/pack.yml" and once with a per-task pack path.
+    result: >-
+      Root pack -> (["evidence_root_deprecated: ..."], None) = VIOLATION. Per-task pack ->
+      ([], None) = clean, no notice. The function takes no brief argument at all. Independently
+      re-executed by a refuter on fresh context, same result.
+    exit: 0
+    ts: "2026-08-31T06:35:00Z"
+    seat: session (Pro) + refuter subagent
+
+  - claim: >-
+      The collision is live, not theoretical, and this exact shape exists in the open queue.
+    cmd: >-
+      `gh pr list --state open` cross-referenced with each PR's file list; `gh pr view 5158 --json files`.
+    result: >-
+      6 open PRs modify the root evidence/brief.yml (#5158 #5072 #5037 #4645 #4644 #4640). #5158
+      carries `evidence/2026-08/agent-air-m5-ops-watcher-coverage-0828-2dd63838/pack.yml` (ADDED)
+      AND `evidence/brief.yml` (MODIFIED) — a file-level diff entry, not a brief_ref string
+      occurrence. Rule 9 green on it. Three fleet-watch queue_unstick messages independently named
+      evidence/brief.yml as the conflicting file on PRs in that set.
+    exit: 0
+    ts: "2026-08-31T06:38:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The tests measure the rule in BOTH directions rather than agreeing with it.
+    cmd: >-
+      Two mutations of the single path comparison, each followed by the brief_root test selection:
+      `if True:` (rule always clean) and `if False:` (rule always fires).
+    result: >-
+      Neutered kills 6 (three guilt cases, the pre-flip notice, the separate-dates test, and the
+      end-to-end wiring case). Over-matching kills 4 (per-task clean, the mandatory-brief_ref
+      innocence case, the CLI threading case, and the resolver seam). The seam test dies under
+      BOTH. Restored: 300 passed.
+    exit: 0
+    ts: "2026-08-31T07:20:00Z"
+    seat: session (Pro)
+
+  - claim: >-
+      The value the workflow passes is diff-relative, so the rule cannot mistake the staged
+      canonical name for a root write — the objection that produced the only DO-NOT-SHIP.
+    cmd: >-
+      Read `resolve_evidence_path` on disk; traced harness-floor.yml Step 2b vs Step 7b ordering.
+    result: >-
+      `resolve_evidence_path(kind, changed_files)` is a pure function over the changed-files LIST
+      — no filesystem access anywhere in its body, so it cannot see the staged tree — and Step 2b
+      runs it long before Step 7b creates /tmp/evidence-check. Now pinned by an executable test
+      across the module seam rather than asserted in a docstring.
+    exit: 0
+    ts: "2026-08-31T07:25:00Z"
+    seat: session (Pro)
+
+  - claim: The change cannot alter the workflow's behaviour beyond passing one more flag.
+    cmd: "`actionlint .github/workflows/harness-floor.yml`; yaml.safe_load; ruff check."
+    result: "actionlint rc=0, YAML parses, ruff clean on both Python files."
+    exit: 0
+    ts: "2026-08-31T07:22:00Z"
+    seat: session (Pro)
+
+dissent:
+  - seat: tp1-glm-5.2
+    status: CONFIRMED
+    round: 1
+    objection: >-
+      "Here is the fatal flaw ... The diff provides ZERO EVIDENCE that BRIEF_PATH actually
+      contains a per-task path. If `scripts/ci/evidence_paths.py` resolves the brief path by
+      inspecting the synthetic tree (which is what runs in CI), its output will be
+      `evidence/brief.yml` for every single PR ... every correct PR in the fleet will ... return a
+      violation. The whole fleet goes red." VERDICT: DO-NOT-SHIP. (It endorsed the no-fallback
+      asymmetry, the inert-not-fail-closed direction and the separate flip date on their merits.)
+    disposition: >-
+      CONCLUSION REFUTED, DEMAND ADOPTED — and the split matters. The mechanism it feared does not
+      exist: `resolve_evidence_path` is a pure function over the changed-files list with no
+      filesystem access, and Step 2b calls it before the staged tree is created. But its actual
+      complaint was that the diff ASSERTED this in a docstring and pinned it nowhere, which was
+      true: the claim spans two modules, so neither module's own corpus covered it. Added
+      `test_brief_root_resolver_seam_produces_diff_relative_paths_not_the_staged_name`, which runs
+      the real resolver over all three diff shapes and feeds each result to the real rule. It is
+      now the only test in this corpus that dies under BOTH mutations.
+
+  - seat: claude-sonnet-5 (independent subagent, in-family)
+    status: CONFIRMED
+    round: 1
+    objection: >-
+      "`test_brief_root_innocence_mandatory_brief_ref_string_is_not_a_root_write`, labeled 'THE
+      load-bearing innocence case', calls lint() without ever passing brief_source_path ... Its
+      assertion would hold identically if the function were deleted — it never exercises the code
+      path it claims to pin."
+    disposition: >-
+      CORRECT, and it was the realest defect in the PR: my own test measured the question next
+      door. Fixing it exposed a SECOND layer the reviewer had not reached — supplying the path
+      still left the test insensitive, because today is before the flip date and an over-matching
+      rule only NOTICEs, which `rc == 0` cannot distinguish from clean. Proven by mutation, not
+      argued: `if False:` left the "fixed" test green. It now asserts on stderr, where a notice
+      actually appears, and dies under over-match. The same insensitivity was found and fixed in
+      two neighbouring tests by the same measurement.
+
+  - seat: kimi-code/k3
+    status: RETRACTED
+    round: 1
+    objection: >-
+      NONE — the seat never answered. `403 You've reached your weekly (7-day) usage limit.`
+    disposition: >-
+      A seat that does not answer did not review. Recorded with ok:false rather than omitted, so
+      the council's real size is visible; never counted as a pass.
+
+  - seat: tp1-qwen3.8-max
+    status: RETRACTED
+    round: 1
+    objection: >-
+      NONE — non-answer. `tp1_call: unparseable response (JSONDecodeError)`, RC=3. The gateway
+      reported 20086 completion tokens (16590 of them reasoning), so the model appears to have
+      produced a review that the wrapper could not parse; no content survived to be read.
+    disposition: >-
+      Recorded as a transport/parse failure, not a verdict. Worth carrying beyond this PR: this is
+      a WRAPPER defect, not a quota one — the seat had capacity and the answer was lost on the way
+      back. Not fixed here (different concern, different file); named so the next lane that loses
+      an answer this way recognises it instead of re-diagnosing it.
+
+  - seat: codex-gpt-5.6-sol
+    status: RETRACTED
+    round: 1
+    objection: >-
+      NONE — the seat never answered. `ERROR: Your workspace is out of credits.`
+    disposition: >-
+      Second distinct failure of this door tonight (it died on a workspace spend cap ~5h earlier
+      in an unrelated lane). Recorded, not replaced silently.
+
+tests:
+  - "scripts/tests/test_evidence_pack_lint.py — 300 passed (275 pre-existing, 25 new)."
+  - "Mutation control, both directions: neutered kills 6, over-match kills 4, seam test dies under both."
+  - "actionlint on the edited workflow — rc=0. ruff — clean."
+
+static:
+  - "ruff: clean on evidence_pack_lint.py and its test file."
+  - "actionlint: clean on harness-floor.yml."
+
+notes: >-
+  WHAT THIS DOES NOT DO, stated rather than left to be discovered.
+
+  (1) It does not migrate the six in-flight PRs that write the root brief. They are other lanes'
+  branches and pushing to them is sibling territory. They are ALREADY blocked by DIRTY today, so
+  this rule breaks no working PR — it explains why already-broken ones are broken, and stops the
+  seventh. Their migration is a separate mandate.
+
+  (2) THE CROSS-FAMILY COUNCIL WAS NEARLY DARK TONIGHT, and this PR does not pretend otherwise.
+  Four seats were dispatched on the real diff; three returned non-answers for three DIFFERENT
+  reasons — kimi a weekly quota ceiling, codex a workspace credit exhaustion, tp1-qwen3.8-max a
+  response the wrapper could not parse despite the model having produced 20k tokens. Only
+  tp1-glm-5.2 answered. GLM is NOT in the lint's COUNCIL_REVIEW_SEATS allowlist (codex-gpt-5.6-sol,
+  kimi-code/k3, tp1-qwen3.8-max), so R9's "two allowlisted seats ok:true" requirement is NOT met
+  and will NOTICE — correctly, and it is left to notice rather than worked around. That three of
+  three allowlisted doors were down simultaneously is the more useful finding here than anything
+  about this diff: any lane relying on that panel tonight got, or will get, silence.
+
+  (3) It adds no lint for the class of "a rule enforces half the surface its own docstring
+  describes". Rule 9 and Rule 12 are now symmetric by hand, not by construction, and a third
+  root-path artifact would need a third rule. That is a real gap and deliberately not invented
+  here — it is a second concern, and this PR is already a correction of an under-enforced cure.

--- a/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-evidence-root-path-guard-cc6192c5/pack.yml
@@ -35,7 +35,7 @@ council_run: council-journal.jsonl
 
 diff:
   files: 7
-  net_lines: 764
+  net_lines: 807
   measured_at: 494583042
   note: >-
     Churn (added+deleted) via `git diff --no-renames --numstat --cached <merge-base>`, measured
@@ -124,6 +124,21 @@ receipts:
     ts: "2026-08-31T08:05:00Z"
     seat: session (Pro)
 
+  - claim: >-
+      This pack's `dissent:` block parses to what its TEXT shows — the property the lint cannot
+      check, and the one this pack broke once already.
+    cmd: >-
+      Count `^  - seat:` lines in the raw text, compare against `len(safe_load(text)["dissent"])`,
+      then run a custom PyYAML loader that reports duplicate keys with line numbers.
+    result: >-
+      7 raw seat lines, 7 parsed entries, MATCH=True; duplicate keys: NONE. Both gate rounds and
+      all three non-answering seats are individually present. The same probe run one commit
+      earlier returned 5 parsed against 6 raw, with duplicate `status`/`round`/`objection`/
+      `disposition` — which is how the corruption was proven rather than argued.
+    exit: 0
+    ts: "2026-08-31T08:20:00Z"
+    seat: session (Pro), on a finding by the final gate
+
 dissent:
   - seat: tp1-glm-5.2
     status: CONFIRMED
@@ -183,6 +198,34 @@ dissent:
       digit-only in both files; `diff.net_lines` below is nevertheless re-measured, because this
       same commit also adds note (4) and this very entry. Limitation named as note (4), uncured:
       it is inherited from the resolver's single-path contract and Rule 9 has it identically.
+
+  - seat: claude-opus-5 (final on-disk gate, fresh context, generator != grader)
+    status: CONFIRMED
+    round: 3
+    objection: >-
+      VERDICT: BLOCK — on the commit that ADOPTED its round-2 conditions. "The commit that applied
+      them corrupted the pack's `dissent:` block: the new gate entry was written OVER the line
+      `- seat: kimi-code/k3` instead of before it, so one YAML mapping now carries duplicate keys.
+      The kimi seat has vanished from the parsed record, and the final on-disk gate's round-2 entry
+      now parses as 'RETRACTED / round 1 / NONE — the seat never answered.' The artifact, as a
+      machine reads it, says the gate that reviewed this PR never answered. That is a worse
+      falsehood than the one it was fixing, and it is in the block whose entire purpose is that the
+      disagreement survives."
+    disposition: >-
+      CORRECT, cured, and the most instructive finding in this PR — bigger than the rule it ships.
+      Re-measured before believing it: `safe_load` returned 5 dissent entries where the text shows
+      6, entry[2] carrying this gate's seat with kimi's status/round/objection. PyYAML accepts
+      duplicate keys SILENTLY, last-wins. Cured by restoring the dropped `- seat: kimi-code/k3`
+      line; the raw `- seat:` count and the parsed length now agree, this entry reads CONFIRMED /
+      round 3, and a duplicate-key scan over the whole file returns nothing — see the receipt that
+      pins all three. WHAT THIS COSTS TO KNOW: the lint had already returned
+      `clean` rc=0 on the corrupted artifact, in the CI shape, with the countable-claims rule
+      active — because every rule reads the PARSED mapping, and the parse is exactly where the
+      damage hid. No machine in this repo could have caught it. Not fixed here (a duplicate-key
+      guard for the pack lint is a separate concern and this PR is already at its third round);
+      named so the next lane does not re-derive it.
+
+  - seat: kimi-code/k3
     status: RETRACTED
     round: 1
     objection: >-

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -682,6 +682,30 @@
             "test_countable_innocence_binary_file_downgrades_line_counts_to_notice",
             "test_countable_end_to_end_red_pack_fails_and_green_pack_passes"
           ]
+        },
+        "check_brief_not_at_deprecated_root": {
+          "scar": [
+            "#9-state-schema-mutation-drift",
+            "W82",
+            "PR-5435-2026-08-31"
+          ],
+          "guilt": [
+            "test_brief_root_guilt_root_path_post_flip_rejected",
+            "test_brief_root_guilt_absolute_root_path_post_flip_rejected",
+            "test_brief_root_guilt_dot_segments_normalize_to_root_post_flip",
+            "test_brief_root_resolver_seam_produces_diff_relative_paths_not_the_staged_name"
+          ],
+          "innocence": [
+            "test_brief_root_innocence_pre_flip_notice_not_fail",
+            "test_brief_root_innocence_per_task_dir_clean_both_sides",
+            "test_brief_root_innocence_no_brief_source_path_skipped",
+            "test_brief_root_innocence_mandatory_brief_ref_string_is_not_a_root_write",
+            "test_brief_root_does_not_ride_the_pack_rules_flip_date",
+            "test_brief_root_end_to_end_notice_pre_flip_does_not_fail",
+            "test_brief_root_cli_accepts_and_threads_brief_source_path",
+            "test_brief_root_cli_absent_flag_leaves_rule_inert",
+            "test_brief_root_resolver_seam_produces_diff_relative_paths_not_the_staged_name"
+          ]
         }
       }
     },

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -479,6 +479,45 @@ EVIDENCE_ROOT_DEPRECATION_DATE = datetime.date(2026, 9, 5)
 #: PR's diff touches neither a root nor a per-task evidence/pack.yml.
 EVIDENCE_ROOT_PACK_PATH = "evidence/pack.yml"
 
+# Rule 12 (evidence root path deprecation — THE BRIEF HALF). Rule 9 above
+# closes only half the surface it was written for: it compares the resolved
+# PACK path against EVIDENCE_ROOT_PACK_PATH and returns clean otherwise, so it
+# is structurally blind to where the BRIEF lives. Measured on origin/main
+# 2026-08-31 by executing check_pack_not_at_deprecated_root directly with
+# `today` past the flip date: a source_path of
+# `evidence/2026-08/<slug>/pack.yml` returns ([], None) — clean at ANY date —
+# while that same PR's diff can still MODIFY the repo-root evidence/brief.yml
+# and collide with every other PR that does. That is not hypothetical: of the
+# 31 open PRs that day, SIX wrote the root brief (#5158 #5072 #5037 #4645
+# #4644 #4640), and #5158 had exactly the invisible shape — pack correctly
+# migrated to a per-task directory, brief still at the root, Rule 9 green.
+#
+# WHAT THIS RULE MUST NOT DO, and the reason it is easy to get wrong: every
+# conformant pack is REQUIRED to declare the literal string
+# `brief_ref: evidence/brief.yml` (the staging contract — harness-floor.yml
+# lints a synthetic tree where both files carry canonical names, see
+# scripts/ci/evidence_paths.py's module docstring). So that exact string
+# appears inside every correct pack in the repo. This rule judges a PATH THIS
+# PR'S DIFF WROTE, never a string in a field — conflating the two would fail
+# every conformant pack in the fleet. The innocence tests pin that distinction.
+#
+# THE DATE IS DELIBERATELY *NOT* EVIDENCE_ROOT_DEPRECATION_DATE. Riding the
+# pack's 2026-09-05 would silently re-price a measurement taken the same day
+# this rule was written: research/operations/2026-08-31-two-nine-enforcement-
+# readiness.md measured "3 PRs newly RED if EVIDENCE_ROOT moves alone"
+# (#5072 #5037 #4640) and Zero's standing instruction there was to move dates
+# only "if we are ready". Adding the brief to that date turns 3 into 6 without
+# anyone re-measuring — a number aging into a lie, which is the exact defect
+# class this file's own PR history spent 2026-08-31 correcting. So: its own
+# constant, one week past the pack's, giving the six in-flight PRs a real
+# window to migrate and giving the next readiness pass a separate number to
+# price.
+EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE = datetime.date(2026, 9, 12)
+
+#: The literal root brief path — the sibling of EVIDENCE_ROOT_PACK_PATH, and
+#: the same value `resolve_evidence_path("brief", ...)` falls back to.
+EVIDENCE_ROOT_BRIEF_PATH = "evidence/brief.yml"
+
 
 # --------------------------------------------------------------------- utils
 
@@ -2428,6 +2467,62 @@ def check_pack_not_at_deprecated_root(
     return [f"evidence_root_deprecated: {message}"], None
 
 
+def check_brief_not_at_deprecated_root(
+    brief_source_path: str | None,
+    repo_root: Path,
+    today: datetime.date | None = None,
+) -> tuple[list[str], str | None]:
+    """Rule 12 — the BRIEF half of the root-path deprecation Rule 9 opened.
+
+    `brief_source_path` must be THIS PR's own diff-relative brief path — the
+    value `scripts/ci/evidence_paths.py --resolve brief` prints, which
+    harness-floor.yml's Step 2b already computes and exposes as
+    `steps.evpaths.outputs.brief`. It is resolved from the PR's changed-files
+    enumeration, so it is the path the diff actually WROTE, never a string
+    read out of the pack.
+
+    That distinction is the whole rule. A conformant pack always declares
+    `brief_ref: evidence/brief.yml` (the staging contract), so the literal
+    root string is present in every correct pack in this repo; judging that
+    string would fail the entire fleet. This function never reads the pack.
+
+    Same "skip, don't guess" shape as its pack sibling: a `None`/empty value
+    means the caller has no diff context, and returns clean with no notice
+    rather than presuming guilt or innocence. Unlike the pack rule there is
+    no CLI default that backfills it from a positional argument — a local
+    `python3 evidence_pack_lint.py evidence/pack.yml` knows the pack's path
+    but genuinely does not know the brief's, and inventing one would be a
+    guess. So this rule is inert outside CI by design, and the workflow is
+    what arms it; that is stated rather than papered over, because "the rule
+    exists" and "the rule is armed" are different claims (superscar #2).
+
+    Returns (violations, notice): before EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE
+    a root-path brief NOTICEs (exit 0); on/after, it is a violation (exit 1).
+    A per-task brief is clean at any date. `today` overridable for tests
+    without monkeypatching date.today()."""
+    if not brief_source_path:
+        return [], None
+    if _pack_source_relpath(brief_source_path, repo_root) != EVIDENCE_ROOT_BRIEF_PATH:
+        return [], None
+    message = (
+        f"{EVIDENCE_ROOT_BRIEF_PATH} is deprecated as a WRITE target — write "
+        "per-task evidence to evidence/<YYYY-MM>/<task-slug>-<8hex>/brief.yml "
+        "instead (scripts/ci/evidence_paths.py --resolve brief). This does NOT "
+        "change the `brief_ref:` contract: a pack must still declare the "
+        "literal `brief_ref: evidence/brief.yml`, because CI lints a staged "
+        "tree using canonical names — only the FILE moves, never the "
+        "reference. Rule 9 deprecates the root pack for the same reason and "
+        "cannot see this half: a PR whose pack is already migrated still "
+        "makes every other root-brief PR mutually exclusive in the merge "
+        "queue by construction (six such PRs measured open on 2026-08-31)."
+    )
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
+    if today < EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE:
+        return [], f"evidence_root_brief_deprecated: {message}"
+    return [f"evidence_root_brief_deprecated: {message}"], None
+
+
 # ------------------------------------------------------------------- lint()
 
 
@@ -2439,6 +2534,7 @@ def lint(
     numstat_text: str | None = None,
     source_path: str | None = None,
     measured_commits: int | None = None,
+    brief_source_path: str | None = None,
 ) -> tuple[int, list[str]]:
     """Returns (exit_code, violations). exit_code: 0 clean, 1 guilty, 2 blind.
 
@@ -2518,6 +2614,19 @@ def lint(
     violations += root_violations
     if root_notice:
         print(f"evidence_pack_lint: NOTICE — {root_notice}", file=sys.stderr)
+
+    # Rule 12 — the brief half. Kept as its own call rather than folded into
+    # the pack rule above because the two take DIFFERENT inputs (the pack's
+    # real path vs the brief's real path) and flip on DIFFERENT dates; one
+    # function taking both would make it far too easy for a future edit to
+    # judge a brief against the pack's constant, which is precisely the
+    # blind spot this rule exists to close.
+    brief_root_violations, brief_root_notice = check_brief_not_at_deprecated_root(
+        brief_source_path, repo_root
+    )
+    violations += brief_root_violations
+    if brief_root_notice:
+        print(f"evidence_pack_lint: NOTICE — {brief_root_notice}", file=sys.stderr)
 
     if changed_files is None:
         # Self-contained notice (not folded into the shared "no
@@ -3827,6 +3936,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--net-lines", type=int, default=None, metavar="INT")
     parser.add_argument("--numstat-file", default=None, metavar="PATH")
     parser.add_argument("--source-path", default=None, metavar="PATH")
+    # Rule 12's input: THIS PR's own real brief path, as resolved from its
+    # changed-files list (`scripts/ci/evidence_paths.py --resolve brief`).
+    # Deliberately has NO positional fallback, unlike --source-path above: a
+    # local invocation is given the pack's path and genuinely does not know
+    # where the brief was written, so defaulting it would be a guess dressed
+    # as a measurement. Omitted => Rule 12 skips, silently and by design.
+    parser.add_argument("--brief-source-path", default=None, metavar="PATH")
     # Countable-claims rule: the PR's commit count. Optional — in CI it is read from the
     # pull_request event payload automatically (see measured_commit_count()),
     # so no workflow change is needed; this flag is for local runs and tests.
@@ -3929,7 +4045,7 @@ def main(argv: list[str] | None = None) -> int:
 
     exit_code, violations = lint(
         pack_path, repo_root, changed_files, measured_net_lines, numstat_text,
-        source_path, measured_commits,
+        source_path, measured_commits, args.brief_source_path,
     )
 
     if args.json:

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -9,7 +9,9 @@ colpevolezza" — each guard needs BOTH proofs registered).
 
 from __future__ import annotations
 
+import contextlib
 import datetime
+import io
 import subprocess
 import sys
 from pathlib import Path
@@ -22,6 +24,7 @@ SCRIPTS = REPO / "scripts"
 
 sys.path.insert(0, str(SCRIPTS))
 from evidence_pack_lint import (  # noqa: E402
+    EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE,
     EVIDENCE_ROOT_DEPRECATION_DATE,
     FLOOR_SOURCE_BOTH,
     FLOOR_SOURCE_NONE,
@@ -43,6 +46,7 @@ from evidence_pack_lint import (  # noqa: E402
     check_council_run_gear3,
     check_countable_claims,
     check_dissent_nonempty_on_gear3,
+    check_brief_not_at_deprecated_root,
     check_gear_floor,
     check_ground_truth_lane,
     check_lanes_build_seat_diversity,
@@ -2244,6 +2248,274 @@ def test_evidence_root_cli_explicit_source_path_overrides_default(tmp_repo):
     payload = _json.loads(result.stdout)
     assert payload["exit"] == 0
     assert not any("evidence_root_deprecated" in v for v in payload["violations"])
+
+
+# ---- rule 12: check_brief_not_at_deprecated_root ---------------------------
+#
+# Rule 9 above judges the PACK's path and is structurally blind to the BRIEF.
+# Measured on origin/main 2026-08-31: six open PRs wrote the root brief, and
+# #5158 had the shape rule 9 cannot see — pack already migrated to a per-task
+# directory, brief still at the root, rule 9 green while the collision was
+# live. These tests pin BOTH the new rule's guilt and the one innocence case
+# that would break the whole fleet if it regressed: the mandatory
+# `brief_ref: evidence/brief.yml` STRING must never be mistaken for a root
+# brief FILE write.
+
+_BRIEF_ROOT_PRE_FLIP = EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE - datetime.timedelta(days=1)
+_BRIEF_ROOT_POST_FLIP = EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE
+
+
+def test_brief_root_guilt_root_path_post_flip_rejected(tmp_path):
+    viol, notice = check_brief_not_at_deprecated_root(
+        "evidence/brief.yml", tmp_path, today=_BRIEF_ROOT_POST_FLIP
+    )
+    assert notice is None
+    assert any("evidence_root_brief_deprecated" in v for v in viol)
+    assert any("evidence/brief.yml is deprecated as a WRITE target" in v for v in viol)
+
+
+def test_brief_root_guilt_absolute_root_path_post_flip_rejected(tmp_path):
+    """An absolute path resolving to repo_root/evidence/brief.yml is judged the
+    same as its repo-relative form — a literal-string match alone would miss
+    it, so the shared resolution helper must be doing the work."""
+    absolute = tmp_path / "evidence" / "brief.yml"
+    viol, notice = check_brief_not_at_deprecated_root(
+        str(absolute), tmp_path, today=_BRIEF_ROOT_POST_FLIP
+    )
+    assert notice is None
+    assert any("evidence_root_brief_deprecated" in v for v in viol)
+
+
+def test_brief_root_guilt_dot_segments_normalize_to_root_post_flip(tmp_path):
+    """`evidence/x/../brief.yml` names the root brief; a textual comparison
+    would pass it as per-task. Same gap a cross-family review caught in rule 9
+    (see _pack_source_relpath's docstring) — it must not reopen here."""
+    viol, notice = check_brief_not_at_deprecated_root(
+        "evidence/x/../brief.yml", tmp_path, today=_BRIEF_ROOT_POST_FLIP
+    )
+    assert notice is None
+    assert any("evidence_root_brief_deprecated" in v for v in viol)
+
+
+def test_brief_root_innocence_pre_flip_notice_not_fail(tmp_path):
+    viol, notice = check_brief_not_at_deprecated_root(
+        "evidence/brief.yml", tmp_path, today=_BRIEF_ROOT_PRE_FLIP
+    )
+    assert viol == []
+    assert notice is not None
+    assert "evidence_root_brief_deprecated" in notice
+
+
+def test_brief_root_innocence_per_task_dir_clean_both_sides():
+    """A per-task brief is clean on EITHER side of the flip — this rule only
+    judges the literal root path, never the per-task shape."""
+    for today in (_BRIEF_ROOT_PRE_FLIP, _BRIEF_ROOT_POST_FLIP):
+        viol, notice = check_brief_not_at_deprecated_root(
+            "evidence/2026-08/ops-evidence-pertask-a0adff64/brief.yml",
+            Path("/repo"),
+            today=today,
+        )
+        assert viol == [] and notice is None
+
+
+def test_brief_root_innocence_no_brief_source_path_skipped(tmp_path):
+    """None/empty means the caller has no diff context — skip, don't guess.
+    This is also the LOCAL-invocation path: `evidence_pack_lint.py
+    evidence/pack.yml` knows the pack but not the brief, and there is
+    deliberately no positional fallback to invent one."""
+    for value in (None, ""):
+        viol, notice = check_brief_not_at_deprecated_root(
+            value, tmp_path, today=_BRIEF_ROOT_POST_FLIP
+        )
+        assert viol == [] and notice is None
+
+
+def test_brief_root_does_not_ride_the_pack_rules_flip_date():
+    """The two dates are deliberately separate (see the constant's comment):
+    adding the brief to the pack's 2026-09-05 would silently re-price the
+    readiness measurement taken the day this rule was written. On the pack's
+    flip date the brief must still only NOTICE."""
+    assert EVIDENCE_ROOT_BRIEF_DEPRECATION_DATE > EVIDENCE_ROOT_DEPRECATION_DATE
+    viol, notice = check_brief_not_at_deprecated_root(
+        "evidence/brief.yml", Path("/repo"), today=EVIDENCE_ROOT_DEPRECATION_DATE
+    )
+    assert viol == []
+    assert notice is not None
+
+
+def test_brief_root_innocence_mandatory_brief_ref_string_is_not_a_root_write(tmp_repo):
+    """THE load-bearing innocence case. Every conformant pack in this repo is
+    REQUIRED to declare the literal `brief_ref: evidence/brief.yml` — the
+    staging contract (scripts/ci/evidence_paths.py's module docstring). A rule
+    that judged that STRING instead of the PR's written PATH would fail every
+    correct pack in the fleet.
+
+    The pack below carries that mandatory string (asserted, not assumed) while
+    the PR's resolved brief path is per-task. The rule therefore RUNS — it is
+    given a real path, so it does not short-circuit — and must still find the
+    pack clean, which is only possible if it never reads `brief_ref` at all.
+
+    IT ASSERTS ON STDERR, NOT ONLY ON THE VIOLATION LIST, and that is the
+    whole point — two drafts of this test were insensitive before this one:
+
+      1. The first omitted `brief_source_path` entirely. VACUOUS: with no path
+         the function returns at its first line, so the assertion held whether
+         the rule existed or not. It pinned the skip-when-blind branch (already
+         covered by test_brief_root_innocence_no_brief_source_path_skipped)
+         while claiming to pin the string-vs-path distinction.
+      2. The second supplied the path but still asserted only `rc == 0` and an
+         empty violation list. Also insensitive: today is BEFORE the flip date,
+         so a rule that over-matched every path would emit a NOTICE and still
+         exit 0 — proven by mutation, `if False:` in place of the path
+         comparison left this test green.
+
+    A notice goes to stderr, so stderr is where an over-matching rule becomes
+    visible before its flip date. Verified by mutation both ways: neutering the
+    comparison kills the guilt tests, over-matching it kills this one."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    pack_file = write_pack()
+    assert "brief_ref: evidence/brief.yml" in pack_file.read_text(encoding="utf-8")
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc, viol = lint(
+            tmp_path / "evidence" / "pack.yml",
+            tmp_path,
+            None,
+            brief_source_path="evidence/2026-08/some-task-a0adff64/brief.yml",
+        )
+    assert rc == 0
+    assert not any("evidence_root_brief_deprecated" in v for v in viol)
+    assert "evidence_root_brief_deprecated" not in err.getvalue()
+
+
+def test_brief_root_end_to_end_notice_pre_flip_does_not_fail(tmp_repo):
+    """End-to-end through lint() with a ROOT brief path: today is before the
+    flip date, so this NOTICEs and exits 0.
+
+    It asserts the notice IS EMITTED, not merely that nothing failed. Asserting
+    only `rc == 0` would leave this test green against a DELETED rule — the
+    guilt tests would still catch that, but a test that cannot tell "correctly
+    silent" from "not wired up at all" is not evidence of wiring, and wiring is
+    exactly what this end-to-end case exists to prove."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    write_pack()
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        rc, viol = lint(
+            tmp_path / "evidence" / "pack.yml",
+            tmp_path,
+            None,
+            brief_source_path="evidence/brief.yml",
+        )
+    assert rc == 0
+    assert not any("evidence_root_brief_deprecated" in v for v in viol)
+    assert "evidence_root_brief_deprecated" in err.getvalue()
+
+
+def test_brief_root_resolver_seam_produces_diff_relative_paths_not_the_staged_name():
+    """THE SEAM TEST, and it exists because a cross-family reviewer refused to
+    take it on faith (tp1-glm-5.2, 2026-08-31, on this PR's own diff).
+
+    Its objection: the rule's safety rests entirely on `--brief-source-path`
+    carrying a DIFF-RELATIVE path. CI lints a synthetic tree where the brief is
+    always staged under the canonical name `evidence/brief.yml`; if the value
+    handed to this rule came from that tree, then on the flip date EVERY
+    conformant PR in the fleet would be judged as writing the root brief and
+    the whole queue would go red. The reviewer's verdict was DO-NOT-SHIP on the
+    grounds that the diff asserted the link in a docstring and pinned it
+    nowhere — the assertion spans two modules, so neither module's own tests
+    covered it.
+
+    The conclusion was wrong and the demand was right. `resolve_evidence_path`
+    is a pure function over the changed-files LIST — it never touches the
+    filesystem, so it cannot see the staged tree, and harness-floor.yml calls
+    it at Step 2b, before staging exists at all. This test pins that end to
+    end rather than restating it: the resolver's real output, for each of the
+    three diff shapes, fed to the real rule."""
+    # scripts/ci is not on sys.path for this module (only scripts/ is), and it
+    # is added HERE rather than at import time on purpose: a module-level
+    # sys.path mutation would change resolution for every other test in this
+    # file, which is a side effect nobody reading them would expect.
+    sys.path.insert(0, str(SCRIPTS / "ci"))
+    from evidence_paths import resolve_evidence_path  # noqa: PLC0415
+
+    per_task = "evidence/2026-08/agent-x-infra-thing-a0adff64/brief.yml"
+
+    # (1) a PR that wrote a per-task brief -> per-task path -> clean, even
+    #     past the flip date. This is the case the reviewer feared would
+    #     collapse to the staged canonical name. It does not.
+    resolved = resolve_evidence_path("brief", ["scripts/x.py", per_task])
+    assert resolved == per_task
+    viol, notice = check_brief_not_at_deprecated_root(
+        resolved, Path("/repo"), today=_BRIEF_ROOT_POST_FLIP
+    )
+    assert viol == [] and notice is None
+
+    # (2) a PR that wrote the ROOT brief -> root path -> flagged. The rule
+    #     must still bite, or it protects nothing.
+    resolved = resolve_evidence_path("brief", ["scripts/x.py", "evidence/brief.yml"])
+    assert resolved == "evidence/brief.yml"
+    viol, _ = check_brief_not_at_deprecated_root(
+        resolved, Path("/repo"), today=_BRIEF_ROOT_POST_FLIP
+    )
+    assert any("evidence_root_brief_deprecated" in v for v in viol)
+
+    # (3) a PR that wrote NO brief also resolves to the root path (documented
+    #     pre-migration fallback). That shape never reaches this rule, because
+    #     harness-floor.yml gates the lint step on the brief being present in
+    #     THIS PR's diff — recorded here so a future reader who finds the
+    #     fallback alarming can see it was considered, not missed.
+    assert resolve_evidence_path("brief", ["scripts/x.py"]) == "evidence/brief.yml"
+
+
+def test_brief_root_cli_accepts_and_threads_brief_source_path(tmp_repo):
+    """CLI contract: --brief-source-path is accepted and reaches the rule. Run
+    with a per-task value so the assertion is about THREADING, not about the
+    date — a value the rule must find clean, on stderr as well as in the
+    violation list (pre-flip, an over-matching rule shows up ONLY on stderr)."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    write_pack()
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPTS / "evidence_pack_lint.py"),
+            "evidence/pack.yml", "--repo-root", str(tmp_path),
+            "--brief-source-path", "evidence/2026-08/some-task-a0adff64/brief.yml",
+            "--json",
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    import json as _json
+
+    payload = _json.loads(result.stdout)
+    assert payload["exit"] == 0
+    assert not any("evidence_root_brief_deprecated" in v for v in payload["violations"])
+    assert "evidence_root_brief_deprecated" not in result.stderr
+
+
+def test_brief_root_cli_absent_flag_leaves_rule_inert(tmp_repo):
+    """CLI contract, and the DIVERGENCE from --source-path worth pinning:
+    --source-path defaults to the positional pack argument, --brief-source-path
+    has NO fallback. Omitted, rule 12 is inert — a local run must not invent a
+    brief location it cannot know."""
+    tmp_path, write_brief, write_pack = tmp_repo
+    write_brief(gear=1)
+    write_pack()
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPTS / "evidence_pack_lint.py"),
+            "evidence/pack.yml", "--repo-root", str(tmp_path), "--json",
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    import json as _json
+
+    payload = _json.loads(result.stdout)
+    assert payload["exit"] == 0
+    assert not any("evidence_root_brief_deprecated" in v for v in payload["violations"])
+    assert "evidence_root_brief_deprecated" not in result.stderr
 
 
 # --------------------------------------------------------- check_countable_claims


### PR DESCRIPTION
## What

Rule 9 deprecates writing the evidence **pack** to the fixed repo-root `evidence/pack.yml`, because a fixed shared path makes any two Gear>=2 PRs mutually exclusive in the merge queue by construction. It compares only the resolved pack path and **takes no brief argument at all**, so it is structurally blind to where the **brief** lives.

Measured by executing `check_pack_not_at_deprecated_root` from `origin/main` with `today` past its flip date:

| `source_path` | verdict |
|---|---|
| `evidence/pack.yml` | VIOLATION |
| `evidence/2026-08/<slug>/pack.yml` | `([], None)` — clean at **any** date |

So a PR whose pack is correctly migrated but whose diff still modifies the root `evidence/brief.yml` is clean under Rule 9 forever, while still colliding.

**Six open PRs write that file today** — #5158, #5072, #5037, #4645, #4644, #4640. Five have pack *and* brief at root, so Rule 9 already sees them. #5158 has the invisible shape exactly: per-task pack (ADDED), root brief (MODIFIED), Rule 9 green. Three `queue_unstick` fleet-watch messages independently named `evidence/brief.yml` as the conflicting file on PRs in that set.

## How it surfaced

Not by reading the code. Counting how many open PRs touch that path gave **6**; this morning's readiness report named **3**. Chasing that discrepancy is what exposed the asymmetry.

## The distinction this rule must not get wrong

Every conformant pack is **required** to declare the literal string `brief_ref: evidence/brief.yml` — the staging contract. That string is therefore present in every correct pack in the repo. This rule judges **the path the PR's diff wrote**, never a field in the pack; a rule that judged the string would fail the entire fleet. Two innocence tests pin it, and one dies under an over-matching mutation.

## Design choices worth arguing with

- **No positional fallback** for `--brief-source-path`, unlike `--source-path`. A local run knows the pack's path and genuinely does not know the brief's — defaulting it would be a guess dressed as a measurement.
- **Inert, not fail-closed**, when the running lint copy lacks the flag. CI stages the brief under the canonical name, so a fallback would accuse every correct pack.
- **Its own flip date, 2026-09-12**, deliberately not the pack's 2026-09-05. Riding that date would silently turn this morning's measured *"3 PRs newly RED"* into 6 with nobody re-measuring, and the standing instruction in that report is to move dates only "if we are ready".

## Verification, in both directions

| mutation of the single path comparison | tests killed |
|---|---|
| always-clean (`if True:`) | **6** — three guilt cases, the pre-flip notice, the separate-dates test, the end-to-end wiring case |
| always-fires (`if False:`) | **4** — per-task clean, the mandatory-`brief_ref` innocence case, CLI threading, the resolver seam |

The resolver-seam test dies under **both**. 300 pass (275 pre-existing + 25 new), `actionlint` rc=0, `ruff` clean.

Two tests were insensitive before mutation testing caught them — one vacuous (never passed the path, so it held against a deleted rule), one date-blind (pre-flip, an over-matching rule only NOTICEs and `rc == 0` cannot tell that from clean). Both now assert on stderr. The history is kept in their docstrings.

## Cross-family review

Nearly dark tonight. Four seats dispatched on the real diff; three returned non-answers for three different reasons — kimi a weekly quota ceiling, codex a workspace credit exhaustion, `tp1-qwen3.8-max` a response its wrapper could not parse despite the model producing ~20k tokens.

**`tp1-glm-5.2` answered DO-NOT-SHIP**: the diff never proved `BRIEF_PATH` carries a diff-relative path, so if the resolver read the staged tree the whole fleet would go red on the flip date. **Conclusion refuted, demand adopted** — `resolve_evidence_path` is a pure function over the changed-files list with no filesystem access, and Step 2b runs it before the staged tree exists; that seam is now pinned by an executable test instead of a docstring.

GLM is not in the lint's `COUNCIL_REVIEW_SEATS` allowlist, so R9's council requirement will NOTICE. Left to notice rather than worked around.

## What this does not do

- Does **not** migrate the six in-flight PRs — other lanes' branches, and they are already blocked by DIRTY today. This breaks no working PR; it explains why already-broken ones are broken and stops the seventh.
- Adds no lint for the class "a rule enforces half the surface its docstring describes". Rules 9 and 12 are symmetric by hand, not by construction.