### PR TITLE
fix(lint): the web-surface lint could be hung by a string of escapes it was reading

### DIFF
--- a/scripts/lint_web_surface.py
+++ b/scripts/lint_web_surface.py
@@ -388,7 +388,13 @@ def _decompose_js(text: str) -> tuple[str, str, list[Span]]:
     return code_s, bare_s, spans
 
 
-_CSS_STRING_RE = re.compile(r"""(['"])((?:\\.|(?!\1).)*)\1""", re.S)
+# The second branch excludes the backslash DELIBERATELY. With `(?!\1).` there, a
+# backslash could be consumed either by `\\.` or by that branch, so every escaped
+# character doubled the number of parses the engine had to try: on an unterminated
+# string of 38 `\a` pairs the match never returned (CodeQL py/redos, found on the PR
+# that shipped this file). Excluding `\\` makes the alternation unambiguous and the
+# scan linear, without changing what it matches — `\\.` already owns every escape.
+_CSS_STRING_RE = re.compile(r"""(['"])((?:\\.|(?!\1)[^\\])*)\1""", re.S)
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
 
 

--- a/scripts/tests/test_lint_web_surface.py
+++ b/scripts/tests/test_lint_web_surface.py
@@ -1416,3 +1416,43 @@ class TestGuardConformance:
             '   type="number" and text-overflow: ellipsis on a price */\n'
         )
         assert hits(tmp_path, "notes.ts", src) == set()
+
+
+class TestCssStringRegexIsLinear:
+    """CodeQL py/redos, found on the PR that shipped this lint.
+
+    `_CSS_STRING_RE` was `(['"])((?:\\\\.|(?!\\1).)*)\\1`. A backslash matched BOTH
+    branches, so every escape doubled the parses the engine had to try and an
+    unterminated string of a few dozen escapes never returned. A linter reads
+    whatever file it is pointed at, so this is reachable by ordinary content.
+    """
+
+    def test_pathological_unterminated_string_returns_promptly(self) -> None:
+        """GUILT: the exact shape that hung. Measured: 38 pairs did not finish in
+        6s against the old pattern; the cured one answers in microseconds."""
+        import time
+
+        pathological = '"' + "\\a" * 38
+        start = time.monotonic()
+        lint._CSS_STRING_RE.search(pathological)
+        elapsed = time.monotonic() - start
+        # ~5 orders of magnitude of headroom: this asserts the COMPLEXITY CLASS,
+        # not the speed of the machine it happens to run on.
+        assert elapsed < 1.0, f"_CSS_STRING_RE took {elapsed:.2f}s — backtracking is back"
+
+    def test_escapes_still_match_exactly_as_before(self) -> None:
+        """INNOCENCE: the fix removes a redundant parse, never a reachable one —
+        `\\\\.` already owned every escape, so what matches must be unchanged."""
+        cases = [
+            (r'"a\"b"', r"a\"b"),
+            (r"'it\'s'", r"it\'s"),
+            ('"plain"', "plain"),
+            (r'"back\\slash"', r"back\\slash"),
+            ('"multi\nline"', "multi\nline"),
+        ]
+        for source, expected_body in cases:
+            match = lint._CSS_STRING_RE.search(source)
+            assert match is not None, f"no match for {source!r}"
+            assert match.group(2) == expected_body, (
+                f"{source!r} -> {match.group(2)!r}, expected {expected_body!r}"
+            )


### PR DESCRIPTION
## The defect

`scripts/lint_web_surface.py:391` on `origin/main`:

```python
_CSS_STRING_RE = re.compile(r"""(['"])((?:\\.|(?!\1).)*)\1""", re.S)
```

A backslash matches **both** alternation branches — `\\.` consumes it as an escape, and `(?!\1).` also accepts it as an ordinary character. Every escape therefore doubles the parses the engine must try, and on an **unterminated** string (no closing quote, so the engine must exhaust every path before failing) the cost is exponential. CodeQL class `py/redos`.

A linter reads whatever file it is pointed at, so this is reachable by ordinary repository content — no attacker required, just a CSS file with a run of escapes and a missing quote.

## Measured, this session, on both patterns

Unterminated string of *n* `\a` pairs:

| n | vulnerable | cured |
|---:|---:|---:|
| 18 | 26.93 ms | 0.02 ms |
| 22 | 429.34 ms | 0.01 ms |
| 26 | **6951.44 ms** | 0.01 ms |

×16 per +4 characters — textbook catastrophic backtracking. The cured pattern is flat.

## The fix

One character class, in the second branch only:

```python
_CSS_STRING_RE = re.compile(r"""(['"])((?:\\.|(?!\1)[^\\])*)\1""", re.S)
```

`\\.` already owned every escape, so forbidding a bare backslash in the *other* branch removes a redundant parse, never a reachable one. What the regex matches is unchanged — which the innocence test pins case by case.

## Verification

- Full lint suite on the cured code: **173 passed in 1.19s**.
- Guilt proven by reverting only the regex and re-running the new test class: it does **not fail — it hangs**, and `timeout 40` kills it (rc=124). That is the right shape of evidence for this defect class: the assertion `elapsed < 1.0` never gets to run because the search never returns.
- The test asserts a **complexity class, not a machine speed** (~5 orders of magnitude of headroom), so it will not flake on a slow runner.

## Provenance — why this is a fresh branch

The fix was written on 2026-08-31 and never pushed: it sat as two byte-identical local commits (`fa48d970f` on `wr2/websurface-cure`, `86527713d` on `wr2/webdesign-doctrine` — same blob hashes for both files, verified with `git ls-tree`, not `git rev-parse <ref>:<path>`, which returns the commit sha and would have "proved" they differed). Neither branch existed on origin; neither had a PR. This branch is cut fresh from `origin/main` and carries only the minimal commit, so the duplicate on the 29-file `webdesign-doctrine` lane can be dropped rather than merged.