### PR TITLE
docs(secondhome): correct a palette comment that made an omission read as a decision

### DIFF
--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -169,11 +169,21 @@ export const MERAH_PUTIH_DAY_VARS = {
   // our own wrapper, rather than editing the shared visa layout — the rest of
   // the funnel is a different lane's perimeter.
   // Inter and Cormorant are self-hosted and mounted on <html> by the root
-  // layout. IBM Plex Mono is NOT loaded in this app (only 4 woff2 files exist:
-  // cormorant, inter, league-spartan, montserrat), so `--font-mono` resolves to
-  // ui-monospace — the same fallback every other mono surface in this app
-  // already uses. Declared, not pretended: loading a fifth face is a perf decision of
-  // its own, tracked in PENDING-ARMS, not smuggled into a palette change.
+  // layout; no IBM Plex Mono webfont exists in this repo (packages/core/fonts
+  // ships exactly 4: cormorant, inter, league-spartan, montserrat), and loading
+  // a fifth face is a perf decision of its own, not one to smuggle into a
+  // palette change.
+  // CORRECTED 2026-09-01: the previous wording claimed `--font-mono` "resolves
+  // to ui-monospace — the same fallback every other mono surface in this app
+  // already uses" and cited a PENDING-ARMS entry. Both were false, and together
+  // they made an omission read as a settled decision. The token DOES exist
+  // (packages/core/tokens/primitives.css) as `"IBM Plex Mono", ui-monospace,
+  // Menlo, monospace`, with ~29 consumers elsewhere in the app, every one of
+  // them naming Plex FIRST — so using it here would need no new file and would
+  // put this surface exactly where those 29 already are. No ledger row for
+  // "Plex" or "font-mono" exists. What is genuinely open, and NOT settled by
+  // this comment: R4 asks for Plex Mono on IDR amounts while the price figures
+  // here use Cormorant + tabular-nums, and nothing on disk records why.
   fontFamily: "var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif",
 } as CSSProperties;
 


### PR DESCRIPTION
`merahPutihDayVars.ts` carried the rationale for why second-home does not use IBM Plex Mono on IDR amounts. Two of its claims were false, and together they turned an undocumented omission into what read like a settled decision — which is exactly how it survived: an investigation into this very question nearly closed on it.

**Claim 1 — false.** It said `--font-mono` *"resolves to ui-monospace — the same fallback every other mono surface in this app already uses."* The token exists in `packages/core/tokens/primitives.css` as `"IBM Plex Mono", ui-monospace, Menlo, monospace`, and ~29 consumers elsewhere (FactBadge, SystemPulse, the terminal components, the KBLI components, admin cards…) name **Plex first**, falling back only on a visitor who lacks it locally. Second-home does not use the token at all. So it is not "the same" — and using it here would need **no new font file**.

**Claim 2 — false.** It said the choice was *"tracked in PENDING-ARMS."* No row for `Plex` or `font-mono` exists in that ledger.

**What was true is kept verbatim:** no Plex Mono webfont ships in this repo (`packages/core/fonts` has exactly four: cormorant, inter, league-spartan, montserrat), and loading a fifth face is its own perf decision, not something to smuggle into a palette change.

The comment now **states the open question instead of answering it**: R4 asks for Plex Mono on IDR amounts, the price figures use Cormorant + `tabular-nums`, and nothing on disk records why. That is an owner decision — it changes how a live client-facing price looks — so the comment names it rather than asserting either way.

### Scope

Comment-only. `git diff -U0` filtered to non-comment lines returns nothing; the `fontFamily` value is byte-identical. `tsc --noEmit` green, Prettier reports the file unchanged.

**Bites:** `apps/mouth/src/lib/theme/merahPutihDayVars.ts` — the next reader of this file. Observed: the false sentence and the phantom ledger citation are gone from the served source, and because no value changed, `/visa/second-home` and `/visa/second-home/studio` render exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
