### PR TITLE
feat(dashboard): show "armed AND red" — the board could not see its own deadlock

### DIFF
--- a/scripts/fleet_dashboard.py
+++ b/scripts/fleet_dashboard.py
@@ -321,6 +321,30 @@ def failing_checks(number: int) -> list[str]:
     return names
 
 
+def is_armed(pr: dict[str, Any]) -> bool:
+    """Has someone asked GitHub to merge this on its own? NEITHER field alone answers it.
+
+    This module's header already records half of this: `autoMergeRequest` is null in
+    three different states — never armed, armed-then-ejected, and armed-then-CONSUMED
+    by the queue — so a PR holding queue position 1 reports "not armed" (measured on
+    #5458/#5459/#5460, and again on #5490 while it sat at position 1). The cure recorded
+    there was "read mergeQueueEntry instead".
+
+    That cure has its OWN blind spot, and it is the one that matters for a stuck board:
+    a RED PR never receives a queue entry at all. GitHub admits a PR to the merge queue
+    only once its required checks pass, so `mergeQueueEntry` is null for every armed PR
+    that is failing — precisely the population a reader needs to see. Measured 2026-09-01:
+    #5158 carried `autoMergeRequest.enabledAt = 2026-09-01T00:48:51Z` with
+    `mergeQueueEntry = null` and one failing check.
+
+    So `mergeQueueEntry` answers "is it in the queue?" and `autoMergeRequest` answers
+    "is a request still pending?" — and ARMED is the union, never either one. Each field
+    is null in a state the other covers, which is why a single-field probe reads as a
+    confident answer to a neighbouring question.
+    """
+    return pr.get("autoMergeRequest") is not None or pr.get("mergeQueueEntry") is not None
+
+
 def is_dependabot(pr: dict[str, Any]) -> bool:
     """True only for Dependabot, judged on the ENTITY and its login together.
 
@@ -488,6 +512,16 @@ def collect() -> dict[str, Any]:
         if p["mergeable"] == "MERGEABLE" and not p["mergeQueueEntry"]
     ]
 
+    # ARMED AND RED: the shape that cannot clear itself. Arming freezes the branch
+    # (THE BUILDER CONTRACT §1), and several gates are designed so the only possible
+    # fix lives INSIDE that same PR's files — check_adversarial_review.py's own
+    # docstring says it outright ("the fix for a FAIL is always 'edit THIS file in THIS
+    # commit', never a follow-up PR"). A PR in this set therefore waits for a
+    # deliberate disarm, and nothing on the board said so before this row existed:
+    # `queued` cannot show it (a red PR never gets a queue entry) and `red` shows it
+    # without saying it is also frozen.
+    stalled_armed = [p for p in red if is_armed(p)]
+
     return {
         "measured_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
         "repo": REPO,
@@ -506,6 +540,11 @@ def collect() -> dict[str, Any]:
             {"n": p["number"], "title": p["title"],
              "bot": is_dependabot(p)}
             for p in ready
+        ],
+        "stalled_armed": [
+            {"n": p["number"], "title": p["title"],
+             "why": fail_map.get(p["number"], [])}
+            for p in stalled_armed
         ],
         "phantom_conflicts": sorted(phantom),
         "real_conflicts": sorted(real),
@@ -645,6 +684,7 @@ def render(d: dict[str, Any]) -> str:
         ("is-wait", len(d["queued"]), "in coda, si fondono da sole"),
         ("is-ok", len(d["ready"]), "verdi e pronte, nessun lavoro da fare"),
         ("is-merah", red_n, "ferme su un controllo rosso"),
+        ("is-merah", len(d["stalled_armed"]), "armate E rosse: congelate, non si sbloccano da sole"),
         ("is-warn", len(d["real_conflicts"]), "conflitti veri, serve una persona"),
         ("is-wait", len(d["phantom_conflicts"]), "conflitti finti (li scioglie una fusione)"),
         ("is-wait", len(d["draft"]), "bozze, non ancora proposte"),
@@ -682,6 +722,12 @@ def render(d: dict[str, Any]) -> str:
         f'<td><span class="pill p-ok">verde</span></td></tr>'
         for r in d["ready"]
     ) or '<tr><td colspan="3">Nessuna in attesa: tutto ciò che è verde è già in coda.</td></tr>'
+
+    stalled_rows = "".join(
+        f'<tr><td>{prlink(x["n"])}</td><td>{esc(x["title"])}</td>'
+        f'<td>{esc(", ".join(x["why"])) or "&mdash;"}</td></tr>'
+        for x in d["stalled_armed"]
+    ) or '<tr><td colspan="3">Nessuna: niente è insieme armato e rosso.</td></tr>'
 
     # The "ready" pile is routinely dominated by dependency bumps, and they are
     # the one case where "all green, arm them all" is the WRONG move: bumps that
@@ -799,11 +845,26 @@ def render(d: dict[str, Any]) -> str:
       <tr><th>Pos.</th><th>Proposta</th><th>Titolo</th></tr>
       {queue_rows}
     </table></div>
-    <div class="note"><b>Nota tecnica, per chi verrà dopo:</b> lo stato «armata» qui è letto da
-    <span class="mono">mergeQueueEntry</span>. Il campo che sembra dirlo,
-    <span class="mono">autoMergeRequest</span>, è vuoto in tre situazioni diverse — mai armata,
-    armata e poi espulsa, armata e <em>consumata dalla coda</em> — quindi una proposta in prima
-    posizione risulterebbe «non armata».</div>
+    <div class="note"><b>Nota tecnica, per chi verrà dopo:</b> «armata» si legge dall\u2019<em>unione</em>
+    di due campi, mai da uno solo. <span class="mono">autoMergeRequest</span> è vuoto in tre
+    situazioni diverse — mai armata, armata e poi espulsa, armata e <em>consumata dalla coda</em> —
+    quindi una proposta in prima posizione risulterebbe «non armata».
+    <span class="mono">mergeQueueEntry</span> ha il difetto opposto: una proposta <em>rossa</em> non
+    entra mai in coda, quindi risulterebbe «non armata» proprio quando è armata e bloccata. Ogni
+    campo è vuoto in uno stato che l\u2019altro copre.</div>
+  </section>
+
+  <section>
+    <div class="eyebrow">Ferme e congelate</div>
+    <h2>Armate e rosse</h2>
+    <p class="sub">Queste hanno chiesto di fondersi da sole, ma un controllo è rosso. Armare
+    <em>congela</em> il ramo, e diversi controlli si riparano solo modificando un file
+    <em>dentro la proposta stessa</em>. Finché nessuno la disarma di proposito, una proposta qui
+    non si sblocca da sola.</p>
+    <div class="scroll"><table>
+      <tr><th>Proposta</th><th>Titolo</th><th>Cosa è rosso</th></tr>
+      {stalled_rows}
+    </table></div>
   </section>
 
   <section>

--- a/scripts/tests/test_fleet_dashboard.py
+++ b/scripts/tests/test_fleet_dashboard.py
@@ -284,3 +284,48 @@ def test_innocence_a_pending_rollup_is_not_treated_as_failing(fd):
 
 def test_a_pr_with_no_commits_yields_the_placeholder_not_a_crash(fd):
     assert fd.rollup_state({"commits": {"nodes": []}}) == "—"
+
+
+# ---------------------------------------------------------------------------
+# is_armed — the union rule. Each field is null in a state the OTHER covers, so
+# a single-field probe is a confident answer to a neighbouring question. Both
+# arms below are guilt tests against a real, previously-shipped single-field
+# reading; the third is the innocence arm (superscar #3: a guard with only one
+# of the two is half a guard).
+# ---------------------------------------------------------------------------
+
+def test_guilt_armed_but_red_is_armed_even_though_it_holds_no_queue_entry(fd):
+    """The blind spot this pins. GitHub admits a PR to the merge queue only once
+    its required checks pass, so `mergeQueueEntry` is null for EVERY armed PR that
+    is failing — exactly the population a stuck board needs to show. Reading armed
+    from mergeQueueEntry alone (what this module did) reports these as unarmed.
+    Measured on #5158, 2026-09-01: autoMergeRequest.enabledAt set, queue entry
+    null, one failing check."""
+    pr = {"autoMergeRequest": {"enabledAt": "2026-09-01T00:48:51Z"}, "mergeQueueEntry": None}
+    assert fd.is_armed(pr), (
+        "an armed PR that is red holds no queue entry; reading mergeQueueEntry "
+        "alone makes the frozen-and-stuck population invisible"
+    )
+
+
+def test_guilt_queued_is_armed_even_though_the_queue_consumed_the_request(fd):
+    """The mirror blind spot, already recorded in this module's header: the queue
+    CONSUMES autoMergeRequest, so a PR at position 1 reports null there. Measured
+    on #5458/#5459/#5460 and again on #5490."""
+    pr = {"autoMergeRequest": None, "mergeQueueEntry": {"position": 1, "state": "AWAITING_CHECKS"}}
+    assert fd.is_armed(pr), (
+        "the merge queue nulls autoMergeRequest on admission; reading it alone "
+        "reports a PR at position 1 as unarmed"
+    )
+
+
+def test_innocence_a_pr_with_neither_field_is_not_armed(fd):
+    assert not fd.is_armed({"autoMergeRequest": None, "mergeQueueEntry": None})
+
+
+def test_innocence_missing_keys_do_not_read_as_armed(fd):
+    """A shape the bulk query cannot currently produce, pinned anyway: if either
+    key is ever dropped from GRAPHQL, `is_armed` must answer "no", never raise and
+    never default to yes — a probe that errors on a schema change is better than
+    one that quietly calls every PR armed."""
+    assert not fd.is_armed({})


### PR DESCRIPTION
A third of the open board sits in a state **no row on this page could name**. Measured 2026-09-01:
of 32 live PRs, **ten are armed and red at once**. The queue held two.

## Why the page was blind — and it is this module's own half-cured scar

The header already records **half** the rule: the merge queue *consumes* `autoMergeRequest`, so a PR
at position 1 reports null there (#5458/#5459/#5460, and #5490 again tonight). The cure recorded was
*"read `mergeQueueEntry` instead"*, and `collect()` did.

That cure has the **mirror** blind spot:

| field | null when… | what it loses |
|---|---|---|
| `autoMergeRequest` | the queue consumed it | PRs in the queue *(already known)* |
| `mergeQueueEntry` | the PR is red — GitHub admits a PR only once checks pass | **every armed PR that is failing** |

So `mergeQueueEntry` answers *"is it in the queue?"* and `autoMergeRequest` answers *"is a request
still pending?"*. Neither answers *"is it armed?"* — **ARMED is the union**. Each field is null in a
state the other covers, which is exactly why either one alone reads as a confident answer to a
neighbouring question.

## Why the set matters, rather than just being one more number

Arming **freezes** the branch (THE BUILDER CONTRACT §1), and several gates are built so the only
possible fix lives *inside that same PR's files* — `check_adversarial_review.py`'s own docstring says
it outright: *"the fix for a FAIL is always 'edit THIS file in THIS commit', never a follow-up PR"*.

So a PR that is armed and *then* goes red **cannot clear itself**: the freeze forbids the in-place
fix, and a fresh PR cannot repair another PR's evidence pack or frontmatter. It waits for a
deliberate disarm. Nothing on the board said so — `queued` structurally cannot contain these (no
queue entry), and `red` showed them without saying they were also frozen.

This PR **reports** that state. It changes no gate and no merge behaviour.

Also corrects the technical note under the queue table, which stated only the `autoMergeRequest`
half of the rule and would now be actively misleading.

## Each guard discriminates

Both mutations run here, each reddening its **own** test and no other:

- read only `mergeQueueEntry` → `test_guilt_armed_but_red_is_armed_...` **RED**
- read only `autoMergeRequest` → `test_guilt_queued_is_armed_...` **RED**

Plus two innocence arms (neither field set; both keys absent → "no", never raise). **46 tests green**
unmutated, 42 of them pre-existing and untouched.

**Bites:** `scripts/fleet_dashboard.py`, run against the live repo **before** this was written — not
a promise that a future run will show it. The generator reported `stalled_armed: 10` and rendered the
section, and that set is **identical** to the ten PRs found independently by a separate shell sweep
over gh's GraphQL API: #4664 #4691 #4913 #5037 #5086 #5100 #5158 #5432 #5464 #5466. Two methods, one
answer.