### PR TITLE
docs(design): open the /design corner with the calibrated probes and the front page

### DIFF
--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -50,9 +50,17 @@ whether it is TRUE.
 - **The August filing count** (`47 KITAS / 9 PT PMA`) is a SHAPE, not a measurement.
   Replace with the real CRM figure or delete the clause. Its methodology line
   (counted on submission, not approval; as-of date) is correct and must survive.
-- **`since 2019` vs `since 2020`** contradict each other across `apps/mouth`
-  (10 vs 14 occurrences), and `lib/trust-figures.ts` contradicts `app/layout.tsx`.
-- **Five live `#1` claims** in `(marketing)/page.tsx` and `layout.tsx` — blocklist class.
+- **`since 2019` vs `since 2020`** contradict each other in the live marketing
+  copy: `apps/mouth/src/lib/trust-figures.ts` says in its own docstring that the
+  "5,000+ clients since 2019" claim has no verifiable source in any system we
+  run, while `apps/mouth/src/app/layout.tsx:49,98` publishes "5000+ clients
+  since **2020**". Same claim, two years, one of them disowned by the file that
+  owns the figures. No repo-wide count is given on purpose — a bare grep for
+  "since 2020" also catches KBLI regulatory dates in `.mdx`/`.json`, so any
+  headline number here would be measuring the wrong thing.
+- **Five live `#1` claims** in `(marketing)/page.tsx` (2) and `layout.tsx` (3) —
+  blocklist class. A raw grep returns 8; three are false positives (the hex
+  colour `#16213a` and two `#1216` issue references).
 - The 5-LLM contest vote.
 
 ## 2. The doctrine, in four rules
@@ -105,10 +113,12 @@ to a photograph and a working answer.
 8. **Prices come from PricingTool only** (CLAUDE.md golden rule #11), and the
    stores disagree: `practice_types.base_price` diverges from the sheet on
    `B1 - VOA` (750k vs 790k). A mockup shows no price.
-9. **Client PII never reaches a mockup.** The one clean-consent image class is
-   `apps/mouth/public/static/team/*.jpg` — staff cards, carrying their own name
-   and role. The immigration-queue photograph in the same tree shows ~15–20
-   identifiable strangers and must NOT be published.
+9. **Client PII never reaches a mockup.** The one clean-consent image class of
+   PEOPLE is `apps/mouth/public/static/team/*.jpg` — staff cards, carrying their
+   own name and role. The immigration-queue photograph in the same tree shows
+   ~15–20 identifiable strangers and must NOT be published. The hero,
+   `static/news/perfect-storm-bali.jpg`, is landscape with no identifiable
+   person and is the one non-staff image this corner uses.
 
 ## 4. What is here
 

--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: design
+description: "Design corner — the shared brain for every Bali Zero visual surface (front page, GARUDA VOA, Visa Oracle, brand pages). Load BEFORE designing, judging or measuring any page, or when Zero says /design, 'la home', 'il rendering', 'la pagina'. Holds: the derivability doctrine (a rule that cannot name its input is a fad), the calibrated probes, the 2026-09-01 front page and how to rebuild it, and the standing rule that a mechanical gate can tell you a page is well-built but never that it is TRUE."
+---
+
+# /design — the visual-surface corner
+
+> Created 2026-09-01 on Zero's order at the close of the front-page rebuild
+> ("salva tutto in un nuovo corner /design che casomai vai a unire cn altre
+> skill/corner"). This is HOT CONTEXT for any session touching a Bali Zero
+> visual surface. **§1 LIVE STATE is only useful while it is true — update it
+> when it changes.**
+
+## 0. What this corner is, and the north star
+
+Bali Zero sells a service that is easy to fake and expensive to get wrong: a
+foreigner's permission to live in Indonesia. Every visual surface therefore has
+one job before it has any other — **be recognisably the work of people who know
+the answer.** The corpus's own documented failure mode is a page that is
+"technically correct and emotionally flat"; the failure mode we shipped and had
+to undo on 2026-09-01 is its sibling, a page that spends itself insisting it is
+legitimate.
+
+**THE NORTH STAR: the product's promise, delivered before anything is claimed.**
+On a visa surface that means an answer in ten seconds. Knowing the answer is the
+only trust signal a copycat cannot reproduce — a website is an afternoon's work,
+knowing which permit someone needs is not. Proof of legitimacy is a line and a
+row of real faces, never a section, never six.
+
+**The unit of quality here is a MEASUREMENT, not an opinion** (SYMBIOSIS Law 7).
+Everything in `strumenti/` exists so a design claim can be falsified. But see
+§3: the measurements bound how well a page is BUILT and say nothing about
+whether it is TRUE.
+
+## 1. LIVE STATE (2026-09-01)
+
+| thing                                                                      | where                                                                     | state                                                                                                                                 |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Front page v2.1**                                                        | artifact `9f30f3b6-72c4-4a87-9e23-17c16581815c`                           | published, private. Source of truth = `prima-pagina/home.tpl.html` HERE                                                               |
+| **Nine rendered states**                                                   | artifact `9f1fcdcd-a398-47df-a6ca-66940f572622`                           | published, private                                                                                                                    |
+| **Design dossier** (110KB synthesis, 12 lane reports, 53+ gates, 11 knobs) | `~/Desktop/Design-Dossier-2026-08-31/`                                    | ⚠️ NOT in git, 29MB, and `~/Desktop` is TCC-denied in readdir — a glob there returns empty WITHOUT error. Read files by explicit path |
+| **5-LLM blind contest** ("la prima pagina")                                | `~/Desktop/Design-Dossier-2026-08-31/concorso-la-prima-pagina/arena.html` | 🔴 **OPEN — awaiting Zero's blind vote.** `mapping.json` is sealed: NEVER put the seat↔letter mapping in prose before the vote        |
+| Calibrated probes                                                          | `strumenti/` HERE                                                         | armed; controls pass                                                                                                                  |
+| Front-page build chain                                                     | `prima-pagina/` HERE                                                      | proven end-to-end from a clean dir on 2026-09-01                                                                                      |
+
+**Open, and they are Zero's, not a session's:**
+
+- **Registry numbers + street address** — the footer carries a dashed placeholder.
+  Nothing invented; needs the real NIB / entity / tax-licence numbers.
+- **The August filing count** (`47 KITAS / 9 PT PMA`) is a SHAPE, not a measurement.
+  Replace with the real CRM figure or delete the clause. Its methodology line
+  (counted on submission, not approval; as-of date) is correct and must survive.
+- **`since 2019` vs `since 2020`** contradict each other across `apps/mouth`
+  (10 vs 14 occurrences), and `lib/trust-figures.ts` contradicts `app/layout.tsx`.
+- **Five live `#1` claims** in `(marketing)/page.tsx` and `layout.tsx` — blocklist class.
+- The 5-LLM contest vote.
+
+## 2. The doctrine, in four rules
+
+**R1 — Derivability (Test A).** A rule that cannot name the input it is computed
+from is a fad, not a principle. "Ground L 18–20%" is derivable; "use a dark
+theme" is not. Every knob in `§5.1` of the dossier names its input.
+
+**R2 — Falsifiability (Test B).** For every claim on a page, name the external
+record that would falsify it. **Your own server renders decoration; a registrar
+renders evidence.** This is why the footer links `oss.go.id`, `ahu.go.id` and
+`sikop.kemenkeu.go.id` instead of showing a badge, and why the Google rating is
+a link to the live profile with the date it was read.
+
+**R3 — One peak per viewport.** Intensity is a budget. On the front page the
+peak is the photograph; everything after it is quiet on purpose.
+
+**R4 — Proof is a line, not a section.** See §0. The 2026-09-01 rebuild moved
+proof from six of eight sections to one line plus six faces, and gave the space
+to a photograph and a working answer.
+
+## 3. Blood-bought rules (each one cost a real defect)
+
+1. **A mechanical gate cannot be wrong about a regulation.** Twelve green gates
+   sat on a widget that named the wrong visa code with confident specificity.
+   Any surface that ANSWERS needs a cross-family refuter pointed at its facts —
+   it is the only instrument aimed there. Ground truth for visas:
+   `research/visa/2026-07-24-w2-factbase-*.md`, re-read on the turn you use it.
+2. **A broken `<img>` passes every layout gate** — it still has a box, an alt
+   string, a contrast ratio and a tap target. Six gates × six states plus six
+   defect classes all reported clean on a page whose seven images were dead.
+   `verify_images.py` exists for this, and it carries a deliberate guilt control.
+3. **Your local render is not the published page.** The artifact wrapper injects
+   `[hidden]{display:none!important}`; a local file without it lets
+   `.opts{display:flex}` beat the `hidden` attribute. `home.tpl.html` now
+   declares the host's rules itself. Whenever the host adds CSS to your document,
+   declare it or you are measuring a different page.
+4. **`loading="lazy"` on a data: URI defers nothing** (there is no request) but
+   leaves cards outside a horizontal scroller undecoded. Pure downside.
+5. **A copy blocklist over-matches on negations.** "We do **not** guarantee
+   outcomes" fires a `guarantee` guard. The side that moves is the GUARD, never
+   the honest sentence — narrow to a positive claim, then re-prove innocence AND
+   guilt (cicatrix family #3).
+6. **The brand mark is not a letter.** Setting it as the "B" of BALI reads
+   "3ALI ZERO" at 26px. The staff cards put the mark BESIDE the wordmark; follow
+   the brand rather than inventing a lockup for it.
+7. **A colour mixed toward white or black outlives its ground** — on dark,
+   lightening raises contrast; on paper it lowers it. Pin the token, not a
+   `color-mix` string. (See memory `discovery_a_colour_mixed_toward_white_...`.)
+8. **Prices come from PricingTool only** (CLAUDE.md golden rule #11), and the
+   stores disagree: `practice_types.base_price` diverges from the sheet on
+   `B1 - VOA` (750k vs 790k). A mockup shows no price.
+9. **Client PII never reaches a mockup.** The one clean-consent image class is
+   `apps/mouth/public/static/team/*.jpg` — staff cards, carrying their own name
+   and role. The immigration-queue photograph in the same tree shows ~15–20
+   identifiable strangers and must NOT be published.
+
+## 4. What is here
+
+```
+strumenti/                 the calibrated probes — all read the RENDERED DOM
+  measure.py    <file>     6 states (mobile/desktop × light/system-dark/forced-dark):
+                           27-pair contrast, horizontal overflow, 44px tap targets,
+                           external requests, no-JS text, derived palette/type metrics
+  defects.py    <root>     six classes a human had to notice once: dead-control,
+                           duplicate-string, heading-order, double-announce,
+                           struck-copy, clipped-sentence. Needs <root>/*/ui.html and
+                           <root>/../calib -> controlli-di-calibrazione
+  occlusion.py             overlap/occlusion pass
+  regression.py            before/after comparison
+  judge.py                 rubric scoring
+  controlli-di-calibrazione/   the innocence + guilt controls. A run whose
+                           innocence is NOISY or whose guilt is SILENT proves nothing
+
+prima-pagina/              the 2026-09-01 front page, rebuildable from repo sources
+  home.tpl.html            THE SOURCE. Tokens __LOGO__ __HERO__ __SURYA__ ... substituted at build
+  assets.py                re-encodes mark + hero + 6 staff cards from apps/mouth/public
+  build.py                 template + assets.json -> home.html
+  render.py                9 states incl. two answered-widget shots and two diagnostics
+  shrink.py / gallery.py   PNG -> JPEG, then the 9-state gallery page
+  verify_images.py         every <img> actually decoded (guilt-controlled)
+  verify_copy.py           drives all 7 widget branches + runs the claim blocklist
+```
+
+Nothing images-shaped is copied into this corner on purpose: the staff photos
+stay in `apps/mouth/public/static/team/` and are re-encoded on demand. A second
+copy is a second thing to keep in sync and a second place they can leak from.
+
+## 5. How to rebuild the front page (proven 2026-09-01, clean dir)
+
+```bash
+C=<repo>/.agents/skills/design ; T=<scratch>/proof ; R=<repo-root>
+V=<repo-root>/apps/backend-rag/.venv/bin/python      # Pillow lives here, not in system python
+mkdir -p "$T"
+"$V" "$C/prima-pagina/assets.py" "$R" "$T"           # -> assets.json  (~159 KB inline)
+python3   "$C/prima-pagina/build.py"  "$T"           # -> home.html    (~241 KB)
+python3   "$C/prima-pagina/verify_images.py" "$T/home.html"   # must say 8/8
+python3   "$C/prima-pagina/verify_copy.py"   "$T/home.html"   # 7 branches + blocklist
+mkdir -p "$T/probe/home" && cp "$T/home.html" "$T/probe/home/ui.html"
+ln -sfn "$C/strumenti/controlli-di-calibrazione" "$T/calib"
+python3   "$C/strumenti/measure.py" "$T/home.html"
+python3   "$C/strumenti/defects.py" "$T/probe"       # must say "probe trusted"
+python3   "$C/prima-pagina/render.py" "$T/home.html" "$T/shots"
+```
+
+The headless Chromium path is resolved per-machine (`CHROME_HEADLESS` env, else
+the newest `~/Library/Caches/ms-playwright/chromium_headless_shell-*`) — M5's
+home is `/Users/balizero`, Pro/Mini's is `/Users/nuzantara`, so a hardcoded path
+is a probe that dies silently on the other machine.
+
+**Read a probe's verdict only after reading its controls.** `defects.py` prints
+them first for exactly this reason.
+
+## 6. Conventions
+
+- **Artifact commentary in Italian, UI copy in English.** Never mixed in one artifact.
+- The study is a STUDY: no product code, no deploy, feature flags stay OFF.
+  Output is research, doctrine and mockups.
+- No external assets in an artifact beyond the CSP allowlist — inline everything
+  as data URIs. Google Fonts is the one stylesheet host that loads.
+- Publish updates to the SAME artifact URL (pass `url`); a new file path claims
+  a new artifact and orphans the link Zero already has.
+
+## 7. Merge candidates (Zero, 2026-09-01: "casomai vai a unire cn altre skill/corner")
+
+This corner deliberately does NOT duplicate what already exists. If it is ever
+consolidated, these are the neighbours and the seam:
+
+| corner / skill                                      | overlap                                                                                                             | seam                                                                                                                                                                              |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bali-zero-brand` (user skill, `~/.agents/skills/`) | palette, type, voice, forbidden phrases; surfaces `carousel-ig`, `internal-print-a4`, `web-mouth`, `email-template` | **It owns the brand tokens; this corner owns the measurement and the web-page doctrine.** A merge should fold §2–§3 in as a `web-front` surface and leave `tokens.json` sovereign |
+| `wr2`                                               | the `carousel-ig` surface and its critic rubric                                                                     | wr2's critic judges slides; `strumenti/` judges pages. Same discipline (guilt+innocence), different DOM                                                                           |
+| `visaoracle`                                        | the front page's widget answers ITS domain                                                                          | visaoracle owns the RulePack and the ENFORCE gate; this corner must never assert a verdict — the widget says "orientation, not a determination" and links out                     |
+| `modus`                                             | Gear 3 governs a redesign of this size                                                                              | no overlap to merge; modus is the loop, this is the terrain                                                                                                                       |

--- a/.agents/skills/design/prima-pagina/assets.py
+++ b/.agents/skills/design/prima-pagina/assets.py
@@ -1,0 +1,65 @@
+"""Rebuild assets.json (inline data-URIs) from the REPO's own image files.
+
+    python3 assets.py <repo-root> <out-dir>
+
+Nothing is copied into this corner: the hero and the six staff cards live in
+apps/mouth/public/static and are re-encoded on demand. That is deliberate --
+the staff photos are the one clean-consent image class we have, and a second
+copy in a skill directory is a second thing to keep in sync and a second place
+they can leak from.
+
+Needs Pillow, which lives in the backend venv, not in system python:
+    apps/backend-rag/.venv/bin/python assets.py <repo-root> <out-dir>
+"""
+import base64, io, json, pathlib, sys
+
+from PIL import Image
+
+if len(sys.argv) != 3:
+    raise SystemExit(__doc__)
+P = pathlib.Path(sys.argv[1]) / "apps/mouth/public/static"
+D = pathlib.Path(sys.argv[2]); D.mkdir(parents=True, exist_ok=True)
+if not P.is_dir():
+    raise SystemExit(f"not a repo root (no {P}): {sys.argv[1]}")
+
+out, total = {}, 0
+
+def jpg(im, w, q, key, crop=None):
+    global total
+    if crop:
+        im = im.crop(crop)
+    im = im.convert("RGB").resize((w, round(im.height * w / im.width)), Image.LANCZOS)
+    b = io.BytesIO(); im.save(b, "JPEG", quality=q, optimize=True, progressive=True)
+    d = b.getvalue(); total += len(d)
+    out[key] = "data:image/jpeg;base64," + base64.b64encode(d).decode()
+    print(f"  {key:16s} {im.size[0]}x{im.size[1]}  {len(d)/1024:6.1f} KB")
+
+# The mark is the brand's own asset, trimmed to its ink and shrunk to the size it
+# is actually drawn at. It is NOT set as the word's letter B: the staff cards put
+# the mark BESIDE the wordmark, and at 26px the "B" reading fails (it reads "3").
+print("MARK")
+m = Image.open(P.parent / "assets/logo/balizero-3-red.png").convert("RGBA")
+bbox = m.getbbox()
+if bbox:
+    m = m.crop(bbox)
+m = m.resize((round(m.width * 102 / m.height), 102), Image.LANCZOS)
+_b = io.BytesIO(); m.save(_b, "PNG", optimize=True)
+_d = _b.getvalue(); total += len(_d)
+out["logo"] = "data:image/png;base64," + base64.b64encode(_d).decode()
+print(f"  {'logo':16s} {m.size[0]}x{m.size[1]}  {len(_d)/1024:6.1f} KB")
+
+print("\nHERO — sized for a 390px phone at 2x, gate 36 budget 150-200 KB")
+jpg(Image.open(P / "news" / "perfect-storm-bali.jpg"), 1100, 72, "hero")
+
+print("\nTEAM — the cards carry their own name and role, so nothing is retyped")
+missing = []
+for t in ["surya", "ari", "sahira", "damar", "krisna", "dewaayu"]:
+    f = P / "team" / f"{t}.jpg"
+    if not f.exists():
+        missing.append(t); print(f"  {t}: MISSING"); continue
+    jpg(Image.open(f), 300, 74, t)
+
+print(f"\nTOTAL {total/1024:.0f} KB")
+(D / "assets.json").write_text(json.dumps(out))
+if missing:
+    raise SystemExit(f"missing team cards: {missing} — the page would ship dead images")

--- a/.agents/skills/design/prima-pagina/build.py
+++ b/.agents/skills/design/prima-pagina/build.py
@@ -1,0 +1,36 @@
+"""Substitute the inline assets into home.tpl.html -> home.html.
+
+    python3 build.py <work-dir>
+
+<work-dir> must hold assets.json (see assets.py). home.tpl.html is read from
+this script's own directory, so the corner is the single source of the template.
+"""
+import json, pathlib, re, sys
+
+if len(sys.argv) != 2:
+    raise SystemExit(__doc__)
+here = pathlib.Path(__file__).resolve().parent
+d = pathlib.Path(sys.argv[1])
+tpl = (here / "home.tpl.html").read_text()
+a = json.loads((d / "assets.json").read_text())
+
+
+def bare(v):
+    """assets.json stores a FULL data URI; the template supplies its own prefix.
+    Feeding it through unstripped produced `data:...base64,data:...base64,AAA`
+    -- which every mechanical gate passed, because a broken <img> still has a
+    box, an alt string and a contrast ratio. Strip the prefix at the seam."""
+    return re.sub(r"^data:image/[a-z+]+;base64,", "", v)
+
+
+tpl = tpl.replace("__LOGO__", bare(a["logo"])).replace("__HERO__", bare(a["hero"]))
+for k in ("surya", "ari", "sahira", "damar", "krisna", "dewaayu"):
+    tpl = tpl.replace("__" + k.upper() + "__", bare(a[k]))
+
+left = sorted(set(re.findall(r"__[A-Z]+__", tpl)))
+if left:
+    raise SystemExit(f"unreplaced tokens: {left}")
+if "base64,data:" in tpl:
+    raise SystemExit("double data-URI prefix survived")
+(d / "home.html").write_text(tpl)
+print(f"home.html  {len(tpl.encode()):,} bytes")

--- a/.agents/skills/design/prima-pagina/gallery.py
+++ b/.agents/skills/design/prima-pagina/gallery.py
@@ -1,0 +1,72 @@
+import base64, pathlib, sys
+d = pathlib.Path(sys.argv[1]); shots = d/"shots_web"
+SHOTS = [
+ ("phone-day", "Giorno · telefono",
+  "390×844. Il primo schermo: fotografia, titolo, e la domanda. Nessun form, nessuna email."),
+ ("phone-day-answered", "Giorno · la risposta",
+  "«Fino a 30 giorni» → B1. La risposta arriva prima del nome. È l'unico segnale di fiducia che un imitatore non sa falsificare, perché richiede di sapere la risposta."),
+ ("phone-night", "Notte · terra neutra",
+  "Ground OKLCH L 19,0%, croma 0,016: grigio caldo, non nero. Distanza di tinta terra→accento 32°."),
+ ("phone-night-answered", "Notte · seconda domanda",
+  "«Un anno o più» apre la domanda sul motivo; poi E33G, con la soglia pubblicata di 60.000 USD l'anno."),
+ ("phone-oxblood", "Notte · campo rosso",
+  "La polarità alternativa della Q10, ancora aperta: il rosso smette di essere accento e diventa la terra."),
+ ("desktop-day", "Giorno · desktop",
+  "1280×900. La colonna di lettura resta a 680px — la misura non cresce con lo schermo — ma i sei volti escono in una banda a piena larghezza."),
+ ("desktop-night", "Notte · desktop",
+  "Stesso documento, stessa banda, tema scelto dal visitatore e non dalla pagina."),
+ ("diagnostic-greyscale", "Diagnostica · scala di grigi",
+  "Nessun significato passa dalla sola tinta: il rosso è l'unico accento e non porta mai un'informazione da solo."),
+ ("diagnostic-sunlight", "Diagnostica · pieno sole",
+  "Contrasto 0,62 · luminosità 1,22 — un telefono tenuto fuori a mezzogiorno, che è dove questa pagina si legge davvero."),
+]
+cards=[]
+for name,title,note in SHOTS:
+    f = shots/f"{name}.jpg"
+    b64 = base64.b64encode(f.read_bytes()).decode()
+    kb = f.stat().st_size/1024
+    cards.append(f"""  <figure>
+    <figcaption><b>{title}</b><span>{note}</span></figcaption>
+    <img src="data:image/jpeg;base64,{b64}" alt="{title}">
+    <p class="meta">{name} · {kb:,.0f} KB · reso a 2×</p>
+  </figure>""")
+html = """<title>Front Page States</title>
+<style>
+:root{--ground:#FCFAF8;--surface:#FFF;--ink:#17120F;--muted:#574E49;--faint:#7A6F69;
+  --rule:#E9E3DC}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]){
+  --ground:#161311;--surface:#211E1C;--ink:#EEEAE7;--muted:#B5B0AC;--faint:#95908C;
+  --rule:#2E2B29}}
+:root[data-theme="dark"]{--ground:#161311;--surface:#211E1C;--ink:#EEEAE7;--muted:#B5B0AC;
+  --faint:#95908C;--rule:#2E2B29}
+*{box-sizing:border-box}
+body{margin:0;background:var(--ground);color:var(--ink);
+  font:15px/1.5 "Public Sans","Helvetica Neue",Arial,sans-serif}
+header{max-width:1180px;margin:0 auto;padding:46px 20px 6px}
+h1{margin:0 0 12px;font-size:31px;font-weight:800;letter-spacing:-.022em;text-wrap:balance}
+header p{margin:0 0 10px;max-width:66ch;color:var(--muted);text-wrap:pretty}
+main{max-width:1180px;margin:0 auto;padding:26px 20px 76px;
+  display:grid;gap:32px;grid-template-columns:repeat(auto-fill,minmax(290px,1fr));
+  align-items:start}
+figure{margin:0;background:var(--surface);border:1px solid var(--rule)}
+figcaption{padding:13px 15px;border-bottom:1px solid var(--rule);display:flex;
+  flex-direction:column;gap:4px}
+figcaption b{font-size:15px}
+figcaption span{color:var(--muted);font-size:13.5px;text-wrap:pretty}
+img{display:block;width:100%;height:auto}
+.meta{margin:0;padding:10px 15px;border-top:1px solid var(--rule);
+  color:var(--faint);font-size:12.5px;font-variant-numeric:tabular-nums}
+</style>
+<header>
+  <h1>Front page, nove stati</h1>
+  <p>Screenshot a piena pagina della stessa sorgente, resi a 2× su Chromium headless.
+     Il tema non è un interruttore decorativo: giorno, notte-neutra e notte-rossa sono tre
+     palette definite a token, e la pagina pubblicata sceglie da sé quella del visitatore.</p>
+  <p>Gli stati «risposta» esistono perché lo scatto di un elemento interattivo vuoto mostra
+     la cornice e non il prodotto. Gli ultimi due non sono design: sono sonde — una toglie
+     il colore, l'altra simula il sole.</p>
+</header>
+<main>
+""" + "\n".join(cards) + "\n</main>\n"
+(d/"gallery.html").write_text(html)
+print("gallery.html %.2f MB" % (len(html.encode())/1024/1024))

--- a/.agents/skills/design/prima-pagina/home.tpl.html
+++ b/.agents/skills/design/prima-pagina/home.tpl.html
@@ -1,0 +1,407 @@
+<title>Bali Zero Front Page</title>
+<meta name="description" content="PT PMA, KITAS and tax filing in Bali. Licensed. Kerobokan.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;600;800&display=swap">
+<style>
+/* ═══════════════════════════════════════════════════════════════════════════
+   Rebuilt 2026-09-01 after the owner's verdict on v1: "an entire home page
+   that hammers over and over that we're real? no image, nothing interesting."
+   He was right, and the diagnosis is precise: v1 optimised for passing the
+   study's gates instead of for the person arriving. Six of eight sections
+   asserted legitimacy. Nobody lands on a visa page wanting to audit an agency.
+
+   The inversion: proof drops from ~60% of the page to one line and a row of
+   real faces. What it buys is a photograph and a thing that WORKS — the
+   product's promise delivered in ten seconds, which is the only trust signal
+   that cannot be faked by someone who does not know the answer.
+
+   Knobs unchanged and still declared at the foot of the page. Ground L 19.0%,
+   hue distance 32°, elevation +7 L, spacing ratio 3.6x, one peak per viewport
+   (now the hero), PAS framing, VERIFY screen class.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+:root{
+  --ground:#FCFAF8; --surface:#FFFFFF; --surface-2:#EEEAE7;
+  --ink:#17120F; --ink-muted:#574E49; --ink-faint:#7A6F69;
+  --rule-subtle:#E9E3DC; --rule-strong:#8A7F77;
+  --accent:#C8102E; --accent-ink:#A50D26; --on-accent:#FFFFFF;
+  --focus:#17120F; --grain:.08; --logo-lift:none;
+  --step-0:14px; --step-1:15px; --step-2:17px; --step-3:21px; --step-4:27px;
+  --display:38px; --hero:40px;
+  --lh-tight:1.1; --lh:1.5;
+  --gap-in:20px; --gap-out:72px;
+  --t-instant:80ms; --t-fast:150ms; --t-base:220ms;
+  --ease:cubic-bezier(.2,0,.38,.9);
+  --measure:34ch;
+}
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --ground:#161311; --surface:#272321; --surface-2:#393432;
+    --ink:#EEEAE7; --ink-muted:#B5B0AC; --ink-faint:#95908C;
+    --rule-subtle:#2E2B29; --rule-strong:#67625F;
+    --accent:#C8102E; --accent-ink:#F0808F; --on-accent:#FFFFFF;
+    --focus:#EEEAE7; --grain:.06; --logo-lift:brightness(1.32) saturate(1.06);
+  }
+  :root:not([data-theme="light"])[data-night="oxblood"]{
+    --ground:#28070A; --surface:#3C1619; --surface-2:#512729;
+    --ink:#F6ECEA; --ink-muted:#D1B7B6; --ink-faint:#A78A89;
+    --rule-subtle:#452223; --rule-strong:#835D5E;
+    --accent:#F6ECEA; --accent-ink:#F6C9C0; --on-accent:#28070A; --focus:#F6ECEA;
+  }
+}
+:root[data-theme="dark"]{
+  --ground:#161311; --surface:#272321; --surface-2:#393432;
+  --ink:#EEEAE7; --ink-muted:#B5B0AC; --ink-faint:#95908C;
+  --rule-subtle:#2E2B29; --rule-strong:#67625F;
+  --accent:#C8102E; --accent-ink:#F0808F; --on-accent:#FFFFFF;
+  --focus:#EEEAE7; --grain:.06; --logo-lift:brightness(1.32) saturate(1.06);
+}
+:root[data-theme="dark"][data-night="oxblood"]{
+  --ground:#28070A; --surface:#3C1619; --surface-2:#512729;
+  --ink:#F6ECEA; --ink-muted:#D1B7B6; --ink-faint:#A78A89;
+  --rule-subtle:#452223; --rule-strong:#835D5E;
+  --accent:#F6ECEA; --accent-ink:#F6C9C0; --on-accent:#28070A; --focus:#F6ECEA;
+}
+
+[hidden]{display:none !important}
+*{box-sizing:border-box}
+body{margin:0; background:var(--ground); color:var(--ink);
+  font-family:"Public Sans","Helvetica Neue",Arial,sans-serif;
+  font-size:var(--step-2); line-height:var(--lh); -webkit-font-smoothing:antialiased}
+h1,h2,h3{margin:0; font-weight:600; letter-spacing:-.018em; text-wrap:balance}
+p{margin:0; text-wrap:pretty}
+a{color:inherit}
+img{display:block; max-width:100%}
+:focus-visible{outline:2px solid var(--focus); outline-offset:2px; border-radius:2px}
+.num{font-variant-numeric:tabular-nums lining-nums}
+.wrap{max-width:680px; margin:0 auto; padding:0 20px}
+
+/* ── HERO ──────────────────────────────────────────────────────────────────
+   The one peak (knob 6). The photograph is not decoration: the headline says
+   people get this wrong in their first month, and the picture is the place
+   they are getting it wrong in, with the weather coming. */
+.hero{position:relative; isolation:isolate; overflow:hidden;
+  background:#0E0C0B; color:#F6F2ED; min-height:520px; display:flex; flex-direction:column}
+.hero img{position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0}
+.hero::after{content:""; position:absolute; inset:0; z-index:1;
+  background:linear-gradient(178deg, rgba(8,7,6,.62) 0%, rgba(8,7,6,.30) 34%, rgba(8,7,6,.80) 78%, rgba(8,7,6,.94) 100%)}
+.hero > *{position:relative; z-index:2}
+.masthead{display:flex; align-items:center; justify-content:space-between; gap:16px;
+  padding:16px 20px 0; max-width:680px; margin:0 auto; width:100%}
+.brand{display:flex; align-items:center; gap:7px; text-decoration:none;
+  min-height:44px; padding-right:8px; margin-left:-4px; padding-left:4px}
+.brand img{position:static; height:26px; width:auto; object-fit:contain;
+  filter:brightness(1.28) saturate(1.06)}
+.brand .word{font-size:var(--step-2); font-weight:600; letter-spacing:.15em; text-transform:uppercase}
+.dateline{font-size:var(--step-0); letter-spacing:.04em; text-align:right; opacity:.82}
+.hero-body{margin-top:auto; padding:64px 20px 46px; max-width:680px; margin-left:auto; margin-right:auto; width:100%}
+.hero h1{font-size:var(--hero); line-height:var(--lh-tight); max-width:16ch; font-weight:800;
+  letter-spacing:-.028em; text-shadow:0 1px 26px rgba(0,0,0,.42)}
+.hero p{margin-top:16px; max-width:38ch; font-size:var(--step-2); opacity:.9}
+
+/* ── THE THING THAT WORKS ─────────────────────────────────────────────────
+   Delivered before anything is claimed. Knowing the answer IS the trust
+   signal; asserting legitimacy is what the copycats do. */
+.ask{margin-top:-30px; position:relative; z-index:3}
+.ask-card{background:var(--surface); border:1px solid var(--rule-strong); padding:22px 20px 20px}
+.ask h2{font-size:var(--step-3); margin-bottom:4px}
+.ask .hint{font-size:var(--step-1); color:var(--ink-muted); margin-bottom:16px}
+.opts{display:flex; flex-wrap:wrap; gap:8px}
+.opts button{min-height:44px; padding:0 14px; font:inherit; font-size:var(--step-1);
+  color:var(--ink); background:transparent; border:1px solid var(--rule-strong);
+  border-radius:2px; cursor:pointer; transition:background var(--t-instant) var(--ease)}
+.opts button:hover{background:var(--surface-2)}
+.opts button[aria-pressed="true"]{background:var(--ink); color:var(--ground); border-color:var(--ink)}
+.answer{margin-top:18px; padding-top:18px; border-top:1px solid var(--rule-subtle)}
+.answer[hidden]{display:none}
+.answer .code{display:inline-block;
+      min-width:1.6em; text-align:center; font-size:var(--step-0); font-weight:600;
+  letter-spacing:.09em; padding:4px 9px; background:var(--accent); color:var(--on-accent); border-radius:2px}
+.answer .name{font-size:var(--step-3); font-weight:600; margin-top:10px}
+.answer .detail{font-size:var(--step-1); color:var(--ink-muted); margin-top:6px; max-width:46ch}
+.answer .go{display:inline-flex; align-items:center; min-height:44px; margin-top:12px;
+  font-size:var(--step-1); color:var(--accent-ink); text-underline-offset:3px}
+.caveat{margin-top:16px; padding-top:14px; border-top:1px solid var(--rule-subtle);
+  font-size:var(--step-1); color:var(--ink-muted); max-width:52ch}
+
+section{margin-top:var(--gap-out)}
+.label{font-size:var(--step-0); text-transform:uppercase; letter-spacing:.1em;
+  color:var(--ink-faint); font-weight:600; margin-bottom:16px}
+
+/* ── doors ─────────────────────────────────────────────────────────────── */
+.door{display:grid; grid-template-columns:1fr auto; align-items:center; gap:14px;
+  min-height:64px; padding:16px 0; border-bottom:1px solid var(--rule-subtle);
+  text-decoration:none; transition:padding-left var(--t-fast) var(--ease)}
+.door:first-of-type{border-top:1px solid var(--rule-subtle)}
+.door:hover,.door:focus-visible{padding-left:8px}
+.door .q{font-size:var(--step-3); line-height:1.24; font-weight:600}
+.door .a{display:block; margin-top:5px; font-size:var(--step-1); color:var(--ink-muted)}
+.door .arrow{font-size:var(--step-3); color:var(--accent-ink)}
+
+/* ── the team: proof rendered as people, not as claims ─────────────────── */
+.team{margin-top:var(--gap-out)}
+.team-inner{max-width:1160px; margin:0 auto; padding:0 20px}
+.team-scroll{display:grid; grid-auto-flow:column; grid-auto-columns:148px; gap:12px;
+  overflow-x:auto; padding-bottom:10px; scroll-snap-type:x mandatory; scrollbar-width:thin;
+  /* the crop was doing the signalling by accident: a card sliced mid-name reads
+     as a layout bug, not as "there is more". Fade the edge and say the count. */
+  -webkit-mask-image:linear-gradient(90deg,#000 86%,rgba(0,0,0,.15));
+  mask-image:linear-gradient(90deg,#000 86%,rgba(0,0,0,.15))}
+.team-scroll figure{margin:0; scroll-snap-align:start}
+.team-scroll img{width:100%; height:auto; border:1px solid var(--rule-subtle)}
+.team-head{display:flex; align-items:baseline; justify-content:space-between; gap:16px}
+.team-head .label,.team-head .swipe{white-space:nowrap; margin-bottom:16px}
+.team-head .swipe{font-size:var(--step-0); color:var(--ink-faint)}
+.team-note{margin-top:14px; font-size:var(--step-1); color:var(--ink-muted); max-width:52ch}
+.door .q,.door .a{max-width:52ch}
+
+/* ── one proof line. One. ─────────────────────────────────────────────── */
+.proof{display:flex; flex-wrap:wrap; align-items:baseline; gap:8px 14px;
+  padding:18px 0; border-top:1px solid var(--rule-strong); border-bottom:1px solid var(--rule-strong);
+  font-size:var(--step-1)}
+.proof b{font-size:var(--step-3); font-weight:600}
+.proof a{display:inline-flex; align-items:center; min-height:44px;
+  text-underline-offset:3px; color:var(--accent-ink)}
+.proof .as-of{font-size:var(--step-0); color:var(--ink-faint); width:100%}
+
+footer{margin-top:calc(var(--gap-out) * .55); padding:26px 0 44px; border-top:1px solid var(--rule-strong);
+  font-size:var(--step-1); color:var(--ink-muted)}
+footer p{max-width:58ch; margin-bottom:12px}
+footer .credit{font-size:var(--step-0); color:var(--ink-faint)}
+.reg{display:flex; flex-wrap:wrap; gap:6px 18px; margin:16px 0 4px; font-size:var(--step-0)}
+.reg a{display:inline-flex; align-items:center; min-height:44px; color:var(--accent-ink); text-underline-offset:3px}
+.pending{display:inline-block; padding:2px 8px; border:1px dashed var(--rule-strong);
+  border-radius:3px; font-size:var(--step-0); color:var(--ink-muted)}
+.controls{display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-top:24px;
+  padding-top:16px; border-top:1px dashed var(--rule-subtle); font-size:var(--step-0); color:var(--ink-faint)}
+.controls button{min-height:44px; padding:0 12px; font:inherit; color:var(--ink);
+  background:var(--surface); border:1px solid var(--rule-strong); border-radius:2px; cursor:pointer}
+.controls button[aria-pressed="true"]{background:var(--ink); color:var(--ground); border-color:var(--ink)}
+details.decl{margin-top:16px; font-size:var(--step-0)}
+details.decl summary{cursor:pointer; min-height:44px; display:flex; align-items:center;
+  letter-spacing:.06em; text-transform:uppercase}
+details.decl pre{overflow-x:auto; padding:14px; background:var(--surface-2);
+  border:1px solid var(--rule-subtle); font-size:12px; line-height:1.6}
+
+@media (min-width:760px){
+  :root{--hero:64px; --display:52px; --step-3:23px; --step-4:34px; --gap-out:96px}
+  .hero{min-height:720px}
+  .hero-body{padding:96px 20px 62px}
+  /* at desktop width all six fit; a scroller here was the mobile compromise
+     leaking upward, so drop the scroll, the mask and the swipe hint together. */
+  .team-scroll{grid-auto-flow:row; grid-template-columns:repeat(6,1fr); gap:16px;
+    overflow-x:visible; -webkit-mask-image:none; mask-image:none}
+  .team-head .swipe{display:none}
+}
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{transition-duration:.001ms !important; animation-duration:.001ms !important}
+}
+@media (prefers-contrast:more){:root{--rule-subtle:var(--rule-strong); --ink-muted:var(--ink)}}
+@media (forced-colors:active){
+  .ask-card,.controls button,.opts button{border:1px solid CanvasText}
+  .hero::after{display:none}
+}
+</style>
+
+<header class="hero">
+  <img src="data:image/jpeg;base64,__HERO__" alt="Rice terraces below Gunung Agung at sunset, with a storm cell breaking over the sea">
+  <div class="masthead">
+    <a class="brand" href="https://balizero.com">
+      <img src="data:image/png;base64,__LOGO__" alt="Bali Zero" width="73" height="102">
+      <span class="word">Bali&nbsp;Zero</span>
+    </a>
+    <div class="dateline num">Kerobokan<br>1 September 2026</div>
+  </div>
+  <div class="hero-body">
+    <h1>Most people moving to Bali pick the wrong visa in the first month.</h1>
+    <p>Tell us how long you are staying and what you will be doing. You will know
+       which permit that is before you tell us your name.</p>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <div class="ask">
+    <div class="ask-card">
+      <h2>How long are you staying?</h2>
+      <p class="hint">Pick one. No form, no email.</p>
+      <div class="opts" id="dur" role="group" aria-label="Length of stay">
+        <button type="button" data-k="30" aria-pressed="false">Up to 30 days</button>
+        <button type="button" data-k="60" aria-pressed="false">Up to 60 days</button>
+        <button type="button" data-k="180" aria-pressed="false">About 6 months</button>
+        <button type="button" data-k="year" aria-pressed="false">A year or more</button>
+      </div>
+
+      <div class="opts" id="why" style="margin-top:10px" role="group" aria-label="Reason" hidden>
+        <button type="button" data-k="tourism" aria-pressed="false">Holiday, family, surfing</button>
+        <button type="button" data-k="remote" aria-pressed="false">Remote work, foreign employer</button>
+        <button type="button" data-k="company" aria-pressed="false">Running a company here</button>
+        <button type="button" data-k="retire" aria-pressed="false">Retiring, 55 or over</button>
+      </div>
+
+      <div class="answer" id="ans" hidden aria-live="polite">
+        <span class="code" id="ans-code"></span>
+        <div class="name" id="ans-name"></div>
+        <p class="detail" id="ans-detail"></p>
+        <a class="go" href="https://balizero.com/visa-oracle">Check it properly in the Visa Oracle →</a>
+      </div>
+
+      <p class="caveat">This is an orientation, not a determination — it reads two answers, and your
+        case has more than two. The price you are quoted afterwards is the whole price, government
+        fee included, and it does not grow at the end.</p>
+    </div>
+  </div>
+
+  <section>
+    <h2 class="label">Or start where you are</h2>
+    <a class="door" href="https://balizero.com/services">
+      <span><span class="q">I'm starting a business</span>
+        <span class="a">PT PMA, NIB, OSS licensing, and the KBLI code that decides everything</span></span>
+      <span class="arrow" aria-hidden="true">→</span></a>
+    <a class="door" href="https://balizero.com/tax-calendar">
+      <span><span class="q">Taxes confuse me</span>
+        <span class="a">NPWP, monthly SPT, Coretax. Indonesian tax has its own alphabet</span></span>
+      <span class="arrow" aria-hidden="true">→</span></a>
+    <a class="door" href="https://balizero.com/property">
+      <span><span class="q">I'm buying property</span>
+        <span class="a">Hak pakai, leasehold, and the due diligence that comes before the deposit</span></span>
+      <span class="arrow" aria-hidden="true">→</span></a>
+  </section>
+
+</div><!-- /.wrap -->
+
+  <section class="team">
+   <div class="team-inner">
+    <div class="team-head">
+      <h2 class="label">The people who file it</h2>
+      <span class="swipe">6 people &rarr;</span>
+    </div>
+    <div class="team-scroll">
+      <figure><img src="data:image/jpeg;base64,__SURYA__" alt="Surya, senior consultant, setup team"></figure>
+      <figure><img src="data:image/jpeg;base64,__ARI__" alt="Ari"></figure>
+      <figure><img src="data:image/jpeg;base64,__SAHIRA__" alt="Sahira"></figure>
+      <figure><img src="data:image/jpeg;base64,__DAMAR__" alt="Damar"></figure>
+      <figure><img src="data:image/jpeg;base64,__KRISNA__" alt="Krisna"></figure>
+      <figure><img src="data:image/jpeg;base64,__DEWAAYU__" alt="Dewa Ayu"></figure>
+    </div>
+    <p class="team-note">One of them signs your file and answers when you write. A copycat can
+      clone a website in an afternoon; it cannot clone the person who takes the call.</p>
+   </div>
+  </section>
+
+<div class="wrap">
+
+  <section>
+    <p class="proof">
+      <b class="num">47</b> KITAS and <b class="num">9</b> PT PMA filed in August ·
+      <b class="num">4.9 ★</b>
+      <a href="https://maps.app.goo.gl/whiMUTNchcDR5naz8" rel="noopener">693 reviews on Google</a>
+      <span class="as-of">Filings counted on submission, not approval, as of 31 August 2026 — the
+        number goes down in quiet months and we leave it up. Reviews hosted by Google, read 14 August 2026.</span>
+    </p>
+  </section>
+
+  <footer>
+    <p>Bali Zero handles immigration, company setup, tax and property matters for foreigners in
+      Indonesia. We do not guarantee outcomes, and no agency lawfully can — the decision belongs to
+      the authority, every time. If the right answer is a different permit, or none, that is the
+      answer you get.</p>
+
+    <div class="reg">
+      <span>Look us up:</span>
+      <a href="https://oss.go.id">NIB on oss.go.id</a>
+      <a href="https://ahu.go.id/pencarian/profil-pt">entity on ahu.go.id</a>
+      <a href="https://sikop.kemenkeu.go.id">tax licence on sikop.kemenkeu.go.id</a>
+    </div>
+    <p><span class="pending">registry numbers + street address — owner supplies</span><br>
+      Kerobokan, Badung, Bali · English · Bahasa Indonesia</p>
+    <p class="credit">Photograph: Sidemen, East Bali — Gunung Agung with the afternoon storm
+      coming in off the Lombok Strait.</p>
+
+    <div class="controls">
+      <span>Preview:</span>
+      <button type="button" data-set="theme" data-val="light" aria-pressed="false">Day</button>
+      <button type="button" data-set="theme" data-val="dark" aria-pressed="false">Night</button>
+      <span style="margin-left:10px">Night polarity (Q10):</span>
+      <button type="button" data-set="night" data-val="neutral" aria-pressed="true">Neutral ground</button>
+      <button type="button" data-set="night" data-val="oxblood" aria-pressed="false">Red field</button>
+    </div>
+
+    <details class="decl">
+      <summary>Generator declaration</summary>
+      <pre>ground lightness         L 19.0%   envelope 18-20%
+H(ground) - H(accent)    32.0deg   envelope 26-46
+elevation step, dark     +7.0 L    gate 8 floor +7
+spacing ratio            3.6x      20px in / 72px between
+intensity peak           the hero  exactly one per viewport
+type                     1 family, 3 weights, discrete steps, no clamp
+easing                   productive  cubic-bezier(.2,0,.38,.9)
+awareness stage          PAS / problem-first (cold traffic)
+screen class             VERIFY - shows everything, hides nothing
+images                   hero 70 KB + 6 team cards 79 KB, all inline, 0 requests
+
+v2 correction: v1 gave six of eight sections to proving we are real. Proof is
+now one line and six faces. The ten-second answer above is the trust signal
+that a copycat cannot reproduce, because it requires knowing the answer.
+
+Absent on purpose: any rank superlative, any affiliation or outcome claim from
+the blocked-string list, a padlock, a self-issued badge, a testimonial signed
+with an initial, a countdown, an animated number, a bento grid, a hero video,
+and the lifetime client total (which has no verifiable source in any system).</pre>
+    </details>
+  </footer>
+</div>
+
+<script>
+(function(){
+  var root=document.documentElement;
+  document.querySelectorAll('.controls button').forEach(function(b){
+    b.addEventListener('click',function(){
+      var k=b.dataset.set,v=b.dataset.val;
+      root.setAttribute(k==='theme'?'data-theme':'data-night',v);
+      document.querySelectorAll('.controls button[data-set="'+k+'"]').forEach(function(o){
+        o.setAttribute('aria-pressed',String(o===b));});
+    });
+  });
+
+  // Orientation only. Real permit families; the Oracle does the actual work.
+  var MAP={
+    "30": {c:"B1", n:"Visa on Arrival",
+      d:"Thirty days, extended once for thirty more, and sixty is the ceiling. Tourism only \u2014 not business meetings, not study, not work."},
+    "60": {c:"C1", n:"Single-entry tourist visa",
+      d:"Applied for before you fly. Sixty days, extendable twice, so a hundred and eighty in one stay. This is the one most people should have taken instead of the VOA."},
+    "180": {c:"C2", n:"Business visit visa",
+      d:"Single entry, sixty days, extendable twice to a hundred and eighty \u2014 which is your six months, in one continuous stay. Needs an Indonesian company to sponsor it, and it does not permit salaried work here."},
+    "year|tourism": {c:"\u2014", n:"You are past what a visit permits",
+      d:"Beyond about six months the honest answer is a stay permit, not a longer visa. Which one depends on what you will actually be doing \u2014 that is the next question, and it is the one that matters."},
+    "year|remote": {c:"E33G", n:"Remote worker KITAS",
+      d:"One year, renewable, self-filed \u2014 no sponsor. The published bar is USD 60,000 a year and a contract with a company incorporated outside Indonesia. It does not let you work for an Indonesian company, invoice Indonesian clients, or own a PT PMA."},
+    "year|company": {c:"E28A", n:"Investor KITAS",
+      d:"Two years, tied to a PT PMA where you hold a director or commissioner seat \u2014 owning shares alone does not qualify. Paid-up capital from IDR 2.5 billion. It covers managing the company, not doing its operational work; that is a different permit."},
+    "year|retire": {c:"E33F", n:"Retirement KITAS",
+      d:"One year, renewable, with proof of USD 3,000 a month from outside Indonesia and an Indonesian sponsor who files it for you. The official page states no age figure \u2014 anyone who tells you the cutoff with certainty is guessing, so we check yours against the office."}
+  };
+  var dur=null, why=null;
+  function press(group,btn){
+    group.querySelectorAll('button').forEach(function(o){o.setAttribute('aria-pressed',String(o===btn));});
+  }
+  function render(){
+    var whyBox=document.getElementById('why'), ans=document.getElementById('ans');
+    whyBox.hidden = (dur!=="year");
+    var key = dur==="year" ? (why? "year|"+why : null) : dur;
+    if(!key||!MAP[key]){ ans.hidden=true; return; }
+    var m=MAP[key];
+    document.getElementById('ans-code').textContent=m.c;
+    document.getElementById('ans-name').textContent=m.n;
+    document.getElementById('ans-detail').textContent=m.d;
+    ans.hidden=false;
+  }
+  document.querySelectorAll('#dur button').forEach(function(b){
+    b.addEventListener('click',function(){ dur=b.dataset.k; press(document.getElementById('dur'),b); render(); });
+  });
+  document.querySelectorAll('#why button').forEach(function(b){
+    b.addEventListener('click',function(){ why=b.dataset.k; press(document.getElementById('why'),b); render(); });
+  });
+})();
+</script>

--- a/.agents/skills/design/prima-pagina/render.py
+++ b/.agents/skills/design/prima-pagina/render.py
@@ -1,0 +1,59 @@
+import sys, pathlib, json
+from playwright.sync_api import sync_playwright
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+src = pathlib.Path(sys.argv[1]); out = pathlib.Path(sys.argv[2]); out.mkdir(exist_ok=True)
+
+# The widget-answered shots exist because a still of an interactive element in its
+# EMPTY state shows the chrome, not the product. What the visitor is promised is
+# the answer, so at least one shot must contain one.
+STATES = [
+ ("phone-day",       390, 844, "light",  "neutral", None),
+ ("phone-night",     390, 844, "dark",   "neutral", None),
+ ("phone-night-answered", 390, 844, "dark", "neutral", ("year","remote")),
+ ("phone-day-answered",   390, 844, "light","neutral", ("30",None)),
+ ("phone-oxblood",   390, 844, "dark",   "oxblood", ("year","company")),
+ ("desktop-day",    1280, 900, "light",  "neutral", None),
+ ("desktop-night",  1280, 900, "dark",   "neutral", ("180",None)),
+ # Two diagnostics, not designs. Greyscale proves nothing on the page carries
+ # meaning by hue alone; the sunlight pass approximates a phone held outdoors
+ # at midday in Bali, which is where this page is actually read.
+ ("diagnostic-greyscale", 390, 844, "light", "neutral", ("60",None), "grayscale(1)"),
+ ("diagnostic-sunlight",  390, 844, "light", "neutral", ("60",None),
+   "contrast(.62) brightness(1.22)"),
+]
+made=[]
+with sync_playwright() as pw:
+    b=pw.chromium.launch(executable_path=CHROME)
+    for st in STATES:
+        name,w,h,theme,night,drive = st[:6]
+        css_filter = st[6] if len(st) > 6 else None
+        pg=b.new_page(viewport={"width":w,"height":h}, device_scale_factor=2,
+                      color_scheme="dark" if theme=="dark" else "light")
+        pg.goto(src.resolve().as_uri(), wait_until="load")
+        pg.evaluate(f"() => {{document.documentElement.setAttribute('data-theme','{theme}');"
+                    f"document.documentElement.setAttribute('data-night','{night}');}}")
+        if drive:
+            d,why = drive
+            pg.click(f'#dur button[data-k="{d}"]')
+            if why: pg.wait_for_timeout(80); pg.click(f'#why button[data-k="{why}"]')
+        if css_filter:
+            pg.add_style_tag(content=f'html{{filter:{css_filter}}}')
+        pg.wait_for_timeout(500)
+        f=out/f"{name}.png"; pg.screenshot(path=str(f), full_page=True)
+        made.append((name, f.stat().st_size)); pg.close()
+    b.close()
+for n,s in made: print(f"{n:<24} {s/1024:7.1f} KB")

--- a/.agents/skills/design/prima-pagina/shrink.py
+++ b/.agents/skills/design/prima-pagina/shrink.py
@@ -1,0 +1,12 @@
+import sys,pathlib
+from PIL import Image
+d=pathlib.Path(sys.argv[1]); out=d/"shots_web"; out.mkdir(exist_ok=True)
+tot=0
+for f in sorted((d/"shots").glob("*.png")):
+    im=Image.open(f).convert("RGB")
+    w = 760 if f.stem.startswith("desktop") else 470
+    if im.width>w: im=im.resize((w,round(im.height*w/im.width)), Image.LANCZOS)
+    g=out/(f.stem+".jpg"); im.save(g,"JPEG",quality=78,optimize=True,progressive=True)
+    tot+=g.stat().st_size
+    print(f"{f.stem:<24} {im.width}x{im.height} {g.stat().st_size/1024:7.0f} KB")
+print(f"TOTAL {tot/1024/1024:.2f} MB  (base64 inflates ~1.34x -> {tot*1.34/1024/1024:.2f} MB)")

--- a/.agents/skills/design/prima-pagina/verify_copy.py
+++ b/.agents/skills/design/prima-pagina/verify_copy.py
@@ -1,0 +1,58 @@
+import sys, re, pathlib
+from playwright.sync_api import sync_playwright
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+p=pathlib.Path(sys.argv[1])
+
+# the live-site blocklist + the GARUDA charter's klaim terlarang, as ENTITIES not spellings
+BLOCK = [
+ (r"\b(?:no\.?\s*)?#\s*1\b|\bnumber one\b|\bnumero uno\b", "rank superlative"),
+ (r"\bbest\b|\bleading\b|\btop[- ]rated\b|\bpremier\b", "rank superlative"),
+ (r"\bofficial (?:partner|reseller|agent)\b|\bauthori[sz]ed partner\b", "affiliation claim"),
+ (r"\bguarantee\w*\b|\bdijamin\b|\b100%\s*(?:approval|success)\b", "outcome guarantee"),
+ (r"\bfastest\b|\b24[- ]hour(?:s)? guarantee\b|\bsame[- ]day guaranteed\b", "speed guarantee"),
+ (r"\bzero risk\b|\brisk[- ]free\b|\bno risk\b", "risk claim"),
+ (r"\btrusted by \d|\b\d[\d,]*\+? (?:happy )?clients since\b", "unsourced lifetime total"),
+ (r"\bwork remotely (?:on|with) (?:a )?b211\b", "B1/B211 work claim"),
+]
+with sync_playwright() as pw:
+    b=pw.chromium.launch(executable_path=CHROME)
+    pg=b.new_page(viewport={"width":390,"height":844})
+    pg.goto(p.resolve().as_uri(), wait_until="load"); pg.wait_for_timeout(300)
+
+    # drive every branch of the answer widget and collect what it says
+    said=[]
+    for d in ["30","60","180"]:
+        pg.click(f'#dur button[data-k="{d}"]'); pg.wait_for_timeout(80)
+        said.append((d, pg.inner_text("#ans-code"), pg.inner_text("#ans-name")))
+    for w in ["tourism","remote","company","retire"]:
+        pg.click('#dur button[data-k="year"]'); pg.wait_for_timeout(50)
+        assert not pg.is_hidden("#why"), "reason row never appeared"
+        pg.click(f'#why button[data-k="{w}"]'); pg.wait_for_timeout(80)
+        assert not pg.is_hidden("#ans"), f"no answer for year|{w}"
+        said.append((f"year|{w}", pg.inner_text("#ans-code"), pg.inner_text("#ans-name")))
+    print("WIDGET — all 7 branches answered:")
+    for k,c,n in said: print(f"   {k:<14} {c:<6} {n}")
+
+    text = pg.evaluate("() => document.body.innerText")
+    b.close()
+
+print("\nBLOCKLIST")
+hits=0
+for pat,why in BLOCK:
+    for m in re.finditer(pat, text, re.I):
+        s=max(0,m.start()-40); print(f"   HIT [{why}] ...{text[s:m.end()+40]!r}"); hits+=1
+print("   clean" if not hits else f"   {hits} hit(s)")

--- a/.agents/skills/design/prima-pagina/verify_images.py
+++ b/.agents/skills/design/prima-pagina/verify_images.py
@@ -1,0 +1,43 @@
+import sys, pathlib
+from playwright.sync_api import sync_playwright
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+p=pathlib.Path(sys.argv[1])
+# Guilt+innocence: a deliberately broken copy must FAIL this probe, or the probe
+# proves nothing. Six mechanical gates passed a page with seven dead images.
+broken = p.with_name("_broken_control.html")
+broken.write_text(p.read_text().replace("base64,", "base64,data:image/jpeg;base64,", 1))
+JS = """() => [...document.images].map(i => ({
+  alt: (i.alt||'').slice(0,40),
+  ok: i.complete && i.naturalWidth > 1 && i.naturalHeight > 1,
+  w: i.naturalWidth, h: i.naturalHeight }))"""
+with sync_playwright() as pw:
+    b=pw.chromium.launch(executable_path=CHROME)
+    def run(f):
+        pg=b.new_page(viewport={"width":390,"height":844})
+        pg.goto(f.resolve().as_uri(), wait_until="load"); pg.wait_for_timeout(600)
+        pg.evaluate("() => window.scrollTo(0, document.body.scrollHeight)")  # trip lazy loads
+        pg.wait_for_timeout(600)
+        r=pg.evaluate(JS); pg.close(); return r
+    ctrl=run(broken); real=run(p); b.close()
+broken.unlink()
+cbad=[i for i in ctrl if not i["ok"]]
+print(f"CONTROL (deliberately broken): {len(cbad)}/{len(ctrl)} dead -> "
+      + ("probe trusted" if cbad else "PROBE BLIND, findings below mean nothing"))
+bad=[i for i in real if not i["ok"]]
+for i in real: print(f"   {'ok ' if i['ok'] else 'DEAD'} {i['w']:>5}x{i['h']:<5} {i['alt']}")
+print(f"-> {len(real)-len(bad)}/{len(real)} images actually decoded")
+sys.exit(1 if bad else 0)

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/bad/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/bad/ui.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Bad</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap">
+<style>
+body{margin:0;padding:24px;background:#FFFFFF;color:#141414;font:16px/1.5 system-ui,sans-serif}
+p.faint{color:#A0A0A0}
+@media (prefers-color-scheme:dark){ .darkonly{color:#EEEEEE} }
+a.tiny{display:inline-block;height:20px;width:30px;overflow:hidden;border:1px solid #ddd}
+.wide{width:2000px;height:8px;background:#eee}
+</style></head><body>
+<h1>Heading</h1>
+<p class="faint">This grey sits at roughly two point five to one and must be caught.</p>
+<p class="darkonly">This colour has its only definition inside a media block.</p>
+<a class="tiny" href="#x">go</a>
+<div class="wide"></div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/buried/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/buried/ui.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>buried</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.4 system-ui,sans-serif;height:900px;position:relative}
+.bar{position:fixed;left:0;right:0;bottom:0;height:80px;background:#111;color:#fff;font-weight:700;display:flex;align-items:center;justify-content:center}
+.buried{position:absolute;left:24px;right:24px;bottom:20px;margin:0}
+</style></head><body>
+<p>Top content.</p>
+<p class="buried">This final line is wholly underneath the bar and cannot be scrolled clear of it.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-guilty.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-guilty.html
@@ -1,0 +1,26 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Guilty control</title>
+<style>
+ :root{--ink:#12181B;--ground:#F4F6F7}
+ body{margin:0;background:var(--ground);color:var(--ink);font:16px/1.55 system-ui,sans-serif;padding:24px}
+ h1{font-size:32px} h2{font-size:20px} h4{font-size:15px}
+ .btn{min-height:44px;font:inherit;padding:0 16px}
+ .gone{text-decoration:line-through}
+</style></head><body>
+ <h2>Your most likely path</h2>
+ <h1>E33G — Remote Worker KITAS</h1>
+ <p class="gone">E33F — Digital Nomad, freelance</p>
+ <h4>A level was skipped to reach this heading</h4>
+ <div class="meter" role="img" aria-label="Three of four requirements match your answers."></div>
+ <p class="conf">Three of four requirements match your answers.</p>
+ <h2>Your most likely path</h2>
+ <p><a class="btn" href="mailto:">Send this to a human</a></p>
+ <p><a href="#">Read the published guide</a></p>
+ <div style="overflow-x:auto">
+   <table style="min-width:600px;border-collapse:collapse;width:100%">
+     <tr><th colspan="3" style="text-align:left;padding:8px">Three of four requirements match your answers.</th></tr>
+     <tr><td style="padding:8px">Employed by a company registered outside Indonesia</td>
+         <td style="padding:8px">MATCH</td><td style="padding:8px">from your answer 2</td></tr>
+   </table>
+ </div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-innocent.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-innocent.html
@@ -1,0 +1,35 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Innocent control</title>
+<style>
+ :root{--ink:#12181B;--ground:#F4F6F7;--rule:#C9D2D6}
+ body{margin:0;background:var(--ground);color:var(--ink);font:16px/1.55 system-ui,sans-serif;padding:24px}
+ h1{font-size:32px;margin:0 0 4px} h2{font-size:20px;margin:24px 0 8px}
+ .btn{min-height:44px;min-width:44px;font:inherit;background:var(--ink);color:var(--ground);border:0;padding:0 16px}
+ .sr{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0)}
+ hr{border:0;border-top:1px solid var(--rule)}
+</style></head><body>
+ <h1>Your most likely path</h1>
+ <p class="lead">The verdict for this applicant, with the evidence that produced it.</p>
+ <h2>What the evidence shows</h2>
+ <ul><li>Passport validity exceeds the required window.</li>
+     <li>Declared income clears the stated threshold.</li>
+     <li>Accommodation is documented for the whole stay.</li></ul>
+ <div class="meter" role="img" aria-label="Three of four requirements match."><hr></div>
+ <p class="note">A different sentence sits beside the meter, so nothing is announced twice.</p>
+ <h2>What happens next</h2>
+ <p>Choose one of the routes below.</p>
+ <p><a href="https://example.org/guide">Read the published guide</a> ·
+    <a href="mailto:desk@example.org">Write to the desk</a></p>
+ <button class="btn" type="button">Send this onward</button>
+ <button class="btn" type="button">See the five answers this came from</button>
+ <div style="overflow-x:auto;border:1px solid var(--rule)">
+   <table style="min-width:600px;border-collapse:collapse;width:100%">
+     <tr><th style="text-align:left;padding:8px">Requirement</th>
+         <th style="text-align:left;padding:8px">State</th>
+         <th style="text-align:left;padding:8px">Provenance</th></tr>
+     <tr><td style="padding:8px">Employed by a company registered outside Indonesia</td>
+         <td style="padding:8px">MATCH</td><td style="padding:8px">from your answer 2</td></tr>
+   </table>
+ </div>
+ <p>A wide data table inside its own scroller is the accepted pattern and must not be reported.</p>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/good/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/good/ui.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Good</title>
+<style>
+:root{--ground:#FFFFFF;--ink:#141414;--muted:#4A4A4A;--line:#6B6B6B;--accent:#0B4F9E}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]){--ground:#111315;--ink:#F2F2F2;--muted:#C9C9C9;--line:#8A8A8A;--accent:#8FC0FF}}
+:root[data-theme="dark"]{--ground:#111315;--ink:#F2F2F2;--muted:#C9C9C9;--line:#8A8A8A;--accent:#8FC0FF}
+*{box-sizing:border-box}
+body{margin:0;padding:24px;background:var(--ground);color:var(--ink);font:16px/1.5 system-ui,sans-serif}
+h1{font-size:32px;margin:0 0 16px}
+p{color:var(--muted);max-width:60ch}
+a.btn{display:inline-flex;align-items:center;min-height:48px;min-width:48px;padding:0 20px;
+  border:1px solid var(--line);color:var(--accent);text-decoration:none}
+a.btn:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
+</style></head><body>
+<h1>A perfectly ordinary heading</h1>
+<p>Body copy that sits comfortably above the four and a half to one threshold in both themes.</p>
+<a class="btn" href="#x">Do the thing</a>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/occluded/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/occluded/ui.html
@@ -1,0 +1,48 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>occluded</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.5 system-ui,sans-serif}
+.bar{position:fixed;left:0;right:0;bottom:0;height:56px;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-weight:700}
+p{margin:0 0 18px}
+
+</style></head><body>
+<p>Line 1 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 2 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 3 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 4 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 5 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 6 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 7 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 8 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 9 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 10 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 11 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 12 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 13 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 14 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 15 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 16 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 17 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 18 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 19 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 20 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 21 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 22 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 23 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 24 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 25 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 26 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 27 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 28 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 29 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 30 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 31 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 32 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 33 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 34 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 35 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 36 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 37 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 38 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 39 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 40 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/reserved/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/reserved/ui.html
@@ -1,0 +1,48 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>reserved</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.5 system-ui,sans-serif}
+.bar{position:fixed;left:0;right:0;bottom:0;height:56px;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-weight:700}
+p{margin:0 0 18px}
+body{padding-bottom:80px}
+</style></head><body>
+<p>Line 1 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 2 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 3 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 4 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 5 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 6 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 7 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 8 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 9 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 10 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 11 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 12 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 13 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 14 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 15 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 16 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 17 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 18 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 19 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 20 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 21 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 22 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 23 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 24 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 25 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 26 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 27 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 28 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 29 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 30 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 31 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 32 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 33 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 34 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 35 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 36 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 37 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 38 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 39 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 40 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/shortbar/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/shortbar/ui.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>shortbar</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.5 system-ui,sans-serif;height:820px}
+.bar{position:fixed;left:0;right:0;bottom:0;height:56px;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-weight:700}
+.last{position:absolute;left:24px;bottom:10px}
+</style></head><body>
+<p>Some content near the top.</p>
+<p class="last">This final line sits behind the bar and cannot be scrolled out from under it.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/defects.py
+++ b/.agents/skills/design/strumenti/defects.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Mechanise the five defect classes that round one found BY HAND.
+
+Round one's mechanical gates (contrast, overflow, tap size, network, no-JS)
+passed all four entries. Everything that actually separated the field was found
+by reading — by me, or by an adversarial critic — and two of those readings were
+themselves wrong. A defect a human had to notice is a defect the next round will
+miss. So each class below is a probe, and each probe is only trusted for a run
+where its INNOCENCE control stays silent and its GUILT control fires.
+
+  dead-control       an interactive-looking element that does nothing
+  duplicate-string   the same >=3-word visible string doing two different jobs
+  heading-order      a heading of higher rank before the h1, or a skipped level
+  double-announce    an aria-label repeating text that is also visible and unhidden
+  struck-copy        line-through applied to supplied verbatim copy
+  clipped-sentence   a whole sentence cut off by an ancestor horizontal scroller
+
+The last one exists because the first five, plus every mechanical gate from
+round one, all passed a screen whose headline claim was cut in half on a 390px
+phone. The document did not overflow -- the scroll container absorbed it, which
+is exactly what the brief asks a wide TABLE to do. A table scrolling its columns
+is the accepted pattern; a SENTENCE that must be scrolled to be read is not. The
+rule distinguishes them the only honest way available: a sentence has a full stop
+and six or more words. A data cell does not.
+
+The probes read the RENDERED accessibility-relevant DOM, not the source text:
+`display:none` content is not a duplicate string, and an aria-label on a hidden
+element is not announced twice.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+PROBE_JS = r"""
+() => {
+  const vis = el => {
+    const s = getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || +s.opacity === 0) return false;
+    if (el.closest('[aria-hidden="true"]')) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+  const norm = t => (t || '').replace(/\s+/g, ' ').trim();
+
+  // --- dead controls -------------------------------------------------------
+  const dead = [];
+  for (const a of document.querySelectorAll('a')) {
+    if (!vis(a)) continue;
+    const h = a.getAttribute('href');
+    const label = norm(a.textContent).slice(0, 60);
+    if (h === null) dead.push({kind: 'anchor-without-href', label});
+    else if (h.trim() === '' || h.trim() === '#') dead.push({kind: 'empty-href', href: h, label});
+    else if (/^mailto:\s*$/i.test(h.trim())) dead.push({kind: 'mailto-without-address', href: h, label});
+    else if (/^tel:\s*$/i.test(h.trim())) dead.push({kind: 'tel-without-number', href: h, label});
+  }
+  // A <button type="button"> in a static mock is NOT a dead control: it names no
+  // destination, so it promises none. Reporting it was this probe's own
+  // over-match (guard-over-match, family #3) -- caught because the innocence
+  // control had been written with the button inside a <form>, a shape none of
+  // the real specimens use. An innocence control that is innocent in a way the
+  // specimens are not proves nothing. The rule is now: a control is dead when it
+  // NAMES a destination it does not have.
+
+  // --- duplicate visible strings ------------------------------------------
+  // Leaf-ish text blocks only, so a container does not duplicate its own child.
+  const seen = {};
+  const BLOCK = 'h1,h2,h3,h4,h5,h6,p,li,td,th,button,a,dt,dd,figcaption,summary,label,span,div';
+  for (const el of document.querySelectorAll(BLOCK)) {
+    if (!vis(el)) continue;
+    if (el.querySelector(BLOCK)) continue;          // not a leaf
+    const t = norm(el.textContent);
+    if (t.split(' ').length < 3) continue;
+    (seen[t] = seen[t] || []).push(el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : ''));
+  }
+  const dupes = Object.entries(seen)
+    .filter(([, w]) => w.length > 1)
+    .map(([text, where]) => ({text: text.slice(0, 80), count: where.length, where}));
+
+  // --- heading order -------------------------------------------------------
+  const heads = [...document.querySelectorAll('h1,h2,h3,h4,h5,h6')]
+    .filter(vis)
+    .map(h => ({level: +h.tagName[1], text: norm(h.textContent).slice(0, 60)}));
+  const horder = [];
+  if (heads.length) {
+    const firstH1 = heads.findIndex(h => h.level === 1);
+    if (firstH1 === -1) horder.push({kind: 'no-h1', detail: 'document has headings but no visible h1'});
+    else if (firstH1 > 0) {
+      horder.push({kind: 'heading-before-h1',
+                   detail: heads.slice(0, firstH1).map(h => `h${h.level} "${h.text}"`).join(' + ')});
+    }
+    for (let i = 1; i < heads.length; i++) {
+      if (heads[i].level > heads[i - 1].level + 1) {
+        horder.push({kind: 'skipped-level',
+                     detail: `h${heads[i - 1].level} -> h${heads[i].level} at "${heads[i].text}"`});
+      }
+    }
+  }
+
+  // --- aria double-announcement -------------------------------------------
+  const doubles = [];
+  const visibleTexts = new Set();
+  for (const el of document.querySelectorAll(BLOCK)) {
+    if (!vis(el)) continue;
+    if (el.querySelector(BLOCK)) continue;
+    const t = norm(el.textContent);
+    if (t.split(' ').length >= 4) visibleTexts.add(t.toLowerCase());
+  }
+  for (const el of document.querySelectorAll('[aria-label]')) {
+    const lab = norm(el.getAttribute('aria-label'));
+    if (lab.split(' ').length < 4) continue;
+    if (el.getAttribute('aria-hidden') === 'true' || el.closest('[aria-hidden="true"]')) continue;
+    const l = lab.toLowerCase();
+    for (const t of visibleTexts) {
+      // exact, or the label is a prefix/superset of a visible block
+      if (t === l || t.startsWith(l) || l.startsWith(t)) {
+        doubles.push({label: lab.slice(0, 90),
+                      on: el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : ''),
+                      also_visible_as: t.slice(0, 90)});
+        break;
+      }
+    }
+  }
+
+  // --- struck-through text -------------------------------------------------
+  const struck = [];
+  for (const el of document.querySelectorAll('*')) {
+    if (!vis(el)) continue;
+    if (el.children.length) continue;
+    const s = getComputedStyle(el);
+    if ((s.textDecorationLine || '').includes('line-through')) {
+      struck.push({text: norm(el.textContent).slice(0, 80),
+                   on: el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : '')});
+    }
+  }
+
+  // --- sentences clipped by an ancestor scroller ---------------------------
+  const clipped = [];
+  const scrollerOf = el => {
+    let p = el.parentElement;
+    while (p) {
+      const cs = getComputedStyle(p);
+      if (cs.overflowX === 'auto' || cs.overflowX === 'scroll' || cs.overflowX === 'hidden') return p;
+      p = p.parentElement;
+    }
+    return null;
+  };
+  for (const el of document.querySelectorAll(BLOCK)) {
+    if (!vis(el)) continue;
+    if (el.querySelector(BLOCK)) continue;
+    const t = norm(el.textContent);
+    if (t.split(' ').length < 6 || !/[.!?]$/.test(t)) continue;   // data cell, not a sentence
+    const sc = scrollerOf(el);
+    if (!sc) continue;
+    const r = el.getBoundingClientRect(), sr = sc.getBoundingClientRect();
+    const cut = Math.round(Math.max(0, r.right - sr.right) + Math.max(0, sr.left - r.left));
+    if (cut > 8) clipped.push({text: t.slice(0, 70), cut_px: cut,
+                               on: el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : ''),
+                               scroller_visible_px: Math.round(sc.clientWidth),
+                               scroller_content_px: Math.round(sc.scrollWidth)});
+  }
+
+  return {dead_controls: dead, duplicate_strings: dupes, heading_order: horder,
+          double_announced: doubles, struck_text: struck, clipped_sentences: clipped,
+          heading_outline: heads.map(h => `h${h.level} ${h.text}`)};
+}
+"""
+
+CLASSES = ("dead_controls", "duplicate_strings", "heading_order", "double_announced",
+           "struck_text", "clipped_sentences")
+
+
+def run(page, path: pathlib.Path) -> dict:
+    page.goto(path.resolve().as_uri(), wait_until="load")
+    page.wait_for_timeout(400)
+    return page.evaluate(PROBE_JS)
+
+
+def main(argv: list[str]) -> int:
+    root = pathlib.Path(argv[1])
+    targets = [(p.parent.name, p) for p in sorted(root.glob("*/ui.html"))]
+    calib = root.parent / "calib"
+    out = {}
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROME)
+        page = b.new_page(viewport={"width": 390, "height": 844})   # the deciding viewport
+
+        # --- controls, before any verdict is trusted ------------------------
+        controls = {}
+        for name in ("innocent", "guilty"):
+            f = calib / f"defects-{name}.html"
+            if f.exists():
+                controls[name] = run(page, f)
+        for name, seat_path in targets:
+            out[name] = run(page, seat_path)
+        b.close()
+
+    if controls:
+        inn = controls.get("innocent", {})
+        gui = controls.get("guilty", {})
+        inn_noise = {c: inn.get(c, []) for c in CLASSES if inn.get(c)}
+        gui_silent = [c for c in CLASSES if not gui.get(c)]
+        print("CONTROLS")
+        print(f"  innocence: {'CLEAN' if not inn_noise else 'NOISY ' + json.dumps(inn_noise)}")
+        print(f"  guilt:     {'ALL FIRE' if not gui_silent else 'SILENT ON ' + ', '.join(gui_silent)}")
+        if inn_noise or gui_silent:
+            print("  -> probe NOT trusted for this run; findings below are unverified\n")
+        else:
+            print("  -> probe trusted for this run\n")
+
+    for name, res in out.items():
+        hits = {c: res[c] for c in CLASSES if res[c]}
+        print(f"== {name} ==")
+        if not hits:
+            print("  clean on all six classes")
+        for c, items in hits.items():
+            print(f"  {c}:")
+            for it in items:
+                print(f"    - {json.dumps(it)}")
+        print(f"  outline: {' | '.join(res['heading_outline'])}")
+        print()
+    (root / "defects.json").write_text(json.dumps({"controls": controls, "seats": out}, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/judge.py
+++ b/.agents/skills/design/strumenti/judge.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Round-two judge: did the revision fix what was named, and what did it break?
+
+Three axes, and the third is the one that matters. Anyone can delete the line a
+critic pointed at. The question is whether the correction was itself correct --
+the fix-of-a-fix trap. So every defect class and every declared value is
+compared against round one, and a defect that appears only in round two is
+reported as INTRODUCED, weighted the same as one that PERSISTS.
+
+Composes the two calibrated instruments rather than re-implementing them:
+  measure.py  declaration <-> pixels
+  defects.py  the five classes round one had to find by hand
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+SEATS = ("qwen", "agy", "claude", "codex")
+CLASSES = ("dead_controls", "duplicate_strings", "heading_order", "double_announced", "struck_text")
+CHECKED = ("ground", "accent", "dark_travel_multiplier", "type_base_px", "type_tiers")
+
+
+def sig(cls: str, item: dict) -> str:
+    """A stable identity for one defect, so round 1 and round 2 can be compared."""
+    if cls == "dead_controls":
+        return f"{item['kind']}:{item.get('label', '')}"
+    if cls == "duplicate_strings":
+        return f"dup:{item['text']}"
+    if cls == "heading_order":
+        return f"{item['kind']}:{item['detail']}"
+    if cls == "double_announced":
+        return f"double:{item['label'][:50]}"
+    if cls == "struck_text":
+        return f"struck:{item['text']}"
+    return json.dumps(item, sort_keys=True)
+
+
+def defect_set(res: dict) -> set[str]:
+    return {sig(c, it) for c in CLASSES for it in res.get(c, [])}
+
+
+def near(a, b, tol=0.06) -> bool:
+    try:
+        a, b = float(a), float(b)
+    except (TypeError, ValueError):
+        return str(a).upper() == str(b).upper()
+    return abs(a - b) <= max(tol, abs(b) * tol)
+
+
+def derivability(decl: dict, der: dict) -> list[tuple[str, str, str, bool]]:
+    rows = []
+    pairs = {
+        "ground": (decl.get("ground"), der.get("ground_light")),
+        "accent": (decl.get("accent"), None),          # accent is not derivable from ground alone
+        "dark_travel_multiplier": (decl.get("dark_travel_multiplier"), der.get("dark_travel_multiplier")),
+        "type_base_px": (decl.get("type_base_px"), der.get("type_base_px")),
+        "type_tiers": (decl.get("type_tiers"), der.get("type_tiers")),
+    }
+    for k in CHECKED:
+        d, m = pairs[k]
+        if m is None:
+            continue
+        rows.append((k, str(d), str(m), near(d, m)))
+    return rows
+
+
+def main(argv: list[str]) -> int:
+    root = pathlib.Path(argv[1])            # ui-contest
+    r1, r2 = root / "final", root / "r2" / "entries"
+    here = pathlib.Path(__file__).parent.parent
+
+    present = [s for s in SEATS if (r2 / s / "ui.html").exists()]
+    if not present:
+        print("no round-two entries on disk yet")
+        return 1
+
+    subprocess.run([sys.executable, str(here / "defects.py"), str(r1)],
+                   capture_output=True, cwd="/tmp", check=True)
+    subprocess.run([sys.executable, str(here / "defects.py"), str(r2)],
+                   capture_output=True, cwd="/tmp", check=True)
+    d1 = json.loads((r1 / "defects.json").read_text())["seats"]
+    d2 = json.loads((r2 / "defects.json").read_text())["seats"]
+
+    m2 = json.loads(subprocess.run(
+        [sys.executable, str(here / "measure.py")] + [str(r2 / s / "ui.html") for s in present],
+        capture_output=True, text=True, cwd="/tmp", check=True).stdout)
+
+    report = {}
+    for s in present:
+        before, after = defect_set(d1[s]), defect_set(d2[s])
+        decl = json.loads((r2 / s / "generator.json").read_text())
+        rows = derivability(decl, m2[s]["derived"])
+        hard = m2[s]
+        report[s] = {
+            "fixed": sorted(before - after),
+            "persists": sorted(before & after),
+            "introduced": sorted(after - before),
+            "derivability": rows,
+            "derivability_score": f"{sum(1 for r in rows if r[3])}/{len(rows)}",
+            "contrast_failures": {k: len(v["contrast_failures"]) for k, v in hard["states"].items()},
+            "overflow": {k: v.get("h_overflow") for k, v in hard["states"].items()},
+            "small_targets": hard["states"]["mobile/light"].get("small_targets", []),
+            "unsettled": hard.get("unsettled", []),
+        }
+
+    for s, r in report.items():
+        print(f"== {s} ==")
+        print(f"  FIXED      ({len(r['fixed'])}): " + ("; ".join(r["fixed"]) or "-"))
+        print(f"  PERSISTS   ({len(r['persists'])}): " + ("; ".join(r["persists"]) or "-"))
+        print(f"  INTRODUCED ({len(r['introduced'])}): " + ("; ".join(r["introduced"]) or "-"))
+        print(f"  derivability {r['derivability_score']}")
+        for k, d, m, ok in r["derivability"]:
+            print(f"    {'ok ' if ok else 'NO '} {k}: declared {d} / measured {m}")
+        cf = sum(r["contrast_failures"].values())
+        ov = [k for k, v in r["overflow"].items() if v]
+        print(f"  contrast failures {cf} | overflow {ov or 'none'} | small targets {len(r['small_targets'])}")
+        if r["unsettled"]:
+            print(f"  UNSETTLED (colour still moving when read): {r['unsettled']}")
+        print()
+
+    (root / "r2" / "judgement.json").write_text(json.dumps(report, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/measure.py
+++ b/.agents/skills/design/strumenti/measure.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""The judging instrument for the "perfect screen" contest.
+
+Everything here measures the RENDERED page, never the source text. Two reference
+files (ref-good.html / ref-bad.html) calibrate it: the instrument is only trusted
+for a run in which the good one passes every gate and the bad one trips the gate
+it was built to trip. A probe made more sensitive without calibration becomes the
+defect it was meant to find.
+"""
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+VIEWPORTS = {"mobile": (390, 844), "desktop": (1440, 900)}
+# Three theme states, because that is how many a viewer actually has: an explicit
+# light choice, the un-stamped default under a dark OS, and an explicit dark choice.
+THEMES = {
+    "light": ("light", "light"),
+    "system-dark": ("dark", None),
+    "forced-dark": ("light", "dark"),
+}
+
+PROBE_JS = r"""
+() => {
+  const srgb = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const lum = ([r, g, b]) => 0.2126 * srgb(r / 255) + 0.7152 * srgb(g / 255) + 0.0722 * srgb(b / 255);
+  const parse = (s) => {
+    const m = String(s).match(/rgba?\(([^)]+)\)/);
+    if (!m) return null;
+    const p = m[1].split(/[\s,\/]+/).filter(Boolean).map(Number);
+    return { rgb: [p[0], p[1], p[2]], a: p.length > 3 ? p[3] : 1 };
+  };
+  const over = (fg, bg, a) => fg.map((c, i) => c * a + bg[i] * (1 - a));
+  const ratio = (a, b) => {
+    const [l1, l2] = [lum(a), lum(b)].sort((x, y) => y - x);
+    return (l1 + 0.05) / (l2 + 0.05);
+  };
+  const path = (el) => {
+    const bits = [];
+    for (let n = el; n && n.nodeType === 1 && bits.length < 4; n = n.parentElement) {
+      bits.unshift(n.tagName.toLowerCase() + (n.className && typeof n.className === "string"
+        ? "." + n.className.trim().split(/\s+/).slice(0, 2).join(".") : ""));
+    }
+    return bits.join(">");
+  };
+
+  // Effective background: walk up until an opaque-enough layer is found. An
+  // element sitting on a background-IMAGE is reported unmeasurable, never passed.
+  const effBg = (el) => {
+    let acc = null, imaged = false;
+    for (let n = el; n; n = n.parentElement) {
+      const cs = getComputedStyle(n);
+      if (cs.backgroundImage && cs.backgroundImage !== "none") imaged = true;
+      const c = parse(cs.backgroundColor);
+      if (c && c.a > 0) {
+        acc = acc === null ? { rgb: c.rgb, a: c.a } : { rgb: over(acc.rgb, c.rgb, acc.a), a: Math.min(1, acc.a + c.a) };
+        if (acc.a >= 0.99) return { rgb: acc.rgb, imaged };
+      }
+    }
+    const html = parse(getComputedStyle(document.documentElement).backgroundColor);
+    const base = html && html.a > 0 ? html.rgb : [255, 255, 255];
+    return { rgb: acc ? over(acc.rgb, base, acc.a) : base, imaged };
+  };
+
+  const visible = (el) => {
+    const cs = getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none" || parseFloat(cs.opacity) < 0.1) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 1 && r.height > 1;
+  };
+
+  const contrast = [], sizes = {}, sizeChars = {}, unmeasurable = [];
+  for (const el of document.querySelectorAll("*")) {
+    const own = Array.from(el.childNodes).some((n) => n.nodeType === 3 && n.textContent.trim().length > 0);
+    if (!own || !visible(el)) continue;
+    const cs = getComputedStyle(el);
+    const fg = parse(cs.color);
+    if (!fg) continue;
+    const bg = effBg(el);
+    const px = parseFloat(cs.fontSize);
+    const weight = parseInt(cs.fontWeight, 10) || 400;
+    // WCAG states large text in POINTS: 18pt = 24px, 14pt bold = 18.66px.
+    const large = px >= 24 || (px >= 18.66 && weight >= 700);
+    const need = large ? 3.0 : 4.5;
+    const colour = fg.a < 1 ? over(fg.rgb, bg.rgb, fg.a) : fg.rgb;
+    const r = ratio(colour, bg.rgb);
+    sizes[px] = (sizes[px] || 0) + 1;
+    const ownText = Array.from(el.childNodes).filter(n => n.nodeType === 3)
+                         .map(n => n.textContent.trim()).join(" ").length;
+    sizeChars[px] = (sizeChars[px] || 0) + ownText;
+    const rec = { path: path(el), px, weight, ratio: Math.round(r * 100) / 100, need,
+                  text: el.textContent.trim().slice(0, 48) };
+    if (bg.imaged) unmeasurable.push(rec);
+    else if (r < need) contrast.push(rec);
+  }
+
+  const targets = [];
+  const SEL = "a[href],button,input,select,textarea,summary,[role=button],[role=link],[tabindex]:not([tabindex='-1'])";
+  for (const el of document.querySelectorAll(SEL)) {
+    if (!visible(el)) continue;
+    const r = el.getBoundingClientRect();
+    // A control may reach 44px through padding on an inline wrapper; measure the
+    // union of the element and its nearest block-level parent's inline box.
+    const w = Math.round(r.width), h = Math.round(r.height);
+    if (w < 44 || h < 44) targets.push({ path: path(el), w, h, text: el.textContent.trim().slice(0, 40) });
+  }
+
+  const de = document.documentElement;
+  return {
+    horizontal_scroll: de.scrollWidth > window.innerWidth + 1,
+    scroll_width: de.scrollWidth,
+    inner_width: window.innerWidth,
+    body_bg: getComputedStyle(document.body).backgroundColor,
+    body_color: getComputedStyle(document.body).color,
+    html_bg: getComputedStyle(de).backgroundColor,
+    contrast_failures: contrast,
+    unmeasurable_over_image: unmeasurable,
+    small_targets: targets,
+    font_sizes: sizes,
+    font_size_chars: sizeChars,
+    text_length: document.body.innerText.replace(/\s+/g, " ").trim().length,
+  };
+}
+"""
+
+
+def rgb_of(css: str) -> tuple[float, float, float] | None:
+    import re
+    m = re.match(r"rgba?\(([^)]+)\)", css or "")
+    if not m:
+        return None
+    p = [float(x) for x in re.split(r"[\s,/]+", m.group(1)) if x]
+    return (p[0], p[1], p[2])
+
+
+def lstar(rgb: tuple[float, float, float]) -> float:
+    def f(c: float) -> float:
+        c /= 255.0
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+    y = 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2])
+    return 116 * (y ** (1 / 3)) - 16 if y > 0.008856 else 903.3 * y
+
+
+def chroma(rgb: tuple[float, float, float]) -> float:
+    """Saturation as a 0-1 fraction, the same shape the brief asked seats to declare."""
+    mx, mn = max(rgb), min(rgb)
+    return 0.0 if mx == 0 else (mx - mn) / mx
+
+
+def measure_file(html: pathlib.Path) -> dict:
+    out: dict = {"file": str(html), "states": {}, "external_requests": [], "errors": []}
+    url = html.resolve().as_uri()
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(executable_path=CHROME)
+        for vname, (w, h) in VIEWPORTS.items():
+            for tname, (cs_scheme, forced) in THEMES.items():
+                ctx = browser.new_context(viewport={"width": w, "height": h},
+                                          color_scheme=cs_scheme, device_scale_factor=2)
+                ext: list[str] = []
+                ctx.on("request", lambda r: ext.append(r.url) if not r.url.startswith(("file:", "data:", "blob:", "about:")) else None)
+                page = ctx.new_page()
+                page.on("pageerror", lambda e: out["errors"].append(f"{vname}/{tname}: {e}"))
+                page.goto(url, wait_until="load")
+                page.wait_for_timeout(250)
+                if forced:
+                    page.evaluate("t => document.documentElement.setAttribute('data-theme', t)", forced)
+                page.wait_for_timeout(700)
+                first = page.evaluate(PROBE_JS)
+                page.wait_for_timeout(400)
+                second = page.evaluate(PROBE_JS)
+                if len(first["contrast_failures"]) != len(second["contrast_failures"]):
+                    out.setdefault("unsettled", []).append(f"{vname}/{tname}")
+                    page.wait_for_timeout(1200)
+                    second = page.evaluate(PROBE_JS)
+                out["states"][f"{vname}/{tname}"] = second
+                out["external_requests"] += ext
+                ctx.close()
+
+        # JS disabled: the screen must already be complete without it.
+        ctx = browser.new_context(viewport={"width": 390, "height": 844}, java_script_enabled=False)
+        page = ctx.new_page()
+        page.goto(url, wait_until="load")
+        out["nojs_text_length"] = page.evaluate("() => document.body.innerText.replace(/\\s+/g,' ').trim().length")
+        out["nojs_text"] = page.evaluate("() => document.body.innerText")
+        ctx.close()
+        browser.close()
+    return out
+
+
+def derive(m: dict) -> dict:
+    """What the pixels say the generator was — to be diffed against what the seat declared."""
+    light = m["states"]["desktop/light"]
+    dark = m["states"]["desktop/forced-dark"]
+    g_light = rgb_of(light["body_bg"]) or rgb_of(light["html_bg"]) or (255, 255, 255)
+    g_dark = rgb_of(dark["body_bg"]) or rgb_of(dark["html_bg"]) or (0, 0, 0)
+    sizes = {float(k): v for k, v in light["font_sizes"].items()}
+    ordered = sorted(sizes)
+    ratios = [round(b / a, 3) for a, b in zip(ordered, ordered[1:]) if a > 0]
+    chars = {float(k): v for k, v in light.get("font_size_chars", {}).items()}
+    base_by_elements = max(sizes.items(), key=lambda kv: kv[1])[0] if sizes else 0.0
+    base = max(chars.items(), key=lambda kv: kv[1])[0] if chars else base_by_elements
+    travel_l = abs(lstar(g_light) - 50.0)
+    travel_d = abs(lstar(g_dark) - 50.0)
+    return {
+        "ground_light": "#%02X%02X%02X" % tuple(int(round(c)) for c in g_light),
+        "ground_dark": "#%02X%02X%02X" % tuple(int(round(c)) for c in g_dark),
+        "ink_light": light["body_color"],
+        "ground_light_L": round(lstar(g_light), 1),
+        "ground_dark_L": round(lstar(g_dark), 1),
+        "dark_travel_multiplier": round(travel_d / travel_l, 2) if travel_l > 0.5 else None,
+        "ground_chroma": round(chroma(g_light), 3),
+        "type_tiers": len(sizes),
+        "type_base_px": base,
+        "type_base_px_by_element_count": base_by_elements,
+        "type_ratio_median": sorted(ratios)[len(ratios) // 2] if ratios else None,
+        "type_sizes": ordered,
+    }
+
+
+def main(argv: list[str]) -> int:
+    results = {}
+    for arg in argv[1:]:
+        p = pathlib.Path(arg)
+        m = measure_file(p)
+        m["derived"] = derive(m)
+        results[p.parent.name] = m
+    print(json.dumps(results, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/occlusion.py
+++ b/.agents/skills/design/strumenti/occlusion.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Does a fixed/sticky overlay cover content the reader needs?
+
+Three earlier versions of this probe were wrong, each caught by a control:
+  v1 "is any text ever covered?"        -> INNOCENCE tripped: a bottom bar covers
+                                           something at nearly every mid-scroll
+                                           offset, and you simply scroll past it.
+  v2 "covered at EVERY offset?"         -> right question, guilt case too weak.
+  v3 centre-point via elementFromPoint  -> blind to partial overlap: a line 6px
+                                           under the bar has its centre in the clear.
+This version measures the AREA of each line's box under an overlay, and separates
+the worst mid-scroll moment from the state at the document's end — the one a
+reader cannot escape by scrolling further.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+COVERED = 0.35
+
+PROBE = r"""
+() => {
+  const alphaOf = (css) => {
+    const m = String(css).match(/rgba?\(([^)]+)\)/);
+    if (!m) return 0;
+    const p = m[1].split(/[\s,\/]+/).filter(Boolean).map(Number);
+    return p.length > 3 ? p[3] : 1;
+  };
+  const overlays = [];
+  for (const el of document.querySelectorAll("*")) {
+    const cs = getComputedStyle(el);
+    if (cs.position !== "fixed" && cs.position !== "sticky") continue;
+    if (cs.visibility === "hidden" || cs.display === "none" || parseFloat(cs.opacity) < 0.5) continue;
+    if (alphaOf(cs.backgroundColor) < 0.5) continue;   // a see-through overlay hides nothing
+    const r = el.getBoundingClientRect();
+    if (r.width > 1 && r.height > 1) overlays.push({ el, r });
+  }
+  if (!overlays.length) return { overlays: 0, items: [] };
+  const inOverlay = (n) => { for (let p = n; p; p = p.parentElement) if (overlays.some(o => o.el === p)) return true; return false; };
+
+  const items = [];
+  for (const el of document.querySelectorAll("*")) {
+    if (inOverlay(el)) continue;
+    if (!Array.from(el.childNodes).some(n => n.nodeType === 3 && n.textContent.trim().length > 0)) continue;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none") continue;
+    const r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) continue;
+    if (r.bottom <= 0 || r.top >= window.innerHeight) continue;
+    const vt = Math.max(r.top, 0), vb = Math.min(r.bottom, window.innerHeight);
+    const vArea = Math.max(0, vb - vt) * r.width;
+    if (vArea < 1) continue;
+    let covered = 0;
+    for (const o of overlays) {
+      const ox = Math.max(0, Math.min(r.right, o.r.right) - Math.max(r.left, o.r.left));
+      const oy = Math.max(0, Math.min(vb, o.r.bottom) - Math.max(vt, o.r.top));
+      covered += ox * oy;
+    }
+    items.push({ text: el.textContent.trim().slice(0, 60), frac: Math.min(1, covered / vArea) });
+  }
+  return { overlays: overlays.length, items };
+}
+"""
+
+
+def check(path: pathlib.Path, step: int = 120) -> dict:
+    seen: dict[str, dict] = {}
+    overlays = 0
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROME)
+        ctx = b.new_context(viewport={"width": 390, "height": 844}, color_scheme="light")
+        page = ctx.new_page()
+        page.goto(path.resolve().as_uri(), wait_until="load")
+        height = page.evaluate("() => document.documentElement.scrollHeight")
+        y = 0
+        while True:
+            page.evaluate("v => window.scrollTo(0, v)", y)
+            page.wait_for_timeout(25)
+            r = page.evaluate(PROBE)
+            overlays = max(overlays, r["overlays"])
+            for it in r["items"]:
+                rec = seen.setdefault(it["text"], {"text": it["text"], "clearest": 1.0})
+                rec["clearest"] = min(rec["clearest"], it["frac"])
+            if y + 844 >= height:
+                break
+            y += step
+        page.evaluate("() => window.scrollTo(0, document.documentElement.scrollHeight)")
+        page.wait_for_timeout(80)
+        end = page.evaluate(PROBE)
+        ctx.close()
+        b.close()
+    return {
+        "file": str(path),
+        "overlays": overlays,
+        "text_elements": len(seen),
+        # even at its clearest, still mostly buried -> the reader can never read it
+        "never_readable": sorted([v for v in seen.values() if v["clearest"] >= COVERED],
+                                 key=lambda v: -v["clearest"]),
+        "covered_at_document_end": sorted([i for i in end["items"] if i["frac"] >= COVERED],
+                                          key=lambda v: -v["frac"]),
+    }
+
+
+def main(argv: list[str]) -> int:
+    print(json.dumps([check(pathlib.Path(a)) for a in argv[1:]], indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/regression.py
+++ b/.agents/skills/design/strumenti/regression.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""What did the revision REMOVE? -- the axis the defect probe cannot see.
+
+The five-class probe reported "zero introduced" for every seat, and it was
+right about what it measures. It was also blind to the thing that actually went
+wrong in round two: one entry deleted a real responsive type tier so that a
+declared number could not be argued with. Nothing broke. Something was lost.
+
+A defect report that names only a discrepancy invites the cheapest
+reconciliation, and the cheapest reconciliation is usually to remove. So this
+probe compares round one against round two on what each screen ACTUALLY
+RENDERS, per viewport, and reports losses as loudly as gains.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+SEATS = ("qwen", "agy", "claude", "codex")
+VIEWS = (("mobile", 390, 844), ("desktop", 1440, 900))
+
+SHAPE_JS = r"""
+() => {
+  const vis = el => { const s = getComputedStyle(el); if (s.display==='none'||s.visibility==='hidden') return false;
+                      const r = el.getBoundingClientRect(); return r.width>0 && r.height>0; };
+  const sizes = new Set(), weights = new Set(), fams = new Set();
+  let textLen = 0, elems = 0;
+  for (const el of document.querySelectorAll('body *')) {
+    if (!vis(el)) continue;
+    elems++;
+    if (el.children.length === 0 && el.textContent.trim()) {
+      const s = getComputedStyle(el);
+      sizes.add(Math.round(parseFloat(s.fontSize) * 100) / 100);
+      weights.add(s.fontWeight);
+      fams.add(s.fontFamily.split(',')[0].replace(/["']/g, '').trim());
+      textLen += el.textContent.trim().length;
+    }
+  }
+  return {sizes: [...sizes].sort((a,b)=>a-b), weights: [...weights].sort(),
+          families: [...fams].sort(), elements: elems, text_chars: textLen,
+          doc_height: document.documentElement.scrollHeight};
+}
+"""
+
+
+def shapes(page, path: pathlib.Path, b) -> dict:
+    out = {}
+    for name, w, h in VIEWS:
+        ctx = b.new_context(viewport={"width": w, "height": h}, color_scheme="light")
+        pg = ctx.new_page()
+        pg.goto(path.resolve().as_uri(), wait_until="load")
+        pg.wait_for_timeout(400)
+        out[name] = pg.evaluate(SHAPE_JS)
+        ctx.close()
+    return out
+
+
+def main(argv: list[str]) -> int:
+    root = pathlib.Path(argv[1])
+    r1, r2 = root / "final", root / "r2" / "entries"
+    data = {}
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROME)
+        for s in SEATS:
+            a, c = r1 / s / "ui.html", r2 / s / "ui.html"
+            if not (a.exists() and c.exists()):
+                continue
+            data[s] = {"before": shapes(None, a, b), "after": shapes(None, c, b)}
+        b.close()
+
+    for s, d in data.items():
+        print(f"== {s} ==")
+        losses, gains = [], []
+        for v, _, _ in VIEWS:
+            bef, aft = d["before"][v], d["after"][v]
+            lost = sorted(set(bef["sizes"]) - set(aft["sizes"]))
+            got = sorted(set(aft["sizes"]) - set(bef["sizes"]))
+            if lost:
+                losses.append(f"{v}: type sizes gone {lost}")
+            if got:
+                gains.append(f"{v}: type sizes new {got}")
+            wl = sorted(set(bef["weights"]) - set(aft["weights"]))
+            if wl:
+                losses.append(f"{v}: weights gone {wl}")
+            fl = sorted(set(bef["families"]) - set(aft["families"]))
+            if fl:
+                losses.append(f"{v}: typefaces gone {fl}")
+            de = aft["elements"] - bef["elements"]
+            dt = aft["text_chars"] - bef["text_chars"]
+            if de:
+                (gains if de > 0 else losses).append(f"{v}: elements {de:+d}")
+            if dt:
+                (gains if dt > 0 else losses).append(f"{v}: rendered characters {dt:+d}")
+        # the tell: a tier that existed at ONE viewport only, now gone everywhere
+        b_all = set(d["before"]["mobile"]["sizes"]) | set(d["before"]["desktop"]["sizes"])
+        a_all = set(d["after"]["mobile"]["sizes"]) | set(d["after"]["desktop"]["sizes"])
+        responsive_lost = sorted(
+            x for x in (b_all - a_all)
+            if (x in d["before"]["desktop"]["sizes"]) != (x in d["before"]["mobile"]["sizes"]))
+        print("  LOST: " + ("; ".join(losses) if losses else "nothing"))
+        print("  GAINED: " + ("; ".join(gains) if gains else "nothing"))
+        if responsive_lost:
+            print(f"  !! RESPONSIVE TIER REMOVED: {responsive_lost} existed at one viewport only "
+                  f"and is now gone from both — a real design feature traded for an unarguable number")
+        print()
+    (root / "r2" / "regression.json").write_text(json.dumps(data, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.claude/skills/design
+++ b/.claude/skills/design
@@ -1,0 +1,1 @@
+../../.agents/skills/design


### PR DESCRIPTION
Zero's order at the close of the front-page rebuild: *"salva tutto in un nuovo corner /design che casomai vai a unire cn altre skill/corner"*. Follows the existing corner convention — `.agents/skills/<name>` plus a `.claude/skills` symlink, same as `wr2` / `visaoracle` / `kbli-navigator`. 156 KB, no images copied in.

## What it holds

**`SKILL.md`** — the north star (deliver the product's promise before claiming anything), four doctrine rules, LIVE STATE naming what is still Zero's, and nine blood-bought rules that each cost a real defect today. §7 names the merge seams instead of duplicating the neighbours: `bali-zero-brand` keeps `tokens.json` sovereign, `visaoracle` keeps the RulePack and the ENFORCE gate, this corner owns measurement and page doctrine.

**`strumenti/`** — the calibrated probes with their innocence AND guilt controls. A verdict is only readable after its controls, which is why `defects.py` prints them first.

**`prima-pagina/`** — the 2026-09-01 front page, rebuildable from repo sources. Nothing images-shaped is copied in: the mark, the hero and the six staff cards are re-encoded on demand from `apps/mouth/public`. A second copy is a second thing to keep in sync and a second place they can leak from.

## Two portability fixes made while lifting the tools out of the dossier

- The headless-Chromium path was hardcoded under `/Users/nuzantara` in **seven** files. M5's home is `/Users/balizero`, so those probes were dead there — and silently, which is the whole problem. Now resolved per-machine (`CHROME_HEADLESS`, else the newest `ms-playwright` cache dir).
- `assets.py` pointed at a throwaway worktree and the session scratchpad. It now takes `<repo-root>` and `<out-dir>`, and **fails loudly** if a staff card is missing rather than shipping a page with dead images — which is exactly the defect that motivated `verify_images.py`.

## Bites

**Consumer:** a session invoking `/design`. **Observed on this branch**, not asserted: the symlink resolves to `SKILL.md`, and the whole chain runs from the corner into an empty directory —

```
assets.py       -> assets.json, 159 KB inline (mark + hero + 6 cards)
build.py        -> home.html, 240,998 bytes
verify_images   -> 8/8 images actually decoded (guilt control fires)
verify_copy     -> 7/7 widget branches answer
measure.py      -> 0 mechanical failures across 6 states, 0 JS errors
defects.py      -> "probe trusted for this run" + clean on all six classes
```

## Scope

Docs/skill only. No product code, no workflow, no deploy. The study's flags stay OFF and the corner asserts no visa verdict — the front page's widget says "orientation, not a determination" and links to the Oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
