### PR TITLE
fix(secondhome): move three sub-24px headings off Cormorant, per R4's own remedy

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -481,6 +481,24 @@ describe("StudioApp", () => {
       expect(masthead).toBeInTheDocument();
       expect(masthead.closest("h1,h2,h3,h4,h5,h6")).toBeNull();
     });
+
+    it("verdict stage: the demoted masthead label is Inter 600, not Cormorant, at its 1.05rem (16.8px) size — below the R4 §3 24px display floor", async () => {
+      window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /strong match/i });
+
+      const masthead = screen.getByText("Check your fit");
+      const styleAttr = masthead.getAttribute("style") ?? "";
+      const fontFamily = styleAttr.match(/font-family:\s*([^;]+)/)?.[1]?.trim();
+      const fontSize = styleAttr.match(/font-size:\s*([^;]+)/)?.[1]?.trim();
+      const fontWeight = styleAttr.match(/font-weight:\s*([^;]+)/)?.[1]?.trim();
+
+      expect(fontFamily).toBe(
+        "var(--font-sans, ui-sans-serif, system-ui, sans-serif)",
+      );
+      expect(fontSize).toBe("1.05rem");
+      expect(fontWeight).toBe("600");
+    });
   });
 
   describe("ScenarioToggle — saved-plan immutability", () => {

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -133,9 +133,14 @@ const mastheadHeadingStyle: React.CSSProperties = {
  *  sees it here. */
 const mastheadLabelStyle: React.CSSProperties = {
   margin: 0,
-  fontFamily: "var(--font-serif, Georgia, serif)",
+  // R4 §3 24px floor: at 1.05rem (16.8px) Cormorant would sit below the
+  // display-only floor — low-DPI Android antialiasing shreds the serif — so
+  // this demoted label uses the UI/body face at Inter 600 instead, per R4
+  // §3's own remedy ("smaller headings are Inter 600"). Size/hierarchy
+  // unchanged — only the face and weight move.
+  fontFamily: "var(--font-sans, ui-sans-serif, system-ui, sans-serif)",
   fontSize: "1.05rem",
-  fontWeight: 500,
+  fontWeight: 600,
   letterSpacing: "-0.01em",
   color: "var(--text-secondary, var(--color-text-muted))",
 };

--- a/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.test.tsx
@@ -140,6 +140,21 @@ describe("MemoPreview", () => {
     expect(spine).toBeInTheDocument();
   });
 
+  it("the 'Your plan so far' summary uses Inter 600, not Cormorant, at --text-sm (14px) — below the R4 §3 24px display floor", () => {
+    render(<MemoPreview plan={basePlan({ age: "under_55" })} />);
+    const summary = screen.getByText("Your plan so far");
+    const styleAttr = summary.getAttribute("style") ?? "";
+    const fontFamily = styleAttr.match(/font-family:\s*([^;]+)/)?.[1]?.trim();
+    const fontSize = styleAttr.match(/font-size:\s*([^;]+)/)?.[1]?.trim();
+    const fontWeight = styleAttr.match(/font-weight:\s*([^;]+)/)?.[1]?.trim();
+
+    expect(fontFamily).toBe(
+      "var(--font-sans, ui-sans-serif, system-ui, sans-serif)",
+    );
+    expect(fontSize).toBe("var(--text-sm, 0.9rem)");
+    expect(fontWeight).toBe("600");
+  });
+
   describe("desktop/mobile dual nature of the disclosure toggle", () => {
     it("makes the summary non-interactive and hides it from AT on desktop", () => {
       mockMatchMedia(true);

--- a/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.tsx
@@ -242,9 +242,15 @@ export function MemoPreview({ plan }: MemoPreviewProps) {
         aria-hidden={isDesktopStatic ? true : undefined}
         style={{
           cursor: "pointer",
-          fontFamily: "var(--font-serif, Georgia, serif)",
+          // R4 §3 24px floor: --text-sm resolves to 0.875rem (14px,
+          // packages/core/tokens/primitives.css) — well below the
+          // display-only floor either way (0.9rem fallback is 14.4px) — so
+          // this disclosure summary uses the UI/body face at Inter 600
+          // instead, per R4 §3's own remedy ("smaller headings are Inter
+          // 600"). Size/hierarchy unchanged — only the face and weight move.
+          fontFamily: "var(--font-sans, ui-sans-serif, system-ui, sans-serif)",
           fontSize: "var(--text-sm, 0.9rem)",
-          fontWeight: 500,
+          fontWeight: 600,
           color: "var(--text-primary)",
         }}
       >

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.test.tsx
@@ -119,6 +119,26 @@ describe("RouteComparator", () => {
     );
   });
 
+  it("route headings (table + mobile cards) use Inter 600, not Cormorant, at 1rem (16px) — below the R4 §3 24px display floor", () => {
+    const { container } = render(<RouteComparator />);
+    const css = container.querySelector("style")?.textContent ?? "";
+    const rule = css.match(/\.bz-shs-route-heading\s*{([^}]+)}/)?.[1] ?? "";
+    const fontFamily = rule.match(/font-family:\s*([^;]+);/)?.[1]?.trim();
+    const fontSize = rule.match(/font-size:\s*([^;]+);/)?.[1]?.trim();
+    const fontWeight = rule.match(/font-weight:\s*([^;]+);/)?.[1]?.trim();
+
+    expect(fontFamily).toBe(
+      "var(--font-sans, ui-sans-serif, system-ui, sans-serif)",
+    );
+    expect(fontSize).toBe("1rem");
+    expect(fontWeight).toBe("600");
+
+    // The class must actually be live on both the table th and the mobile
+    // card h3, not just declared in an unused stylesheet rule.
+    const headings = container.querySelectorAll(".bz-shs-route-heading");
+    expect(headings.length).toBeGreaterThanOrEqual(6); // 3 table + 3 cards
+  });
+
   it("keeps text AA and identity marks perceivable on every route tint", () => {
     const { container } = render(<RouteComparator />);
     const css = container.querySelector("style")?.textContent ?? "";

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
@@ -305,9 +305,15 @@ export function RouteComparator({ highlight = false }: RouteComparatorProps) {
           align-items: center;
           gap: var(--space-2, 0.5rem);
           min-width: 0;
-          font-family: var(--font-serif, Georgia, serif);
+          /* R4 §3 24px floor: at 1rem (16px) Cormorant would sit below the
+             display-only floor — low-DPI Android antialiasing shreds the
+             serif — so this heading (shared by the table th and the mobile
+             card h3) uses the UI/body face at Inter 600 instead, per R4 §3's
+             own remedy ("smaller headings are Inter 600"). Size/hierarchy
+             unchanged — only the face and weight move. */
+          font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
           font-size: 1rem;
-          font-weight: 700;
+          font-weight: 600;
           line-height: 1.25;
         }
 


### PR DESCRIPTION
R4 §3's typography table: Cormorant Garamond is h1/h2 only, **minimum 24px** — *"below that, low-DPI Android antialiasing shreds the serif (panel), so smaller headings are **Inter 600**."*

The rule states its own remedy. This applies that remedy rather than inventing one — and in particular it does **not** enlarge the type: these are small labels by design, and 24px would break the layouts they sit in.

| Site | Before | After |
|---|---|---|
| `StudioApp.tsx` `mastheadLabelStyle` (verdict-stage masthead) | Cormorant · `1.05rem` = **16.8px** | Inter 600, size unchanged |
| `RouteComparator.tsx` `.bz-shs-route-heading` | Cormorant 700 · `1rem` = **16px** | Inter 600, size unchanged |
| `MemoPreview.tsx` "Your plan so far" summary | Cormorant 500 · `--text-sm` → `0.875rem` = **14px** | Inter 600, size unchanged |

`.bz-shs-route-heading` was verified **live in both** the table header and the mobile card view — not dead CSS — and the new test asserts it renders ≥6 times so it cannot regress to dead CSS unnoticed.

### What was deliberately left alone

- Everywhere else the floor is already enforced (14+ sites clamp to ≥1.5rem, several with an explicit *"R4 §3: never below 24px"* comment). These three were the exceptions, not the rule.
- `ReadinessChecklist.tsx`'s `h2` sits **exactly on** 24px (`clamp(1.5rem, 3vw, 1.75rem)`). On the line is compliant; it is not touched.
- **No colour changes, and red-as-text specifically.** An audit initially flagged `--accent-funnel-text`-as-text at 9 sites as a contrast-law violation; that verdict was **retracted** — R4 §4.1 explicitly permits *"the logo-red family (5.11-6.24 across its cells)"* as text on carta/white, and those sites measure 4.76-5.52, inside the allowed band. The forbidden "bright reds" are the 3.20-3.66 family, which is retired and absent from this code.

Weight moves to 600 at all three sites per the spec's wording, which changes RouteComparator's heading from 700 and MemoPreview's summary from 500.

### Bites

`apps/mouth` vitest — **51/51 green** (48 pre-existing + 3 new), re-run independently of the author. Each new assertion was reverted to the small-size serif and observed red first: `expected 'var(--font-serif, Georgia, serif)' to be 'var(--font-sans, …'`. `tsc --noEmit` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)