### PR TITLE
fix(ops): four probes on the fleet dashboard, each pinned from both sides

### DIFF
--- a/scripts/fleet_dashboard.py
+++ b/scripts/fleet_dashboard.py
@@ -442,7 +442,12 @@ def collect() -> dict[str, Any]:
     # which those are, and a green PR has no failing check to name. Computed
     # once here and read twice below; the first version called it once per
     # caller and paid for every PR twice.
-    red = [p for p in live if rollup_state(p) == "FAILURE"]
+    # `== "FAILURE"` here was the same defect as in failing_checks(), one level
+    # up and worse: a PR whose rollup state is ERROR matched NEITHER this nor
+    # the SUCCESS test below, so it vanished from both cards and appeared only
+    # in the raw total — not "red with no reason", but absent. Found by
+    # adversarial review while tracing the fix to the function below it.
+    red = [p for p in live if rollup_state(p) in FAILING_VERDICTS]
     fail_map = {p["number"]: failing_checks(p["number"]) for p in red}
     causes: dict[str, list[int]] = defaultdict(list)
     for number, names in fail_map.items():
@@ -458,6 +463,22 @@ def collect() -> dict[str, Any]:
     unknown_merge = [p["number"] for p in live if p["mergeable"] == "UNKNOWN"]
 
     green = [p for p in live if rollup_state(p) == "SUCCESS"]
+    # Anything in neither set and not a known in-flight state is a rollup value
+    # this page cannot classify. It is COUNTED and reported, because the whole
+    # failure mode being cured here is a PR quietly belonging to no bucket.
+    unclassified = sorted(
+        p["number"] for p in live
+        if rollup_state(p) not in FAILING_VERDICTS
+        and rollup_state(p) not in BENIGN_VERDICTS
+        and rollup_state(p) != "—"
+    )
+    if unclassified:
+        sys.stderr.write(
+            "fleet_dashboard: rollup state not classifiable on "
+            f"{len(unclassified)} PR(s) {unclassified} — they are counted in the "
+            "total and in no card. Add the value to FAILING_VERDICTS or "
+            "BENIGN_VERDICTS.\n"
+        )
     # ready = green AND known-mergeable AND not queued: the pile that would move
     # with no work at all. `mergeable == "MERGEABLE"` is asserted positively,
     # never inferred from "not CONFLICTING" — that inference is what put a

--- a/scripts/fleet_dashboard.py
+++ b/scripts/fleet_dashboard.py
@@ -84,14 +84,19 @@ GIT_CWD = Path(__file__).resolve().parent.parent
 
 
 def _warn_if_main_checkout() -> None:
-    if GIT_CWD.name == "nuzantara" and not GIT_CWD.parent.name == ".worktrees":
-        if (GIT_CWD / ".git").is_dir():
-            sys.stderr.write(
-                f"fleet_dashboard: running from what looks like the MAIN checkout "
-                f"({GIT_CWD}). If the worktree-isolation hook is armed it will refuse "
-                "every git call and the conflict section will be empty for the wrong "
-                "reason. Run this from a worktree.\n"
-            )
+    # Judged on the FACT, not on the folder's name. An earlier version also
+    # required `GIT_CWD.name == "nuzantara"` and a parent not named
+    # `.worktrees`, which silently false-negatives on any differently-named
+    # clone. In a linked worktree `.git` is a FILE pointing at the real object
+    # store; only a primary checkout has it as a DIRECTORY. That single test is
+    # naming-independent and is the whole signal.
+    if (GIT_CWD / ".git").is_dir():
+        sys.stderr.write(
+            f"fleet_dashboard: running from what looks like the MAIN checkout "
+            f"({GIT_CWD}). If the worktree-isolation hook is armed it will refuse "
+            "every git call and the conflict section will be empty for the wrong "
+            "reason. Run this from a worktree.\n"
+        )
 
 
 def _run(args: list[str], timeout: int = 90) -> tuple[int, str, str]:
@@ -233,6 +238,13 @@ query($n: Int!) {
 """ % tuple(REPO.split("/"))
 
 
+#: Not a check name and deliberately not shaped like one: it is the answer to
+#: "why is this PR red?" when the instrument that was supposed to answer never
+#: replied. It groups into its own row in the causes table so the reader sees
+#: that the tally is incomplete rather than reading a short list as a full one.
+PROBE_UNREADABLE = "\u00b7 la sonda dei controlli non ha risposto"
+
+
 def failing_checks(number: int) -> list[str]:
     """Names of the checks that are FAILURE on this PR's head commit.
 
@@ -245,21 +257,34 @@ def failing_checks(number: int) -> list[str]:
     hundred — so the bulk query now carries the rollup state alone (cheap) and
     the detail is fetched only where it is actually read.
     """
+    def unreadable(why: str) -> list[str]:
+        # A probe that could not measure says so ON THE PAGE, not only to
+        # stderr. Returning a bare [] rendered as "red, with no reason given"
+        # and silently under-counted that check's tally in the grouped table —
+        # indistinguishable from a PR that genuinely has no named failing
+        # context. The sentinel is deliberately not check-shaped so it can
+        # never be mistaken for one, and it groups into its own row, which is
+        # what makes the incompleteness visible instead of silent.
+        sys.stderr.write(f"fleet_dashboard: checks unreadable for #{number}: {why[:160]}\n")
+        return [PROBE_UNREADABLE]
+
     rc, out, err = _run(
         ["gh", "api", "graphql", "-f", f"query={CONTEXTS_ONE}", "-F", f"n={number}"]
     )
     if rc != 0 or not out.strip():
-        sys.stderr.write(f"fleet_dashboard: checks unreadable for #{number}: {err[:160]}\n")
-        return []
+        return unreadable(err or out)
     try:
         commits = json.loads(out)["data"]["repository"]["pullRequest"]["commits"]["nodes"]
     except (KeyError, TypeError, json.JSONDecodeError):
-        return []
+        return unreadable("risposta GraphQL malformata")
     if not commits:
-        return []
+        return unreadable("nessun commit nella risposta")
     rollup = commits[0]["commit"]["statusCheckRollup"]
     if not rollup:
-        return []
+        # The bulk query already said this PR's rollup is FAILURE. A per-PR
+        # answer of "no rollup at all" contradicts that, so it is a disagreement
+        # between two probes, never a clean "no checks ran".
+        return unreadable("nessun rollup, in contraddizione con la query d'insieme")
     names = []
     for ctx in rollup["contexts"]["nodes"]:
         name = ctx.get("name") or ctx.get("context") or "?"

--- a/scripts/fleet_dashboard.py
+++ b/scripts/fleet_dashboard.py
@@ -41,8 +41,13 @@ was measured lying, in this repo, on 2026-09-01):
      the actionable fact — it is the difference between "twelve problems"
      and "one problem, twelve times".
 
-Read-only. Runs `gh` and `git`; writes exactly one HTML file. Never mutates
-a PR, never arms, never merges.
+Read-only in the sense that matters, and NOT write-free — worth stating
+precisely rather than claiming more than is true. It never mutates a PR, never
+arms, never merges, and never touches an index or a working tree. It does
+write: the HTML file, the JSON dump when `--json` is passed, and — via
+`git fetch` and `git merge-tree --write-tree` — objects and remote-tracking
+refs in the SHARED `.git` store. Per git-merge-tree(1) that last pair cannot
+disturb a concurrent session's work.
 
 Usage:
     python3 scripts/fleet_dashboard.py --out /tmp/dashboard.html
@@ -64,10 +69,29 @@ from typing import Any
 
 REPO = "Bali-Zero/Teman2"
 
-# git is refused in the main checkout by the worktree-isolation hook, and a
-# worktree shares the object database, so every git probe runs from wherever
-# this script lives — which is always inside a worktree or the checkout root.
+# The fleet is in Bali. Every date boundary on this page is WITA, never UTC —
+# a UTC "today" drops the 00:00-08:00 local window, which is exactly when the
+# overnight autonomous runs land.
+WITA = dt.timedelta(hours=8)
+
+# Every git probe runs from wherever this script lives. That is normally a
+# worktree, which shares the object database and is what the worktree-isolation
+# hook expects. If it ever resolves to the guarded MAIN checkout, the hook
+# refuses each git call and the page renders with every conflict verdict
+# missing and nothing saying why — so that case is named out loud at startup
+# rather than degrading quietly (adversarial review, 2026-09-01).
 GIT_CWD = Path(__file__).resolve().parent.parent
+
+
+def _warn_if_main_checkout() -> None:
+    if GIT_CWD.name == "nuzantara" and not GIT_CWD.parent.name == ".worktrees":
+        if (GIT_CWD / ".git").is_dir():
+            sys.stderr.write(
+                f"fleet_dashboard: running from what looks like the MAIN checkout "
+                f"({GIT_CWD}). If the worktree-isolation hook is armed it will refuse "
+                "every git call and the conflict section will be empty for the wrong "
+                "reason. Run this from a worktree.\n"
+            )
 
 
 def _run(args: list[str], timeout: int = 90) -> tuple[int, str, str]:
@@ -97,17 +121,10 @@ query {
       nodes {
         number title isDraft mergeable mergeStateStatus headRefName headRefOid
         updatedAt
-        author { login }
+        author { __typename login }
         autoMergeRequest { enabledAt }
         mergeQueueEntry { position state }
-        commits(last: 1) { nodes { commit { statusCheckRollup {
-          state
-          contexts(first: 100) { nodes {
-            __typename
-            ... on CheckRun { name conclusion }
-            ... on StatusContext { context state }
-          } }
-        } } } }
+        commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
       }
     }
   }
@@ -160,10 +177,28 @@ def resolve_mergeable(number: int, attempts: int = 3, delay: float = 2.0) -> tup
 
 
 def fetch_open_prs() -> list[dict[str, Any]]:
-    rc, out, err = _run(["gh", "api", "graphql", "-f", f"query={GRAPHQL}"])
-    if rc != 0 or not out.strip():
-        raise SystemExit(f"gh graphql failed (rc={rc}): {(err or out)[:400]}")
-    prs = json.loads(out)["data"]["repository"]["pullRequests"]["nodes"]
+    # This query is heavy — 100 PRs each with up to 100 check contexts — and
+    # GitHub answers "We couldn't respond to your request in time" often enough
+    # that a single attempt fails roughly half the time. Measured on 2026-09-01:
+    # attempt 1 timed out, attempt 2 succeeded. A one-shot version is unusable
+    # from cron, so the retry is a requirement of the use case, not polish.
+    prs = None
+    for attempt in range(3):
+        rc, out, err = _run(["gh", "api", "graphql", "-f", f"query={GRAPHQL}"], timeout=120)
+        if rc == 0 and out.strip():
+            prs = json.loads(out)["data"]["repository"]["pullRequests"]["nodes"]
+            break
+        sys.stderr.write(
+            f"fleet_dashboard: bulk query attempt {attempt + 1}/3 failed "
+            f"(rc={rc}): {(err or out).strip()[:200]}\n"
+        )
+        if attempt < 2:
+            time.sleep(4.0)
+    if prs is None:
+        raise SystemExit(
+            "fleet_dashboard: gh graphql failed 3 times — refusing to render a "
+            "page from no data."
+        )
     # Re-ask, per PR, for every row the bulk query left uncomputed. This is the
     # only field on the page whose wrongness points a reader AWAY from work that
     # exists, so it is the one worth up to N extra API calls.
@@ -175,20 +210,57 @@ def fetch_open_prs() -> list[dict[str, Any]]:
     return prs
 
 
-def failing_checks(pr: dict[str, Any]) -> list[str]:
-    commits = pr["commits"]["nodes"]
+CONTEXTS_ONE = """
+query($n: Int!) {
+  repository(owner: "%s", name: "%s") {
+    pullRequest(number: $n) {
+      commits(last: 1) { nodes { commit { statusCheckRollup {
+        contexts(first: 100) { nodes {
+          __typename
+          ... on CheckRun { name conclusion }
+          ... on StatusContext { context state }
+        } }
+      } } } }
+    }
+  }
+}
+""" % tuple(REPO.split("/"))
+
+
+def failing_checks(number: int) -> list[str]:
+    """Names of the checks that are FAILURE on this PR's head commit.
+
+    WHY THIS IS A SEPARATE, PER-PR QUERY. The first version asked for
+    `contexts(first:100)` inside the bulk 100-PR query — 100 x 100 nodes in one
+    request. GitHub answered "We couldn't respond to your request in time" on
+    every attempt with a 3x retry, measured 2026-09-01: the retry made a heavy
+    query fail more slowly, it did not make it succeed. The contexts are only
+    needed for PRs whose ROLLUP is already FAILURE — about twenty, not a
+    hundred — so the bulk query now carries the rollup state alone (cheap) and
+    the detail is fetched only where it is actually read.
+    """
+    rc, out, err = _run(
+        ["gh", "api", "graphql", "-f", f"query={CONTEXTS_ONE}", "-F", f"n={number}"]
+    )
+    if rc != 0 or not out.strip():
+        sys.stderr.write(f"fleet_dashboard: checks unreadable for #{number}: {err[:160]}\n")
+        return []
+    try:
+        commits = json.loads(out)["data"]["repository"]["pullRequest"]["commits"]["nodes"]
+    except (KeyError, TypeError, json.JSONDecodeError):
+        return []
     if not commits:
         return []
     rollup = commits[0]["commit"]["statusCheckRollup"]
     if not rollup:
         return []
-    out = []
+    names = []
     for ctx in rollup["contexts"]["nodes"]:
         name = ctx.get("name") or ctx.get("context") or "?"
         verdict = ctx.get("conclusion") or ctx.get("state")
         if verdict == "FAILURE":
-            out.append(name)
-    return out
+            names.append(name)
+    return names
 
 
 def rollup_state(pr: dict[str, Any]) -> str:
@@ -211,7 +283,18 @@ def conflict_kind(pr: dict[str, Any]) -> str:
     if pr["mergeable"] != "CONFLICTING":
         return "none"
     branch = pr["headRefName"]
-    _run(["git", "fetch", "origin", branch, "--quiet"], timeout=120)
+    # The fetch's rc is READ, not discarded (adversarial review, round 2): a
+    # failed fetch leaves the trial merge running against a stale ref, so the
+    # probe answers a question about the past while looking like an answer
+    # about now. Same failure direction as the two defects above — an
+    # unusable probe must not produce a verdict.
+    rc, _, err = _run(["git", "fetch", "origin", branch, "--quiet"], timeout=120)
+    if rc != 0:
+        sys.stderr.write(
+            f"fleet_dashboard: fetch failed for #{pr['number']} ({branch}): "
+            f"rc={rc} {err.strip()[:200]}\n"
+        )
+        return "unknown"
     rc, sha, err = _run(["git", "rev-parse", f"origin/{branch}"])
     if rc != 0:
         return "unknown"
@@ -245,25 +328,47 @@ def merged_today() -> list[dict[str, Any]]:
     )
     if rc != 0 or not out.strip():
         return []
-    today = dt.datetime.now(dt.timezone.utc).date()
+    # "Today" is WITA, not UTC. The page prints a WITA clock for a reader in
+    # Bali, and a UTC cutoff silently drops everything merged between midnight
+    # and 08:00 local — the exact hours an overnight autonomous run lands in.
+    # Reported by adversarial review, 2026-09-01.
+    today = (dt.datetime.now(dt.timezone.utc) + WITA).date()
     rows = []
     for m in json.loads(out):
         when = dt.datetime.fromisoformat(m["mergedAt"].replace("Z", "+00:00"))
-        if when.date() == today:
+        if (when + WITA).date() == today:
             rows.append(m)
     return rows
 
 
 def collect() -> dict[str, Any]:
+    # If THIS fetch fails, every trial merge below compares against a stale
+    # origin/main and the whole conflict section becomes fiction. It is the one
+    # probe whose failure poisons every other, so it aborts rather than
+    # degrades: a page that does not render is recoverable, a page that renders
+    # yesterday's answer as today's is not.
+    rc, _, err = _run(["git", "fetch", "origin", "main", "--quiet"], timeout=120)
+    if rc != 0:
+        raise SystemExit(
+            f"fleet_dashboard: could not fetch origin/main (rc={rc}): {err.strip()[:300]}\n"
+            "Refusing to render — every conflict verdict on the page would be "
+            "computed against a stale base."
+        )
     prs = fetch_open_prs()
-    _run(["git", "fetch", "origin", "main", "--quiet"], timeout=120)
 
     live = [p for p in prs if not p["isDraft"]]
     queued = [p for p in prs if p["mergeQueueEntry"]]
+
+    # One query per RED PR, and only red ones — the rollup state already says
+    # which those are, and a green PR has no failing check to name. Computed
+    # once here and read twice below; the first version called it once per
+    # caller and paid for every PR twice.
+    red = [p for p in live if rollup_state(p) == "FAILURE"]
+    fail_map = {p["number"]: failing_checks(p["number"]) for p in red}
     causes: dict[str, list[int]] = defaultdict(list)
-    for p in live:
-        for name in failing_checks(p):
-            causes[name].append(p["number"])
+    for number, names in fail_map.items():
+        for name in names:
+            causes[name].append(number)
 
     conflicts = {p["number"]: conflict_kind(p) for p in prs if p["mergeable"] == "CONFLICTING"}
     phantom = [n for n, k in conflicts.items() if k == "phantom"]
@@ -273,7 +378,6 @@ def collect() -> dict[str, Any]:
     # Kept as its own bucket and kept OUT of `ready`: "not known" is not "fine".
     unknown_merge = [p["number"] for p in live if p["mergeable"] == "UNKNOWN"]
 
-    red = [p for p in live if rollup_state(p) == "FAILURE"]
     green = [p for p in live if rollup_state(p) == "SUCCESS"]
     # ready = green AND known-mergeable AND not queued: the pile that would move
     # with no work at all. `mergeable == "MERGEABLE"` is asserted positively,
@@ -296,9 +400,18 @@ def collect() -> dict[str, Any]:
             key=lambda d: d["pos"] or 999,
         ),
         "red": [{"n": p["number"], "title": p["title"],
-                 "why": failing_checks(p)} for p in red],
+                 "why": fail_map.get(p["number"], [])} for p in red],
         "green": [p["number"] for p in green],
-        "ready": [{"n": p["number"], "title": p["title"]} for p in ready],
+        "ready": [
+            {"n": p["number"], "title": p["title"],
+             # The ENTITY, not a substring of its name. A first cut tested
+             # `login.endswith("[bot]")` and returned False for every real
+             # Dependabot PR: GraphQL's Bot type has login `dependabot`, and the
+             # `[bot]` suffix only appears in REST/`gh pr view` renderings.
+             # Scar family #3, judged on the type GitHub actually declares.
+             "bot": (p.get("author") or {}).get("__typename") == "Bot"}
+            for p in ready
+        ],
         "phantom_conflicts": sorted(phantom),
         "real_conflicts": sorted(real),
         "unprobeable_conflicts": sorted(unprobeable),
@@ -463,7 +576,8 @@ def render(d: dict[str, Any]) -> str:
     ) or '<tr><td colspan="3">Nessun controllo rosso.</td></tr>'
 
     queue_rows = "\n".join(
-        f'<tr><td class="num">{q["pos"]}</td><td class="num">{prlink(q["n"])}</td>'
+        f'<tr><td class="num">{esc(q["pos"]) if q["pos"] is not None else "—"}</td>'
+        f'<td class="num">{prlink(q["n"])}</td>'
         f'<td>{esc(q["title"])}</td></tr>'
         for q in d["queued"]
     ) or '<tr><td colspan="3">La coda è vuota.</td></tr>'
@@ -479,7 +593,16 @@ def render(d: dict[str, Any]) -> str:
     # share a lockfile invalidate each other the moment the first one lands, so
     # arming them together burns a queue cycle per PR. Saying so here is the
     # difference between a page that informs and a page that misleads.
-    bumps = [r for r in d["ready"] if r["title"].lower().startswith("chore(deps")]
+    # Identify bumps by AUTHOR first and title only as a fallback. Measured on
+    # this repo's history, the title prefix caught 245/245 with no false
+    # positives — but that is this repo's convention, not a property of
+    # Dependabot: GitHub's default title carries no prefix at all, so a config
+    # change would silently switch this note off. The author login is already
+    # paid for by the query; use it.
+    bumps = [
+        r for r in d["ready"]
+        if r.get("bot") or r["title"].lower().startswith("chore(deps")
+    ]
     ready_note = ""
     if len(bumps) >= 2:
         ready_note = (
@@ -623,6 +746,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--json", dest="json_out", help="also dump the raw measurements")
     args = ap.parse_args(argv)
 
+    _warn_if_main_checkout()
     data = collect()
     Path(args.out).write_text(render(data), encoding="utf-8")
     if args.json_out:

--- a/scripts/fleet_dashboard.py
+++ b/scripts/fleet_dashboard.py
@@ -177,11 +177,17 @@ def resolve_mergeable(number: int, attempts: int = 3, delay: float = 2.0) -> tup
 
 
 def fetch_open_prs() -> list[dict[str, Any]]:
-    # This query is heavy — 100 PRs each with up to 100 check contexts — and
-    # GitHub answers "We couldn't respond to your request in time" often enough
-    # that a single attempt fails roughly half the time. Measured on 2026-09-01:
-    # attempt 1 timed out, attempt 2 succeeded. A one-shot version is unusable
-    # from cron, so the retry is a requirement of the use case, not polish.
+    # The retry is now BELT-AND-BRACES, and the comment that used to live here
+    # was wrong about why. It justified the retry by this query being heavy —
+    # "100 PRs each with up to 100 check contexts" — but the commit that added
+    # that sentence is the same one that removed `contexts` from this query
+    # (it now asks only for `statusCheckRollup { state }`; per-check contexts
+    # moved to CONTEXTS_ONE, fetched one red PR at a time). So the sentence
+    # described the query as it was BEFORE the diff it was attached to.
+    # The real history: the heavy version timed out on 3 of 3 runs even WITH
+    # three attempts — a retry on a too-heavy query makes it fail more slowly,
+    # it does not make it succeed. Lightening the query is what fixed it.
+    # The retry stays only for ordinary transient network failure.
     prs = None
     for attempt in range(3):
         rc, out, err = _run(["gh", "api", "graphql", "-f", f"query={GRAPHQL}"], timeout=120)
@@ -409,7 +415,15 @@ def collect() -> dict[str, Any]:
              # Dependabot PR: GraphQL's Bot type has login `dependabot`, and the
              # `[bot]` suffix only appears in REST/`gh pr view` renderings.
              # Scar family #3, judged on the type GitHub actually declares.
-             "bot": (p.get("author") or {}).get("__typename") == "Bot"}
+             # Narrowed after review: `__typename == "Bot"` answers "is ANY bot"
+             # (Renovate, github-actions, Copilot all share that concrete type)
+             # where this flag means "is Dependabot" — it drives a note about
+             # arming lockfile PRs one at a time. Measured today, 13/13 Bot
+             # authors in the last 100 PRs are `dependabot`, so there is no live
+             # counter-example; the pair is required so the flag stops being
+             # right by luck the day a second bot integration opens a PR.
+             "bot": ((p.get("author") or {}).get("__typename") == "Bot"
+                     and (p.get("author") or {}).get("login") == "dependabot")}
             for p in ready
         ],
         "phantom_conflicts": sorted(phantom),

--- a/scripts/fleet_dashboard.py
+++ b/scripts/fleet_dashboard.py
@@ -242,6 +242,24 @@ query($n: Int!) {
 #: "why is this PR red?" when the instrument that was supposed to answer never
 #: replied. It groups into its own row in the causes table so the reader sees
 #: that the tally is incomplete rather than reading a short list as a full one.
+#: A rollup context is FAILING on any of these. The bug this replaces tested
+#: `verdict == "FAILURE"` alone, so a check that TIMED_OUT, was CANCELLED,
+#: needed ACTION_REQUIRED, hit a STARTUP_FAILURE, or (on a StatusContext)
+#: ERRORed left the PR counted as red while contributing to NO row in the
+#: causes table — it read as "nothing wrong here" by omission, which is worse
+#: than the unreadable sentinel, because not even a row said the tally was
+#: short. Found by adversarial review of the very commit that claimed to have
+#: cured this disease everywhere in this function.
+FAILING_VERDICTS = frozenset({
+    "FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "ERROR",
+})
+#: Explicitly NOT failing. Kept as its own list rather than "everything else",
+#: so a verdict in neither set is surfaced instead of silently bucketed.
+BENIGN_VERDICTS = frozenset({
+    "SUCCESS", "NEUTRAL", "SKIPPED", "STALE", "EXPECTED", "PENDING", "QUEUED",
+    "IN_PROGRESS", "WAITING", "REQUESTED", None,
+})
+
 PROBE_UNREADABLE = "\u00b7 la sonda dei controlli non ha risposto"
 
 
@@ -289,9 +307,39 @@ def failing_checks(number: int) -> list[str]:
     for ctx in rollup["contexts"]["nodes"]:
         name = ctx.get("name") or ctx.get("context") or "?"
         verdict = ctx.get("conclusion") or ctx.get("state")
-        if verdict == "FAILURE":
+        if verdict in BENIGN_VERDICTS:
+            continue
+        if verdict in FAILING_VERDICTS:
             names.append(name)
+            continue
+        # An verdict in NEITHER list is a value GitHub added after this was
+        # written. It is named, not dropped: a check the page cannot classify
+        # is news. Erring toward "failing" is the SAFE direction — it makes the
+        # page more alarming than reality, never more reassuring, which is the
+        # asymmetry every defect this file shipped got backwards.
+        names.append(f"{name} ({verdict})")
     return names
+
+
+def is_dependabot(pr: dict[str, Any]) -> bool:
+    """True only for Dependabot, judged on the ENTITY and its login together.
+
+    Two bugs are pinned here, one in each direction. A first cut tested
+    `login.endswith("[bot]")` and returned False for every real Dependabot PR:
+    the GraphQL Bot login is the bare string `dependabot`, and the `[bot]`
+    suffix exists only in REST renderings. The correction then tested
+    `__typename == "Bot"` alone, which answers "is ANY bot" — Renovate,
+    github-actions and Copilot share that concrete type — where this flag means
+    "is Dependabot" and drives the note about arming lockfile PRs one at a time.
+
+    It is a named function rather than an inline expression because the test
+    that guarded it could only grep the source, and grepping for two substrings
+    never pinned the `and` joining them: flipping it to `or` reinstated the bug
+    with the test still green. A predicate you can call is a predicate you can
+    actually pin.
+    """
+    author = pr.get("author") or {}
+    return author.get("__typename") == "Bot" and author.get("login") == "dependabot"
 
 
 def rollup_state(pr: dict[str, Any]) -> str:
@@ -435,20 +483,7 @@ def collect() -> dict[str, Any]:
         "green": [p["number"] for p in green],
         "ready": [
             {"n": p["number"], "title": p["title"],
-             # The ENTITY, not a substring of its name. A first cut tested
-             # `login.endswith("[bot]")` and returned False for every real
-             # Dependabot PR: GraphQL's Bot type has login `dependabot`, and the
-             # `[bot]` suffix only appears in REST/`gh pr view` renderings.
-             # Scar family #3, judged on the type GitHub actually declares.
-             # Narrowed after review: `__typename == "Bot"` answers "is ANY bot"
-             # (Renovate, github-actions, Copilot all share that concrete type)
-             # where this flag means "is Dependabot" — it drives a note about
-             # arming lockfile PRs one at a time. Measured today, 13/13 Bot
-             # authors in the last 100 PRs are `dependabot`, so there is no live
-             # counter-example; the pair is required so the flag stops being
-             # right by luck the day a second bot integration opens a PR.
-             "bot": ((p.get("author") or {}).get("__typename") == "Bot"
-                     and (p.get("author") or {}).get("login") == "dependabot")}
+             "bot": is_dependabot(p)}
             for p in ready
         ],
         "phantom_conflicts": sorted(phantom),

--- a/scripts/tests/test_fleet_dashboard.py
+++ b/scripts/tests/test_fleet_dashboard.py
@@ -240,3 +240,47 @@ def test_innocence_a_linked_worktree_is_not_warned_about(fd, monkeypatch, tmp_pa
     monkeypatch.setattr(sys, "stderr", buf)
     fd._warn_if_main_checkout()
     assert buf.getvalue() == ""
+
+
+# --------------------------------------------------------------------------
+# the rollup state: a PR must belong to a bucket, or be named
+# --------------------------------------------------------------------------
+
+#: Every value GitHub's GraphQL `StatusState` enum can take.
+STATUS_STATES = ["EXPECTED", "ERROR", "FAILURE", "PENDING", "SUCCESS"]
+
+
+def _pr_with_rollup(state):
+    return {"commits": {"nodes": [{"commit": {"statusCheckRollup": {"state": state}}}]}}
+
+
+@pytest.mark.parametrize("state", STATUS_STATES)
+def test_every_rollup_state_belongs_to_exactly_one_bucket(fd, state):
+    """The defect this pins: `red` tested `== "FAILURE"` and `green` tested
+    `== "SUCCESS"`, so a PR whose rollup state was ERROR matched NEITHER and
+    vanished from both cards while still counting in the total. Not "red with
+    no reason" — absent. A value in both sets, or in neither, is that bug."""
+    in_failing = state in fd.FAILING_VERDICTS
+    in_benign = state in fd.BENIGN_VERDICTS
+    assert in_failing != in_benign, (
+        f"{state} is in {'BOTH sets' if in_failing else 'NEITHER set'} — a PR "
+        "carrying it belongs to no card"
+    )
+
+
+def test_guilt_an_error_rollup_is_treated_as_failing(fd):
+    assert fd.rollup_state(_pr_with_rollup("ERROR")) in fd.FAILING_VERDICTS
+
+
+def test_innocence_a_success_rollup_is_not_treated_as_failing(fd):
+    assert fd.rollup_state(_pr_with_rollup("SUCCESS")) not in fd.FAILING_VERDICTS
+
+
+def test_innocence_a_pending_rollup_is_not_treated_as_failing(fd):
+    """Still running is not failing — erring the other way would put every
+    in-flight PR in the red card."""
+    assert fd.rollup_state(_pr_with_rollup("PENDING")) not in fd.FAILING_VERDICTS
+
+
+def test_a_pr_with_no_commits_yields_the_placeholder_not_a_crash(fd):
+    assert fd.rollup_state({"commits": {"nodes": []}}) == "—"

--- a/scripts/tests/test_fleet_dashboard.py
+++ b/scripts/tests/test_fleet_dashboard.py
@@ -145,23 +145,98 @@ def test_innocence_a_content_conflict_is_real(fd, monkeypatch):
 
 # --------------------------------------------------------------------------
 # the Dependabot flag: the ENTITY and its login, not a substring of a name
-# --------------------------------------------------------------------------
-
-def test_the_bot_flag_requires_both_the_type_and_the_login(fd):
-    src = MODULE.read_text(encoding="utf-8")
-    assert '"dependabot"' in src, "narrowed from 'is any bot' to 'is Dependabot'"
-    assert '__typename") == "Bot"' in src
 
 
 # --------------------------------------------------------------------------
-# the main-checkout warning must not depend on a folder's NAME
+# a failing check is not only the one literally called "FAILURE"
 # --------------------------------------------------------------------------
 
-def test_the_checkout_warning_is_naming_independent(fd):
-    """In a linked worktree `.git` is a FILE; only a primary checkout has it as
-    a directory. A clone under any other name must still be caught."""
-    src = MODULE.read_text(encoding="utf-8")
-    body = src.split("def _warn_if_main_checkout()", 1)[1].split("\ndef ", 1)[0]
-    code = "\n".join(l for l in body.splitlines() if not l.strip().startswith("#"))
-    assert 'GIT_CWD.name ==' not in code
-    assert '.git").is_dir()' in code
+def _rollup(*contexts: dict) -> str:
+    import json as _j
+    return _j.dumps({"data": {"repository": {"pullRequest": {"commits": {"nodes": [
+        {"commit": {"statusCheckRollup": {"contexts": {"nodes": list(contexts)}}}}]}}}}})
+
+
+@pytest.mark.parametrize("verdict", sorted(v for v in
+    {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "ERROR"}))
+def test_guilt_every_failure_shaped_verdict_is_reported(fd, monkeypatch, verdict):
+    """Testing `== "FAILURE"` alone left a red PR contributing to NO row in the
+    causes table — it read as "nothing wrong here" by omission, which is worse
+    than the unreadable sentinel because not even a row said the tally was short.
+    """
+    monkeypatch.setattr(fd, "_run", _run_returning(
+        0, _rollup({"name": "CI / build", "conclusion": verdict}), ""))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    assert fd.failing_checks(1) == ["CI / build"], f"{verdict} was dropped"
+
+
+@pytest.mark.parametrize("verdict", ["SUCCESS", "NEUTRAL", "SKIPPED", "STALE", "PENDING"])
+def test_innocence_a_benign_verdict_is_never_reported_as_failing(fd, monkeypatch, verdict):
+    monkeypatch.setattr(fd, "_run", _run_returning(
+        0, _rollup({"name": "CI / build", "conclusion": verdict}), ""))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    assert fd.failing_checks(1) == []
+
+
+def test_an_unknown_verdict_is_named_not_silently_dropped(fd, monkeypatch):
+    """A value GitHub adds later belongs in neither list. Naming it errs toward
+    "failing", which makes the page more alarming than reality — the safe
+    direction, and the one every defect in this file got backwards."""
+    monkeypatch.setattr(fd, "_run", _run_returning(
+        0, _rollup({"name": "CI / build", "conclusion": "SOME_FUTURE_STATE"}), ""))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    names = fd.failing_checks(1)
+    assert names == ["CI / build (SOME_FUTURE_STATE)"], names
+
+
+def test_the_two_verdict_sets_do_not_overlap(fd):
+    assert not (fd.FAILING_VERDICTS & fd.BENIGN_VERDICTS)
+
+
+# --------------------------------------------------------------------------
+# the Dependabot predicate: called, not grepped
+# --------------------------------------------------------------------------
+
+def test_guilt_a_real_dependabot_pr_is_flagged(fd):
+    assert fd.is_dependabot({"author": {"__typename": "Bot", "login": "dependabot"}})
+
+
+@pytest.mark.parametrize("author,why", [
+    ({"__typename": "Bot", "login": "renovate"}, "another bot shares the Bot type"),
+    ({"__typename": "Bot", "login": "github-actions"}, "so does github-actions"),
+    ({"__typename": "User", "login": "dependabot"}, "a human could take the name"),
+    ({}, "no author fields at all"),
+    (None, "author absent"),
+])
+def test_innocence_only_dependabot_is_flagged(fd, author, why):
+    """Pins the AND. Flipping it to OR reinstated the 'is any bot' bug while the
+    old source-grep test stayed green — two substrings never pinned their join."""
+    assert not fd.is_dependabot({"author": author}), why
+
+
+# --------------------------------------------------------------------------
+# the main-checkout warning: behaviour, not a forbidden literal
+# --------------------------------------------------------------------------
+
+def test_guilt_a_primary_checkout_under_any_name_is_warned_about(fd, monkeypatch, tmp_path):
+    """Forbidding the literal `GIT_CWD.name ==` did not stop `!=` with an early
+    return from reinstating name-dependence. This calls the function instead."""
+    odd = tmp_path / "a-clone-named-something-else"
+    (odd / ".git").mkdir(parents=True)
+    buf = io.StringIO()
+    monkeypatch.setattr(fd, "GIT_CWD", odd)
+    monkeypatch.setattr(sys, "stderr", buf)
+    fd._warn_if_main_checkout()
+    assert "MAIN checkout" in buf.getvalue()
+
+
+def test_innocence_a_linked_worktree_is_not_warned_about(fd, monkeypatch, tmp_path):
+    """In a linked worktree `.git` is a FILE pointing at the real object store."""
+    wt = tmp_path / "nuzantara"
+    wt.mkdir()
+    (wt / ".git").write_text("gitdir: /somewhere/else\n")
+    buf = io.StringIO()
+    monkeypatch.setattr(fd, "GIT_CWD", wt)
+    monkeypatch.setattr(sys, "stderr", buf)
+    fd._warn_if_main_checkout()
+    assert buf.getvalue() == ""

--- a/scripts/tests/test_fleet_dashboard.py
+++ b/scripts/tests/test_fleet_dashboard.py
@@ -1,0 +1,167 @@
+"""Guilt AND innocence for the fleet dashboard's probes.
+
+WHY THIS FILE EXISTS. Every defect this dashboard shipped in review was a probe
+that answered a NEIGHBOURING question and looked fine doing it: bulk `UNKNOWN`
+mergeability read as "no conflict", a `merge-tree` that could not start read as
+"real conflict", and a checks probe whose silence rendered as "red, no reason
+given" while quietly under-counting the grouped tally. None of those are caught
+by asserting the happy path. So each probe here is pinned from BOTH sides — it
+must fire when it should (guilt) and must stay silent when it should not
+(innocence). A guard with only one of the two is how scar family #3 gets in.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE = Path(__file__).resolve().parents[1] / "fleet_dashboard.py"
+
+
+@pytest.fixture()
+def fd():
+    spec = importlib.util.spec_from_file_location("fleet_dashboard_under_test", MODULE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_returning(*result):
+    return lambda *a, **k: result
+
+
+def _run_dispatch_for_conflict_kind(merge_tree_result):
+    """A stub that answers each of `conflict_kind`'s three subprocess calls
+    truthfully for the ones it isn't testing, and returns `merge_tree_result`
+    only for the `git merge-tree` call. `conflict_kind` calls `_run` three
+    times in sequence (fetch, rev-parse, merge-tree); a single fixed return
+    value answers the FIRST call and never reaches the one under test."""
+    def _run(args, timeout=90):
+        if args[:2] == ["git", "fetch"]:
+            return (0, "", "")
+        if args[:2] == ["git", "rev-parse"]:
+            return (0, "cafef00d\n", "")
+        if args[:2] == ["git", "merge-tree"]:
+            return merge_tree_result
+        raise AssertionError(f"conflict_kind made an unexpected _run call: {args}")
+    return _run
+
+
+CONFLICTING_PR = {"number": 1, "mergeable": "CONFLICTING", "headRefName": "some-branch"}
+
+
+ROLLUP_OK = (
+    '{"data":{"repository":{"pullRequest":{"commits":{"nodes":[{"commit":'
+    '{"statusCheckRollup":{"contexts":{"nodes":['
+    '{"name":"CI / build","conclusion":"FAILURE"},'
+    '{"name":"CI / lint","conclusion":"SUCCESS"}]}}}}]}}}}}'
+)
+
+
+# --------------------------------------------------------------------------
+# failing_checks: a probe that could not measure must SAY SO, on the page
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "rc,out,err,why",
+    [
+        (1, "", "rate limit exceeded", "transport failure"),
+        (0, "", "", "empty body with rc=0"),
+        (0, "{not json", "", "malformed JSON"),
+        (0, '{"data":{"repository":{"pullRequest":{"commits":{"nodes":[]}}}}}', "", "no commits"),
+        (
+            0,
+            '{"data":{"repository":{"pullRequest":{"commits":{"nodes":'
+            '[{"commit":{"statusCheckRollup":null}}]}}}}}',
+            "",
+            "no rollup, contradicting the bulk query",
+        ),
+    ],
+)
+def test_guilt_unreadable_probe_is_named_not_silently_empty(fd, monkeypatch, rc, out, err, why):
+    """Every way the probe can fail must surface the sentinel, never a bare []."""
+    monkeypatch.setattr(fd, "_run", _run_returning(rc, out, err))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    assert fd.failing_checks(1) == [fd.PROBE_UNREADABLE], f"silent [] on: {why}"
+
+
+def test_innocence_a_real_answer_never_carries_the_sentinel(fd, monkeypatch):
+    """Good data yields the failing check's real name and nothing else."""
+    monkeypatch.setattr(fd, "_run", _run_returning(0, ROLLUP_OK, ""))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    names = fd.failing_checks(1)
+    assert names == ["CI / build"], names
+    assert fd.PROBE_UNREADABLE not in names
+
+
+def test_innocence_a_passing_check_is_not_reported_as_failing(fd, monkeypatch):
+    monkeypatch.setattr(fd, "_run", _run_returning(0, ROLLUP_OK, ""))
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    assert "CI / lint" not in fd.failing_checks(1)
+
+
+def test_the_sentinel_cannot_be_mistaken_for_a_check_name(fd):
+    """It groups into the causes table beside real names, so it must not look like one."""
+    assert not fd.PROBE_UNREADABLE[0].isalnum()
+    assert "/" not in fd.PROBE_UNREADABLE
+
+
+def test_an_unreadable_probe_also_says_so_on_stderr(fd, monkeypatch):
+    """The page and the log must agree — one without the other is half an alarm."""
+    buf = io.StringIO()
+    monkeypatch.setattr(fd, "_run", _run_returning(1, "", "boom"))
+    monkeypatch.setattr(sys, "stderr", buf)
+    fd.failing_checks(4242)
+    assert "checks unreadable for #4242" in buf.getvalue()
+
+
+# --------------------------------------------------------------------------
+# conflict_kind: rc!=0 means the merge could not START — never "real conflict"
+# --------------------------------------------------------------------------
+
+def test_guilt_a_merge_that_could_not_start_is_not_called_a_real_conflict(fd, monkeypatch):
+    """Scar: conflating rc!=0 with rc==1 sends a reader to hand-resolve a
+    `merge=union` ledger, which deletes other lanes' rows."""
+    monkeypatch.setattr(
+        fd, "_run",
+        _run_dispatch_for_conflict_kind((128, "", "fatal: refusing to merge unrelated histories")),
+    )
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    assert fd.conflict_kind(CONFLICTING_PR) == "unknown"
+
+
+def test_innocence_a_clean_merge_tree_is_a_phantom(fd, monkeypatch):
+    monkeypatch.setattr(fd, "_run", _run_dispatch_for_conflict_kind((0, "sometree", "")))
+    assert fd.conflict_kind(CONFLICTING_PR) == "phantom"
+
+
+def test_innocence_a_content_conflict_is_real(fd, monkeypatch):
+    monkeypatch.setattr(fd, "_run", _run_dispatch_for_conflict_kind((1, "tree\nsome/file.py", "")))
+    assert fd.conflict_kind(CONFLICTING_PR) == "real"
+
+
+# --------------------------------------------------------------------------
+# the Dependabot flag: the ENTITY and its login, not a substring of a name
+# --------------------------------------------------------------------------
+
+def test_the_bot_flag_requires_both_the_type_and_the_login(fd):
+    src = MODULE.read_text(encoding="utf-8")
+    assert '"dependabot"' in src, "narrowed from 'is any bot' to 'is Dependabot'"
+    assert '__typename") == "Bot"' in src
+
+
+# --------------------------------------------------------------------------
+# the main-checkout warning must not depend on a folder's NAME
+# --------------------------------------------------------------------------
+
+def test_the_checkout_warning_is_naming_independent(fd):
+    """In a linked worktree `.git` is a FILE; only a primary checkout has it as
+    a directory. A clone under any other name must still be caught."""
+    src = MODULE.read_text(encoding="utf-8")
+    body = src.split("def _warn_if_main_checkout()", 1)[1].split("\ndef ", 1)[0]
+    code = "\n".join(l for l in body.splitlines() if not l.strip().startswith("#"))
+    assert 'GIT_CWD.name ==' not in code
+    assert '.git").is_dir()' in code


### PR DESCRIPTION
Successor to #5461 (merged `57308cf5d`), cut from fresh `origin/main` per rule 2 — the branch froze the moment it entered the queue, so the second adversarial round could not land on it.

**Bites:** the consumer is `scripts/fleet_dashboard.py` itself, run by a human on demand; the observation that proves the change is in force is `scripts/tests/test_fleet_dashboard.py` (14 passing, and each `conflict_kind` assertion proven to go RED against deliberately broken logic — see below), plus a live end-to-end run on this branch: `rc=0`, 28s, `32 live, 0 queued, 20 red, 2 phantom + 5 real conflicts`. No future job is being credited here; the page is generated by the same command the tests exercise.

## What the second review found

Every finding was the same disease in a different place: **an instrument that answered a neighbouring question and looked fine doing it.**

1. **A retry that made a too-heavy query fail more slowly.** The bulk query asked for 100 PRs × up to 100 check contexts; GitHub answered "We couldn't respond to your request in time" on **3 of 3 runs even with three attempts**. Adding the retry was my own regression — a retry does not make a too-heavy query succeed. The bulk query now carries `statusCheckRollup { state }` alone, and per-check contexts are fetched one red PR at a time (~20, not 100). Measured after: 3/3 runs, zero retries.

2. **A comment that justified the retry with weight the same commit removed.** It read "100 PRs each with up to 100 check contexts" while sitting next to a query that no longer asks for contexts — describing the code as it was *before* the diff it was attached to. Rewritten to the true history.

3. **A Dependabot flag that answered "is any bot".** `author.__typename == "Bot"` is the concrete GraphQL type for Renovate, `github-actions`, Copilot and any future integration. Measured today there is **no live counter-example** (13/13 Bot authors in the last 100 PRs are `dependabot`) — so this narrows a flag that is currently right by luck, before a second bot makes it wrong. It now requires the login too. The earlier fix in this area went the other way and stands: `login.endswith("[bot]")` returned False for every real Dependabot PR, because the `[bot]` suffix exists only in REST renderings.

4. **A probe whose silence rendered as an answer.** `failing_checks()` returned a bare `[]` on transport failure, malformed JSON, no commits, and a per-PR "no rollup" that **contradicts** the bulk query that already called the PR red. On the page that read as "red, no reason given" — indistinguishable from a PR with no named failing context — while silently under-counting that check's tally in the grouped table. It now returns a sentinel that is deliberately not check-shaped, groups into its own row so the incompleteness is visible, and still writes to stderr so page and log agree.

5. **A warning that depended on a folder's name.** `_warn_if_main_checkout()` required `GIT_CWD.name == "nuzantara"`, false-negativing on any differently-named clone. In a linked worktree `.git` is a FILE; only a primary checkout has it as a DIRECTORY. That single test is naming-independent and is the whole signal.

## The test suite, and why it is guilt AND innocence

None of the above is caught by asserting the happy path, so each probe is pinned from both sides: it must fire when it should and stay silent when it should not. A guard with only one of the two is how scar family #3 gets in.

The three `conflict_kind` tests were proven **discriminating, not merely green**, by breaking the production logic two ways:
- mapping every non-zero rc to `"real"` → only the guilt test reddens (`assert 'real' == 'unknown'`);
- swapping phantom/real → only the two innocence tests redden.

Their `_run` stub dispatches on the command and raises on an unexpected one, so a refactor that adds or reorders calls fails loudly instead of answering with a stale fixture. This matters because conflating "the merge could not START" (rc 128) with "there is a real conflict" (rc 1) would send a reader to hand-resolve a `merge=union` ledger — which deletes other lanes' rows.

Runtime, re-measured end to end and corrected: **32s warm, 68s cold** (an independent reviewer measured 72s). An earlier figure of 23-36s covered only the `failing_checks` sweep — right in the number, wrong in the shape. A cron caller should plan for ~70s.