### PR TITLE
docs(design): bring the calibrated design probes into git

### DIFF
--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/bad/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/bad/ui.html
@@ -1,0 +1,16 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Bad</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter&display=swap">
+<style>
+body{margin:0;padding:24px;background:#FFFFFF;color:#141414;font:16px/1.5 system-ui,sans-serif}
+p.faint{color:#A0A0A0}
+@media (prefers-color-scheme:dark){ .darkonly{color:#EEEEEE} }
+a.tiny{display:inline-block;height:20px;width:30px;overflow:hidden;border:1px solid #ddd}
+.wide{width:2000px;height:8px;background:#eee}
+</style></head><body>
+<h1>Heading</h1>
+<p class="faint">This grey sits at roughly two point five to one and must be caught.</p>
+<p class="darkonly">This colour has its only definition inside a media block.</p>
+<a class="tiny" href="#x">go</a>
+<div class="wide"></div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/buried/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/buried/ui.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>buried</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.4 system-ui,sans-serif;height:900px;position:relative}
+.bar{position:fixed;left:0;right:0;bottom:0;height:80px;background:#111;color:#fff;font-weight:700;display:flex;align-items:center;justify-content:center}
+.buried{position:absolute;left:24px;right:24px;bottom:20px;margin:0}
+</style></head><body>
+<p>Top content.</p>
+<p class="buried">This final line is wholly underneath the bar and cannot be scrolled clear of it.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-guilty.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-guilty.html
@@ -1,0 +1,26 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Guilty control</title>
+<style>
+ :root{--ink:#12181B;--ground:#F4F6F7}
+ body{margin:0;background:var(--ground);color:var(--ink);font:16px/1.55 system-ui,sans-serif;padding:24px}
+ h1{font-size:32px} h2{font-size:20px} h4{font-size:15px}
+ .btn{min-height:44px;font:inherit;padding:0 16px}
+ .gone{text-decoration:line-through}
+</style></head><body>
+ <h2>Your most likely path</h2>
+ <h1>E33G — Remote Worker KITAS</h1>
+ <p class="gone">E33F — Digital Nomad, freelance</p>
+ <h4>A level was skipped to reach this heading</h4>
+ <div class="meter" role="img" aria-label="Three of four requirements match your answers."></div>
+ <p class="conf">Three of four requirements match your answers.</p>
+ <h2>Your most likely path</h2>
+ <p><a class="btn" href="mailto:">Send this to a human</a></p>
+ <p><a href="#">Read the published guide</a></p>
+ <div style="overflow-x:auto">
+   <table style="min-width:600px;border-collapse:collapse;width:100%">
+     <tr><th colspan="3" style="text-align:left;padding:8px">Three of four requirements match your answers.</th></tr>
+     <tr><td style="padding:8px">Employed by a company registered outside Indonesia</td>
+         <td style="padding:8px">MATCH</td><td style="padding:8px">from your answer 2</td></tr>
+   </table>
+ </div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-innocent.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/defects-innocent.html
@@ -1,0 +1,35 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Innocent control</title>
+<style>
+ :root{--ink:#12181B;--ground:#F4F6F7;--rule:#C9D2D6}
+ body{margin:0;background:var(--ground);color:var(--ink);font:16px/1.55 system-ui,sans-serif;padding:24px}
+ h1{font-size:32px;margin:0 0 4px} h2{font-size:20px;margin:24px 0 8px}
+ .btn{min-height:44px;min-width:44px;font:inherit;background:var(--ink);color:var(--ground);border:0;padding:0 16px}
+ .sr{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0)}
+ hr{border:0;border-top:1px solid var(--rule)}
+</style></head><body>
+ <h1>Your most likely path</h1>
+ <p class="lead">The verdict for this applicant, with the evidence that produced it.</p>
+ <h2>What the evidence shows</h2>
+ <ul><li>Passport validity exceeds the required window.</li>
+     <li>Declared income clears the stated threshold.</li>
+     <li>Accommodation is documented for the whole stay.</li></ul>
+ <div class="meter" role="img" aria-label="Three of four requirements match."><hr></div>
+ <p class="note">A different sentence sits beside the meter, so nothing is announced twice.</p>
+ <h2>What happens next</h2>
+ <p>Choose one of the routes below.</p>
+ <p><a href="https://example.org/guide">Read the published guide</a> ·
+    <a href="mailto:desk@example.org">Write to the desk</a></p>
+ <button class="btn" type="button">Send this onward</button>
+ <button class="btn" type="button">See the five answers this came from</button>
+ <div style="overflow-x:auto;border:1px solid var(--rule)">
+   <table style="min-width:600px;border-collapse:collapse;width:100%">
+     <tr><th style="text-align:left;padding:8px">Requirement</th>
+         <th style="text-align:left;padding:8px">State</th>
+         <th style="text-align:left;padding:8px">Provenance</th></tr>
+     <tr><td style="padding:8px">Employed by a company registered outside Indonesia</td>
+         <td style="padding:8px">MATCH</td><td style="padding:8px">from your answer 2</td></tr>
+   </table>
+ </div>
+ <p>A wide data table inside its own scroller is the accepted pattern and must not be reported.</p>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/good/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/good/ui.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>Good</title>
+<style>
+:root{--ground:#FFFFFF;--ink:#141414;--muted:#4A4A4A;--line:#6B6B6B;--accent:#0B4F9E}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]){--ground:#111315;--ink:#F2F2F2;--muted:#C9C9C9;--line:#8A8A8A;--accent:#8FC0FF}}
+:root[data-theme="dark"]{--ground:#111315;--ink:#F2F2F2;--muted:#C9C9C9;--line:#8A8A8A;--accent:#8FC0FF}
+*{box-sizing:border-box}
+body{margin:0;padding:24px;background:var(--ground);color:var(--ink);font:16px/1.5 system-ui,sans-serif}
+h1{font-size:32px;margin:0 0 16px}
+p{color:var(--muted);max-width:60ch}
+a.btn{display:inline-flex;align-items:center;min-height:48px;min-width:48px;padding:0 20px;
+  border:1px solid var(--line);color:var(--accent);text-decoration:none}
+a.btn:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
+</style></head><body>
+<h1>A perfectly ordinary heading</h1>
+<p>Body copy that sits comfortably above the four and a half to one threshold in both themes.</p>
+<a class="btn" href="#x">Do the thing</a>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/occluded/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/occluded/ui.html
@@ -1,0 +1,48 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>occluded</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.5 system-ui,sans-serif}
+.bar{position:fixed;left:0;right:0;bottom:0;height:56px;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-weight:700}
+p{margin:0 0 18px}
+
+</style></head><body>
+<p>Line 1 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 2 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 3 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 4 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 5 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 6 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 7 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 8 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 9 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 10 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 11 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 12 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 13 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 14 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 15 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 16 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 17 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 18 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 19 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 20 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 21 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 22 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 23 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 24 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 25 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 26 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 27 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 28 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 29 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 30 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 31 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 32 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 33 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 34 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 35 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 36 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 37 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 38 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 39 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 40 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/reserved/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/reserved/ui.html
@@ -1,0 +1,48 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>reserved</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.5 system-ui,sans-serif}
+.bar{position:fixed;left:0;right:0;bottom:0;height:56px;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-weight:700}
+p{margin:0 0 18px}
+body{padding-bottom:80px}
+</style></head><body>
+<p>Line 1 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 2 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 3 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 4 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 5 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 6 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 7 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 8 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 9 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 10 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 11 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 12 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 13 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 14 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 15 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 16 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 17 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 18 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 19 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 20 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 21 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 22 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 23 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 24 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 25 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 26 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 27 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 28 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 29 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 30 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 31 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 32 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 33 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 34 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 35 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 36 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 37 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 38 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 39 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<p>Line 40 — the last of these must stay readable when scrolled to the bottom of the document.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/controlli-di-calibrazione/shortbar/ui.html
+++ b/.agents/skills/design/strumenti/controlli-di-calibrazione/shortbar/ui.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>shortbar</title><style>
+body{margin:0;padding:24px;background:#fff;color:#111;font:16px/1.5 system-ui,sans-serif;height:820px}
+.bar{position:fixed;left:0;right:0;bottom:0;height:56px;display:flex;align-items:center;justify-content:center;background:#111;color:#fff;font-weight:700}
+.last{position:absolute;left:24px;bottom:10px}
+</style></head><body>
+<p>Some content near the top.</p>
+<p class="last">This final line sits behind the bar and cannot be scrolled out from under it.</p>
+<div class="bar">MOCKUP — NOT LEGAL ADVICE AND NOT A QUOTE.</div>
+</body></html>

--- a/.agents/skills/design/strumenti/defects.py
+++ b/.agents/skills/design/strumenti/defects.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Mechanise the five defect classes that round one found BY HAND.
+
+Round one's mechanical gates (contrast, overflow, tap size, network, no-JS)
+passed all four entries. Everything that actually separated the field was found
+by reading — by me, or by an adversarial critic — and two of those readings were
+themselves wrong. A defect a human had to notice is a defect the next round will
+miss. So each class below is a probe, and each probe is only trusted for a run
+where its INNOCENCE control stays silent and its GUILT control fires.
+
+  dead-control       an interactive-looking element that does nothing
+  duplicate-string   the same >=3-word visible string doing two different jobs
+  heading-order      a heading of higher rank before the h1, or a skipped level
+  double-announce    an aria-label repeating text that is also visible and unhidden
+  struck-copy        line-through applied to supplied verbatim copy
+  clipped-sentence   a whole sentence cut off by an ancestor horizontal scroller
+
+The last one exists because the first five, plus every mechanical gate from
+round one, all passed a screen whose headline claim was cut in half on a 390px
+phone. The document did not overflow -- the scroll container absorbed it, which
+is exactly what the brief asks a wide TABLE to do. A table scrolling its columns
+is the accepted pattern; a SENTENCE that must be scrolled to be read is not. The
+rule distinguishes them the only honest way available: a sentence has a full stop
+and six or more words. A data cell does not.
+
+The probes read the RENDERED accessibility-relevant DOM, not the source text:
+`display:none` content is not a duplicate string, and an aria-label on a hidden
+element is not announced twice.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+PROBE_JS = r"""
+() => {
+  const vis = el => {
+    const s = getComputedStyle(el);
+    if (s.display === 'none' || s.visibility === 'hidden' || +s.opacity === 0) return false;
+    if (el.closest('[aria-hidden="true"]')) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;
+  };
+  const norm = t => (t || '').replace(/\s+/g, ' ').trim();
+
+  // --- dead controls -------------------------------------------------------
+  const dead = [];
+  for (const a of document.querySelectorAll('a')) {
+    if (!vis(a)) continue;
+    const h = a.getAttribute('href');
+    const label = norm(a.textContent).slice(0, 60);
+    if (h === null) dead.push({kind: 'anchor-without-href', label});
+    else if (h.trim() === '' || h.trim() === '#') dead.push({kind: 'empty-href', href: h, label});
+    else if (/^mailto:\s*$/i.test(h.trim())) dead.push({kind: 'mailto-without-address', href: h, label});
+    else if (/^tel:\s*$/i.test(h.trim())) dead.push({kind: 'tel-without-number', href: h, label});
+  }
+  // A <button type="button"> in a static mock is NOT a dead control: it names no
+  // destination, so it promises none. Reporting it was this probe's own
+  // over-match (guard-over-match, family #3) -- caught because the innocence
+  // control had been written with the button inside a <form>, a shape none of
+  // the real specimens use. An innocence control that is innocent in a way the
+  // specimens are not proves nothing. The rule is now: a control is dead when it
+  // NAMES a destination it does not have.
+
+  // --- duplicate visible strings ------------------------------------------
+  // Leaf-ish text blocks only, so a container does not duplicate its own child.
+  const seen = {};
+  const BLOCK = 'h1,h2,h3,h4,h5,h6,p,li,td,th,button,a,dt,dd,figcaption,summary,label,span,div';
+  for (const el of document.querySelectorAll(BLOCK)) {
+    if (!vis(el)) continue;
+    if (el.querySelector(BLOCK)) continue;          // not a leaf
+    const t = norm(el.textContent);
+    if (t.split(' ').length < 3) continue;
+    (seen[t] = seen[t] || []).push(el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : ''));
+  }
+  const dupes = Object.entries(seen)
+    .filter(([, w]) => w.length > 1)
+    .map(([text, where]) => ({text: text.slice(0, 80), count: where.length, where}));
+
+  // --- heading order -------------------------------------------------------
+  const heads = [...document.querySelectorAll('h1,h2,h3,h4,h5,h6')]
+    .filter(vis)
+    .map(h => ({level: +h.tagName[1], text: norm(h.textContent).slice(0, 60)}));
+  const horder = [];
+  if (heads.length) {
+    const firstH1 = heads.findIndex(h => h.level === 1);
+    if (firstH1 === -1) horder.push({kind: 'no-h1', detail: 'document has headings but no visible h1'});
+    else if (firstH1 > 0) {
+      horder.push({kind: 'heading-before-h1',
+                   detail: heads.slice(0, firstH1).map(h => `h${h.level} "${h.text}"`).join(' + ')});
+    }
+    for (let i = 1; i < heads.length; i++) {
+      if (heads[i].level > heads[i - 1].level + 1) {
+        horder.push({kind: 'skipped-level',
+                     detail: `h${heads[i - 1].level} -> h${heads[i].level} at "${heads[i].text}"`});
+      }
+    }
+  }
+
+  // --- aria double-announcement -------------------------------------------
+  const doubles = [];
+  const visibleTexts = new Set();
+  for (const el of document.querySelectorAll(BLOCK)) {
+    if (!vis(el)) continue;
+    if (el.querySelector(BLOCK)) continue;
+    const t = norm(el.textContent);
+    if (t.split(' ').length >= 4) visibleTexts.add(t.toLowerCase());
+  }
+  for (const el of document.querySelectorAll('[aria-label]')) {
+    const lab = norm(el.getAttribute('aria-label'));
+    if (lab.split(' ').length < 4) continue;
+    if (el.getAttribute('aria-hidden') === 'true' || el.closest('[aria-hidden="true"]')) continue;
+    const l = lab.toLowerCase();
+    for (const t of visibleTexts) {
+      // exact, or the label is a prefix/superset of a visible block
+      if (t === l || t.startsWith(l) || l.startsWith(t)) {
+        doubles.push({label: lab.slice(0, 90),
+                      on: el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : ''),
+                      also_visible_as: t.slice(0, 90)});
+        break;
+      }
+    }
+  }
+
+  // --- struck-through text -------------------------------------------------
+  const struck = [];
+  for (const el of document.querySelectorAll('*')) {
+    if (!vis(el)) continue;
+    if (el.children.length) continue;
+    const s = getComputedStyle(el);
+    if ((s.textDecorationLine || '').includes('line-through')) {
+      struck.push({text: norm(el.textContent).slice(0, 80),
+                   on: el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : '')});
+    }
+  }
+
+  // --- sentences clipped by an ancestor scroller ---------------------------
+  const clipped = [];
+  const scrollerOf = el => {
+    let p = el.parentElement;
+    while (p) {
+      const cs = getComputedStyle(p);
+      if (cs.overflowX === 'auto' || cs.overflowX === 'scroll' || cs.overflowX === 'hidden') return p;
+      p = p.parentElement;
+    }
+    return null;
+  };
+  for (const el of document.querySelectorAll(BLOCK)) {
+    if (!vis(el)) continue;
+    if (el.querySelector(BLOCK)) continue;
+    const t = norm(el.textContent);
+    if (t.split(' ').length < 6 || !/[.!?]$/.test(t)) continue;   // data cell, not a sentence
+    const sc = scrollerOf(el);
+    if (!sc) continue;
+    const r = el.getBoundingClientRect(), sr = sc.getBoundingClientRect();
+    const cut = Math.round(Math.max(0, r.right - sr.right) + Math.max(0, sr.left - r.left));
+    if (cut > 8) clipped.push({text: t.slice(0, 70), cut_px: cut,
+                               on: el.tagName.toLowerCase() + (el.className ? '.' + String(el.className).split(' ')[0] : ''),
+                               scroller_visible_px: Math.round(sc.clientWidth),
+                               scroller_content_px: Math.round(sc.scrollWidth)});
+  }
+
+  return {dead_controls: dead, duplicate_strings: dupes, heading_order: horder,
+          double_announced: doubles, struck_text: struck, clipped_sentences: clipped,
+          heading_outline: heads.map(h => `h${h.level} ${h.text}`)};
+}
+"""
+
+CLASSES = ("dead_controls", "duplicate_strings", "heading_order", "double_announced",
+           "struck_text", "clipped_sentences")
+
+
+def run(page, path: pathlib.Path) -> dict:
+    page.goto(path.resolve().as_uri(), wait_until="load")
+    page.wait_for_timeout(400)
+    return page.evaluate(PROBE_JS)
+
+
+def main(argv: list[str]) -> int:
+    root = pathlib.Path(argv[1])
+    targets = [(p.parent.name, p) for p in sorted(root.glob("*/ui.html"))]
+    calib = root.parent / "calib"
+    out = {}
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROME)
+        page = b.new_page(viewport={"width": 390, "height": 844})   # the deciding viewport
+
+        # --- controls, before any verdict is trusted ------------------------
+        controls = {}
+        for name in ("innocent", "guilty"):
+            f = calib / f"defects-{name}.html"
+            if f.exists():
+                controls[name] = run(page, f)
+        for name, seat_path in targets:
+            out[name] = run(page, seat_path)
+        b.close()
+
+    if controls:
+        inn = controls.get("innocent", {})
+        gui = controls.get("guilty", {})
+        inn_noise = {c: inn.get(c, []) for c in CLASSES if inn.get(c)}
+        gui_silent = [c for c in CLASSES if not gui.get(c)]
+        print("CONTROLS")
+        print(f"  innocence: {'CLEAN' if not inn_noise else 'NOISY ' + json.dumps(inn_noise)}")
+        print(f"  guilt:     {'ALL FIRE' if not gui_silent else 'SILENT ON ' + ', '.join(gui_silent)}")
+        if inn_noise or gui_silent:
+            print("  -> probe NOT trusted for this run; findings below are unverified\n")
+        else:
+            print("  -> probe trusted for this run\n")
+
+    for name, res in out.items():
+        hits = {c: res[c] for c in CLASSES if res[c]}
+        print(f"== {name} ==")
+        if not hits:
+            print("  clean on all six classes")
+        for c, items in hits.items():
+            print(f"  {c}:")
+            for it in items:
+                print(f"    - {json.dumps(it)}")
+        print(f"  outline: {' | '.join(res['heading_outline'])}")
+        print()
+    (root / "defects.json").write_text(json.dumps({"controls": controls, "seats": out}, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/judge.py
+++ b/.agents/skills/design/strumenti/judge.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Round-two judge: did the revision fix what was named, and what did it break?
+
+Three axes, and the third is the one that matters. Anyone can delete the line a
+critic pointed at. The question is whether the correction was itself correct --
+the fix-of-a-fix trap. So every defect class and every declared value is
+compared against round one, and a defect that appears only in round two is
+reported as INTRODUCED, weighted the same as one that PERSISTS.
+
+Composes the two calibrated instruments rather than re-implementing them:
+  measure.py  declaration <-> pixels
+  defects.py  the five classes round one had to find by hand
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+SEATS = ("qwen", "agy", "claude", "codex")
+CLASSES = ("dead_controls", "duplicate_strings", "heading_order", "double_announced", "struck_text")
+CHECKED = ("ground", "accent", "dark_travel_multiplier", "type_base_px", "type_tiers")
+
+
+def sig(cls: str, item: dict) -> str:
+    """A stable identity for one defect, so round 1 and round 2 can be compared."""
+    if cls == "dead_controls":
+        return f"{item['kind']}:{item.get('label', '')}"
+    if cls == "duplicate_strings":
+        return f"dup:{item['text']}"
+    if cls == "heading_order":
+        return f"{item['kind']}:{item['detail']}"
+    if cls == "double_announced":
+        return f"double:{item['label'][:50]}"
+    if cls == "struck_text":
+        return f"struck:{item['text']}"
+    return json.dumps(item, sort_keys=True)
+
+
+def defect_set(res: dict) -> set[str]:
+    return {sig(c, it) for c in CLASSES for it in res.get(c, [])}
+
+
+def near(a, b, tol=0.06) -> bool:
+    try:
+        a, b = float(a), float(b)
+    except (TypeError, ValueError):
+        return str(a).upper() == str(b).upper()
+    return abs(a - b) <= max(tol, abs(b) * tol)
+
+
+def derivability(decl: dict, der: dict) -> list[tuple[str, str, str, bool]]:
+    rows = []
+    pairs = {
+        "ground": (decl.get("ground"), der.get("ground_light")),
+        "accent": (decl.get("accent"), None),          # accent is not derivable from ground alone
+        "dark_travel_multiplier": (decl.get("dark_travel_multiplier"), der.get("dark_travel_multiplier")),
+        "type_base_px": (decl.get("type_base_px"), der.get("type_base_px")),
+        "type_tiers": (decl.get("type_tiers"), der.get("type_tiers")),
+    }
+    for k in CHECKED:
+        d, m = pairs[k]
+        if m is None:
+            continue
+        rows.append((k, str(d), str(m), near(d, m)))
+    return rows
+
+
+def main(argv: list[str]) -> int:
+    root = pathlib.Path(argv[1])            # ui-contest
+    r1, r2 = root / "final", root / "r2" / "entries"
+    here = pathlib.Path(__file__).parent.parent
+
+    present = [s for s in SEATS if (r2 / s / "ui.html").exists()]
+    if not present:
+        print("no round-two entries on disk yet")
+        return 1
+
+    subprocess.run([sys.executable, str(here / "defects.py"), str(r1)],
+                   capture_output=True, cwd="/tmp", check=True)
+    subprocess.run([sys.executable, str(here / "defects.py"), str(r2)],
+                   capture_output=True, cwd="/tmp", check=True)
+    d1 = json.loads((r1 / "defects.json").read_text())["seats"]
+    d2 = json.loads((r2 / "defects.json").read_text())["seats"]
+
+    m2 = json.loads(subprocess.run(
+        [sys.executable, str(here / "measure.py")] + [str(r2 / s / "ui.html") for s in present],
+        capture_output=True, text=True, cwd="/tmp", check=True).stdout)
+
+    report = {}
+    for s in present:
+        before, after = defect_set(d1[s]), defect_set(d2[s])
+        decl = json.loads((r2 / s / "generator.json").read_text())
+        rows = derivability(decl, m2[s]["derived"])
+        hard = m2[s]
+        report[s] = {
+            "fixed": sorted(before - after),
+            "persists": sorted(before & after),
+            "introduced": sorted(after - before),
+            "derivability": rows,
+            "derivability_score": f"{sum(1 for r in rows if r[3])}/{len(rows)}",
+            "contrast_failures": {k: len(v["contrast_failures"]) for k, v in hard["states"].items()},
+            "overflow": {k: v.get("h_overflow") for k, v in hard["states"].items()},
+            "small_targets": hard["states"]["mobile/light"].get("small_targets", []),
+            "unsettled": hard.get("unsettled", []),
+        }
+
+    for s, r in report.items():
+        print(f"== {s} ==")
+        print(f"  FIXED      ({len(r['fixed'])}): " + ("; ".join(r["fixed"]) or "-"))
+        print(f"  PERSISTS   ({len(r['persists'])}): " + ("; ".join(r["persists"]) or "-"))
+        print(f"  INTRODUCED ({len(r['introduced'])}): " + ("; ".join(r["introduced"]) or "-"))
+        print(f"  derivability {r['derivability_score']}")
+        for k, d, m, ok in r["derivability"]:
+            print(f"    {'ok ' if ok else 'NO '} {k}: declared {d} / measured {m}")
+        cf = sum(r["contrast_failures"].values())
+        ov = [k for k, v in r["overflow"].items() if v]
+        print(f"  contrast failures {cf} | overflow {ov or 'none'} | small targets {len(r['small_targets'])}")
+        if r["unsettled"]:
+            print(f"  UNSETTLED (colour still moving when read): {r['unsettled']}")
+        print()
+
+    (root / "r2" / "judgement.json").write_text(json.dumps(report, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/measure.py
+++ b/.agents/skills/design/strumenti/measure.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""The judging instrument for the "perfect screen" contest.
+
+Everything here measures the RENDERED page, never the source text. Two reference
+files (ref-good.html / ref-bad.html) calibrate it: the instrument is only trusted
+for a run in which the good one passes every gate and the bad one trips the gate
+it was built to trip. A probe made more sensitive without calibration becomes the
+defect it was meant to find.
+"""
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+VIEWPORTS = {"mobile": (390, 844), "desktop": (1440, 900)}
+# Three theme states, because that is how many a viewer actually has: an explicit
+# light choice, the un-stamped default under a dark OS, and an explicit dark choice.
+THEMES = {
+    "light": ("light", "light"),
+    "system-dark": ("dark", None),
+    "forced-dark": ("light", "dark"),
+}
+
+PROBE_JS = r"""
+() => {
+  const srgb = (c) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const lum = ([r, g, b]) => 0.2126 * srgb(r / 255) + 0.7152 * srgb(g / 255) + 0.0722 * srgb(b / 255);
+  const parse = (s) => {
+    const m = String(s).match(/rgba?\(([^)]+)\)/);
+    if (!m) return null;
+    const p = m[1].split(/[\s,\/]+/).filter(Boolean).map(Number);
+    return { rgb: [p[0], p[1], p[2]], a: p.length > 3 ? p[3] : 1 };
+  };
+  const over = (fg, bg, a) => fg.map((c, i) => c * a + bg[i] * (1 - a));
+  const ratio = (a, b) => {
+    const [l1, l2] = [lum(a), lum(b)].sort((x, y) => y - x);
+    return (l1 + 0.05) / (l2 + 0.05);
+  };
+  const path = (el) => {
+    const bits = [];
+    for (let n = el; n && n.nodeType === 1 && bits.length < 4; n = n.parentElement) {
+      bits.unshift(n.tagName.toLowerCase() + (n.className && typeof n.className === "string"
+        ? "." + n.className.trim().split(/\s+/).slice(0, 2).join(".") : ""));
+    }
+    return bits.join(">");
+  };
+
+  // Effective background: walk up until an opaque-enough layer is found. An
+  // element sitting on a background-IMAGE is reported unmeasurable, never passed.
+  const effBg = (el) => {
+    let acc = null, imaged = false;
+    for (let n = el; n; n = n.parentElement) {
+      const cs = getComputedStyle(n);
+      if (cs.backgroundImage && cs.backgroundImage !== "none") imaged = true;
+      const c = parse(cs.backgroundColor);
+      if (c && c.a > 0) {
+        acc = acc === null ? { rgb: c.rgb, a: c.a } : { rgb: over(acc.rgb, c.rgb, acc.a), a: Math.min(1, acc.a + c.a) };
+        if (acc.a >= 0.99) return { rgb: acc.rgb, imaged };
+      }
+    }
+    const html = parse(getComputedStyle(document.documentElement).backgroundColor);
+    const base = html && html.a > 0 ? html.rgb : [255, 255, 255];
+    return { rgb: acc ? over(acc.rgb, base, acc.a) : base, imaged };
+  };
+
+  const visible = (el) => {
+    const cs = getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none" || parseFloat(cs.opacity) < 0.1) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 1 && r.height > 1;
+  };
+
+  const contrast = [], sizes = {}, sizeChars = {}, unmeasurable = [];
+  for (const el of document.querySelectorAll("*")) {
+    const own = Array.from(el.childNodes).some((n) => n.nodeType === 3 && n.textContent.trim().length > 0);
+    if (!own || !visible(el)) continue;
+    const cs = getComputedStyle(el);
+    const fg = parse(cs.color);
+    if (!fg) continue;
+    const bg = effBg(el);
+    const px = parseFloat(cs.fontSize);
+    const weight = parseInt(cs.fontWeight, 10) || 400;
+    // WCAG states large text in POINTS: 18pt = 24px, 14pt bold = 18.66px.
+    const large = px >= 24 || (px >= 18.66 && weight >= 700);
+    const need = large ? 3.0 : 4.5;
+    const colour = fg.a < 1 ? over(fg.rgb, bg.rgb, fg.a) : fg.rgb;
+    const r = ratio(colour, bg.rgb);
+    sizes[px] = (sizes[px] || 0) + 1;
+    const ownText = Array.from(el.childNodes).filter(n => n.nodeType === 3)
+                         .map(n => n.textContent.trim()).join(" ").length;
+    sizeChars[px] = (sizeChars[px] || 0) + ownText;
+    const rec = { path: path(el), px, weight, ratio: Math.round(r * 100) / 100, need,
+                  text: el.textContent.trim().slice(0, 48) };
+    if (bg.imaged) unmeasurable.push(rec);
+    else if (r < need) contrast.push(rec);
+  }
+
+  const targets = [];
+  const SEL = "a[href],button,input,select,textarea,summary,[role=button],[role=link],[tabindex]:not([tabindex='-1'])";
+  for (const el of document.querySelectorAll(SEL)) {
+    if (!visible(el)) continue;
+    const r = el.getBoundingClientRect();
+    // A control may reach 44px through padding on an inline wrapper; measure the
+    // union of the element and its nearest block-level parent's inline box.
+    const w = Math.round(r.width), h = Math.round(r.height);
+    if (w < 44 || h < 44) targets.push({ path: path(el), w, h, text: el.textContent.trim().slice(0, 40) });
+  }
+
+  const de = document.documentElement;
+  return {
+    horizontal_scroll: de.scrollWidth > window.innerWidth + 1,
+    scroll_width: de.scrollWidth,
+    inner_width: window.innerWidth,
+    body_bg: getComputedStyle(document.body).backgroundColor,
+    body_color: getComputedStyle(document.body).color,
+    html_bg: getComputedStyle(de).backgroundColor,
+    contrast_failures: contrast,
+    unmeasurable_over_image: unmeasurable,
+    small_targets: targets,
+    font_sizes: sizes,
+    font_size_chars: sizeChars,
+    text_length: document.body.innerText.replace(/\s+/g, " ").trim().length,
+  };
+}
+"""
+
+
+def rgb_of(css: str) -> tuple[float, float, float] | None:
+    import re
+    m = re.match(r"rgba?\(([^)]+)\)", css or "")
+    if not m:
+        return None
+    p = [float(x) for x in re.split(r"[\s,/]+", m.group(1)) if x]
+    return (p[0], p[1], p[2])
+
+
+def lstar(rgb: tuple[float, float, float]) -> float:
+    def f(c: float) -> float:
+        c /= 255.0
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+    y = 0.2126 * f(rgb[0]) + 0.7152 * f(rgb[1]) + 0.0722 * f(rgb[2])
+    return 116 * (y ** (1 / 3)) - 16 if y > 0.008856 else 903.3 * y
+
+
+def chroma(rgb: tuple[float, float, float]) -> float:
+    """Saturation as a 0-1 fraction, the same shape the brief asked seats to declare."""
+    mx, mn = max(rgb), min(rgb)
+    return 0.0 if mx == 0 else (mx - mn) / mx
+
+
+def measure_file(html: pathlib.Path) -> dict:
+    out: dict = {"file": str(html), "states": {}, "external_requests": [], "errors": []}
+    url = html.resolve().as_uri()
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(executable_path=CHROME)
+        for vname, (w, h) in VIEWPORTS.items():
+            for tname, (cs_scheme, forced) in THEMES.items():
+                ctx = browser.new_context(viewport={"width": w, "height": h},
+                                          color_scheme=cs_scheme, device_scale_factor=2)
+                ext: list[str] = []
+                ctx.on("request", lambda r: ext.append(r.url) if not r.url.startswith(("file:", "data:", "blob:", "about:")) else None)
+                page = ctx.new_page()
+                page.on("pageerror", lambda e: out["errors"].append(f"{vname}/{tname}: {e}"))
+                page.goto(url, wait_until="load")
+                page.wait_for_timeout(250)
+                if forced:
+                    page.evaluate("t => document.documentElement.setAttribute('data-theme', t)", forced)
+                page.wait_for_timeout(700)
+                first = page.evaluate(PROBE_JS)
+                page.wait_for_timeout(400)
+                second = page.evaluate(PROBE_JS)
+                if len(first["contrast_failures"]) != len(second["contrast_failures"]):
+                    out.setdefault("unsettled", []).append(f"{vname}/{tname}")
+                    page.wait_for_timeout(1200)
+                    second = page.evaluate(PROBE_JS)
+                out["states"][f"{vname}/{tname}"] = second
+                out["external_requests"] += ext
+                ctx.close()
+
+        # JS disabled: the screen must already be complete without it.
+        ctx = browser.new_context(viewport={"width": 390, "height": 844}, java_script_enabled=False)
+        page = ctx.new_page()
+        page.goto(url, wait_until="load")
+        out["nojs_text_length"] = page.evaluate("() => document.body.innerText.replace(/\\s+/g,' ').trim().length")
+        out["nojs_text"] = page.evaluate("() => document.body.innerText")
+        ctx.close()
+        browser.close()
+    return out
+
+
+def derive(m: dict) -> dict:
+    """What the pixels say the generator was — to be diffed against what the seat declared."""
+    light = m["states"]["desktop/light"]
+    dark = m["states"]["desktop/forced-dark"]
+    g_light = rgb_of(light["body_bg"]) or rgb_of(light["html_bg"]) or (255, 255, 255)
+    g_dark = rgb_of(dark["body_bg"]) or rgb_of(dark["html_bg"]) or (0, 0, 0)
+    sizes = {float(k): v for k, v in light["font_sizes"].items()}
+    ordered = sorted(sizes)
+    ratios = [round(b / a, 3) for a, b in zip(ordered, ordered[1:]) if a > 0]
+    chars = {float(k): v for k, v in light.get("font_size_chars", {}).items()}
+    base_by_elements = max(sizes.items(), key=lambda kv: kv[1])[0] if sizes else 0.0
+    base = max(chars.items(), key=lambda kv: kv[1])[0] if chars else base_by_elements
+    travel_l = abs(lstar(g_light) - 50.0)
+    travel_d = abs(lstar(g_dark) - 50.0)
+    return {
+        "ground_light": "#%02X%02X%02X" % tuple(int(round(c)) for c in g_light),
+        "ground_dark": "#%02X%02X%02X" % tuple(int(round(c)) for c in g_dark),
+        "ink_light": light["body_color"],
+        "ground_light_L": round(lstar(g_light), 1),
+        "ground_dark_L": round(lstar(g_dark), 1),
+        "dark_travel_multiplier": round(travel_d / travel_l, 2) if travel_l > 0.5 else None,
+        "ground_chroma": round(chroma(g_light), 3),
+        "type_tiers": len(sizes),
+        "type_base_px": base,
+        "type_base_px_by_element_count": base_by_elements,
+        "type_ratio_median": sorted(ratios)[len(ratios) // 2] if ratios else None,
+        "type_sizes": ordered,
+    }
+
+
+def main(argv: list[str]) -> int:
+    results = {}
+    for arg in argv[1:]:
+        p = pathlib.Path(arg)
+        m = measure_file(p)
+        m["derived"] = derive(m)
+        results[p.parent.name] = m
+    print(json.dumps(results, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/occlusion.py
+++ b/.agents/skills/design/strumenti/occlusion.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Does a fixed/sticky overlay cover content the reader needs?
+
+Three earlier versions of this probe were wrong, each caught by a control:
+  v1 "is any text ever covered?"        -> INNOCENCE tripped: a bottom bar covers
+                                           something at nearly every mid-scroll
+                                           offset, and you simply scroll past it.
+  v2 "covered at EVERY offset?"         -> right question, guilt case too weak.
+  v3 centre-point via elementFromPoint  -> blind to partial overlap: a line 6px
+                                           under the bar has its centre in the clear.
+This version measures the AREA of each line's box under an overlay, and separates
+the worst mid-scroll moment from the state at the document's end — the one a
+reader cannot escape by scrolling further.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+COVERED = 0.35
+
+PROBE = r"""
+() => {
+  const alphaOf = (css) => {
+    const m = String(css).match(/rgba?\(([^)]+)\)/);
+    if (!m) return 0;
+    const p = m[1].split(/[\s,\/]+/).filter(Boolean).map(Number);
+    return p.length > 3 ? p[3] : 1;
+  };
+  const overlays = [];
+  for (const el of document.querySelectorAll("*")) {
+    const cs = getComputedStyle(el);
+    if (cs.position !== "fixed" && cs.position !== "sticky") continue;
+    if (cs.visibility === "hidden" || cs.display === "none" || parseFloat(cs.opacity) < 0.5) continue;
+    if (alphaOf(cs.backgroundColor) < 0.5) continue;   // a see-through overlay hides nothing
+    const r = el.getBoundingClientRect();
+    if (r.width > 1 && r.height > 1) overlays.push({ el, r });
+  }
+  if (!overlays.length) return { overlays: 0, items: [] };
+  const inOverlay = (n) => { for (let p = n; p; p = p.parentElement) if (overlays.some(o => o.el === p)) return true; return false; };
+
+  const items = [];
+  for (const el of document.querySelectorAll("*")) {
+    if (inOverlay(el)) continue;
+    if (!Array.from(el.childNodes).some(n => n.nodeType === 3 && n.textContent.trim().length > 0)) continue;
+    const cs = getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none") continue;
+    const r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) continue;
+    if (r.bottom <= 0 || r.top >= window.innerHeight) continue;
+    const vt = Math.max(r.top, 0), vb = Math.min(r.bottom, window.innerHeight);
+    const vArea = Math.max(0, vb - vt) * r.width;
+    if (vArea < 1) continue;
+    let covered = 0;
+    for (const o of overlays) {
+      const ox = Math.max(0, Math.min(r.right, o.r.right) - Math.max(r.left, o.r.left));
+      const oy = Math.max(0, Math.min(vb, o.r.bottom) - Math.max(vt, o.r.top));
+      covered += ox * oy;
+    }
+    items.push({ text: el.textContent.trim().slice(0, 60), frac: Math.min(1, covered / vArea) });
+  }
+  return { overlays: overlays.length, items };
+}
+"""
+
+
+def check(path: pathlib.Path, step: int = 120) -> dict:
+    seen: dict[str, dict] = {}
+    overlays = 0
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROME)
+        ctx = b.new_context(viewport={"width": 390, "height": 844}, color_scheme="light")
+        page = ctx.new_page()
+        page.goto(path.resolve().as_uri(), wait_until="load")
+        height = page.evaluate("() => document.documentElement.scrollHeight")
+        y = 0
+        while True:
+            page.evaluate("v => window.scrollTo(0, v)", y)
+            page.wait_for_timeout(25)
+            r = page.evaluate(PROBE)
+            overlays = max(overlays, r["overlays"])
+            for it in r["items"]:
+                rec = seen.setdefault(it["text"], {"text": it["text"], "clearest": 1.0})
+                rec["clearest"] = min(rec["clearest"], it["frac"])
+            if y + 844 >= height:
+                break
+            y += step
+        page.evaluate("() => window.scrollTo(0, document.documentElement.scrollHeight)")
+        page.wait_for_timeout(80)
+        end = page.evaluate(PROBE)
+        ctx.close()
+        b.close()
+    return {
+        "file": str(path),
+        "overlays": overlays,
+        "text_elements": len(seen),
+        # even at its clearest, still mostly buried -> the reader can never read it
+        "never_readable": sorted([v for v in seen.values() if v["clearest"] >= COVERED],
+                                 key=lambda v: -v["clearest"]),
+        "covered_at_document_end": sorted([i for i in end["items"] if i["frac"] >= COVERED],
+                                          key=lambda v: -v["frac"]),
+    }
+
+
+def main(argv: list[str]) -> int:
+    print(json.dumps([check(pathlib.Path(a)) for a in argv[1:]], indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.agents/skills/design/strumenti/regression.py
+++ b/.agents/skills/design/strumenti/regression.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""What did the revision REMOVE? -- the axis the defect probe cannot see.
+
+The five-class probe reported "zero introduced" for every seat, and it was
+right about what it measures. It was also blind to the thing that actually went
+wrong in round two: one entry deleted a real responsive type tier so that a
+declared number could not be argued with. Nothing broke. Something was lost.
+
+A defect report that names only a discrepancy invites the cheapest
+reconciliation, and the cheapest reconciliation is usually to remove. So this
+probe compares round one against round two on what each screen ACTUALLY
+RENDERS, per viewport, and reports losses as loudly as gains.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+from playwright.sync_api import sync_playwright
+
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+SEATS = ("qwen", "agy", "claude", "codex")
+VIEWS = (("mobile", 390, 844), ("desktop", 1440, 900))
+
+SHAPE_JS = r"""
+() => {
+  const vis = el => { const s = getComputedStyle(el); if (s.display==='none'||s.visibility==='hidden') return false;
+                      const r = el.getBoundingClientRect(); return r.width>0 && r.height>0; };
+  const sizes = new Set(), weights = new Set(), fams = new Set();
+  let textLen = 0, elems = 0;
+  for (const el of document.querySelectorAll('body *')) {
+    if (!vis(el)) continue;
+    elems++;
+    if (el.children.length === 0 && el.textContent.trim()) {
+      const s = getComputedStyle(el);
+      sizes.add(Math.round(parseFloat(s.fontSize) * 100) / 100);
+      weights.add(s.fontWeight);
+      fams.add(s.fontFamily.split(',')[0].replace(/["']/g, '').trim());
+      textLen += el.textContent.trim().length;
+    }
+  }
+  return {sizes: [...sizes].sort((a,b)=>a-b), weights: [...weights].sort(),
+          families: [...fams].sort(), elements: elems, text_chars: textLen,
+          doc_height: document.documentElement.scrollHeight};
+}
+"""
+
+
+def shapes(page, path: pathlib.Path, b) -> dict:
+    out = {}
+    for name, w, h in VIEWS:
+        ctx = b.new_context(viewport={"width": w, "height": h}, color_scheme="light")
+        pg = ctx.new_page()
+        pg.goto(path.resolve().as_uri(), wait_until="load")
+        pg.wait_for_timeout(400)
+        out[name] = pg.evaluate(SHAPE_JS)
+        ctx.close()
+    return out
+
+
+def main(argv: list[str]) -> int:
+    root = pathlib.Path(argv[1])
+    r1, r2 = root / "final", root / "r2" / "entries"
+    data = {}
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROME)
+        for s in SEATS:
+            a, c = r1 / s / "ui.html", r2 / s / "ui.html"
+            if not (a.exists() and c.exists()):
+                continue
+            data[s] = {"before": shapes(None, a, b), "after": shapes(None, c, b)}
+        b.close()
+
+    for s, d in data.items():
+        print(f"== {s} ==")
+        losses, gains = [], []
+        for v, _, _ in VIEWS:
+            bef, aft = d["before"][v], d["after"][v]
+            lost = sorted(set(bef["sizes"]) - set(aft["sizes"]))
+            got = sorted(set(aft["sizes"]) - set(bef["sizes"]))
+            if lost:
+                losses.append(f"{v}: type sizes gone {lost}")
+            if got:
+                gains.append(f"{v}: type sizes new {got}")
+            wl = sorted(set(bef["weights"]) - set(aft["weights"]))
+            if wl:
+                losses.append(f"{v}: weights gone {wl}")
+            fl = sorted(set(bef["families"]) - set(aft["families"]))
+            if fl:
+                losses.append(f"{v}: typefaces gone {fl}")
+            de = aft["elements"] - bef["elements"]
+            dt = aft["text_chars"] - bef["text_chars"]
+            if de:
+                (gains if de > 0 else losses).append(f"{v}: elements {de:+d}")
+            if dt:
+                (gains if dt > 0 else losses).append(f"{v}: rendered characters {dt:+d}")
+        # the tell: a tier that existed at ONE viewport only, now gone everywhere
+        b_all = set(d["before"]["mobile"]["sizes"]) | set(d["before"]["desktop"]["sizes"])
+        a_all = set(d["after"]["mobile"]["sizes"]) | set(d["after"]["desktop"]["sizes"])
+        responsive_lost = sorted(
+            x for x in (b_all - a_all)
+            if (x in d["before"]["desktop"]["sizes"]) != (x in d["before"]["mobile"]["sizes"]))
+        print("  LOST: " + ("; ".join(losses) if losses else "nothing"))
+        print("  GAINED: " + ("; ".join(gains) if gains else "nothing"))
+        if responsive_lost:
+            print(f"  !! RESPONSIVE TIER REMOVED: {responsive_lost} existed at one viewport only "
+                  f"and is now gone from both — a real design feature traded for an unarguable number")
+        print()
+    (root / "r2" / "regression.json").write_text(json.dumps(data, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/evidence/2026-09/agent-nuzantara-docs-design-tools-0901/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-docs-design-tools-0901/brief.yml
@@ -1,0 +1,72 @@
+task_id: design-corner-tools-0901
+gear: 2
+l_level: L1
+gate_class: opus
+objective: |
+  Bring the calibrated design probes into git. They were written during the 2026-08-31 design
+  study and have lived only under ~/Desktop/Design-Dossier-2026-08-31/strumenti/ — outside the
+  repo, on a TCC-denied directory where a glob returns empty WITHOUT an error, i.e. one
+  accidental cleanup away from gone. This PR is half of Zero's 2026-09-01 order to open a
+  /design corner ("salva tutto in un nuovo corner /design"); the SKILL.md brain and the
+  front-page build chain are the sibling PR, deliberately split because the two halves together
+  are 2,048 lines of churn and the Agent PR Contract's rule 1 forbids that in one concern.
+
+  What the tools are: six probes that read the RENDERED accessibility DOM, not source text.
+  measure.py sweeps 6 states (mobile/desktop x light/system-dark/forced-dark) for 27-pair
+  contrast, horizontal overflow, 44px tap targets, external requests, no-JS text and derived
+  palette/type metrics. defects.py mechanises six defect classes a human had to notice once
+  each — dead-control, duplicate-string, heading-order, double-announce, struck-copy,
+  clipped-sentence — and, crucially, ships its own INNOCENCE and GUILT controls and prints
+  their result BEFORE any verdict: a run whose innocence is noisy or whose guilt is silent
+  proves nothing, and the tool says so rather than leaving the reader to remember it.
+  occlusion.py, regression.py and judge.py are the overlap, before/after and rubric passes.
+
+  ONE BEHAVIOUR CHANGE, made while lifting them out of the dossier: the headless-Chromium path
+  was a hardcoded /Users/nuzantara/... literal in all four Playwright probes. M5's home is
+  /Users/balizero, so every one of these probes was dead on M5 — and dead silently, which is
+  the failure class the repo's own cicatrix #1/#2 families exist for. Replaced with a
+  per-machine resolver: CHROME_HEADLESS if set, else the newest ms-playwright cache dir, else
+  a loud SystemExit naming the env var. No other line of probe logic is touched.
+constraints:
+  - "Additive only: 13 new files under .agents/skills/design/strumenti/. Touches zero existing
+    file, no workflow, no product code, no migration."
+  - "Fresh worktree cut from origin/main after PR #5505 (the unsplit version) was closed."
+  - "The calibration controls are copied VERBATIM. Their whole value is that they are the
+    fixtures the probes were tuned against; editing them would silently decalibrate every
+    future verdict."
+  - "No PII: the calibration fixtures are synthetic HTML written for this purpose. No client
+    data, no staff photograph, no OSINT — this half of the corner contains no image at all."
+acceptance:
+  - "defects.py, run against the calibration directory it ships, prints `innocence: CLEAN` /
+    `guilt: ALL FIRE` / `-> probe trusted for this run` — observed 2026-09-01 on this content."
+  - "measure.py runs to completion on a real page and reports its 6 states with an empty
+    `errors` list — observed 2026-09-01."
+  - "No absolute /Users/... path survives in live code: every remaining occurrence is inside
+    the _find_chrome() docstring that explains the M5-vs-Pro home split. Verified by an
+    independent read, not by the author's grep."
+consumer_map:
+  - "The sibling PR's SKILL.md §4/§5, which names these files and gives the command block that
+    runs them. That PR is serialized AFTER this one for exactly this reason — if it landed
+    first, its file inventory would name a directory that does not yet exist."
+  - "Any future session judging a Bali Zero visual surface. Before this PR the only copy was
+    outside git on a TCC-denied path; after it, `python3 .agents/skills/design/strumenti/
+    defects.py <root>` is reachable from any checkout on any of the three machines."
+risks:
+  - "The probes are Playwright-dependent and are NOT wired into CI by this PR, deliberately:
+    they are an on-demand instrument for a design session, not a required check. Nothing here
+    can turn a PR red, which also means nothing here is exercised automatically — a future
+    session must run them and read their controls, exactly as the tools' own output insists."
+  - "judge.py is a rubric scorer and is the least exercised of the five; it is included for
+    completeness of the set rather than because this session leaned on it."
+grader: |
+  Generator != grader held. This session wrote the corner; an independent subagent on fresh
+  context verified the claims against disk rather than against the description — it confirmed
+  the symlink resolution, the file inventory in both directions, that all 14 remaining
+  /Users/ hits are docstring and not live code, that every script's argv arity matches the
+  documented command block, and that defects.py's main() really does read <root>/*/ui.html and
+  <root>/../calib. It also found and reddened one claim in the sibling PR's SKILL.md that did
+  not reproduce, which was removed rather than adjusted.
+budget: |
+  Gear 2, solo-orchestrator, 1 independent verification dispatch. No council: the divergent-
+  priors test does not fire on a file move plus a path-portability fix.
+pii: none


### PR DESCRIPTION
Half of Zero's 2026-09-01 order to open a `/design` corner (*"salva tutto in un nuovo corner /design"*). The other half — the `SKILL.md` brain and the front-page build chain — is a sibling PR, **serialized after this one** because its file inventory names this directory.

Split deliberately: together the two halves are 2,048 lines of churn, which the Agent PR Contract's rule 1 forbids in one concern. This half is 1,168, floor 2, and carries `evidence/brief.yml` declaring gear 2. (The predecessor #5505 was closed for exactly this — the `Harness floor recompute` gate caught a real contract violation, not a false positive.)

## Why commit these rather than rewrite them

They were written during the 2026-08-31 design study and have lived only under `~/Desktop/Design-Dossier-2026-08-31/strumenti/` — outside the repo, on a directory where a glob returns empty **without an error**, one accidental cleanup away from gone.

`defects.py` mechanises six defect classes that a human had to notice once each — dead-control, duplicate-string, heading-order, double-announce, struck-copy, clipped-sentence — and ships its own **innocence and guilt controls**, printing their result *before* any verdict. A run whose innocence is noisy or whose guilt is silent proves nothing, and the tool says so rather than leaving the reader to remember it. `measure.py` sweeps six states for 27-pair contrast, overflow, 44px tap targets, external requests and no-JS text. The calibration fixtures are copied **verbatim**: they are what the probes were tuned against, so editing them would silently decalibrate every future verdict.

## One behaviour change, and it is a real fix

The headless-Chromium path was a hardcoded `/Users/nuzantara/...` literal in all four Playwright probes. **M5's home is `/Users/balizero`, so every one of these probes was dead there — and dead silently**, which is the failure class cicatrix families #1 and #2 exist for. Now resolved per-machine: `CHROME_HEADLESS` if set, else the newest `ms-playwright` cache dir, else a loud `SystemExit` naming the env var. No other line of probe logic is touched.

An independent subagent on fresh context verified that all 14 remaining `/Users/` occurrences are inside the resolver's docstring and none is live path construction.

## Bites

**Consumer:** `python3 .agents/skills/design/strumenti/defects.py <root>` from any checkout. **Observed on this branch**, against the calibration directory this PR ships:

```
innocence: CLEAN
guilt:     ALL FIRE
-> probe trusted for this run
```

and `measure.py` completing its six states with an empty `errors` list.

## Scope and what this PR deliberately does not do

Additive only, 13 new files, zero existing files touched. **Not wired into CI on purpose** — these are an on-demand instrument for a design session, not a required check. Nothing here can turn a PR red, which also means nothing here is exercised automatically: a future session must run them and read their controls, exactly as the tools' own output insists. No image, no PII: the fixtures are synthetic HTML written for this purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
