### PR TITLE
chore(organism): mark WR2 organs manual-only (Zero ruling 2026-09-01)

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: dda387afc1f6d9a204948eaa0e285e40dcfb2171130c276fc0a29ce32cda2708
+checksum: d4447087b67244cbed18855d24c8b920d2fe52063ad9f2827a79e0ac3f016a72
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -494,6 +494,8 @@ organs:
 - id: wr2.supervisor
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 300
   owner_module: scripts/wr2_supervisor.py
   dependencies:
@@ -511,6 +513,8 @@ organs:
 - id: wr2.oracle
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 1209600
   owner_module: backend.services.cognitive.oracle_cli
   dependencies:
@@ -637,6 +641,8 @@ organs:
 - id: mata_garuda.wr2_bridge_hourly.pro
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 7200
   owner_module: apps/mata-garuda/scripts/run_wr2_bridge.py
   dependencies:
@@ -870,6 +876,8 @@ organs:
 - id: wr2.connector
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 90000
   owner_module: apps/war-room/scripts/wr2_connector.py
   dependencies:
@@ -885,6 +893,8 @@ organs:
 - id: wr2.dossier_compiler
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 90000
   owner_module: apps/war-room/scripts/wr2_dossier_compiler.py
   dependencies:
@@ -899,6 +909,8 @@ organs:
 - id: wr2.draft_generator
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: scripts/wr2_draft_generator.py
   dependencies:
@@ -914,6 +926,8 @@ organs:
 - id: wr2.hardening
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: apps/war-room/scripts/wr2_hardening.py
   dependencies:
@@ -929,6 +943,8 @@ organs:
 - id: wr2.image_generator
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: scripts/wr2_image_generator.py
   dependencies:
@@ -942,6 +958,8 @@ organs:
 - id: wr2.learner_nightly
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 90000
   owner_module: apps/war-room/scripts/wr2_learner_nightly.py
   dependencies:
@@ -957,6 +975,8 @@ organs:
 - id: wr2.measurer
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: apps/war-room/scripts/wr2_measurer.py
   dependencies:
@@ -986,6 +1006,8 @@ organs:
 - id: wr2.sla_worker
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: apps/war-room/scripts/wr2_sla_worker.py
   dependencies:
@@ -1000,6 +1022,8 @@ organs:
 - id: wr2.strategos
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 691200
   owner_module: apps/war-room/scripts/wr2_strategos.py
   dependencies:
@@ -1015,6 +1039,8 @@ organs:
 - id: wr2.topic_selector
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 90000
   owner_module: scripts/wr2_topic_selector.py
   dependencies:
@@ -1030,6 +1056,8 @@ organs:
 - id: wr2.trend_hunter
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: apps/war-room/scripts/wr2_trend_hunter.py
   dependencies:
@@ -1270,6 +1298,8 @@ organs:
 - id: wr2.canva_oauth_watchdog
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 3600
   owner_module: scripts/wr2-canva-oauth-watchdog.sh
   dependencies:
@@ -1283,6 +1313,8 @@ organs:
 - id: wr2.deploy_puller
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: scripts/wr2-deploy-pull.sh
   dependencies: []
@@ -1295,6 +1327,8 @@ organs:
 - id: wr2.fact_checker
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 1800
   owner_module: scripts/wr2_fact_checker.py
   starved_after_periods: 2
@@ -1311,6 +1345,8 @@ organs:
 - id: wr2.fact_extractor
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 1800
   owner_module: scripts/wr2_fact_extractor.py
   starved_after_periods: 2
@@ -1327,6 +1363,8 @@ organs:
 - id: wr2.ig_scraper_daily
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 90000
   owner_module: skills/bali-zero-brand/_ig-metrics-scraper.py
   dependencies:
@@ -1340,6 +1378,8 @@ organs:
 - id: wr2.queue_server
   runtime: pro_launchd
   type: daemon
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 300
   owner_module: skills/bali-zero-brand/_damar-queue-server.py
   dependencies:
@@ -1353,6 +1393,8 @@ organs:
 - id: wr2.reflexion_weekly
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 691200
   owner_module: .claude/skills/bali-zero-brand/_reflexion-synthesis.py
   dependencies:
@@ -1366,6 +1408,8 @@ organs:
 - id: wr2.ig_metrics_analyst_weekly
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 691200
   owner_module: infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
   dependencies:
@@ -1379,6 +1423,8 @@ organs:
 - id: wr2.external_bench_monthly
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 2764800
   owner_module: infra/launchagents/wrappers/wr2-external-bench-run.sh
   dependencies:
@@ -1392,6 +1438,8 @@ organs:
 - id: wr2.supervisor_watchdog
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 600
   owner_module: scripts/wr2_supervisor_watchdog.py
   dependencies:
@@ -1405,6 +1453,8 @@ organs:
 - id: wr2.voyager_weekly
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 691200
   owner_module: skills/bali-zero-brand/_voyager-curriculum.py
   dependencies:
@@ -2076,6 +2126,8 @@ organs:
 - id: pro.wr2_daily_carousel
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 64800
   owner_module: scripts/wr2_daily_reconciler.py
   dependencies:
@@ -2093,6 +2145,8 @@ organs:
 - id: pro.wr2_worktree_gc
   runtime: pro_launchd
   type: cron
+  enabled: false
+  disabled_reason: 'manual-only since 2026-09-01 — Zero ruling: WR2 runs only on command (runtime booted out + launchctl disabled on Pro; rollback in ~/.tokenaudit/rollback.sh)'
   expected_hb_seconds: 129600
   owner_module: scripts/wr2_worktree_gc.py
   dependencies: []


### PR DESCRIPTION
Zero ruled 2026-09-01: WR2 (the Instagram carousel pipeline) runs only on command. The runtime side is already done on Pro — 32 `com.balizero.wr2.*` launchd agents + `com.matagaruda.wr2-bridge` are booted out, `launchctl disable`d, and their plists renamed `.disabled` (kept: `com.balizero.wr2.pg-proxy` = Postgres proxy infrastructure, `com.balizero.wr2control` = GUI command surface).

This PR is the GENOME half: it marks the 27 corresponding organs in `apps/organism/organism/organs_registry.yaml` as `enabled: false` with a `disabled_reason`, mirroring EXACTLY the convention already used by `wr2.newsletter` and `wr2.canva_apply` (both already `enabled: false` for their own prior, unrelated reasons — left untouched). Without this, the healer/organism supervisor would keep treating these 27 organs as dead and attempt `launchctl_kickstart` resurrection against a job that was intentionally disabled on the machine.

**27 organs marked manual-only**: `wr2.supervisor`, `wr2.oracle`, `wr2.connector`, `wr2.dossier_compiler`, `wr2.draft_generator`, `wr2.hardening`, `wr2.image_generator`, `wr2.learner_nightly`, `wr2.measurer`, `wr2.sla_worker`, `wr2.strategos`, `wr2.topic_selector`, `wr2.trend_hunter`, `wr2.canva_oauth_watchdog`, `wr2.deploy_puller`, `wr2.fact_checker`, `wr2.fact_extractor`, `wr2.ig_scraper_daily`, `wr2.queue_server`, `wr2.reflexion_weekly`, `wr2.ig_metrics_analyst_weekly`, `wr2.external_bench_monthly`, `wr2.supervisor_watchdog`, `wr2.voyager_weekly`, `pro.wr2_daily_carousel`, `pro.wr2_worktree_gc`, `mata_garuda.wr2_bridge_hourly.pro`.

**Untouched, deliberately**: `wr2.pg_proxy` (kept live — Postgres proxy infra), `{m5,pro,mini}.wr2_control_app` (kept live — GUI command surface), `wr2.newsletter` + `wr2.canva_apply` (already `enabled: false`, different prior reasons), `wr2.newsletter_daily_task` (Fly, not a Pro launchd job), anything WR3.

**Checksum note**: the registry carries a SHA256 checksum over its parsed organ list. I patched only the `checksum:` line by hand rather than running `validate_organs_registry.py --update-checksum`, because that tool does a full `yaml.safe_load`/`dump` round-trip and silently deleted 5 unrelated explanatory comments elsewhere in the file (pyyaml round-trips don't preserve comments) — out of scope for a one-concern PR. Net diff is 55 insertions / 1 deletion, all inside the 27 target blocks plus the checksum line.

## Verification

- `PYTHONPATH=apps/organism python3 -m organism.tools.validate_organs_registry apps/organism/organism/organs_registry.yaml` → `✓ organs_registry.yaml valid`
- `python3 infra/organ-conformance/check_organ_conformance.py` → `✓ organ conformance: 189 plists scanned, 121 grandfathered, 0 regressions, 0 non-conformant births`
- `python3 infra/organ-conformance/check_baseline_ratchet.py --base origin/main` → `✓ ratchet holds: 135 grandfathered (was 135), no growth`
- `python3 -m pytest infra/organ-conformance/ -q` → `169 passed`
- `python3 -m pytest apps/organism/tests/ -q` (PYTHONPATH=apps/organism) → `1 failed, 325 passed, 1 skipped` — the 1 failure (`test_genome_no_active_active.py::test_no_active_active_enrollment_outside_whitelist`, `com.balizero.wr2control: hosts=['mini','pro']`) is **pre-existing**: reproduced identically against the unmodified registry (verified via `git stash`). Not caused by this PR and out of this PR's one concern (`wr2control` is one of the explicit "kept live" organs).
- `python3 -m pytest scripts/tests/test_healer_receptor_running_status.py scripts/tests/test_healer_receptor_parse_ts.py scripts/tests/test_healer_receptor_yaml_fallback.py scripts/tests/test_organ_heartbeat_exceeds_poller_interval.py scripts/tests/test_organ_heartbeat_workflow_wiring.py scripts/tests/test_prepush_classify.py -q` → `177 passed, 1 skipped` (the 1 skip is the documented live-snapshot-drift check, only observable on Pro's own live checkout)

**Follow-up flagged, not fixed here (separate concern)**: `infra/launchagents/com.balizero.wr2.*.plist` (the git canon `scripts/wr2_plist_watchdog.sh` restores from) still ships these plists un-renamed/active in git — only `wr2.newsletter`'s plist carries a `.disabled-*` suffix in the repo. If `wr2_plist_watchdog.sh`'s own cron were ever re-armed, it would copy the still-active git-canon plists back into `~/Library/LaunchAgents/` and re-`launchctl bootstrap` them, undoing the runtime-side disable. Renaming ~27 plist files in `infra/launchagents/` (and any watchdog-script consequences) is a distinct, larger concern from the registry genome and is out of this PR's ≤400-line/one-concern budget.

Bites: `scripts/healer_receptor_registry.py --node pro --json`, run live on Pro from this worktree, no longer reports the 27 WR2 organs as check-eligible/dead. Before this change: `checked=137 ok=39 stale=1 dead=8 never_armed=89 skipped_exempt=9` — 2 of the 8 dead were WR2 (`wr2.ig_metrics_analyst_weekly`, `wr2.external_bench_monthly`), meaning the healer would have `launchctl_kickstart`'d them. After this change: `checked=110 ok=36 stale=0 dead=6 never_armed=68 skipped_exempt=36` — 0 WR2 organs in `dead`. Delta: `-27 checked / +27 skipped_exempt / -2 dead`, exactly the 27 organs this PR marks `enabled: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHzindMnigrHLGi4ciBNzr
