### PR TITLE
fix(infra): worktree reaper trusts a MERGED PR, not just stale content match

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -1219,6 +1219,99 @@ def _content_subset_ok(
     return added_lines.issubset(main_lines)
 
 
+def _gh_pr_state_for_branch(
+    branch: str, *, cwd: Path, timeout: int = 15
+) -> str | None:
+    """Best-effort GitHub PR state for `branch`'s most recently created PR.
+
+    ``gh pr list --search head:<branch> --state all`` — the third, authoritative
+    arm added 2026-09-01 alongside the pre-existing ancestry/content arms (see
+    `_branch_merge_status`): GitHub is the only party that knows a SQUASH
+    merge landed, which is how every PR in this repo merges (W88) — the
+    ancestor test can never be true for a squash-merged branch, and the
+    content/blob-equality fallback answers a different question ("is main's
+    CURRENT copy byte-identical to mine", not "did my work land") and reads a
+    fully-landed branch as unmerged the moment anyone edits one of its files
+    afterward. Measured 2026-09-01: PR #5434 (MERGED) has 3 authored files of
+    which 1 now differs from main; PR #5354 (MERGED) has 15 of which 2 differ.
+
+    Returns one of GitHub's own state strings — "MERGED" / "OPEN" / "CLOSED" —
+    for the most recently created PR whose head is this branch (a branch can
+    accumulate more than one PR over its life — closed-then-reopened, or
+    rebuilt after a squash — ties are broken by `createdAt`, latest wins).
+    Returns "NONE" when `gh` succeeded but no PR was ever opened for this
+    branch — the single most dangerous row on the reaper's board (measured
+    2026-09-01: `wr2/websurface-cure`, `infra/hookw119`, `ops/fix5331` — real
+    committed work that exists nowhere else), which the caller must protect
+    and report distinctly, never fold silently into the generic "unmerged"
+    message.
+
+    Returns None on ANY failure to get a trustworthy answer — `gh` missing,
+    timeout, non-zero exit, unparseable JSON, or an unrecognized `state`
+    value. The caller MUST treat that as "cannot verify via GitHub" and fall
+    through to the offline ancestry/content path, never as "NONE" and never
+    as "MERGED" (W84: cannot-verify must never read as proven — an API
+    failure may only ever make the verdict MORE conservative, never less).
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--search", f"head:{branch}",
+                "--state", "all",
+                "--json", "number,state,createdAt",
+            ],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning(
+            "gh pr list failed for branch %s (%s) — falling back to offline "
+            "ancestry/content check",
+            branch, exc,
+        )
+        return None
+    if proc.returncode != 0:
+        logger.warning(
+            "gh pr list exited %s for branch %s (%s) — falling back to "
+            "offline ancestry/content check",
+            proc.returncode, branch, (proc.stderr or "").strip(),
+        )
+        return None
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        logger.warning(
+            "gh pr list returned unparseable JSON for branch %s — falling "
+            "back to offline ancestry/content check",
+            branch,
+        )
+        return None
+    if not isinstance(data, list):
+        return None
+    if not data:
+        return "NONE"
+
+    def _created_at(row: object) -> str:
+        return row.get("createdAt") or "" if isinstance(row, dict) else ""
+
+    latest = max(data, key=_created_at)
+    if not isinstance(latest, dict):
+        return None
+    state = latest.get("state")
+    if state not in ("MERGED", "OPEN", "CLOSED"):
+        logger.warning(
+            "gh pr list returned unrecognized state %r for branch %s — "
+            "falling back to offline ancestry/content check",
+            state, branch,
+        )
+        return None
+    return state
+
+
 def _worktree_head_branch(worktree: Path) -> str:
     """Short branch name HEAD points to inside ``worktree``, or "" if detached
     or unreadable. Factored out of ``_branch_in_origin_main`` so a caller can
@@ -1233,24 +1326,67 @@ def _worktree_head_branch(worktree: Path) -> str:
     return head.stdout.strip() if head.returncode == 0 else ""
 
 
-def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) -> bool:
-    """True iff the worktree's HEAD is fully merged into ``origin/main``.
+def _branch_merge_status(
+    worktree: Path, *, expect_branch: str | None = None
+) -> tuple[bool, str]:
+    """(merged, reason) — the full verdict AND why, behind `_branch_in_origin_main`
+    (now a thin bool-only wrapper around this).
 
     W80 ANTIBODY guard #2. The reaper must NOT remove a worktree whose work is
     not yet consolidated upstream — a branch that is pushed-but-not-merged (open
     PR) carries the only physical checkout the operator may still be iterating on.
 
-    Implementation: ``git -C <wt> merge-base --is-ancestor HEAD origin/main``
-    (exit 0 ⇒ HEAD is an ancestor of origin/main ⇒ every commit is already in
-    main upstream; exit 1 ⇒ HEAD has commits NOT in origin/main — but the
-    ancestor test is a PROXY that lies on squash-merged/reworked branches
-    (W88), so exit 1 falls through to a per-file CONTENT check: the branch is
-    merged iff every file it authored since its merge-base matches on
-    origin/main. Never the three-dot diff — post-squash the merge-base
-    regresses and three-dot counts main's own progress as branch-only
-    changes, the W88 second-degree trap).
+    Returning the reason alongside the verdict lets a caller's skip message
+    name what was ACTUALLY checked instead of re-deriving (or, worse,
+    assuming) a cause after the fact — the exact W65/W105 trap this file was
+    already burned by once (a skip message asserted "unmerged commits not in
+    origin/main" for a worktree whose real problem was a mid-flight branch
+    rename, which the merge-status check never even looked at). `reason` is
+    one of:
 
-    The per-file check is TWO checks, not one, because "matches" means a
+      "dir-gone"           — worktree directory no longer exists (merged=True)
+      "head-mismatch"      — HEAD is on a different branch than expect_branch (merged=False)
+      "ancestor"           — HEAD is a git ancestor of origin/main (merged=True)
+      "gh-merged"          — branch's most recent PR is MERGED (merged=True)
+      "gh-open"            — branch's most recent PR is still OPEN (merged=False)
+      "gh-closed"          — branch's most recent PR was CLOSED unmerged (merged=False)
+      "gh-no-pr"           — gh succeeded, no PR ever existed for this branch (merged=False)
+      "content-match"      — gh unusable; every changed file matches origin/main by content (merged=True)
+      "content-mismatch"   — gh unusable; at least one changed file differs from origin/main (merged=False)
+      "probe-inconclusive" — merge-base itself failed, or gh unusable AND the
+                              merge-base-vs-origin/main probe failed too (merged=False)
+
+    Three arms, tried in order, on a HEAD that is not a plain ancestor of
+    origin/main:
+
+      1. ``git -C <wt> merge-base --is-ancestor HEAD origin/main`` (exit 0 ⇒
+         HEAD is an ancestor of origin/main ⇒ every commit is already in main
+         upstream). This is the only arm that needs neither `gh` nor a fresh
+         fetch, and it is exact — never a proxy — for a branch with no
+         commits of its own yet.
+      2. The PULL REQUEST arm (added 2026-09-01): ``gh pr list --search
+         head:<branch>`` — GitHub is the only party that knows a SQUASH merge
+         landed, which is how every PR in this repo merges (W88), so the
+         ancestor test in arm 1 can NEVER be true for a squash-merged branch.
+         This arm is AUTHORITATIVE: a MERGED PR means landed regardless of
+         what arm 3 would conclude from current file content (which can go
+         stale the moment anyone else edits a touched file post-merge — see
+         `_gh_pr_state_for_branch`'s docstring for the measured cases). A PR
+         that is OPEN or CLOSED-unmerged, or a branch with NO PR at all,
+         protects immediately — none of those fall through to arm 3, because
+         "no PR" and "PR still open" are answers, not "cannot verify".
+      3. The pre-existing per-file CONTENT check — used only when `gh` itself
+         is unusable (missing/timeout/non-zero exit/bad JSON, i.e.
+         `_gh_pr_state_for_branch` returns None, "cannot verify via GitHub").
+         The branch is judged merged iff every file it authored since its
+         merge-base matches on origin/main. Never the three-dot diff —
+         post-squash the merge-base regresses and three-dot counts main's own
+         progress as branch-only changes (the W88 second-degree trap). This
+         arm is intentionally the LAST resort, not the primary check: it asks
+         "is main's CURRENT copy byte-identical to mine", not "did my work
+         land", and goes stale the instant anyone else touches a shared file.
+
+    Arm 3's per-file check is TWO checks, not one, because "matches" means a
     different thing depending on the path (both findings opened 2026-08-09
     while curing the broker, see PENDING-ARMS.md):
 
@@ -1283,8 +1419,9 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
         bug case, but it ALSO reads >0 for the merge-base check, so we use the
         unambiguous ancestor test against the integration branch directly.
 
-    FAIL-SAFE TO FALSE ("treat as NOT merged ⇒ do NOT reap") on any git error or
-    missing origin/main. A worktree we cannot prove is merged is protected.
+    FAIL-SAFE TO FALSE ("treat as NOT merged ⇒ do NOT reap") on any git error,
+    any `gh` failure, or missing origin/main. A worktree we cannot prove is
+    merged is protected.
 
     `expect_branch` is how a caller that is about to DELETE a branch says which
     entity the verdict must be about. Without it this function answers only
@@ -1294,14 +1431,16 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
     deletes; an earlier version of this docstring claimed detached HEAD failed
     safe, and that was simply not true.
 
-    Note: this does not fetch — it tests against the locally-known origin/main
-    ref. The daily cron environment refreshes refs out of band; a stale
-    origin/main only ever makes us MORE conservative (protect, not reap).
+    Note on freshness: arm 1 and arm 3 test against the locally-known
+    origin/main ref and do NOT fetch themselves — `cmd_cleanup` fetches once
+    per run (`_refresh_origin_main_once`) before calling this at all, so a
+    stale ref here is a fetch-failure/offline case, not the normal path. Arm 2
+    (the PR check) needs no fetch at all — it asks GitHub directly.
     """
     if not worktree.is_dir():
         # Directory already gone — nothing to protect; let cleanup proceed to
         # prune the stale metadata/pointer.
-        return True
+        return True, "dir-gone"
 
     if expect_branch is not None:
         # Every question below is answered by the worktree's HEAD, but the
@@ -1322,7 +1461,7 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
                 "under judgement (%s) — cannot prove that branch is merged",
                 worktree, actual or "detached/unknown", expect_branch,
             )
-            return False
+            return False, "head-mismatch"
 
     proc = _run_git(
         ["merge-base", "--is-ancestor", "HEAD", "origin/main"],
@@ -1330,26 +1469,43 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
         check=False,
     )
     if proc.returncode == 0:
-        return True
+        return True, "ancestor"
     if proc.returncode == 1:
-        # Ancestor check failed (unmerged commits present) — BUT squash merges
-        # and reworks break the ancestor proxy (W88). We must verify by CONTENT
-        # before refusing to reap. A branch is safe to reap if every file it
-        # authored (changed since its merge-base) matches on origin/main —
-        # by ls-tree entry (mode+type+blob) normally, by line-subset for a
-        # declared merge=union path (see this function's own docstring).
+        # Ancestor check failed (unmerged commits present, by ancestry) — the
+        # NORMAL case for a squash-merged branch (W88). Try the authoritative
+        # PR arm before falling to the content check.
+        branch_for_pr = expect_branch or _worktree_head_branch(worktree)
+        if branch_for_pr:
+            pr_state = _gh_pr_state_for_branch(branch_for_pr, cwd=worktree)
+            if pr_state == "MERGED":
+                return True, "gh-merged"
+            if pr_state == "OPEN":
+                return False, "gh-open"
+            if pr_state == "CLOSED":
+                return False, "gh-closed"
+            if pr_state == "NONE":
+                return False, "gh-no-pr"
+            # pr_state is None: gh unusable (missing/timeout/error/bad JSON) —
+            # fall through to the offline content check exactly as before
+            # this arm was added.
+
+        # ARM 3 (offline path): verify by CONTENT. A branch is safe to reap if
+        # every file it authored (changed since its merge-base) matches on
+        # origin/main — by ls-tree entry (mode+type+blob) normally, by
+        # line-subset for a declared merge=union path (see this function's
+        # own docstring).
         mb_proc = _run_git(
             ["merge-base", "origin/main", "HEAD"], cwd=worktree, check=False
         )
         if mb_proc.returncode != 0:
-            return False
+            return False, "probe-inconclusive"
         mb = mb_proc.stdout.strip()
 
         diff_proc = _run_git(
             ["diff", "--name-only", mb, "HEAD"], cwd=worktree, check=False
         )
         if diff_proc.returncode != 0:
-            return False
+            return False, "probe-inconclusive"
 
         for f in diff_proc.stdout.splitlines():
             f = f.strip()
@@ -1358,17 +1514,17 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
 
             if _is_union_merge_path(f, cwd=worktree):
                 if not _content_subset_ok(mb, "HEAD", "origin/main", f, cwd=worktree):
-                    return False
+                    return False, "content-mismatch"
                 continue
 
             bh = _ls_tree_entry("HEAD", f, cwd=worktree)
             mh = _ls_tree_entry("origin/main", f, cwd=worktree)
             if bh != mh:
-                return False
+                return False, "content-mismatch"
 
         # If all changed files match origin/main (entry or line-subset), the
         # content is merged.
-        return True
+        return True, "content-match"
 
     # rc >= 128 (bad ref, not a git dir, unknown HEAD): fail-safe to protect.
     logger.warning(
@@ -1378,7 +1534,20 @@ def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) 
         proc.returncode,
         (proc.stderr or "").strip(),
     )
-    return False
+    return False, "probe-inconclusive"
+
+
+def _branch_in_origin_main(worktree: Path, *, expect_branch: str | None = None) -> bool:
+    """True iff the worktree's HEAD is fully merged into ``origin/main``.
+
+    Thin bool-only wrapper around `_branch_merge_status` — see that function's
+    docstring for the full three-arm rationale (ancestor / GitHub PR / content)
+    and the meaning of every `reason` value. Callers that need to explain a
+    "not merged" verdict (e.g. `cmd_cleanup`'s skip messages) should call
+    `_branch_merge_status` directly rather than re-deriving the reason here.
+    """
+    merged, _reason = _branch_merge_status(worktree, expect_branch=expect_branch)
+    return merged
 
 
 def _resolve_worktree_gitdir(worktree: Path) -> Path | None:
@@ -1505,6 +1674,54 @@ def cmd_list() -> int:
 # ---------------------------------------------------------------------------
 
 
+def _refresh_origin_main_once(*, cwd: Path, timeout: int = 30) -> bool:
+    """``git fetch origin main`` once per ``--cleanup`` run, so the ancestry/
+    content merge-status arms compare against a fresh ``origin/main`` instead
+    of whatever the last fetch — possibly days old — left in place. Cause (1)
+    of the reaper-never-reaps defect measured 2026-09-01: `_branch_merge_status`
+    (formerly `_branch_in_origin_main`)'s own docstring already said neither
+    arm fetches, so a daily cron comparing against a stale `origin/main`
+    called recently-merged work unmerged.
+
+    Called ONCE per `cmd_cleanup` invocation, before the per-worktree loop —
+    not once per worktree: linked worktrees share the same underlying git
+    object database and remote-tracking refs, so a single fetch from any one
+    of them (here, the main checkout) refreshes `origin/main` for every
+    worktree's `_branch_merge_status` call in the same run.
+
+    Best-effort: a failed/offline fetch is logged and `cmd_cleanup` proceeds
+    against the locally-known `origin/main` ref, which only ever makes the
+    ancestry/content arms MORE conservative (protect, never reap) — the
+    authoritative GitHub PR arm doesn't need a fresh `origin/main` at all, it
+    asks GitHub directly. Returns True on success, False otherwise (the
+    caller only logs; cleanup proceeds unconditionally either way).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning(
+            "cleanup: git fetch origin main raised %s — continuing with the "
+            "locally-known origin/main ref",
+            exc,
+        )
+        return False
+    if proc.returncode != 0:
+        logger.warning(
+            "cleanup: git fetch origin main exited %s (%s) — continuing "
+            "with the locally-known origin/main ref",
+            proc.returncode, (proc.stderr or "").strip(),
+        )
+        return False
+    return True
+
+
 def cmd_cleanup(
     *, force: bool = False, skip_recent_minutes: int = RECENT_ACTIVITY_MINUTES
 ) -> int:
@@ -1524,6 +1741,10 @@ def cmd_cleanup(
     skip_recent_minutes=0 disables only the recent-activity guard.
     Returns 0 if every expired worktree was removed cleanly OR no work
     needed; 1 if at least one removal was skipped for WIP / errored.
+
+    Refreshes `origin/main` ONCE for the whole run (`_refresh_origin_main_once`)
+    before any merge-status comparison — see that function's docstring for why
+    once-per-run rather than once-per-worktree is sufficient.
     """
     if _kill_switch_active():
         raise SystemExit(
@@ -1534,6 +1755,8 @@ def cmd_cleanup(
     if not rows:
         print("(nothing to cleanup)")
         return 0
+
+    _refresh_origin_main_once(cwd=REPO_ROOT)
 
     now = datetime.now(timezone.utc)
     issues = 0
@@ -1596,16 +1819,14 @@ def cmd_cleanup(
                     "— active session, will reap when idle"
                 )
                 continue
-            if not _branch_in_origin_main(wt, expect_branch=meta.branch):
-                actual_head = _worktree_head_branch(wt)
-                if actual_head and actual_head != meta.branch:
-                    # Not a merge-status finding at all — HEAD was renamed
-                    # mid-flight (e.g. `git checkout -b <new>` inside the
-                    # worktree) and the registry still names the old branch.
-                    # Reporting "has commits not in origin/main" here would be
-                    # a claim this code path never actually checked (W65 —
-                    # even a guard's own diagnostic can hallucinate a specific
-                    # cause it never verified).
+            merged, reason = _branch_merge_status(wt, expect_branch=meta.branch)
+            if not merged:
+                # Call `_branch_merge_status` ONCE and branch on its own
+                # `reason` — never re-derive a cause after the fact (the
+                # exact W65/W105 trap this file was already burned by: a skip
+                # message must only ever name what was ACTUALLY checked).
+                if reason == "head-mismatch":
+                    actual_head = _worktree_head_branch(wt)
                     logger.warning(
                         "cleanup skip %s — worktree HEAD is on branch %s, "
                         "registered branch is %s (renamed mid-flight?) — "
@@ -1619,7 +1840,50 @@ def cmd_cleanup(
                         f"registered branch is '{meta.branch}') — cannot verify "
                         "merge status, protecting checkout"
                     )
+                elif reason == "gh-no-pr":
+                    # The single most dangerous row on the board (measured
+                    # 2026-09-01: wr2/websurface-cure, infra/hookw119,
+                    # ops/fix5331 — real committed work that exists nowhere
+                    # else) — report it distinctly, never fold it into the
+                    # generic "unmerged commits" message below.
+                    logger.warning(
+                        "cleanup skip %s — branch %s has no pull request at "
+                        "all — this work exists nowhere else, protecting checkout",
+                        meta.task_id,
+                        meta.branch,
+                    )
+                    print(
+                        f"WARN: skip {meta.task_id} (branch '{meta.branch}' has "
+                        "no pull request at all) — protecting checkout, this "
+                        "work exists nowhere else"
+                    )
+                elif reason == "gh-open":
+                    logger.info(
+                        "cleanup skip %s — branch %s has an OPEN pull request",
+                        meta.task_id,
+                        meta.branch,
+                    )
+                    print(
+                        f"skip {meta.task_id} (branch '{meta.branch}' has an "
+                        "OPEN pull request) — protecting checkout, will reap "
+                        "once merged or closed"
+                    )
+                elif reason == "gh-closed":
+                    logger.warning(
+                        "cleanup skip %s — branch %s's pull request was "
+                        "CLOSED without merging",
+                        meta.task_id,
+                        meta.branch,
+                    )
+                    print(
+                        f"WARN: skip {meta.task_id} (branch '{meta.branch}''s "
+                        "pull request was CLOSED without merging) — "
+                        "protecting checkout, operator must inspect"
+                    )
                 else:
+                    # "content-mismatch" / "probe-inconclusive": gh was
+                    # unusable (missing/timeout/error) and the offline
+                    # ancestry/content check also could not prove merged.
                     logger.warning(
                         "cleanup skip %s — branch %s has commits not in origin/main "
                         "(W80: unmerged work, refusing to reap its only checkout)",
@@ -1736,9 +2000,12 @@ def cmd_release(task_id: str, *, force: bool = False) -> int:
         # of safety whatever the recorded base was — the work is upstream, so
         # deleting the branch loses nothing — and `_branch_in_origin_main`
         # fail-safes to False on any git error or missing ref.
-        merged = _branch_in_origin_main(wt, expect_branch=meta.branch)
+        merged, merge_reason = _branch_merge_status(wt, expect_branch=meta.branch)
         if merged:
-            proven_by = "content already on origin/main"
+            proven_by = (
+                "merged PR" if merge_reason == "gh-merged"
+                else "content already on origin/main"
+            )
     if not merged and not force:
         if not _rev_exists(base):
             reason = (

--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -1224,8 +1224,8 @@ def _gh_pr_state_for_branch(
 ) -> str | None:
     """Best-effort GitHub PR state for `branch`'s most recently created PR.
 
-    ``gh pr list --search head:<branch> --state all`` — the third, authoritative
-    arm added 2026-09-01 alongside the pre-existing ancestry/content arms (see
+    ``gh pr list --head <branch> --state all`` — the third, authoritative arm
+    added 2026-09-01 alongside the pre-existing ancestry/content arms (see
     `_branch_merge_status`): GitHub is the only party that knows a SQUASH
     merge landed, which is how every PR in this repo merges (W88) — the
     ancestor test can never be true for a squash-merged branch, and the
@@ -1235,16 +1235,34 @@ def _gh_pr_state_for_branch(
     afterward. Measured 2026-09-01: PR #5434 (MERGED) has 3 authored files of
     which 1 now differs from main; PR #5354 (MERGED) has 15 of which 2 differ.
 
+    ``--head`` (exact filter), NEVER ``--search head:<branch>`` (a search
+    QUALIFIER, prefix-matching and index-backed — superscar family #3,
+    guard-over-match). Measured live 2026-09-01 on a real sibling pair in
+    this repo: `agent/nuzantara/infra/organ-hb-cadence` is a strict prefix of
+    `agent/nuzantara/infra/organ-hb-cadence-wiring`; `--search head:` for the
+    SHORTER branch returned BOTH PRs (including the longer sibling's, #5440,
+    created later), while `--head` returned only the one PR that actually
+    belongs to it (#5431). Because this function is the AUTHORITATIVE arm
+    (a MERGED verdict overrides the content check), the search-qualifier form
+    would let a sibling branch's newer MERGED PR reap a DIFFERENT worktree
+    whose own PR is still OPEN — silent deletion of live, unmerged work, the
+    fail-OPEN direction every other branch of this function is deliberately
+    fail-CLOSED against. `headRefName` is also fetched and used to filter the
+    result set defensively before the `createdAt` tie-break, so a future `gh`
+    regression that reintroduces prefix-matching degrades to "picks the wrong
+    still-correctly-scoped row" at worst, never silently reads a plainly
+    wrong branch's PR as this branch's own.
+
     Returns one of GitHub's own state strings — "MERGED" / "OPEN" / "CLOSED" —
-    for the most recently created PR whose head is this branch (a branch can
-    accumulate more than one PR over its life — closed-then-reopened, or
-    rebuilt after a squash — ties are broken by `createdAt`, latest wins).
-    Returns "NONE" when `gh` succeeded but no PR was ever opened for this
-    branch — the single most dangerous row on the reaper's board (measured
-    2026-09-01: `wr2/websurface-cure`, `infra/hookw119`, `ops/fix5331` — real
-    committed work that exists nowhere else), which the caller must protect
-    and report distinctly, never fold silently into the generic "unmerged"
-    message.
+    for the most recently created PR whose head is EXACTLY this branch (a
+    branch can accumulate more than one PR over its life — closed-then-
+    reopened, or rebuilt after a squash — ties are broken by `createdAt`,
+    latest wins). Returns "NONE" when `gh` succeeded but no PR was ever
+    opened for this branch — the single most dangerous row on the reaper's
+    board (measured 2026-09-01: `wr2/websurface-cure`, `infra/hookw119`,
+    `ops/fix5331` — real committed work that exists nowhere else), which the
+    caller must protect and report distinctly, never fold silently into the
+    generic "unmerged" message.
 
     Returns None on ANY failure to get a trustworthy answer — `gh` missing,
     timeout, non-zero exit, unparseable JSON, or an unrecognized `state`
@@ -1257,9 +1275,9 @@ def _gh_pr_state_for_branch(
         proc = subprocess.run(
             [
                 "gh", "pr", "list",
-                "--search", f"head:{branch}",
+                "--head", branch,
                 "--state", "all",
-                "--json", "number,state,createdAt",
+                "--json", "number,state,createdAt,headRefName",
             ],
             cwd=str(cwd),
             capture_output=True,
@@ -1292,15 +1310,22 @@ def _gh_pr_state_for_branch(
         return None
     if not isinstance(data, list):
         return None
-    if not data:
+    # Defensive exact-match filter (belt-and-suspenders on top of `--head`):
+    # only rows whose own headRefName is EXACTLY this branch ever count. This
+    # is what keeps a future `gh` regression, or a differently-scoped `--head`
+    # behavior on some other `gh` version, from silently reading a sibling
+    # branch's PR as this branch's own.
+    rows = [
+        row for row in data
+        if isinstance(row, dict) and row.get("headRefName") == branch
+    ]
+    if not rows:
         return "NONE"
 
-    def _created_at(row: object) -> str:
-        return row.get("createdAt") or "" if isinstance(row, dict) else ""
+    def _created_at(row: dict) -> str:
+        return row.get("createdAt") or ""
 
-    latest = max(data, key=_created_at)
-    if not isinstance(latest, dict):
-        return None
+    latest = max(rows, key=_created_at)
     state = latest.get("state")
     if state not in ("MERGED", "OPEN", "CLOSED"):
         logger.warning(
@@ -1364,9 +1389,11 @@ def _branch_merge_status(
          upstream). This is the only arm that needs neither `gh` nor a fresh
          fetch, and it is exact — never a proxy — for a branch with no
          commits of its own yet.
-      2. The PULL REQUEST arm (added 2026-09-01): ``gh pr list --search
-         head:<branch>`` — GitHub is the only party that knows a SQUASH merge
-         landed, which is how every PR in this repo merges (W88), so the
+      2. The PULL REQUEST arm (added 2026-09-01): ``gh pr list --head
+         <branch>`` (exact filter — see `_gh_pr_state_for_branch`'s docstring
+         for why never the `--search head:` qualifier, which prefix-matches)
+         — GitHub is the only party that knows a SQUASH merge landed, which
+         is how every PR in this repo merges (W88), so the
          ancestor test in arm 1 can NEVER be true for a squash-merged branch.
          This arm is AUTHORITATIVE: a MERGED PR means landed regardless of
          what arm 3 would conclude from current file content (which can go

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -1024,6 +1024,350 @@ def test_cleanup_reaps_when_no_process_and_merged(fake_repo, monkeypatch):
     assert not wt.exists()  # reaped — both guards cleared
 
 
+# ---------------------------------------------------------------------------
+# cleanup — GitHub PR arm (2026-09-01): the reaper-never-reaps defect
+#
+# `_branch_in_origin_main` (now `_branch_merge_status`) never fetched
+# `origin/main` and judged "landed" by blob equality against main's CURRENT
+# content — the wrong question the instant anyone edits a touched file after
+# a squash merge lands (W88: every PR in this repo merges by squash, so the
+# ancestor arm can never fire either). Measured 2026-09-01: PR #5434 (MERGED)
+# has 1/3 authored files since diverged from main; PR #5354 (MERGED) has 2/15
+# diverged. 39 worktrees accumulated this way and filled the disk to 97%.
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_reaps_branch_with_merged_pr_even_when_content_now_differs(
+    fake_repo, monkeypatch
+):
+    """GUILT: a branch whose most recent PR is MERGED must be reap-eligible
+    even when the pre-existing blob-equality content check would say
+    otherwise, because a later, unrelated edit to a file the branch also
+    touched has made main's CURRENT copy differ from what the branch itself
+    authored. This is the defect itself: the OLD content-only check protects
+    such a branch forever once anyone edits a shared file after merge.
+
+    Proof this exercises the new PR arm and not a fluke: revert the PR-arm
+    change (or run this test against the pre-fix module) and it goes RED —
+    `assert not wt.exists()` fails because the content check alone (the only
+    arm the old code had) reads `shared.txt` as diverged and protects the
+    worktree. `monkeypatch.setattr(..., raising=False)` lets this SAME test
+    run unmodified against both the old module (attribute doesn't exist yet,
+    created but never consulted -> red) and the new one (attribute exists,
+    consulted by the PR arm -> green).
+    """
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "merged-pr-diverged", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "shared.txt").write_text("mine\n")
+    _commit_in_worktree(wt, mod, "shared.txt", "add shared.txt")
+    branch = mod._worktree_head_branch(wt)
+    _backdate_worktree_mtime(wt, minutes=120)  # idle
+    monkeypatch.setattr(mod, "_worktree_has_live_process", lambda p: False)
+    monkeypatch.setattr(
+        mod,
+        "_gh_pr_state_for_branch",
+        lambda b, **kw: "MERGED" if b == branch else None,
+        raising=False,
+    )
+    # main moves on WITHOUT ever containing this branch's exact content —
+    # modelling a later, unrelated edit to the same file after the (squash)
+    # merge landed, which is what actually happened on PR #5434 / #5354.
+    env = dict(os.environ)
+    env.update(
+        GIT_AUTHOR_NAME="Test",
+        GIT_AUTHOR_EMAIL="test@example.com",
+        GIT_COMMITTER_NAME="Test",
+        GIT_COMMITTER_EMAIL="test@example.com",
+    )
+    (repo / "shared.txt").write_text("someone changed it after merge\n")
+    subprocess.run(
+        ["git", "add", "shared.txt"], cwd=repo, check=True, capture_output=True,
+        text=True, env=env,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "later unrelated edit"],
+        cwd=repo, check=True, capture_output=True, text=True, env=env,
+    )
+    subprocess.run(
+        ["git", "push", "origin", "main"], cwd=repo, check=True,
+        capture_output=True, text=True, env=env,
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert not wt.exists()  # reaped: the PR arm overrides the stale content mismatch
+
+
+def test_cleanup_wip_protects_even_with_merged_pr(fake_repo, monkeypatch):
+    """INNOCENCE (1/4): uncommitted changes protect a worktree even when its
+    branch's PR is MERGED — the WIP guard still runs before ANY merge-status
+    check (existing guard ORDER, unweakened by the new PR arm)."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "wip-merged-pr", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "wip.txt").write_text("not committed\n")
+    _backdate_worktree_mtime(wt, minutes=120)
+    monkeypatch.setattr(
+        mod, "_gh_pr_state_for_branch", lambda b, **kw: "MERGED", raising=False
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 1  # WIP failure, unchanged
+    assert wt.exists()
+
+
+def test_cleanup_recent_activity_protects_even_with_merged_pr(fake_repo, monkeypatch):
+    """INNOCENCE (2/4): a recently-touched (live-session) worktree stays
+    protected even when its branch's PR is MERGED — the recent-activity
+    guard still runs before the merge-status check."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "recent-merged-pr", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)  # expired by the clock
+    work_file = wt / "live.txt"
+    work_file.write_text("active session output\n")
+    _commit_in_worktree(wt, mod, "live.txt", "active work")  # clean, fresh mtime
+    monkeypatch.setattr(
+        mod, "_gh_pr_state_for_branch", lambda b, **kw: "MERGED", raising=False
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert wt.exists()  # preserved — recent-activity guard fires first
+
+
+def test_cleanup_protects_branch_with_open_pr(fake_repo, monkeypatch):
+    """INNOCENCE (3/4): a branch whose most recent PR is still OPEN must not
+    be reaped — its only checkout may still be under active iteration. This
+    also proves the PR arm is consulted BEFORE the content check: content
+    here would happen to protect anyway (real unpushed commit), but the PR
+    arm must be the one deciding, short-circuiting before any content diff."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "open-pr", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "work.txt").write_text("work in review\n")
+    _commit_in_worktree(wt, mod, "work.txt", "feature commit")
+    branch = mod._worktree_head_branch(wt)
+    _backdate_worktree_mtime(wt, minutes=120)  # idle on mtime
+    monkeypatch.setattr(mod, "_worktree_has_live_process", lambda p: False)
+    monkeypatch.setattr(
+        mod,
+        "_gh_pr_state_for_branch",
+        lambda b, **kw: "OPEN" if b == branch else None,
+        raising=False,
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert wt.exists()
+
+
+def test_cleanup_protects_branch_with_closed_unmerged_pr(fake_repo, monkeypatch):
+    """CLOSED (not merged) is NOT landed — protect, same as OPEN."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "closed-pr", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "work.txt").write_text("abandoned work\n")
+    _commit_in_worktree(wt, mod, "work.txt", "feature commit")
+    branch = mod._worktree_head_branch(wt)
+    _backdate_worktree_mtime(wt, minutes=120)
+    monkeypatch.setattr(mod, "_worktree_has_live_process", lambda p: False)
+    monkeypatch.setattr(
+        mod,
+        "_gh_pr_state_for_branch",
+        lambda b, **kw: "CLOSED" if b == branch else None,
+        raising=False,
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert wt.exists()
+
+
+def test_cleanup_protects_branch_with_no_pr_at_all_and_reports_distinctly(
+    fake_repo, capsys, monkeypatch
+):
+    """INNOCENCE (4/4): a branch with real committed work but NO pull request
+    at all is the single most dangerous row on the reaper's board (real work
+    that exists nowhere else) — it must stay protected AND the skip message
+    must say so distinctly, never folded into the generic 'has commits not
+    in origin/main' line (measured 2026-09-01: wr2/websurface-cure,
+    infra/hookw119, ops/fix5331)."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "no-pr-at-all", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "work.txt").write_text("orphaned work\n")
+    _commit_in_worktree(wt, mod, "work.txt", "feature commit")
+    branch = mod._worktree_head_branch(wt)
+    _backdate_worktree_mtime(wt, minutes=120)
+    monkeypatch.setattr(mod, "_worktree_has_live_process", lambda p: False)
+    monkeypatch.setattr(
+        mod,
+        "_gh_pr_state_for_branch",
+        lambda b, **kw: "NONE" if b == branch else None,
+        raising=False,
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    assert wt.exists()
+    out = capsys.readouterr().out
+    assert "no-pr-at-all" in out
+    assert "no pull request" in out.lower()
+    assert "unmerged commits not in origin/main" not in out
+
+
+def test_cleanup_gh_unreachable_falls_back_to_content_check_still_protects(
+    fake_repo, monkeypatch
+):
+    """OFFLINE: `gh` failing/timing out must fall back to the pre-existing
+    ancestry/content check, never silently reap. A branch the content check
+    would protect (real unmerged content, differs from origin/main) must
+    still be protected when gh is unreachable — an API failure may only ever
+    make the verdict MORE conservative, never less (W84)."""
+    mod, _ = fake_repo
+    wt = mod.cmd_create("wr2", "gh-down", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    (wt / "work.txt").write_text("unmerged work\n")
+    _commit_in_worktree(wt, mod, "work.txt", "feature commit")
+    _backdate_worktree_mtime(wt, minutes=120)  # idle on mtime
+    monkeypatch.setattr(mod, "_worktree_has_live_process", lambda p: False)
+    monkeypatch.setattr(
+        mod, "_gh_pr_state_for_branch", lambda b, **kw: None, raising=False
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0  # protection, not a failure
+    assert wt.exists()  # content check (offline path) still protects correctly
+
+
+def test_cleanup_fetches_origin_main_once_per_run_not_per_worktree(
+    fake_repo, monkeypatch
+):
+    """`_refresh_origin_main_once` must be called exactly ONCE per `--cleanup`
+    invocation, even with multiple expired worktrees pending — not once per
+    worktree (cause (1) of the 2026-09-01 defect: the reaper never refreshed
+    `origin/main` at all; the fix is one fetch per run, not a per-worktree
+    fetch storm)."""
+    mod, _ = fake_repo
+    wt1 = mod.cmd_create("wr2", "multi-a", ttl_minutes=5)
+    wt2 = mod.cmd_create("wr2", "multi-b", ttl_minutes=5)
+    _backdate_metadata(wt1, mod, minutes=120)
+    _backdate_metadata(wt2, mod, minutes=120)
+    _backdate_worktree_mtime(wt1, minutes=120)
+    _backdate_worktree_mtime(wt2, minutes=120)
+    calls: list[int] = []
+    real = mod._refresh_origin_main_once
+
+    def counting(*a, **kw):
+        calls.append(1)
+        return real(*a, **kw)
+
+    monkeypatch.setattr(mod, "_refresh_origin_main_once", counting)
+    mod.cmd_cleanup()
+    assert len(calls) == 1
+
+
+def test_cleanup_continues_when_git_fetch_actually_fails(fake_repo, monkeypatch):
+    """A genuinely failed `git fetch origin main` (offline / unreachable
+    remote) must not abort cleanup — it logs and continues comparing against
+    the locally-known `origin/main` ref, exactly as before this fetch was
+    added (a stale ref only ever makes the ancestry/content arms MORE
+    conservative, never less)."""
+    mod, repo = fake_repo
+    wt = mod.cmd_create("wr2", "fetch-fail-real", ttl_minutes=5)
+    _backdate_metadata(wt, mod, minutes=120)
+    _backdate_worktree_mtime(wt, minutes=120)
+    # Break the remote so `git fetch origin main` genuinely fails.
+    subprocess.run(
+        ["git", "remote", "set-url", "origin", "/nonexistent/path.git"],
+        cwd=repo, check=True, capture_output=True, text=True,
+    )
+    rc = mod.cmd_cleanup()
+    assert rc == 0
+    # A trivial branch (no commits beyond what was already pushed before the
+    # remote broke) is still an ancestor of the LOCALLY-known origin/main —
+    # reaped via arm 1, which needs no fetch to have succeeded at all.
+    assert not wt.exists()
+
+
+# ---------------------------------------------------------------------------
+# `_gh_pr_state_for_branch` — direct subprocess-level tests (fake `gh` on PATH)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_gh(bin_dir: Path, body: str) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "gh"
+    script.write_text(body, encoding="utf-8")
+    script.chmod(0o755)
+
+
+def test_gh_pr_state_for_branch_picks_most_recently_created_pr(
+    fake_repo, monkeypatch, tmp_path
+):
+    mod, repo = fake_repo
+    bin_dir = tmp_path / "fakebin"
+    _install_fake_gh(
+        bin_dir,
+        "#!/bin/sh\n"
+        "echo '["
+        '{"number": 41, "state": "CLOSED", "createdAt": "2026-08-20T00:00:00Z"}, '
+        '{"number": 42, "state": "MERGED", "createdAt": "2026-08-25T00:00:00Z"}'
+        "]'\n",
+    )
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) == "MERGED"
+
+
+def test_gh_pr_state_for_branch_no_pr_returns_none_sentinel(
+    fake_repo, monkeypatch, tmp_path
+):
+    mod, repo = fake_repo
+    bin_dir = tmp_path / "fakebin"
+    _install_fake_gh(bin_dir, "#!/bin/sh\necho '[]'\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) == "NONE"
+
+
+def test_gh_pr_state_for_branch_nonzero_exit_returns_python_none(
+    fake_repo, monkeypatch, tmp_path
+):
+    mod, repo = fake_repo
+    bin_dir = tmp_path / "fakebin"
+    _install_fake_gh(bin_dir, "#!/bin/sh\necho 'boom' >&2\nexit 1\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) is None
+
+
+def test_gh_pr_state_for_branch_missing_gh_returns_none(
+    fake_repo, monkeypatch, tmp_path
+):
+    mod, repo = fake_repo
+    empty_bin = tmp_path / "emptybin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+    assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) is None
+
+
+def test_gh_pr_state_for_branch_timeout_returns_none(
+    fake_repo, monkeypatch, tmp_path
+):
+    mod, repo = fake_repo
+    bin_dir = tmp_path / "fakebin"
+    _install_fake_gh(bin_dir, "#!/bin/sh\nsleep 3\necho '[]'\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    assert mod._gh_pr_state_for_branch("some/branch", cwd=repo, timeout=1) is None
+
+
+def test_gh_pr_state_for_branch_unrecognized_state_returns_none(
+    fake_repo, monkeypatch, tmp_path
+):
+    mod, repo = fake_repo
+    bin_dir = tmp_path / "fakebin"
+    _install_fake_gh(
+        bin_dir,
+        "#!/bin/sh\n"
+        "echo '[{\"number\": 1, \"state\": \"DRAFT\", "
+        '"createdAt": "2026-08-20T00:00:00Z"}]\'\n',
+    )
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) is None
+
+
 def test_worktree_has_live_process_real_lsof(fake_repo):
     """Empirical (no-mock) test of `_worktree_has_live_process` against the REAL
     `lsof` (W64: prove the guard with the actual kernel call, not just bash -n).

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -1305,12 +1305,70 @@ def test_gh_pr_state_for_branch_picks_most_recently_created_pr(
         bin_dir,
         "#!/bin/sh\n"
         "echo '["
-        '{"number": 41, "state": "CLOSED", "createdAt": "2026-08-20T00:00:00Z"}, '
-        '{"number": 42, "state": "MERGED", "createdAt": "2026-08-25T00:00:00Z"}'
+        '{"number": 41, "state": "CLOSED", "createdAt": "2026-08-20T00:00:00Z", '
+        '"headRefName": "some/branch"}, '
+        '{"number": 42, "state": "MERGED", "createdAt": "2026-08-25T00:00:00Z", '
+        '"headRefName": "some/branch"}'
         "]'\n",
     )
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
     assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) == "MERGED"
+
+
+def test_gh_pr_state_for_branch_uses_exact_head_flag_and_discards_prefix_sibling_rows(
+    fake_repo, monkeypatch, tmp_path
+):
+    """GUILT (found in review, 2026-09-01): `gh pr list --search head:<branch>`
+    is a SEARCH QUALIFIER — prefix-matching and index-backed, superscar
+    family #3 (guard-over-match) — not an exact filter. Measured live on a
+    real sibling pair in this repo: `agent/nuzantara/infra/organ-hb-cadence`
+    is a strict prefix of `agent/nuzantara/infra/organ-hb-cadence-wiring`;
+    `--search head:` for the SHORTER branch returned BOTH PRs, including the
+    longer sibling's newer MERGED one (#5440), while `--head` (exact)
+    returned only the branch's own (#5431). Because this function is the
+    AUTHORITATIVE arm — a MERGED verdict overrides the content check — the
+    search-qualifier form would let a sibling's newer MERGED PR reap a
+    DIFFERENT worktree whose own PR is still OPEN: silent deletion of live,
+    unmerged work, the fail-OPEN direction this function is everywhere else
+    deliberately fail-CLOSED against.
+
+    Two independent things must hold, so this test cannot pass by accident
+    if the flag regresses back to `--search`/`head:`:
+      1. The exact argv the fake `gh` receives must use `--head`, never
+         `--search` — asserted directly, not inferred from the return value.
+      2. Even given a raw JSON payload shaped exactly like what `--search
+         head:` really returns (both the sibling's row AND this branch's own
+         row), the function's own defensive `headRefName` filter must still
+         discard the sibling's row and return this branch's OWN state
+         ("OPEN"), never the sibling's ("MERGED") — the belt-and-suspenders
+         half of the fix, independent of the flag itself.
+    """
+    mod, repo = fake_repo
+    branch = "agent/nuzantara/infra/organ-hb-cadence"
+    sibling = "agent/nuzantara/infra/organ-hb-cadence-wiring"
+    bin_dir = tmp_path / "fakebin"
+    argv_file = tmp_path / "argv.txt"
+    _install_fake_gh(
+        bin_dir,
+        "#!/bin/sh\n"
+        f'printf \'%s\\n\' "$@" > "{argv_file}"\n'
+        "echo '["
+        f'{{"number": 5440, "state": "MERGED", '
+        f'"createdAt": "2026-08-31T08:00:32Z", "headRefName": "{sibling}"}}, '
+        f'{{"number": 5431, "state": "OPEN", '
+        f'"createdAt": "2026-08-31T06:46:29Z", "headRefName": "{branch}"}}'
+        "]'\n",
+    )
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    state = mod._gh_pr_state_for_branch(branch, cwd=repo)
+
+    assert state == "OPEN"  # NOT "MERGED" — the sibling's row must be discarded
+    argv_lines = argv_file.read_text().splitlines()
+    assert "--head" in argv_lines
+    assert branch in argv_lines
+    assert "--search" not in argv_lines
+    assert f"head:{branch}" not in argv_lines
 
 
 def test_gh_pr_state_for_branch_no_pr_returns_none_sentinel(
@@ -1362,7 +1420,7 @@ def test_gh_pr_state_for_branch_unrecognized_state_returns_none(
         bin_dir,
         "#!/bin/sh\n"
         "echo '[{\"number\": 1, \"state\": \"DRAFT\", "
-        '"createdAt": "2026-08-20T00:00:00Z"}]\'\n',
+        '"createdAt": "2026-08-20T00:00:00Z", "headRefName": "some/branch"}]\'\n',
     )
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
     assert mod._gh_pr_state_for_branch("some/branch", cwd=repo) is None


### PR DESCRIPTION
## Summary

- `_branch_in_origin_main` (now `_branch_merge_status`) never fetched `origin/main` and judged "landed" by per-file blob equality against main's CURRENT content — the wrong question in a squash-merge repo (W88): the ancestor arm can never fire for a squash-merged branch, and the content arm reads a fully-landed branch as unmerged the instant anyone edits a touched file afterward. Measured 2026-09-01: PR #5434 and PR #5354 (both MERGED) have authored files that now differ from main. The daily `agent-worktree-cleanup` cron reaped nothing for long enough that 39 worktrees × ~1.3GB filled the disk to 97%, at which point `agent_start.py` itself started failing with "No space left on device".
- Adds a third, **authoritative** arm: `gh pr list --search head:<branch> --state all`. A branch whose most recent PR is `MERGED` is landed, regardless of what the content check would conclude. `OPEN` / `CLOSED` / no-PR-at-all all protect — no-PR is reported **distinctly** in the skip message (it's real committed work that exists nowhere else, the single most dangerous row on the reaper's board; measured: `wr2/websurface-cure`, `infra/hookw119`, `ops/fix5331`).
- `gh` unusable (missing / timeout / non-zero exit / bad JSON) falls back to the pre-existing offline ancestry/content path unchanged — an API failure only ever makes the verdict MORE conservative, never less.
- Fetches `origin/main` once per `--cleanup` run (never before this change) so the offline arms compare against a fresh ref instead of a possibly days-old one. A failed/offline fetch logs and continues with the local ref.
- `_branch_in_origin_main` is now a thin bool wrapper around `_branch_merge_status`, which returns `(merged, reason)` so `cmd_cleanup`'s skip messages name what was **actually checked** instead of re-deriving a cause after the fact (the W65/W105 trap this exact file was already burned by once).
- Every existing guard — WIP-safe, skip-recent, live-process, kill switch, registered-branch-mismatch abstention — is unweakened. This only adds a way to say **yes**, never removes a way to say **no**.

## Test plan

- [x] Guilt test `test_cleanup_reaps_branch_with_merged_pr_even_when_content_now_differs` — verified RED against pre-fix `agent_start.py` (content check alone protects a MERGED-but-content-diverged branch forever), GREEN against the fix.
- [x] 4 innocence tests: uncommitted WIP protects even with a MERGED PR; recently-touched worktree protects even with a MERGED PR; `OPEN` PR protects; no-PR-at-all protects and is reported distinctly.
- [x] `CLOSED` (not merged) protects.
- [x] Offline test: `gh` unusable falls back to the existing content logic, still protects a genuinely-unmerged branch.
- [x] Registered-branch-mismatch (mid-flight rename) abstention still protects — pre-existing test unchanged and still green.
- [x] Fetch-once-per-run: exactly one `_refresh_origin_main_once` call across a multi-worktree `--cleanup` run.
- [x] Fetch-failure: a genuinely broken remote doesn't abort cleanup.
- [x] 6 direct subprocess-level tests of `_gh_pr_state_for_branch` against a fake `gh` on `PATH` (most-recent-PR selection, no-PR, non-zero exit, missing binary, timeout, unrecognized state).
- [x] Full existing suite green: `scripts/tests/test_agent_start.py` (99 passed, 1 skipped — pre-existing lsof-PATH skip, unrelated), `test_agent_worktree_cleanup_cron.py` + `test_worktree_gc_universal.py` (61 passed), `tests/integration/test_no_stale_worktrees.py` (7 passed).
- [x] `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)