### PR TITLE
fix(secondhome): give four resting controls a boundary that meets the 3:1 floor

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.test.tsx
@@ -134,6 +134,12 @@ describe("QuestionCard > OptionButton selection control", () => {
         /\.bz-shs-option\[data-selected="true"\]\s*\{([^}]*)\}/s,
       )?.[1] ?? "";
     expect(baseRule).toMatch(/border:\s*1px solid/);
+    // WCAG 2.2 SC 1.4.11 regression guard: the resting-state boundary must
+    // be --border-strong (3.64:1 on carta / 3.94:1 on white), never the
+    // decorative --color-border-subtle (1.21:1 / 1.31:1) — this is the
+    // OptionButton's only boundary at rest (transparent fill).
+    expect(baseRule).toMatch(/border:\s*1px solid var\(--border-strong\)/);
+    expect(baseRule).not.toMatch(/--color-border-subtle/);
     expect(selectedRule).not.toMatch(/(?:^|;)\s*border\s*:/);
     expect(selectedRule).not.toMatch(/border-width\s*:/);
     // Ink, not red: R4 §3/§4.5 gives red exactly two duties (structure and

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -200,9 +200,17 @@ export function QuestionCard({
          * actually take effect — an inline style attribute always beats a
          * stylesheet rule regardless of pseudo-class, so a hover rule
          * targeting a JS-computed inline border/background would silently
-         * never apply. */
+         * never apply.
+         * WCAG 2.2 SC 1.4.11 (2026-09-01): this is the sole resting-state
+         * boundary of every wizard option, and --color-border-subtle
+         * composites to 1.21:1 on carta / 1.31:1 on white — the hairline is
+         * decorative-only (merahPutihDayVars.ts's own comment says so) and
+         * never the sole identifier of an interactive component. RadioAffordance
+         * and CheckAffordance below already use --border-strong (3.64:1 on
+         * carta / 3.94:1 on white) for the same reason; this outer boundary
+         * now matches instead of undercutting them. */
         .bz-shs-option {
-          border: 1px solid var(--color-border-subtle);
+          border: 1px solid var(--border-strong);
           background: transparent;
           box-shadow: inset 0 0 0 0 transparent;
           transition:

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -9,6 +9,32 @@ const originalPrintDescriptor = Object.getOwnPropertyDescriptor(
   "print",
 );
 
+describe("SavePlanBar resting-state boundary (WCAG 2.2 SC 1.4.11)", () => {
+  // Regression guard (2026-09-01): Save/Copy-Link/Print share `buttonStyle`,
+  // whose border is their ONLY resting-state boundary (transparent fill).
+  // --color-border-subtle composites to 1.21:1 on carta / 1.31:1 on white —
+  // decorative-only per merahPutihDayVars.ts's own comment, and below the
+  // 3:1 non-text UI floor (WCAG 1.4.11). --border-strong (#7a8093) measures
+  // 3.64:1 on carta / 3.94:1 on white — the same token StudioApp.tsx's
+  // navButtonStyle already uses for its Back button boundary. The "Clear
+  // saved plan" button is deliberately excluded: it owns a separate
+  // treatment via CLEAR_BUTTON_STYLES, pinned by its own tests below.
+  it("gives Save, Copy-Link and Print an AA-clearing resting border, never the decorative hairline", () => {
+    render(<SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />);
+
+    for (const name of [
+      "Save on this device",
+      "Copy plan link",
+      "Print / Save as PDF",
+    ]) {
+      const button = screen.getByRole("button", { name });
+      const inlineStyle = button.getAttribute("style") ?? "";
+      expect(inlineStyle).toContain("border: 1px solid var(--border-strong)");
+      expect(inlineStyle).not.toContain("--color-border-subtle");
+    }
+  });
+});
+
 describe("SavePlanBar print action", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -294,7 +294,14 @@ const buttonStyle: React.CSSProperties = {
   // (var(--space-4, 1.5rem)), well clear of that section's own 12px
   // corner curve, so there's no tight-nesting mismatch to avoid.
   borderRadius: 12,
-  border: "1px solid var(--color-border-subtle)",
+  // WCAG 2.2 SC 1.4.11 (2026-09-01): this is the ONLY resting-state boundary
+  // for Save/Copy-Link/Print (transparent fill) — --color-border-subtle
+  // composited to 1.21:1 on carta / 1.31:1 on white, decorative-only per
+  // merahPutihDayVars.ts's own comment. --border-strong (#7a8093) measures
+  // 3.64:1 on carta / 3.94:1 on white, clearing the 3:1 non-text floor — the
+  // same token StudioApp.tsx's navButtonStyle already uses for its Back
+  // button boundary.
+  border: "1px solid var(--border-strong)",
   background: "transparent",
   color: "var(--text-primary)",
   cursor: "pointer",

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.test.tsx
@@ -48,9 +48,14 @@ describe("ScenarioToggle", () => {
     expect(inlineStyle).not.toMatch(
       /(?:^|;)\s*(?:border|background|color)\s*:/,
     );
-    expect(restingRule).toContain(
-      "border: 1px solid var(--color-border-subtle)",
-    );
+    // WCAG 2.2 SC 1.4.11 regression guard: this is the trigger's ONLY
+    // resting-state boundary (transparent fill) — --border-strong measures
+    // 3.64:1 on carta / 3.94:1 on white, clearing the 3:1 non-text floor.
+    // --color-border-subtle (1.21:1 / 1.31:1) is decorative-only per
+    // merahPutihDayVars.ts's own comment and must never be the sole
+    // identifier of this control.
+    expect(restingRule).toContain("border: 1px solid var(--border-strong)");
+    expect(restingRule).not.toContain("--color-border-subtle");
     expect(restingRule).toContain("color: var(--text-secondary)");
     expect(restingRule).not.toContain("--accent-funnel");
     // The hover label reads the FLAT accent token. It used to be

--- a/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ScenarioToggle.tsx
@@ -25,7 +25,7 @@ import { TimelineView } from "./TimelineView";
 import { VerdictPanel } from "./VerdictPanel";
 
 type RestingScenarioTriggerStyle = {
-  borderColor: "var(--color-border-subtle)";
+  borderColor: "var(--border-strong)";
   color: "var(--text-secondary)";
 };
 
@@ -33,8 +33,16 @@ type RestingScenarioTriggerStyle = {
 // points to it or focuses it, preserving the funnel accent for the price box.
 // These values belong to the class rule only; putting them on the element's
 // inline style would prevent the interaction selectors below from winning.
+//
+// WCAG 2.2 SC 1.4.11 (2026-09-01): borderColor used to read
+// --color-border-subtle, which composites to 1.21:1 on carta / 1.31:1 on
+// white — decorative-only per merahPutihDayVars.ts's own comment, and this
+// is the trigger's ONLY resting-state boundary (transparent fill). Now reads
+// --border-strong (#7a8093), 3.64:1 on carta / 3.94:1 on white — the same
+// token StudioApp.tsx's navButtonStyle and QuestionCard.tsx's affordance
+// rings already use for the identical reason.
 const restingScenarioTriggerStyle = {
-  borderColor: "var(--color-border-subtle)",
+  borderColor: "var(--border-strong)",
   color: "var(--text-secondary)",
 } satisfies RestingScenarioTriggerStyle;
 


### PR DESCRIPTION
WCAG 2.2 SC 1.4.11 sets a **3:1 floor** for the boundary that identifies an interactive component. Four controls in the second-home studio had a transparent fill and `--color-border-subtle` as their **only** resting-state boundary:

| Control | File | on carta | on white |
|---|---|---|---|
| `.bz-shs-option` (every wizard question) | `QuestionCard.tsx` | 1.21 → **3.64** | 1.31 → **3.94** |
| Trigger at rest | `ScenarioToggle.tsx` | 1.21 → **3.64** | 1.31 → **3.94** |
| Save / Copy-Link / Print | `SavePlanBar.tsx` | 1.21 → **3.64** | 1.31 → **3.94** |

### This is not a judgment call, and the remedy was not invented here

Three independent sources already prescribed it, and the fix copies the existing pattern rather than introducing a token or a value:

1. **R4 §4.6** — *"interactive boundaries use border-input (≥3:1); hairline is decoration."*
2. **`merahPutihDayVars.ts`'s own comment** — `--color-border-subtle` is *"DECORATIVE ONLY, never the sole identifier of an interactive component"*, and such controls *"must read `--border-strong`"*.
3. **The repo already did this** — `StudioApp.tsx`'s Back button and `QuestionCard.tsx`'s affordance rings use `--border-strong` with a comment describing the same reasoning. These four controls were simply never brought along.

Resting state only. Hover, focus, selected and disabled are untouched; selection stays ink and never red; no red-as-text is touched.

### A test was certifying the defect

`ScenarioToggle.test.tsx` contained `toContain("border: 1px solid var(--color-border-subtle)")` — the buggy value pinned as correct. The defect was not merely uncaught, it was **certified**, and any fix would have been failed by CI. That assertion is rewritten rather than supplemented, and every touched test now also asserts `not.toContain("--color-border-subtle")`.

### Bites

`apps/mouth` vitest — **32/32 green**, re-run independently of the author. Every new assertion was reverted to `--color-border-subtle` and observed red first, e.g. `expected '…border: 1px solid var(--color-b…' to contain 'border: 1px solid var(--border-strong)'`. Ratios computed with the WCAG relative-luminance formula, controls verified first (white/black 21.00, `#767676`/white 4.54).

`--border-strong` confirmed **defined** in the DAY bridge (`merahPutihDayVars.ts:82`, `#7a8093`) — an undefined custom property would make the declaration invalid and remove the border entirely, turning a 1.21:1 boundary into none at all. That was checked before shipping, not assumed. `tsc --noEmit` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)