### PR TITLE
feat(mouth): put the round-2 written assessment online at /interview_natalie

### DIFF
--- a/apps/mouth/src/app/(assessment)/interview_natalie/data.ts
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/data.ts
@@ -1,0 +1,397 @@
+/**
+ * Round 2 written assessment — Finance & Client Services Coordinator.
+ *
+ * Content is the on-screen twin of the printed booklet rendered 2026-08-30
+ * (`Bali-Zero-Round2-Assessment-Booklet-EN.pdf`). The figures below were
+ * machine-verified before that print: bank closing 133.750.000, cash-book
+ * closing 116.385.000, difference 17.365.000, reconciled exactly by the four
+ * planted items (MDR 850.000 · cut-off 27.000.000 · double payment 8.750.000 ·
+ * bank charge 35.000). Do not "tidy" a number here without re-running that
+ * arithmetic — a test whose numbers do not add up punishes the candidate who
+ * is good enough to notice.
+ *
+ * All company names, figures and documents are invented. They describe no
+ * Bali Zero client.
+ */
+
+export interface Field {
+  id: string;
+  label: string;
+  placeholder?: string;
+  /** Single-line input instead of a textarea. */
+  short?: boolean;
+  /** Minimum characters before the exercise counts as attempted. */
+  hint?: string;
+}
+
+export interface Exercise {
+  key: string;
+  letter: string;
+  title: string;
+  minutes: number;
+  /** Language rule shown in the exercise header. */
+  language: string;
+  intro: string;
+  fields: Field[];
+}
+
+export interface LedgerRow {
+  date: string;
+  description: string;
+  amount: string;
+  balance: string;
+}
+
+export const BANK_ROWS: LedgerRow[] = [
+  {
+    date: "01/07",
+    description: "SALDO AWAL",
+    amount: "—",
+    balance: "96.500.000",
+  },
+  {
+    date: "03/07",
+    description: "TRSF E-BANKING CR — AGODA PAYOUT JULI",
+    amount: "+38.400.000",
+    balance: "134.900.000",
+  },
+  {
+    date: "05/07",
+    description: "PAYROLL — GAJI KARYAWAN JULI",
+    amount: "−62.300.000",
+    balance: "72.600.000",
+  },
+  {
+    date: "07/07",
+    description: "PLN / PDAM — UTILITAS",
+    amount: "−7.840.000",
+    balance: "64.760.000",
+  },
+  {
+    date: "08/07",
+    description: "TRSF MASUK — PT SANDALWOOD",
+    amount: "+15.000.000",
+    balance: "79.760.000",
+  },
+  {
+    date: "10/07",
+    description: "TRSF KELUAR — CV BALI SEGAR",
+    amount: "−11.250.000",
+    balance: "68.510.000",
+  },
+  {
+    date: "12/07",
+    description: "SETTLEMENT EDC BCA — PERIODE 01-11/07",
+    amount: "+41.650.000",
+    balance: "110.160.000",
+  },
+  {
+    date: "14/07",
+    description: "TRSF KELUAR — CV TIRTA BERSIH",
+    amount: "−8.750.000",
+    balance: "101.410.000",
+  },
+  {
+    date: "16/07",
+    description: "TRSF KELUAR — CV TIRTA BERSIH",
+    amount: "−8.750.000",
+    balance: "92.660.000",
+  },
+  {
+    date: "18/07",
+    description: "TRSF E-BANKING CR — AIRBNB PAYOUT",
+    amount: "+22.150.000",
+    balance: "114.810.000",
+  },
+  {
+    date: "20/07",
+    description: "TRSF KELUAR — SEWA KANTOR JULI",
+    amount: "−15.000.000",
+    balance: "99.810.000",
+  },
+  {
+    date: "22/07",
+    description: "TRSF KELUAR — KOMISI OTA",
+    amount: "−6.100.000",
+    balance: "93.710.000",
+  },
+  {
+    date: "25/07",
+    description: "TRSF MASUK — BPK. WIJAYA",
+    amount: "+18.000.000",
+    balance: "111.710.000",
+  },
+  {
+    date: "28/07",
+    description: "TRSF KELUAR — BPJS TK + KESEHATAN",
+    amount: "−4.925.000",
+    balance: "106.785.000",
+  },
+  {
+    date: "31/07",
+    description: "TRSF MASUK — K. LINDQVIST",
+    amount: "+27.000.000",
+    balance: "133.785.000",
+  },
+  {
+    date: "31/07",
+    description: "BIAYA ADMINISTRASI",
+    amount: "−35.000",
+    balance: "133.750.000",
+  },
+];
+
+export const CASHBOOK_ROWS: LedgerRow[] = [
+  {
+    date: "01/07",
+    description: "Saldo awal",
+    amount: "—",
+    balance: "96.500.000",
+  },
+  {
+    date: "03/07",
+    description: "Agoda payout July",
+    amount: "+38.400.000",
+    balance: "134.900.000",
+  },
+  {
+    date: "05/07",
+    description: "Payroll July",
+    amount: "−62.300.000",
+    balance: "72.600.000",
+  },
+  {
+    date: "07/07",
+    description: "Utilities — PLN / PDAM",
+    amount: "−7.840.000",
+    balance: "64.760.000",
+  },
+  {
+    date: "08/07",
+    description: "Management fee — PT Sandalwood",
+    amount: "+15.000.000",
+    balance: "79.760.000",
+  },
+  {
+    date: "10/07",
+    description: "Food supplier — CV Bali Segar",
+    amount: "−11.250.000",
+    balance: "68.510.000",
+  },
+  {
+    date: "12/07",
+    description: "Card sales settlement (EDC)",
+    amount: "+42.500.000",
+    balance: "111.010.000",
+  },
+  {
+    date: "14/07",
+    description: "Laundry & linen — CV Tirta Bersih",
+    amount: "−8.750.000",
+    balance: "102.260.000",
+  },
+  {
+    date: "18/07",
+    description: "Airbnb payout",
+    amount: "+22.150.000",
+    balance: "124.410.000",
+  },
+  {
+    date: "20/07",
+    description: "Office rent — July",
+    amount: "−15.000.000",
+    balance: "109.410.000",
+  },
+  {
+    date: "22/07",
+    description: "OTA commission",
+    amount: "−6.100.000",
+    balance: "103.310.000",
+  },
+  {
+    date: "25/07",
+    description: "Owner transfer — Bpk. Wijaya",
+    amount: "+18.000.000",
+    balance: "121.310.000",
+  },
+  {
+    date: "28/07",
+    description: "BPJS TK + Kesehatan",
+    amount: "−4.925.000",
+    balance: "116.385.000",
+  },
+];
+
+export interface OtherExpenseRow {
+  item: string;
+  june: string;
+  july: string;
+}
+
+export const OTHER_EXPENSES: OtherExpenseRow[] = [
+  {
+    item: "Perizinan — permit extension, agent fee",
+    june: "—",
+    july: "1.200.000",
+  },
+  {
+    item: "Bank administration & transfer charges",
+    june: "340.000",
+    july: "385.000",
+  },
+  { item: "Staff medical reimbursement", june: "—", july: "2.150.000" },
+  {
+    item: "Repairs — pool pump replacement",
+    june: "1.200.000",
+    july: "3.500.000",
+  },
+  { item: "Entertainment / client meals", june: "1.100.000", july: "900.000" },
+  {
+    item: "Legal translation — notaris document",
+    june: "—",
+    july: "1.750.000",
+  },
+  {
+    item: "Miscellaneous — no description",
+    june: "5.760.000",
+    july: "1.875.000",
+  },
+];
+
+export const EXERCISES: Exercise[] = [
+  {
+    key: "A",
+    letter: "A",
+    title: "Reconciliation",
+    minutes: 20,
+    language: "English or Bahasa Indonesia — your choice.",
+    intro:
+      "Sunset Villas & Kitchen is a villa management and restaurant operator in Seminyak and a client of ours. Below is its bank statement for July 2026 and the cash book the client's own staff kept for the same month. The two closing balances do not agree.",
+    fields: [
+      {
+        id: "a_differences",
+        label:
+          "1 — Every difference you find, one per line, with its amount and a one-line cause.",
+        placeholder: "1. 850.000 — ...\n2. ...\n3. ...\n4. ...",
+        hint: "Cash book 116.385.000 · bank statement 133.750.000.",
+      },
+      {
+        id: "a_reconciliation",
+        label:
+          "2 — The reconciliation. Start from the cash book balance and finish at the bank balance.",
+        placeholder:
+          "Cash book balance 31/07          116.385.000\n+ ...\n= Bank balance 31/07             133.750.000",
+      },
+      {
+        id: "a_actions",
+        label:
+          "3 — Anything that needs doing beyond an accounting entry. If nothing, write none and say why.",
+        placeholder: "",
+      },
+    ],
+  },
+  {
+    key: "B",
+    letter: "B",
+    title: "Judgement",
+    minutes: 15,
+    language: "English or Bahasa Indonesia — your choice.",
+    intro:
+      "Same client. The July management report is due to the owner tomorrow. Other expenses have risen 40% against June. You have the ledger detail below and you do not yet know why.",
+    fields: [
+      {
+        id: "b_checks",
+        label: "1 — What do you check, and in what order?",
+        placeholder: "",
+      },
+      {
+        id: "b_owner",
+        label:
+          "2 — What do you tell the owner tomorrow, before you have the full answer?",
+        placeholder: "",
+      },
+      {
+        id: "b_not_real",
+        label: "3 — Is anything here not a real increase in cost? Say why.",
+        placeholder: "",
+      },
+    ],
+  },
+  {
+    key: "C",
+    letter: "C",
+    title: "Client email",
+    minutes: 15,
+    language:
+      "English only — the English is the exercise. We will not explain wording here.",
+    intro:
+      "It is 21:40. This email arrives from an Italian client. Write the reply you would send tonight. No phone, no dictionary.",
+    fields: [
+      {
+        id: "c_reply",
+        label: "Your reply",
+        placeholder: "Dear Mr Ferrari,",
+      },
+    ],
+  },
+  {
+    key: "D",
+    letter: "D",
+    title: "Fact sheet",
+    minutes: 10,
+    language: "English or Bahasa Indonesia — your choice.",
+    intro:
+      "Every line, please. Where a line asks for a number or a date, give a number or a date.",
+    fields: [
+      {
+        id: "d_software",
+        label: "Accounting software you have used, by name",
+        short: true,
+      },
+      {
+        id: "d_coretax",
+        label: "Coretax / e-Faktur — used, seen, or neither",
+        short: true,
+      },
+      {
+        id: "d_volume",
+        label: "Entities handled at once, and transactions per month",
+        short: true,
+      },
+      {
+        id: "d_managed",
+        label: "People you managed, and their roles",
+        short: true,
+      },
+      {
+        id: "d_reported",
+        label: "Who you reported to, and their title",
+        short: true,
+      },
+      { id: "d_leaving", label: "Reason for leaving your current role" },
+      { id: "d_notice", label: "Notice period, as a date", short: true },
+      {
+        id: "d_salary",
+        label: "Salary expectation, as a monthly number (IDR)",
+        short: true,
+      },
+      {
+        id: "d_availability",
+        label: "Availability over the first 90 days",
+        short: true,
+      },
+      {
+        id: "d_dates",
+        label:
+          "Two dates we need to fix — your file records the start of your Toshiba role as 1993 in one place and 1998 in another. Write the correct year, and where the other came from.",
+      },
+      {
+        id: "d_question",
+        label:
+          "One last question, and it is not a test — what do you want to know about this job that nobody has told you yet?",
+      },
+    ],
+  },
+];
+
+export const TOTAL_MINUTES = EXERCISES.reduce((n, e) => n + e.minutes, 0);

--- a/apps/mouth/src/app/(assessment)/interview_natalie/layout.tsx
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Round 2 Written Assessment",
+  description:
+    "Bali Zero — Finance & Client Services Coordinator, round 2 written assessment.",
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function InterviewLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/apps/mouth/src/app/(assessment)/interview_natalie/page.tsx
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/page.tsx
@@ -1,0 +1,780 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  BANK_ROWS,
+  CASHBOOK_ROWS,
+  EXERCISES,
+  OTHER_EXPENSES,
+  TOTAL_MINUTES,
+  type Exercise,
+} from "./data";
+import {
+  countWords,
+  emptyField,
+  flagSummary,
+  flagsFor,
+  JUMP_THRESHOLD,
+  type ExerciseTelemetry,
+  type FieldTelemetry,
+} from "./telemetry";
+
+const CANDIDATE = "Natalie Mahodim";
+const ROLE = "Finance & Client Services Coordinator";
+const PANEL_INBOX = "zero@balizero.com";
+const STORAGE_KEY = "bz-interview-natalie-v1";
+
+type Phase = "intro" | "running" | "done";
+
+interface Persisted {
+  answers: Record<string, string>;
+  index: number;
+  submitted: string[];
+  startedAt: number | null;
+}
+
+function mmss(totalSeconds: number): string {
+  const s = Math.max(0, Math.floor(totalSeconds));
+  return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function wita(): string {
+  return new Date().toLocaleString("en-GB", {
+    timeZone: "Asia/Makassar",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function newExerciseTelemetry(ex: Exercise): ExerciseTelemetry {
+  const fields: Record<string, FieldTelemetry> = {};
+  for (const f of ex.fields) fields[f.id] = emptyField();
+  return { elapsedMs: 0, awayMs: 0, awayCount: 0, fields, autoLocked: false };
+}
+
+export default function InterviewNataliePage() {
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [index, setIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [submitted, setSubmitted] = useState<string[]>([]);
+  const [sending, setSending] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [remaining, setRemaining] = useState(EXERCISES[0].minutes * 60);
+  const [restored, setRestored] = useState(false);
+
+  const exercise = EXERCISES[index];
+  const startedRef = useRef<number | null>(null);
+  const telemRef = useRef<ExerciseTelemetry>(
+    newExerciseTelemetry(EXERCISES[0]),
+  );
+  const allTelemRef = useRef<Record<string, ExerciseTelemetry>>({});
+  const lastEditRef = useRef<Record<string, number>>({});
+  const focusedAtRef = useRef<Record<string, number>>({});
+  const awaySinceRef = useRef<number | null>(null);
+  const submitRef = useRef<(auto: boolean) => void>(() => {});
+
+  // ── Restore an interrupted session ──────────────────────────────
+  // Sixty minutes of handwriting cannot be asked for twice: a reload, a flat
+  // battery or a stray back-gesture must not cost the candidate her answers.
+  // Telemetry deliberately does NOT survive the reload — it would be a
+  // fabricated measurement of a session this page did not watch.
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const saved = JSON.parse(raw) as Persisted;
+      if (saved && typeof saved === "object" && saved.answers) {
+        setAnswers(saved.answers);
+        setSubmitted(saved.submitted || []);
+        const idx = Math.min(
+          Math.max(saved.index || 0, 0),
+          EXERCISES.length - 1,
+        );
+        setIndex(idx);
+        setRestored(true);
+      }
+    } catch {
+      /* a browser that refuses storage is not a reason to fail the exam */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (phase === "intro") return;
+    try {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          answers,
+          index,
+          submitted,
+          startedAt: startedRef.current,
+        }),
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [answers, index, submitted, phase]);
+
+  // ── Countdown ───────────────────────────────────────────────────
+  useEffect(() => {
+    if (phase !== "running") return;
+    const id = setInterval(() => {
+      const started = startedRef.current;
+      if (!started) return;
+      const elapsedMs = Date.now() - started;
+      telemRef.current.elapsedMs = elapsedMs;
+      const left = exercise.minutes * 60 - Math.floor(elapsedMs / 1000);
+      setRemaining(left);
+      if (left <= 0) {
+        telemRef.current.autoLocked = true;
+        submitRef.current(true);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [phase, exercise]);
+
+  // ── Away-from-tab detection ─────────────────────────────────────
+  useEffect(() => {
+    if (phase !== "running") return;
+    const leave = () => {
+      if (awaySinceRef.current === null) {
+        awaySinceRef.current = Date.now();
+        telemRef.current.awayCount += 1;
+      }
+    };
+    const back = () => {
+      if (awaySinceRef.current !== null) {
+        telemRef.current.awayMs += Date.now() - awaySinceRef.current;
+        awaySinceRef.current = null;
+      }
+    };
+    const visibility = () => (document.hidden ? leave() : back());
+    window.addEventListener("blur", leave);
+    window.addEventListener("focus", back);
+    document.addEventListener("visibilitychange", visibility);
+    return () => {
+      window.removeEventListener("blur", leave);
+      window.removeEventListener("focus", back);
+      document.removeEventListener("visibilitychange", visibility);
+    };
+  }, [phase]);
+
+  // ── Field instrumentation ───────────────────────────────────────
+  const field = (id: string): FieldTelemetry => {
+    const t = telemRef.current.fields[id];
+    if (t) return t;
+    telemRef.current.fields[id] = emptyField();
+    return telemRef.current.fields[id];
+  };
+
+  const onFocus = (id: string) => {
+    if (!focusedAtRef.current[id]) focusedAtRef.current[id] = Date.now();
+  };
+
+  const onKeyDown = (id: string, e: React.KeyboardEvent) => {
+    const t = field(id);
+    if (e.key === "Backspace" || e.key === "Delete") {
+      t.backspaces += 1;
+      return;
+    }
+    // Printable keys only: single-character key values, no modifier combo.
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+      t.keystrokes += 1;
+      if (t.timeToFirstKeyMs === null) {
+        const from =
+          focusedAtRef.current[id] || startedRef.current || Date.now();
+        t.timeToFirstKeyMs = Date.now() - from;
+      }
+    }
+  };
+
+  const onPaste = (id: string, e: React.ClipboardEvent) => {
+    e.preventDefault();
+    const t = field(id);
+    t.pasteAttempts += 1;
+    t.pastedChars += (e.clipboardData?.getData("text") || "").length;
+    setNotice(
+      "Pasting is disabled in this assessment. Please type your answer.",
+    );
+    window.setTimeout(() => setNotice(null), 3500);
+  };
+
+  const onCopy = (id: string, kind: "copy" | "cut") => {
+    const t = field(id);
+    if (kind === "cut") t.cutEvents += 1;
+    else t.copyEvents += 1;
+  };
+
+  const onChange = (id: string, value: string) => {
+    const t = field(id);
+    const before = answers[id] || "";
+    const delta = value.length - before.length;
+    if (delta > JUMP_THRESHOLD) {
+      t.jumpInsertions += 1;
+      t.jumpChars += delta;
+    }
+    const now = Date.now();
+    const last = lastEditRef.current[id];
+    if (last) t.maxIdleMs = Math.max(t.maxIdleMs, now - last);
+    lastEditRef.current[id] = now;
+    t.chars = value.length;
+    t.words = countWords(value);
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  };
+
+  // ── Submit one exercise ─────────────────────────────────────────
+  const submitExercise = useCallback(
+    async (auto: boolean) => {
+      if (sending || submitted.includes(exercise.key)) return;
+      setSending(true);
+
+      // Close any open away-window so the last stretch is counted.
+      if (awaySinceRef.current !== null) {
+        telemRef.current.awayMs += Date.now() - awaySinceRef.current;
+        awaySinceRef.current = null;
+      }
+      if (startedRef.current) {
+        telemRef.current.elapsedMs = Date.now() - startedRef.current;
+      }
+
+      const telem = telemRef.current;
+      allTelemRef.current[exercise.key] = telem;
+      const flags = flagsFor(telem);
+      const usedSec = Math.round(telem.elapsedMs / 1000);
+
+      let body = `<h2>Exercise ${exercise.letter} — ${exercise.title}</h2>`;
+      body += `<p><strong>Candidate:</strong> ${esc(CANDIDATE)} · ${esc(ROLE)}<br/>`;
+      body += `<strong>Submitted:</strong> ${wita()} WITA<br/>`;
+      body += `<strong>Time used:</strong> ${mmss(usedSec)} of ${exercise.minutes}:00${auto ? " (window expired — auto-submitted)" : ""}<br/>`;
+      body += `<strong>Away from tab:</strong> ${telem.awayCount}× · ${Math.round(telem.awayMs / 1000)}s</p>`;
+
+      body += `<h3>Integrity signals</h3>`;
+      if (flags.length === 0) {
+        body += `<p>No signal raised. This is not proof of anything — it means this instrument saw nothing unusual.</p>`;
+      } else {
+        body += `<ul>`;
+        for (const f of flags) {
+          body += `<li><strong>${f.code}</strong> (${f.severity}) — ${esc(f.detail)}</li>`;
+        }
+        body += `</ul><p style="font-size:12px;color:#666">Signals, not a verdict. Dictation, transcribing from paper, and an unusual keyboard trip the same wires as a chatbot.</p>`;
+      }
+
+      body += `<h3>Per-field measurements</h3>`;
+      body += `<table border="1" cellpadding="6" cellspacing="0" style="border-collapse:collapse;font-size:12px">`;
+      body += `<tr><th>field</th><th>chars</th><th>words</th><th>keys</th><th>corrections</th><th>paste</th><th>jumps</th><th>longest pause</th></tr>`;
+      for (const f of exercise.fields) {
+        const t = telem.fields[f.id] || emptyField();
+        body += `<tr><td>${f.id}</td><td>${t.chars}</td><td>${t.words}</td><td>${t.keystrokes}</td><td>${t.backspaces}</td><td>${t.pasteAttempts} (${t.pastedChars}c)</td><td>${t.jumpInsertions} (${t.jumpChars}c)</td><td>${Math.round(t.maxIdleMs / 1000)}s</td></tr>`;
+      }
+      body += `</table>`;
+
+      body += `<h3>Answers</h3>`;
+      for (const f of exercise.fields) {
+        const a = (answers[f.id] || "").trim();
+        body += `<p style="margin-bottom:4px"><strong>${esc(f.label)}</strong></p>`;
+        body += `<pre style="white-space:pre-wrap;font-family:ui-monospace,monospace;background:#f5f5f5;padding:12px;border-radius:6px;margin-top:0">${esc(a || "(left blank)")}</pre>`;
+      }
+
+      try {
+        const res = await fetch("/api/assessment/submit", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            to: PANEL_INBOX,
+            subject: `[Round 2] ${CANDIDATE} — Exercise ${exercise.letter} ${exercise.title} · ${mmss(usedSec)} · ${flagSummary(flags)}`,
+            body,
+          }),
+        });
+        if (!res.ok) throw new Error(`server ${res.status}`);
+        setNotice(null);
+      } catch {
+        // The answers are already on disk in localStorage; say so plainly
+        // rather than implying the work is lost.
+        setNotice(
+          `Exercise ${exercise.letter} could not be sent to the panel. Your answers are saved in this browser — tell the panel now, do not close this tab.`,
+        );
+      }
+
+      setSubmitted((prev) => [...prev, exercise.key]);
+      setSending(false);
+
+      if (index < EXERCISES.length - 1) {
+        const next = index + 1;
+        setIndex(next);
+        telemRef.current = newExerciseTelemetry(EXERCISES[next]);
+        startedRef.current = Date.now();
+        setRemaining(EXERCISES[next].minutes * 60);
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      } else {
+        setPhase("done");
+      }
+    },
+    [answers, exercise, index, sending, submitted],
+  );
+
+  submitRef.current = submitExercise;
+
+  const begin = () => {
+    startedRef.current = Date.now();
+    telemRef.current = newExerciseTelemetry(EXERCISES[index]);
+    setRemaining(EXERCISES[index].minutes * 60);
+    setPhase("running");
+  };
+
+  const answeredSomething = useMemo(
+    () => exercise.fields.some((f) => (answers[f.id] || "").trim().length > 0),
+    [answers, exercise],
+  );
+
+  const warn = remaining <= 120;
+  const danger = remaining <= 30;
+
+  // ── Render ──────────────────────────────────────────────────────
+  return (
+    <div
+      className="min-h-screen bg-[#0a0a0b] text-[#e8e6e1]"
+      onContextMenu={(e) => {
+        if (phase === "running") {
+          const t = telemRef.current.fields[exercise.fields[0].id];
+          if (t) t.contextMenus += 1;
+        }
+        return e;
+      }}
+    >
+      <header className="sticky top-0 z-50 border-b border-white/5 bg-[#0a0a0b]/95 backdrop-blur">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-3">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/static/balizero-logo-clean.png"
+              alt="Bali Zero"
+              className="h-9 w-9 rounded-full"
+            />
+            <div className="flex flex-col leading-tight">
+              <span className="text-sm font-semibold tracking-wide text-white">
+                BALI ZERO
+              </span>
+              <span className="text-xs text-white/40">
+                Round 2 · Written assessment
+              </span>
+            </div>
+          </div>
+
+          {phase === "running" && (
+            <div className="flex items-center gap-5">
+              <div className="hidden text-xs uppercase tracking-[0.2em] text-white/35 sm:block">
+                {exercise.letter} · {exercise.title}
+              </div>
+              <div
+                className={`font-mono text-2xl tabular-nums ${
+                  danger
+                    ? "animate-pulse text-[#c23c2c]"
+                    : warn
+                      ? "text-amber-400"
+                      : "text-white/85"
+                }`}
+                aria-live="off"
+              >
+                {mmss(remaining)}
+              </div>
+            </div>
+          )}
+        </div>
+        {phase === "running" && (
+          <div className="h-[2px] w-full bg-white/5">
+            <div
+              className={`h-full transition-[width] duration-1000 ease-linear ${danger ? "bg-[#c23c2c]" : warn ? "bg-amber-400" : "bg-white/25"}`}
+              style={{
+                width: `${Math.max(0, Math.min(100, (remaining / (exercise.minutes * 60)) * 100))}%`,
+              }}
+            />
+          </div>
+        )}
+        {notice && (
+          <div className="border-t border-[#c23c2c]/40 bg-[#c23c2c]/15 px-6 py-3 text-center text-sm text-[#ffd9d3]">
+            {notice}
+          </div>
+        )}
+      </header>
+
+      <main className="mx-auto max-w-4xl px-6 py-10">
+        {/* ── INTRO ─────────────────────────────────────────────── */}
+        {phase === "intro" && (
+          <div className="space-y-8">
+            <div className="space-y-3 py-6 text-center">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src="/static/balizero-logo-clean.png"
+                alt="Bali Zero"
+                className="mx-auto h-28 w-28 rounded-full shadow-2xl shadow-[#c23c2c]/20"
+              />
+              <div className="pt-4 text-xs font-semibold uppercase tracking-[0.3em] text-[#c23c2c]">
+                Bali Zero · Round 2
+              </div>
+              <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                Written Assessment
+              </h1>
+              <p className="text-white/50">{ROLE}</p>
+            </div>
+
+            <div className="space-y-4 rounded-lg border border-white/[0.06] bg-white/[0.03] p-6">
+              <p className="text-white/75">
+                Welcome,{" "}
+                <span className="font-medium text-white">{CANDIDATE}</span>.
+              </p>
+              <p className="text-sm text-white/60">
+                Four exercises, {TOTAL_MINUTES} minutes in total. Each exercise
+                opens in its own timed window; when the window closes, that
+                exercise is sent and the next one opens. You cannot go back.
+                Every candidate for this vacancy receives this same pack, so
+                that the results compare.
+              </p>
+              <ul className="space-y-2 pt-2 text-sm">
+                {EXERCISES.map((e) => (
+                  <li key={e.key} className="flex items-baseline gap-3">
+                    <span className="w-4 shrink-0 font-mono text-[#c23c2c]">
+                      {e.letter}
+                    </span>
+                    <span className="text-white/80">{e.title}</span>
+                    <span className="ml-auto font-mono text-xs text-white/40">
+                      {e.minutes} min
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="space-y-3 rounded-lg border border-amber-400/20 bg-amber-400/[0.04] p-6 text-sm text-white/70">
+              <div className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-400/90">
+                Please read — what this page records
+              </div>
+              <p>
+                This is an unaided written test. Pasting is disabled. The page
+                records how long each exercise takes, how much of it is typed,
+                whether text arrives without being typed, and whether the tab is
+                left during an exercise. It records those measurements alongside
+                your answers and sends both to the panel. It does not record
+                your screen, your camera, or anything outside this page.
+              </p>
+              <p>
+                Write in your own words. If you use a phone, another tab, or an
+                AI assistant, the measurements will show it and we would rather
+                you simply did not.
+              </p>
+              <p className="text-white/50">
+                Exercises A, B and D may be answered in English or Bahasa
+                Indonesia. Exercise C must be in English — the English is the
+                exercise. If an instruction is unclear, ask the panel; for
+                Exercise C we will not explain wording.
+              </p>
+            </div>
+
+            {restored && (
+              <p className="text-sm text-amber-400/80">
+                A previous session was found in this browser and your answers
+                have been restored. You are resuming at Exercise{" "}
+                {EXERCISES[index].letter}.
+              </p>
+            )}
+
+            <button
+              onClick={begin}
+              className="w-full rounded-lg bg-[#c23c2c] px-6 py-4 text-base font-semibold text-white transition hover:bg-[#a83326] focus:outline-none focus:ring-2 focus:ring-[#c23c2c]/50"
+            >
+              Start Exercise {exercise.letter} — {exercise.minutes} minutes
+            </button>
+            <p className="text-center text-xs text-white/30">
+              The countdown starts the moment you press this button.
+            </p>
+          </div>
+        )}
+
+        {/* ── RUNNING ───────────────────────────────────────────── */}
+        {phase === "running" && (
+          <div className="space-y-8">
+            <div className="flex items-center gap-3 text-xs text-white/35">
+              {EXERCISES.map((e, i) => (
+                <span
+                  key={e.key}
+                  className={`rounded px-2 py-1 font-mono ${
+                    i === index
+                      ? "bg-[#c23c2c]/20 text-[#e8a79c]"
+                      : submitted.includes(e.key)
+                        ? "text-white/30 line-through"
+                        : "text-white/20"
+                  }`}
+                >
+                  {e.letter}
+                </span>
+              ))}
+              <span className="ml-auto">
+                Exercise {index + 1} of {EXERCISES.length}
+              </span>
+            </div>
+
+            <div className="space-y-3">
+              <div className="flex items-baseline gap-4">
+                <span className="font-mono text-5xl font-bold text-[#c23c2c]">
+                  {exercise.letter}
+                </span>
+                <div>
+                  <h2 className="text-2xl font-semibold">{exercise.title}</h2>
+                  <p className="text-xs uppercase tracking-[0.2em] text-white/35">
+                    {exercise.minutes} minutes
+                  </p>
+                </div>
+              </div>
+              <p className="text-sm text-white/70">{exercise.intro}</p>
+              <p className="text-xs text-amber-400/70">{exercise.language}</p>
+            </div>
+
+            {exercise.key === "A" && (
+              <div className="space-y-6">
+                <LedgerTable
+                  caption="Bank statement — BCA · July 2026 · Sunset Villas & Kitchen"
+                  rows={BANK_ROWS}
+                  closing="Closing balance per bank statement, 31/07/2026 — 133.750.000"
+                />
+                <LedgerTable
+                  caption="Cash book — July 2026, kept by the client's staff"
+                  rows={CASHBOOK_ROWS}
+                  closing="Closing balance per cash book, 31/07/2026 — 116.385.000"
+                />
+                <p className="rounded border border-white/10 bg-white/[0.02] p-3 text-xs text-white/50">
+                  The merchant discount rate on the restaurant&apos;s card
+                  terminal is 2% of gross card sales.
+                </p>
+              </div>
+            )}
+
+            {exercise.key === "B" && (
+              <div className="overflow-x-auto rounded-lg border border-white/10">
+                <table className="w-full text-sm">
+                  <caption className="px-4 py-3 text-left text-xs uppercase tracking-[0.2em] text-white/40">
+                    Other expenses — ledger detail
+                  </caption>
+                  <thead className="bg-white/[0.04] text-xs uppercase tracking-wide text-white/40">
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium">Item</th>
+                      <th className="px-4 py-2 text-right font-medium">
+                        June (IDR)
+                      </th>
+                      <th className="px-4 py-2 text-right font-medium">
+                        July (IDR)
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {OTHER_EXPENSES.map((r) => (
+                      <tr key={r.item} className="border-t border-white/5">
+                        <td className="px-4 py-2 text-white/75">{r.item}</td>
+                        <td className="px-4 py-2 text-right font-mono tabular-nums text-white/60">
+                          {r.june}
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono tabular-nums text-white/60">
+                          {r.july}
+                        </td>
+                      </tr>
+                    ))}
+                    <tr className="border-t border-white/20 font-semibold">
+                      <td className="px-4 py-2">Total other expenses</td>
+                      <td className="px-4 py-2 text-right font-mono tabular-nums">
+                        8.400.000
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono tabular-nums">
+                        11.760.000
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {exercise.key === "C" && (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-white/10 bg-white/[0.02] p-5 font-mono text-sm leading-relaxed text-white/70">
+                  <div className="mb-3 space-y-0.5 text-xs text-white/40">
+                    <div>From: g.ferrari@&lt;client&gt;.it</div>
+                    <div>Sent: 21:40</div>
+                    <div>Subject: Invoice — this is not acceptable</div>
+                  </div>
+                  <p className="whitespace-pre-wrap">
+                    {`Why is my monthly invoice higher than last month? Nobody told me
+about extra costs. I need an answer tonight, I have a payment
+deadline tomorrow and this is the second time this happens.`}
+                  </p>
+                </div>
+                <div className="rounded border border-white/10 bg-white/[0.02] p-4 text-xs text-white/55">
+                  <div className="mb-1 uppercase tracking-[0.2em] text-white/35">
+                    What you know, and what you do not
+                  </div>
+                  The increase is a legitimate pass-through charge and it was
+                  disclosed in the engagement letter he signed. The colleague
+                  who normally handles this client is unavailable until tomorrow
+                  morning, so you cannot confirm the exact figure tonight.
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-6">
+              {exercise.fields.map((f) => {
+                const value = answers[f.id] || "";
+                const shared = {
+                  value,
+                  onFocus: () => onFocus(f.id),
+                  onKeyDown: (e: React.KeyboardEvent) => onKeyDown(f.id, e),
+                  onPaste: (e: React.ClipboardEvent) => onPaste(f.id, e),
+                  onCopy: () => onCopy(f.id, "copy"),
+                  onCut: () => onCopy(f.id, "cut"),
+                  onDrop: (e: React.DragEvent) => e.preventDefault(),
+                  spellCheck: false,
+                  autoComplete: "off",
+                  disabled: sending,
+                };
+                return (
+                  <div key={f.id} className="space-y-2">
+                    <label
+                      htmlFor={f.id}
+                      className="block whitespace-pre-wrap text-sm font-medium text-white/85"
+                    >
+                      {f.label}
+                    </label>
+                    {f.hint && (
+                      <p className="font-mono text-xs text-white/35">
+                        {f.hint}
+                      </p>
+                    )}
+                    {f.short ? (
+                      <input
+                        id={f.id}
+                        type="text"
+                        {...shared}
+                        onChange={(e) => onChange(f.id, e.target.value)}
+                        placeholder={f.placeholder}
+                        className="w-full rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/90 placeholder:text-white/20 focus:border-[#c23c2c]/60 focus:outline-none"
+                      />
+                    ) : (
+                      <textarea
+                        id={f.id}
+                        rows={f.id === "c_reply" ? 14 : 6}
+                        {...shared}
+                        onChange={(e) => onChange(f.id, e.target.value)}
+                        placeholder={f.placeholder}
+                        className="w-full resize-y rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 font-mono text-sm leading-relaxed text-white/90 placeholder:text-white/20 focus:border-[#c23c2c]/60 focus:outline-none"
+                      />
+                    )}
+                    <div className="text-right font-mono text-[11px] text-white/25">
+                      {countWords(value)} words · {value.length} characters
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="space-y-3 border-t border-white/5 pt-6">
+              <button
+                onClick={() => submitExercise(false)}
+                disabled={sending || !answeredSomething}
+                className="w-full rounded-lg bg-[#c23c2c] px-6 py-4 font-semibold text-white transition hover:bg-[#a83326] disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
+              >
+                {sending
+                  ? "Sending…"
+                  : index < EXERCISES.length - 1
+                    ? `Submit ${exercise.letter} and open ${EXERCISES[index + 1].letter}`
+                    : `Submit ${exercise.letter} and finish`}
+              </button>
+              <p className="text-center text-xs text-white/30">
+                Submitting is final for this exercise. When the countdown
+                reaches zero it submits on its own.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ── DONE ──────────────────────────────────────────────── */}
+        {phase === "done" && (
+          <div className="space-y-6 py-16 text-center">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/static/balizero-logo-clean.png"
+              alt="Bali Zero"
+              className="mx-auto h-24 w-24 rounded-full opacity-80"
+            />
+            <h2 className="text-2xl font-semibold">Assessment complete</h2>
+            <p className="mx-auto max-w-md text-sm text-white/60">
+              All four exercises have been sent to the panel. Thank you,{" "}
+              {CANDIDATE} — please close this tab and rejoin the room. The
+              conversation follows.
+            </p>
+            <p className="font-mono text-xs text-white/25">{wita()} WITA</p>
+          </div>
+        )}
+      </main>
+
+      <footer className="border-t border-white/5 px-6 py-6 text-center text-xs text-white/25">
+        balizero.com · internal use · all figures in this assessment are
+        invented and describe no Bali Zero client
+      </footer>
+    </div>
+  );
+}
+
+function LedgerTable({
+  caption,
+  rows,
+  closing,
+}: {
+  caption: string;
+  rows: {
+    date: string;
+    description: string;
+    amount: string;
+    balance: string;
+  }[];
+  closing: string;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border border-white/10">
+      <table className="w-full text-sm">
+        <caption className="px-4 py-3 text-left text-xs uppercase tracking-[0.2em] text-white/40">
+          {caption}
+        </caption>
+        <thead className="bg-white/[0.04] text-xs uppercase tracking-wide text-white/40">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">Date</th>
+            <th className="px-3 py-2 text-left font-medium">Description</th>
+            <th className="px-3 py-2 text-right font-medium">Amount</th>
+            <th className="px-3 py-2 text-right font-medium">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={`${r.date}-${i}`} className="border-t border-white/5">
+              <td className="whitespace-nowrap px-3 py-1.5 font-mono text-white/45">
+                {r.date}
+              </td>
+              <td className="px-3 py-1.5 text-white/75">{r.description}</td>
+              <td className="whitespace-nowrap px-3 py-1.5 text-right font-mono tabular-nums text-white/60">
+                {r.amount}
+              </td>
+              <td className="whitespace-nowrap px-3 py-1.5 text-right font-mono tabular-nums text-white/45">
+                {r.balance}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="border-t border-white/15 px-4 py-2.5 text-right font-mono text-xs text-white/70">
+        {closing}
+      </div>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/(assessment)/interview_natalie/page.tsx
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/page.tsx
@@ -23,13 +23,23 @@ const CANDIDATE = "Natalie Mahodim";
 const ROLE = "Finance & Client Services Coordinator";
 const PANEL_INBOX = "zero@balizero.com";
 const STORAGE_KEY = "bz-interview-natalie-v1";
+const SUBMIT_TIMEOUT_MS = 20_000;
 
-type Phase = "intro" | "running" | "done";
+/**
+ * The URL is guessable and the page is public. Nothing identifying — not the
+ * candidate's name, not the question about the two dates in her file — renders
+ * before this code is entered. The panel reads it out in the room; it is a
+ * shutter, not an authentication system, and it is not asked to be one.
+ */
+const ACCESS_CODE = "SUNSET-2026";
+
+type Phase = "locked" | "intro" | "running" | "done";
 
 interface Persisted {
   answers: Record<string, string>;
   index: number;
   submitted: string[];
+  /** Epoch ms at which the CURRENT exercise's window opened. */
   startedAt: number | null;
 }
 
@@ -54,60 +64,82 @@ function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function newExerciseTelemetry(ex: Exercise): ExerciseTelemetry {
+function newExerciseTelemetry(
+  ex: Exercise,
+  restored = false,
+): ExerciseTelemetry {
   const fields: Record<string, FieldTelemetry> = {};
   for (const f of ex.fields) fields[f.id] = emptyField();
-  return { elapsedMs: 0, awayMs: 0, awayCount: 0, fields, autoLocked: false };
+  return {
+    elapsedMs: 0,
+    awayMs: 0,
+    awayCount: 0,
+    fields,
+    autoLocked: false,
+    restored,
+    composedChars: 0,
+  };
 }
 
 export default function InterviewNataliePage() {
-  const [phase, setPhase] = useState<Phase>("intro");
+  const [phase, setPhase] = useState<Phase>("locked");
+  const [code, setCode] = useState("");
+  const [codeError, setCodeError] = useState(false);
   const [index, setIndex] = useState(0);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [submitted, setSubmitted] = useState<string[]>([]);
+  const [failed, setFailed] = useState<string[]>([]);
   const [sending, setSending] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [remaining, setRemaining] = useState(EXERCISES[0].minutes * 60);
-  const [restored, setRestored] = useState(false);
+  const [restoredSession, setRestoredSession] = useState(false);
+  const [storageWorks, setStorageWorks] = useState(true);
+  const [locked, setLocked] = useState(false);
 
   const exercise = EXERCISES[index];
+
+  // Epoch, not performance.now(): the window has to survive a reload, and only
+  // a wall-clock baseline can say how much of it the candidate already spent.
   const startedRef = useRef<number | null>(null);
   const telemRef = useRef<ExerciseTelemetry>(
     newExerciseTelemetry(EXERCISES[0]),
   );
-  const allTelemRef = useRef<Record<string, ExerciseTelemetry>>({});
   const lastEditRef = useRef<Record<string, number>>({});
   const focusedAtRef = useRef<Record<string, number>>({});
   const awaySinceRef = useRef<number | null>(null);
+  const composingRef = useRef<Record<string, boolean>>({});
   const submitRef = useRef<(auto: boolean) => void>(() => {});
+  const restoredStartRef = useRef<number | null>(null);
 
   // ── Restore an interrupted session ──────────────────────────────
-  // Sixty minutes of handwriting cannot be asked for twice: a reload, a flat
-  // battery or a stray back-gesture must not cost the candidate her answers.
-  // Telemetry deliberately does NOT survive the reload — it would be a
-  // fabricated measurement of a session this page did not watch.
+  // Sixty minutes cannot be asked for twice: a reload, a flat battery or a
+  // stray back-gesture must not cost the candidate her answers. What it DOES
+  // cost is the keystroke record, so the restored exercise is marked and its
+  // keystroke flags are suppressed rather than fired at someone who did
+  // nothing wrong. The clock is NOT refunded either — resuming reopens the
+  // window where it was, not at the top.
   useEffect(() => {
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
       if (!raw) return;
       const saved = JSON.parse(raw) as Persisted;
-      if (saved && typeof saved === "object" && saved.answers) {
-        setAnswers(saved.answers);
-        setSubmitted(saved.submitted || []);
-        const idx = Math.min(
-          Math.max(saved.index || 0, 0),
-          EXERCISES.length - 1,
-        );
-        setIndex(idx);
-        setRestored(true);
-      }
+      if (!saved || typeof saved !== "object" || !saved.answers) return;
+      setAnswers(saved.answers);
+      setSubmitted(saved.submitted || []);
+      const idx = Math.min(Math.max(saved.index || 0, 0), EXERCISES.length - 1);
+      setIndex(idx);
+      restoredStartRef.current = saved.startedAt ?? null;
+      setRestoredSession(true);
     } catch {
-      /* a browser that refuses storage is not a reason to fail the exam */
+      setStorageWorks(false);
     }
   }, []);
 
   useEffect(() => {
-    if (phase === "intro") return;
+    // Only while an exercise is open. Persisting on "done" too would re-write
+    // the record the final submit had just deleted, and leave her salary
+    // expectation in the fields for whoever opens this URL next.
+    if (phase !== "running") return;
     try {
       window.localStorage.setItem(
         STORAGE_KEY,
@@ -116,30 +148,44 @@ export default function InterviewNataliePage() {
           index,
           submitted,
           startedAt: startedRef.current,
-        }),
+        } satisfies Persisted),
       );
     } catch {
-      /* ignore */
+      setStorageWorks(false);
     }
   }, [answers, index, submitted, phase]);
 
   // ── Countdown ───────────────────────────────────────────────────
+  const tick = useCallback(() => {
+    const started = startedRef.current;
+    if (!started) return;
+    const elapsedMs = Date.now() - started;
+    telemRef.current.elapsedMs = elapsedMs;
+    const left = exercise.minutes * 60 - Math.floor(elapsedMs / 1000);
+    setRemaining(left);
+    if (left <= 0 && !telemRef.current.autoLocked) {
+      telemRef.current.autoLocked = true;
+      setLocked(true);
+      submitRef.current(true);
+    }
+  }, [exercise]);
+
   useEffect(() => {
     if (phase !== "running") return;
-    const id = setInterval(() => {
-      const started = startedRef.current;
-      if (!started) return;
-      const elapsedMs = Date.now() - started;
-      telemRef.current.elapsedMs = elapsedMs;
-      const left = exercise.minutes * 60 - Math.floor(elapsedMs / 1000);
-      setRemaining(left);
-      if (left <= 0) {
-        telemRef.current.autoLocked = true;
-        submitRef.current(true);
-      }
-    }, 1000);
-    return () => clearInterval(id);
-  }, [phase, exercise]);
+    const id = setInterval(tick, 1000);
+    // A background tab throttles setInterval to once a minute or freezes it
+    // outright, so the window would sit open past zero until the candidate came
+    // back. Recomputing on return closes it on the spot instead of waiting for
+    // the next throttled tick.
+    const resync = () => tick();
+    window.addEventListener("focus", resync);
+    document.addEventListener("visibilitychange", resync);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener("focus", resync);
+      document.removeEventListener("visibilitychange", resync);
+    };
+  }, [phase, tick]);
 
   // ── Away-from-tab detection ─────────────────────────────────────
   useEffect(() => {
@@ -185,7 +231,13 @@ export default function InterviewNataliePage() {
       t.backspaces += 1;
       return;
     }
-    // Printable keys only: single-character key values, no modifier combo.
+    // An IME and some virtual keyboards report "Process" or "Unidentified"
+    // instead of the character; counting only single-character keys would read
+    // an honest candidate on such a keyboard as never having typed at all.
+    if (e.key === "Process" || e.key === "Unidentified") {
+      t.keystrokes += 1;
+      return;
+    }
     if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
       t.keystrokes += 1;
       if (t.timeToFirstKeyMs === null) {
@@ -201,23 +253,38 @@ export default function InterviewNataliePage() {
     const t = field(id);
     t.pasteAttempts += 1;
     t.pastedChars += (e.clipboardData?.getData("text") || "").length;
-    setNotice(
-      "Pasting is disabled in this assessment. Please type your answer.",
-    );
-    window.setTimeout(() => setNotice(null), 3500);
+    flash("Pasting is disabled in this assessment. Please type your answer.");
   };
 
-  const onCopy = (id: string, kind: "copy" | "cut") => {
-    const t = field(id);
-    if (kind === "cut") t.cutEvents += 1;
-    else t.copyEvents += 1;
+  // Cut is blocked as well as paste. Allowing one without the other lets the
+  // candidate destroy a paragraph she cannot then put back — the instrument
+  // must not be able to eat her work.
+  const onCut = (id: string, e: React.ClipboardEvent) => {
+    e.preventDefault();
+    field(id).cutEvents += 1;
+    flash(
+      "Cut is disabled — pasting is blocked, so cutting would lose the text.",
+    );
+  };
+
+  const onCopy = (id: string) => {
+    field(id).copyEvents += 1;
+  };
+
+  const flash = (msg: string) => {
+    setNotice(msg);
+    window.setTimeout(() => setNotice((n) => (n === msg ? null : n)), 4000);
   };
 
   const onChange = (id: string, value: string) => {
     const t = field(id);
     const before = answers[id] || "";
     const delta = value.length - before.length;
-    if (delta > JUMP_THRESHOLD) {
+    // An in-flight composition (IME, predictive keyboard, autocorrect) commits
+    // several characters in one input event. That is typing, not an insertion.
+    if (composingRef.current[id]) {
+      if (delta > 0) telemRef.current.composedChars += delta;
+    } else if (delta > JUMP_THRESHOLD) {
       t.jumpInsertions += 1;
       t.jumpChars += delta;
     }
@@ -236,7 +303,6 @@ export default function InterviewNataliePage() {
       if (sending || submitted.includes(exercise.key)) return;
       setSending(true);
 
-      // Close any open away-window so the last stretch is counted.
       if (awaySinceRef.current !== null) {
         telemRef.current.awayMs += Date.now() - awaySinceRef.current;
         awaySinceRef.current = null;
@@ -246,7 +312,6 @@ export default function InterviewNataliePage() {
       }
 
       const telem = telemRef.current;
-      allTelemRef.current[exercise.key] = telem;
       const flags = flagsFor(telem);
       const usedSec = Math.round(telem.elapsedMs / 1000);
 
@@ -258,13 +323,13 @@ export default function InterviewNataliePage() {
 
       body += `<h3>Integrity signals</h3>`;
       if (flags.length === 0) {
-        body += `<p>No signal raised. This is not proof of anything — it means this instrument saw nothing unusual.</p>`;
+        body += `<p>No signal raised. That is not proof of anything — it means this instrument saw nothing unusual.</p>`;
       } else {
         body += `<ul>`;
         for (const f of flags) {
           body += `<li><strong>${f.code}</strong> (${f.severity}) — ${esc(f.detail)}</li>`;
         }
-        body += `</ul><p style="font-size:12px;color:#666">Signals, not a verdict. Dictation, transcribing from paper, and an unusual keyboard trip the same wires as a chatbot.</p>`;
+        body += `</ul><p style="font-size:12px;color:#666">Signals, not a verdict. Dictation, a predictive keyboard, and transcribing an answer drafted on paper trip the same wires as a chatbot. Read the answer, then decide what the signal means.</p>`;
       }
 
       body += `<h3>Per-field measurements</h3>`;
@@ -283,49 +348,89 @@ export default function InterviewNataliePage() {
         body += `<pre style="white-space:pre-wrap;font-family:ui-monospace,monospace;background:#f5f5f5;padding:12px;border-radius:6px;margin-top:0">${esc(a || "(left blank)")}</pre>`;
       }
 
+      let ok = false;
       try {
         const res = await fetch("/api/assessment/submit", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          // Without a deadline a server that accepts the connection and never
+          // answers leaves every field disabled and the next window unopened.
+          signal: AbortSignal.timeout(SUBMIT_TIMEOUT_MS),
           body: JSON.stringify({
             to: PANEL_INBOX,
             subject: `[Round 2] ${CANDIDATE} — Exercise ${exercise.letter} ${exercise.title} · ${mmss(usedSec)} · ${flagSummary(flags)}`,
             body,
           }),
         });
-        if (!res.ok) throw new Error(`server ${res.status}`);
-        setNotice(null);
+        ok = res.ok;
       } catch {
-        // The answers are already on disk in localStorage; say so plainly
-        // rather than implying the work is lost.
-        setNotice(
-          `Exercise ${exercise.letter} could not be sent to the panel. Your answers are saved in this browser — tell the panel now, do not close this tab.`,
-        );
+        ok = false;
       }
 
-      setSubmitted((prev) => [...prev, exercise.key]);
       setSending(false);
+
+      if (!ok) {
+        // A failed send must NOT count as a submission: marking it would retire
+        // an exercise nobody received and hand the candidate no way back to it.
+        setFailed((prev) =>
+          prev.includes(exercise.key) ? prev : [...prev, exercise.key],
+        );
+        setNotice(
+          storageWorks
+            ? `Exercise ${exercise.letter} did not reach the panel. Your answers are safe in this browser — press Send again, and tell the panel now. Do not close this tab.`
+            : `Exercise ${exercise.letter} did not reach the panel, and this browser is not saving a copy. Do not close this tab — call the panel over now.`,
+        );
+        return;
+      }
+
+      setNotice(null);
+      setFailed((prev) => prev.filter((k) => k !== exercise.key));
+      setSubmitted((prev) => [...prev, exercise.key]);
 
       if (index < EXERCISES.length - 1) {
         const next = index + 1;
         setIndex(next);
         telemRef.current = newExerciseTelemetry(EXERCISES[next]);
         startedRef.current = Date.now();
+        setLocked(false);
         setRemaining(EXERCISES[next].minutes * 60);
         window.scrollTo({ top: 0, behavior: "smooth" });
       } else {
+        // Shared machine: the next person to open this URL must not find her
+        // salary expectation and her employment history sitting in the fields.
+        try {
+          window.localStorage.removeItem(STORAGE_KEY);
+        } catch {
+          /* nothing to clear */
+        }
         setPhase("done");
       }
     },
-    [answers, exercise, index, sending, submitted],
+    [answers, exercise, index, sending, storageWorks, submitted],
   );
 
   submitRef.current = submitExercise;
 
+  const unlock = () => {
+    if (code.trim().toUpperCase() !== ACCESS_CODE) {
+      setCodeError(true);
+      return;
+    }
+    setCodeError(false);
+    setPhase("intro");
+  };
+
   const begin = () => {
-    startedRef.current = Date.now();
-    telemRef.current = newExerciseTelemetry(EXERCISES[index]);
-    setRemaining(EXERCISES[index].minutes * 60);
+    const resumed = restoredStartRef.current;
+    // Resuming reopens the window where it was left, it does not restart it.
+    startedRef.current = resumed ?? Date.now();
+    telemRef.current = newExerciseTelemetry(
+      EXERCISES[index],
+      restoredSession && resumed !== null,
+    );
+    const spent = Math.floor((Date.now() - startedRef.current) / 1000);
+    setRemaining(EXERCISES[index].minutes * 60 - spent);
+    setLocked(false);
     setPhase("running");
   };
 
@@ -336,19 +441,11 @@ export default function InterviewNataliePage() {
 
   const warn = remaining <= 120;
   const danger = remaining <= 30;
+  const retry = failed.includes(exercise.key);
 
   // ── Render ──────────────────────────────────────────────────────
   return (
-    <div
-      className="min-h-screen bg-[#0a0a0b] text-[#e8e6e1]"
-      onContextMenu={(e) => {
-        if (phase === "running") {
-          const t = telemRef.current.fields[exercise.fields[0].id];
-          if (t) t.contextMenus += 1;
-        }
-        return e;
-      }}
-    >
+    <div className="min-h-screen bg-[#0a0a0b] text-[#e8e6e1]">
       <header className="sticky top-0 z-50 border-b border-white/5 bg-[#0a0a0b]/95 backdrop-blur">
         <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
@@ -381,7 +478,6 @@ export default function InterviewNataliePage() {
                       ? "text-amber-400"
                       : "text-white/85"
                 }`}
-                aria-live="off"
               >
                 {mmss(remaining)}
               </div>
@@ -406,6 +502,54 @@ export default function InterviewNataliePage() {
       </header>
 
       <main className="mx-auto max-w-4xl px-6 py-10">
+        {/* ── LOCKED ────────────────────────────────────────────── */}
+        {phase === "locked" && (
+          <div className="mx-auto max-w-sm space-y-6 py-20 text-center">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/static/balizero-logo-clean.png"
+              alt="Bali Zero"
+              className="mx-auto h-24 w-24 rounded-full opacity-90"
+            />
+            <div className="space-y-1">
+              <div className="text-xs font-semibold uppercase tracking-[0.3em] text-[#c23c2c]">
+                Bali Zero
+              </div>
+              <h1 className="text-2xl font-semibold">Written assessment</h1>
+              <p className="text-sm text-white/45">
+                The panel will give you the code for this session.
+              </p>
+            </div>
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value);
+                setCodeError(false);
+              }}
+              onKeyDown={(e) => e.key === "Enter" && unlock()}
+              placeholder="Session code"
+              autoComplete="off"
+              className={`w-full rounded-lg border bg-white/[0.03] px-4 py-3 text-center font-mono uppercase tracking-[0.2em] text-white/90 placeholder:normal-case placeholder:tracking-normal placeholder:text-white/20 focus:outline-none ${
+                codeError
+                  ? "border-[#c23c2c]"
+                  : "border-white/10 focus:border-white/30"
+              }`}
+            />
+            {codeError && (
+              <p className="text-sm text-[#c23c2c]">
+                That code is not right. Ask the panel to repeat it.
+              </p>
+            )}
+            <button
+              onClick={unlock}
+              className="w-full rounded-lg bg-[#c23c2c] px-6 py-3 font-semibold text-white transition hover:bg-[#a83326]"
+            >
+              Enter
+            </button>
+          </div>
+        )}
+
         {/* ── INTRO ─────────────────────────────────────────────── */}
         {phase === "intro" && (
           <div className="space-y-8">
@@ -434,8 +578,10 @@ export default function InterviewNataliePage() {
                 Four exercises, {TOTAL_MINUTES} minutes in total. Each exercise
                 opens in its own timed window; when the window closes, that
                 exercise is sent and the next one opens. You cannot go back.
-                Every candidate for this vacancy receives this same pack, so
-                that the results compare.
+                Every candidate for this vacancy answers the same four
+                exercises, so that the results compare — the last few lines of
+                the fact sheet are the exception, as they are about your own
+                file.
               </p>
               <ul className="space-y-2 pt-2 text-sm">
                 {EXERCISES.map((e) => (
@@ -457,17 +603,19 @@ export default function InterviewNataliePage() {
                 Please read — what this page records
               </div>
               <p>
-                This is an unaided written test. Pasting is disabled. The page
-                records how long each exercise takes, how much of it is typed,
-                whether text arrives without being typed, and whether the tab is
-                left during an exercise. It records those measurements alongside
-                your answers and sends both to the panel. It does not record
-                your screen, your camera, or anything outside this page.
+                This is an unaided written test. Pasting and cutting are
+                disabled. Alongside your answers, the page records how long each
+                exercise takes, how many keys you press, whether text appears in
+                a field without being typed, and whether you leave this tab
+                during an exercise. It sends those measurements to the panel
+                with your answers. It does not record your screen, your camera,
+                or anything outside this page.
               </p>
               <p>
-                Write in your own words. If you use a phone, another tab, or an
-                AI assistant, the measurements will show it and we would rather
-                you simply did not.
+                Those are measurements, not accusations — the panel reads them
+                next to your answer, and asks you about anything odd rather than
+                assuming. We ask you plainly instead: no phone, no other tab, no
+                AI assistant.
               </p>
               <p className="text-white/50">
                 Exercises A, B and D may be answered in English or Bahasa
@@ -477,17 +625,24 @@ export default function InterviewNataliePage() {
               </p>
             </div>
 
-            {restored && (
+            {restoredSession && (
               <p className="text-sm text-amber-400/80">
                 A previous session was found in this browser and your answers
                 have been restored. You are resuming at Exercise{" "}
-                {EXERCISES[index].letter}.
+                {exercise.letter}, with the time that was left on it — not a
+                fresh window.
+              </p>
+            )}
+            {!storageWorks && (
+              <p className="text-sm text-[#c23c2c]">
+                This browser is not letting the page keep a local copy of your
+                answers. Please tell the panel before you start.
               </p>
             )}
 
             <button
               onClick={begin}
-              className="w-full rounded-lg bg-[#c23c2c] px-6 py-4 text-base font-semibold text-white transition hover:bg-[#a83326] focus:outline-none focus:ring-2 focus:ring-[#c23c2c]/50"
+              className="w-full rounded-lg bg-[#c23c2c] px-6 py-4 text-base font-semibold text-white transition hover:bg-[#a83326]"
             >
               Start Exercise {exercise.letter} — {exercise.minutes} minutes
             </button>
@@ -632,12 +787,18 @@ deadline tomorrow and this is the second time this happens.`}
                   onFocus: () => onFocus(f.id),
                   onKeyDown: (e: React.KeyboardEvent) => onKeyDown(f.id, e),
                   onPaste: (e: React.ClipboardEvent) => onPaste(f.id, e),
-                  onCopy: () => onCopy(f.id, "copy"),
-                  onCut: () => onCopy(f.id, "cut"),
+                  onCopy: () => onCopy(f.id),
+                  onCut: (e: React.ClipboardEvent) => onCut(f.id, e),
                   onDrop: (e: React.DragEvent) => e.preventDefault(),
+                  onCompositionStart: () => {
+                    composingRef.current[f.id] = true;
+                  },
+                  onCompositionEnd: () => {
+                    composingRef.current[f.id] = false;
+                  },
                   spellCheck: false,
                   autoComplete: "off",
-                  disabled: sending,
+                  disabled: sending || locked,
                 };
                 return (
                   <div key={f.id} className="space-y-2">
@@ -659,7 +820,7 @@ deadline tomorrow and this is the second time this happens.`}
                         {...shared}
                         onChange={(e) => onChange(f.id, e.target.value)}
                         placeholder={f.placeholder}
-                        className="w-full rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/90 placeholder:text-white/20 focus:border-[#c23c2c]/60 focus:outline-none"
+                        className="w-full rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 text-sm text-white/90 placeholder:text-white/20 focus:border-[#c23c2c]/60 focus:outline-none disabled:opacity-60"
                       />
                     ) : (
                       <textarea
@@ -668,7 +829,7 @@ deadline tomorrow and this is the second time this happens.`}
                         {...shared}
                         onChange={(e) => onChange(f.id, e.target.value)}
                         placeholder={f.placeholder}
-                        className="w-full resize-y rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 font-mono text-sm leading-relaxed text-white/90 placeholder:text-white/20 focus:border-[#c23c2c]/60 focus:outline-none"
+                        className="w-full resize-y rounded-lg border border-white/10 bg-white/[0.03] px-4 py-3 font-mono text-sm leading-relaxed text-white/90 placeholder:text-white/20 focus:border-[#c23c2c]/60 focus:outline-none disabled:opacity-60"
                       />
                     )}
                     <div className="text-right font-mono text-[11px] text-white/25">
@@ -680,16 +841,23 @@ deadline tomorrow and this is the second time this happens.`}
             </div>
 
             <div className="space-y-3 border-t border-white/5 pt-6">
+              {locked && !retry && (
+                <p className="text-center text-sm text-amber-400/80">
+                  The window for Exercise {exercise.letter} has closed.
+                </p>
+              )}
               <button
                 onClick={() => submitExercise(false)}
-                disabled={sending || !answeredSomething}
+                disabled={sending || (!answeredSomething && !retry)}
                 className="w-full rounded-lg bg-[#c23c2c] px-6 py-4 font-semibold text-white transition hover:bg-[#a83326] disabled:cursor-not-allowed disabled:bg-white/10 disabled:text-white/30"
               >
                 {sending
                   ? "Sending…"
-                  : index < EXERCISES.length - 1
-                    ? `Submit ${exercise.letter} and open ${EXERCISES[index + 1].letter}`
-                    : `Submit ${exercise.letter} and finish`}
+                  : retry
+                    ? `Send Exercise ${exercise.letter} again`
+                    : index < EXERCISES.length - 1
+                      ? `Submit ${exercise.letter} and open ${EXERCISES[index + 1].letter}`
+                      : `Submit ${exercise.letter} and finish`}
               </button>
               <p className="text-center text-xs text-white/30">
                 Submitting is final for this exercise. When the countdown
@@ -710,9 +878,9 @@ deadline tomorrow and this is the second time this happens.`}
             />
             <h2 className="text-2xl font-semibold">Assessment complete</h2>
             <p className="mx-auto max-w-md text-sm text-white/60">
-              All four exercises have been sent to the panel. Thank you,{" "}
-              {CANDIDATE} — please close this tab and rejoin the room. The
-              conversation follows.
+              All four exercises reached the panel. Thank you, {CANDIDATE} —
+              please close this tab and rejoin the room. The conversation
+              follows.
             </p>
             <p className="font-mono text-xs text-white/25">{wita()} WITA</p>
           </div>

--- a/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.test.ts
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  countWords,
+  emptyField,
+  flagsFor,
+  type ExerciseTelemetry,
+} from "./telemetry";
+
+function ex(overrides: Partial<ExerciseTelemetry> = {}): ExerciseTelemetry {
+  return {
+    elapsedMs: 600_000,
+    awayMs: 0,
+    awayCount: 0,
+    fields: {},
+    autoLocked: false,
+    ...overrides,
+  };
+}
+
+function typed(chars: number, keys: number, backs = 0) {
+  return { ...emptyField(), chars, keystrokes: keys, backspaces: backs };
+}
+
+const codes = (t: ExerciseTelemetry) => flagsFor(t).map((f) => f.code);
+
+describe("countWords", () => {
+  it("ignores surrounding and repeated whitespace", () => {
+    expect(countWords("  two   words \n")).toBe(2);
+    expect(countWords("   ")).toBe(0);
+  });
+});
+
+describe("KEYSTROKE_DEFICIT", () => {
+  it("fires when text is longer than the keys that produced it", () => {
+    // 900 characters submitted, 40 keys pressed: the text was not typed here.
+    expect(codes(ex({ fields: { a: typed(900, 40, 30) } }))).toContain(
+      "KEYSTROKE_DEFICIT",
+    );
+  });
+
+  it("stays quiet for ordinary typing with corrections", () => {
+    // Corrections mean MORE keys than final characters, never fewer.
+    expect(codes(ex({ fields: { a: typed(900, 1050, 150) } }))).not.toContain(
+      "KEYSTROKE_DEFICIT",
+    );
+  });
+
+  it("stays quiet on a short answer, where the ratio is noise", () => {
+    expect(codes(ex({ fields: { a: typed(60, 10) } }))).not.toContain(
+      "KEYSTROKE_DEFICIT",
+    );
+  });
+});
+
+describe("EXTERNAL_INSERT", () => {
+  it("fires on a large insertion even when no paste event was seen", () => {
+    const f = { ...typed(900, 950, 100), jumpInsertions: 1, jumpChars: 400 };
+    expect(codes(ex({ fields: { a: f } }))).toContain("EXTERNAL_INSERT");
+  });
+});
+
+describe("TAB_AWAY", () => {
+  it("is silent for a glance away", () => {
+    expect(codes(ex({ awayMs: 4_000, awayCount: 1 }))).not.toContain(
+      "TAB_AWAY",
+    );
+  });
+
+  it("fires on a long absence and escalates past a minute", () => {
+    const flags = flagsFor(ex({ awayMs: 90_000, awayCount: 2 }));
+    const away = flags.find((f) => f.code === "TAB_AWAY");
+    expect(away?.severity).toBe("high");
+  });
+
+  it("fires on repeated short absences", () => {
+    expect(codes(ex({ awayMs: 6_000, awayCount: 3 }))).toContain("TAB_AWAY");
+  });
+});
+
+describe("a clean session raises nothing", () => {
+  it("returns no flags for plausible human writing", () => {
+    // 1200 characters over 10 minutes = ~24 wpm, revised throughout.
+    expect(codes(ex({ fields: { a: typed(1200, 1400, 200) } }))).toEqual([]);
+  });
+});
+
+describe("SUSTAINED_SPEED", () => {
+  it("measures against active time, not wall-clock", () => {
+    // 1200 chars in 60s of active time (600s elapsed, 540s away) = 240 wpm.
+    const t = ex({
+      elapsedMs: 600_000,
+      awayMs: 540_000,
+      awayCount: 1,
+      fields: { a: typed(1200, 1400, 200) },
+    });
+    expect(codes(t)).toContain("SUSTAINED_SPEED");
+  });
+});

--- a/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.test.ts
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.test.ts
@@ -13,6 +13,8 @@ function ex(overrides: Partial<ExerciseTelemetry> = {}): ExerciseTelemetry {
     awayCount: 0,
     fields: {},
     autoLocked: false,
+    restored: false,
+    composedChars: 0,
     ...overrides,
   };
 }
@@ -72,8 +74,8 @@ describe("TAB_AWAY", () => {
     expect(away?.severity).toBe("high");
   });
 
-  it("fires on repeated short absences", () => {
-    expect(codes(ex({ awayMs: 6_000, awayCount: 3 }))).toContain("TAB_AWAY");
+  it("fires on repeated absences that add up", () => {
+    expect(codes(ex({ awayMs: 15_000, awayCount: 3 }))).toContain("TAB_AWAY");
   });
 });
 
@@ -94,5 +96,29 @@ describe("SUSTAINED_SPEED", () => {
       fields: { a: typed(1200, 1400, 200) },
     });
     expect(codes(t)).toContain("SUSTAINED_SPEED");
+  });
+});
+
+describe("the honest candidate is not accused", () => {
+  it("suppresses the keystroke family after a restored session", () => {
+    // A reload keeps the text and loses the keystrokes. Comparing one against
+    // the other afterwards accuses her of exactly what the reload cost her.
+    const f = { ...typed(900, 1, 0), jumpInsertions: 1, jumpChars: 900 };
+    const got = codes(ex({ restored: true, fields: { a: f } }));
+    expect(got).toContain("RESTORED_SESSION");
+    expect(got).not.toContain("KEYSTROKE_DEFICIT");
+    expect(got).not.toContain("EXTERNAL_INSERT");
+  });
+
+  it("counts IME and predictive-keyboard compositions as typing", () => {
+    // 900 characters, 120 keydowns the browser reported, the rest committed
+    // through composition events: an honest candidate on such a keyboard.
+    const t = ex({ composedChars: 780, fields: { a: typed(900, 120, 20) } });
+    expect(codes(t)).not.toContain("KEYSTROKE_DEFICIT");
+  });
+
+  it("still catches transplanted text when no composition explains it", () => {
+    const t = ex({ composedChars: 0, fields: { a: typed(900, 120, 20) } });
+    expect(codes(t)).toContain("KEYSTROKE_DEFICIT");
   });
 });

--- a/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.ts
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.ts
@@ -1,0 +1,179 @@
+/**
+ * Assessment integrity telemetry.
+ *
+ * These are SIGNALS, never a verdict. Every flag says what was observed, not
+ * what it means: "text appeared that was not typed" is a fact; "she used AI"
+ * is an inference the panel makes with the answer in front of it. A page that
+ * prints a verdict would be trusted as one, and this instrument cannot earn
+ * that trust — a candidate typing with a dictation tool, or one who drafted on
+ * paper first and transcribed, trips the same wires as a candidate pasting
+ * from a chatbot.
+ *
+ * The load-bearing signal is KEYSTROKE_DEFICIT: it compares characters that
+ * ended up in the field against printable keys actually pressed. It survives
+ * a blocked paste handler, drag-and-drop, middle-click, autofill, speech
+ * input, and any devtools insertion, because it measures the RESULT rather
+ * than the gesture. Every other flag is corroboration.
+ */
+
+export interface FieldTelemetry {
+  /** Printable keydowns observed in this field. */
+  keystrokes: number;
+  /** Backspace / Delete presses — human prose revises, transplanted text does not. */
+  backspaces: number;
+  /** Paste gestures intercepted (the paste itself is blocked). */
+  pasteAttempts: number;
+  /** Characters carried by those blocked pastes. */
+  pastedChars: number;
+  /** Copy / cut out of the page — the question text going somewhere else. */
+  copyEvents: number;
+  cutEvents: number;
+  /** Right-click / context menu opens. */
+  contextMenus: number;
+  /** Input events that added more characters at once than a keypress can. */
+  jumpInsertions: number;
+  jumpChars: number;
+  /** ms from field first focused to first printable key. */
+  timeToFirstKeyMs: number | null;
+  /** Longest gap between two consecutive edits, ms. */
+  maxIdleMs: number;
+  /** Final content size. */
+  chars: number;
+  words: number;
+}
+
+export interface ExerciseTelemetry {
+  /** Wall-clock ms from the moment the exercise window opened. */
+  elapsedMs: number;
+  /** ms the tab spent hidden or unfocused while this exercise was open. */
+  awayMs: number;
+  /** Number of times focus left the tab. */
+  awayCount: number;
+  /** Per-field detail, keyed by field id. */
+  fields: Record<string, FieldTelemetry>;
+  /** True when the countdown reached zero and the window locked itself. */
+  autoLocked: boolean;
+}
+
+export function emptyField(): FieldTelemetry {
+  return {
+    keystrokes: 0,
+    backspaces: 0,
+    pasteAttempts: 0,
+    pastedChars: 0,
+    copyEvents: 0,
+    cutEvents: 0,
+    contextMenus: 0,
+    jumpInsertions: 0,
+    jumpChars: 0,
+    timeToFirstKeyMs: null,
+    maxIdleMs: 0,
+    chars: 0,
+    words: 0,
+  };
+}
+
+export function countWords(text: string): number {
+  const t = text.trim();
+  return t ? t.split(/\s+/).length : 0;
+}
+
+/** A paste gesture cannot deliver fewer characters than this and still matter. */
+export const JUMP_THRESHOLD = 25;
+
+export interface Flag {
+  code: string;
+  detail: string;
+  /** high = the text demonstrably did not come from this keyboard. */
+  severity: "high" | "medium" | "low";
+}
+
+/**
+ * Aggregate one exercise's fields into flags.
+ *
+ * Thresholds are deliberately generous. A false positive costs a candidate a
+ * question she has to answer in the room; the panel should be arguing about
+ * two flags, not thirty.
+ */
+export function flagsFor(ex: ExerciseTelemetry): Flag[] {
+  const flags: Flag[] = [];
+  const fields = Object.values(ex.fields);
+
+  const chars = fields.reduce((n, f) => n + f.chars, 0);
+  const keys = fields.reduce((n, f) => n + f.keystrokes, 0);
+  const backs = fields.reduce((n, f) => n + f.backspaces, 0);
+  const pastes = fields.reduce((n, f) => n + f.pasteAttempts, 0);
+  const pastedChars = fields.reduce((n, f) => n + f.pastedChars, 0);
+  const jumps = fields.reduce((n, f) => n + f.jumpInsertions, 0);
+  const jumpChars = fields.reduce((n, f) => n + f.jumpChars, 0);
+  const copies = fields.reduce((n, f) => n + f.copyEvents + f.cutEvents, 0);
+
+  // The primary signal. Typing produces roughly one printable key per
+  // character; below 70% the surplus text arrived some other way.
+  if (chars >= 120 && keys < chars * 0.7) {
+    flags.push({
+      code: "KEYSTROKE_DEFICIT",
+      detail: `${chars} characters submitted, ${keys} printable keys observed (${Math.round((keys / Math.max(chars, 1)) * 100)}%).`,
+      severity: "high",
+    });
+  }
+
+  if (jumps > 0) {
+    flags.push({
+      code: "EXTERNAL_INSERT",
+      detail: `${jumps} insertion(s) larger than ${JUMP_THRESHOLD} characters at once, ${jumpChars} characters in total — drag-and-drop, autofill, dictation or a paste route the handler did not see.`,
+      severity: "high",
+    });
+  }
+
+  if (pastes > 0) {
+    flags.push({
+      code: "PASTE_BLOCKED",
+      detail: `${pastes} paste attempt(s) blocked, carrying ${pastedChars} characters.`,
+      severity: "medium",
+    });
+  }
+
+  if (copies > 0) {
+    flags.push({
+      code: "COPY_OUT",
+      detail: `${copies} copy/cut event(s) — text was taken off this page.`,
+      severity: "medium",
+    });
+  }
+
+  if (ex.awayMs > 20_000 || ex.awayCount >= 3) {
+    flags.push({
+      code: "TAB_AWAY",
+      detail: `Left the tab ${ex.awayCount} time(s), ${Math.round(ex.awayMs / 1000)}s away in total.`,
+      severity: ex.awayMs > 60_000 ? "high" : "medium",
+    });
+  }
+
+  // Unrevised prose is the shape of transcription, not composition.
+  if (chars >= 400 && keys > 0 && backs / keys < 0.015) {
+    flags.push({
+      code: "LOW_REVISION",
+      detail: `${backs} corrections across ${keys} keys (${((backs / keys) * 100).toFixed(1)}%) — text written without revising.`,
+      severity: "low",
+    });
+  }
+
+  const typingMs = Math.max(ex.elapsedMs - ex.awayMs, 1);
+  const wpm = chars / 5 / (typingMs / 60_000);
+  if (chars >= 200 && wpm > 90) {
+    flags.push({
+      code: "SUSTAINED_SPEED",
+      detail: `${Math.round(wpm)} words per minute sustained over ${Math.round(typingMs / 1000)}s of active time.`,
+      severity: "low",
+    });
+  }
+
+  return flags;
+}
+
+/** Compact one-line summary for the subject line of the panel's email. */
+export function flagSummary(flags: Flag[]): string {
+  if (flags.length === 0) return "clean";
+  return flags.map((f) => f.code).join(",");
+}

--- a/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.ts
+++ b/apps/mouth/src/app/(assessment)/interview_natalie/telemetry.ts
@@ -53,6 +53,16 @@ export interface ExerciseTelemetry {
   fields: Record<string, FieldTelemetry>;
   /** True when the countdown reached zero and the window locked itself. */
   autoLocked: boolean;
+  /**
+   * True when this exercise's text was restored from a previous browser
+   * session. The text survives a reload; the keystrokes that produced it do
+   * not. Counting one against the other after a restore accuses an honest
+   * candidate of exactly the thing the reload cost her — so the keystroke
+   * family is suppressed and the panel is told why.
+   */
+  restored: boolean;
+  /** Characters entered through an IME / predictive keyboard composition. */
+  composedChars: number;
 }
 
 export function emptyField(): FieldTelemetry {
@@ -110,15 +120,27 @@ export function flagsFor(ex: ExerciseTelemetry): Flag[] {
 
   // The primary signal. Typing produces roughly one printable key per
   // character; below 70% the surplus text arrived some other way.
-  if (chars >= 120 && keys < chars * 0.7) {
+  //
+  // `composedChars` is added to the key count, not subtracted from the
+  // characters: an IME, an Indonesian predictive keyboard or an autocorrect
+  // substitution commits several characters against one or two keydowns, and
+  // without this an honest candidate on a phone keyboard fails every time.
+  if (ex.restored) {
+    flags.push({
+      code: "RESTORED_SESSION",
+      detail:
+        "This exercise was resumed after a reload. Keystroke accounting is not meaningful for it and was suppressed — read the answer on its merits.",
+      severity: "low",
+    });
+  } else if (chars >= 120 && keys + ex.composedChars < chars * 0.7) {
     flags.push({
       code: "KEYSTROKE_DEFICIT",
-      detail: `${chars} characters submitted, ${keys} printable keys observed (${Math.round((keys / Math.max(chars, 1)) * 100)}%).`,
+      detail: `${chars} characters submitted, ${keys + ex.composedChars} keys/compositions observed (${Math.round(((keys + ex.composedChars) / Math.max(chars, 1)) * 100)}%).`,
       severity: "high",
     });
   }
 
-  if (jumps > 0) {
+  if (jumps > 0 && !ex.restored) {
     flags.push({
       code: "EXTERNAL_INSERT",
       detail: `${jumps} insertion(s) larger than ${JUMP_THRESHOLD} characters at once, ${jumpChars} characters in total — drag-and-drop, autofill, dictation or a paste route the handler did not see.`,
@@ -137,12 +159,12 @@ export function flagsFor(ex: ExerciseTelemetry): Flag[] {
   if (copies > 0) {
     flags.push({
       code: "COPY_OUT",
-      detail: `${copies} copy/cut event(s) — text was taken off this page.`,
+      detail: `${copies} copy event(s) from an answer field. Where the text went is not observable from here — it may have been copied within the answer.`,
       severity: "medium",
     });
   }
 
-  if (ex.awayMs > 20_000 || ex.awayCount >= 3) {
+  if (ex.awayMs > 20_000 || (ex.awayCount >= 3 && ex.awayMs > 8_000)) {
     flags.push({
       code: "TAB_AWAY",
       detail: `Left the tab ${ex.awayCount} time(s), ${Math.round(ex.awayMs / 1000)}s away in total.`,


### PR DESCRIPTION
The candidate sits round 2 in the office tomorrow. The assessment pack existed only as three printed PDFs rendered 2026-08-30; this makes the **candidate half** of it a timed web surface, so the panel gets the answers and the timing without transcribing anything by hand. The panel pack (answer key, scoring rubric, the eight frozen vacancy questions) stays off the web deliberately — none of it is in this diff.

### What it is
`/interview_natalie` — four exercises, each in its own countdown window: A Reconciliation 20' · B Judgement 15' · C Client email 15' · D Fact sheet 10'. At zero the window locks and submits itself; there is no going back. Submission reuses the existing `/api/assessment/submit` route, so the browser never holds the backend key and the panel inbox stays the only permitted recipient.

The exercises are the printed booklet's twin, figures unchanged: bank closing 133.750.000 against cash-book 116.385.000, reconciled exactly by the four planted items (MDR 850.000 · cut-off 27.000.000 · double payment 8.750.000 · bank charge 35.000). Those numbers were machine-verified before the print. They are not to be tidied — a test whose numbers do not add up produces a fifth phantom difference, and the candidate good enough to find it is the one the instrument would then punish.

### Integrity signals, not a verdict
Paste is blocked and counted. The page also measures characters submitted against printable keys actually pressed (`KEYSTROKE_DEFICIT`), single insertions larger than a keypress can produce (`EXTERNAL_INSERT`), time away from the tab, revision rate, and sustained speed.

`KEYSTROKE_DEFICIT` is the load-bearing one because it measures the **result** rather than the gesture: it survives drag-and-drop, middle-click, autofill, dictation and any devtools insertion a paste handler never sees.

Every flag states what was observed and nothing about what it means. Dictation, or transcribing an answer drafted on paper, trips the same wires as a chatbot — a page that printed a verdict would be trusted as one, and this instrument cannot earn that. The panel judges with the answer in front of it.

**The candidate is told all of this before she starts**, in plain words on the intro screen. A measurement taken without saying so would be worth less, not more.

### Verified live, not asserted
Against `next start` (production build), with Playwright:

| probe | result |
|---|---|
| countdown ticks | `19:59` → `19:56` |
| synthetic paste of 300 chars | 0 characters inserted, banner raised |
| four submissions | reach the route, recipient `zero@balizero.com`, subject carries exercise + time + flags |
| answer placed by `fill()` (no keystrokes) | `KEYSTROKE_DEFICIT,EXTERNAL_INSERT,PASTE_BLOCKED,SUSTAINED_SPEED` |
| three exercises typed normally | `clean` |
| console / page errors | none |

Guilt **and** innocence exercised — a guard proven on only one side is not proven. Plus 10 unit tests on the flag thresholds (`telemetry.test.ts`), which cover the shape that would otherwise fire on every candidate: corrections produce *more* keys than final characters, never fewer.

### Notes
- Route is `noindex, nofollow, nocache` and absent from the sitemap. It carries the candidate's name in the path at the codeowner's explicit instruction; nothing else identifying is rendered until she types it.
- Answers autosave to `localStorage`, so a reload does not cost sixty minutes. Telemetry deliberately does **not** survive the reload — carrying it across would be a fabricated measurement of a session this page did not watch.
- Additive only: five new files, no existing file touched.
- Temporary surface, like the `/assessment` route it sits beside. It should be deleted once the hire is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kqcrJhDxpjSos6PgTgN18