### PR TITLE
fix(mouth): read the relay credential at request time, and say so when it is missing

### DIFF
--- a/apps/mouth/src/app/api/assessment/submit/route.ts
+++ b/apps/mouth/src/app/api/assessment/submit/route.ts
@@ -11,12 +11,23 @@ import { logger } from "@/lib/logger";
  * Temporary — will be removed after the assessment.
  */
 
-const BACKEND_URL =
-  process.env.NUZANTARA_API_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  "https://nuzantara-rag.fly.dev";
+// Read at request time, never at module scope. A module-scope read is
+// evaluated once per lambda build/boot, so a corrected secret does not reach a
+// running deployment until something forces a fresh build — which is invisible,
+// because the symptom is a 401 from the backend that looks like a backend
+// problem. Measured 2026-09-01: the key on Vercel was the one revoked on
+// 2026-07-12, and two redeploys did not pick up the replacement.
+function backendUrl(): string {
+  return (
+    process.env.NUZANTARA_API_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "https://nuzantara-rag.fly.dev"
+  );
+}
 
-const API_KEY = process.env.INTERNAL_API_KEY || process.env.API_KEY || "";
+function apiKey(): string {
+  return process.env.INTERNAL_API_KEY || process.env.API_KEY || "";
+}
 
 interface SubmitBody {
   to: string;
@@ -33,13 +44,35 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid recipient" }, { status: 400 });
     }
 
+    // Say plainly that the deployment has no credential, instead of forwarding
+    // an empty header and letting the backend answer 401. That 401 reads as
+    // "the backend rejected us" and sends the reader hunting in the wrong
+    // service; this names the actual cause, in the only place that can see it.
+    const key = apiKey();
+    if (!key) {
+      logger.error(
+        "[assessment/submit] INTERNAL_API_KEY is not set on this deployment — refusing to send",
+        { component: "assessment", action: "submit" },
+      );
+      return NextResponse.json(
+        {
+          error: "Email relay is not configured",
+          detail:
+            "INTERNAL_API_KEY is missing from this deployment's environment.",
+        },
+        { status: 503 },
+      );
+    }
+
     // Forward to backend
-    const backendUrl = BACKEND_URL.replace(/\/+$/, "").replace(/\/api$/, "");
-    const res = await fetch(`${backendUrl}/api/notifications/send-email`, {
+    const base = backendUrl()
+      .replace(/\/+$/, "")
+      .replace(/\/api$/, "");
+    const res = await fetch(`${base}/api/notifications/send-email`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-API-Key": API_KEY,
+        "X-API-Key": key,
       },
       body: JSON.stringify({
         to: payload.to,


### PR DESCRIPTION
The round-2 assessment page (#5473) went live and its submissions returned **401**. The `INTERNAL_API_KEY` on Vercel was the one revoked on 2026-07-12 — but replacing it did not fix it, and two redeploys did not either. Two defects in this route made that hunt much longer than it needed to be, and both are worth closing regardless of the immediate incident.

### 1. The credential was read at module scope

`BACKEND_URL` and `API_KEY` were top-level `const`s, evaluated once when the lambda module is first loaded. A corrected secret therefore does not reach a deployment that is already built and warm — you change the variable, nothing happens, and there is no signal telling you why. Both are now read **inside the handler**, per request.

### 2. The route blamed the backend for its own missing configuration

With no key it forwarded `X-API-Key: ""` and returned whatever came back. The backend's `HybridAuthMiddleware` rejects an empty header *before* the router's own `verify_internal_api_key` dependency runs, so the reply is `{"detail":"Authentication required"}` — not the dependency's own `"API key required. Provide X-API-Key header."`. That difference matters: the message reads as *"the backend refused our credential"* and sends the reader into the wrong service hunting a key problem that is not there. I spent a round of diagnosis on exactly that, having assumed the two messages would discriminate empty-header from wrong-key. They do not; the middleware answers first for both.

The route now checks its own configuration before sending and returns **503** naming the missing variable — the only place in the system that can actually see it.

### Verified
`tsc` clean, `eslint` clean, production build compiles. The behavioural proof is the live submit on `balizero.com/interview_natalie`, which is the point of the change and which follows the deploy.

### Scope
One file, one concern. Note that the 401 was being surfaced correctly to the candidate the whole time — the page keeps her answers and offers a retry rather than silently retiring the exercise (a cure from #5473's adversarial round). This PR is about making the *cause* legible to whoever reads the failure, not about the failure being silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kqcrJhDxpjSos6PgTgN18