### PR TITLE
docs(contract): re-certify Autonomous Ops L2 — Antonello, 2026-09-01

### DIFF
--- a/AUTONOMOUS_OPS.md
+++ b/AUTONOMOUS_OPS.md
@@ -34,6 +34,9 @@ dozen unrelated ISO dates that must never govern.)
 (re-certified 2026-07-19 by Antonello — routine 30-day refresh; Level 2 unchanged.
 As of 2026-08-31 that is 43 days: this contract is LAPSED by its own rule below,
 and no session was told, because of the defect described above.)
+(re-certified 2026-09-01 by Antonello — ordered in the M5 interactive session
+("rinnova il contratto") after the wave-2 dashboard surfaced the 43-day lapse;
+Level 2 unchanged.)
 
 If today's date is >30 days after "active since" without a refresh commit,
 Claude falls back to conservative mode and pings the user to re-certify.
@@ -282,6 +285,10 @@ decides this.
   two of four sampled merges read "3 not green" purely as a function of when the sample
   was taken. Still open and NOT closed by this audit: the monthly restore drill, the three
   unrequired suites (see L2.1 above), and enforcement-under-race.
+- **2026-09-01** — Re-certified by Antonello ("rinnova il contratto", M5 interactive
+  session). The 2026-07-19 certification lapsed on 2026-08-18 and no session was told:
+  the mtime-based staleness hook was dead on all three machines. The durable check now
+  lives in `scripts/check_autonomous_ops_staleness.py` (PR #5425). Level 2 unchanged.
 - **2026-07-19** — Re-certified by Antonello (routine 30-day refresh after the
   2026-06-11 certification lapsed). Level 2 unchanged.
 - **2026-04-21** — File created by Claude at Zero's request. Level 1 active


### PR DESCRIPTION
Zero's order in the M5 interactive session, 2026-09-01: «rinnova il contratto».

The 2026-07-19 certification lapsed on 2026-08-18 (43 days by 2026-08-31) and no
session was told — the mtime-based staleness hook is dead on all three machines
(cured durably by `scripts/check_autonomous_ops_staleness.py`, PR #5425). This PR
adds the 2026-09-01 re-certification line to the `## Active level` block and a
changelog entry. Level 2 unchanged.

Bites: `python3 scripts/check_autonomous_ops_staleness.py` on this branch prints
`CURRENT: Autonomous Ops contract certified 2026-09-01, 0 days old (limit 30)` —
run and observed before this PR was opened. The consumer is every session's
conservative-mode decision, which reads this declared date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMfdnv645BiC7rBprf5Kiq