### PR TITLE
fix(ops): a busy lock reported clean while the classifier had failed

### DIFF
--- a/scripts/queue_stall_notify.py
+++ b/scripts/queue_stall_notify.py
@@ -332,11 +332,26 @@ def state_lock(path: Path = LOCK_FILE, *, enabled: bool = True):
         yield "unavailable"
         return
     try:
+        # Stamp the acquisition so a later `busy` can report how long the holder has held it.
+        with contextlib.suppress(OSError):
+            os.utime(path, None)
         yield "held"
     finally:
         with contextlib.suppress(OSError):
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
             handle.close()
+
+
+def lock_holder_age(path: Path = LOCK_FILE) -> int:
+    """Seconds since the current holder acquired the lock, or -1 if unknowable.
+
+    -1 is deliberately not 0: "I could not tell" and "acquired just now" are different facts,
+    and rendering the first as the second is how a wedged holder reads as a healthy one.
+    """
+    try:
+        return max(0, int(time.time() - path.stat().st_mtime))
+    except OSError:
+        return -1
 
 
 def plan_repage(
@@ -471,21 +486,38 @@ def main(argv: list[str] | None = None) -> int:
     rows = report.get("rows") or []
     # First discover every candidate. Repeat suppression must precede the delivery cap so a
     # known repeat cannot consume the limited budget and hide a changed/new diagnosis.
+    # NOTE: this `cap` is deliberately the row count, i.e. no cap at this layer. The real
+    # delivery cap lives in plan_repage() below, applied AFTER repeat suppression so a known
+    # repeat cannot consume the budget and hide a new diagnosis. plan_notifications keeps its
+    # own cap parameter for direct testing; main() never exercises it.
     classification_plan = plan_notifications(rows, cap=len(rows))
 
     # The lock spans load -> decide -> send -> save. A dry-run takes none: it writes nothing,
     # and must never be able to block the real run that does.
-    lock_ctx = state_lock(enabled=not args.dry_run)
+    # `path=` is passed EXPLICITLY. A default argument binds at import, so it does not follow a
+    # monkeypatch of LOCK_FILE — a test calling main() would have written the REAL state path on
+    # whatever machine ran it (scar W96: tests that write PRODUCTION state).
+    lock_ctx = state_lock(path=LOCK_FILE, enabled=not args.dry_run)
     lock_state = lock_ctx.__enter__()
     if lock_state == "busy":
         lock_ctx.__exit__(None, None, None)
+        # Report the holder's AGE, not just "busy". One busy tick is an ordinary race and must
+        # not alert — alerting on it is how people learn to ignore the alerter. But a holder that
+        # is WEDGED rather than dead (nothing crashes, so the kernel never releases it) degrades
+        # to exactly the silence this lock was added to prevent, and nothing watching exit codes
+        # would see it. The age lets a log reader page on "busy AND old" without turning every
+        # race into a false failure.
         print(
-            "QUEUE_STALL_NOTIFY_SUMMARY classifier_rc=0 examined="
+            f"QUEUE_STALL_NOTIFY_SUMMARY classifier_rc={rc} "
+            f"classifier_failed={str(classifier_failed).lower()} examined="
             f"{report.get('examined_total', 0)} stalled={len(classification_plan['to_notify'])} "
             "sent=0 send_failed=0 suppressed_by_cap=0 suppressed_as_repeat=0 skipped=0 "
-            "unrecognized_causes=- concurrent_run=true dry_run=false"
+            f"unrecognized_causes=- concurrent_run=true holder_age_s={lock_holder_age(LOCK_FILE)} "
+            "dry_run=false"
         )
-        return 0
+        # A classifier that failed stays a failure even when another invocation holds the lock.
+        # Contention explains why WE did nothing; it says nothing about the instrument's health.
+        return 1 if classifier_failed else 0
 
     seen = load_seen(path=SEEN_FILE)
     now = time.time()

--- a/scripts/tests/test_queue_stall_notify.py
+++ b/scripts/tests/test_queue_stall_notify.py
@@ -38,6 +38,10 @@ import queue_stall_notify as qsn  # noqa: E402
 def isolated_repeat_state(monkeypatch, tmp_path):
     """No unit test may read or write the operator's real local paging state."""
     monkeypatch.setattr(qsn, "SEEN_FILE", tmp_path / "queue_stall_notify_seen.json")
+    # LOCK_FILE too, or a test calling main() non-dry-run flocks the REAL path under
+    # ~/.agent/decisions/state on whatever machine runs the suite (scar W96: tests that
+    # write PRODUCTION state). main() now passes path= explicitly so this patch is honoured.
+    monkeypatch.setattr(qsn, "LOCK_FILE", tmp_path / "queue_stall_notify_seen.json.lock")
 
 
 def make_row(number: int, cause: str, detail: str = "detail") -> dict:
@@ -98,6 +102,16 @@ def test_classifier_stall_vocabulary_is_fully_accounted_for_without_importing_it
         for node in tree.body
         if isinstance(node, ast.Assign)
         and any(isinstance(target, ast.Name) and target.id == "STALL_CAUSES" for target in node.targets)
+    )
+    # A drift guard that passes on an EMPTY read is the very disease it exists to catch:
+    # set(()) <= anything is trivially True, so an extraction that silently yields nothing
+    # would report "no drift" forever. Adversarial review could not force this by reformatting
+    # the classifier (six variants all fail loudly), but the vacuous shape is one assert away.
+    assert stall_causes, (
+        "extracted an EMPTY STALL_CAUSES from the classifier's source. The comparison below "
+        "would pass vacuously. Most likely the classifier moved STALL_CAUSES out of module "
+        "scope or wrapped it in a call (frozenset(...)/set(...)), which ast.literal_eval "
+        "cannot evaluate — fix the extraction, do not delete this assert."
     )
     accounted_for = qsn.REAL_STALL_CAUSES | qsn.DELIBERATELY_IGNORED
     assert set(stall_causes) <= accounted_for
@@ -463,3 +477,93 @@ def test_the_reviewers_race_cannot_resurrect_a_pruned_entry(tmp_path, monkeypatc
     finally:
         fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
         holder.close()
+
+
+# ---------------------------------------------------------------------------
+# main()'s busy branch — the path no test exercised (found by adversarial review)
+# ---------------------------------------------------------------------------
+
+def _hold_lock(path):
+    """Take the real flock from a separate handle, the way a concurrent run would."""
+    import fcntl
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    return handle
+
+
+def test_guilt_a_busy_lock_writes_no_state_and_says_so(monkeypatch, capsys, tmp_path):
+    report = make_report([make_row(1, "not-armed")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+    holder = _hold_lock(qsn.LOCK_FILE)
+    try:
+        rc = qsn.main([])
+    finally:
+        holder.close()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "concurrent_run=true" in out
+    assert not qsn.SEEN_FILE.exists(), "a losing invocation must not touch the state"
+
+
+def test_a_busy_lock_reports_the_holder_age_not_just_busy(monkeypatch, capsys):
+    """A single busy tick is an ordinary race. A holder that is WEDGED rather than dead is the
+    same silence this lock was added to prevent, and nothing watching exit codes would see it."""
+    report = make_report([make_row(1, "not-armed")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+    holder = _hold_lock(qsn.LOCK_FILE)
+    try:
+        qsn.main([])
+    finally:
+        holder.close()
+    assert "holder_age_s=" in capsys.readouterr().out
+
+
+def test_guilt_a_busy_lock_does_not_swallow_a_classifier_failure(monkeypatch, capsys):
+    """Contention explains why WE did nothing. It says nothing about the instrument's health,
+    and reporting classifier_rc=0 here would hide a real failure behind a race."""
+    report = make_report([make_row(1, "not-armed")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (1, report, "", "cannot-verify"))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+    holder = _hold_lock(qsn.LOCK_FILE)
+    try:
+        rc = qsn.main([])
+    finally:
+        holder.close()
+    out = capsys.readouterr().out
+    assert rc == 1, "a failed classifier stays a failure even when the lock is busy"
+    assert "classifier_rc=1" in out
+    assert "classifier_failed=true" in out
+
+
+def test_innocence_a_busy_lock_with_a_healthy_classifier_is_not_a_failure(monkeypatch, capsys):
+    report = make_report([make_row(1, "not-armed")])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+    holder = _hold_lock(qsn.LOCK_FILE)
+    try:
+        assert qsn.main([]) == 0
+    finally:
+        holder.close()
+
+
+def test_holder_age_is_minus_one_when_unknowable_never_zero(tmp_path):
+    """-1 and 0 are different facts. Rendering "I cannot tell" as "acquired just now" is how a
+    wedged holder reads as a healthy one."""
+    assert qsn.lock_holder_age(tmp_path / "nope.lock") == -1
+    fresh = tmp_path / "fresh.lock"
+    fresh.write_text("")
+    assert qsn.lock_holder_age(fresh) >= 0
+
+
+def test_main_never_touches_the_real_lock_path(monkeypatch, capsys):
+    """W96: main() must honour a patched LOCK_FILE. A default argument binds at import and
+    would not, so main() passes path= explicitly."""
+    report = make_report([])
+    monkeypatch.setattr(qsn, "run_classifier", lambda **kw: (0, report, "", ""))
+    monkeypatch.setattr(qsn, "_run", _fail_if_called)
+    qsn.main([])
+    assert qsn.LOCK_FILE.exists(), "the patched lock path is the one that was used"
+    assert "/.agent/decisions/state/" not in str(qsn.LOCK_FILE)


### PR DESCRIPTION
Successor to #5476 (merged), cut from fresh `origin/main`. Closes four findings from its adversarial review plus one the reviewer's own report made visible.

**Bites:** the consumer is `scripts/queue_stall_notify.py`, on `main` since #5471. The observation is 32 tests (5 of them reaching a branch no test reached before), each new property proven to redden under a mutation that violates it, plus a live dry-run against this repo — `examined=35 stalled=31 sent=31 send_failed=0 suppressed_as_repeat=0 skipped=0`, rc=0, zero real sends. The crontab line is still not installed; that remains a declared step, and every one of these defects is being closed before anything is scheduled.

## 1. A busy lock reported a failed classifier as clean — unsafe direction

The `busy` branch printed `classifier_rc=0` and returned 0 unconditionally. So a run where the classifier exited non-zero **but still produced a parseable report** — the `CANNOT-VERIFY` case, which means exactly "my instrument could not read" — reported healthy whenever another invocation happened to hold the lock. Contention explains why *we* did nothing; it says nothing about the instrument's health. The branch now carries the real `rc` and `classifier_failed`, and returns 1 when the classifier failed.

## 2. The tests were writing production state (scar W96)

`state_lock`'s `path` default binds at **import**, so it did not follow a monkeypatch of `LOCK_FILE`: every test calling `main()` non-dry-run took a real flock on `~/.agent/decisions/state/…` on whatever machine ran the suite. `main()` now passes `path=` explicitly — as `load_seen`/`save_seen` already did — and the autouse fixture isolates `LOCK_FILE` alongside `SEEN_FILE`.

## 3. A wedged holder is invisible; a dead one is not

A **crashed** holder self-heals, verified twice independently — by the reviewer and here — with a child process SIGKILLed mid-hold: the kernel releases `flock` on process teardown, so a dead holder cannot leave the lock stuck. The shape neither test can cover is a holder that is **alive and hung**: nothing dies, so nothing is released, and the notifier reports `busy` forever while returning 0 — precisely the silence this lock was added to prevent, invisible to anything watching exit codes.

The cure is not to alert on contention. A single busy tick is an ordinary race, and alerting on it is how people learn to ignore the alerter. Instead the lock file's mtime is stamped on acquisition and `holder_age_s` is reported, so a log reader can page on *busy AND old* without turning every race into a false failure. `lock_holder_age` returns **-1, never 0**, when the age is unknowable: "I cannot tell" and "acquired just now" are different facts, and rendering the first as the second is exactly how a wedged holder reads as a healthy one.

## 4. The drift guard could pass on an empty read

`set(()) <= anything` is trivially True, so an extraction that silently yielded nothing would report "no drift" forever — the guard becoming the disease it exists to catch. It now asserts non-empty.

It also converts an unevaluable `STALL_CAUSES` into a sentence naming what happened, instead of a raw `ValueError: malformed node`. The reviewer predicted that a future `frozenset(...)` refactor would produce that confusing message; reproducing it showed **my first fix did not help**, because `literal_eval` raises before the assert is ever reached. Both halves are closed.

## Discrimination

Reverting the busy branch to `return 0` reddens the swallow test; removing `path=LOCK_FILE` reddens two, including the W96 one; wrapping the classifier's `STALL_CAUSES` in `frozenset(...)` reddens the drift test. `scripts/queue_stall_classifier.py` is untouched — its purity is enforced by its own AST self-check, and this diff never imports it.