### PR TITLE
perf(mos-plus): run the Haiku compression call without harness bootstrap

### DIFF
--- a/scripts/mos-plus-compression-worker.py
+++ b/scripts/mos-plus-compression-worker.py
@@ -33,6 +33,13 @@ Tailscale IP — see the OLLAMA_HOST comment below for why (cascade-fix
 translate-articles.py's cron on the same machine).
 
 Scheduled: every 10min via launchd. NOT inline.
+
+Headless claude invocation (perf, 2026-09-01, D-006): the claude_haiku call runs
+with `--setting-sources "" --strict-mcp-config` — a bare headless `claude -p` run
+from `~/scripts` still pays full harness bootstrap (SessionStart hooks + CLAUDE.md
++ MCP schemas), measured at ~350K input tokens/call vs ~13K with these flags
+(tokenaudit 2026-09-01, ~/.tokenaudit/reports/04-rightsizing.md). This compression
+prompt needs no tools, no hooks, no MCP — it is a single-turn synthesis call.
 """
 import json
 import os
@@ -173,7 +180,11 @@ def save_counter(c: dict) -> None:
 def call_claude_haiku(prompt: str) -> str | None:
     try:
         r = subprocess.run(
-            [CLAUDE_BIN, "--model", "claude-haiku-4-5-20251001", "-p", prompt],
+            [
+                CLAUDE_BIN, "--model", "claude-haiku-4-5-20251001",
+                "--setting-sources", "", "--strict-mcp-config",
+                "-p", prompt,
+            ],
             capture_output=True, text=True, timeout=LLM_TIMEOUT,
             env={**os.environ, "ANTHROPIC_API_KEY": ""},
         )

--- a/scripts/tests/test_mos_plus_compression_worker_headless_flags.py
+++ b/scripts/tests/test_mos_plus_compression_worker_headless_flags.py
@@ -1,0 +1,110 @@
+"""mos-plus-compression-worker.py — headless claude invocation (D-006, 2026-09-01).
+
+The claude_haiku tier call must run with `--setting-sources "" --strict-mcp-config`
+so it skips SessionStart hooks + CLAUDE.md + MCP schema injection — measured
+~350K -> ~13K input tokens/call (tokenaudit 2026-09-01,
+~/.tokenaudit/reports/04-rightsizing.md). `-p prompt` must stay the LAST two argv
+elements: a list-valued flag placed AFTER `-p` would swallow the prompt as its
+own value instead of leaving it as `-p`'s positional argument.
+
+Same import shape as test_mos_plus_compression_worker.py (W96 class): the module
+does real work at import (os.path.expanduser("~/.claude/...") evaluated at load),
+so HOME is redirected to a throwaway tmp_path BEFORE import, and the module is
+loaded by path (hyphenated filename, not a valid Python identifier). `main()` is
+guarded by `if __name__ == "__main__":` (verified: only that guarded call site
+invokes it), so importing this module never executes the worker loop.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "scripts" / "mos-plus-compression-worker.py"
+
+
+@pytest.fixture()
+def worker(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("MOS_PLUS_OLLAMA_URL", raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        "mos_plus_compression_worker_headless", SRC
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["mos_plus_compression_worker_headless"] = mod
+    spec.loader.exec_module(mod)
+    try:
+        yield mod
+    finally:
+        sys.modules.pop("mos_plus_compression_worker_headless", None)
+
+
+def test_claude_haiku_call_runs_headless_without_harness_bootstrap(worker, monkeypatch):
+    captured = {}
+
+    class FakeResult:
+        returncode = 0
+        stdout = "synthesized"
+        stderr = ""
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return FakeResult()
+
+    monkeypatch.setattr(worker.subprocess, "run", fake_run)
+
+    out = worker.call_claude_haiku("compress these observations")
+
+    assert out == "synthesized"
+    argv = captured["argv"]
+
+    assert "--setting-sources" in argv, "must skip global/project/local settings load"
+    idx = argv.index("--setting-sources")
+    assert argv[idx + 1] == "", (
+        "--setting-sources must be given the empty string (no settings sources), "
+        f"got {argv[idx + 1]!r}"
+    )
+    assert "--strict-mcp-config" in argv, "must not load any ambient MCP server config"
+
+    # `-p prompt` must be the LAST two argv elements — a list-valued flag placed
+    # after `-p` would swallow the prompt as its own value instead of leaving it
+    # as -p's positional argument (the exact agy-cli trap this repo already hit,
+    # cf. the call_agy_gemini comment in this same file).
+    assert argv[-2:] == ["-p", "compress these observations"], (
+        f"-p <prompt> must be the trailing pair of argv, got tail={argv[-3:]}"
+    )
+
+
+def test_claude_haiku_argv_flags_precede_the_prompt(worker, monkeypatch):
+    """Guilt: a flag reordering that put --setting-sources/--strict-mcp-config
+    AFTER -p would silently break the prompt delivery (agy-cli class of bug) —
+    this pins the ordering, not just the presence of each flag."""
+    captured = {}
+
+    class FakeResult:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    monkeypatch.setattr(
+        worker.subprocess, "run",
+        lambda argv, **kwargs: captured.setdefault("argv", argv) or FakeResult(),
+    )
+
+    worker.call_claude_haiku("hello")
+    argv = captured["argv"]
+
+    p_idx = argv.index("-p")
+    setting_idx = argv.index("--setting-sources")
+    strict_idx = argv.index("--strict-mcp-config")
+
+    assert setting_idx < p_idx and strict_idx < p_idx, (
+        "both flags must precede -p so the prompt stays -p's own trailing value"
+    )


### PR DESCRIPTION
perf(mos-plus): run the Haiku compression call without harness bootstrap

The claude_haiku tier of mos-plus-compression-worker.py's routing matrix
invoked `claude -p <prompt>` with no --setting-sources / --strict-mcp-config
flags, so every call paid full interactive-harness bootstrap (SessionStart
hooks + CLAUDE.md + MCP schema injection) despite being a single-turn
synthesis call needing no tools, no hooks, no MCP. Measured
(~/.tokenaudit/reports/04-rightsizing.md, 2026-09-01): ~350K input
tokens/call vs ~13K with the flags added.

Fix: argv becomes
  [CLAUDE_BIN, "--model", "claude-haiku-4-5-20251001",
   "--setting-sources", "", "--strict-mcp-config", "-p", prompt]
with `-p prompt` kept as the trailing pair — a list-valued flag placed
after `-p` would swallow the prompt as its own value instead of leaving it
as -p's positional argument (the same class of bug this file's
call_agy_gemini already documents and works around for the agy CLI).

Adds scripts/tests/test_mos_plus_compression_worker_headless_flags.py:
asserts the flags are present, in the correct order (before -p, not after),
and that `-p <prompt>` stays the last two argv elements.

Bites: consumer is the launchd job com.balizero.mos-plus.compression on Pro
(StartInterval=1800s), whose claude_haiku tier calls this argv on every
cloud-tier tick (counter cap DAILY_CAP_CLOUD=50/day) and logs to
~/.claude/state/mos-plus-compression.log. Pre-merge observation: `ruff
check` clean + `python -m py_compile` clean + full suite
scripts/tests/test_mos_plus_compression_worker.py +
scripts/tests/test_mos_plus_compression_worker_headless_flags.py = 20
passed. Post-merge observation (for the orchestrating session, which owns
refreshing the declared home-fork pair ~/scripts/mos-plus-compression-
worker.py per infra/home-fork/declared-pairs.json — not done by this PR):
`ps` on the next live claude_haiku invocation should show
--setting-sources "" --strict-mcp-config in the argv, and per-call wall
time / token spend should drop accordingly.

NOTE ON SCOPE: this PR does NOT touch ~/scripts/ (the live copy is a
declared home-fork pair refreshed by the orchestrating session, not by
worktree-scoped agent work). The live copy on Pro (`~/scripts/`, launchd
`com.balizero.mos-plus.compression`) was found stale at the 2026-08-13
promotion sha (392 lines) and is refreshed from origin/main by the
orchestrating session, not by this PR.

KNOWN GOTCHA CHECKED (memory discovery_setting_sources_empty_also_drops_
tool_permissions_2026_09_01, landed same day this PR was opened):
`--setting-sources ""` also drops `permissions.allow`, so a headless call
that needs a tool (e.g. Read on a file) can fail silently with an empty/
wrong verdict at rc 0. This call site does NOT depend on that gotcha —
call_claude_haiku is a pure text-in/JSON-out synthesis prompt (all
observation data is inlined into PROMPT_TEMPLATE; the model is never asked
to invoke Read/Bash/any tool). Verified empirically this session with the
real `claude` CLI, exact new argv, `--output-format json`, a synthetic
prompt shaped like the real one: `num_turns:1`, `permission_denials:[]`,
`is_error:false`, correct JSON result — no silent tool-denial regression.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
