### PR TITLE
fix(ops): make good on #5488's item 4, which described code that was never in it

### DIFF
--- a/scripts/queue_stall_notify.py
+++ b/scripts/queue_stall_notify.py
@@ -168,7 +168,7 @@ def run_classifier(
     *,
     repo: str,
     min_age_minutes: int,
-    classifier_path: Path = CLASSIFIER,
+    classifier_path: Path | None = None,
     timeout: int = CLASSIFIER_TIMEOUT,
 ) -> tuple[int, dict[str, Any] | None, str, str]:
     """Invoke queue_stall_classifier.py as a SUBPROCESS with `--json`. Returns
@@ -181,6 +181,13 @@ def run_classifier(
     row among otherwise-fine rows, for instance — and this notifier must still be able to act on
     and report those rows precisely, not collapse "the classifier's rc was 1" into "there is
     nothing here to look at"."""
+    # Resolved HERE, never as a `Path = CLASSIFIER` default: a default argument binds at
+    # IMPORT, so it does not follow a monkeypatch of CLASSIFIER. That is the exact shape that
+    # had this suite flocking the real ~/.agent state path (scar W96). Today's only caller
+    # passes classifier_path= explicitly, so the landmine is unarmed — it is removed rather
+    # than commented, so a future caller cannot arm it by writing less code.
+    if classifier_path is None:
+        classifier_path = CLASSIFIER
     argv = [
         sys.executable,
         str(classifier_path),

--- a/scripts/tests/test_queue_stall_notify.py
+++ b/scripts/tests/test_queue_stall_notify.py
@@ -97,21 +97,39 @@ def test_classifier_stall_vocabulary_is_fully_accounted_for_without_importing_it
     """The subprocess boundary stays intact: inspect source AST, never import the classifier."""
     source = qsn.CLASSIFIER.read_text()
     tree = ast.parse(source)
-    stall_causes = next(
-        ast.literal_eval(node.value)
-        for node in tree.body
+    assigns = [
+        node for node in tree.body
         if isinstance(node, ast.Assign)
-        and any(isinstance(target, ast.Name) and target.id == "STALL_CAUSES" for target in node.targets)
-    )
+        and any(isinstance(t, ast.Name) and t.id == "STALL_CAUSES" for t in node.targets)
+    ]
+    # Both ways this extraction can break used to surface as a stack trace naming neither the
+    # cause nor the cure: a rename or a move out of module scope raised a bare StopIteration
+    # from next(), and wrapping the value in frozenset(...)/set(...) raised
+    # "ValueError: malformed node or string". Both still FAILED — nothing was ever silently
+    # skipped — but a guard whose failure does not say what to do is a guard the next person
+    # deletes. FIRST assignment wins, matching the previous next() semantics.
+    if not assigns:
+        pytest.fail(
+            "no module-level STALL_CAUSES assignment in the classifier: it was renamed, removed, "
+            "or moved inside a function. This test is the only thing keeping the notifier's cause "
+            "vocabulary aligned with the classifier's — repoint the extraction, do not delete it."
+        )
+    try:
+        stall_causes = ast.literal_eval(assigns[0].value)
+    except ValueError as exc:
+        pytest.fail(
+            f"STALL_CAUSES is no longer a literal the AST can evaluate ({exc}). It was most "
+            "likely wrapped in a call such as frozenset(...) or set(...). Read the call's "
+            "argument instead — do not delete this test: without it, a new cause in the "
+            "classifier is dropped by the notifier with no trace at all."
+        )
     # A drift guard that passes on an EMPTY read is the very disease it exists to catch:
-    # set(()) <= anything is trivially True, so an extraction that silently yields nothing
-    # would report "no drift" forever. Adversarial review could not force this by reformatting
-    # the classifier (six variants all fail loudly), but the vacuous shape is one assert away.
+    # set(()) <= anything is trivially True, so an extraction yielding nothing would report
+    # "no drift" forever.
     assert stall_causes, (
-        "extracted an EMPTY STALL_CAUSES from the classifier's source. The comparison below "
-        "would pass vacuously. Most likely the classifier moved STALL_CAUSES out of module "
-        "scope or wrapped it in a call (frozenset(...)/set(...)), which ast.literal_eval "
-        "cannot evaluate — fix the extraction, do not delete this assert."
+        "extracted an EMPTY STALL_CAUSES from the classifier's source — the comparison below "
+        "would pass vacuously. The extraction found the assignment but it evaluates to nothing; "
+        "fix the extraction, do not delete this assert."
     )
     accounted_for = qsn.REAL_STALL_CAUSES | qsn.DELIBERATELY_IGNORED
     assert set(stall_causes) <= accounted_for
@@ -567,3 +585,24 @@ def test_main_never_touches_the_real_lock_path(monkeypatch, capsys):
     qsn.main([])
     assert qsn.LOCK_FILE.exists(), "the patched lock path is the one that was used"
     assert "/.agent/decisions/state/" not in str(qsn.LOCK_FILE)
+
+
+def test_run_classifier_follows_a_patched_classifier_path_not_the_import_time_one(monkeypatch, tmp_path):
+    """Scar W96 in its second home in this file. A `Path = CLASSIFIER` default binds at IMPORT,
+    so a test that patches CLASSIFIER would still have shelled out to the REAL classifier on
+    disk. Today's only caller passes classifier_path= explicitly, so this never fired in
+    production — which is exactly why it needs a test: an unarmed landmine leaves no evidence
+    behind on the day someone arms it by writing one argument less."""
+    decoy = tmp_path / "decoy_classifier.py"
+    decoy.write_text("# never executed: the subprocess seam is stubbed\n")
+    monkeypatch.setattr(qsn, "CLASSIFIER", decoy)
+    seen: list[list[str]] = []
+    monkeypatch.setattr(qsn, "_run", lambda cmd, timeout=30: (seen.append(cmd) or (0, "{}", "")))
+
+    qsn.run_classifier(repo="owner/repo", min_age_minutes=30)
+
+    assert len(seen) == 1, "the classifier subprocess seam was not the only thing invoked"
+    assert str(decoy) in seen[0], (
+        "run_classifier ignored the patched CLASSIFIER and used the import-time default: "
+        f"{seen[0]}"
+    )


### PR DESCRIPTION
## The correction comes first

The squash commit `fee9156bfe` (#5488) claims, in its **item 4**, that the drift guard
"converts an unevaluable `STALL_CAUSES` into a sentence naming what happened, instead of a raw
`ValueError: malformed node`".

**That was false when written and is false on `main` today.** Read with `git ls-tree origin/main`
+ `git cat-file` (never `git show <ref>:<path>` — zsh eats the `:path` as a modifier and prints
the whole commit): `scripts/tests/test_queue_stall_notify.py` on `main` contains **zero**
occurrences of `except ValueError`.

**How it happened, because the mechanism is the point.** The patch adding that `try/except` was
inside a Bash call the orchestration hook **blocked**. It never ran. I then ran a *different*
command, watched the test go red, and read the red as confirmation — but it was reddening for
the **old** reason, the very raw `ValueError` the patch was supposed to replace. *A guard firing
is not evidence that the guard says what you claim it says.*

This PR carries the code that claim described, plus the measurement I owed it, and one more
finding from the same review.

## What is actually here

**1 — The drift guard's two breakage shapes now name their cure.** The extraction could break two
ways, and both surfaced as a stack trace naming neither cause nor cure: a rename raised a bare
`StopIteration` from `next()`; a `frozenset(...)`/`set(...)` wrap raised `ValueError: malformed
node or string`. Neither was ever silently skipped — both always **failed**. So this is
legibility, not coverage. It still matters: a guard whose failure does not say what to do is the
guard the next person deletes.

| mutation applied to the classifier | what the test now says |
|---|---|
| wrap in `frozenset(...)` | `STALL_CAUSES is no longer a literal the AST can evaluate (…). It was most likely wrapped in a call such as frozenset(...) or set(...). Read the call's argument instead` |
| rename `STALL_CAUSES` | `no module-level STALL_CAUSES assignment in the classifier: it was renamed, removed, or moved inside a function` |

The raw `ValueError` is still visible as the **chained** cause above my sentence; what changed is
that it is no longer the last word. The extraction takes the **first** matching assignment,
matching `next()`'s semantics exactly — not the last, as I had it in my head until the reviewer
corrected me.

**2 — Scar W96's second home in this file, removed rather than documented.**
`run_classifier(classifier_path: Path = CLASSIFIER)` is the identical shape that had this suite
flocking the operator's real `~/.agent` state path: a default argument binds at **import**, so it
does not follow a monkeypatch of `CLASSIFIER`. It is **dead today** — the sole caller passes
`classifier_path=` explicitly — which is precisely why it needed removing rather than a comment:
*an unarmed landmine leaves no evidence behind on the day a future caller arms it by writing one
argument less.* The default is now `None`, resolved in the body, matching what `main()` already
does for the lock and the seen-file.

## Each guard discriminates

Measured **in this worktree, on the code being shipped**, classifier restored byte-identical
afterwards (`git diff origin/main --name-only -- scripts/queue_stall_classifier.py` empty):

- wrap `STALL_CAUSES` in `frozenset(...)` → vocabulary test **RED**, message above
- rename `STALL_CAUSES` → vocabulary test **RED**, message above
- restore `classifier_path: Path = CLASSIFIER` → the new W96 test **RED**

33 tests green unmutated. `scripts/queue_stall_classifier.py` is untouched.

**Bites:** `scripts/tests/test_queue_stall_notify.py`, run by this PR's own CI job. The
observation is the three mutation runs above — each made **before** this was written, not
promised for later: the suite is green at HEAD and goes red under each reverted cure, so the
guards are in force rather than merely present.