### PR TITLE
feat(kbli): add --pma-only to kbli_documents_cure — sync the PMA tuple without touching prose

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -1306,12 +1306,16 @@ async def main() -> int | None:
                     # Server-side merge of the tuple ONLY: `||` overwrites the 7
                     # bound keys (a JSON null value still overwrites, it does not
                     # delete) and leaves every other key exactly as stored.
-                    # coalesce(): `NULL || x` is NULL, which would make a row
-                    # with an empty metadata column a silent no-op.
+                    # The CASE guards the LEFT operand: `NULL || x` is NULL (a
+                    # silent no-op on an empty column), and a JSON scalar or
+                    # array on the left — `'null'::jsonb || {..}` — does not
+                    # merge, it BUILDS AN ARRAY, so the next run would not be
+                    # idempotent. `coalesce` alone only covers the SQL NULL.
                     assert plan.new_metadata is not None
                     await conn.execute(
                         "UPDATE kbli_documents "
-                        "SET metadata = coalesce(metadata, '{}'::jsonb) || $2::text::jsonb, "
+                        "SET metadata = (CASE WHEN jsonb_typeof(metadata) = 'object' "
+                        "THEN metadata ELSE '{}'::jsonb END) || $2::text::jsonb, "
                         "updated_at = now() WHERE kode_kbli = $1",
                         code,
                         json.dumps(pma_metadata_patch(plan.new_metadata), ensure_ascii=False),

--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -318,6 +318,34 @@ PMA_METADATA_KEYS: tuple[str, ...] = (
     "pma_cap_verified",
 )
 
+_ABSENT = object()  # a key that is not there is not the same as a key holding null
+
+
+def _json_differs(a: object, b: object) -> bool:
+    """Type-strict inequality for JSON-shaped values.
+
+    Python's `==` says `False == 0` and `1 == True`; jsonb does not, and
+    neither does the channel (`_public_pma_cap` demands a real bool before it
+    publishes a cap). Comparing the serialised forms makes `false`/`0` and
+    `80`/`80.0` differ exactly the way the store and the reader see them, so
+    a bool-coerced tuple is reported stale instead of "already cured".
+    """
+    return json.dumps(a, sort_keys=True, ensure_ascii=False) != json.dumps(
+        b, sort_keys=True, ensure_ascii=False
+    )
+
+
+def pma_metadata_patch(new_metadata: dict) -> dict:
+    """Pure. The ONLY keys a `--pma-only` apply binds to its UPDATE.
+
+    The write is a server-side merge (`metadata || $2::jsonb`), never a
+    replacement of the whole column: the row's other keys are not
+    round-tripped through Python (no float re-encoding of a value we did not
+    plan to touch) and a write landing on some other key between our SELECT
+    and our UPDATE is not clobbered.
+    """
+    return {key: new_metadata[key] for key in PMA_METADATA_KEYS}
+
 
 def quarantined_codes(dataset: list[dict]) -> list[str]:
     """Codes whose canonical record carries ANY `per_skala_disputed_*` key —
@@ -845,7 +873,10 @@ def plan_pma_only(code: str, record: dict | None, current_row: dict | None) -> D
     new_metadata = dict(old_metadata)
     for key in PMA_METADATA_KEYS:
         new_metadata[key] = pma[key]
-    update_row = new_metadata != old_metadata
+    # Type-strict on purpose: a row holding `pma_cap_verified: 1` or
+    # `pma_max_asing: false` reads as unverified at the surface, so it is
+    # stale even though Python's `==` would call it equal to `True` / `0`.
+    update_row = _json_differs(new_metadata, old_metadata)
     return DocumentCurePlan(
         code=code,
         found_in_canonical=True,
@@ -865,10 +896,19 @@ def pma_tuple_delta(old_metadata: dict | None, new_metadata: dict | None) -> str
     the run report must say WHAT moved, not just that a row was touched."""
     old = old_metadata or {}
     new = new_metadata or {}
+
+    def _moved(o: object, n: object) -> bool:
+        if (o is _ABSENT) or (n is _ABSENT):
+            return o is not n  # absent -> null IS a move; absent -> absent is not
+        return _json_differs(o, n)
+
+    def _show(v: object) -> str:
+        return "<absent>" if v is _ABSENT else repr(v)
+
     return ", ".join(
-        f"{key}: {old.get(key)!r} -> {new.get(key)!r}"
+        f"{key}: {_show(old.get(key, _ABSENT))} -> {_show(new.get(key, _ABSENT))}"
         for key in PMA_METADATA_KEYS
-        if old.get(key) != new.get(key)
+        if _moved(old.get(key, _ABSENT), new.get(key, _ABSENT))
     )
 
 
@@ -1263,11 +1303,18 @@ async def main() -> int | None:
                 # $N::text::jsonb placeholder so the server casts text->jsonb
                 # exactly once.
                 if plan.pma_only:
+                    # Server-side merge of the tuple ONLY: `||` overwrites the 7
+                    # bound keys (a JSON null value still overwrites, it does not
+                    # delete) and leaves every other key exactly as stored.
+                    # coalesce(): `NULL || x` is NULL, which would make a row
+                    # with an empty metadata column a silent no-op.
+                    assert plan.new_metadata is not None
                     await conn.execute(
-                        "UPDATE kbli_documents SET metadata = $2::text::jsonb, "
+                        "UPDATE kbli_documents "
+                        "SET metadata = coalesce(metadata, '{}'::jsonb) || $2::text::jsonb, "
                         "updated_at = now() WHERE kode_kbli = $1",
                         code,
-                        json.dumps(plan.new_metadata, ensure_ascii=False),
+                        json.dumps(pma_metadata_patch(plan.new_metadata), ensure_ascii=False),
                     )
                 else:
                     await conn.execute(

--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -297,6 +297,26 @@ class DocumentCurePlan:
     new_metadata: dict | None
     update_row: bool
     skip_reason: str | None
+    # True when the plan touches ONLY the PMA evidence tuple inside `metadata`:
+    # `judul` and `content` are left byte-identical by construction (see
+    # `plan_pma_only`), so the apply path must not rewrite them either.
+    pma_only: bool = False
+
+
+# The PMA evidence tuple `build_cured_metadata` writes — and the ONLY keys a
+# `--pma-only` plan may touch. Read by the channel as one atomic disclosure
+# (`_pma_disclosure_fields`): a partial sync (status without basis/vintage)
+# reads as NOT_VERIFIED at the surface, so the tuple moves together or not at
+# all.
+PMA_METADATA_KEYS: tuple[str, ...] = (
+    "pma_status",
+    "pma_max_asing",
+    "pma_verification_status",
+    "pma_official_basis",
+    "pma_source_vintage",
+    "pma_cap_special",
+    "pma_cap_verified",
+)
 
 
 def quarantined_codes(dataset: list[dict]) -> list[str]:
@@ -777,6 +797,81 @@ def plan_cure(code: str, record: dict | None, current_row: dict | None) -> Docum
     )
 
 
+def plan_pma_only(code: str, record: dict | None, current_row: dict | None) -> DocumentCurePlan:
+    """Pure decision function for `--pma-only` — no I/O.
+
+    Syncs the PMA evidence tuple in `metadata` from canonical and NOTHING else:
+    `judul`, `content` and every other metadata key (`per_skala`,
+    `licensing_status`, `pp28_sources`, ...) are carried over unchanged. This is
+    the cure for a row whose hand-written prose must survive: the full rebuild
+    (`plan_cure`) replaces `content` wholesale, which is exactly what the
+    content-preservation gate refuses on such rows — and since v34 the channel
+    never injects `content` anyway, so the structured tuple is the only thing
+    the client can still be told wrong.
+
+    The tuple comes from `disclose_pma(record)` — the same fail-closed reader
+    the channel uses — so a canonical record without a located basis+vintage
+    syncs as NOT_VERIFIED rather than as a bare status.
+    """
+    if record is None:
+        return DocumentCurePlan(
+            code=code,
+            found_in_canonical=False,
+            found_in_table=current_row is not None,
+            is_gap=None,
+            new_judul=None,
+            new_content=None,
+            new_metadata=None,
+            update_row=False,
+            skip_reason="not in canonical dataset",
+            pma_only=True,
+        )
+    if current_row is None:
+        return DocumentCurePlan(
+            code=code,
+            found_in_canonical=True,
+            found_in_table=False,
+            is_gap=None,
+            new_judul=None,
+            new_content=None,
+            new_metadata=None,
+            update_row=False,
+            skip_reason="not in kbli_documents table",
+            pma_only=True,
+        )
+
+    old_metadata = dict(current_row.get("metadata") or {})
+    pma = disclose_pma(record)
+    new_metadata = dict(old_metadata)
+    for key in PMA_METADATA_KEYS:
+        new_metadata[key] = pma[key]
+    update_row = new_metadata != old_metadata
+    return DocumentCurePlan(
+        code=code,
+        found_in_canonical=True,
+        found_in_table=True,
+        is_gap=(record.get("per_skala") == []),
+        new_judul=None,
+        new_content=None,
+        new_metadata=new_metadata if update_row else None,
+        update_row=update_row,
+        skip_reason=None if update_row else "already cured (metadata PMA tuple matches canonical)",
+        pma_only=True,
+    )
+
+
+def pma_tuple_delta(old_metadata: dict | None, new_metadata: dict | None) -> str:
+    """Pure. `key: old -> new` for every PMA key a `--pma-only` plan changes —
+    the run report must say WHAT moved, not just that a row was touched."""
+    old = old_metadata or {}
+    new = new_metadata or {}
+    return ", ".join(
+        f"{key}: {old.get(key)!r} -> {new.get(key)!r}"
+        for key in PMA_METADATA_KEYS
+        if old.get(key) != new.get(key)
+    )
+
+
 def archive_params(code: str, current_row: dict) -> tuple:
     """Pure — the exact, byte-unaltered params for the archive INSERT.
     Kept as a standalone function so the "archive is byte-exact" invariant
@@ -828,6 +923,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="comma-separated list of 5-digit codes to process "
         "(mandatory unless --all-quarantined or --all-licensing-absent)",
+    )
+    ap.add_argument(
+        "--pma-only",
+        action="store_true",
+        help="with --only: sync ONLY the PMA evidence tuple inside `metadata` from canonical "
+        "(pma_status, cap, verification status, official basis, source vintage). `judul`, "
+        "`content` and every other metadata key are left byte-identical — the cure for rows "
+        "whose hand-written prose the full rebuild would destroy. Refuses to combine with any "
+        "--all-* selector.",
     )
     ap.add_argument(
         "--all-quarantined",
@@ -903,6 +1007,25 @@ def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> 
         parser.error(
             "--cure-run is REQUIRED when --apply is passed — each cure pass declares its own stable id"
         )
+    # --pma-only is a NARROWER write on an operator-named scope, never a sweep:
+    # the --all-* selectors each justify a WHOLESALE rebuild (marker / detector /
+    # stored text), and none of them says anything about the PMA tuple alone.
+    if getattr(args, "pma_only", False):
+        sweep = [
+            name
+            for name, on in (
+                ("--all-quarantined", getattr(args, "all_quarantined", False)),
+                ("--all-licensing-absent", getattr(args, "all_licensing_absent", False)),
+                ("--all-machine-template", getattr(args, "all_machine_template", False)),
+            )
+            if on
+        ]
+        if sweep:
+            parser.error(
+                f"--pma-only cannot be combined with {' or '.join(sweep)} — name the codes with --only"
+            )
+        if not args.only:
+            parser.error("--pma-only requires --only <codes> — it never guesses scope")
     if not args.cure_run:
         return "dry-run"
     cure_run = args.cure_run.strip()
@@ -1051,7 +1174,9 @@ async def main() -> int | None:
             if not codes:
                 logger.warning("gate refused every selected row — nothing to do")
                 return
-        elif not args.all_quarantined:
+        elif not args.all_quarantined and not args.pma_only:
+            # (`--pma-only` is exempt: it rewrites no prose, so the warning
+            # below would be a false alarm about an overwrite that cannot happen.)
             # `--only` BYPASSES the gate above, and that is the trap this block
             # exists to make loud. The gate cannot run here: a hand-written
             # scope means the operator, not a predicate, chose these codes, and
@@ -1103,19 +1228,32 @@ async def main() -> int | None:
                     "created_at": row["created_at"],
                     "updated_at": row["updated_at"],
                 }
-            plan = plan_cure(code, by_code.get(code), current_row)
+            if args.pma_only:
+                plan = plan_pma_only(code, by_code.get(code), current_row)
+            else:
+                plan = plan_cure(code, by_code.get(code), current_row)
             plans.append(plan)
 
             if not plan.update_row:
                 logger.info("SKIP %s: %s", code, plan.skip_reason)
                 continue
 
-            logger.info(
-                "  %s: would update kbli_documents (%d chars)%s",
-                code,
-                len(plan.new_content or ""),
-                " [GAP]" if plan.is_gap else " [RESTORED]",
-            )
+            if plan.pma_only:
+                assert current_row is not None
+                logger.info(
+                    "  %s: %s metadata PMA tuple only (judul/content byte-identical): %s",
+                    code,
+                    "syncing" if args.apply else "would sync",
+                    pma_tuple_delta(current_row.get("metadata"), plan.new_metadata),
+                )
+            else:
+                logger.info(
+                    "  %s: %s kbli_documents (%d chars)%s",
+                    code,
+                    "updating" if args.apply else "would update",
+                    len(plan.new_content or ""),
+                    " [GAP]" if plan.is_gap else " [RESTORED]",
+                )
             if args.apply:
                 assert current_row is not None  # update_row=True implies found_in_table=True
                 params = archive_params(code, current_row)
@@ -1124,14 +1262,22 @@ async def main() -> int | None:
                 # precedent): bind the pre-serialized json.dumps() string to a
                 # $N::text::jsonb placeholder so the server casts text->jsonb
                 # exactly once.
-                await conn.execute(
-                    "UPDATE kbli_documents SET judul = $2, content = $3, "
-                    "metadata = $4::text::jsonb, updated_at = now() WHERE kode_kbli = $1",
-                    code,
-                    plan.new_judul,
-                    plan.new_content,
-                    json.dumps(plan.new_metadata, ensure_ascii=False),
-                )
+                if plan.pma_only:
+                    await conn.execute(
+                        "UPDATE kbli_documents SET metadata = $2::text::jsonb, "
+                        "updated_at = now() WHERE kode_kbli = $1",
+                        code,
+                        json.dumps(plan.new_metadata, ensure_ascii=False),
+                    )
+                else:
+                    await conn.execute(
+                        "UPDATE kbli_documents SET judul = $2, content = $3, "
+                        "metadata = $4::text::jsonb, updated_at = now() WHERE kode_kbli = $1",
+                        code,
+                        plan.new_judul,
+                        plan.new_content,
+                        json.dumps(plan.new_metadata, ensure_ascii=False),
+                    )
     finally:
         await conn.close()
 

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -1816,8 +1816,15 @@ def test_main_pma_only_apply_merges_the_tuple_and_never_binds_judul_or_content(m
     updates = conn.updates()
     assert len(updates) == 1, [q for q, _ in conn.executes]
     sql, args = updates[0]
-    assert "coalesce(metadata, '{}'::jsonb) || $2::text::jsonb" in sql
+    # Left operand guarded by TYPE, not by coalesce: `'null'::jsonb || {..}`
+    # builds an array, so an object-or-empty CASE is the only idempotent shape.
+    assert (
+        "(CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END) "
+        "|| $2::text::jsonb"
+    ) in sql
     assert "judul" not in sql and "content" not in sql
+    # the predicate is pinned too: `<> $1` would cure every row but the target
+    assert sql.rstrip().endswith("WHERE kode_kbli = $1")
     assert args[0] == "96210"
     bound = _json_obl.loads(args[1])
     assert set(bound) == set(PMA_METADATA_KEYS)
@@ -1860,4 +1867,5 @@ def test_main_full_only_apply_still_rewrites_judul_and_content(monkeypatch):
     sql, args = updates[0]
     assert "judul = $2, content = $3" in sql
     assert "||" not in sql
+    assert sql.rstrip().endswith("WHERE kode_kbli = $1")
     assert args[1] is not None and args[2] is not None

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -1513,3 +1513,168 @@ def test_apply_passes_cli_cure_run_to_archive_row_cure(monkeypatch):
 
     assert len(archive_calls) == 1
     assert archive_calls[0]["cure_run"] == "kbli_cure:2026-08-08"
+
+
+# ---------------------------------------------------------------------------
+# --pma-only (2026-09-01). Measured on prod that day: the conformance detector
+# named 11 `pma_status` divergences; 6 of the rows carried hand-written prose
+# the full rebuild (`plan_cure`) would have replaced wholesale (and 03110 would
+# have become a 55k-char document). Since v34 the channel never injects
+# `content` — it reads the structured PMA tuple off `metadata` — so the honest
+# cure for such a row is the tuple alone, with judul/content byte-identical.
+from backend.scripts.kbli_documents_cure import (  # noqa: E402
+    PMA_METADATA_KEYS,
+    plan_pma_only,
+    pma_tuple_delta,
+)
+
+HAND_WRITTEN_ROW_96210 = {
+    "judul": "AKTIVITAS PENATAAN DAN PANGKAS RAMBUT",
+    "content": (
+        "KBLI 96210: AKTIVITAS PENATAAN DAN PANGKAS RAMBUT\n\nWHAT IT MEANS:\n"
+        "Hair salon and barbershop — cutting, styling, coloring.\n\nBALI CONTEXT:\n"
+        "Bali's expat areas are packed with premium salons."
+    ),
+    "metadata": {
+        "judul": "AKTIVITAS PENATAAN DAN PANGKAS RAMBUT",
+        "kode_kbli_2025": "96210",
+        "licensing_status": "N/A",
+        "per_skala": [{"skala": "Mikro", "kategori_risiko": "Rendah"}],
+        "pma_status": "TERBUKA",
+        "pp28_sources": ["96111"],
+        "sektor_id": "S",
+        "status_mapping": "MATCH_LANGSUNG",
+    },
+}
+
+RECORD_96210_LOCATED = {
+    "kode_kbli_2025": "96210",
+    "judul": "Aktivitas Penataan dan Pangkas Rambut",
+    "uraian": "Kelompok ini mencakup usaha jasa pelayanan penataan dan pangkas rambut.",
+    "pma_status": "TERBATAS",
+    "pma_max_asing": 0,
+    "pma_verification_status": "located",
+    "pma_official_basis": "Perpres 49/2021 Lampiran II (DIALOKASIKAN untuk Koperasi dan UMKM) fixture",
+    "pma_source_vintage": "2021-05-25",
+    "pma_cap_verified": True,
+    # Deliberately DIFFERENT from the row's per_skala: a pma-only plan must not
+    # touch it even when canonical disagrees — that is the full rebuild's job.
+    "per_skala": [
+        {"skala": "Mikro", "kategori_risiko": "Rendah"},
+        {"skala": "Kecil", "kategori_risiko": "Rendah"},
+    ],
+}
+
+
+def test_pma_only_guilt_syncs_the_tuple_and_nothing_else():
+    plan = plan_pma_only("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210)
+    assert plan.pma_only is True
+    assert plan.update_row is True
+    # judul/content are never part of the plan — the apply path has nothing to write there.
+    assert plan.new_judul is None
+    assert plan.new_content is None
+    old = HAND_WRITTEN_ROW_96210["metadata"]
+    new = plan.new_metadata
+    assert new["pma_status"] == "TERBATAS"
+    assert new["pma_max_asing"] == 0
+    assert new["pma_verification_status"] == "located"
+    assert new["pma_official_basis"].startswith("Perpres 49/2021 Lampiran II")
+    assert new["pma_source_vintage"] == "2021-05-25"
+    assert new["pma_cap_verified"] is True
+    assert new["pma_cap_special"] is False
+    # Every key that is NOT in the tuple is carried over byte-identical —
+    # including per_skala, which canonical disagrees with in this fixture.
+    for key, value in old.items():
+        if key not in PMA_METADATA_KEYS:
+            assert new[key] == value, key
+    assert set(new) - set(old) <= set(PMA_METADATA_KEYS)
+
+
+def test_pma_only_writes_the_same_tuple_the_full_rebuild_would():
+    """Two paths, one disclosure: a pma-only sync may never disagree with what
+    `build_cured_metadata` writes for the same record (W105 — two tools that
+    must agree about one fact)."""
+    narrow = plan_pma_only("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210).new_metadata
+    full = build_cured_metadata("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210["metadata"])
+    assert {k: narrow[k] for k in PMA_METADATA_KEYS} == {k: full[k] for k in PMA_METADATA_KEYS}
+
+
+def test_pma_only_really_differs_from_the_full_rebuild_on_a_hand_written_row():
+    """The reason the mode exists: on this row the full rebuild REPLACES content."""
+    full = plan_cure("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210)
+    assert full.update_row is True
+    assert full.new_content is not None
+    assert full.new_content != HAND_WRITTEN_ROW_96210["content"]
+    assert full.new_metadata["per_skala"] == RECORD_96210_LOCATED["per_skala"]
+    narrow = plan_pma_only("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210)
+    assert narrow.new_content is None
+    assert narrow.new_metadata["per_skala"] == HAND_WRITTEN_ROW_96210["metadata"]["per_skala"]
+
+
+def test_pma_only_innocence_is_idempotent():
+    first = plan_pma_only("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210)
+    cured_row = {**HAND_WRITTEN_ROW_96210, "metadata": first.new_metadata}
+    second = plan_pma_only("96210", RECORD_96210_LOCATED, cured_row)
+    assert second.update_row is False
+    assert second.new_metadata is None
+    assert "already cured" in (second.skip_reason or "")
+
+
+def test_pma_only_fails_closed_on_a_declared_gap_record():
+    """A canonical record without a located basis+vintage must sync as
+    NOT_VERIFIED / declared_gap — never as its raw working `pma_status`."""
+    gap_record = {k: v for k, v in RECORD_96210_LOCATED.items() if k != "pma_official_basis"}
+    plan = plan_pma_only("96210", gap_record, HAND_WRITTEN_ROW_96210)
+    assert plan.update_row is True
+    assert plan.new_metadata["pma_status"] == "NOT_VERIFIED"
+    assert plan.new_metadata["pma_verification_status"] == "declared_gap"
+    assert plan.new_metadata["pma_max_asing"] is None
+    assert plan.new_metadata["pma_cap_verified"] is False
+
+
+def test_pma_only_skips_when_canonical_or_table_is_missing():
+    no_record = plan_pma_only("96210", None, HAND_WRITTEN_ROW_96210)
+    assert no_record.update_row is False
+    assert no_record.pma_only is True
+    assert no_record.skip_reason == "not in canonical dataset"
+    no_row = plan_pma_only("96210", RECORD_96210_LOCATED, None)
+    assert no_row.update_row is False
+    assert no_row.pma_only is True
+    assert no_row.skip_reason == "not in kbli_documents table"
+
+
+def test_pma_tuple_delta_names_only_the_keys_that_move():
+    old = HAND_WRITTEN_ROW_96210["metadata"]
+    new = plan_pma_only("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210).new_metadata
+    delta = pma_tuple_delta(old, new)
+    assert delta.startswith("pma_status: 'TERBUKA' -> 'TERBATAS'")
+    assert "pma_official_basis: None -> " in delta
+    # An unchanged tuple reports as empty, never as a list of no-ops.
+    assert pma_tuple_delta(new, dict(new)) == ""
+
+
+def test_parser_pma_only_requires_an_only_scope():
+    ap = _cure_build_parser()
+    args = ap.parse_args(["--pma-only"])
+    with pytest.raises(SystemExit):
+        _cure_validate_args(ap, args)
+
+
+@pytest.mark.parametrize(
+    "sweep", ["--all-quarantined", "--all-licensing-absent", "--all-machine-template"]
+)
+def test_parser_pma_only_refuses_every_sweep_selector(sweep):
+    ap = _cure_build_parser()
+    args = ap.parse_args(["--pma-only", "--only", "96210", sweep])
+    with pytest.raises(SystemExit):
+        _cure_validate_args(ap, args)
+
+
+def test_parser_pma_only_with_only_is_accepted_in_both_modes():
+    ap = _cure_build_parser()
+    dry = ap.parse_args(["--pma-only", "--only", "96210,03110"])
+    assert _cure_validate_args(ap, dry) == "dry-run"
+    live = ap.parse_args(
+        ["--pma-only", "--only", "96210", "--apply", "--cure-run", "kbli_cure:2026-09-01-pma-only"]
+    )
+    assert _cure_validate_args(ap, live) == "kbli_cure:2026-09-01-pma-only"

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -1648,7 +1648,8 @@ def test_pma_tuple_delta_names_only_the_keys_that_move():
     new = plan_pma_only("96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210).new_metadata
     delta = pma_tuple_delta(old, new)
     assert delta.startswith("pma_status: 'TERBUKA' -> 'TERBATAS'")
-    assert "pma_official_basis: None -> " in delta
+    # The hand-written row never had the key: that is `<absent>`, not `None`.
+    assert "pma_official_basis: <absent> -> " in delta
     # An unchanged tuple reports as empty, never as a list of no-ops.
     assert pma_tuple_delta(new, dict(new)) == ""
 
@@ -1678,3 +1679,185 @@ def test_parser_pma_only_with_only_is_accepted_in_both_modes():
         ["--pma-only", "--only", "96210", "--apply", "--cure-run", "kbli_cure:2026-09-01-pma-only"]
     )
     assert _cure_validate_args(ap, live) == "kbli_cure:2026-09-01-pma-only"
+
+
+# --- refuter round 1 (Codex sol, 2026-09-01): the four findings, pinned ----------
+from backend.scripts.kbli_documents_cure import pma_metadata_patch  # noqa: E402
+
+_CURED_TUPLE_96210 = plan_pma_only(
+    "96210", RECORD_96210_LOCATED, HAND_WRITTEN_ROW_96210
+).new_metadata
+
+
+def test_pma_only_reports_a_bool_int_confused_tuple_as_stale():
+    """GUILT (MAJOR #2). `False == 0` and `1 == True` in Python, so a plain
+    `!=` on the dicts called this row 'already cured' — while the channel's
+    `_public_pma_cap` refuses a cap whose `pma_cap_verified` is not a real
+    bool, i.e. the client was still told NOT_VERIFIED."""
+    assert _CURED_TUPLE_96210 is not None
+    coerced = dict(_CURED_TUPLE_96210)
+    coerced["pma_max_asing"] = False  # canonical: 0
+    coerced["pma_cap_special"] = 0  # canonical: False
+    coerced["pma_cap_verified"] = 1  # canonical: True
+    row = {**HAND_WRITTEN_ROW_96210, "metadata": coerced}
+    plan = plan_pma_only("96210", RECORD_96210_LOCATED, row)
+    assert plan.update_row is True, plan.skip_reason
+    patch = pma_metadata_patch(plan.new_metadata)
+    assert patch["pma_max_asing"] == 0 and type(patch["pma_max_asing"]) is int
+    assert patch["pma_cap_special"] is False
+    assert patch["pma_cap_verified"] is True
+    # and the report names the three coercions, not an empty delta
+    delta = pma_tuple_delta(coerced, plan.new_metadata)
+    assert "pma_max_asing: False -> 0" in delta
+    assert "pma_cap_special: 0 -> False" in delta
+    assert "pma_cap_verified: 1 -> True" in delta
+
+
+def test_pma_metadata_patch_binds_the_tuple_and_nothing_else():
+    """BLOCKER #1. The UPDATE merges server-side; what crosses the wire is the
+    seven keys, so `per_skala`, `pp28_sources`, ... are never re-encoded."""
+    assert _CURED_TUPLE_96210 is not None
+    patch = pma_metadata_patch(_CURED_TUPLE_96210)
+    assert set(patch) == set(PMA_METADATA_KEYS)
+    assert "per_skala" not in patch and "pp28_sources" not in patch
+
+
+def test_pma_tuple_delta_names_an_absent_key_as_absent_not_as_none():
+    """MINOR #4. A repair that only ADDS keys holding null used to render as an
+    empty delta (`.get()` on both sides said None -> None). Absent -> null is a
+    move; null -> null is not."""
+    assert _CURED_TUPLE_96210 is not None
+    without_basis = {k: v for k, v in _CURED_TUPLE_96210.items() if k != "pma_official_basis"}
+    with_null_basis = {**_CURED_TUPLE_96210, "pma_official_basis": None}
+    assert pma_tuple_delta(without_basis, with_null_basis) == (
+        "pma_official_basis: <absent> -> None"
+    )
+    assert pma_tuple_delta(with_null_basis, dict(with_null_basis)) == ""
+
+
+class _UpdateSpyConn:
+    """asyncpg stand-in that RECORDS every execute() so the SQL the apply path
+    really binds can be asserted — the plan-level tests cannot see it."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.executes: list[tuple[str, tuple]] = []
+
+    async def execute(self, query: str, *args):
+        self.executes.append((query, args))
+        return "UPDATE 1"
+
+    async def fetch(self, _sql, codes):
+        return [r for r in self._rows if r["kode_kbli"] in codes]
+
+    async def fetchval(self, _sql, *_a):
+        return True  # archive schema already has cure_run + composite constraint
+
+    async def close(self):
+        return None
+
+    def updates(self) -> list[tuple[str, tuple]]:
+        return [
+            (q, a)
+            for q, a in self.executes
+            if q.lstrip().upper().startswith("UPDATE KBLI_DOCUMENTS")
+        ]
+
+
+def _drive_apply(monkeypatch, argv, rows, dataset):
+    monkeypatch.setattr(_sys, "argv", argv)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fake/fake")
+    conn = _UpdateSpyConn(rows)
+
+    async def _dataset(_source):
+        return list(dataset)
+
+    async def _connect(_dsn):
+        return conn
+
+    archive_calls: list[dict] = []
+
+    async def _spy_archive_row(_conn, code, params, cure_run, **kw):
+        archive_calls.append({"code": code, "params": params, "cure_run": cure_run})
+
+    monkeypatch.setattr(_cure, "load_dataset", _dataset)
+    monkeypatch.setattr(_cure.asyncpg, "connect", _connect)
+    monkeypatch.setattr(_cure, "archive_row", _spy_archive_row)
+    rc = _asyncio.run(_cure.main())
+    return rc, conn, archive_calls
+
+
+_ROW_96210_IN_TABLE = {
+    "kode_kbli": "96210",
+    "created_at": None,
+    "updated_at": None,
+    **HAND_WRITTEN_ROW_96210,
+}
+_PMA_ONLY_APPLY_ARGV = [
+    "cure",
+    "--pma-only",
+    "--only",
+    "96210",
+    "--apply",
+    "--cure-run",
+    "kbli_cure:2026-09-01-pma-only",
+]
+
+
+def test_main_pma_only_apply_merges_the_tuple_and_never_binds_judul_or_content(monkeypatch, caplog):
+    """GUILT (MAJOR #3). Driven through main(): the mutation `if plan.pma_only`
+    -> `if False` survived every plan-level test while the full UPDATE would
+    have written `judul = NULL, content = NULL` on a hand-written row."""
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, _PMA_ONLY_APPLY_ARGV, [_ROW_96210_IN_TABLE], [RECORD_96210_LOCATED]
+        )
+    assert not rc  # main() returns None on success, a non-zero int on refusal
+    updates = conn.updates()
+    assert len(updates) == 1, [q for q, _ in conn.executes]
+    sql, args = updates[0]
+    assert "coalesce(metadata, '{}'::jsonb) || $2::text::jsonb" in sql
+    assert "judul" not in sql and "content" not in sql
+    assert args[0] == "96210"
+    bound = _json_obl.loads(args[1])
+    assert set(bound) == set(PMA_METADATA_KEYS)
+    assert bound["pma_status"] == "TERBATAS" and bound["pma_max_asing"] == 0
+    assert bound["pma_verification_status"] == "located"
+    # the snapshot is still taken, keyed by the CLI cure_run
+    assert [c["cure_run"] for c in archive_calls] == ["kbli_cure:2026-09-01-pma-only"]
+    assert archive_calls[0]["params"][2] == HAND_WRITTEN_ROW_96210["content"]
+    messages = [r.getMessage() for r in caplog.records]
+    assert not [m for m in messages if "content-preservation gate" in m], messages
+    assert any("syncing metadata PMA tuple only" in m for m in messages), messages
+
+
+def test_main_pma_only_dry_run_binds_no_update_and_takes_no_snapshot(monkeypatch, caplog):
+    """INNOCENCE. Without --apply the same drive reports and writes nothing."""
+    argv = [
+        a
+        for a in _PMA_ONLY_APPLY_ARGV
+        if a not in ("--apply", "--cure-run", "kbli_cure:2026-09-01-pma-only")
+    ]
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, argv, [_ROW_96210_IN_TABLE], [RECORD_96210_LOCATED]
+        )
+    assert not rc  # main() returns None on success, a non-zero int on refusal
+    assert conn.updates() == []
+    assert archive_calls == []
+    assert any("would sync metadata PMA tuple only" in r.getMessage() for r in caplog.records)
+
+
+def test_main_full_only_apply_still_rewrites_judul_and_content(monkeypatch):
+    """INNOCENCE for the branch itself: the mutation `if plan.pma_only` ->
+    `if True` would route every full rebuild through the merge and silently
+    stop replacing prose. The plain `--only` apply must still bind all three."""
+    argv = [a for a in _PMA_ONLY_APPLY_ARGV if a != "--pma-only"]
+    rc, conn, _ = _drive_apply(monkeypatch, argv, [_ROW_96210_IN_TABLE], [RECORD_96210_LOCATED])
+    assert not rc  # main() returns None on success, a non-zero int on refusal
+    updates = conn.updates()
+    assert len(updates) == 1
+    sql, args = updates[0]
+    assert "judul = $2, content = $3" in sql
+    assert "||" not in sql
+    assert args[1] is not None and args[2] is not None


### PR DESCRIPTION
## What

`kbli_documents_cure.py --pma-only --only <codes>`: sync ONLY the 7-key PMA evidence tuple in `metadata` from canonical (through the same fail-closed `disclose_pma` the channel reads). `judul`, `content` and every other metadata key stay byte-identical; the apply path is a metadata-only `UPDATE`, the pre-cure row is still archived under the run's `cure_run`. Refuses every `--all-*` selector and requires `--only`.

## Why

The 2026-09-01 conformance detector run on Pro measured **11 `pma_status` divergences** between canonical and `kbli_documents`. Five rows were machine-shaped → cured today with the existing rebuild (`--only … --cure-run kbli_cure:2026-09-01-pma-sync`, verified via the read-only role). The other six — `03110 55105 65111 65121 96100 96210` — carry hand-written editorial prose: the full rebuild would replace their `content` wholesale (the content-preservation gate exists precisely to refuse that), and `03110` would become a **55,694-char** document on a table whose max is 25,483.

Since v34 (2026-08-15) the channel never injects `content`; it reads the structured PMA tuple off `metadata`. So the honest cure for those rows is the tuple alone — measured, not assumed: none of the six `content` bodies states a PMA verdict (the only wrong fact is `metadata.pma_status`).

## Tests

10 new unit tests in `test_kbli_documents_cure.py` (110 pass in the file): guilt (only the tuple moves — `per_skala` is left even when canonical disagrees), parity with `build_cured_metadata` (W105: two paths, one disclosure), divergence from the full rebuild on a hand-written row, idempotence, fail-closed on a `declared_gap` record, missing-record/row skips, the `key: old -> new` delta reporter, parser refusals (no `--only`, any `--all-*`) and acceptance.

## Consumer map / deploy

Merging this touches `apps/backend-rag/**` → `fly-deploy.yml` deploys. Auto-merge is armed only outside the WhatsApp window (08:00–20:00 WITA), per the 2026-09-01 memory rule.

**Bites:** after the deploy, inside the Fly image:
`python backend/scripts/kbli_documents_cure.py --pma-only --only 03110,55105,65111,65121,96100,96210 --dataset <raw URL pinned to the merge SHA> --apply --cure-run kbli_cure:2026-09-01-pma-only`
then the Pro organ `infra/launchagents/wrappers/kbli-surface-conformance-run.sh` must report `pma_status disagrees with VERIFIED canonical: 0` (11 this morning; 6 after the machine-shaped rows were cured), read back through the read-only role, not the tool's own log.

Related, applied today with existing tools (no code change): Qdrant `kbli_2025_final_hybrid` PMA-layer sync on the 54 canonical-`located` codes (53 points written, re-dry-run 54/54 agree), `inspect_kbli` cache bust (5 evicted), KG `kg_kbli_resync.py --only` loop on the same 54 (in progress). Proven live: `inspect_kbli 96220` → TERBATAS 0% with the Lampiran II basis (was NOT_VERIFIED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jne5CZvgNcjcy2D3hFYmE
