### PR TITLE
feat(ops): the stall alarm exists, works, and is connected to nothing — this is the wire

### DIFF
--- a/scripts/queue_stall_notify.py
+++ b/scripts/queue_stall_notify.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""queue_stall_notify.py — the delivery wire for scripts/queue_stall_classifier.py.
+
+WHY THIS EXISTS: queue_stall_classifier.py is a deliberately pure reporter (see its own module
+docstring) — zero disk writes, zero `os.environ` reads, read-only `gh api` GETs only, its own
+test suite enforces that with a static AST proof. Nothing invokes it and nobody reads its
+output: `git grep -l queue_stall_classifier origin/main` returns only the script itself, its
+test, and evidence-pack references — no crontab entry anywhere in the fleet. A working alarm
+that speaks to nobody is exactly scar family #2 (green != working, cron theater): the
+classifier's OWN exit code is 0 whenever it ran cleanly, REGARDLESS of whether it found a single
+stalled PR — so a naive cron wiring (`cron-runner.sh queue_stall_classifier.py`) would produce a
+permanently green job, its stall table landing in a logfile nobody tails. This script is the
+delivery wire: it runs the classifier, reads its report, and fleet-mails every row that names an
+actual problem.
+
+THIS SCRIPT DOES NOT TOUCH queue_stall_classifier.py. All side effects — the classifier
+subprocess call, the fleet_mail.sh broadcasts — live HERE, in a separate, named, independently
+testable module, so the classifier's own purity invariant (and its AST self-check) is never put
+at risk by an edit to this file.
+
+SUBPROCESS, NEVER IMPORT: queue_stall_classifier.py is run via `sys.executable
+queue_stall_classifier.py --json`, not imported and called in-process. Importing it would still
+be technically read-only, but it would blur the classifier's own "this script never mutates
+anything" claim into "this script is never run in the same process as something that does" — a
+materially weaker guarantee its own AST test cannot see across an import boundary. Team-lead
+mandate, verbatim: "do NOT import it — subprocess keeps the purity boundary visible." A
+consequence: this module cannot import CANNOT_VERIFY/STALL_CAUSES from the classifier either —
+its cause vocabulary is duplicated below as literal strings (STANDALONE-by-design, the same
+convention queue_stall_classifier.py itself uses for read_fable_gate_state vs
+scripts/ci/harness_gate_read.py — see that module's docstring trap (e)). If the classifier's
+cause vocabulary ever changes, this file's REAL_STALL_CAUSES/CANNOT_VERIFY must be updated by
+hand; nothing across the subprocess boundary can catch that drift automatically.
+
+CAUSE VOCABULARY: classify_stall()'s 5-bucket STALL_CAUSES set is NOT uniformly "a problem".
+"queued-and-advancing" is its own documented default — "armed/queued, no known blocker; may
+simply be slow" — the classifier's own way of saying nothing is actionably wrong. Fleet-mailing
+that bucket every DEFAULT_MIN_AGE_MINUTES=30 tick would be noise-by-design, not signal, so
+REAL_STALL_CAUSES below deliberately excludes it. The other 4 causes
+(conflict/gate-verdict-missing/required-check-red/not-armed) each name something a human or the
+next gate session should look at, and so does CANNOT-VERIFY — a row the classifier could not
+read is news (its own instrument failed to measure), not silence.
+
+DEDUP KEY ENCODES THE CAUSE, NOT JUST THE PR NUMBER: `queue_stall:<number>:<cause>`. The
+classifier holds no state of its own (unlike queue_unstick.py, which fingerprints a DIRTY signal
+on head-sha + conflict-digest across ticks) and the fleet mailbox reader
+(infra/claude-hooks/mailbox_inject.py) keeps only the newest file per key, marking a broadcast
+seen-once-per-session. A key of `queue_stall:<number>` alone would mean a PR whose stall CAUSE
+changes (say, `not-armed` today, `required-check-red` tomorrow, after someone manually armed it
+and CI then failed) never resurfaces once the first key's file already exists — the exact
+silent-drop shape this module exists to avoid.
+
+Kill switch: QUEUE_STALL_NOTIFY_ENABLED=false makes every invocation a no-op that still prints a
+receipt line (superscar #2: a mute cron is a dead cron — silence must never be the only signal
+that nothing happened). Checked BEFORE the classifier subprocess is even invoked.
+
+--dry-run performs ZERO fleet-mail sends (and zero subprocess calls of any kind beyond the
+classifier read itself) and prints exactly what it would have sent. This is how the conductor
+verifies this script.
+
+Env overrides:
+  QUEUE_STALL_NOTIFY_ENABLED            "false"/"0"/"no"/"off" -> no-op (default: on)
+  QUEUE_STALL_NOTIFY_REPO               default "Bali-Zero/Teman2"
+  QUEUE_STALL_NOTIFY_MIN_AGE_MINUTES    default 30 (passed to the classifier as
+                                         --min-age-minutes; duplicates
+                                         queue_stall_classifier.py's own
+                                         DEFAULT_MIN_AGE_MINUTES, STANDALONE-by-design)
+  QUEUE_STALL_NOTIFY_CAP                default 5 (max fleet-mail sends per run; an UNMEASURED
+                                         placeholder, same honesty as queue_unstick.py's own
+                                         QUEUE_UNSTICK_CAP comment — chosen only because a bad
+                                         night must not storm the fleet mailbox, not because 5
+                                         was derived from anything)
+  QUEUE_STALL_NOTIFY_FLEET_MAIL_HOST    default "pro" (host arg to fleet_mail.sh)
+  QUEUE_STALL_NOTIFY_CLASSIFIER_TIMEOUT default 180 (seconds, subprocess timeout for the
+                                         classifier call — it pages through every open PR and
+                                         can legitimately take a while on a busy queue)
+
+Exit codes: 0 = ran clean (the classifier ran clean AND every attempted send succeeded, whether
+or not any PR was actually stalled); 1 = the classifier itself failed (non-zero rc — propagated
+as a failure even if every row that DID parse was delivered successfully) OR at least one
+fleet-mail send failed.
+
+Tests: scripts/tests/test_queue_stall_notify.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = Path(__file__).resolve().parent
+CLASSIFIER = SCRIPTS_DIR / "queue_stall_classifier.py"
+
+REPO = os.environ.get("QUEUE_STALL_NOTIFY_REPO", "Bali-Zero/Teman2")
+MIN_AGE_MINUTES = int(os.environ.get("QUEUE_STALL_NOTIFY_MIN_AGE_MINUTES", "30"))
+# UNMEASURED placeholder — see module docstring env-override table. Deliberately small: the
+# harm of under-sending (a stall waits one more 30-minute tick to resurface) is bounded and
+# self-healing; the harm of over-sending (storming the fleet mailbox on a bad night) is not.
+CAP = int(os.environ.get("QUEUE_STALL_NOTIFY_CAP", "5"))
+FLEET_MAIL_HOST = os.environ.get("QUEUE_STALL_NOTIFY_FLEET_MAIL_HOST", "pro")
+CLASSIFIER_TIMEOUT = int(os.environ.get("QUEUE_STALL_NOTIFY_CLASSIFIER_TIMEOUT", "180"))
+
+# Duplicated from queue_stall_classifier.py's own CANNOT_VERIFY sentinel — see module docstring
+# "SUBPROCESS, NEVER IMPORT" for why this is a literal, not an import.
+CANNOT_VERIFY = "CANNOT-VERIFY"
+
+# The 4 STALL_CAUSES that name an actual problem — see module docstring "CAUSE VOCABULARY" for
+# why "queued-and-advancing" is deliberately excluded from this set.
+REAL_STALL_CAUSES = frozenset(
+    {
+        "conflict",
+        "gate-verdict-missing",
+        "required-check-red",
+        "not-armed",
+    }
+)
+
+
+def _enabled() -> bool:
+    return os.environ.get("QUEUE_STALL_NOTIFY_ENABLED", "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _run(cmd: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run a command; never raises. Returns (rc, stdout, stderr). Duplicated boundary shape
+    from queue_unstick.py::_run (STANDALONE-by-design, same convention as the rest of this
+    family) — including `errors="replace"`, which is what makes "never raises" actually true:
+    with the default strict decoding, `text=True` raises UnicodeDecodeError (a ValueError,
+    caught by neither except arm) the moment a subprocess prints a non-UTF-8 byte."""
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, errors="replace", timeout=timeout
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 127, "", f"{type(exc).__name__}: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Classifier invocation — subprocess only, see module docstring.
+# ---------------------------------------------------------------------------
+
+
+def run_classifier(
+    *,
+    repo: str,
+    min_age_minutes: int,
+    classifier_path: Path = CLASSIFIER,
+    timeout: int = CLASSIFIER_TIMEOUT,
+) -> tuple[int, dict[str, Any] | None, str, str]:
+    """Invoke queue_stall_classifier.py as a SUBPROCESS with `--json`. Returns
+    (rc, report_or_None, raw_stdout, raw_stderr).
+
+    `report` is None ONLY when stdout could not be parsed as JSON at all (python itself failed
+    to start, or crashed before printing anything) — never fabricated from a non-zero `rc`
+    alone. The classifier's OWN contract (its module docstring, trap (g) and the CANNOT-VERIFY
+    row shape) prints a full JSON report even on some of its rc=1 paths — a single CANNOT-VERIFY
+    row among otherwise-fine rows, for instance — and this notifier must still be able to act on
+    and report those rows precisely, not collapse "the classifier's rc was 1" into "there is
+    nothing here to look at"."""
+    argv = [
+        sys.executable,
+        str(classifier_path),
+        "--repo",
+        repo,
+        "--min-age-minutes",
+        str(min_age_minutes),
+        "--json",
+    ]
+    rc, out, err = _run(argv, timeout=timeout)
+    report: dict[str, Any] | None = None
+    if out.strip():
+        try:
+            report = json.loads(out)
+        except json.JSONDecodeError:
+            report = None
+    return rc, report, out, err
+
+
+# ---------------------------------------------------------------------------
+# Pure planning — no I/O. What scripts/tests/test_queue_stall_notify.py exercises directly.
+# ---------------------------------------------------------------------------
+
+
+def plan_notifications(rows: list[dict[str, Any]], *, cap: int) -> dict[str, list]:
+    """Pure: no I/O. Decides, for each classifier row (in the order given), whether it is
+    notify-worthy, its fleet-mail dedup key, and whether the per-run cap suppresses it.
+
+    See module docstring "DEDUP KEY ENCODES THE CAUSE" for why the key is
+    `queue_stall:<number>:<cause>`, never `queue_stall:<number>` alone.
+
+    Returns {
+        "to_notify": [ {"number","cause","key","cannot_verify","detail"}, ... ]  (len <= cap,
+                       in the SAME order `rows` arrived in — this function never reorders),
+        "suppressed_by_cap": [ same shape, every notify-worthy row past the cap ],
+        "skipped": [ (number, cause), ... ]  # not notify-worthy at all: "queued-and-advancing"
+                                              # or any cause this module does not recognise
+                                              # (never signalled, and never counted toward
+                                              # `stalled` in the summary line)
+    }
+    """
+    to_notify: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+    skipped: list[tuple[Any, Any]] = []
+
+    for row in rows:
+        cause = row.get("cause")
+        number = row.get("number")
+        if cause == CANNOT_VERIFY:
+            cannot_verify = True
+        elif cause in REAL_STALL_CAUSES:
+            cannot_verify = False
+        else:
+            skipped.append((number, cause))
+            continue
+
+        item = {
+            "number": number,
+            "cause": cause,
+            "key": f"queue_stall:{number}:{cause}",
+            "cannot_verify": cannot_verify,
+            "detail": row.get("detail", ""),
+        }
+        if len(to_notify) < cap:
+            to_notify.append(item)
+        else:
+            suppressed.append(item)
+
+    return {"to_notify": to_notify, "suppressed_by_cap": suppressed, "skipped": skipped}
+
+
+def _format_message(item: dict[str, Any]) -> str:
+    """Pure: the fleet-mail body text. CANNOT-VERIFY gets a DISTINCT wording — "an instrument
+    that could not read is news, not silence" (team-lead mandate, verbatim) — never the same
+    sentence shape as a real stall cause, so a reader of the mailbox can tell the two apart at a
+    glance without opening the classifier report."""
+    number = item["number"]
+    cause = item["cause"]
+    detail = item.get("detail", "")
+    if item["cannot_verify"]:
+        return (
+            f"queue_stall: PR #{number} — the classifier COULD NOT VERIFY this PR's stall state "
+            f"({detail}). An instrument that could not read is news, not silence — this is not "
+            "the same as 'no stall found'."
+        )
+    return f"queue_stall: PR #{number} is stalled ({cause}): {detail}"
+
+
+# ---------------------------------------------------------------------------
+# Delivery — side-effecting.
+# ---------------------------------------------------------------------------
+
+
+def send_notification(
+    item: dict[str, Any], *, dry_run: bool, repo_root: Path = REPO_ROOT
+) -> tuple[bool, str]:
+    """Mirrors queue_unstick.py::send_dirty_signal's shape (team-lead mandate: "Copy the exact
+    invocation shape used by scripts/queue_unstick.py around lines 632 and 647-651") — same
+    fleet_mail.sh argv shape, same dry-run / missing-file / non-zero-rc handling. Returns
+    (ok, detail_line_for_the_log)."""
+    msg = _format_message(item)
+    number = item["number"]
+
+    if dry_run:
+        return True, (
+            f"[dry-run] would signal PR #{number} ({item['cause']}) via fleet_mail.sh "
+            f"{FLEET_MAIL_HOST} broadcast --key {item['key']}: {msg}"
+        )
+
+    fleet_mail = repo_root / "scripts" / "fleet_mail.sh"
+    if not fleet_mail.is_file():
+        return False, f"signal FAILED PR #{number}: fleet_mail.sh not found at {fleet_mail}"
+    rc, out, err = _run(
+        ["bash", str(fleet_mail), FLEET_MAIL_HOST, "broadcast", "--key", item["key"], msg],
+        timeout=30,
+    )
+    if rc != 0:
+        return False, f"signal FAILED PR #{number} rc={rc}: {err.strip()[:300]}"
+    return True, f"signal OK PR #{number}: {out.strip() or 'sent'}"
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0] if __doc__ else "queue_stall_notify"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="perform zero fleet-mail sends; print exactly what would be sent",
+    )
+    parser.add_argument("--repo", default=REPO)
+    parser.add_argument("--min-age-minutes", type=int, default=MIN_AGE_MINUTES)
+    parser.add_argument(
+        "--cap", type=int, default=CAP,
+        help="max fleet-mail sends per run (default %(default)s)",
+    )
+    parser.add_argument(
+        "--classifier-path", default=str(CLASSIFIER),
+        help="override queue_stall_classifier.py location (tests only)",
+    )
+    parser.add_argument("--classifier-timeout", type=int, default=CLASSIFIER_TIMEOUT)
+    args = parser.parse_args(argv)
+
+    # Kill switch checked FIRST — before the classifier subprocess ever runs (module docstring:
+    # "Checked BEFORE the classifier subprocess is even invoked").
+    if not _enabled():
+        print(
+            "QUEUE_STALL_NOTIFY_SUMMARY disabled=true examined=0 stalled=0 sent=0 "
+            f"send_failed=0 suppressed_by_cap=0 dry_run={str(args.dry_run).lower()}"
+        )
+        return 0
+
+    rc, report, out, err = run_classifier(
+        repo=args.repo,
+        min_age_minutes=args.min_age_minutes,
+        classifier_path=Path(args.classifier_path),
+        timeout=args.classifier_timeout,
+    )
+    classifier_failed = rc != 0
+
+    if report is None:
+        # The classifier's stdout could not be parsed as JSON at all — nothing to plan over.
+        # Still a structured, loud receipt (superscar #2), never a silent return.
+        detail = (err or out or "no output").strip()[:300]
+        print(
+            f"QUEUE_STALL_NOTIFY_SUMMARY classifier_rc={rc} classifier_failed=true "
+            "examined=0 stalled=0 sent=0 send_failed=0 suppressed_by_cap=0 "
+            f"dry_run={str(args.dry_run).lower()} error={detail!r}"
+        )
+        return 1
+
+    rows = report.get("rows") or []
+    plan = plan_notifications(rows, cap=args.cap)
+
+    sent = 0
+    send_failed = 0
+    for item in plan["to_notify"]:
+        ok, detail_line = send_notification(item, dry_run=args.dry_run)
+        print(detail_line)
+        if ok:
+            sent += 1
+        else:
+            send_failed += 1
+
+    stalled = len(plan["to_notify"]) + len(plan["suppressed_by_cap"])
+    summary = (
+        f"QUEUE_STALL_NOTIFY_SUMMARY classifier_rc={rc} "
+        f"examined={report.get('examined_total', 0)} stalled={stalled} sent={sent} "
+        f"send_failed={send_failed} suppressed_by_cap={len(plan['suppressed_by_cap'])} "
+        f"cap={args.cap} dry_run={str(args.dry_run).lower()}"
+    )
+    print(summary)
+
+    # Exit codes — module docstring: the classifier's own failure propagates as a failure here
+    # EVEN IF every row that did parse was delivered successfully, and a send failure is its own
+    # independent reason to be non-zero. A clean run (classifier rc=0, all sends ok) is 0
+    # regardless of whether any PR was actually stalled.
+    return 1 if (classifier_failed or send_failed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/queue_stall_notify_cron.sh
+++ b/scripts/queue_stall_notify_cron.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# queue_stall_notify_cron.sh — cron payload for cron-runner.sh, delivering
+# scripts/queue_stall_classifier.py's findings to the fleet mailbox via
+# scripts/queue_stall_notify.py.
+#
+# cron-runner executes payloads with /bin/bash, so the python notifier needs
+# this thin wrapper. It lives IN THE REPO and the crontab line points here
+# directly (never a ~/scripts copy — superscar #1 HOME-fork).
+#
+# ── Crontab wiring (installed by the conductor after PROVE-LIVE, NOT here) ──
+#
+# This is a REPORTER, not an actuator: queue_stall_classifier.py never
+# mutates a PR (its own AST self-check enforces that), and neither does this
+# wrapper's payload — it only reads the classifier's report and fleet-mails
+# it. A slower cadence than queue_unstick_cron.sh's 10 minutes is therefore
+# appropriate: */30, matching queue_stall_classifier.py's own
+# DEFAULT_MIN_AGE_MINUTES=30 — running more often than the classifier's own
+# age floor would just re-examine the same PRs before anything about them
+# could plausibly have changed.
+#
+#   */30 * * * * /bin/bash /Users/nuzantara/scripts/cron-runner.sh \
+#     /Users/nuzantara/nuzantara/scripts/queue_stall_notify_cron.sh \
+#     >> /Users/nuzantara/logs/cron-tmp/queue-stall-notify.log 2>&1
+#
+# No launchd plist exists for this family, and none should be invented here:
+# the sibling queue_unstick_cron.sh runs from a raw crontab line on Mini
+# (verified live), and queue_shepherd is the one member of this family that
+# is plist-driven. Follow queue_unstick's precedent, not queue_shepherd's.
+#
+# Kill switch (no crontab edit needed): export
+# QUEUE_STALL_NOTIFY_ENABLED=false in the environment cron-runner.sh runs
+# under, or wrap the crontab line with `QUEUE_STALL_NOTIFY_ENABLED=false
+# /bin/bash ...` to disable in place.
+#
+# Prerequisites the conductor should verify before installing:
+#   - `gh auth status` succeeds as a principal with repo READ access (the
+#     classifier subprocess needs it; this wrapper itself makes no gh call
+#     and neither does queue_stall_notify.py outside that subprocess).
+#   - `scripts/fleet_mail.sh` reachable and its `pro` SSH target answers
+#     BatchMode (see fleet_mail.sh header) — a stall signal silently failing
+#     to send is exactly the kind of mute-cron regression superscar #2
+#     exists to catch; queue_stall_notify.py's own summary line reports
+#     send_failed>0 when this happens, but only if something reads the log.
+#
+# REPO PATH — derived from this script's own location (same discipline as
+# queue_unstick_cron.sh / qwen_quota_watch_cron.sh): the checkout path
+# differs per machine, so a hardcoded path is a machine-specific landmine.
+#
+# Exit-code mapping: queue_stall_notify.py's 0 (ran clean, whether or not it
+# found/delivered any stalls) is the only "ok" state for cron-runner's
+# receipt. Non-zero (the classifier itself failed, OR a fleet-mail send
+# failed) propagates as a real failure, so cron-runner's alert_failure fires
+# and the receipt records last_error — a gh/network hiccup here must be
+# loud, never a silent "nothing was stuck" (superscar #2/#9).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+NOTIFIER="$REPO/scripts/queue_stall_notify.py"
+
+if [ ! -f "$NOTIFIER" ]; then
+    echo "queue_stall_notify_cron: notifier not found at $NOTIFIER (checkout behind?)" >&2
+    exit 66  # armed-to-nothing must be a loud receipt, never a silent green (W81)
+fi
+
+/usr/bin/env python3 "$NOTIFIER"
+rc=$?
+echo "queue_stall_notify_cron: notifier rc=$rc" >&2
+exit "$rc"

--- a/scripts/tests/test_queue_stall_notify.py
+++ b/scripts/tests/test_queue_stall_notify.py
@@ -1,0 +1,306 @@
+"""test_queue_stall_notify.py — pure-function tests over synthetic classifier reports, plus
+monkeypatched-I/O tests for main(). No network, no real gh/fleet_mail.sh calls: the classifier
+subprocess and fleet_mail.sh are both stubbed at their module-level seams
+(`qsn.run_classifier`, `qsn._run`), and every stubbing test asserts that stub was the only
+thing invoked — never merely that the assertions on its output happen to pass.
+
+Covers the mandate's explicit cases:
+  1. kill switch OFF -> zero sends, receipt line still printed (guilt: run_classifier must
+     never even be called).
+  2. --dry-run -> zero subprocess calls beyond the classifier read, intended payload printed.
+  3. a real stall row -> exactly one send, dedup key contains BOTH the PR number and the cause.
+  4. innocence: a clean board (no stalled rows) -> zero sends, rc 0, summary says stalled=0.
+  5. innocence: a "queued-and-advancing" row (classifier's own "not actionably stuck" default)
+     -> no send.
+  6. classifier rc=1 -> notifier exits non-zero, even when nothing needed to be sent.
+  7. a send that fails -> notifier exits non-zero, send_failed appears in the summary.
+  8. the cap: more notify-worthy rows than the cap -> sends stop at the cap,
+     suppressed_by_cap is non-zero.
+  9. CANNOT-VERIFY rows are delivered, distinctly worded, not dropped — even though the
+     classifier's own rc is 1 for that same run (propagated as failure regardless of delivery).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import queue_stall_notify as qsn  # noqa: E402
+
+
+def make_row(number: int, cause: str, detail: str = "detail") -> dict:
+    return {"number": number, "title": f"PR {number}", "age_minutes": 45, "cause": cause, "detail": detail}
+
+
+def make_report(rows: list[dict], *, examined_total: int | None = None, fetch_error: str | None = None) -> dict:
+    return {
+        "repo": "Bali-Zero/Teman2",
+        "generated_at": "2026-09-01T00:00:00Z",
+        "min_age_minutes": 30,
+        "examined_total": examined_total if examined_total is not None else len(rows),
+        "excluded_drafts": 0,
+        "rows": rows,
+        "fetch_error": fetch_error,
+    }
+
+
+def _fail_if_called(*_args, **_kwargs):
+    raise AssertionError("this stub must never be invoked in this scenario")
+
+
+# ── plan_notifications: pure ────────────────────────────────────────────────
+
+
+def test_real_stall_cause_is_notify_worthy_key_has_number_and_cause():
+    plan = qsn.plan_notifications([make_row(202, "not-armed", "x")], cap=10)
+    assert len(plan["to_notify"]) == 1
+    item = plan["to_notify"][0]
+    assert item["number"] == 202
+    assert item["cause"] == "not-armed"
+    assert item["key"] == "queue_stall:202:not-armed"
+    assert item["cannot_verify"] is False
+
+
+def test_same_pr_number_different_cause_yields_different_keys():
+    # This is the exact property the mandate calls out: "the dedup key must encode the CAUSE,
+    # not just the PR number" — a PR-number-only key would collapse these two into one.
+    plan = qsn.plan_notifications(
+        [make_row(707, "not-armed", "x"), make_row(707, "conflict", "y")], cap=10
+    )
+    keys = [item["key"] for item in plan["to_notify"]]
+    assert keys == ["queue_stall:707:not-armed", "queue_stall:707:conflict"]
+    assert len(set(keys)) == 2
+
+
+def test_queued_and_advancing_is_not_notify_worthy():
+    plan = qsn.plan_notifications([make_row(303, "queued-and-advancing", "no known blocker")], cap=10)
+    assert plan["to_notify"] == []
+    assert plan["suppressed_by_cap"] == []
+    assert plan["skipped"] == [(303, "queued-and-advancing")]
+
+
+def test_cannot_verify_is_notify_worthy_and_flagged_distinctly():
+    plan = qsn.plan_notifications([make_row(606, qsn.CANNOT_VERIFY, "checkSuites fetch failed")], cap=10)
+    assert len(plan["to_notify"]) == 1
+    item = plan["to_notify"][0]
+    assert item["cannot_verify"] is True
+    assert item["key"] == "queue_stall:606:CANNOT-VERIFY"
+
+
+def test_cap_suppresses_past_the_limit_in_order():
+    rows = [make_row(n, "not-armed", "x") for n in (501, 502, 503)]
+    plan = qsn.plan_notifications(rows, cap=1)
+    assert [i["number"] for i in plan["to_notify"]] == [501]
+    assert [i["number"] for i in plan["suppressed_by_cap"]] == [502, 503]
+
+
+def test_cannot_verify_message_wording_is_distinct_from_a_real_stall():
+    real = qsn._format_message(
+        {"number": 1, "cause": "conflict", "cannot_verify": False, "detail": "mergeStateStatus=DIRTY"}
+    )
+    unverifiable = qsn._format_message(
+        {"number": 2, "cause": qsn.CANNOT_VERIFY, "cannot_verify": True, "detail": "network flap"}
+    )
+    assert "COULD NOT VERIFY" in unverifiable
+    assert "COULD NOT VERIFY" not in real
+
+
+# ── main(): kill switch ─────────────────────────────────────────────────────
+
+
+def test_kill_switch_off_zero_sends_and_receipt_line_printed(monkeypatch, capsys):
+    monkeypatch.setenv("QUEUE_STALL_NOTIFY_ENABLED", "false")
+    monkeypatch.setattr(qsn, "run_classifier", _fail_if_called)
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "disabled=true" in out
+    assert "sent=0" in out
+
+
+# ── main(): --dry-run ───────────────────────────────────────────────────────
+
+
+def test_dry_run_zero_subprocess_calls_intended_payload_printed(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(101, "conflict", "mergeStateStatus=DIRTY")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    rc = qsn.main(["--dry-run"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "[dry-run] would signal PR #101" in out
+    assert "queue_stall:101:conflict" in out
+    assert "sent=1" in out
+
+
+# ── main(): a real stall row -> exactly one send ────────────────────────────
+
+
+def test_real_stall_row_produces_exactly_one_send(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(202, "not-armed", "autoMergeRequest=null and mergeQueueEntry=null")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+
+    calls = []
+
+    def fake_run(cmd, timeout=30):
+        calls.append(cmd)
+        return 0, "delivered", ""
+
+    monkeypatch.setattr(qsn, "_run", fake_run)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert len(calls) == 1
+    cmd = calls[0]
+    assert cmd[0] == "bash"
+    assert cmd[1] == str(qsn.REPO_ROOT / "scripts" / "fleet_mail.sh")
+    key_index = cmd.index("--key") + 1
+    assert cmd[key_index] == "queue_stall:202:not-armed"
+    assert "sent=1" in out
+    assert "send_failed=0" in out
+
+
+# ── main(): innocence — clean board ─────────────────────────────────────────
+
+
+def test_clean_board_zero_sends_rc0_summary_says_so(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([], examined_total=12)
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "examined=12" in out
+    assert "stalled=0" in out
+    assert "sent=0" in out
+
+
+# ── main(): innocence — a not-stalled row must not produce a send ──────────
+
+
+def test_queued_and_advancing_row_produces_no_send(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(303, "queued-and-advancing", "no known blocker")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "stalled=0" in out
+    assert "sent=0" in out
+
+
+# ── main(): classifier failure propagates ───────────────────────────────────
+
+
+def test_classifier_rc1_propagates_as_notifier_failure(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([], examined_total=0, fetch_error="gh api graphql failed rc=1: simulated")
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (1, report, "", "boom"))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc != 0
+    assert "classifier_rc=1" in out
+
+
+def test_classifier_unparseable_output_is_still_a_loud_nonzero_receipt(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (127, None, "", "python: command not found"))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc != 0
+    assert "classifier_failed=true" in out
+
+
+# ── main(): a send failure ──────────────────────────────────────────────────
+
+
+def test_send_failure_makes_notifier_exit_nonzero_and_counted(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(404, "required-check-red", "statusCheckRollup=FAILURE")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", lambda cmd, timeout=30: (1, "", "network flap"))
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc != 0
+    assert "send_failed=1" in out
+
+
+# ── main(): the cap ──────────────────────────────────────────────────────────
+
+
+def test_cap_stops_sends_and_reports_suppressed(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    rows = [make_row(n, "not-armed", "x") for n in (501, 502, 503)]
+    report = make_report(rows)
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+
+    calls = []
+
+    def fake_run(cmd, timeout=30):
+        calls.append(cmd)
+        return 0, "ok", ""
+
+    monkeypatch.setattr(qsn, "_run", fake_run)
+
+    rc = qsn.main(["--cap", "1"])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert len(calls) == 1
+    assert "suppressed_by_cap=2" in out
+    assert "stalled=3" in out
+
+
+# ── main(): CANNOT-VERIFY delivery ──────────────────────────────────────────
+
+
+def test_cannot_verify_row_is_delivered_distinctly_even_though_classifier_failed(monkeypatch, capsys):
+    # The classifier itself reports rc=1 whenever ANY row is CANNOT-VERIFY (its own contract) —
+    # this run must still deliver the row (news, not silence) AND propagate the failure.
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(606, qsn.CANNOT_VERIFY, "checkSuites fetch failed: timeout")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (1, report, "", ""))
+
+    calls = []
+
+    def fake_run(cmd, timeout=30):
+        calls.append(cmd)
+        return 0, "ok", ""
+
+    monkeypatch.setattr(qsn, "_run", fake_run)
+
+    rc = qsn.main([])
+    out = capsys.readouterr().out
+
+    assert rc != 0  # classifier_failed propagates even though the send itself succeeded
+    assert len(calls) == 1
+    key_index = calls[0].index("--key") + 1
+    assert calls[0][key_index] == "queue_stall:606:CANNOT-VERIFY"
+    msg = calls[0][-1]
+    assert "COULD NOT VERIFY" in msg
+    assert "sent=1" in out


### PR DESCRIPTION
`scripts/queue_stall_classifier.py` classifies exactly why a PR is stuck. Verified today: **nothing invokes it.** `git grep -l queue_stall_classifier origin/main` returns the script, its test, and three evidence-pack files — no wrapper, no caller. No crontab entry on Pro or on Mini.

**Bites:** the consumer is `scripts/queue_stall_notify.py`, which ships in this PR and is runnable now. The observation that proves it is in force is a live end-to-end dry-run against this repo — `--dry-run --min-age-minutes 60 --cap 3` → `examined=40 stalled=30 sent=3 send_failed=0 suppressed_by_cap=27 cap=3 dry_run=true`, rc=0, zero mutations — plus 16 tests, three of them proven discriminating by breaking the property and watching the right test redden. **What this PR does NOT ship is the crontab line**, and I am not going to dress that up: until it is installed the wire is built and not armed. It is a declared follow-up, not a claim, and it is deliberately one command.

## Why a cron line alone would have been theatre

The classifier exits `1` only on `fetch_error`, `examined_total == 0`, or a `CANNOT-VERIFY` row. **It exits `0` on a clean run whether or not anything is stuck.** `cron-runner.sh` raises its Telegram P0 on a non-zero exit — so the obvious wiring would have produced a permanently green cron job writing its findings into a logfile nobody opens. Green, and reporting nothing. That is scar family #2 in its purest form, so **the delivery is the wire**; the schedule is just when it runs.

## Shape

- **The classifier is not touched** (`git diff --name-only` on it: empty). It is deliberately pure — zero disk writes, zero `os.environ` reads, read-only `gh` GETs only, with an AST self-check in its own suite enforcing that. Delivery would have broken its invariant, so every side effect lives in a separate, named, testable file.
- **The dedup key carries the CAUSE, not just the number** — `queue_stall:<number>:<cause>`. The classifier holds no state of its own (unlike `queue_unstick.py`, which has a sha+conflict-digest fingerprint file), and the mailbox keeps only the newest message per key. With a number-only key, a PR whose stall *cause* changed would silently never resurface.
- **`queued-and-advancing` is excluded** from "real stall" — the classifier's own docstring calls it "no known blocker; may simply be slow". Notifying on it every 30 minutes would be noise by design.
- **`CANNOT-VERIFY` rows are delivered, distinctly.** An instrument reporting that it could not read is news, not silence.
- Kill switch `QUEUE_STALL_NOTIFY_ENABLED` that still prints a receipt when off — never a silent no-op — plus `--dry-run` and a send cap so a bad day cannot storm the fleet mailbox.
- **No plist invented.** Verified on the machines, not in the files: the sibling `queue_unstick` runs from a raw crontab line on Mini (installed 2026-08-25); `queue_shepherd` is the plist-driven one. Copying the wrong sibling's shape would have produced an organ invisible to the heartbeat-margin rule.
- Cadence `*/30`, tied to the classifier's own `DEFAULT_MIN_AGE_MINUTES=30`. This is a reporter, not an actuator.

## Discrimination, not just green

Three properties broken → the right test reddened → restored → green:
1. kill switch bypassed → the stub's assertion fired;
2. key reduced to `queue_stall:<number>` → the two-causes-one-PR test failed with two identical keys;
3. `stalled` counted from `examined_total` instead of notify-worthy rows → the clean-board innocence test failed with `stalled=12` on an empty-rows report. That third one is a real bug class, not a synthetic one: conflating "examined" with "stalled" is how a quiet board reports as busy.

139 tests green overall (16 new + 123 sibling, no regressions). Ruff clean.