### PR TITLE
fix(ops): classify codex/codex-spark BALANCE_DEAD and MODEL_ERR, not UNKNOWN_ERR

### DIFF
--- a/docs/runbooks/arsenal-probe.md
+++ b/docs/runbooks/arsenal-probe.md
@@ -49,6 +49,8 @@ Credential values are never printed, logged, or reported (scrub layer; scar #4).
 | Seat dead               | Cure (operator unless noted)                                                                                                                                                                                                                                                                                     |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | codex AUTH_DEAD         | interactive `codex login` on that machine                                                                                                                                                                                                                                                                        |
+| codex BALANCE_DEAD      | top up ChatGPT Pro / Codex workspace credits (evidence: "Your workspace is out of credits. Add credits to continue.") — was misclassified `UNKNOWN_ERR` before 2026-08-31, see the note below                                                                                                                    |
+| codex-spark MODEL_ERR   | `gpt-5.3-codex-spark` is rejected on this ChatGPT-account plan ("model is not supported when using Codex with a ChatGPT account") — verify the current model roster (`~/.codex/models_cache.json`) before pinning that slug again; was misclassified `UNKNOWN_ERR` before 2026-08-31                             |
 | claude AUTH/QUOTA       | `claude auth status`; window cap → wait reset or switch slot                                                                                                                                                                                                                                                     |
 | glm AUTH_DEAD           | re-copy token from a live keychain (see memory `discovery_glm_mini_seat_armed_fable_model_leak_2026_07_06`)                                                                                                                                                                                                      |
 | glm MODEL_ERR           | config drift — launch from repo cwd or pin `--model glm-5.2` (fable-5[1m] leak)                                                                                                                                                                                                                                  |
@@ -70,6 +72,15 @@ but the classifier fell through to a bare `UNKNOWN_ERR` for both (the same shape
 providers configured" already had a local override for). Matched locally per-seat now, mirroring
 the existing `kimi` pattern — `scripts/tests/test_arsenal_probe.py` carries the guilt+innocence
 pair for each.
+
+Note (2026-08-31, healer tick, Mini): same disease, two more seats. `codex` ("Your workspace is
+out of credits. Add credits to continue.") and `codex-spark` ("The 'gpt-5.3-codex-spark' model is
+not supported when using Codex with a ChatGPT account.") both fell through to `UNKNOWN_ERR` —
+`_BALANCE_DEAD_PAT`/`_MODEL_ERR_PAT` only matched `402`/`insufficient balance` and
+`1211`/`unknown model`, not either observed phrase. Widened both patterns (`out of credits`,
+`model is not supported`) with guilt+innocence pairs in `scripts/tests/test_arsenal_probe.py` and
+canned entries in `_SELFTEST_CANNED`. Operator-gated either way (top up credits / verify the model
+roster) — this only fixes which cure the board points at.
 
 ## Selftest / CI
 

--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -278,8 +278,8 @@ _QUOTA_DEAD_PAT = re.compile(
     r"out of extra usage|usage limit|weekly limit|quota|\b429\b|rate.?limit|exhausted",
     re.IGNORECASE,
 )
-_BALANCE_DEAD_PAT = re.compile(r"\b402\b|insufficient balance", re.IGNORECASE)
-_MODEL_ERR_PAT = re.compile(r"\b1211\b|unknown model", re.IGNORECASE)
+_BALANCE_DEAD_PAT = re.compile(r"\b402\b|insufficient balance|out of credits", re.IGNORECASE)
+_MODEL_ERR_PAT = re.compile(r"\b1211\b|unknown model|model is not supported", re.IGNORECASE)
 _SHED_PAT = re.compile(r"\b529\b|overloaded", re.IGNORECASE)
 
 
@@ -1201,6 +1201,18 @@ _SELFTEST_CANNED = [
     ("deepseek", "HTTP 402 Insufficient Balance", BALANCE_DEAD, "deepseek 402"),
     ("claude", "out of extra usage for this session", QUOTA_DEAD, "claude quota string"),
     ("codex", "rate limit exceeded, 429", QUOTA_DEAD, "codex 429 quota"),
+    (
+        "codex",
+        "ERROR: Your workspace is out of credits. Add credits to continue.",
+        BALANCE_DEAD,
+        "codex out-of-credits (real observed evidence, 2026-08-31)",
+    ),
+    (
+        "codex-spark",
+        "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account.",
+        MODEL_ERR,
+        "codex-spark model unsupported on ChatGPT plan (real observed evidence, 2026-08-31)",
+    ),
 ]
 
 

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -130,6 +130,26 @@ def test_unknown_model_text_classifies_model_err():
     assert ap.classify_generic(ev, live_signal=False, seat="codex", ssh_context=False) == ap.MODEL_ERR
 
 
+def test_codex_spark_model_unsupported_classifies_model_err():
+    # real observed evidence, 2026-08-31 — codex-spark probes gpt-5.3-codex-spark, which
+    # this ChatGPT-account plan rejects; was misclassified UNKNOWN_ERR before this fix.
+    ev = (
+        '{"error":{"type":"invalid_request_error","message":"The '
+        "'gpt-5.3-codex-spark' model is not supported when using Codex with a "
+        'ChatGPT account."}}'
+    )
+    assert ap.classify_generic(ev, live_signal=False, seat="codex-spark", ssh_context=False) == ap.MODEL_ERR
+
+
+def test_models_plural_not_supported_is_not_model_err():
+    # innocence: the plural/adjacent phrasing "not all models are supported" must not
+    # false-positive — only the exact "model is not supported" shape does.
+    ev = "not all models are supported in this region yet"
+    status = ap.classify_generic(ev, live_signal=False, seat="codex-spark", ssh_context=False)
+    assert status != ap.MODEL_ERR
+    assert status == ap.UNKNOWN_ERR
+
+
 def test_529_classifies_shed_never_model_err():
     ev = "HTTP 529 the server is overloaded, please retry"
     status = ap.classify_generic(ev, live_signal=False, seat="codex", ssh_context=False)
@@ -150,6 +170,23 @@ def test_402_classifies_balance_dead():
 def test_insufficient_balance_text_classifies_balance_dead():
     ev = "Insufficient Balance on this account"
     assert ap.classify_generic(ev, live_signal=False, seat="deepseek", ssh_context=False) == ap.BALANCE_DEAD
+
+
+def test_codex_out_of_credits_classifies_balance_dead():
+    # real observed evidence, 2026-08-31 — was misclassified UNKNOWN_ERR before this fix,
+    # which hid the operator-actionable cure (top up ChatGPT Pro credits) behind an
+    # ambiguous status the runbook's cure table has no row for.
+    ev = "ERROR: Your workspace is out of credits. Add credits to continue."
+    assert ap.classify_generic(ev, live_signal=False, seat="codex", ssh_context=False) == ap.BALANCE_DEAD
+
+
+def test_credits_remaining_mention_is_not_balance_dead():
+    # innocence: a benign "credits" mention with no "out of" phrase must not
+    # false-positive into BALANCE_DEAD.
+    ev = "workspace credits: 500 remaining, all good"
+    status = ap.classify_generic(ev, live_signal=False, seat="codex", ssh_context=False)
+    assert status != ap.BALANCE_DEAD
+    assert status == ap.UNKNOWN_ERR
 
 
 def test_quota_strings_classify_quota_dead():


### PR DESCRIPTION
## Summary
- `arsenal_probe.py`'s classifier only matched `402`/`insufficient balance` for BALANCE_DEAD and `1211`/`unknown model` for MODEL_ERR, so codex's real "out of credits" evidence and codex-spark's real "model is not supported when using Codex with a ChatGPT account" evidence both fell through to `UNKNOWN_ERR` — a status with no cure documented anywhere, hiding the actionable fix from the healer/operator.
- Widened `_BALANCE_DEAD_PAT` (`out of credits`) and `_MODEL_ERR_PAT` (`model is not supported`), added guilt+innocence test pairs using the real observed evidence strings, and added two `_SELFTEST_CANNED` entries.
- Documented the new cure rows in `docs/runbooks/arsenal-probe.md`, mirroring the 2026-08-05 note for the same disease shape (claude/nlm falling through to UNKNOWN_ERR).

Found during a Mini healer tick (receptor: `arsenal:codex:UNKNOWN_ERR,codex-spark:UNKNOWN_ERR`) — evidence read from `~/.organism/arsenal/last.json`'s last live probe (2026-08-31), no new live LLM calls made per healer mandate.

## Test plan
- [x] `python3 -m pytest scripts/tests/test_arsenal_probe.py -q` — 177 passed (was 173; +4 new tests)
- [x] `python3 scripts/arsenal_probe.py --selftest` — `SELFTEST OK — 16 checks`
- [x] `ruff check scripts/arsenal_probe.py scripts/tests/test_arsenal_probe.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)