### PR TITLE
fix(ops): the stall notifier had no memory, so a stuck PR paged every tick forever

### DIFF
--- a/scripts/queue_stall_notify.py
+++ b/scripts/queue_stall_notify.py
@@ -40,14 +40,13 @@ REAL_STALL_CAUSES below deliberately excludes it. The other 4 causes
 next gate session should look at, and so does CANNOT-VERIFY — a row the classifier could not
 read is news (its own instrument failed to measure), not silence.
 
-DEDUP KEY ENCODES THE CAUSE, NOT JUST THE PR NUMBER: `queue_stall:<number>:<cause>`. The
-classifier holds no state of its own (unlike queue_unstick.py, which fingerprints a DIRTY signal
-on head-sha + conflict-digest across ticks) and the fleet mailbox reader
-(infra/claude-hooks/mailbox_inject.py) keeps only the newest file per key, marking a broadcast
-seen-once-per-session. A key of `queue_stall:<number>` alone would mean a PR whose stall CAUSE
-changes (say, `not-armed` today, `required-check-red` tomorrow, after someone manually armed it
-and CI then failed) never resurfaces once the first key's file already exists — the exact
-silent-drop shape this module exists to avoid.
+DEDUP KEY ENCODES THE CAUSE, NOT JUST THE PR NUMBER: `queue_stall:<number>:<cause>`. Every
+fleet_mail.sh send mints a fresh timestamped filename, and mailbox_inject.py's per-key
+supersession chooses only among files simultaneously on disk; delivery history is tracked by
+filename. Therefore a later broadcast with a changed cause was never at risk of being erased by
+the mailbox. The cause belongs in this notifier's local repeat-page state instead: a changed
+diagnosis (say, `not-armed` today, `required-check-red` tomorrow) is new information and must
+send immediately, while the unchanged `(number, cause)` pair is a repeat eligible for throttling.
 
 Kill switch: QUEUE_STALL_NOTIFY_ENABLED=false makes every invocation a no-op that still prints a
 receipt line (superscar #2: a mute cron is a dead cron — silence must never be the only signal
@@ -73,6 +72,13 @@ Env overrides:
   QUEUE_STALL_NOTIFY_CLASSIFIER_TIMEOUT default 180 (seconds, subprocess timeout for the
                                          classifier call — it pages through every open PR and
                                          can legitimately take a while on a busy queue)
+  QUEUE_STALL_NOTIFY_REPAGE_HOURS       default 6. At the documented 30-minute cadence this
+                                         reduces an unchanged stall from 48 broadcasts/day to at
+                                         most 4: frequent enough to re-surface a genuinely stuck
+                                         PR during an operator day, but far enough apart that the
+                                         alarm itself does not become fleet-mailbox noise.
+  QUEUE_STALL_NOTIFY_STATE_DIR          default ~/.agent/decisions/state (local repeat-page
+                                         state; tests may override it)
 
 Exit codes: 0 = ran clean (the classifier ran clean AND every attempted send succeeded, whether
 or not any PR was actually stalled); 1 = the classifier itself failed (non-zero rc — propagated
@@ -86,9 +92,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -104,6 +112,9 @@ MIN_AGE_MINUTES = int(os.environ.get("QUEUE_STALL_NOTIFY_MIN_AGE_MINUTES", "30")
 CAP = int(os.environ.get("QUEUE_STALL_NOTIFY_CAP", "5"))
 FLEET_MAIL_HOST = os.environ.get("QUEUE_STALL_NOTIFY_FLEET_MAIL_HOST", "pro")
 CLASSIFIER_TIMEOUT = int(os.environ.get("QUEUE_STALL_NOTIFY_CLASSIFIER_TIMEOUT", "180"))
+REPAGE_SECONDS = 60 * 60 * int(os.environ.get("QUEUE_STALL_NOTIFY_REPAGE_HOURS", "6"))
+STATE_DIR = Path(os.environ.get("QUEUE_STALL_NOTIFY_STATE_DIR", os.path.expanduser("~/.agent/decisions/state")))
+SEEN_FILE = STATE_DIR / "queue_stall_notify_seen.json"
 
 # Duplicated from queue_stall_classifier.py's own CANNOT_VERIFY sentinel — see module docstring
 # "SUBPROCESS, NEVER IMPORT" for why this is a literal, not an import.
@@ -119,6 +130,9 @@ REAL_STALL_CAUSES = frozenset(
         "not-armed",
     }
 )
+# Explicitly ignored because the classifier defines it as "no known blocker", not an actionable
+# stall. Kept separate from unknown values so the vocabulary-drift test can make omissions loud.
+DELIBERATELY_IGNORED = frozenset({"queued-and-advancing"})
 
 
 def _enabled() -> bool:
@@ -235,6 +249,58 @@ def plan_notifications(rows: list[dict[str, Any]], *, cap: int) -> dict[str, lis
     return {"to_notify": to_notify, "suppressed_by_cap": suppressed, "skipped": skipped}
 
 
+# ---------------------------------------------------------------------------
+# Repeat-page state — local file, mutated only outside --dry-run.
+# ---------------------------------------------------------------------------
+
+
+def load_seen(path: Path = SEEN_FILE) -> dict[str, float]:
+    """Load last-successful-send times. Any state-file fault returns empty state so the next
+    run PAGES rather than silently suppressing an alarm."""
+    try:
+        raw = json.loads(path.read_text())
+        if not isinstance(raw, dict):
+            return {}
+        return {
+            str(key): float(value)
+            for key, value in raw.items()
+            if isinstance(key, str) and isinstance(value, (int, float)) and math.isfinite(float(value))
+        }
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError, ValueError):
+        return {}
+
+
+def save_seen(state: dict[str, float], path: Path = SEEN_FILE) -> None:
+    """Persist state atomically enough for a local cron receipt; callers only invoke after sends."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, sort_keys=True))
+    tmp.replace(path)
+
+
+def plan_repage(
+    candidates: list[dict[str, Any]], *, seen: dict[str, float], now: float, cap: int
+) -> dict[str, list]:
+    """Suppress unchanged recent keys, then apply the per-run delivery cap.
+
+    Applying repeat suppression before the cap means already-known stalls cannot consume the
+    entire delivery budget and hide a new diagnosis.
+    """
+    eligible: list[dict[str, Any]] = []
+    repeats: list[dict[str, Any]] = []
+    for item in candidates:
+        last_sent = seen.get(item["key"])
+        if last_sent is not None and last_sent <= now and now - last_sent < REPAGE_SECONDS:
+            repeats.append(item)
+        else:
+            eligible.append(item)
+    return {
+        "to_notify": eligible[:cap],
+        "suppressed_by_cap": eligible[cap:],
+        "suppressed_as_repeat": repeats,
+    }
+
+
 def _format_message(item: dict[str, Any]) -> str:
     """Pure: the fleet-mail body text. CANNOT-VERIFY gets a DISTINCT wording — "an instrument
     that could not read is news, not silence" (team-lead mandate, verbatim) — never the same
@@ -316,7 +382,8 @@ def main(argv: list[str] | None = None) -> int:
     if not _enabled():
         print(
             "QUEUE_STALL_NOTIFY_SUMMARY disabled=true examined=0 stalled=0 sent=0 "
-            f"send_failed=0 suppressed_by_cap=0 dry_run={str(args.dry_run).lower()}"
+            f"send_failed=0 suppressed_by_cap=0 suppressed_as_repeat=0 skipped=0 "
+            f"unrecognized_causes=- dry_run={str(args.dry_run).lower()}"
         )
         return 0
 
@@ -335,29 +402,63 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"QUEUE_STALL_NOTIFY_SUMMARY classifier_rc={rc} classifier_failed=true "
             "examined=0 stalled=0 sent=0 send_failed=0 suppressed_by_cap=0 "
+            f"suppressed_as_repeat=0 skipped=0 unrecognized_causes=- "
             f"dry_run={str(args.dry_run).lower()} error={detail!r}"
         )
         return 1
 
     rows = report.get("rows") or []
-    plan = plan_notifications(rows, cap=args.cap)
+    # First discover every candidate. Repeat suppression must precede the delivery cap so a
+    # known repeat cannot consume the limited budget and hide a changed/new diagnosis.
+    classification_plan = plan_notifications(rows, cap=len(rows))
+    seen = load_seen(path=SEEN_FILE)
+    now = time.time()
+    re_page_plan = plan_repage(
+        classification_plan["to_notify"], seen=seen, now=now, cap=args.cap
+    )
 
     sent = 0
     send_failed = 0
-    for item in plan["to_notify"]:
+    successful_keys: set[str] = set()
+    for item in re_page_plan["to_notify"]:
         ok, detail_line = send_notification(item, dry_run=args.dry_run)
         print(detail_line)
         if ok:
             sent += 1
+            successful_keys.add(item["key"])
         else:
             send_failed += 1
 
-    stalled = len(plan["to_notify"]) + len(plan["suppressed_by_cap"])
+    # Retain only still-stalled pairs, so resolving a PR clears it and a later re-stall sends
+    # immediately. Successful sends then refresh their own timestamp. Dry-runs remain read-only.
+    active_keys = {item["key"] for item in classification_plan["to_notify"]}
+    new_seen = {key: timestamp for key, timestamp in seen.items() if key in active_keys}
+    if not args.dry_run:
+        for key in successful_keys:
+            new_seen[key] = now
+        if new_seen != seen:
+            try:
+                save_seen(new_seen, path=SEEN_FILE)
+            except OSError as exc:
+                print(f"QUEUE_STALL_NOTIFY_STATE_WRITE_FAILED error={type(exc).__name__}: {exc}")
+
+    unrecognized_causes = sorted(
+        {str(cause) for _, cause in classification_plan["skipped"] if cause not in DELIBERATELY_IGNORED}
+    )
+    unrecognized_text = ",".join(unrecognized_causes) if unrecognized_causes else "-"
+    stalled = (
+        len(re_page_plan["to_notify"])
+        + len(re_page_plan["suppressed_by_cap"])
+        + len(re_page_plan["suppressed_as_repeat"])
+    )
     summary = (
         f"QUEUE_STALL_NOTIFY_SUMMARY classifier_rc={rc} "
         f"examined={report.get('examined_total', 0)} stalled={stalled} sent={sent} "
-        f"send_failed={send_failed} suppressed_by_cap={len(plan['suppressed_by_cap'])} "
-        f"cap={args.cap} dry_run={str(args.dry_run).lower()}"
+        f"send_failed={send_failed} suppressed_by_cap={len(re_page_plan['suppressed_by_cap'])} "
+        f"suppressed_as_repeat={len(re_page_plan['suppressed_as_repeat'])} "
+        f"skipped={len(classification_plan['skipped'])} "
+        f"unrecognized_causes={unrecognized_text} cap={args.cap} "
+        f"dry_run={str(args.dry_run).lower()}"
     )
     print(summary)
 

--- a/scripts/queue_stall_notify.py
+++ b/scripts/queue_stall_notify.py
@@ -91,6 +91,9 @@ Tests: scripts/tests/test_queue_stall_notify.py.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import errno
+import fcntl
 import json
 import math
 import os
@@ -278,6 +281,64 @@ def save_seen(state: dict[str, float], path: Path = SEEN_FILE) -> None:
     tmp.replace(path)
 
 
+# ---------------------------------------------------------------------------
+# Mutual exclusion over the repeat-page state.
+# ---------------------------------------------------------------------------
+
+LOCK_FILE = SEEN_FILE.with_name(SEEN_FILE.name + ".lock")
+
+
+@contextlib.contextmanager
+def state_lock(path: Path = LOCK_FILE, *, enabled: bool = True):
+    """Serialise the read-modify-write on the repeat-page state. Yields a status string.
+
+    WHY. Without this, `load_seen -> decide -> send -> save_seen` is a last-writer-wins full
+    overwrite. Adversarial review reproduced the loss directly: a SLOW process reads the state,
+    a FAST one starts later, correctly prunes a resolved PR and writes {}, and then the slow one
+    writes back its stale view — resurrecting a "sent" ghost. A genuinely re-stalled PR then
+    reads as a repeat and is SUPPRESSED for a whole repage window. That is the unsafe direction:
+    the alarm misses a real stall, which is worse than paging twice.
+
+    Three outcomes, deliberately distinct, because collapsing them is how a lock silences an
+    alarm it was added to protect:
+      "held"        -- we own it; proceed and mutate.
+      "busy"        -- another invocation owns it. Do NOT write. Its run covers this tick, so
+                       this is correct behaviour and not a failure.
+      "unavailable" -- the lock itself could not be created (read-only dir, bad perms...).
+                       Proceed WITHOUT it and say so. A broken lock must never be a reason to
+                       stop paging; a duplicate page is survivable, a missed stall is not.
+    """
+    if not enabled:
+        yield "held"
+        return
+    handle = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = path.open("a+")
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        yield "busy"
+        return
+    except OSError as exc:
+        if handle is not None:
+            with contextlib.suppress(OSError):
+                handle.close()
+        sys.stderr.write(
+            f"queue_stall_notify: state lock unavailable ({type(exc).__name__}: "
+            f"{errno.errorcode.get(exc.errno, exc.errno)}) — proceeding UNLOCKED rather than "
+            "skipping; a broken lock must not silence the alarm\n"
+        )
+        yield "unavailable"
+        return
+    try:
+        yield "held"
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            handle.close()
+
+
 def plan_repage(
     candidates: list[dict[str, Any]], *, seen: dict[str, float], now: float, cap: int
 ) -> dict[str, list]:
@@ -411,6 +472,21 @@ def main(argv: list[str] | None = None) -> int:
     # First discover every candidate. Repeat suppression must precede the delivery cap so a
     # known repeat cannot consume the limited budget and hide a changed/new diagnosis.
     classification_plan = plan_notifications(rows, cap=len(rows))
+
+    # The lock spans load -> decide -> send -> save. A dry-run takes none: it writes nothing,
+    # and must never be able to block the real run that does.
+    lock_ctx = state_lock(enabled=not args.dry_run)
+    lock_state = lock_ctx.__enter__()
+    if lock_state == "busy":
+        lock_ctx.__exit__(None, None, None)
+        print(
+            "QUEUE_STALL_NOTIFY_SUMMARY classifier_rc=0 examined="
+            f"{report.get('examined_total', 0)} stalled={len(classification_plan['to_notify'])} "
+            "sent=0 send_failed=0 suppressed_by_cap=0 suppressed_as_repeat=0 skipped=0 "
+            "unrecognized_causes=- concurrent_run=true dry_run=false"
+        )
+        return 0
+
     seen = load_seen(path=SEEN_FILE)
     now = time.time()
     re_page_plan = plan_repage(
@@ -441,6 +517,7 @@ def main(argv: list[str] | None = None) -> int:
                 save_seen(new_seen, path=SEEN_FILE)
             except OSError as exc:
                 print(f"QUEUE_STALL_NOTIFY_STATE_WRITE_FAILED error={type(exc).__name__}: {exc}")
+    lock_ctx.__exit__(None, None, None)
 
     unrecognized_causes = sorted(
         {str(cause) for _, cause in classification_plan["skipped"] if cause not in DELIBERATELY_IGNORED}

--- a/scripts/tests/test_queue_stall_notify.py
+++ b/scripts/tests/test_queue_stall_notify.py
@@ -22,12 +22,21 @@ Covers the mandate's explicit cases:
 
 from __future__ import annotations
 
+import ast
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import queue_stall_notify as qsn  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def isolated_repeat_state(monkeypatch, tmp_path):
+    """No unit test may read or write the operator's real local paging state."""
+    monkeypatch.setattr(qsn, "SEEN_FILE", tmp_path / "queue_stall_notify_seen.json")
 
 
 def make_row(number: int, cause: str, detail: str = "detail") -> dict:
@@ -63,15 +72,13 @@ def test_real_stall_cause_is_notify_worthy_key_has_number_and_cause():
     assert item["cannot_verify"] is False
 
 
-def test_same_pr_number_different_cause_yields_different_keys():
-    # This is the exact property the mandate calls out: "the dedup key must encode the CAUSE,
-    # not just the PR number" — a PR-number-only key would collapse these two into one.
-    plan = qsn.plan_notifications(
-        [make_row(707, "not-armed", "x"), make_row(707, "conflict", "y")], cap=10
-    )
-    keys = [item["key"] for item in plan["to_notify"]]
-    assert keys == ["queue_stall:707:not-armed", "queue_stall:707:conflict"]
-    assert len(set(keys)) == 2
+def test_same_pr_across_invocations_changed_cause_is_not_a_repeat():
+    first = qsn.plan_notifications([make_row(707, "not-armed", "x")], cap=1)["to_notify"]
+    first_key = first[0]["key"]
+    second = qsn.plan_notifications([make_row(707, "conflict", "y")], cap=1)["to_notify"]
+    re_page = qsn.plan_repage(second, seen={first_key: 1_000.0}, now=1_001.0, cap=1)
+    assert [item["key"] for item in re_page["to_notify"]] == ["queue_stall:707:conflict"]
+    assert re_page["suppressed_as_repeat"] == []
 
 
 def test_queued_and_advancing_is_not_notify_worthy():
@@ -79,6 +86,20 @@ def test_queued_and_advancing_is_not_notify_worthy():
     assert plan["to_notify"] == []
     assert plan["suppressed_by_cap"] == []
     assert plan["skipped"] == [(303, "queued-and-advancing")]
+
+
+def test_classifier_stall_vocabulary_is_fully_accounted_for_without_importing_it():
+    """The subprocess boundary stays intact: inspect source AST, never import the classifier."""
+    source = qsn.CLASSIFIER.read_text()
+    tree = ast.parse(source)
+    stall_causes = next(
+        ast.literal_eval(node.value)
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "STALL_CAUSES" for target in node.targets)
+    )
+    accounted_for = qsn.REAL_STALL_CAUSES | qsn.DELIBERATELY_IGNORED
+    assert set(stall_causes) <= accounted_for
 
 
 def test_cannot_verify_is_notify_worthy_and_flagged_distinctly():
@@ -139,6 +160,55 @@ def test_dry_run_zero_subprocess_calls_intended_payload_printed(monkeypatch, cap
     assert "[dry-run] would signal PR #101" in out
     assert "queue_stall:101:conflict" in out
     assert "sent=1" in out
+    assert not qsn.SEEN_FILE.exists()
+
+
+def test_repeat_is_suppressed_then_repages_after_interval(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(111, "conflict", "mergeStateStatus=DIRTY")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn.time, "time", lambda: 10_000.0)
+    calls = []
+    monkeypatch.setattr(qsn, "_run", lambda cmd, timeout=30: (calls.append(cmd) or (0, "ok", "")))
+
+    assert qsn.main([]) == 0
+    assert qsn.main([]) == 0
+    assert len(calls) == 1
+    assert "suppressed_as_repeat=1" in capsys.readouterr().out
+
+    monkeypatch.setattr(qsn.time, "time", lambda: 10_000.0 + qsn.REPAGE_SECONDS)
+    assert qsn.main([]) == 0
+    assert len(calls) == 2
+
+
+def test_changed_cause_sends_immediately_even_when_same_pr_was_just_sent(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    first = make_report([make_row(222, "not-armed", "not queued")])
+    second = make_report([make_row(222, "required-check-red", "statusCheckRollup=FAILURE")])
+    reports = iter((first, second))
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, next(reports), "", ""))
+    monkeypatch.setattr(qsn.time, "time", lambda: 20_000.0)
+    calls = []
+    monkeypatch.setattr(qsn, "_run", lambda cmd, timeout=30: (calls.append(cmd) or (0, "ok", "")))
+
+    assert qsn.main([]) == 0
+    assert qsn.main([]) == 0
+    assert len(calls) == 2
+    assert calls[1][calls[1].index("--key") + 1] == "queue_stall:222:required-check-red"
+    assert "suppressed_as_repeat=0" in capsys.readouterr().out
+
+
+def test_corrupt_state_file_still_pages(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    qsn.SEEN_FILE.write_text("this is not json")
+    report = make_report([make_row(333, "conflict", "mergeStateStatus=DIRTY")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    calls = []
+    monkeypatch.setattr(qsn, "_run", lambda cmd, timeout=30: (calls.append(cmd) or (0, "ok", "")))
+
+    assert qsn.main([]) == 0
+    assert len(calls) == 1
+    assert "sent=1" in capsys.readouterr().out
 
 
 # ── main(): a real stall row -> exactly one send ────────────────────────────
@@ -204,6 +274,18 @@ def test_queued_and_advancing_row_produces_no_send(monkeypatch, capsys):
     assert rc == 0
     assert "stalled=0" in out
     assert "sent=0" in out
+
+
+def test_unrecognized_cause_is_visible_in_summary(monkeypatch, capsys):
+    monkeypatch.delenv("QUEUE_STALL_NOTIFY_ENABLED", raising=False)
+    report = make_report([make_row(304, "new-classifier-cause", "future vocabulary drift")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+
+    assert qsn.main([]) == 0
+    out = capsys.readouterr().out
+    assert "skipped=1" in out
+    assert "unrecognized_causes=new-classifier-cause" in out
 
 
 # ── main(): classifier failure propagates ───────────────────────────────────

--- a/scripts/tests/test_queue_stall_notify.py
+++ b/scripts/tests/test_queue_stall_notify.py
@@ -23,6 +23,7 @@ Covers the mandate's explicit cases:
 from __future__ import annotations
 
 import ast
+import json
 import sys
 from pathlib import Path
 
@@ -386,3 +387,79 @@ def test_cannot_verify_row_is_delivered_distinctly_even_though_classifier_failed
     msg = calls[0][-1]
     assert "COULD NOT VERIFY" in msg
     assert "sent=1" in out
+
+
+# ---------------------------------------------------------------------------
+# Mutual exclusion: a stale writer must not resurrect a pruned "sent" ghost
+# ---------------------------------------------------------------------------
+
+def test_lock_is_held_then_released(tmp_path):
+    lock = tmp_path / "s.lock"
+    with qsn.state_lock(lock) as status:
+        assert status == "held"
+    # released: a second acquisition succeeds
+    with qsn.state_lock(lock) as status:
+        assert status == "held"
+
+
+def test_guilt_a_second_holder_is_told_busy_not_held(tmp_path):
+    """The whole point: a concurrent invocation must NOT proceed to mutate state."""
+    import fcntl
+    lock = tmp_path / "s.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    other = lock.open("a+")
+    fcntl.flock(other.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with qsn.state_lock(lock) as status:
+            assert status == "busy", status
+    finally:
+        fcntl.flock(other.fileno(), fcntl.LOCK_UN)
+        other.close()
+
+
+def test_innocence_a_broken_lock_proceeds_unlocked_and_never_goes_silent(tmp_path):
+    """A lock that cannot be created must NOT stop the alarm. A duplicate page is
+    survivable; a missed stall is not. This is the failure direction that matters."""
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("i am a file")
+    with qsn.state_lock(blocker / "sub" / "s.lock") as status:
+        assert status == "unavailable", status
+
+
+def test_disabled_lock_yields_held_so_dry_run_never_blocks_a_real_run(tmp_path):
+    with qsn.state_lock(tmp_path / "s.lock", enabled=False) as status:
+        assert status == "held"
+
+
+def test_the_reviewers_race_cannot_resurrect_a_pruned_entry(tmp_path, monkeypatch):
+    """Reproduces the reported loss, then shows the lock forecloses it.
+
+    Reported sequence: a SLOW process loads state, a FAST one starts later, correctly prunes a
+    resolved PR and writes {}, then the SLOW one writes back its stale view — resurrecting a
+    'sent' ghost, so a genuinely re-stalled PR reads as a repeat and is suppressed for a whole
+    repage window. Unsafe direction: the alarm misses a real stall.
+    """
+    state = tmp_path / "seen.json"
+    lock = tmp_path / "seen.json.lock"
+    key = "queue_stall:100:not-armed"
+
+    # WITHOUT the lock, the stale writer wins — this is the defect, pinned so it stays fixed.
+    state.write_text(json.dumps({key: 0.0}))
+    slow_view = qsn.load_seen(path=state)          # slow process reads
+    qsn.save_seen({}, path=state)                  # fast process prunes and writes
+    qsn.save_seen(slow_view, path=state)           # slow process writes its stale view
+    assert qsn.load_seen(path=state) == {key: 0.0}, "the race itself must be real"
+
+    # WITH the lock, the slow process cannot be inside the section while the fast one writes.
+    import fcntl
+    state.write_text(json.dumps({key: 0.0}))
+    holder = lock.open("a+")
+    fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with qsn.state_lock(lock) as status:
+            assert status == "busy"
+            # the losing process must not have written anything
+        assert qsn.load_seen(path=state) == {key: 0.0}
+    finally:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()


### PR DESCRIPTION
Successor to #5471 (merged), cut from fresh `origin/main`. Closes the two defects its adversarial review found, and corrects a justification I had written myself and that turned out to be false.

**Bites:** the consumer is `scripts/queue_stall_notify.py`, which shipped in #5471 and is on `main` now. The observation is a live end-to-end dry-run against this repo — `examined=37 stalled=30 sent=30 send_failed=0 suppressed_by_cap=0 suppressed_as_repeat=0 skipped=0 unrecognized_causes=- cap=200 dry_run=true`, rc=0, zero sends — plus 21 tests with four properties proven discriminating. **The crontab line is still not installed**, and that is the point of the timing: this fix lands *before* anything is scheduled, so the defect below never reaches anyone.

## 1. No memory between runs — the one that mattered

Measured live: **31 PRs stalled**. At the documented `*/30` cadence that is 31 broadcasts every half hour, about **1,488 messages a day**, into a mailbox every session on the fleet reads. That is not a noisy alarm — it is how an alarm stops being read, and an unread mailbox is an alarm that does not sound. The mailbox's own S3 fix names "one PR paged 12 times" as the disease it cured; this would have reintroduced it at scale.

The sibling had already solved it and says why: `queue_unstick.py`'s `DIRTY_SEEN_FILE` exists "so a PR stuck dirty for 6 hours doesn't emit 36 messages". Same pattern here, keyed on `(number, cause)`:
- a **changed cause sends immediately** — a changed diagnosis is new information, not a repeat;
- an entry is **cleaned up** when the PR stops being stalled, so a later re-stall pages again instead of being suppressed by a stale record;
- the state file **fails safe**: unreadable, corrupt or missing behaves as if nothing was ever sent, so it pages rather than going quiet. A notifier silenced by its own broken state file is the worst available outcome;
- `--dry-run` writes no state, and the summary gains `suppressed_as_repeat` so a quiet run is distinguishable from a broken one.

## 2. A justification of mine that was false

The docstring claimed a number-only dedup key would let a PR "whose stall CAUSE changes never resurface". **I wrote that, and it is wrong.** The reviewer read the mechanism instead of believing it: `fleet_mail.sh` mints a fresh timestamped filename on every send, `mailbox_inject.py`'s per-key supersession only chooses among files *simultaneously on disk*, and delivery is tracked by filename. A changed cause was never at risk.

Corrected in place, not deleted — this file's whole subject is claims that do not match the code beside them, so the fix is to say what is true. The real reason the cause belongs in the key is that it distinguishes a changed diagnosis from a repeat, which is exactly what the new state keys on.

The test meant to cover this fed `plan_notifications` two rows for the **same** PR number in one report — an input the classifier cannot produce (one `_classify_one` per PR per run). It now tests the real case: the same PR across two *invocations*, cause changed.

## 3. An unrecognized cause was dropped with zero trace

The `skipped` branch was computed and never read. The cause vocabulary is duplicated across two files with nothing keeping them aligned (scar family #9) — it matches exactly today, which is precisely when a drift guard is cheap. `skipped` and the offending names now reach the summary line, and a test reads `STALL_CAUSES` out of the classifier's **source** (never importing it — its purity is enforced by its own AST self-check) and fails if any value is neither notified nor in an explicit `DELIBERATELY_IGNORED` set.

## Discrimination, and one honest near-miss

- re-page interval → 0 reddens the suppression test;
- narrowing the state-file `except` so a corrupt file kills the run reddens the fail-safe test, **and only that one**;
- removing a cause from the notifier's vocabulary reddens the drift test.

My **first** attempt at the fail-safe mutation left all 21 green. It injected a key nothing reads, so it never violated the property — the test was fine, my mutation was not. A mutation that does not break the property proves nothing about the test, which is why the one recorded above is the one that actually kills the run.

Built on the **codex seat** (`gpt-5.6-terra`): the routing floor blocked a fourth consecutive Anthropic build dispatch, correctly. `scripts/queue_stall_classifier.py` is byte-identical to `origin/main`.