### PR TITLE
docs(secondhome): record Zero's IDR-typeface ruling and arm it with a test

### DIFF
--- a/apps/mouth/src/app/visa/second-home/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.test.tsx
@@ -93,6 +93,36 @@ describe("SecondHomeLanding", () => {
     });
   });
 
+  /**
+   * IDR typeface, RULED 2026-09-01 (Zero, Legge 5 — «dobbiamo restare coerenti
+   * e non passare a plex mono»). R4's typography table asks for IBM Plex Mono
+   * on price figures; that requirement is AMENDED AWAY for these two routes,
+   * and the amendment note under the table in
+   * research/design/2026-08-27-r4-identity-merah-putih-token-spec.md is the law.
+   * Without this test the ruling lives only in prose, and prose does not stop
+   * the next session from "fixing" the divergence back toward mono.
+   *
+   * Sibling of the test below, and they pull in OPPOSITE directions on purpose:
+   * the price is an aligned figure and takes tabular digits; the hero
+   * statistics are prose and must stay proportional.
+   */
+  it("renders the IDR price in the page's own serif with tabular figures, never mono", () => {
+    renderLanding();
+
+    const expectedPrice = getExactSnapshotPrice(
+      "kitas_permits",
+      "E33 Second Home (5 Years)",
+    );
+    expect(expectedPrice).not.toBeNull();
+
+    const price = screen.getByText(expectedPrice as string);
+    // Assert on the value, not a boolean, so a failure prints the face that
+    // replaced the serif instead of an opaque `expected true to be false`.
+    expect(price.style.fontFamily).toBe("var(--font-serif, Georgia, serif)");
+    expect(price.style.fontVariantNumeric).toBe("tabular-nums");
+    expect(price.style.fontFeatureSettings).toMatch(/tnum/);
+  });
+
   it("keeps the hero statistics proportional rather than tabular", () => {
     renderLanding();
 

--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -181,9 +181,23 @@ export const MERAH_PUTIH_DAY_VARS = {
   // Menlo, monospace`, with ~29 consumers elsewhere in the app, every one of
   // them naming Plex FIRST — so using it here would need no new file and would
   // put this surface exactly where those 29 already are. No ledger row for
-  // "Plex" or "font-mono" exists. What is genuinely open, and NOT settled by
-  // this comment: R4 asks for Plex Mono on IDR amounts while the price figures
-  // here use Cormorant + tabular-nums, and nothing on disk records why.
+  // "Plex" or "font-mono" exists.
+  //
+  // SETTLED 2026-09-01 (Zero, Legge 5 — «dobbiamo restare coerenti e non
+  // passare a plex mono»): the divergence the paragraph above left open is now
+  // a decision, not an omission. IDR amounts on THESE TWO ROUTES keep the
+  // surface's own faces with `tabular-nums` + `tnum` (VerdictPanel and the
+  // landing already render them that way); coherence of one small surface beat
+  // adding a second numeric voice to it. `--font-mono` is NOT deprecated and
+  // its ~29 consumers elsewhere are untouched, the VOA payment screen still
+  // renders IDR in mono, and the never-wrap-mid-amount constraint is
+  // typeface-independent and still binds here. The hero statistics are the
+  // deliberate counter-example — prose figures, NOT a column, and
+  // second-home/page.test.tsx pins them proportional; the ruling is about the
+  // price figures, not about every digit on the page. Written down in
+  // research/design/2026-08-27-r4-identity-merah-putih-token-spec.md (the
+  // amendment note under the typography table) — this comment is the pointer,
+  // that file is the law.
   fontFamily: "var(--font-sans), Inter, ui-sans-serif, system-ui, sans-serif",
 } as CSSProperties;
 

--- a/research/design/2026-08-27-r4-identity-merah-putih-token-spec.md
+++ b/research/design/2026-08-27-r4-identity-merah-putih-token-spec.md
@@ -89,8 +89,42 @@ The symmetry is measured: on warm paper only the logo family carries text (5.11-
 |---|---|---|
 | display | Cormorant Garamond 500/600 | h1/h2 only; sentence case; **minimum 24px** — below that, low-DPI Android antialiasing shreds the serif (panel), so smaller headings are Inter 600 |
 | UI/body | Inter 400/500/600 | everything else; line-height tokens must absorb Bahasa Indonesia's longer words (directionally +20-30% — declared judgment, not measured) without clipping |
-| data/mono | IBM Plex Mono 400/500 | visa codes, prices, timestamps — IDR amounts carry many zeros: mono + thousands separators, never wrapping mid-amount at 360px |
+| data/mono | IBM Plex Mono 400/500 | visa codes, prices, timestamps — IDR amounts carry many zeros: mono + thousands separators, never wrapping mid-amount at 360px. **⚠️ AMENDED 2026-09-01 for the two second-home routes ONLY — read the note under this table before implementing this cell there.** |
 | — retired from web | Montserrat, Arial Black, Impact, JetBrains Mono | Montserrat is in the funnels today only because `visa/layout.tsx` forces it (R0) — a layout inheritance, not a per-surface choice; it stays on IG covers (S5) |
+
+> **AMENDMENT 2026-09-01 — IDR typeface on the second-home surfaces (Zero, Legge 5).** Asked to
+> choose between adopting Plex Mono for the IDR figures or keeping the faces already on the page,
+> Zero ruled: *«dobbiamo restare coerenti e non passare a plex mono»*. So on **`/visa/second-home`
+> and `/visa/second-home/studio`** the IDR amounts stay in the surface's own faces with
+> `font-variant-numeric: tabular-nums` + `font-feature-settings: "tnum"` — which is what actually
+> buys the digit alignment the mono rule was reaching for. Coherence of a single small surface beat
+> introducing a second numeric voice on it.
+>
+> **What this reads as on disk, measured 2026-09-01 on `origin/main`** — the price figures
+> (`SecondHomeLanding.tsx`, the route amounts and the «from» price) render in `var(--font-serif)`
+> = Cormorant at `clamp(1.75rem, 3.6vw, 2.4rem)` and `clamp(2.4rem, 6vw, 3.6rem)`, i.e. always
+> above R4's own 24px serif floor, with `tabular-nums` + `tnum`; the studio's `VerdictPanel` sets
+> `tabular-nums` on the panel container. **The hero statistics are the deliberate exception and
+> must stay proportional** — «5 years», «USD 130,000», «Free» are prose, not a column to align, and
+> `second-home/page.test.tsx` («keeps the hero statistics proportional rather than tabular») already
+> pins them that way. Do not read this amendment as «put tabular-nums on every figure».
+>
+> **The scope is exactly those two routes, and three things this does NOT change:**
+>
+> 1. **The VOA payment screen keeps mono** — §5 «Pricing surfaces» below still reads *«IDR amounts
+>    render in mono with thousands separators»*, and that sentence is untouched. Do not propagate
+>    this amendment there by analogy; it was decided for one surface, on the argument that the
+>    surface was already coherent without a fifth face.
+> 2. **The never-wrap constraint is typeface-independent** and still binds everywhere, including
+>    here: an IDR amount must not break mid-number at 360px, whatever face renders it.
+> 3. **The `--font-mono` token is not deprecated.** It exists in `packages/core/tokens/primitives.css`
+>    as `"IBM Plex Mono", ui-monospace, Menlo, monospace` with ~29 consumers elsewhere in the app;
+>    every one of them stays as it is. This amendment removes a *requirement* on two routes, it does
+>    not retire a face.
+>
+> Recorded on disk because the previous state of this file asked for Plex here while the code had
+> shipped Cormorant + `tnum`, and nothing anywhere said why — an undocumented divergence that reads
+> to the next session as a defect to "fix".
 
 **Shape, spacing, motion — NEW spec values (judgment, not inherited measurements)**: radius 12 for cards/CTAs/inputs (home and my measure 12 today; VO's Start CTA at 20 rounds down — its question cards already measure 12; GARUDA's 4 rounds up), pills 9999; **nesting law**: inner radius = outer radius − padding, and full-width bottom sheets round top corners only. Spacing on a 4px base with a 24/32/48 section scale — a new value this spec sets, not an R0 measurement. Motion: slide+fade at 200-250ms (GARUDA has slide+fade today; the duration is new), `prefers-reduced-motion` honored, the VO verdict morph survives as the one signature move. Icons: outline 1.5px, ink/ink-soft only. Photography: real people and places over stock (weak, directional evidence — R1); my's tempio+luna illustration may generalize to empty states.
 


### PR DESCRIPTION
R4's typography table asks for **IBM Plex Mono** on price figures. The second-home landing and studio ship the price in the page's own serif with tabular figures instead, and until now nothing on disk said why — an undocumented divergence that reads to the next session as a defect to "fix" back toward mono.

Zero ruled it (Legge 5): *«dobbiamo restare coerenti e non passare a plex mono»*. Coherence of one small surface beat adding a second numeric voice to it.

### Three changes, one concern

- **`research/design/2026-08-27-r4-identity-merah-putih-token-spec.md`** carries the amendment under its typography table, with the scope fenced explicitly: **the two second-home routes ONLY**. The VOA payment screen's mono rule in §5 is untouched, the never-wrap-mid-amount constraint is typeface-independent and still binds, and `--font-mono` is *not* deprecated — its ~29 consumers elsewhere stay as they are. The table row now points at the note, because a reader who scans only the row is exactly who would implement the superseded cell.
- **`merahPutihDayVars.ts`** closes the paragraph #5470 opened yesterday: what it recorded as *genuinely open* is now a decision.
- **`second-home/page.test.tsx`** pins the price face and its tabular figures. A verdict that exists only in prose is not in force.

### The two tests pull in opposite directions on purpose

The new test is the sibling of the existing *"keeps the hero statistics proportional rather than tabular"*. The price is an **aligned figure** and takes tabular digits; the hero statistics («5 years», «USD 130,000», «Free») are **prose** and must stay proportional. Both are now pinned, so neither gets tidied into the other — and the amendment says so in as many words.

### Bites

`apps/mouth` vitest — `src/app/visa/second-home/page.test.tsx` runs in the existing suite. Measured in the worktree:

| run | result |
|---|---|
| unmodified source | **10/10 pass** |
| price face flipped to `var(--font-mono)` | **FAIL** — `expected 'var(--font-mono)' to be 'var(--font-serif, Georgia, serif)'` |
| `...tabularNums` dropped from the price | **FAIL** — `expected '' to be 'tabular-nums'` |

Source restored clean after both mutations; `tsc --noEmit` rc=0. The assertions are on the *value*, not a boolean, so a future failure prints the face that replaced the serif instead of an opaque `expected true to be false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)