### PR TITLE
test(ci): cover the cancelled-deploy case in post-deploy-health's reachability proof

### DIFF
--- a/scripts/verify_post_deploy_health_reachability.py
+++ b/scripts/verify_post_deploy_health_reachability.py
@@ -225,6 +225,15 @@ JOB_SCENARIOS = [
         "INNOCENCE 3 — deploy itself skipped (pre-deploy run-migrations blocked it)",
         "skipped", "skipped", "skipped", False,
     ),
+    (
+        "INNOCENCE 4 — deploy itself cancelled (its own timeout-minutes kill, or "
+        "the workflow run was cancelled): no new image shipped, nothing to "
+        "health-check or roll back, same as INNOCENCE 2's deploy=failure sibling "
+        "(deploy-failure-alert's widened if:, PR #5434, owns this case instead — "
+        "job_runs() already returns False here by construction, since it checks "
+        "only deploy_result == 'success'; this scenario was previously unmodeled)",
+        "cancelled", "skipped", "skipped", False,
+    ),
 ]
 
 # (label, job_ran, health_check_passed, expect_rollback_and_alert)


### PR DESCRIPTION
## What

`scripts/verify_post_deploy_health_reachability.py`'s `JOB_SCENARIOS` guilt/innocence table
proves `post-deploy-health`'s `if:` condition (`always() && needs.deploy.result == 'success'`)
against every result `deploy` can conclude with — `success`/`failure`/`skipped` — except
`cancelled`, which was never modeled.

**Coverage-only, no logic changed.** `job_runs()` already handles `cancelled` correctly by
construction: it only ever compares `deploy_result == "success"`, so `"cancelled"` was already
falling into the same `False` branch as `"failure"`/`"skipped"`. This PR just adds the missing
scenario tuple so that correctness is asserted, not merely incidental.

## Why now

Found while cross-checking PR #5434 (the `deploy-failure-alert` `if:` widening to also catch
`cancelled`, merged earlier today) against this script's own scenario table — same file family,
same-day follow-up, same underlying reason `cancelled` needs first-class treatment across this
workflow's failure/alert/health-check chain.

## Change

```python
(
    "INNOCENCE 4 — deploy itself cancelled (its own timeout-minutes kill, or "
    "the workflow run was cancelled): no new image shipped, nothing to "
    "health-check or roll back, same as INNOCENCE 2's deploy=failure sibling "
    "(deploy-failure-alert's widened if:, PR #5434, owns this case instead — "
    "job_runs() already returns False here by construction, since it checks "
    "only deploy_result == 'success'; this scenario was previously unmodeled)",
    "cancelled", "skipped", "skipped", False,
),
```

## Verification

- `python3 scripts/verify_post_deploy_health_reachability.py` → **all 15 scenarios PASS**
  (was 14) — including the script's own self-check against the real `fly-deploy.yml` YAML
  (fails loudly, exit 2, if the job's `needs:`/`if:` ever drifts from what this script models).
- `ruff check` — clean
- `python3 -m py_compile` — clean
- Not hot-zone: `evidence_pack_lint.py --print-floor-source` → `none`. Per
  `harness-floor.yml`'s own contract, a floor<3 PR with no `evidence/brief.yml` resolves to
  pass — no evidence pack built for this one, proportionate to a 9-line, additive-only,
  non-hot-zone test-coverage PR.

## Scope note

Separate from PR #5436 (comment-accuracy fix, same session, same file family, different file —
`.github/workflows/fly-deploy.yml` comments vs this script) and PR #5434 (the `if:` widening
itself, merged). Disjoint files, disjoint branches, each cut independently from a fresh
`origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)