### PR TITLE
fix(ci): the depot-retry comment overclaimed what it measured

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -201,9 +201,10 @@ jobs:
           # blocked for one continuous four-hour stretch. Each of the four
           # still burned exactly ONE of the three attempts: at the time, the
           # retry branch below only matched the LEASE signature (it has since
-          # been widened, in this same change, to also match the DEPOT
-          # signature a few lines down), so every one of these four failures
-          # fell straight through to `exit` on attempt 1. So on each of those
+          # been widened, in PR #5422 -- already merged, not part of this
+          # comment-only diff -- to also match the DEPOT signature a few
+          # lines down), so every one of these four failures fell straight
+          # through to `exit` on attempt 1. So on each of those
           # four runs the loop had two unused attempts. Depot stays the
           # default (it is faster); this only says that when depot itself is
           # the thing that is down, the retry must use a different builder.

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -188,16 +188,25 @@ jobs:
         run: |
           # `--depot=false` is appended only from attempt 2 onward, and only after a
           # depot-builder failure: a retry that changes nothing is a repetition,
-          # not a retry. Measured 2026-08-31: FOUR consecutive deploys died on
+          # not a retry. Measured 2026-08-31 against real job logs: the depot
+          # builder failed FOUR times between 23:06Z and 03:04Z (jobs
+          # 99336828116/99344068116/99365231097/99367317411), each dying on
           # `Waiting for depot builder...` -> `error releasing builder:
           # deadline_exceeded` -> `failed to fetch an image or build from
-          # source`, roughly 23:06Z to 03:04Z. Each burned exactly ONE of the
-          # three attempts, because the retry branch below only ever matched the
-          # LEASE signature; every other failure fell straight through to `exit`.
-          # So the loop had two unused attempts while delivery was blocked for
-          # four hours. Depot stays the default (it is faster); this only says
-          # that when depot itself is the thing that is down, the retry must use
-          # a different builder.
+          # source`. These four did NOT form one unbroken run: a fifth deploy
+          # in the same window (job 99361567807, 02:14-02:21Z) used the same
+          # default depot builder and succeeded, landing chronologically
+          # between the second and third failures -- so this was an
+          # intermittent fault, not a sustained outage, and delivery was not
+          # blocked for one continuous four-hour stretch. Each of the four
+          # still burned exactly ONE of the three attempts: at the time, the
+          # retry branch below only matched the LEASE signature (it has since
+          # been widened, in this same change, to also match the DEPOT
+          # signature a few lines down), so every one of these four failures
+          # fell straight through to `exit` on attempt 1. So on each of those
+          # four runs the loop had two unused attempts. Depot stays the
+          # default (it is faster); this only says that when depot itself is
+          # the thing that is down, the retry must use a different builder.
           depot_flag=""
           for attempt in 1 2 3; do
             echo "Fly deploy attempt ${attempt}/3${depot_flag:+ (${depot_flag})}"
@@ -224,14 +233,22 @@ jobs:
               continue
             fi
 
-            # Only "error releasing builder" is depot-specific. Measured 2026-08-31 against real
-            # job logs: "Waiting for depot builder" is the routine build-phase banner and
-            # appears in a SUCCESSFUL deploy (job 99361567807) and in three release-command
-            # failures that had nothing to do with depot (99306685764/99310369478/99317094020);
-            # "failed to fetch an image or build from source" is flyctl's build-phase wrapper,
-            # not a depot signature. Either term would make a broken Dockerfile burn two
-            # pointless retries and delay the failure alert. "error releasing builder" was
-            # present in all four real depot incidents and absent from every clean sample.
+            # Only "error releasing builder" is depot-specific.
+            #
+            # MEASURED, 2026-08-31, against real job logs: "Waiting for depot builder" is the
+            # routine build-phase banner -- it appears in a SUCCESSFUL deploy (job 99361567807)
+            # and in five release-command failures that had nothing to do with depot
+            # (99306685764/99310369478/99317094020/99327541263/99318055618), every one of which
+            # reached a successful build and died only when the release_command (DB migration)
+            # step ran.
+            #
+            # REASONED, not measured, from the above: "failed to fetch an image or build from
+            # source" is flyctl's generic build-phase wrapper text, not a depot-specific
+            # signature -- a finite log sample cannot measure a string's general meaning into a
+            # "never depot-specific" guarantee, so this is inference, not a grep result. Either
+            # term would make a broken Dockerfile burn two pointless retries and delay the
+            # failure alert. "error releasing builder" was present in all four real depot
+            # incidents and absent from every clean sample.
             if grep -Eiq "error releasing builder" fly-deploy.log && [ "$attempt" -lt 3 ]; then
               echo "::warning::Fly depot builder unreachable; retrying on the non-depot remote builder"
               depot_flag="--depot=false"

--- a/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/brief.yml
@@ -1,0 +1,126 @@
+task_id: comment-accuracy-0831
+gear: 3
+l_level: L2
+gate_class: opus
+objective: |
+  Correct two self-descriptive comment blocks in `.github/workflows/fly-deploy.yml` (the
+  `deploy` job's depot-retry loop, merged via PR #5422 earlier today) whose "Measured
+  2026-08-31" claims do not match the real job logs. Both defects were found and reported by
+  the dispatching team lead, cross-checked against an independent judge's diagnosis, and
+  RE-MEASURED by this task from scratch (fresh `gh run list` / `gh run view --job <id> --log`
+  calls in this session, not copied from either party) before any text was written, per the
+  team lead's explicit standing instruction: "rimisura tu prima di scrivere ... se la tua
+  misura diverge dalla mia, la tua vince e voglio saperlo."
+
+  DEFECT 1 (lines 191-198 on the pre-fix blob, now the first edited block): the comment said
+  "FOUR consecutive deploys died ... roughly 23:06Z to 03:04Z ... delivery was blocked for
+  four hours." Re-measured this session via `gh run list --workflow=fly-deploy.yml` +
+  `gh run view <run> --json jobs` for the window: there ARE exactly four depot-signature
+  failures in that window (deploy jobs 99336828116/99344068116/99365231097/99367317411,
+  23:10:53Z-03:04:23Z), but they are NOT consecutive -- a fifth deploy in the same window
+  (job 99361567807, 02:14:54-02:21:40Z) used the same default depot builder and SUCCEEDED,
+  sitting chronologically between the second and third failures. So this was an intermittent
+  depot fault, not a sustained outage, and delivery was not blocked for one continuous
+  four-hour stretch. This matches the dispatching team lead's own `gh run list` measurement
+  exactly (their message gave the same 5-run table, same success job id, same timestamp).
+
+  DEFECT 2 (lines 227-234 on the pre-fix blob, now the second edited block): the comment's
+  "Measured 2026-08-31 against real job logs:" header covered a mix of two different kinds of
+  claim without saying so -- a MEASURED claim (grep results against real job logs: which two
+  banner strings appear in which jobs) and a REASONED claim (an inference about what
+  "failed to fetch an image or build from source" IS -- flyctl's generic build-phase wrapper
+  text, not a depot-specific signature -- which is not something a finite log sample can
+  measure into a universal "never depot-specific", it is argued from what the string means).
+  Presenting both under one "Measured" header lets the reasoned sentence borrow the measured
+  sentence's authority. Fix: split the block so the header covers only the grep-verified
+  facts, and the inference is explicitly labelled "Reasoned, not measured". The block's own
+  discriminating conclusion -- '"error releasing builder" was present in all four real depot
+  incidents and absent from every clean sample' -- is independently re-verified TRUE this
+  session (see receipts) and is left byte-for-byte unchanged, per the team lead's explicit
+  instruch not to weaken it. The original block cited 3 non-depot release-command failures as
+  its "clean sample" (99306685764/99310369478/99317094020); the team lead's follow-up message
+  named 2 more (99327541263/99318055618) that belong to the same clean-sample class and were
+  missing from the comment -- this task re-verified all 5 by reading their actual job logs
+  (not just conclusions) and adds all 5 to the corrected text.
+
+  Both defects are TEXT-ONLY (comments inside a `run: |` block) -- no change to the retry
+  loop's executable logic, no change to the alert-stage fix shipped separately in PR #5434
+  (different branch, different worktree, not touched by this diff).
+
+constraints:
+  - "Text-only: no change to any executable line in fly-deploy.yml. Verified via
+    `git diff --cached` review before commit -- every changed line is inside a `#`-prefixed
+    comment."
+  - "Do not touch PR #5434 (alert-stage `if:` fix, separate branch
+    agent/nuzantara/infra/alert-stage, open with auto-merge armed) or its worktree -- disjoint
+    line ranges (that PR touches the deploy-failure-alert job's 'Determine failing stage'
+    step, far below the `deploy` job this PR edits), disjoint branches, cut from the same
+    fresh origin/main independently."
+  - "Every job ID cited in the corrected text must resolve to a real GitHub Actions job with
+    log content matching the claim made about it -- verified this session via
+    `gh run view --job <id> --log` for all 4 depot-incident jobs + all 5 non-depot-failure
+    jobs + the 1 successful job (10 total), not merely via job conclusion/metadata."
+  - 'The block''s final, undisputed sentence (''"error releasing builder" was present in all
+    four real depot incidents and absent from every clean sample'') is preserved verbatim --
+    only the material BEFORE it is restructured to separate measured from reasoned.'
+
+acceptance:
+  - text: >
+      WHEN a reader reads the depot-retry loop's first comment block (the `--depot=false`
+      rationale), the four-incident timing claim SHALL name the four specific job IDs and
+      SHALL state explicitly that they were not consecutive, naming the intervening
+      successful job.
+    probe: "grep -A2 '23:06Z and 03:04Z' .github/workflows/fly-deploy.yml | grep -c 'NOT'"
+  - text: >
+      WHEN a reader reads the same block's conclusion about blocked delivery, it SHALL NOT
+      claim a single continuous four-hour block -- it SHALL name the intermittent nature and
+      point at the successful job sitting inside the window.
+    probe: "grep -c 'blocked for.*four hours\\.' .github/workflows/fly-deploy.yml (expect 0 as a bare, unqualified claim); grep -c 'did NOT form one unbroken run' .github/workflows/fly-deploy.yml (expect 1)"
+  - text: >
+      WHEN a reader reads the second comment block (why "error releasing builder" was chosen
+      as the trigger string), the claim about "Waiting for depot builder" SHALL cite five
+      non-depot release-command failure job IDs (not three), and the claim about
+      "failed to fetch an image or build from source" not being depot-specific SHALL be
+      labelled as reasoning, not measurement.
+    probe: "grep -ic 'REASONED, not measured' .github/workflows/fly-deploy.yml (expect >=1); grep -c '99327541263/99318055618' .github/workflows/fly-deploy.yml (expect 1)"
+  - text: >
+      WHILE the file is linted with `actionlint -shellcheck=` (the exact invocation the
+      REQUIRED CI gate runs), the finding count SHALL be 0, matching origin/main -- comment-only
+      changes cannot introduce a schema/expression finding, and shellcheck itself is disabled
+      on this gate.
+    probe: "actionlint -shellcheck= .github/workflows/fly-deploy.yml"
+  - text: >
+      WHERE bare `actionlint` (shellcheck enabled) is applied, the finding count SHALL stay at
+      the pre-existing baseline (14, all pre-existing SC2086/SC2129 findings in unrelated
+      `run:` blocks) -- this diff touches no shell code, only comments.
+    probe: "actionlint .github/workflows/fly-deploy.yml | wc -l (expect 56 lines / 4 lines-per-finding = 14)"
+
+consumer_map:
+  - "`.github/workflows/fly-deploy.yml`, `deploy` job -- human operators reading the retry
+    loop's own comments during an incident (the exact audience the two corrected claims were
+    misleading)."
+  - "PR #5422's own review trail / this Gear-3 gate's caveat history -- the caveat that started
+    this whole thread; this PR is the second, independent correction on the same file the same
+    day (first was the `if:` stage-attribution fix in #5434)."
+  - "No PENDING-ARMS row needed -- a merged GitHub Actions workflow file is armed by
+    construction (GitHub picks it up on the next matching push), same reasoning #5422's and
+    #5434's own packs recorded for the same file."
+
+risks:
+  - "Residual, LOW severity: this task did not attempt to independently re-derive the 'absent
+    from every clean sample' universal claim against a wider corpus than the 6 jobs actually
+    checked (1 success + 5 non-depot failures) -- the corrected text's own final sentence
+    scopes the claim to 'every clean sample' as defined by the jobs actually cited, not a
+    claim about all Fly deploy history. If a wider corpus later surfaces a non-depot failure
+    that DOES contain 'error releasing builder', that would falsify the trigger-string choice
+    itself (a defect in PR #5422's code, not in this PR's comment accuracy) -- out of scope
+    here, this PR only makes the comment match the sample it already cites."
+  - "This task could not obtain the OTHER agent's/judge's literal corrected sentence for the
+    second block (the summary handed to this session paraphrased its content and purpose but
+    did not preserve the exact string) -- rather than fabricate a quotation, this task wrote
+    its own corrected text grounded in its own fresh log reads, structured to satisfy the same
+    stated requirement (separate measured from reasoned; add the 2 missing job IDs; leave the
+    final sentence unweakened). If the dispatching team lead specifically wanted the other
+    party's exact wording reproduced verbatim, that is a follow-up, not a defect in the
+    underlying facts -- every fact stated in the new text was independently re-verified this
+    session against real job logs."

--- a/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/brief.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/brief.yml
@@ -70,7 +70,7 @@ acceptance:
       rationale), the four-incident timing claim SHALL name the four specific job IDs and
       SHALL state explicitly that they were not consecutive, naming the intervening
       successful job.
-    probe: "grep -A2 '23:06Z and 03:04Z' .github/workflows/fly-deploy.yml | grep -c 'NOT'"
+    probe: "grep -c '99336828116/99344068116/99365231097/99367317411' .github/workflows/fly-deploy.yml (expect 1, all 4 job IDs named); grep -c 'did NOT form one unbroken run' .github/workflows/fly-deploy.yml (expect 1, the not-consecutive claim, naming job 99361567807 as the intervening success in the same sentence)"
   - text: >
       WHEN a reader reads the same block's conclusion about blocked delivery, it SHALL NOT
       claim a single continuous four-hour block -- it SHALL name the intermittent nature and

--- a/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/pack.yml
@@ -1,0 +1,261 @@
+brief_ref: evidence/brief.yml
+plan_ref: "none -- single-session text fix, no separate plan doc"
+
+lanes:
+  - lane: D1
+    role: build
+    seat: claude
+  - lane: D2
+    role: review
+    seat: gemini-3.1-pro
+
+seat_diversity_note: >
+  Two lanes declared: build (claude, this session) and review (gemini-3.1-pro via `agy`,
+  non-Anthropic). Cross-family adversarial review requirement satisfied by the review lane.
+  Kimi K3 was attempted first and returned a 403 weekly-quota-exhausted error (see receipts);
+  Codex was not attempted for this PR specifically -- superscar/memory flags `codex-spalla.sh`
+  exit 2 as meaning "codex never ran" on the currently pinned CLI version (`--full-auto`
+  removed in codex-cli 0.149.1, this repo pins 0.142.0 in doctrine) -- so agy was used directly
+  rather than burning a call on a known-broken invocation shape.
+
+diff:
+  net_lines: >
+    Measured via `git diff --cached --numstat` + `evidence_pack_lint.py --print-measured`
+    after staging BOTH the workflow fix and this pack: three files changed. The workflow
+    comment fix is 33 inserted lines and 16 deleted lines in one file
+    (.github/workflows/fly-deploy.yml). The evidence brief is 126 inserted lines, zero deleted,
+    in a new file. This pack file, once staged, adds its own inserted lines on top of that --
+    see the canonical sentence in receipts for the exact combined total this task actually
+    committed, which is authoritative over any number restated here.
+  behaviour_change: |
+    TEXT-ONLY. Zero executable-line changes in fly-deploy.yml -- every changed line is inside
+    a `#`-prefixed comment in the `deploy` job's "Deploy (rolling strategy, monorepo context)"
+    step. Confirmed by manual diff review before staging: every `+`/`-` line in the diff hunk
+    begins with whitespace then `#`.
+
+    WHAT CHANGED AND WHY (two independent corrections to the same retry-loop comment block,
+    both self-measured this session from `gh run list`/`gh run view --job <id> --log`, not
+    copied from any other party's report):
+
+    1. First comment block (the `--depot=false` rationale, right before the retry `for` loop):
+       replaced "FOUR consecutive deploys died ... delivery was blocked for four hours" with
+       an accurate account -- four depot-signature failures in the 23:06Z-03:04Z window
+       (jobs 99336828116/99344068116/99365231097/99367317411), but NOT an unbroken run: a
+       fifth deploy in the same window (job 99361567807, 02:14-02:21Z) used the same depot
+       builder and succeeded, landing between the second and third failures. So: intermittent
+       fault, not sustained outage; delivery was not blocked for one continuous four-hour
+       stretch. Also clarified (per adversarial review, see receipts) that "the retry branch
+       below only matched the LEASE signature" describes historical (pre-widening) behavior,
+       not the code as it reads today a few lines below -- to avoid the comment appearing to
+       contradict the code it sits above.
+
+    2. Second comment block (why "error releasing builder" was chosen as the retry-trigger
+       string): the original put a measured claim and a reasoned claim under one "Measured
+       2026-08-31" header, letting the reasoned claim (that "failed to fetch an image or build
+       from source" is generic, non-depot-specific flyctl wrapper text) borrow the measured
+       claim's authority. Split into two explicitly labelled paragraphs -- "MEASURED, ... :"
+       (grep-verified: which banner strings appear in which of 6 real job logs) and "REASONED,
+       not measured, from the above:" (the inference about what the generic string means).
+       Also added 2 more non-depot release-command failure job IDs (99327541263/99318055618)
+       to the measured clean-sample list, alongside the original 3, after independently
+       reading all 5 jobs' actual log content (not just their conclusion) and confirming each
+       one reached a successful build and died only at the release_command (DB migration)
+       step -- zero occurrence of any depot-specific string in any of the 5.
+       The block's own discriminating conclusion -- "error releasing builder" was present in
+       all four real depot incidents and absent from every clean sample -- is left BYTE-FOR-
+       BYTE UNCHANGED (verified via a de-wrapped text diff against origin/main's version of
+       the same sentence, see receipts): re-independently-confirmed true this session, not
+       weakened, not retracted, per explicit instruction not to touch it.
+
+    NOT changed: the retry loop's `if`/`grep`/`continue`/`exit` logic (0 lines), the LEASE
+    retry branch, the `timeout-minutes: 35` comment above the job (separate, already-accurate
+    block), PR #5434's alert-stage fix (different branch/worktree, disjoint line ranges).
+
+receipts:
+  - claim:
+      "Run-level table for the 23:06Z-03:04Z window: 7 runs total in a wider scan, exactly
+      5 within the disputed window, 4 failures NOT consecutive (1 success at 02:09:58Z-
+      02:34:36Z start, job 33349807468, sits between window-failure #2 and #3)."
+    cmd: 'gh run list --workflow=fly-deploy.yml --limit 60 --json databaseId,status,conclusion,createdAt,updatedAt,headBranch,event | python3 -c "...filter 2026-08-30T22:00Z..2026-08-31T04:00Z..."'
+    exit: 0
+    ts: "2026-08-31T (this session, re-measured independently of the dispatching team lead's own report -- numbers matched exactly)"
+    seat: claude
+  - claim:
+      "Deploy-job IDs + start/end timestamps for the 4 window failures: 99336828116
+      (23:10:53-23:21:22Z), 99344068116 (00:11:01-00:21:29Z), 99365231097 (02:39:20-02:49:47Z),
+      99367317411 (02:53:56-03:04:23Z). Last failure's completedAt (03:04:23Z) matches the
+      comment's 'to 03:04Z' claim exactly."
+    cmd: 'gh run view <runid> --json jobs -q ''.jobs[] | select(.name|contains("deploy")) | ...'''
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      'All 4 window-failure jobs'' actual log content confirmed identical depot signature:
+      ''Waiting for depot builder...'' then (twice) ''error releasing builder: deadline_exceeded:
+      context deadline exceeded'' then ''Error: failed to fetch an image or build from source:
+      error building: timed out connecting to machine: failed to list workers: Unavailable:
+      connection error: desc = "transport: authentication handshake failed: EOF"'' -- and
+      each job''s log shows exactly ONE ''Fly deploy attempt X/3'' line (''attempt 1/3''), meaning
+      the outer bash retry loop never reached attempt 2 on any of them (consistent with these
+      4 incidents predating this same PR''s depot-matching retry branch).'
+    cmd: "gh run view --job <id> --log | grep -iE 'Fly deploy attempt|Waiting for depot|error releasing builder|Error: failed to fetch'"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "Success job 99361567807 (inside run 33349807468) ran 02:14:54-02:21:40Z, deploy
+      conclusion=success -- confirms it sits chronologically between window-failure #2
+      (ends 00:21:29Z) and #3 (starts 02:39:20Z), i.e. genuinely 'in the middle', not merely
+      adjacent to one end."
+    cmd: 'gh run view 33349807468 --json jobs -q ''.jobs[] | select(.name|contains("deploy"))'''
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "All 5 non-depot 'clean sample' jobs (99306685764/99310369478/99317094020 from the
+      original comment, plus 99327541263/99318055618 added by this task) independently
+      confirmed via actual log content, not just conclusion: every one reached 'Running
+      nuzantara-rag release_command: sh -c python -m backend.db.migrate apply-all && python -m
+      backend.db.schema_audit' (i.e. build succeeded) and then failed AT that step (either
+      'timeout reached waiting for machine's state to change' or 'exited with non-zero status
+      of 1') -- ZERO occurrence of 'error releasing builder' or 'failed to fetch an image' in
+      any of the 5."
+    cmd: "gh run view --job <id> --log | grep -iE 'Waiting for depot builder|error releasing builder|failed to fetch an image|release_command|Error:'"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "actionlint -shellcheck= (the exact REQUIRED-gate invocation) reports 0 findings on
+      the corrected file; bare actionlint (shellcheck enabled) reports 14 findings -- identical
+      count to origin/main's baseline, all pre-existing SC2086/SC2129 in unrelated `run:`
+      blocks this diff does not touch."
+    cmd: "actionlint -shellcheck= .github/workflows/fly-deploy.yml && actionlint .github/workflows/fly-deploy.yml | grep -c '^\\.worktrees'"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "python3 yaml.safe_load() parses the corrected file without error, both after the
+      initial 2-block edit and again after the 3-point adversarial-review refinement."
+    cmd: 'python3 -c "import yaml; yaml.safe_load(open(''.github/workflows/fly-deploy.yml''))"'
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      'The block''s closing sentence (''"error releasing builder" was present in all four
+      real depot incidents and absent from every clean sample.'') is byte-for-byte identical,
+      after de-wrapping both to single lines, between this branch and origin/main''s version of
+      the same sentence -- confirms the required-untouched claim was not accidentally reworded
+      during the 2-pass edit.'
+    cmd: "diff <(git show origin/main:.github/workflows/fly-deploy.yml | sed -n '227,234p' | sed 's/^ *# \\{0,1\\}//' | tr '\\n' ' ') <(sed -n '236,251p' .github/workflows/fly-deploy.yml | sed 's/^ *# \\{0,1\\}//' | tr '\\n' ' ')"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "Kimi K3 review attempt returned 403 weekly-quota-exhausted before this task started
+      (carried over from the same session's earlier alert-stage PR attempt, same weekly
+      window) -- not re-attempted for this second PR since the quota state does not reset
+      mid-session."
+    cmd: "kimi -p '<review prompt>' -m kimi-code/k3"
+    exit: 1
+    ts: "2026-08-31T (earlier in this session, alert-stage PR work)"
+    seat: kimi
+  - claim:
+      "Gemini 3.1 Pro (agy) cross-family adversarial review completed: confirmed (a) and
+      (b) sound, flagged (c) the inline 'Reasoned, not measured:' label as still creating
+      epistemic confusion under an authoritative 'Measured' header (fixed: split into two
+      explicitly labelled paragraphs, MEASURED / REASONED), flagged (d) the LEASE-signature
+      sentence as readable as contradicting the current code a few lines below if not marked
+      historical (fixed: added 'at the time ... it has since been widened' framing), found (e)
+      no YAML/bash mechanical defect."
+    cmd: 'agy -p "$(cat /tmp/comment-accuracy-full-prompt.txt)" --print-timeout 4m'
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: gemini-3.1-pro
+  - claim:
+      "Canonical measured diff total (evidence_pack_lint.py --print-measured), all three
+      staged files included (workflow fix + brief.yml + pack.yml itself): 3 files, +420/-16,
+      1 commits. This is the authoritative number for this pack -- restated here, not in the
+      diff.net_lines prose above, to avoid the self-reference problem of a pack describing its
+      own not-yet-final line count."
+    cmd: "git diff --cached --numstat > /tmp/numstat3.txt && python3 scripts/evidence_pack_lint.py --numstat-file /tmp/numstat3.txt --commit-count 1 --print-measured"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "All 4 brief.yml acceptance probes re-run against the FINAL (post-review-refinement)
+      file text and all pass: 'did NOT form one unbroken run' present (1x); a bare unqualified
+      'blocked for...four hours.' claim absent (0x); 'REASONED, not measured' present
+      case-insensitively (1x); the 5-job clean-sample list '99327541263/99318055618' present
+      (1x). The two probes as ORIGINALLY worded in the first brief.yml draft ('NOT' near the
+      timestamp line, exact-case 'Reasoned, not measured') returned 0 against this final text
+      because the adversarial-review refinement pass (see the gemini-3.1-pro receipt above)
+      reworded both sentences after the probes were first written -- brief.yml's probe text was
+      updated to match the refined wording rather than leaving a stale probe pointing at text
+      that no longer exists."
+    cmd: "grep -c 'did NOT form one unbroken run' .github/workflows/fly-deploy.yml; grep -c 'blocked for.*four hours\\.' .github/workflows/fly-deploy.yml; grep -ic 'REASONED, not measured' .github/workflows/fly-deploy.yml; grep -c '99327541263/99318055618' .github/workflows/fly-deploy.yml"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+  - claim:
+      "PR #5434 (alert-stage `if:` fix, same-session earlier work) confirmed still OPEN,
+      mergeable=MERGEABLE, auto-merge armed, base an ancestor of current origin/main with only
+      one unrelated commit (#5430) landed since -- confirms this PR's disjoint-branch,
+      disjoint-line-range claim in constraints/consumer_map is accurate as of this task, not
+      stale."
+    cmd: "gh pr view 5434 --json state,mergeable,mergeStateStatus,autoMergeRequest,baseRefOid,headRefOid"
+    exit: 0
+    ts: "2026-08-31T (this session)"
+    seat: claude
+
+pii_scan: clean
+pii_scan_note: >
+  Diff touches only GitHub Actions job-run metadata (numeric job/run IDs, UTC timestamps,
+  flyctl/depot error strings) and a new evidence brief describing the same. No client name,
+  phone, email, passport/KTP/NPWP, or chat content anywhere in the diff.
+
+dissent:
+  - seat: gemini-3.1-pro
+    objection:
+      "The inline 'Reasoned, not measured:' label mid-paragraph does not fully fix the
+      defect -- it still sits under an authoritative 'Measured 2026-08-31 against real job
+      logs:' header covering the whole paragraph, creating epistemic confusion about which
+      sentences are measured vs reasoned."
+    status: CONFIRMED
+    resolution:
+      'Restructured into two separate comment paragraphs with their own headers
+      (MEASURED.../REASONED, not measured, from the above:...), separated by a blank `#` line
+      -- addresses the reviewer''s own suggested fix verbatim ("split the comment into two
+      explicit structural sections").'
+  - seat: gemini-3.1-pro
+    objection:
+      '"These four were NOT consecutive" could be colloquially misread as "no two of
+      these failures were consecutive", when in fact only claiming the four did not form one
+      unbroken run of four.'
+    status: CONFIRMED
+    resolution:
+      'Reworded to "These four did NOT form one unbroken run", matching the
+      reviewer''s own suggested stronger formulation in substance.'
+  - seat: gemini-3.1-pro
+    objection:
+      "The LEASE-signature sentence ('the retry branch below only ever matched the LEASE
+      signature') could read as contradicting the current code immediately below it, which now
+      also matches the DEPOT signature."
+    status: CONFIRMED
+    resolution:
+      'Added explicit historical framing: "at the time, the retry branch below only
+      matched the LEASE signature (it has since been widened, in this same change, to also
+      match the DEPOT signature a few lines down)".'
+  - seat: claude
+    objection:
+      "Risk that this task's own corrected text, while independently re-verified, might
+      not match the exact wording another agent/judge in the dispatching thread already
+      proposed verbatim -- the conversation summary handed to this session paraphrased that
+      party's content/purpose but did not preserve their literal string."
+    status: RETRACTED
+    resolution:
+      "Per the dispatching team lead's own explicit standing instruction
+      ('rimisura tu ... se la tua misura diverge dalla mia, la tua vince') this task's own
+      independently fresh-measured facts take precedence over reproducing anyone else's
+      prose; fabricating a 'verbatim quote' this task does not actually possess would itself
+      be an anti-hallucination violation. Flagged transparently in brief.yml risks and in the
+      final report to the team lead instead of silently guessing at the missing string."

--- a/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/pack.yml
+++ b/evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/pack.yml
@@ -97,7 +97,8 @@ receipts:
       connection error: desc = "transport: authentication handshake failed: EOF"'' -- and
       each job''s log shows exactly ONE ''Fly deploy attempt X/3'' line (''attempt 1/3''), meaning
       the outer bash retry loop never reached attempt 2 on any of them (consistent with these
-      4 incidents predating this same PR''s depot-matching retry branch).'
+      4 incidents predating PR #5422''s depot-matching retry branch -- #5422 is a separate,
+      already-merged PR, not this diff, which is comment-only).'
     cmd: "gh run view --job <id> --log | grep -iE 'Fly deploy attempt|Waiting for depot|error releasing builder|Error: failed to fetch'"
     exit: 0
     ts: "2026-08-31T (this session)"
@@ -172,30 +173,50 @@ receipts:
     ts: "2026-08-31T (this session)"
     seat: gemini-3.1-pro
   - claim:
-      "Canonical measured diff total (evidence_pack_lint.py --print-measured), all three
-      staged files included (workflow fix + brief.yml + pack.yml itself): 3 files, +420/-16,
-      1 commits. This is the authoritative number for this pack -- restated here, not in the
-      diff.net_lines prose above, to avoid the self-reference problem of a pack describing its
-      own not-yet-final line count."
-    cmd: "git diff --cached --numstat > /tmp/numstat3.txt && python3 scripts/evidence_pack_lint.py --numstat-file /tmp/numstat3.txt --commit-count 1 --print-measured"
+      "Canonical measured diff total (evidence_pack_lint.py --print-measured), measured against
+      the origin/main merge-base (not HEAD~1, to avoid undercounting after the round-2
+      gate-fix commit), all three files included (workflow fix + brief.yml + pack.yml itself):
+      3 files, +466/-16, 2 commits. This is the authoritative number for this pack -- restated
+      here, not in the diff.net_lines prose above, to avoid the self-reference problem of a
+      pack describing its own not-yet-final line count."
+    cmd: 'MERGE_BASE=$(git merge-base HEAD origin/main) && git diff "$MERGE_BASE" --numstat > /tmp/numstat-total.txt && python3 scripts/evidence_pack_lint.py --numstat-file /tmp/numstat-total.txt --commit-count 2 --print-measured'
     exit: 0
     ts: "2026-08-31T (this session)"
     seat: claude
   - claim:
-      "All 4 brief.yml acceptance probes re-run against the FINAL (post-review-refinement)
-      file text and all pass: 'did NOT form one unbroken run' present (1x); a bare unqualified
-      'blocked for...four hours.' claim absent (0x); 'REASONED, not measured' present
-      case-insensitively (1x); the 5-job clean-sample list '99327541263/99318055618' present
-      (1x). The two probes as ORIGINALLY worded in the first brief.yml draft ('NOT' near the
-      timestamp line, exact-case 'Reasoned, not measured') returned 0 against this final text
-      because the adversarial-review refinement pass (see the gemini-3.1-pro receipt above)
-      reworded both sentences after the probes were first written -- brief.yml's probe text was
-      updated to match the refined wording rather than leaving a stale probe pointing at text
-      that no longer exists."
-    cmd: "grep -c 'did NOT form one unbroken run' .github/workflows/fly-deploy.yml; grep -c 'blocked for.*four hours\\.' .github/workflows/fly-deploy.yml; grep -ic 'REASONED, not measured' .github/workflows/fly-deploy.yml; grep -c '99327541263/99318055618' .github/workflows/fly-deploy.yml"
+      "All 4 brief.yml acceptance probes, AS CURRENTLY WORDED IN brief.yml (post-gate-round-1
+      fix, see the harness/fable-gate receipt below), pass against the final file text: the 4
+      job IDs are named (1x) and 'did NOT form one unbroken run' is present (1x); a bare
+      unqualified 'blocked for...four hours.' claim is absent (0x); 'REASONED, not measured' is
+      present case-insensitively (1x); the 5-job clean-sample list '99327541263/99318055618' is
+      present (1x)."
+    cmd: "grep -c '99336828116/99344068116/99365231097/99367317411' .github/workflows/fly-deploy.yml; grep -c 'did NOT form one unbroken run' .github/workflows/fly-deploy.yml; grep -c 'blocked for.*four hours\\.' .github/workflows/fly-deploy.yml; grep -ic 'REASONED, not measured' .github/workflows/fly-deploy.yml; grep -c '99327541263/99318055618' .github/workflows/fly-deploy.yml"
     exit: 0
-    ts: "2026-08-31T (this session)"
+    ts: "2026-08-31T (this session, post-gate-round-1)"
     seat: claude
+  - claim:
+      'harness/fable-gate round 1 verdict on commit 23fd1dd6e: failure, REWORK-BUILD, two named
+      findings, both CONFIRMED real on inspection (not stale-rollup/timing noise -- verified via
+      the team lead''s own timestamp-check discipline: this was the FIRST verdict for this head
+      SHA, nothing to be stale against). (1) ''probe A1 returns 0 while a receipt claims all 4
+      pass'': TRUE -- brief.yml acceptance item 1''s `probe:` field still read the ORIGINAL
+      pre-refinement text (`grep -A2 ''23:06Z and 03:04Z'' ... | grep -c ''NOT''`), literally
+      returns 0 against the final file (the -A2 window is too narrow to reach the reworded
+      sentence a few lines later), while a pack.yml receipt separately claimed all 4 probes
+      pass using DIFFERENT, already-corrected probe commands -- a real self-consistency defect:
+      the receipt''s claim and the brief''s own stated probe disagreed. Fixed: item 1''s `probe:`
+      field rewritten to the two greps actually used to verify it (job-ID citation + the
+      not-consecutive sentence). (2) "''in this same change'' credits this diff with #5422''s
+      merged widening": TRUE -- the LEASE-signature historical-framing sentence (added during
+      the Gemini-review refinement pass, see dissent entry 3) said the DEPOT-matching retry
+      branch ''...has since been widened, in this same change...'' -- factually wrong, since this
+      diff is comment-only and the DEPOT-matching branch was added by PR #5422 (already merged
+      on origin/main before this branch was ever cut). Fixed: reworded to name PR #5422
+      explicitly (''in PR #5422 -- already merged, not part of this comment-only diff'').'
+    cmd: 'gh api repos/Bali-Zero/Teman2/commits/23fd1dd6e6d600c5cffa2506fcbf63b752d1943a/status -q ''.statuses[] | select(.context=="harness/fable-gate")'''
+    exit: 0
+    ts: "2026-08-31T08:24:27Z (verdict) / 2026-08-31T (this session, fixes applied same session)"
+    seat: harness-fable-gate
   - claim:
       "PR #5434 (alert-stage `if:` fix, same-session earlier work) confirmed still OPEN,
       mergeable=MERGEABLE, auto-merge armed, base an ancestor of current origin/main with only
@@ -214,6 +235,25 @@ pii_scan_note: >
   phone, email, passport/KTP/NPWP, or chat content anywhere in the diff.
 
 dissent:
+  - seat: harness-fable-gate
+    objection:
+      "Round-1 verdict on commit 23fd1dd6e: REWORK-BUILD, two findings. (1) brief.yml
+      acceptance item 1's `probe:` field still read the pre-refinement text (`grep -A2
+      '23:06Z and 03:04Z' ... | grep -c 'NOT'`), which literally returns 0 against the final
+      file, while a pack.yml receipt separately claimed all 4 probes pass using different,
+      already-corrected commands -- the brief's own stated probe and the receipt's claim
+      disagreed. (2) the LEASE-signature historical-framing sentence said the DEPOT-matching
+      retry branch was widened 'in this same change' -- false attribution: this diff is
+      comment-only, the DEPOT branch was added by PR #5422 (already merged before this branch
+      was cut)."
+    status: CONFIRMED
+    resolution:
+      "Both are real defects, not stale-rollup noise (this was the first verdict on this head
+      SHA, so there was nothing to be stale against). (1) fixed: item 1's `probe:` field
+      rewritten to the two greps actually used (job-ID citation + not-consecutive sentence),
+      matching the corrected receipt. (2) fixed: reworded to name PR #5422 explicitly instead
+      of implying this diff added the DEPOT-matching branch. See the dedicated
+      harness-fable-gate receipt above for the full verdict text and fix detail."
   - seat: gemini-3.1-pro
     objection:
       "The inline 'Reasoned, not measured:' label mid-paragraph does not fully fix the
@@ -243,8 +283,13 @@ dissent:
     status: CONFIRMED
     resolution:
       'Added explicit historical framing: "at the time, the retry branch below only
-      matched the LEASE signature (it has since been widened, in this same change, to also
-      match the DEPOT signature a few lines down)".'
+      matched the LEASE signature (it has since been widened, in PR #5422 -- already merged,
+      not part of this comment-only diff -- to also match the DEPOT signature a few lines
+      down)". NOTE: the wording quoted here is the FINAL text, corrected after
+      harness-fable-gate round 1 caught this exact sentence attributing the DEPOT widening to
+      "this same change" instead of PR #5422 -- see the harness-fable-gate dissent entry above
+      for the full story. The intermediate (round-1) wording this entry originally described
+      is not reproduced here to avoid this entry itself going stale a second time.'
   - seat: claude
     objection:
       "Risk that this task's own corrected text, while independently re-verified, might


### PR DESCRIPTION
## What

Two "Measured 2026-08-31" claims in `fly-deploy.yml`'s depot-retry loop comments (merged today
in #5422) do not match the real job logs. Found by the dispatching team lead, cross-checked
against an independent judge, **independently re-measured from scratch in this session**
(fresh `gh run list` / `gh run view --job <id> --log`, not copied from either party's numbers)
per the team lead's explicit instruction to re-measure before writing.

**Text-only** — zero executable-line changes. Every changed line is inside a `#` comment.

## Defect 1: "FOUR consecutive... blocked for four hours" (false)

The four depot incidents are real (deploy jobs `99336828116`/`99344068116`/`99365231097`/
`99367317411`, log-content-verified: each shows `Waiting for depot builder...` →
`error releasing builder: deadline_exceeded` (x2) → `Error: failed to fetch an image or build
from source: ... failed to list workers: ... authentication handshake failed: EOF`, byte-
identical across all 4). But they were **NOT consecutive**: a fifth deploy in the same window
(job `99361567807`, 02:14:54-02:21:40Z) used the same default depot builder and **succeeded**,
sitting chronologically between the 2nd and 3rd failures. Confirmed via the run-level table
below — matches the team lead's own `gh run list` measurement exactly.

| run | created | conclusion |
|---|---|---|
| 33340938229 | 23:06:48Z | **failure** (depot) |
| 33343542886 | 00:05:50Z | **failure** (depot) |
| 33349807468 | 02:09:58Z | success ← sits in the middle |
| 33351104076 | 02:34:36Z | **failure** (depot) |
| 33351904563 | 02:50:08Z | **failure** (depot), completes 03:04:23Z |

So: an intermittent depot fault, not a sustained 4-hour outage. Fixed the comment to say this
explicitly, and to name all 4 job IDs + the intervening success. Also clarified — per
adversarial review — that "the retry branch below only matched the LEASE signature" describes
**historical** (pre-widening) behavior, since the code a few lines below now also matches the
DEPOT signature; left unclarified, the comment could read as contradicting the code under it.

## Defect 2: reasoning dressed as measurement

The "why `error releasing builder` was chosen as the trigger string" block put a **measured**
claim (which banner strings appear in which real job logs) and a **reasoned** claim (that
`failed to fetch an image or build from source` is flyctl's generic wrapper text, not
depot-specific — an inference about what the string *means*, not something a finite sample can
measure into a universal guarantee) under one `Measured 2026-08-31` header. Split into two
explicitly labelled paragraphs (`MEASURED, ...:` / `REASONED, not measured, from the above:`).

Also added the 2 additional non-depot "clean sample" job IDs the team lead's follow-up named
(`99327541263`/`99318055618`), independently verified via actual log content (not just
conclusion) — all 5 non-depot jobs reach `Running nuzantara-rag release_command: ... migrate
apply-all && ... schema_audit` (build succeeded) and fail only at that step, zero occurrence of
any depot signature in any of them.

**The block's own discriminating conclusion — `"error releasing builder" was present in all
four real depot incidents and absent from every clean sample` — is left byte-for-byte
unchanged** (verified via a de-wrapped text diff against `origin/main`'s version of the same
sentence, see pack.yml receipts). Independently re-confirmed true this session; not weakened,
not retracted, per explicit instruction.

## Cross-family review

Gemini 3.1 Pro (`agy`) adversarial review flagged 3 wording-precision issues, all fixed:
- "NOT consecutive" could be misread as "no two were consecutive" → reworded to "did NOT form
  one unbroken run"
- an inline "Reasoned, not measured:" label mid-paragraph still sat under an authoritative
  "Measured" header → restructured into two separate labelled paragraphs
- the historical-LEASE-signature ambiguity noted above

Kimi K3 returned 403 (weekly quota exhausted, carried over from earlier in this session) — not
re-attempted. Codex not attempted: `codex-spalla.sh` exit 2 means "codex never ran" on the
currently pinned CLI (`--full-auto` removed in 0.149.1, this repo pins 0.142.0).

## Verification

- `actionlint -shellcheck=` (the exact REQUIRED-gate invocation): **0 findings**
- bare `actionlint` (shellcheck on): **14 findings**, unchanged from `origin/main` baseline (all
  pre-existing SC2086/SC2129 in unrelated `run:` blocks this diff does not touch)
- `python3 yaml.safe_load()`: parses clean
- `evidence_pack_lint.py`: clean (2 non-blocking NOTICEs — acceptance-probe verbatim-text
  matching and council_run journal, both pre-existing non-enforced items, same as this
  session's earlier PR #5434)

## Scope note

Does not touch PR #5434 (the separate `if:`/stage-attribution fix from earlier in this same
session, branch `agent/nuzantara/infra/alert-stage`) — disjoint line ranges, disjoint branches,
both cut independently from a fresh `origin/main`.

## Known gap (disclosed, not hidden)

The conversation summary handed to this session paraphrased another agent/judge's proposed
corrected wording for Defect 2 but did not preserve their literal string. Rather than fabricate
a "verbatim quote" this session does not actually possess, this PR's text was written fresh
from this session's own independently-verified facts, structured to satisfy the same stated
requirement (separate measured from reasoned; add the 2 missing job IDs; leave the closing
sentence unweakened). Flagged transparently — see `pack.yml` dissent entry 4.

Evidence: `evidence/2026-08/agent-nuzantara-infra-comment-accuracy-c289768b/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)