### PR TITLE
fix(secondhome): make the WhatsApp exit the card-with-icon component R4 specifies

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -720,21 +720,35 @@ export function SecondHomeLanding() {
             gap: 8,
             padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
             borderRadius: 12,
-            // WCAG AA fix (measured 2026-08-24): `--text-on-accent` resolves
-            // to #fff here, which on the WhatsApp green computes to ~1.98:1,
-            // failing the 4.5:1 normal-text floor. Ratified cure
-            // (app/(visa-oracle)/visa-oracle/oracle.css:23-30, 2026-07-17
-            // adversarial review): #0d3a1f on #25D366 ~6.45:1. Only this
-            // call site's ink changes — the shared token and the brand
-            // green stay untouched.
-            background: "var(--accent-whatsapp, #25D366)",
-            color: "#0d3a1f",
+            // R4 identity spec (research/design/2026-08-27-r4-identity-
+            // merah-putih-token-spec.md §3/§4): WhatsApp is the ICON of the
+            // human exit, never a text surface — not even at a passing
+            // ratio. The 2026-08-24 fix below answered a different
+            // question ("what ink passes AA on a green button?") and its
+            // #0d3a1f-on-#25D366 ~6.45:1 does pass, but the spec names
+            // ink-on-green explicitly and rejects it anyway: it breaks the
+            // platform's mental model (a solid-green pill reads as the
+            // WhatsApp app icon). The cure that survives is the SHAPE —
+            // elevated card, border-input boundary, green confined to the
+            // icon, ink label — which is the card-with-icon component the
+            // spec's token table names. Green-on-surface-raised now
+            // measures ~1.98:1, which is EXPECTED and spec-sanctioned
+            // ("icon-only"): the adjacent text label carries the meaning
+            // independently, so WCAG 1.4.11's "graphical object required
+            // to understand content" does not apply to this icon.
+            background: "var(--surface-raised)",
+            border: "1px solid var(--border-strong)",
+            color: "var(--text-primary)",
             fontWeight: 600,
             textDecoration: "none",
             minHeight: 44,
           }}
         >
-          <Phone size={18} aria-hidden />
+          <Phone
+            size={18}
+            aria-hidden
+            color="var(--accent-whatsapp, #25d366)"
+          />
           {t("secondHome.cta.button")}
         </WhatsAppLeadButton>
       </section>

--- a/apps/mouth/src/app/visa/second-home/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.test.tsx
@@ -189,25 +189,49 @@ describe("SecondHomeLanding", () => {
     expect(screen.queryByRole("button", { name: /apply/i })).toBeNull();
   });
 
-  // WCAG AA contrast guard (measured 2026-08-24): white text on the
-  // WhatsApp brand green (`#25D366`) computes to ~1.98:1, badly failing the
-  // 4.5:1 normal-text floor. Ratified cure
-  // (app/(visa-oracle)/visa-oracle/oracle.css:23-30, 2026-07-17 adversarial
-  // review): `#0d3a1f` on `#25D366` ~6.45:1. jsdom resolves neither
-  // `color-mix()` nor custom properties, so this asserts on the literal
-  // inline style value rather than a computed color (confirmed live via
-  // Playwright render — see the shipping commit for the measured
-  // rgb()/contrast numbers).
-  it("keeps the WhatsApp CTA's ink dark enough on the brand green (WCAG AA)", () => {
+  // R4 identity spec guard (research/design/2026-08-27-r4-identity-merah-
+  // putih-token-spec.md §3/§4, cure landed 2026-09-01): WhatsApp is the
+  // ICON of the human exit, never a text surface — not even at a passing
+  // ratio. The 2026-08-24 ink-on-green fix below (`#0d3a1f` on `#25D366`
+  // ~6.45:1, ratified app/(visa-oracle)/visa-oracle/oracle.css:23-30)
+  // answered a different question ("what ink passes AA on a green
+  // button?") and the spec rejects a green button outright, on
+  // mental-model grounds. The CTA is now the card-with-icon component:
+  // elevated surface (`--surface-raised`), `--border-strong` boundary, ink
+  // label (`--text-primary`), with the brand green confined to the Phone
+  // glyph alone. jsdom resolves neither `color-mix()` nor custom
+  // properties, so this asserts on the literal inline style / SVG
+  // attribute value rather than a computed color (confirmed empirically
+  // against this jsdom version: a plain `var(...)` reference with no
+  // jsdom-resolvable fallback color is kept as the literal string, unlike
+  // a bare hex which jsdom's CSSOM normalizes to `rgb()` form — see the
+  // old green-pill assertions this test replaces).
+  it("renders the card-with-icon shape: elevated surface, border-strong boundary, ink label", () => {
     renderLanding();
 
     const cta = screen.getByRole("link", { name: /free fit memo/i });
-    // Brand green stays byte-identical — only the ink moves. (jsdom's CSSOM
-    // normalizes the literal hex it parses to rgb() form; the var()
-    // fallback expression is left as-is since it isn't a plain color.)
-    expect(cta.style.background).toBe("var(--accent-whatsapp, #25D366)");
-    expect(cta.style.color).toBe("rgb(13, 58, 31)"); // #0d3a1f
+    expect(cta.style.background).toBe("var(--surface-raised)");
+    expect(cta.style.border).toBe("1px solid var(--border-strong)");
+    expect(cta.style.color).toBe("var(--text-primary)");
     expect(cta.style.color).not.toBe("var(--text-on-accent)");
+  });
+
+  it("confines the WhatsApp green to the icon — never a background or label color", () => {
+    renderLanding();
+
+    const cta = screen.getByRole("link", { name: /free fit memo/i });
+    const icon = cta.querySelector("svg");
+
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("stroke")).toBe(
+      "var(--accent-whatsapp, #25d366)",
+    );
+
+    // Guard against a regression back to the green pill: neither the
+    // link's background nor its label color may carry the brand green.
+    const green = /25d366/i;
+    expect(cta.style.background).not.toMatch(green);
+    expect(cta.style.color).not.toMatch(green);
   });
 
   it("never states a forbidden claim", () => {

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.test.tsx
@@ -6,17 +6,24 @@ import type { Verdict } from "@/lib/secondhome-studio/types";
 import { WhatsAppHandoff } from "./WhatsAppHandoff";
 
 /**
- * WCAG AA contrast guard (measured 2026-08-24): white text on the WhatsApp
- * brand green (`#25D366`) computes to ~1.98:1, badly failing the 4.5:1
- * normal-text floor. Ratified cure (app/(visa-oracle)/visa-oracle/oracle.css
- * :23-30, 2026-07-17 adversarial review): `#0d3a1f` on `#25D366` ~6.45:1.
+ * R4 identity spec guard (research/design/2026-08-27-r4-identity-merah-
+ * putih-token-spec.md §3/§4, cure landed 2026-09-01): WhatsApp is the ICON
+ * of the human exit, never a text surface — not even at a passing ratio.
+ * The 2026-08-24 ink-on-green fix (`#0d3a1f` on `#25D366` ~6.45:1, ratified
+ * app/(visa-oracle)/visa-oracle/oracle.css:23-30) answered a different
+ * question ("what ink passes AA on a green button?") and the spec rejects
+ * a green button outright, on mental-model grounds. The button is now the
+ * card-with-icon component: elevated surface (`--surface-raised`),
+ * `--border-strong` boundary, ink label (`--text-primary`), with the brand
+ * green confined to the Phone glyph alone.
  *
  * jsdom resolves neither `color-mix()` nor custom properties, so this
- * asserts on the literal inline style value the component sets rather than
- * a computed color (jsdom's CSSOM normalizes a literal hex it parses to
- * `rgb()` form, hence the expected values below — confirmed live via
- * Playwright render, see the shipping commit for the measured
- * rgb()/contrast numbers).
+ * asserts on the literal inline style / SVG attribute value the component
+ * sets rather than a computed color — a plain `var(...)` reference (no
+ * fallback color jsdom's parser can resolve) is kept as the literal string,
+ * confirmed empirically against this jsdom version before writing these
+ * assertions (unlike a bare hex, which jsdom's CSSOM normalizes to `rgb()`
+ * form — see the old green-pill assertions this test replaces).
  */
 describe("WhatsAppHandoff", () => {
   const verdict: Verdict = {
@@ -26,14 +33,31 @@ describe("WhatsAppHandoff", () => {
     humanReviewNote: null,
   };
 
-  it("keeps the WhatsApp button's ink dark enough on the brand green (WCAG AA)", () => {
+  it("renders the card-with-icon shape: elevated surface, border-strong boundary, ink label", () => {
     render(<WhatsAppHandoff plan={emptyPlan()} verdict={verdict} />);
 
     const cta = screen.getByRole("link", { name: /ask us to review my plan/i });
 
-    // Brand green stays byte-identical — only the ink moves.
-    expect(cta.style.background).toBe("rgb(37, 211, 102)"); // #25D366
-    expect(cta.style.color).toBe("rgb(13, 58, 31)"); // #0d3a1f
-    expect(cta.style.color).not.toBe("rgb(255, 255, 255)"); // was #fff
+    expect(cta.style.background).toBe("var(--surface-raised)");
+    expect(cta.style.border).toBe("1px solid var(--border-strong)");
+    expect(cta.style.color).toBe("var(--text-primary)");
+  });
+
+  it("confines the WhatsApp green to the icon — never a background or label color", () => {
+    render(<WhatsAppHandoff plan={emptyPlan()} verdict={verdict} />);
+
+    const cta = screen.getByRole("link", { name: /ask us to review my plan/i });
+    const icon = cta.querySelector("svg");
+
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("stroke")).toBe(
+      "var(--accent-whatsapp, #25d366)",
+    );
+
+    // Guard against a regression back to the green pill: neither the link's
+    // background nor its label color may carry the brand green again.
+    const green = /25d366/i;
+    expect(cta.style.background).not.toMatch(green);
+    expect(cta.style.color).not.toMatch(green);
   });
 });

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
@@ -69,19 +69,33 @@ export function WhatsAppHandoff({ plan, verdict }: WhatsAppHandoffProps) {
           gap: 8,
           padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
           borderRadius: 12,
-          // WCAG AA fix (measured 2026-08-24): white on the WhatsApp brand
-          // green computes to ~1.98:1, failing the 4.5:1 normal-text floor.
-          // Ratified cure (app/(visa-oracle)/visa-oracle/oracle.css:23-30,
-          // 2026-07-17 adversarial review): #0d3a1f on #25D366 ~6.45:1. The
-          // brand green stays untouched — only the ink moves.
-          background: "#25D366",
-          color: "#0d3a1f",
+          // R4 identity spec (research/design/2026-08-27-r4-identity-
+          // merah-putih-token-spec.md §3/§4): WhatsApp is the ICON of the
+          // human exit, never a text surface — not even at a passing
+          // ratio. The 2026-08-24 fix below answered a different question
+          // ("what ink passes AA on a green button?") and its
+          // #0d3a1f-on-#25D366 ~6.45:1 does pass, but the spec names
+          // ink-on-green explicitly and rejects it anyway: it breaks the
+          // platform's mental model (a solid-green pill reads as the
+          // WhatsApp app icon). The cure that survives is the SHAPE —
+          // elevated card, border-input boundary, green confined to the
+          // icon, ink label — which is the card-with-icon component the
+          // spec's token table names (this call site's card already had
+          // the outer <section>; this is the button ITSELF adopting the
+          // same pattern). Green-on-surface-raised now measures ~1.98:1,
+          // which is EXPECTED and spec-sanctioned ("icon-only"): the
+          // adjacent text label carries the meaning independently, so
+          // WCAG 1.4.11's "graphical object required to understand
+          // content" does not apply to this icon.
+          background: "var(--surface-raised)",
+          border: "1px solid var(--border-strong)",
+          color: "var(--text-primary)",
           fontWeight: 600,
           textDecoration: "none",
           minHeight: 44,
         }}
       >
-        <Phone size={18} aria-hidden />
+        <Phone size={18} aria-hidden color="var(--accent-whatsapp, #25d366)" />
         {getCopy("whatsapp.button")}
       </WhatsAppLeadButton>
       <p

--- a/apps/mouth/src/lib/theme/merahPutihDayVars.ts
+++ b/apps/mouth/src/lib/theme/merahPutihDayVars.ts
@@ -151,8 +151,20 @@ export const MERAH_PUTIH_DAY_VARS = {
   "--state-error": "#a83a44",
   "--color-error": "#a83a44",
 
-  // WhatsApp is the ICON of the human exit — never a green button with white
-  // text on it (white on #25d366 measures 1.98). The ink is what carries text.
+  // WhatsApp is the ICON of the human exit — never a green button, and
+  // never a green TEXT surface even at a passing ratio (R4 §3/§4: the
+  // 2026-08-24 ink-on-green cure measured AA-passing at ~6.45:1 and was
+  // superseded anyway, because it answered "what ink passes on a green
+  // button" when the real defect was the button SHAPE — a solid-green pill
+  // reads as the WhatsApp app icon, breaking the platform's mental model).
+  // The call sites (SecondHomeLanding.tsx, WhatsAppHandoff.tsx) now render
+  // the card-with-icon component instead: elevated surface + border-input
+  // boundary + ink label, with `--accent-whatsapp` confined to the Phone
+  // glyph alone (icon-only, ~1.98:1 on `--surface-raised` — spec-sanctioned
+  // because the adjacent ink label carries the meaning independently).
+  // `--accent-whatsapp-ink` is kept as a token — some other surface may
+  // still legitimately need ink-on-green — but no consumer in this lane's
+  // perimeter uses it for label text any more.
   "--accent-whatsapp": "#25d366",
   "--accent-whatsapp-ink": "#0d3a1f",
 


### PR DESCRIPTION
R4's token table does not merely forbid a green button — it **names the component that replaces it**:

> `| whatsapp | #25d366 | the ICON of the human exit — never a text surface (white on it 1.98; and **ink-on-green, though it measures 8.07, breaks the platform's mental model**). **The WhatsApp component is: elevated card, border-input, official green icon, ink label.** | icon-only |`

### Why this is not a contrast fix

Both second-home call sites shipped a solid green pill — and that was **not an oversight**. It carried a deliberate 2026-08-24 cure (`#0d3a1f` on `#25D366`, ~6.45:1) citing the ratified `oracle.css` precedent of 2026-07-17, which correctly answered *"what ink passes AA on a green button?"*.

The spec had already answered a different question. It names ink-on-green **explicitly and rejects it anyway**, despite the passing ratio, because a solid-green pill reads as the WhatsApp app icon. The defect was the **shape**, and no ratio was ever going to cure it.

| Part | Before | After | Ratio on the card |
|---|---|---|---|
| Surface | `#25D366` fill | `var(--surface-raised)` | — |
| Boundary | none | `1px solid var(--border-strong)` | **3.94** |
| Label | `#0d3a1f` on green | `var(--text-primary)` | **16.00** |
| Green | the whole button | the `<Phone>` glyph only | 1.98 — *declared, see below* |

### What was deliberately not touched

- **The shared `WhatsAppLeadButton`** — a pass-through `<a>` used by funnels outside this perimeter. The entire change lives in what these two callers hand it.
- **`WhatsAppHandoff`'s outer card border** — a container, not an interactive control, so the decorative token is correct there. A sibling PR owns the real interactive cases; this one does not collide with it.
- **Red-as-text** — R4 §4.1 explicitly permits *"the logo-red family (5.11-6.24 across its cells)"* as text on carta/white.

### The 1.98 is declared, not hidden

The green icon measures ~1.98:1 on the card. The spec sanctions it as `icon-only`, and the adjacent ink label carries the meaning independently, so WCAG 1.4.11's *"graphical object required to understand content"* does not reach it. Both call sites say so in a comment — otherwise the next reader finds an unexplained 1.98 and "fixes" it.

The superseded 2026-08-24 reasoning is **kept** in the comments rather than deleted, so nobody concludes ink-on-green was careless. It was a considered fix to a neighbouring question.

### Commercial visibility

This is the one change in this conformance pass with a visible commercial effect: a filled green CTA becomes an outlined card on a lead-capture surface. **Approved by the owner on 2026-09-01 before implementation.**

### Bites

`apps/mouth` vitest — `second-home/page.test.tsx` + `WhatsAppHandoff.test.tsx`, **13/13 green**, re-run independently of the author. Assertions pin all four parts plus the icon's stroke, with regression guards that the green never returns as a background or label colour; each was mutation-proven against the restored green pill. Ratios computed with the WCAG formula, controls first (white/black 21.00, `#767676`/white 4.54). Verified after the change that no `#25D366`/`#0d3a1f` survives in the perimeter outside comments and the two icon props. `tsc --noEmit` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)