### PR TITLE
docs(competitive): add 2026-09 competitor digest

### DIFF
--- a/research/competitive/2026-09-digest.md
+++ b/research/competitive/2026-09-digest.md
@@ -1,0 +1,200 @@
+# Competitive Digest — 2026-09
+
+**Window**: 2026-06-01 to 2026-09-01 (see Methodology — cadence gap) · **Author**: competitor-monitor agent · **Status**: published
+**cold_start**: false — diffed against the 2026-06-01 snapshot (last one on disk)
+**unreachable**: [flado, https://flado.com/] (2nd consecutive observed check, same SSL error as June)
+
+---
+
+## Executive Summary
+
+- **Emerhub's Bali page now states a new regulatory restriction, verbatim**: "Since May 2026, new foreign-owned companies registered at a Bali address can no longer take on low and medium-low risk activities." This claim was **not present in the June snapshot**. It is unverified by this agent — cross-check with NB-INTEL/legal before it is repeated internally or to clients, and before assuming it does or doesn't affect Bali Zero's own PT PMA intake.
+- **Emerhub repositioned its homepage trust signals and quietly dropped its speed claims.** Client-count claim jumped from "3,000+ companies" (June) to "11,700+ companies... since 2011," and named enterprise clients (BNP Paribas, Fujitsu, Citigroup, PWC, TELUS, Philips, Virgin Group) replaced the anonymous framing. At the same time, the explicit "5 working days" / "3-5 working days" timeline claims that appeared on three separate pages in June (Indonesia, PT PMA, Bali) are absent from the same three pages in September. PT PMA pricing itself is unchanged ($1,700 / $2,249 / $4,229 per year).
+- **Lets Move Indonesia's catalogue and pricing posture are stable**, but Instagram surfaced a new bundled price point — "BUNDLE 5: Your Complete Business Expansion Package, Ready to Go — IDR 23,000,000" — and a recurring "Ask the Expert" Q&A format that did not appear in June's visible grid.
+- **Flado remains fully unreachable** (identical SSL certificate error to June). This is the second consecutive check with no signal, three months apart — see Action Items.
+- **Both Emerhub and Lets Move Indonesia are converging on Bali-specific, lifestyle-adjacent content** (retirement visas, tourist tax, Second Home visa, property zoning) — territory Bali Zero already occupies. Competitive density on that surface is increasing.
+
+---
+
+## Lets Move Indonesia
+
+### Web — Homepage & Services
+
+Profile unchanged from June: letsmoveindonesia.com, same awards claimed ("Best Visa & Business Consultancy in Indonesia," "Most Trusted Visa & Legal Agency in Indonesia" — no certifying body, no date), same four offices (Jakarta HQ, Seminyak, Canggu, Sanur).
+
+**Service catalogue**: no new or removed service lines detected across homepage, `/legal-services/`, `/visa-services/`. The full visa list (30+ types including Global Citizenship of Indonesia, Golden Visa E33B, Second Home E33, Remote Work E33G) matches June exactly. Legal services (PT/PMA/Representative Office, licenses, trademark, LKPM, virtual office, OSS transition) also match June exactly.
+
+**Pricing**: still no service pricing disclosed on any web page. One figure surfaced this month that wasn't called out in June's summary: "Second Home Visa: minimum deposit of 2,000,000,000 IDR is required." This is the statutory deposit requirement for that visa class (a government figure, not a Lets Move service fee) — noted here for completeness, not as a Lets Move price change. Per the no-paraphrase rule, treat this as their disclosure of a regulatory figure, not their own pricing.
+
+**Blog (`/news/`) — top 5 visible**: identical titles to June (Indonesia Tax Handbook 2026, Global Visa launch, GCI announcement, Single Entry Social Visa 2026 guide, VOA 2026 guide). The news index has not visibly refreshed in three months. Either the featured list is static/pinned, or publishing cadence has slowed — this agent cannot distinguish the two from the index page alone.
+
+### IG Content — @letsmoveindonesia
+
+**Profile stats** (2026-09-01, unauthenticated Playwright): 7,997 followers (June: 8,089, −92 / −1.1%), 67 following (unchanged). Bio unchanged: "Indonesia's Most Trusted Agency. Visa Services | Company Establishment | Tax & Accountancy | Mortgage & Real Estate..." A Linktree link (linktr.ee/LetsMoveIndonesia) is visible in the bio this month; it was not visible in June's screenshot (may be a rendering difference, not necessarily new).
+
+**Grid visibility**: 11 post tiles rendered before the login wall this run (vs 6 in June) — Instagram's unauthenticated render depth varies session to session; this is a scraping-condition difference, not evidence that Lets Move posted more.
+
+**qwen2.5vl:7b pre-filter** (local Ollama, invoked via `/api/generate` with base64 image — the `ollama run` CLI does not accept an inline image path in the installed version, noted for next month's runbook): model read 10 of the 11 visible tiles (one price-bearing tile was partly obscured by the login modal and one testimonial tile was missed). Classification:
+
+| # | Tile text | Class | Keep/Drop |
+|---|---|---|---|
+| 1 | "How Serious Are You About Moving to Indonesia?" | (b) promotional/CTA | Keep |
+| 2 | "You Thought The Trip Was The Hard Part..." | (b) promotional/CTA | Keep |
+| 3 | "BUNDLE 5 — Your Complete Business Expansion Package, Ready to Go — IDR 23,000,000" | (b) promotional/CTA with price | Keep (recovered manually — model missed this tile, obscured by login modal) |
+| 4 | Testimonial carousel ("Our Clients [Say] About LetsMoveIndonesia," star ratings) | (b) promotional/CTA (trust signal) | Keep (recovered manually — model missed this tile) |
+| 5 | "Ask the Expert" (staff photo + mascot, first instance) | (a) educational/informational | Keep |
+| 6 | "Which Visa Matches Your Next Adventure?" | (a) educational/informational | Keep |
+| 7 | "Do You Really Understand Tax in Indonesia?" | (a) educational/informational | Keep |
+| 8 | "Ask the Expert: Clear Expert Guidance on Indonesia Visa Matters" (three staff photos, second instance) | (a) educational/informational | Keep |
+| 9 | "Establish Your Business in Indonesia with Confidence" | (b) promotional/CTA | Keep |
+| 10 | "81 Years of Freedom. A Future Full of Possibilities" (Indonesian Independence Day) | (c) lifestyle/aesthetic | Drop |
+| 11 | "A Month of Freedom & New Opportunities" | (c) lifestyle/aesthetic | Drop |
+
+Dropped 2 of 11 (both Independence Day seasonal content). No factually questionable regulatory claim visible in this window (June's flagged "NEWS: Bali Introduces New Restrictions on Foreign-Owned Business Registrations" post has aged out of the visible 30-day-ish window and was not re-observed).
+
+**Sonnet analysis on kept posts**:
+
+- **"BUNDLE 5 — IDR 23,000,000"**: new public price point for a bundled "business expansion package." Angle: pricing/promotional. This is comparable in scope to Emerhub's mid-tier PT PMA package (USD 2,249 ≈ IDR 36M at ~16,000/USD), though the exact deliverables behind "Bundle 5" aren't disclosed on the tile — worth pulling the linked landing page before treating this as a like-for-like comparison.
+- **"Ask the Expert" (appears twice in the visible window)**: a recurring Q&A format hosted by named staff (not just the mascot), mixing trust-signal and FAQ angles. This looks like a deliberate content series rather than a one-off. Bali Zero gap: worth checking whether Bali Zero runs an equivalent recurring "ask a real person" format on IG, distinct from static educational carousels.
+- **"Which Visa Matches Your Next Adventure?"**: quiz/matching framing for visa selection — a specific top-of-funnel tactic (interactive-feeling content) distinct from a plain listicle.
+- **"Do You Really Understand Tax in Indonesia?"**: myth-busting/educational framing on tax literacy — standard vertical, no gap.
+- **"How Serious Are You About Moving to Indonesia?" / "You Thought The Trip Was The Hard Part..."**: qualifying/pain-point framing aimed at relocation intent, not a specific service — top-of-funnel brand content, no factual claims to check.
+- **Testimonial carousel**: standard trust-signal format, no gap.
+
+### Bali Zero Implications
+
+1. **New IG price point (IDR 23,000,000 bundle)**: pull the linked landing page to see what's actually bundled, then compare against Bali Zero's equivalent offer before treating this as a pricing signal either way.
+2. **"Ask the Expert" recurring format**: a content-format gap worth 10 minutes of review — does Bali Zero have an equivalent named-staff Q&A series, or is it currently all illustrated/educational carousels?
+3. **Follower count**: −1.1% month-over-month (well within normal churn) — not treated as material.
+4. **Blog stagnation**: same top-5 for three months running. If Bali Zero's own content cadence is faster, that is a differentiator worth stating internally, not worth publicly contrasting (avoid competitive-bashing voice).
+
+---
+
+## Emerhub
+
+### Web — Homepage & Positioning
+
+**Hero headline (verbatim, June → September)**: "Start and scale your business in Southeast Asia" → "Helping investors expand to new markets."
+
+**Subheading (verbatim, June → September)**: "One partner. One dashboard. Zero guesswork." → "Local teams across Southeast Asia, clearing the path from first filing to fully operating."
+
+This reads as a deliberate move away from "single tech platform" framing toward "local teams/service" framing — evidence for a voice/positioning shift, not a guess.
+
+**Trust signals (June → September)**: "98% client retention, 12+ years in Asia, 8+ countries, trusted by 3,000+ companies" (no named clients) → "helped 11,700+ companies... since 2011 (14+ years)," with named enterprise clients: BNP Paribas, Fujitsu, Citigroup, PWC, TELUS, Philips, Virgin Group, and "40+ others." The 98% retention figure was not observed in this month's extraction (may simply not have been surfaced by the fetch — not confirmed removed).
+
+**Markets listed**: June — Indonesia, Philippines, Malaysia, Singapore, Vietnam, Bali, Thailand, Cambodia, Saudi Arabia, Qatar, Oman (11). September — Indonesia, Malaysia, Philippines, Singapore, Thailand, Vietnam, Cambodia, Hong Kong, Bali, UAE (10). Hong Kong is newly listed on the homepage; Saudi Arabia, Qatar, and Oman are absent from this month's homepage list (their standalone service pages were not checked, so this may reflect homepage curation rather than market exit).
+
+### Web — Pricing & Timeline Claims
+
+**PT PMA pricing — unchanged from June**:
+
+| Package | Price | Includes |
+|---|---|---|
+| Incorporation | US$1,700 | PT PMA registration, state fees, commercial address |
+| Incorporation + Basic Compliance | US$2,249 | + virtual address (12mo), quarterly LKPM (12mo) |
+| Incorporation + Full Compliance | US$4,229/year | + monthly tax reporting (≤20 tx/mo), payroll (≤5 employees), annual CIT |
+
+No pricing change detected — three consecutive checks (per baseline memory, dated 2026-06-01) at the same figures.
+
+**Timeline claims — removed since June, verbatim comparison**:
+
+| Page | June (verbatim) | September |
+|---|---|---|
+| `/indonesia/` | "Register your company in Indonesia in 5 working days" | No working-day figure found; only generic "typical duration assumes a clean case" |
+| `/indonesia/pt-pma/` | "Total incorporation can be as fast as 5 working days; standard 2-4 working days" | No working-day figure found |
+| `/bali/` | "Business Setup in 3-5 Working Days" | No working-day figure found |
+
+All three pages that carried an explicit day-count in June carry none in September. This is a genuine claim removal, not a paraphrase — flagged as a pattern change worth watching for a re-appearance or a replacement claim next month.
+
+### Web — Bali Page: Service Depth Expanded
+
+June's Bali page listed four generic service lines: Company Registration, Tax & Accounting, Property Services, Visas & Work Permits. September's Bali page lists seven, materially more granular and Bali-specific:
+
+1. Company setup (PT PMA under appropriate KBLI classification)
+2. Property and ownership structure — title verification, zoning (KKPR), legal structures
+3. Building permits and SLF — PBG permits and fitness certificates for villas/commercial properties
+4. Licensing for activities — accommodation, hospitality, wellness licenses (Standard Certificate)
+5. Visas and relocation — Investor KITAS, remote-worker, Second Home visa routes
+6. Employer of Record — staff hiring/payroll without a local entity
+7. Accounting and compliance — tax filings, quarterly LKPM, bookkeeping
+
+Employer of Record and the explicit KKPR/PBG/SLF property-permitting detail are new relative to June's four-line summary. This overlaps directly with Bali Zero's property vertical, at a level of detail Emerhub did not previously show in this monitor.
+
+**New regulatory claim (verbatim, unverified)**: "Since May 2026, new foreign-owned companies registered at a Bali address can no longer take on low and medium-low risk activities." A second, related line: "The 2026 block applies to new registrations" (re: virtual office restriction). **This is not present in the June snapshot.** Per the no-paraphrase rule: this is Emerhub's claim, quoted exactly, not a confirmed fact. It needs cross-check against NB-INTEL or legal before Bali Zero references it, and before assuming or denying any effect on Bali Zero's own PT PMA/virtual-office intake for Bali-address clients.
+
+### Web — Blog
+
+The blog now shows a visible corpus size: "940 articles" (new data point; not disclosed in June's extraction). Top 5 most recent by date, all non-Indonesia — same pattern as June:
+
+1. Cost of Setting Up a Company in Singapore (Aug 31)
+2. Registered Address vs. Business Address in Hong Kong (Aug 29)
+3. BOI Registration Requirements in the Philippines (Aug 28, updated)
+4. Cloud Computing Company in Vietnam (Aug 28)
+5. Corporate Income Tax in Malaysia (Aug 27, updated)
+
+However, the broader August publishing list (roughly 20 posts visible) shows this is not a full de-prioritization of Indonesia: 7 of ~20 recent posts are Indonesia- or Bali-specific, including two that sit squarely in Bali Zero / Lets Move Indonesia's lifestyle-immigration territory rather than Emerhub's usual B2B register:
+
+- **"Retire in Bali: Visa Options, Cost, and Best Locations"** (Aug 19)
+- **"Bali Tourist Tax: Cost, Payment, and Exemptions"** (Aug 7)
+
+Combined with the Bali page's new Second Home/Employer of Record/property-permitting depth, this reads as Emerhub broadening from pure B2B PT PMA work into Bali consumer/expat-facing content — a genuine widening of their competitive footprint into Bali Zero's core territory, not just an isolated blog post.
+
+**Voice note**: the site footer newsletter pitch now reads "Breaking barriers... One email, twice a month... We don't pad the email," a more casual, direct tone than June's corporate "One partner. One dashboard. Zero guesswork." Consistent with the homepage headline/subhead change above — this looks like a broader tone shift, not an isolated homepage edit.
+
+### IG — @emerhub
+
+No change from June: the handle is still held by an unrelated user "Kim" (8 followers, 4 following, 0 posts). @emerhub is not usable as a monitoring surface. No IG content to analyze this month. Recommend Antonello confirm whether Emerhub uses any other active handle (per June's outstanding action item — still unresolved).
+
+### Bali Zero Implications
+
+1. **Regulatory claim — verify before use.** The Bali low/medium-low-risk KBLI restriction claim is the single most consequential item in this month's digest if true. Flag to legal/Damar before it shapes any client-facing communication, and before assuming Bali Zero's own PT PMA process for Bali-address clients is or isn't affected.
+2. **Pricing benchmark unchanged.** Emerhub's PT PMA floor remains US$1,700 / US$2,249 / US$4,229 per year — stable reference point for company-setup positioning.
+3. **Speed claims disappeared.** If Bali Zero has ever positioned against Emerhub's "5 working days" claim, that specific claim is no longer on their site as of this check — any positioning copy referencing it should be re-verified against Emerhub's current pages before reuse.
+4. **Bali page and blog both deepened into property/lifestyle-immigration territory** (KKPR zoning, PBG/SLF permits, Second Home visa, Employer of Record, Retire in Bali, Bali Tourist Tax). This is the closest Emerhub has come to Bali Zero's actual positioning in the three checks on record. Worth a closer read of Emerhub's Bali page and these two blog posts for content-gap analysis next cycle.
+5. **Client-roster escalation** (3,000+ → 11,700+ companies, named enterprise logos) is a credibility push aimed at larger corporate clients, not directly competitive with Bali Zero's SME/individual client base — noted for awareness, not action.
+
+---
+
+## Flado
+
+**Status**: `unreachable: [flado, https://flado.com/]`
+
+Both `https://flado.com/` and `http://flado.com/` returned the identical SSL error observed in June: "unable to get local issuer certificate." Retried once per protocol, per spec. No web content retrievable.
+
+**Instagram @flado**: still a private account, 0 followers visible, no posts accessible without authentication. No change from June.
+
+Flado remains fully dark. This is now two consecutive checks with zero signal, spanning June to September (no July/August run occurred to test the interval more finely — see Methodology). Per the failure-mode guidance in the agent spec, this crosses the "2+ consecutive months unreachable" threshold — see Action Items.
+
+---
+
+## Cross-Competitor Patterns
+
+- **Pricing disclosure posture is unchanged overall**: Emerhub remains the only competitor with fully published tiered pricing; Lets Move now shows one bundled IG price point (IDR 23,000,000) plus a government-mandated deposit figure, but nothing on its own web pages; Flado is dark.
+- **Timeline/speed claims moved in opposite directions**: Emerhub removed its explicit "X working days" claims from three pages this cycle. Lets Move has never made a timeline claim in any check to date. Neither currently commits to a public number — a potential opening for Bali Zero to either match with a specific commitment or explicitly position on thoroughness over speed, whichever reflects the current internal SLA.
+- **Bali-specific convergence**: both Emerhub (new Bali page depth, two new Bali/retirement-adjacent blog posts) and Lets Move (unchanged but already the widest visa catalogue in the set) are active on the exact territory Bali Zero occupies — visa, property, lifestyle-immigration for Bali specifically. This is the clearest cross-competitor signal this cycle.
+- **IG signal remains asymmetric**: only Lets Move Indonesia has a real, public, active account (7,997 followers). Emerhub's tracked handle is squatted; Flado is private. This has not changed since June.
+- **GCI (Global Citizenship of Indonesia)**: still listed only by Lets Move Indonesia among the three. No new signal from Emerhub or Flado this cycle — June's open item stands.
+
+---
+
+## Action Items (Antonello)
+
+- [ ] **Verify Emerhub's Bali regulatory claim**: "new foreign-owned companies registered at a Bali address can no longer take on low and medium-low risk activities" since May 2026. Quote is verbatim from emerhub.com/bali/, unconfirmed by this agent. High priority — potential direct relevance to Bali Zero's own PT PMA intake.
+- [ ] **Pull Lets Move's "Bundle 5" landing page** to see what's actually included in the IDR 23,000,000 business expansion package, then compare against Bali Zero's equivalent bundle.
+- [ ] **Review Bali Zero's IG for an "Ask the Expert"-equivalent recurring named-staff Q&A format** — Lets Move is running this as a repeat series; check whether Bali Zero already does an equivalent or has a gap.
+- [ ] **Re-check any Bali Zero copy that references Emerhub's "5 working days" claim** — that specific claim is no longer visible on Emerhub's site as of this check.
+- [ ] **Decide on Flado's continued inclusion in scope**: two consecutive unreachable checks (2026-06, 2026-09), no July/August data point in between. Keep monitoring, or replace per the spec's failure-mode guidance.
+- [ ] **Resume monthly cadence**: no digest was produced for July or August. This run had to diff against a three-month-old baseline instead of last month's — reduces the precision of "material change" detection. Confirm the cron/manual-trigger plan going forward.
+- [ ] **Confirm what active Instagram handle (if any) Emerhub uses** — still open from June; @emerhub is squatted by an unrelated account.
+
+---
+
+## Methodology Notes
+
+- **cold_start**: false. A prior snapshot exists at `~/.claude/projects/-Users-nuzantara/competitive-snapshots/2026-06/`. However, no digest was produced for July or August, so this run diffs against a three-month-old baseline rather than a true one-month window. Flagged above as an action item — the "material change" read this month is therefore a three-month delta, not a 30-day one, and some of what looks like a sudden shift (e.g., Emerhub's homepage repositioning) could have happened gradually across July–August.
+- **Web fetch**: `WebFetch` (30s timeout, retry once) used for all pages except Emerhub's blog index, which returned only navigation chrome via the static-HTML converter (likely client-side-rendered article listings). Fell back to a headless Playwright render (Chromium via `npx playwright`, domcontentloaded + 4s settle) for that one page, which succeeded and returned the full post list including dates and authors.
+- **Flado**: unreachable on both HTTPS and HTTP, retried once each, per spec. Logged as `unreachable: [flado, https://flado.com/]`.
+- **IG scraping**: unauthenticated headless Playwright (Chromium, 1280×2400 viewport, standard desktop UA). Screenshots saved to `/tmp/competitor-2026-09/`. Only Lets Move Indonesia yielded a usable grid (11 tiles pre-login-wall); Emerhub confirmed squatted; Flado confirmed private. Same access pattern as June — no authenticated session cookie has been set up yet (still an open recommendation from June's digest).
+- **qwen2.5vl:7b pre-filter**: invoked via Ollama's HTTP API (`POST /api/generate` with a base64-encoded image), not the `ollama run` CLI — the installed CLI version does not resolve an inline image file path typed into the prompt text as an attachment; it only reads it as literal text. This is a runbook correction for next month: don't rely on the CLI path attaching images, always use the API with a base64 payload. The model correctly parsed 10 of 11 visible grid tiles and classified 2 as lifestyle/aesthetic (dropped) and 8 as educational/promotional (kept). Two additional tiles containing a price disclosure and a testimonial were manually recovered by this agent's own direct read of the same screenshot during data verification, since a pricing tile is exactly the kind of thing the no-paraphrase/no-fabrication rule requires capturing precisely rather than letting a partial vision-model miss drop it silently.
+- **Sonnet analysis**: performed by this agent on the 10 kept Lets Move Indonesia tiles. No Emerhub or Flado IG content was available to analyze this month (squatted / private, respectively).
+- **Pricing/regulatory freshness**: Emerhub PT PMA pricing re-verified 2026-09-01, unchanged from the 2026-06-01 baseline in `reference_emerhub_pricing_2026_06.md`. All regulatory claims from both competitors are quoted verbatim in this digest and are NOT independently confirmed by this agent — the competitor-monitor agent's toolset (Read/Write/Bash/WebFetch) does not include NotebookLM access, so verification against NB-INTEL must happen separately.

--- a/research/competitive/2026-09-digest.md
+++ b/research/competitive/2026-09-digest.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: codex
+---
+
 # Competitive Digest — 2026-09
 
 **Window**: 2026-06-01 to 2026-09-01 (see Methodology — cadence gap) · **Author**: competitor-monitor agent · **Status**: published
@@ -22,9 +26,9 @@
 
 Profile unchanged from June: letsmoveindonesia.com, same awards claimed ("Best Visa & Business Consultancy in Indonesia," "Most Trusted Visa & Legal Agency in Indonesia" — no certifying body, no date), same four offices (Jakarta HQ, Seminyak, Canggu, Sanur).
 
-**Service catalogue**: no new or removed service lines detected across homepage, `/legal-services/`, `/visa-services/`. The full visa list (30+ types including Global Citizenship of Indonesia, Golden Visa E33B, Second Home E33, Remote Work E33G) matches June exactly. Legal services (PT/PMA/Representative Office, licenses, trademark, LKPM, virtual office, OSS transition) also match June exactly.
+**Service catalogue**: no new or removed service lines detected across homepage, `/legal-services/`, `/visa-services/`. The visa list (30+ types) still includes the same named examples confirmed in June — Global Citizenship of Indonesia, Remote Work Visa E33G — plus Golden Visa E33B and Second Home E33 observed this month. Legal services (PT/PMA/Representative Office, licenses, trademark, LKPM, virtual office, OSS transition) match June's description. **[CORRECTED per codex adversarial review, 2026-09-02]** Originally claimed "the full visa list... matches June exactly" — the June digest never itemized a complete 30+ visa list to match against (it named GCI and E33G as examples, not an enumerated full catalogue, and its "30+" examples were mostly global-destination visas, not Indonesian permit types); "matches exactly" overstates what June actually established.
 
-**Pricing**: still no service pricing disclosed on any web page. One figure surfaced this month that wasn't called out in June's summary: "Second Home Visa: minimum deposit of 2,000,000,000 IDR is required." This is the statutory deposit requirement for that visa class (a government figure, not a Lets Move service fee) — noted here for completeness, not as a Lets Move price change. Per the no-paraphrase rule, treat this as their disclosure of a regulatory figure, not their own pricing.
+**Pricing**: still no service pricing disclosed on any web page. One figure surfaced this month that wasn't called out in June's summary: "Second Home Visa: minimum deposit of 2,000,000,000 IDR is required." This reads as the deposit requirement for that visa class (a government figure, not a Lets Move service fee) — noted here for completeness, not as a Lets Move price change. Per the no-paraphrase rule, treat this as their disclosure of a regulatory figure, not their own pricing. **[CORRECTED per codex adversarial review, 2026-09-02]** Labeling this "statutory" is not independently confirmed by this agent (this agent's toolset has no NB-INTEL/legal access, per the Methodology note that regulatory claims are unverified) — flagged here rather than asserted; it is directionally consistent with Bali Zero's own base-E33 fact registry (USD 130,000 ≈ IDR ~2.08B at prevailing rates, per `.claude/skills/secondhome/SKILL.md`), but that is a rough cross-check, not a citation.
 
 **Blog (`/news/`) — top 5 visible**: identical titles to June (Indonesia Tax Handbook 2026, Global Visa launch, GCI announcement, Single Entry Social Visa 2026 guide, VOA 2026 guide). The news index has not visibly refreshed in three months. Either the featured list is static/pinned, or publishing cadence has slowed — this agent cannot distinguish the two from the index page alone.
 
@@ -34,7 +38,7 @@ Profile unchanged from June: letsmoveindonesia.com, same awards claimed ("Best V
 
 **Grid visibility**: 11 post tiles rendered before the login wall this run (vs 6 in June) — Instagram's unauthenticated render depth varies session to session; this is a scraping-condition difference, not evidence that Lets Move posted more.
 
-**qwen2.5vl:7b pre-filter** (local Ollama, invoked via `/api/generate` with base64 image — the `ollama run` CLI does not accept an inline image path in the installed version, noted for next month's runbook): model read 10 of the 11 visible tiles (one price-bearing tile was partly obscured by the login modal and one testimonial tile was missed). Classification:
+**qwen2.5vl:7b pre-filter** (local Ollama, invoked via `/api/generate` with base64 image — the `ollama run` CLI does not accept an inline image path in the installed version, noted for next month's runbook): model classified 9 of the 11 visible tiles automatically; 2 tiles (one price-bearing tile obscured by the login modal, one testimonial tile) were missed by the model and recovered manually by this agent's own read of the same screenshot. **[CORRECTED per codex adversarial review, 2026-09-02]** The original wording here said "read 10 of the 11... one... obscured... and one... was missed" — that describes 2 misses while asserting a 10/11 read rate, which is arithmetically inconsistent (a 10/11 read implies only 1 miss). Classification:
 
 | # | Tile text | Class | Keep/Drop |
 |---|---|---|---|
@@ -65,8 +69,8 @@ Dropped 2 of 11 (both Independence Day seasonal content). No factually questiona
 
 1. **New IG price point (IDR 23,000,000 bundle)**: pull the linked landing page to see what's actually bundled, then compare against Bali Zero's equivalent offer before treating this as a pricing signal either way.
 2. **"Ask the Expert" recurring format**: a content-format gap worth 10 minutes of review — does Bali Zero have an equivalent named-staff Q&A series, or is it currently all illustrated/educational carousels?
-3. **Follower count**: −1.1% month-over-month (well within normal churn) — not treated as material.
-4. **Blog stagnation**: same top-5 for three months running. If Bali Zero's own content cadence is faster, that is a differentiator worth stating internally, not worth publicly contrasting (avoid competitive-bashing voice).
+3. **Follower count**: −92 / −1.1% since the June snapshot (well within normal churn) — not treated as material. **[CORRECTED per codex adversarial review, 2026-09-02]** Originally labeled "month-over-month"; no July/August observation exists (see Methodology cadence gap), so this is a three-month endpoint delta, not a monthly rate.
+4. **Blog stagnation**: identical top-5 at both endpoints checked (June, September). **[CORRECTED per codex adversarial review, 2026-09-02]** Originally read "same top-5 for three months running," which implies continuous monitoring; only two endpoint checks exist, three months apart, with no July/August observation. If Bali Zero's own content cadence is faster, that is a differentiator worth stating internally, not worth publicly contrasting (avoid competitive-bashing voice).
 
 ---
 
@@ -76,13 +80,13 @@ Dropped 2 of 11 (both Independence Day seasonal content). No factually questiona
 
 **Hero headline (verbatim, June → September)**: "Start and scale your business in Southeast Asia" → "Helping investors expand to new markets."
 
-**Subheading (verbatim, June → September)**: "One partner. One dashboard. Zero guesswork." → "Local teams across Southeast Asia, clearing the path from first filing to fully operating."
+**Subheading (verbatim, June → September)**: "From incorporation to compliance, we handle the complexity of Southeast Asia and beyond so you can focus on growth. One partner. One dashboard. Zero guesswork." → "Local teams across Southeast Asia, clearing the path from first filing to fully operating." **[CORRECTED per codex adversarial review, 2026-09-02]** The June side was originally truncated to only "One partner. One dashboard. Zero guesswork." while labeled "verbatim" — restored to June's full recorded subheading text above.
 
 This reads as a deliberate move away from "single tech platform" framing toward "local teams/service" framing — evidence for a voice/positioning shift, not a guess.
 
 **Trust signals (June → September)**: "98% client retention, 12+ years in Asia, 8+ countries, trusted by 3,000+ companies" (no named clients) → "helped 11,700+ companies... since 2011 (14+ years)," with named enterprise clients: BNP Paribas, Fujitsu, Citigroup, PWC, TELUS, Philips, Virgin Group, and "40+ others." The 98% retention figure was not observed in this month's extraction (may simply not have been surfaced by the fetch — not confirmed removed).
 
-**Markets listed**: June — Indonesia, Philippines, Malaysia, Singapore, Vietnam, Bali, Thailand, Cambodia, Saudi Arabia, Qatar, Oman (11). September — Indonesia, Malaysia, Philippines, Singapore, Thailand, Vietnam, Cambodia, Hong Kong, Bali, UAE (10). Hong Kong is newly listed on the homepage; Saudi Arabia, Qatar, and Oman are absent from this month's homepage list (their standalone service pages were not checked, so this may reflect homepage curation rather than market exit).
+**Markets listed**: September — Indonesia, Malaysia, Philippines, Singapore, Thailand, Vietnam, Cambodia, Hong Kong, Bali, UAE (10). **[CORRECTED per codex adversarial review, 2026-09-02]** This paragraph originally presented an 11-market "June" list (…Saudi Arabia, Qatar, Oman) and framed Hong Kong as "newly listed" and the Gulf states as "absent" relative to it. The June 2026-06 digest on disk records only "8+ countries, not Bali-specific" for Emerhub — it does not itemize a market-by-market list, so no June baseline exists in this repo to diff September's 10-market list against. The June-side list and the "newly listed" / "absent" framing are therefore withdrawn as unsubstantiated; only this month's observed 10-market list stands.
 
 ### Web — Pricing & Timeline Claims
 
@@ -94,9 +98,9 @@ This reads as a deliberate move away from "single tech platform" framing toward 
 | Incorporation + Basic Compliance | US$2,249 | + virtual address (12mo), quarterly LKPM (12mo) |
 | Incorporation + Full Compliance | US$4,229/year | + monthly tax reporting (≤20 tx/mo), payroll (≤5 employees), annual CIT |
 
-No pricing change detected — three consecutive checks (per baseline memory, dated 2026-06-01) at the same figures.
+No pricing change detected between the two checks on disk (June and September, three months apart — per baseline memory, dated 2026-06-01) at the same figures. **[CORRECTED per codex adversarial review, 2026-09-02]** Originally said "three consecutive checks"; only two digests exist (June, September), not three.
 
-**Timeline claims — removed since June, verbatim comparison**:
+**Timeline claims — removed since June, verbatim comparison**. **[CORRECTED per codex adversarial review, 2026-09-02]** The June digest recorded these same three quotes (the "5 working days" / "2-4 working days" pair, plus the Bali page's "3-5 Working Days") but did not itemize which came from `/indonesia/` vs `/indonesia/pt-pma/` specifically — the first two were grouped under one "Web — Homepage & Services" note. The per-URL split below is this month's own page-by-page check, not a June-recorded fact; the substance (all three day-count claims present in June, absent in September) is unaffected.
 
 | Page | June (verbatim) | September |
 |---|---|---|
@@ -137,7 +141,7 @@ However, the broader August publishing list (roughly 20 posts visible) shows thi
 - **"Retire in Bali: Visa Options, Cost, and Best Locations"** (Aug 19)
 - **"Bali Tourist Tax: Cost, Payment, and Exemptions"** (Aug 7)
 
-Combined with the Bali page's new Second Home/Employer of Record/property-permitting depth, this reads as Emerhub broadening from pure B2B PT PMA work into Bali consumer/expat-facing content — a genuine widening of their competitive footprint into Bali Zero's core territory, not just an isolated blog post.
+Combined with the Bali page's new Second Home/Employer of Record/property-permitting depth, this reads as Emerhub deepening from June's already-present Bali-page mix (Property Services, Visas & Work Permits alongside Company Registration and Tax & Accounting) into more granular consumer/expat-facing content — a genuine widening of their competitive footprint into Bali Zero's core territory, not just an isolated blog post. **[CORRECTED per codex adversarial review, 2026-09-02]** Originally framed the June baseline as "pure B2B PT PMA work" — June's own Bali page already listed Property Services and Visas & Work Permits, so the June starting point was not purely B2B/corporate; what changed is granularity and depth, not category.
 
 **Voice note**: the site footer newsletter pitch now reads "Breaking barriers... One email, twice a month... We don't pad the email," a more casual, direct tone than June's corporate "One partner. One dashboard. Zero guesswork." Consistent with the homepage headline/subhead change above — this looks like a broader tone shift, not an isolated homepage edit.
 
@@ -148,9 +152,9 @@ No change from June: the handle is still held by an unrelated user "Kim" (8 foll
 ### Bali Zero Implications
 
 1. **Regulatory claim — verify before use.** The Bali low/medium-low-risk KBLI restriction claim is the single most consequential item in this month's digest if true. Flag to legal/Damar before it shapes any client-facing communication, and before assuming Bali Zero's own PT PMA process for Bali-address clients is or isn't affected.
-2. **Pricing benchmark unchanged.** Emerhub's PT PMA floor remains US$1,700 / US$2,249 / US$4,229 per year — stable reference point for company-setup positioning.
+2. **Pricing benchmark unchanged.** Emerhub's PT PMA floor remains US$1,700 (incorporation) / US$2,249 (+basic compliance) / US$4,229/year (+full compliance) — stable reference point for company-setup positioning. **[CORRECTED per codex adversarial review, 2026-09-02]** Originally read "$4,229 per year" applied to all three tiers; per both digests' own pricing tables, only the third tier is an annual figure.
 3. **Speed claims disappeared.** If Bali Zero has ever positioned against Emerhub's "5 working days" claim, that specific claim is no longer on their site as of this check — any positioning copy referencing it should be re-verified against Emerhub's current pages before reuse.
-4. **Bali page and blog both deepened into property/lifestyle-immigration territory** (KKPR zoning, PBG/SLF permits, Second Home visa, Employer of Record, Retire in Bali, Bali Tourist Tax). This is the closest Emerhub has come to Bali Zero's actual positioning in the three checks on record. Worth a closer read of Emerhub's Bali page and these two blog posts for content-gap analysis next cycle.
+4. **Bali page and blog both deepened into property/lifestyle-immigration territory** (KKPR zoning, PBG/SLF permits, Second Home visa, Employer of Record, Retire in Bali, Bali Tourist Tax). This is the closest Emerhub has come to Bali Zero's actual positioning in the two checks on record (June, September). Worth a closer read of Emerhub's Bali page and these two blog posts for content-gap analysis next cycle.
 5. **Client-roster escalation** (3,000+ → 11,700+ companies, named enterprise logos) is a credibility push aimed at larger corporate clients, not directly competitive with Bali Zero's SME/individual client base — noted for awareness, not action.
 
 ---
@@ -195,6 +199,60 @@ Flado remains fully dark. This is now two consecutive checks with zero signal, s
 - **Web fetch**: `WebFetch` (30s timeout, retry once) used for all pages except Emerhub's blog index, which returned only navigation chrome via the static-HTML converter (likely client-side-rendered article listings). Fell back to a headless Playwright render (Chromium via `npx playwright`, domcontentloaded + 4s settle) for that one page, which succeeded and returned the full post list including dates and authors.
 - **Flado**: unreachable on both HTTPS and HTTP, retried once each, per spec. Logged as `unreachable: [flado, https://flado.com/]`.
 - **IG scraping**: unauthenticated headless Playwright (Chromium, 1280×2400 viewport, standard desktop UA). Screenshots saved to `/tmp/competitor-2026-09/`. Only Lets Move Indonesia yielded a usable grid (11 tiles pre-login-wall); Emerhub confirmed squatted; Flado confirmed private. Same access pattern as June — no authenticated session cookie has been set up yet (still an open recommendation from June's digest).
-- **qwen2.5vl:7b pre-filter**: invoked via Ollama's HTTP API (`POST /api/generate` with a base64-encoded image), not the `ollama run` CLI — the installed CLI version does not resolve an inline image file path typed into the prompt text as an attachment; it only reads it as literal text. This is a runbook correction for next month: don't rely on the CLI path attaching images, always use the API with a base64 payload. The model correctly parsed 10 of 11 visible grid tiles and classified 2 as lifestyle/aesthetic (dropped) and 8 as educational/promotional (kept). Two additional tiles containing a price disclosure and a testimonial were manually recovered by this agent's own direct read of the same screenshot during data verification, since a pricing tile is exactly the kind of thing the no-paraphrase/no-fabrication rule requires capturing precisely rather than letting a partial vision-model miss drop it silently.
-- **Sonnet analysis**: performed by this agent on the 10 kept Lets Move Indonesia tiles. No Emerhub or Flado IG content was available to analyze this month (squatted / private, respectively).
+- **qwen2.5vl:7b pre-filter**: invoked via Ollama's HTTP API (`POST /api/generate` with a base64-encoded image), not the `ollama run` CLI — the installed CLI version does not resolve an inline image file path typed into the prompt text as an attachment; it only reads it as literal text. This is a runbook correction for next month: don't rely on the CLI path attaching images, always use the API with a base64 payload. **[CORRECTED per codex adversarial review, 2026-09-02 — the original count here ("10 of 11... 2 dropped + 8 kept") did not match the 11-row table (9 Keep, 2 Drop) and double-counted the 2 manually-recovered tiles as model output.]** Of the 11 visible grid tiles, the model automatically classified 9 (2 as lifestyle/aesthetic, dropped; 7 as educational/promotional, kept) and missed 2, which were manually recovered by this agent's own direct read of the same screenshot during data verification — bringing the final Keep/Drop table to 9 kept / 2 dropped. A pricing tile and a testimonial tile are exactly the kind of thing the no-paraphrase/no-fabrication rule requires capturing precisely rather than letting a partial vision-model miss drop them silently.
+- **Sonnet analysis**: performed by this agent on the 9 kept Lets Move Indonesia tiles (**[CORRECTED per codex adversarial review, 2026-09-02]** — was "10," see qwen2.5vl:7b pre-filter correction above). No Emerhub or Flado IG content was available to analyze this month (squatted / private, respectively).
 - **Pricing/regulatory freshness**: Emerhub PT PMA pricing re-verified 2026-09-01, unchanged from the 2026-06-01 baseline in `reference_emerhub_pricing_2026_06.md`. All regulatory claims from both competitors are quoted verbatim in this digest and are NOT independently confirmed by this agent — the competitor-monitor agent's toolset (Read/Write/Bash/WebFetch) does not include NotebookLM access, so verification against NB-INTEL must happen separately.
+
+## Adversarial review
+
+**Date**: 2026-09-02. **Seat**: `codex` (`gpt-5.6-sol`, `model_reasoning_effort=high`,
+`--sandbox read-only`, stance REFUTE — generator≠grader, this seat did not author the document).
+Checked every claimed June→September delta against what `research/competitive/2026-06-digest.md`
+(the only prior digest on disk) actually says, and checked the September document's internal
+arithmetic/coherence. Every finding below was independently re-verified in this session (direct
+re-read of both digest files) before being folded in — not taken on the refuter's word alone.
+
+**Confirmed and corrected in place:**
+
+- IG pre-filter arithmetic was internally inconsistent (claimed "10 of 11 read" + "2 dropped + 8
+  kept" while the table shows 9 Keep/2 Drop and 2 tiles were manually recovered, not 1) —
+  corrected to 9 auto-classified + 2 manually recovered = 11, 9 kept overall.
+- "−1.1% month-over-month" follower delta mislabeled — it is a three-month endpoint delta (June
+  to September), no July/August observation exists.
+- "Three consecutive checks" / "three checks on record" for Emerhub pricing — only two digests
+  exist on disk (June, September); corrected to "two checks, three months apart" (×2 instances).
+- "$4,229 per year" applied to all three Emerhub PT PMA tiers in the Implications prose —
+  corrected; only the third tier is annual, per both digests' own pricing tables.
+- "Same top-5 for three months running" — corrected to note only two endpoint checks exist, not
+  continuous monitoring.
+- "Full visa list... matches June exactly" — June never itemized a complete visa list to match
+  against; corrected to name only the specific items June actually recorded (GCI, E33G).
+- Emerhub's June subheading quoted as "verbatim" but truncated (dropped the first sentence) —
+  restored to June's full recorded text.
+- The claimed 11-market "June" list (with Saudi Arabia/Qatar/Oman) and the "Hong Kong newly
+  listed" / "absent" framing built on it — **withdrawn**. The June digest records only "8+
+  countries, not Bali-specific" with no market-by-market list; there is no June baseline in this
+  repo to diff September's 10-market list against.
+- "Broadening from pure B2B PT PMA work" as the June baseline for Emerhub's Bali page — June's
+  own Bali page already listed Property Services and Visas & Work Permits; corrected to describe
+  this as deepening/granularity, not a category change.
+- Timeline-claim per-URL attribution (`/indonesia/` vs `/indonesia/pt-pma/`) — June recorded the
+  same three quotes but did not itemize which URL each came from; flagged as this month's own
+  page-by-page check, not a June-recorded fact.
+- "Statutory" label on the Second Home IDR 2B deposit figure — flagged as not independently
+  confirmed by this agent's toolset (no NB-INTEL/legal access), with a rough cross-check against
+  Bali Zero's own base-E33 fact registry noted instead of an unqualified regulatory citation.
+
+**Not corrected (self-disclosed, judgment call, not a factual error):** the refuter also
+questioned whether Flado's two checks (June, September, no July/August run) should count as
+"2+ consecutive months unreachable" per the agent spec's threshold language. The document already
+discloses the gap explicitly ("no July/August run occurred to test the interval more finely") in
+the same sentence that invokes the threshold, so this is left as the document's own transparent
+judgment call rather than a corrected factual claim.
+
+**BLOCKER: none surviving.** All raised issues were either genuine arithmetic/attribution errors
+(corrected above, all independently re-verified against the June digest and the September
+document's own tables) or a disclosed interpretive judgment call (left as-is with reasoning
+noted). None of the corrections change the digest's substantive competitive read (Emerhub's
+positioning shift, Lets Move's new IG price point and content format, Flado's continued
+unreachability).


### PR DESCRIPTION
## Summary
Monthly competitive intelligence digest (competitor-monitor agent) for Lets Move Indonesia, Emerhub, and Flado, covering the window 2026-06-01 to 2026-09-01 (diffed against the 2026-06 snapshot — no July/August runs exist, flagged as a cadence gap in the digest itself).

## Key findings
- Emerhub's Bali page added a new, unverified regulatory claim about a May-2026 KBLI restriction for foreign-owned Bali-address companies — quoted verbatim, flagged for NB-INTEL/legal cross-check.
- Emerhub repositioned homepage trust signals (3,000+ -> 11,700+ companies, named enterprise clients) and dropped explicit "X working days" timeline claims from 3 pages that had them in June. PT PMA pricing unchanged.
- Lets Move Indonesia surfaced a new IG price point (IDR 23,000,000 bundle) and a recurring "Ask the Expert" content format.
- Flado unreachable for the 2nd consecutive check (same SSL error as June).

Docs-only change (research artifact), no code/schema touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>