### PR TITLE
docs(design): the /design corner brain and the front-page build chain

### DIFF
--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: design
+description: "Design corner — the shared brain for every Bali Zero visual surface (front page, GARUDA VOA, Visa Oracle, brand pages). Load BEFORE designing, judging or measuring any page, or when Zero says /design, 'la home', 'il rendering', 'la pagina'. Holds: the derivability doctrine (a rule that cannot name its input is a fad), the calibrated probes, the 2026-09-01 front page and how to rebuild it, and the standing rule that a mechanical gate can tell you a page is well-built but never that it is TRUE."
+---
+
+# /design — the visual-surface corner
+
+> Created 2026-09-01 on Zero's order at the close of the front-page rebuild
+> ("salva tutto in un nuovo corner /design che casomai vai a unire cn altre
+> skill/corner"). This is HOT CONTEXT for any session touching a Bali Zero
+> visual surface. **§1 LIVE STATE is only useful while it is true — update it
+> when it changes.**
+
+## 0. What this corner is, and the north star
+
+Bali Zero sells a service that is easy to fake and expensive to get wrong: a
+foreigner's permission to live in Indonesia. Every visual surface therefore has
+one job before it has any other — **be recognisably the work of people who know
+the answer.** The corpus's own documented failure mode is a page that is
+"technically correct and emotionally flat"; the failure mode we shipped and had
+to undo on 2026-09-01 is its sibling, a page that spends itself insisting it is
+legitimate.
+
+**THE NORTH STAR: the product's promise, delivered before anything is claimed.**
+On a visa surface that means an answer in ten seconds. Knowing the answer is the
+only trust signal a copycat cannot reproduce — a website is an afternoon's work,
+knowing which permit someone needs is not. Proof of legitimacy is a line and a
+row of real faces, never a section, never six.
+
+**The unit of quality here is a MEASUREMENT, not an opinion** (SYMBIOSIS Law 7).
+Everything in `strumenti/` exists so a design claim can be falsified. But see
+§3: the measurements bound how well a page is BUILT and say nothing about
+whether it is TRUE.
+
+## 1. LIVE STATE (2026-09-01)
+
+| thing                                                                      | where                                                                     | state                                                                                                                                 |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Front page v2.1**                                                        | artifact `9f30f3b6-72c4-4a87-9e23-17c16581815c`                           | published, private. Source of truth = `prima-pagina/home.tpl.html` HERE                                                               |
+| **Nine rendered states**                                                   | artifact `9f1fcdcd-a398-47df-a6ca-66940f572622`                           | published, private                                                                                                                    |
+| **Design dossier** (110KB synthesis, 12 lane reports, 53+ gates, 11 knobs) | `~/Desktop/Design-Dossier-2026-08-31/`                                    | ⚠️ NOT in git, 29MB, and `~/Desktop` is TCC-denied in readdir — a glob there returns empty WITHOUT error. Read files by explicit path |
+| **5-LLM blind contest** ("la prima pagina")                                | `~/Desktop/Design-Dossier-2026-08-31/concorso-la-prima-pagina/arena.html` | 🔴 **OPEN — awaiting Zero's blind vote.** `mapping.json` is sealed: NEVER put the seat↔letter mapping in prose before the vote        |
+| Calibrated probes                                                          | `strumenti/` HERE                                                         | armed; controls pass                                                                                                                  |
+| Front-page build chain                                                     | `prima-pagina/` HERE                                                      | proven end-to-end from a clean dir on 2026-09-01                                                                                      |
+
+**Open, and they are Zero's, not a session's:**
+
+- **Registry numbers + street address** — the footer carries a dashed placeholder.
+  Nothing invented; needs the real NIB / entity / tax-licence numbers.
+- **The August filing count** (`47 KITAS / 9 PT PMA`) is a SHAPE, not a measurement.
+  Replace with the real CRM figure or delete the clause. Its methodology line
+  (counted on submission, not approval; as-of date) is correct and must survive.
+- **`since 2019` vs `since 2020`** contradict each other in the live marketing
+  copy: `apps/mouth/src/lib/trust-figures.ts` says in its own docstring that the
+  "5,000+ clients since 2019" claim has no verifiable source in any system we
+  run, while `apps/mouth/src/app/layout.tsx:49,98` publishes "5000+ clients
+  since **2020**". Same claim, two years, one of them disowned by the file that
+  owns the figures. No repo-wide count is given on purpose — a bare grep for
+  "since 2020" also catches KBLI regulatory dates in `.mdx`/`.json`, so any
+  headline number here would be measuring the wrong thing.
+- **Five live `#1` claims** in `(marketing)/page.tsx` (2) and `layout.tsx` (3) —
+  blocklist class. A raw grep returns 8; three are false positives (the hex
+  colour `#16213a` and two `#1216` issue references).
+- The 5-LLM contest vote.
+
+## 2. The doctrine, in four rules
+
+**R1 — Derivability (Test A).** A rule that cannot name the input it is computed
+from is a fad, not a principle. "Ground L 18–20%" is derivable; "use a dark
+theme" is not. Every knob in `§5.1` of the dossier names its input.
+
+**R2 — Falsifiability (Test B).** For every claim on a page, name the external
+record that would falsify it. **Your own server renders decoration; a registrar
+renders evidence.** This is why the footer links `oss.go.id`, `ahu.go.id` and
+`sikop.kemenkeu.go.id` instead of showing a badge, and why the Google rating is
+a link to the live profile with the date it was read.
+
+**R3 — One peak per viewport.** Intensity is a budget. On the front page the
+peak is the photograph; everything after it is quiet on purpose.
+
+**R4 — Proof is a line, not a section.** See §0. The 2026-09-01 rebuild moved
+proof from six of eight sections to one line plus six faces, and gave the space
+to a photograph and a working answer.
+
+## 3. Blood-bought rules (each one cost a real defect)
+
+1. **A mechanical gate cannot be wrong about a regulation.** Twelve green gates
+   sat on a widget that named the wrong visa code with confident specificity.
+   Any surface that ANSWERS needs a cross-family refuter pointed at its facts —
+   it is the only instrument aimed there. Ground truth for visas:
+   `research/visa/2026-07-24-w2-factbase-*.md`, re-read on the turn you use it.
+2. **A broken `<img>` passes every layout gate** — it still has a box, an alt
+   string, a contrast ratio and a tap target. Six gates × six states plus six
+   defect classes all reported clean on a page whose seven images were dead.
+   `verify_images.py` exists for this, and it carries a deliberate guilt control.
+3. **Your local render is not the published page.** The artifact wrapper injects
+   `[hidden]{display:none!important}`; a local file without it lets
+   `.opts{display:flex}` beat the `hidden` attribute. `home.tpl.html` now
+   declares the host's rules itself. Whenever the host adds CSS to your document,
+   declare it or you are measuring a different page.
+4. **`loading="lazy"` on a data: URI defers nothing** (there is no request) but
+   leaves cards outside a horizontal scroller undecoded. Pure downside.
+5. **A copy blocklist over-matches on negations.** "We do **not** guarantee
+   outcomes" fires a `guarantee` guard. The side that moves is the GUARD, never
+   the honest sentence — narrow to a positive claim, then re-prove innocence AND
+   guilt (cicatrix family #3).
+6. **The brand mark is not a letter.** Setting it as the "B" of BALI reads
+   "3ALI ZERO" at 26px. The staff cards put the mark BESIDE the wordmark; follow
+   the brand rather than inventing a lockup for it.
+7. **A colour mixed toward white or black outlives its ground** — on dark,
+   lightening raises contrast; on paper it lowers it. Pin the token, not a
+   `color-mix` string. (See memory `discovery_a_colour_mixed_toward_white_...`.)
+8. **Prices come from PricingTool only** (CLAUDE.md golden rule #11), and the
+   stores disagree: `practice_types.base_price` diverges from the sheet on
+   `B1 - VOA` (750k vs 790k). A mockup shows no price.
+9. **Client PII never reaches a mockup.** The one clean-consent image class of
+   PEOPLE is `apps/mouth/public/static/team/*.jpg` — staff cards, carrying their
+   own name and role. The immigration-queue photograph in the same tree shows
+   ~15–20 identifiable strangers and must NOT be published. The hero,
+   `static/news/perfect-storm-bali.jpg`, is landscape with no identifiable
+   person and is the one non-staff image this corner uses.
+
+## 4. What is here
+
+```
+strumenti/                 the calibrated probes — all read the RENDERED DOM
+  measure.py    <file>     6 states (mobile/desktop × light/system-dark/forced-dark):
+                           27-pair contrast, horizontal overflow, 44px tap targets,
+                           external requests, no-JS text, derived palette/type metrics
+  defects.py    <root>     six classes a human had to notice once: dead-control,
+                           duplicate-string, heading-order, double-announce,
+                           struck-copy, clipped-sentence. Needs <root>/*/ui.html and
+                           <root>/../calib -> controlli-di-calibrazione
+  occlusion.py             overlap/occlusion pass
+  regression.py            before/after comparison
+  judge.py                 rubric scoring
+  controlli-di-calibrazione/   the innocence + guilt controls. A run whose
+                           innocence is NOISY or whose guilt is SILENT proves nothing
+
+prima-pagina/              the 2026-09-01 front page, rebuildable from repo sources
+  home.tpl.html            THE SOURCE. Tokens __LOGO__ __HERO__ __SURYA__ ... substituted at build
+  assets.py                re-encodes mark + hero + 6 staff cards from apps/mouth/public
+  build.py                 template + assets.json -> home.html
+  render.py                9 states incl. two answered-widget shots and two diagnostics
+  shrink.py / gallery.py   PNG -> JPEG, then the 9-state gallery page
+  verify_images.py         every <img> actually decoded (guilt-controlled)
+  verify_copy.py           drives all 7 widget branches + runs the claim blocklist
+```
+
+Nothing images-shaped is copied into this corner on purpose: the staff photos
+stay in `apps/mouth/public/static/team/` and are re-encoded on demand. A second
+copy is a second thing to keep in sync and a second place they can leak from.
+
+## 5. How to rebuild the front page (proven 2026-09-01, clean dir)
+
+```bash
+C=<repo>/.agents/skills/design ; T=<scratch>/proof ; R=<repo-root>
+V=<repo-root>/apps/backend-rag/.venv/bin/python      # Pillow lives here, not in system python
+mkdir -p "$T"
+"$V" "$C/prima-pagina/assets.py" "$R" "$T"           # -> assets.json  (~159 KB inline)
+python3   "$C/prima-pagina/build.py"  "$T"           # -> home.html    (~241 KB)
+python3   "$C/prima-pagina/verify_images.py" "$T/home.html"   # must say 8/8
+python3   "$C/prima-pagina/verify_copy.py"   "$T/home.html"   # 7 branches + blocklist
+mkdir -p "$T/probe/home" && cp "$T/home.html" "$T/probe/home/ui.html"
+ln -sfn "$C/strumenti/controlli-di-calibrazione" "$T/calib"
+python3   "$C/strumenti/measure.py" "$T/home.html"
+python3   "$C/strumenti/defects.py" "$T/probe"       # must say "probe trusted"
+python3   "$C/prima-pagina/render.py" "$T/home.html" "$T/shots"
+```
+
+The headless Chromium path is resolved per-machine (`CHROME_HEADLESS` env, else
+the newest `~/Library/Caches/ms-playwright/chromium_headless_shell-*`) — M5's
+home is `/Users/balizero`, Pro/Mini's is `/Users/nuzantara`, so a hardcoded path
+is a probe that dies silently on the other machine.
+
+**Read a probe's verdict only after reading its controls.** `defects.py` prints
+them first for exactly this reason.
+
+## 6. Conventions
+
+- **Artifact commentary in Italian, UI copy in English.** Never mixed in one artifact.
+- The study is a STUDY: no product code, no deploy, feature flags stay OFF.
+  Output is research, doctrine and mockups.
+- No external assets in an artifact beyond the CSP allowlist — inline everything
+  as data URIs. Google Fonts is the one stylesheet host that loads.
+- Publish updates to the SAME artifact URL (pass `url`); a new file path claims
+  a new artifact and orphans the link Zero already has.
+
+## 7. Merge candidates (Zero, 2026-09-01: "casomai vai a unire cn altre skill/corner")
+
+This corner deliberately does NOT duplicate what already exists. If it is ever
+consolidated, these are the neighbours and the seam:
+
+| corner / skill                                      | overlap                                                                                                             | seam                                                                                                                                                                              |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bali-zero-brand` (user skill, `~/.agents/skills/`) | palette, type, voice, forbidden phrases; surfaces `carousel-ig`, `internal-print-a4`, `web-mouth`, `email-template` | **It owns the brand tokens; this corner owns the measurement and the web-page doctrine.** A merge should fold §2–§3 in as a `web-front` surface and leave `tokens.json` sovereign |
+| `wr2`                                               | the `carousel-ig` surface and its critic rubric                                                                     | wr2's critic judges slides; `strumenti/` judges pages. Same discipline (guilt+innocence), different DOM                                                                           |
+| `visaoracle`                                        | the front page's widget answers ITS domain                                                                          | visaoracle owns the RulePack and the ENFORCE gate; this corner must never assert a verdict — the widget says "orientation, not a determination" and links out                     |
+| `modus`                                             | Gear 3 governs a redesign of this size                                                                              | no overlap to merge; modus is the loop, this is the terrain                                                                                                                       |

--- a/.agents/skills/design/prima-pagina/assets.py
+++ b/.agents/skills/design/prima-pagina/assets.py
@@ -1,0 +1,65 @@
+"""Rebuild assets.json (inline data-URIs) from the REPO's own image files.
+
+    python3 assets.py <repo-root> <out-dir>
+
+Nothing is copied into this corner: the hero and the six staff cards live in
+apps/mouth/public/static and are re-encoded on demand. That is deliberate --
+the staff photos are the one clean-consent image class we have, and a second
+copy in a skill directory is a second thing to keep in sync and a second place
+they can leak from.
+
+Needs Pillow, which lives in the backend venv, not in system python:
+    apps/backend-rag/.venv/bin/python assets.py <repo-root> <out-dir>
+"""
+import base64, io, json, pathlib, sys
+
+from PIL import Image
+
+if len(sys.argv) != 3:
+    raise SystemExit(__doc__)
+P = pathlib.Path(sys.argv[1]) / "apps/mouth/public/static"
+D = pathlib.Path(sys.argv[2]); D.mkdir(parents=True, exist_ok=True)
+if not P.is_dir():
+    raise SystemExit(f"not a repo root (no {P}): {sys.argv[1]}")
+
+out, total = {}, 0
+
+def jpg(im, w, q, key, crop=None):
+    global total
+    if crop:
+        im = im.crop(crop)
+    im = im.convert("RGB").resize((w, round(im.height * w / im.width)), Image.LANCZOS)
+    b = io.BytesIO(); im.save(b, "JPEG", quality=q, optimize=True, progressive=True)
+    d = b.getvalue(); total += len(d)
+    out[key] = "data:image/jpeg;base64," + base64.b64encode(d).decode()
+    print(f"  {key:16s} {im.size[0]}x{im.size[1]}  {len(d)/1024:6.1f} KB")
+
+# The mark is the brand's own asset, trimmed to its ink and shrunk to the size it
+# is actually drawn at. It is NOT set as the word's letter B: the staff cards put
+# the mark BESIDE the wordmark, and at 26px the "B" reading fails (it reads "3").
+print("MARK")
+m = Image.open(P.parent / "assets/logo/balizero-3-red.png").convert("RGBA")
+bbox = m.getbbox()
+if bbox:
+    m = m.crop(bbox)
+m = m.resize((round(m.width * 102 / m.height), 102), Image.LANCZOS)
+_b = io.BytesIO(); m.save(_b, "PNG", optimize=True)
+_d = _b.getvalue(); total += len(_d)
+out["logo"] = "data:image/png;base64," + base64.b64encode(_d).decode()
+print(f"  {'logo':16s} {m.size[0]}x{m.size[1]}  {len(_d)/1024:6.1f} KB")
+
+print("\nHERO — sized for a 390px phone at 2x, gate 36 budget 150-200 KB")
+jpg(Image.open(P / "news" / "perfect-storm-bali.jpg"), 1100, 72, "hero")
+
+print("\nTEAM — the cards carry their own name and role, so nothing is retyped")
+missing = []
+for t in ["surya", "ari", "sahira", "damar", "krisna", "dewaayu"]:
+    f = P / "team" / f"{t}.jpg"
+    if not f.exists():
+        missing.append(t); print(f"  {t}: MISSING"); continue
+    jpg(Image.open(f), 300, 74, t)
+
+print(f"\nTOTAL {total/1024:.0f} KB")
+(D / "assets.json").write_text(json.dumps(out))
+if missing:
+    raise SystemExit(f"missing team cards: {missing} — the page would ship dead images")

--- a/.agents/skills/design/prima-pagina/build.py
+++ b/.agents/skills/design/prima-pagina/build.py
@@ -1,0 +1,36 @@
+"""Substitute the inline assets into home.tpl.html -> home.html.
+
+    python3 build.py <work-dir>
+
+<work-dir> must hold assets.json (see assets.py). home.tpl.html is read from
+this script's own directory, so the corner is the single source of the template.
+"""
+import json, pathlib, re, sys
+
+if len(sys.argv) != 2:
+    raise SystemExit(__doc__)
+here = pathlib.Path(__file__).resolve().parent
+d = pathlib.Path(sys.argv[1])
+tpl = (here / "home.tpl.html").read_text()
+a = json.loads((d / "assets.json").read_text())
+
+
+def bare(v):
+    """assets.json stores a FULL data URI; the template supplies its own prefix.
+    Feeding it through unstripped produced `data:...base64,data:...base64,AAA`
+    -- which every mechanical gate passed, because a broken <img> still has a
+    box, an alt string and a contrast ratio. Strip the prefix at the seam."""
+    return re.sub(r"^data:image/[a-z+]+;base64,", "", v)
+
+
+tpl = tpl.replace("__LOGO__", bare(a["logo"])).replace("__HERO__", bare(a["hero"]))
+for k in ("surya", "ari", "sahira", "damar", "krisna", "dewaayu"):
+    tpl = tpl.replace("__" + k.upper() + "__", bare(a[k]))
+
+left = sorted(set(re.findall(r"__[A-Z]+__", tpl)))
+if left:
+    raise SystemExit(f"unreplaced tokens: {left}")
+if "base64,data:" in tpl:
+    raise SystemExit("double data-URI prefix survived")
+(d / "home.html").write_text(tpl)
+print(f"home.html  {len(tpl.encode()):,} bytes")

--- a/.agents/skills/design/prima-pagina/gallery.py
+++ b/.agents/skills/design/prima-pagina/gallery.py
@@ -1,0 +1,72 @@
+import base64, pathlib, sys
+d = pathlib.Path(sys.argv[1]); shots = d/"shots_web"
+SHOTS = [
+ ("phone-day", "Giorno · telefono",
+  "390×844. Il primo schermo: fotografia, titolo, e la domanda. Nessun form, nessuna email."),
+ ("phone-day-answered", "Giorno · la risposta",
+  "«Fino a 30 giorni» → B1. La risposta arriva prima del nome. È l'unico segnale di fiducia che un imitatore non sa falsificare, perché richiede di sapere la risposta."),
+ ("phone-night", "Notte · terra neutra",
+  "Ground OKLCH L 19,0%, croma 0,016: grigio caldo, non nero. Distanza di tinta terra→accento 32°."),
+ ("phone-night-answered", "Notte · seconda domanda",
+  "«Un anno o più» apre la domanda sul motivo; poi E33G, con la soglia pubblicata di 60.000 USD l'anno."),
+ ("phone-oxblood", "Notte · campo rosso",
+  "La polarità alternativa della Q10, ancora aperta: il rosso smette di essere accento e diventa la terra."),
+ ("desktop-day", "Giorno · desktop",
+  "1280×900. La colonna di lettura resta a 680px — la misura non cresce con lo schermo — ma i sei volti escono in una banda a piena larghezza."),
+ ("desktop-night", "Notte · desktop",
+  "Stesso documento, stessa banda, tema scelto dal visitatore e non dalla pagina."),
+ ("diagnostic-greyscale", "Diagnostica · scala di grigi",
+  "Nessun significato passa dalla sola tinta: il rosso è l'unico accento e non porta mai un'informazione da solo."),
+ ("diagnostic-sunlight", "Diagnostica · pieno sole",
+  "Contrasto 0,62 · luminosità 1,22 — un telefono tenuto fuori a mezzogiorno, che è dove questa pagina si legge davvero."),
+]
+cards=[]
+for name,title,note in SHOTS:
+    f = shots/f"{name}.jpg"
+    b64 = base64.b64encode(f.read_bytes()).decode()
+    kb = f.stat().st_size/1024
+    cards.append(f"""  <figure>
+    <figcaption><b>{title}</b><span>{note}</span></figcaption>
+    <img src="data:image/jpeg;base64,{b64}" alt="{title}">
+    <p class="meta">{name} · {kb:,.0f} KB · reso a 2×</p>
+  </figure>""")
+html = """<title>Front Page States</title>
+<style>
+:root{--ground:#FCFAF8;--surface:#FFF;--ink:#17120F;--muted:#574E49;--faint:#7A6F69;
+  --rule:#E9E3DC}
+@media (prefers-color-scheme:dark){:root:not([data-theme="light"]){
+  --ground:#161311;--surface:#211E1C;--ink:#EEEAE7;--muted:#B5B0AC;--faint:#95908C;
+  --rule:#2E2B29}}
+:root[data-theme="dark"]{--ground:#161311;--surface:#211E1C;--ink:#EEEAE7;--muted:#B5B0AC;
+  --faint:#95908C;--rule:#2E2B29}
+*{box-sizing:border-box}
+body{margin:0;background:var(--ground);color:var(--ink);
+  font:15px/1.5 "Public Sans","Helvetica Neue",Arial,sans-serif}
+header{max-width:1180px;margin:0 auto;padding:46px 20px 6px}
+h1{margin:0 0 12px;font-size:31px;font-weight:800;letter-spacing:-.022em;text-wrap:balance}
+header p{margin:0 0 10px;max-width:66ch;color:var(--muted);text-wrap:pretty}
+main{max-width:1180px;margin:0 auto;padding:26px 20px 76px;
+  display:grid;gap:32px;grid-template-columns:repeat(auto-fill,minmax(290px,1fr));
+  align-items:start}
+figure{margin:0;background:var(--surface);border:1px solid var(--rule)}
+figcaption{padding:13px 15px;border-bottom:1px solid var(--rule);display:flex;
+  flex-direction:column;gap:4px}
+figcaption b{font-size:15px}
+figcaption span{color:var(--muted);font-size:13.5px;text-wrap:pretty}
+img{display:block;width:100%;height:auto}
+.meta{margin:0;padding:10px 15px;border-top:1px solid var(--rule);
+  color:var(--faint);font-size:12.5px;font-variant-numeric:tabular-nums}
+</style>
+<header>
+  <h1>Front page, nove stati</h1>
+  <p>Screenshot a piena pagina della stessa sorgente, resi a 2× su Chromium headless.
+     Il tema non è un interruttore decorativo: giorno, notte-neutra e notte-rossa sono tre
+     palette definite a token, e la pagina pubblicata sceglie da sé quella del visitatore.</p>
+  <p>Gli stati «risposta» esistono perché lo scatto di un elemento interattivo vuoto mostra
+     la cornice e non il prodotto. Gli ultimi due non sono design: sono sonde — una toglie
+     il colore, l'altra simula il sole.</p>
+</header>
+<main>
+""" + "\n".join(cards) + "\n</main>\n"
+(d/"gallery.html").write_text(html)
+print("gallery.html %.2f MB" % (len(html.encode())/1024/1024))

--- a/.agents/skills/design/prima-pagina/home.tpl.html
+++ b/.agents/skills/design/prima-pagina/home.tpl.html
@@ -1,0 +1,407 @@
+<title>Bali Zero Front Page</title>
+<meta name="description" content="PT PMA, KITAS and tax filing in Bali. Licensed. Kerobokan.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;600;800&display=swap">
+<style>
+/* ═══════════════════════════════════════════════════════════════════════════
+   Rebuilt 2026-09-01 after the owner's verdict on v1: "an entire home page
+   that hammers over and over that we're real? no image, nothing interesting."
+   He was right, and the diagnosis is precise: v1 optimised for passing the
+   study's gates instead of for the person arriving. Six of eight sections
+   asserted legitimacy. Nobody lands on a visa page wanting to audit an agency.
+
+   The inversion: proof drops from ~60% of the page to one line and a row of
+   real faces. What it buys is a photograph and a thing that WORKS — the
+   product's promise delivered in ten seconds, which is the only trust signal
+   that cannot be faked by someone who does not know the answer.
+
+   Knobs unchanged and still declared at the foot of the page. Ground L 19.0%,
+   hue distance 32°, elevation +7 L, spacing ratio 3.6x, one peak per viewport
+   (now the hero), PAS framing, VERIFY screen class.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+:root{
+  --ground:#FCFAF8; --surface:#FFFFFF; --surface-2:#EEEAE7;
+  --ink:#17120F; --ink-muted:#574E49; --ink-faint:#7A6F69;
+  --rule-subtle:#E9E3DC; --rule-strong:#8A7F77;
+  --accent:#C8102E; --accent-ink:#A50D26; --on-accent:#FFFFFF;
+  --focus:#17120F; --grain:.08; --logo-lift:none;
+  --step-0:14px; --step-1:15px; --step-2:17px; --step-3:21px; --step-4:27px;
+  --display:38px; --hero:40px;
+  --lh-tight:1.1; --lh:1.5;
+  --gap-in:20px; --gap-out:72px;
+  --t-instant:80ms; --t-fast:150ms; --t-base:220ms;
+  --ease:cubic-bezier(.2,0,.38,.9);
+  --measure:34ch;
+}
+@media (prefers-color-scheme:dark){
+  :root:not([data-theme="light"]){
+    --ground:#161311; --surface:#272321; --surface-2:#393432;
+    --ink:#EEEAE7; --ink-muted:#B5B0AC; --ink-faint:#95908C;
+    --rule-subtle:#2E2B29; --rule-strong:#67625F;
+    --accent:#C8102E; --accent-ink:#F0808F; --on-accent:#FFFFFF;
+    --focus:#EEEAE7; --grain:.06; --logo-lift:brightness(1.32) saturate(1.06);
+  }
+  :root:not([data-theme="light"])[data-night="oxblood"]{
+    --ground:#28070A; --surface:#3C1619; --surface-2:#512729;
+    --ink:#F6ECEA; --ink-muted:#D1B7B6; --ink-faint:#A78A89;
+    --rule-subtle:#452223; --rule-strong:#835D5E;
+    --accent:#F6ECEA; --accent-ink:#F6C9C0; --on-accent:#28070A; --focus:#F6ECEA;
+  }
+}
+:root[data-theme="dark"]{
+  --ground:#161311; --surface:#272321; --surface-2:#393432;
+  --ink:#EEEAE7; --ink-muted:#B5B0AC; --ink-faint:#95908C;
+  --rule-subtle:#2E2B29; --rule-strong:#67625F;
+  --accent:#C8102E; --accent-ink:#F0808F; --on-accent:#FFFFFF;
+  --focus:#EEEAE7; --grain:.06; --logo-lift:brightness(1.32) saturate(1.06);
+}
+:root[data-theme="dark"][data-night="oxblood"]{
+  --ground:#28070A; --surface:#3C1619; --surface-2:#512729;
+  --ink:#F6ECEA; --ink-muted:#D1B7B6; --ink-faint:#A78A89;
+  --rule-subtle:#452223; --rule-strong:#835D5E;
+  --accent:#F6ECEA; --accent-ink:#F6C9C0; --on-accent:#28070A; --focus:#F6ECEA;
+}
+
+[hidden]{display:none !important}
+*{box-sizing:border-box}
+body{margin:0; background:var(--ground); color:var(--ink);
+  font-family:"Public Sans","Helvetica Neue",Arial,sans-serif;
+  font-size:var(--step-2); line-height:var(--lh); -webkit-font-smoothing:antialiased}
+h1,h2,h3{margin:0; font-weight:600; letter-spacing:-.018em; text-wrap:balance}
+p{margin:0; text-wrap:pretty}
+a{color:inherit}
+img{display:block; max-width:100%}
+:focus-visible{outline:2px solid var(--focus); outline-offset:2px; border-radius:2px}
+.num{font-variant-numeric:tabular-nums lining-nums}
+.wrap{max-width:680px; margin:0 auto; padding:0 20px}
+
+/* ── HERO ──────────────────────────────────────────────────────────────────
+   The one peak (knob 6). The photograph is not decoration: the headline says
+   people get this wrong in their first month, and the picture is the place
+   they are getting it wrong in, with the weather coming. */
+.hero{position:relative; isolation:isolate; overflow:hidden;
+  background:#0E0C0B; color:#F6F2ED; min-height:520px; display:flex; flex-direction:column}
+.hero img{position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0}
+.hero::after{content:""; position:absolute; inset:0; z-index:1;
+  background:linear-gradient(178deg, rgba(8,7,6,.62) 0%, rgba(8,7,6,.30) 34%, rgba(8,7,6,.80) 78%, rgba(8,7,6,.94) 100%)}
+.hero > *{position:relative; z-index:2}
+.masthead{display:flex; align-items:center; justify-content:space-between; gap:16px;
+  padding:16px 20px 0; max-width:680px; margin:0 auto; width:100%}
+.brand{display:flex; align-items:center; gap:7px; text-decoration:none;
+  min-height:44px; padding-right:8px; margin-left:-4px; padding-left:4px}
+.brand img{position:static; height:26px; width:auto; object-fit:contain;
+  filter:brightness(1.28) saturate(1.06)}
+.brand .word{font-size:var(--step-2); font-weight:600; letter-spacing:.15em; text-transform:uppercase}
+.dateline{font-size:var(--step-0); letter-spacing:.04em; text-align:right; opacity:.82}
+.hero-body{margin-top:auto; padding:64px 20px 46px; max-width:680px; margin-left:auto; margin-right:auto; width:100%}
+.hero h1{font-size:var(--hero); line-height:var(--lh-tight); max-width:16ch; font-weight:800;
+  letter-spacing:-.028em; text-shadow:0 1px 26px rgba(0,0,0,.42)}
+.hero p{margin-top:16px; max-width:38ch; font-size:var(--step-2); opacity:.9}
+
+/* ── THE THING THAT WORKS ─────────────────────────────────────────────────
+   Delivered before anything is claimed. Knowing the answer IS the trust
+   signal; asserting legitimacy is what the copycats do. */
+.ask{margin-top:-30px; position:relative; z-index:3}
+.ask-card{background:var(--surface); border:1px solid var(--rule-strong); padding:22px 20px 20px}
+.ask h2{font-size:var(--step-3); margin-bottom:4px}
+.ask .hint{font-size:var(--step-1); color:var(--ink-muted); margin-bottom:16px}
+.opts{display:flex; flex-wrap:wrap; gap:8px}
+.opts button{min-height:44px; padding:0 14px; font:inherit; font-size:var(--step-1);
+  color:var(--ink); background:transparent; border:1px solid var(--rule-strong);
+  border-radius:2px; cursor:pointer; transition:background var(--t-instant) var(--ease)}
+.opts button:hover{background:var(--surface-2)}
+.opts button[aria-pressed="true"]{background:var(--ink); color:var(--ground); border-color:var(--ink)}
+.answer{margin-top:18px; padding-top:18px; border-top:1px solid var(--rule-subtle)}
+.answer[hidden]{display:none}
+.answer .code{display:inline-block;
+      min-width:1.6em; text-align:center; font-size:var(--step-0); font-weight:600;
+  letter-spacing:.09em; padding:4px 9px; background:var(--accent); color:var(--on-accent); border-radius:2px}
+.answer .name{font-size:var(--step-3); font-weight:600; margin-top:10px}
+.answer .detail{font-size:var(--step-1); color:var(--ink-muted); margin-top:6px; max-width:46ch}
+.answer .go{display:inline-flex; align-items:center; min-height:44px; margin-top:12px;
+  font-size:var(--step-1); color:var(--accent-ink); text-underline-offset:3px}
+.caveat{margin-top:16px; padding-top:14px; border-top:1px solid var(--rule-subtle);
+  font-size:var(--step-1); color:var(--ink-muted); max-width:52ch}
+
+section{margin-top:var(--gap-out)}
+.label{font-size:var(--step-0); text-transform:uppercase; letter-spacing:.1em;
+  color:var(--ink-faint); font-weight:600; margin-bottom:16px}
+
+/* ── doors ─────────────────────────────────────────────────────────────── */
+.door{display:grid; grid-template-columns:1fr auto; align-items:center; gap:14px;
+  min-height:64px; padding:16px 0; border-bottom:1px solid var(--rule-subtle);
+  text-decoration:none; transition:padding-left var(--t-fast) var(--ease)}
+.door:first-of-type{border-top:1px solid var(--rule-subtle)}
+.door:hover,.door:focus-visible{padding-left:8px}
+.door .q{font-size:var(--step-3); line-height:1.24; font-weight:600}
+.door .a{display:block; margin-top:5px; font-size:var(--step-1); color:var(--ink-muted)}
+.door .arrow{font-size:var(--step-3); color:var(--accent-ink)}
+
+/* ── the team: proof rendered as people, not as claims ─────────────────── */
+.team{margin-top:var(--gap-out)}
+.team-inner{max-width:1160px; margin:0 auto; padding:0 20px}
+.team-scroll{display:grid; grid-auto-flow:column; grid-auto-columns:148px; gap:12px;
+  overflow-x:auto; padding-bottom:10px; scroll-snap-type:x mandatory; scrollbar-width:thin;
+  /* the crop was doing the signalling by accident: a card sliced mid-name reads
+     as a layout bug, not as "there is more". Fade the edge and say the count. */
+  -webkit-mask-image:linear-gradient(90deg,#000 86%,rgba(0,0,0,.15));
+  mask-image:linear-gradient(90deg,#000 86%,rgba(0,0,0,.15))}
+.team-scroll figure{margin:0; scroll-snap-align:start}
+.team-scroll img{width:100%; height:auto; border:1px solid var(--rule-subtle)}
+.team-head{display:flex; align-items:baseline; justify-content:space-between; gap:16px}
+.team-head .label,.team-head .swipe{white-space:nowrap; margin-bottom:16px}
+.team-head .swipe{font-size:var(--step-0); color:var(--ink-faint)}
+.team-note{margin-top:14px; font-size:var(--step-1); color:var(--ink-muted); max-width:52ch}
+.door .q,.door .a{max-width:52ch}
+
+/* ── one proof line. One. ─────────────────────────────────────────────── */
+.proof{display:flex; flex-wrap:wrap; align-items:baseline; gap:8px 14px;
+  padding:18px 0; border-top:1px solid var(--rule-strong); border-bottom:1px solid var(--rule-strong);
+  font-size:var(--step-1)}
+.proof b{font-size:var(--step-3); font-weight:600}
+.proof a{display:inline-flex; align-items:center; min-height:44px;
+  text-underline-offset:3px; color:var(--accent-ink)}
+.proof .as-of{font-size:var(--step-0); color:var(--ink-faint); width:100%}
+
+footer{margin-top:calc(var(--gap-out) * .55); padding:26px 0 44px; border-top:1px solid var(--rule-strong);
+  font-size:var(--step-1); color:var(--ink-muted)}
+footer p{max-width:58ch; margin-bottom:12px}
+footer .credit{font-size:var(--step-0); color:var(--ink-faint)}
+.reg{display:flex; flex-wrap:wrap; gap:6px 18px; margin:16px 0 4px; font-size:var(--step-0)}
+.reg a{display:inline-flex; align-items:center; min-height:44px; color:var(--accent-ink); text-underline-offset:3px}
+.pending{display:inline-block; padding:2px 8px; border:1px dashed var(--rule-strong);
+  border-radius:3px; font-size:var(--step-0); color:var(--ink-muted)}
+.controls{display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-top:24px;
+  padding-top:16px; border-top:1px dashed var(--rule-subtle); font-size:var(--step-0); color:var(--ink-faint)}
+.controls button{min-height:44px; padding:0 12px; font:inherit; color:var(--ink);
+  background:var(--surface); border:1px solid var(--rule-strong); border-radius:2px; cursor:pointer}
+.controls button[aria-pressed="true"]{background:var(--ink); color:var(--ground); border-color:var(--ink)}
+details.decl{margin-top:16px; font-size:var(--step-0)}
+details.decl summary{cursor:pointer; min-height:44px; display:flex; align-items:center;
+  letter-spacing:.06em; text-transform:uppercase}
+details.decl pre{overflow-x:auto; padding:14px; background:var(--surface-2);
+  border:1px solid var(--rule-subtle); font-size:12px; line-height:1.6}
+
+@media (min-width:760px){
+  :root{--hero:64px; --display:52px; --step-3:23px; --step-4:34px; --gap-out:96px}
+  .hero{min-height:720px}
+  .hero-body{padding:96px 20px 62px}
+  /* at desktop width all six fit; a scroller here was the mobile compromise
+     leaking upward, so drop the scroll, the mask and the swipe hint together. */
+  .team-scroll{grid-auto-flow:row; grid-template-columns:repeat(6,1fr); gap:16px;
+    overflow-x:visible; -webkit-mask-image:none; mask-image:none}
+  .team-head .swipe{display:none}
+}
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{transition-duration:.001ms !important; animation-duration:.001ms !important}
+}
+@media (prefers-contrast:more){:root{--rule-subtle:var(--rule-strong); --ink-muted:var(--ink)}}
+@media (forced-colors:active){
+  .ask-card,.controls button,.opts button{border:1px solid CanvasText}
+  .hero::after{display:none}
+}
+</style>
+
+<header class="hero">
+  <img src="data:image/jpeg;base64,__HERO__" alt="Rice terraces below Gunung Agung at sunset, with a storm cell breaking over the sea">
+  <div class="masthead">
+    <a class="brand" href="https://balizero.com">
+      <img src="data:image/png;base64,__LOGO__" alt="Bali Zero" width="73" height="102">
+      <span class="word">Bali&nbsp;Zero</span>
+    </a>
+    <div class="dateline num">Kerobokan<br>1 September 2026</div>
+  </div>
+  <div class="hero-body">
+    <h1>Most people moving to Bali pick the wrong visa in the first month.</h1>
+    <p>Tell us how long you are staying and what you will be doing. You will know
+       which permit that is before you tell us your name.</p>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <div class="ask">
+    <div class="ask-card">
+      <h2>How long are you staying?</h2>
+      <p class="hint">Pick one. No form, no email.</p>
+      <div class="opts" id="dur" role="group" aria-label="Length of stay">
+        <button type="button" data-k="30" aria-pressed="false">Up to 30 days</button>
+        <button type="button" data-k="60" aria-pressed="false">Up to 60 days</button>
+        <button type="button" data-k="180" aria-pressed="false">About 6 months</button>
+        <button type="button" data-k="year" aria-pressed="false">A year or more</button>
+      </div>
+
+      <div class="opts" id="why" style="margin-top:10px" role="group" aria-label="Reason" hidden>
+        <button type="button" data-k="tourism" aria-pressed="false">Holiday, family, surfing</button>
+        <button type="button" data-k="remote" aria-pressed="false">Remote work, foreign employer</button>
+        <button type="button" data-k="company" aria-pressed="false">Running a company here</button>
+        <button type="button" data-k="retire" aria-pressed="false">Retiring, 55 or over</button>
+      </div>
+
+      <div class="answer" id="ans" hidden aria-live="polite">
+        <span class="code" id="ans-code"></span>
+        <div class="name" id="ans-name"></div>
+        <p class="detail" id="ans-detail"></p>
+        <a class="go" href="https://balizero.com/visa-oracle">Check it properly in the Visa Oracle →</a>
+      </div>
+
+      <p class="caveat">This is an orientation, not a determination — it reads two answers, and your
+        case has more than two. The price you are quoted afterwards is the whole price, government
+        fee included, and it does not grow at the end.</p>
+    </div>
+  </div>
+
+  <section>
+    <h2 class="label">Or start where you are</h2>
+    <a class="door" href="https://balizero.com/services">
+      <span><span class="q">I'm starting a business</span>
+        <span class="a">PT PMA, NIB, OSS licensing, and the KBLI code that decides everything</span></span>
+      <span class="arrow" aria-hidden="true">→</span></a>
+    <a class="door" href="https://balizero.com/tax-calendar">
+      <span><span class="q">Taxes confuse me</span>
+        <span class="a">NPWP, monthly SPT, Coretax. Indonesian tax has its own alphabet</span></span>
+      <span class="arrow" aria-hidden="true">→</span></a>
+    <a class="door" href="https://balizero.com/property">
+      <span><span class="q">I'm buying property</span>
+        <span class="a">Hak pakai, leasehold, and the due diligence that comes before the deposit</span></span>
+      <span class="arrow" aria-hidden="true">→</span></a>
+  </section>
+
+</div><!-- /.wrap -->
+
+  <section class="team">
+   <div class="team-inner">
+    <div class="team-head">
+      <h2 class="label">The people who file it</h2>
+      <span class="swipe">6 people &rarr;</span>
+    </div>
+    <div class="team-scroll">
+      <figure><img src="data:image/jpeg;base64,__SURYA__" alt="Surya, senior consultant, setup team"></figure>
+      <figure><img src="data:image/jpeg;base64,__ARI__" alt="Ari"></figure>
+      <figure><img src="data:image/jpeg;base64,__SAHIRA__" alt="Sahira"></figure>
+      <figure><img src="data:image/jpeg;base64,__DAMAR__" alt="Damar"></figure>
+      <figure><img src="data:image/jpeg;base64,__KRISNA__" alt="Krisna"></figure>
+      <figure><img src="data:image/jpeg;base64,__DEWAAYU__" alt="Dewa Ayu"></figure>
+    </div>
+    <p class="team-note">One of them signs your file and answers when you write. A copycat can
+      clone a website in an afternoon; it cannot clone the person who takes the call.</p>
+   </div>
+  </section>
+
+<div class="wrap">
+
+  <section>
+    <p class="proof">
+      <b class="num">47</b> KITAS and <b class="num">9</b> PT PMA filed in August ·
+      <b class="num">4.9 ★</b>
+      <a href="https://maps.app.goo.gl/whiMUTNchcDR5naz8" rel="noopener">693 reviews on Google</a>
+      <span class="as-of">Filings counted on submission, not approval, as of 31 August 2026 — the
+        number goes down in quiet months and we leave it up. Reviews hosted by Google, read 14 August 2026.</span>
+    </p>
+  </section>
+
+  <footer>
+    <p>Bali Zero handles immigration, company setup, tax and property matters for foreigners in
+      Indonesia. We do not guarantee outcomes, and no agency lawfully can — the decision belongs to
+      the authority, every time. If the right answer is a different permit, or none, that is the
+      answer you get.</p>
+
+    <div class="reg">
+      <span>Look us up:</span>
+      <a href="https://oss.go.id">NIB on oss.go.id</a>
+      <a href="https://ahu.go.id/pencarian/profil-pt">entity on ahu.go.id</a>
+      <a href="https://sikop.kemenkeu.go.id">tax licence on sikop.kemenkeu.go.id</a>
+    </div>
+    <p><span class="pending">registry numbers + street address — owner supplies</span><br>
+      Kerobokan, Badung, Bali · English · Bahasa Indonesia</p>
+    <p class="credit">Photograph: Sidemen, East Bali — Gunung Agung with the afternoon storm
+      coming in off the Lombok Strait.</p>
+
+    <div class="controls">
+      <span>Preview:</span>
+      <button type="button" data-set="theme" data-val="light" aria-pressed="false">Day</button>
+      <button type="button" data-set="theme" data-val="dark" aria-pressed="false">Night</button>
+      <span style="margin-left:10px">Night polarity (Q10):</span>
+      <button type="button" data-set="night" data-val="neutral" aria-pressed="true">Neutral ground</button>
+      <button type="button" data-set="night" data-val="oxblood" aria-pressed="false">Red field</button>
+    </div>
+
+    <details class="decl">
+      <summary>Generator declaration</summary>
+      <pre>ground lightness         L 19.0%   envelope 18-20%
+H(ground) - H(accent)    32.0deg   envelope 26-46
+elevation step, dark     +7.0 L    gate 8 floor +7
+spacing ratio            3.6x      20px in / 72px between
+intensity peak           the hero  exactly one per viewport
+type                     1 family, 3 weights, discrete steps, no clamp
+easing                   productive  cubic-bezier(.2,0,.38,.9)
+awareness stage          PAS / problem-first (cold traffic)
+screen class             VERIFY - shows everything, hides nothing
+images                   hero 70 KB + 6 team cards 79 KB, all inline, 0 requests
+
+v2 correction: v1 gave six of eight sections to proving we are real. Proof is
+now one line and six faces. The ten-second answer above is the trust signal
+that a copycat cannot reproduce, because it requires knowing the answer.
+
+Absent on purpose: any rank superlative, any affiliation or outcome claim from
+the blocked-string list, a padlock, a self-issued badge, a testimonial signed
+with an initial, a countdown, an animated number, a bento grid, a hero video,
+and the lifetime client total (which has no verifiable source in any system).</pre>
+    </details>
+  </footer>
+</div>
+
+<script>
+(function(){
+  var root=document.documentElement;
+  document.querySelectorAll('.controls button').forEach(function(b){
+    b.addEventListener('click',function(){
+      var k=b.dataset.set,v=b.dataset.val;
+      root.setAttribute(k==='theme'?'data-theme':'data-night',v);
+      document.querySelectorAll('.controls button[data-set="'+k+'"]').forEach(function(o){
+        o.setAttribute('aria-pressed',String(o===b));});
+    });
+  });
+
+  // Orientation only. Real permit families; the Oracle does the actual work.
+  var MAP={
+    "30": {c:"B1", n:"Visa on Arrival",
+      d:"Thirty days, extended once for thirty more, and sixty is the ceiling. Tourism only \u2014 not business meetings, not study, not work."},
+    "60": {c:"C1", n:"Single-entry tourist visa",
+      d:"Applied for before you fly. Sixty days, extendable twice, so a hundred and eighty in one stay. This is the one most people should have taken instead of the VOA."},
+    "180": {c:"C2", n:"Business visit visa",
+      d:"Single entry, sixty days, extendable twice to a hundred and eighty \u2014 which is your six months, in one continuous stay. Needs an Indonesian company to sponsor it, and it does not permit salaried work here."},
+    "year|tourism": {c:"\u2014", n:"You are past what a visit permits",
+      d:"Beyond about six months the honest answer is a stay permit, not a longer visa. Which one depends on what you will actually be doing \u2014 that is the next question, and it is the one that matters."},
+    "year|remote": {c:"E33G", n:"Remote worker KITAS",
+      d:"One year, renewable, self-filed \u2014 no sponsor. The published bar is USD 60,000 a year and a contract with a company incorporated outside Indonesia. It does not let you work for an Indonesian company, invoice Indonesian clients, or own a PT PMA."},
+    "year|company": {c:"E28A", n:"Investor KITAS",
+      d:"Two years, tied to a PT PMA where you hold a director or commissioner seat \u2014 owning shares alone does not qualify. Paid-up capital from IDR 2.5 billion. It covers managing the company, not doing its operational work; that is a different permit."},
+    "year|retire": {c:"E33F", n:"Retirement KITAS",
+      d:"One year, renewable, with proof of USD 3,000 a month from outside Indonesia and an Indonesian sponsor who files it for you. The official page states no age figure \u2014 anyone who tells you the cutoff with certainty is guessing, so we check yours against the office."}
+  };
+  var dur=null, why=null;
+  function press(group,btn){
+    group.querySelectorAll('button').forEach(function(o){o.setAttribute('aria-pressed',String(o===btn));});
+  }
+  function render(){
+    var whyBox=document.getElementById('why'), ans=document.getElementById('ans');
+    whyBox.hidden = (dur!=="year");
+    var key = dur==="year" ? (why? "year|"+why : null) : dur;
+    if(!key||!MAP[key]){ ans.hidden=true; return; }
+    var m=MAP[key];
+    document.getElementById('ans-code').textContent=m.c;
+    document.getElementById('ans-name').textContent=m.n;
+    document.getElementById('ans-detail').textContent=m.d;
+    ans.hidden=false;
+  }
+  document.querySelectorAll('#dur button').forEach(function(b){
+    b.addEventListener('click',function(){ dur=b.dataset.k; press(document.getElementById('dur'),b); render(); });
+  });
+  document.querySelectorAll('#why button').forEach(function(b){
+    b.addEventListener('click',function(){ why=b.dataset.k; press(document.getElementById('why'),b); render(); });
+  });
+})();
+</script>

--- a/.agents/skills/design/prima-pagina/render.py
+++ b/.agents/skills/design/prima-pagina/render.py
@@ -1,0 +1,59 @@
+import sys, pathlib, json
+from playwright.sync_api import sync_playwright
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+src = pathlib.Path(sys.argv[1]); out = pathlib.Path(sys.argv[2]); out.mkdir(exist_ok=True)
+
+# The widget-answered shots exist because a still of an interactive element in its
+# EMPTY state shows the chrome, not the product. What the visitor is promised is
+# the answer, so at least one shot must contain one.
+STATES = [
+ ("phone-day",       390, 844, "light",  "neutral", None),
+ ("phone-night",     390, 844, "dark",   "neutral", None),
+ ("phone-night-answered", 390, 844, "dark", "neutral", ("year","remote")),
+ ("phone-day-answered",   390, 844, "light","neutral", ("30",None)),
+ ("phone-oxblood",   390, 844, "dark",   "oxblood", ("year","company")),
+ ("desktop-day",    1280, 900, "light",  "neutral", None),
+ ("desktop-night",  1280, 900, "dark",   "neutral", ("180",None)),
+ # Two diagnostics, not designs. Greyscale proves nothing on the page carries
+ # meaning by hue alone; the sunlight pass approximates a phone held outdoors
+ # at midday in Bali, which is where this page is actually read.
+ ("diagnostic-greyscale", 390, 844, "light", "neutral", ("60",None), "grayscale(1)"),
+ ("diagnostic-sunlight",  390, 844, "light", "neutral", ("60",None),
+   "contrast(.62) brightness(1.22)"),
+]
+made=[]
+with sync_playwright() as pw:
+    b=pw.chromium.launch(executable_path=CHROME)
+    for st in STATES:
+        name,w,h,theme,night,drive = st[:6]
+        css_filter = st[6] if len(st) > 6 else None
+        pg=b.new_page(viewport={"width":w,"height":h}, device_scale_factor=2,
+                      color_scheme="dark" if theme=="dark" else "light")
+        pg.goto(src.resolve().as_uri(), wait_until="load")
+        pg.evaluate(f"() => {{document.documentElement.setAttribute('data-theme','{theme}');"
+                    f"document.documentElement.setAttribute('data-night','{night}');}}")
+        if drive:
+            d,why = drive
+            pg.click(f'#dur button[data-k="{d}"]')
+            if why: pg.wait_for_timeout(80); pg.click(f'#why button[data-k="{why}"]')
+        if css_filter:
+            pg.add_style_tag(content=f'html{{filter:{css_filter}}}')
+        pg.wait_for_timeout(500)
+        f=out/f"{name}.png"; pg.screenshot(path=str(f), full_page=True)
+        made.append((name, f.stat().st_size)); pg.close()
+    b.close()
+for n,s in made: print(f"{n:<24} {s/1024:7.1f} KB")

--- a/.agents/skills/design/prima-pagina/shrink.py
+++ b/.agents/skills/design/prima-pagina/shrink.py
@@ -1,0 +1,12 @@
+import sys,pathlib
+from PIL import Image
+d=pathlib.Path(sys.argv[1]); out=d/"shots_web"; out.mkdir(exist_ok=True)
+tot=0
+for f in sorted((d/"shots").glob("*.png")):
+    im=Image.open(f).convert("RGB")
+    w = 760 if f.stem.startswith("desktop") else 470
+    if im.width>w: im=im.resize((w,round(im.height*w/im.width)), Image.LANCZOS)
+    g=out/(f.stem+".jpg"); im.save(g,"JPEG",quality=78,optimize=True,progressive=True)
+    tot+=g.stat().st_size
+    print(f"{f.stem:<24} {im.width}x{im.height} {g.stat().st_size/1024:7.0f} KB")
+print(f"TOTAL {tot/1024/1024:.2f} MB  (base64 inflates ~1.34x -> {tot*1.34/1024/1024:.2f} MB)")

--- a/.agents/skills/design/prima-pagina/verify_copy.py
+++ b/.agents/skills/design/prima-pagina/verify_copy.py
@@ -1,0 +1,58 @@
+import sys, re, pathlib
+from playwright.sync_api import sync_playwright
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+p=pathlib.Path(sys.argv[1])
+
+# the live-site blocklist + the GARUDA charter's klaim terlarang, as ENTITIES not spellings
+BLOCK = [
+ (r"\b(?:no\.?\s*)?#\s*1\b|\bnumber one\b|\bnumero uno\b", "rank superlative"),
+ (r"\bbest\b|\bleading\b|\btop[- ]rated\b|\bpremier\b", "rank superlative"),
+ (r"\bofficial (?:partner|reseller|agent)\b|\bauthori[sz]ed partner\b", "affiliation claim"),
+ (r"\bguarantee\w*\b|\bdijamin\b|\b100%\s*(?:approval|success)\b", "outcome guarantee"),
+ (r"\bfastest\b|\b24[- ]hour(?:s)? guarantee\b|\bsame[- ]day guaranteed\b", "speed guarantee"),
+ (r"\bzero risk\b|\brisk[- ]free\b|\bno risk\b", "risk claim"),
+ (r"\btrusted by \d|\b\d[\d,]*\+? (?:happy )?clients since\b", "unsourced lifetime total"),
+ (r"\bwork remotely (?:on|with) (?:a )?b211\b", "B1/B211 work claim"),
+]
+with sync_playwright() as pw:
+    b=pw.chromium.launch(executable_path=CHROME)
+    pg=b.new_page(viewport={"width":390,"height":844})
+    pg.goto(p.resolve().as_uri(), wait_until="load"); pg.wait_for_timeout(300)
+
+    # drive every branch of the answer widget and collect what it says
+    said=[]
+    for d in ["30","60","180"]:
+        pg.click(f'#dur button[data-k="{d}"]'); pg.wait_for_timeout(80)
+        said.append((d, pg.inner_text("#ans-code"), pg.inner_text("#ans-name")))
+    for w in ["tourism","remote","company","retire"]:
+        pg.click('#dur button[data-k="year"]'); pg.wait_for_timeout(50)
+        assert not pg.is_hidden("#why"), "reason row never appeared"
+        pg.click(f'#why button[data-k="{w}"]'); pg.wait_for_timeout(80)
+        assert not pg.is_hidden("#ans"), f"no answer for year|{w}"
+        said.append((f"year|{w}", pg.inner_text("#ans-code"), pg.inner_text("#ans-name")))
+    print("WIDGET — all 7 branches answered:")
+    for k,c,n in said: print(f"   {k:<14} {c:<6} {n}")
+
+    text = pg.evaluate("() => document.body.innerText")
+    b.close()
+
+print("\nBLOCKLIST")
+hits=0
+for pat,why in BLOCK:
+    for m in re.finditer(pat, text, re.I):
+        s=max(0,m.start()-40); print(f"   HIT [{why}] ...{text[s:m.end()+40]!r}"); hits+=1
+print("   clean" if not hits else f"   {hits} hit(s)")

--- a/.agents/skills/design/prima-pagina/verify_images.py
+++ b/.agents/skills/design/prima-pagina/verify_images.py
@@ -1,0 +1,43 @@
+import sys, pathlib
+from playwright.sync_api import sync_playwright
+import os as _os, glob as _glob
+def _find_chrome():
+    """The headless binary is per-machine (M5 is /Users/balizero, Pro/Mini
+    /Users/nuzantara) and its version dir changes on every Playwright bump, so a
+    hardcoded path is a probe that dies silently on the other machine."""
+    if _os.environ.get("CHROME_HEADLESS"):
+        return _os.environ["CHROME_HEADLESS"]
+    pat = _os.path.expanduser(
+        "~/Library/Caches/ms-playwright/chromium_headless_shell-*/"
+        "chrome-headless-shell-mac-*/chrome-headless-shell")
+    hits = sorted(_glob.glob(pat))
+    if not hits:
+        raise SystemExit("no chrome-headless-shell found; set CHROME_HEADLESS")
+    return hits[-1]
+CHROME = _find_chrome()
+p=pathlib.Path(sys.argv[1])
+# Guilt+innocence: a deliberately broken copy must FAIL this probe, or the probe
+# proves nothing. Six mechanical gates passed a page with seven dead images.
+broken = p.with_name("_broken_control.html")
+broken.write_text(p.read_text().replace("base64,", "base64,data:image/jpeg;base64,", 1))
+JS = """() => [...document.images].map(i => ({
+  alt: (i.alt||'').slice(0,40),
+  ok: i.complete && i.naturalWidth > 1 && i.naturalHeight > 1,
+  w: i.naturalWidth, h: i.naturalHeight }))"""
+with sync_playwright() as pw:
+    b=pw.chromium.launch(executable_path=CHROME)
+    def run(f):
+        pg=b.new_page(viewport={"width":390,"height":844})
+        pg.goto(f.resolve().as_uri(), wait_until="load"); pg.wait_for_timeout(600)
+        pg.evaluate("() => window.scrollTo(0, document.body.scrollHeight)")  # trip lazy loads
+        pg.wait_for_timeout(600)
+        r=pg.evaluate(JS); pg.close(); return r
+    ctrl=run(broken); real=run(p); b.close()
+broken.unlink()
+cbad=[i for i in ctrl if not i["ok"]]
+print(f"CONTROL (deliberately broken): {len(cbad)}/{len(ctrl)} dead -> "
+      + ("probe trusted" if cbad else "PROBE BLIND, findings below mean nothing"))
+bad=[i for i in real if not i["ok"]]
+for i in real: print(f"   {'ok ' if i['ok'] else 'DEAD'} {i['w']:>5}x{i['h']:<5} {i['alt']}")
+print(f"-> {len(real)-len(bad)}/{len(real)} images actually decoded")
+sys.exit(1 if bad else 0)

--- a/.claude/skills/design
+++ b/.claude/skills/design
@@ -1,0 +1,1 @@
+../../.agents/skills/design

--- a/evidence/2026-09/agent-nuzantara-docs-design-brain-0901/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-docs-design-brain-0901/brief.yml
@@ -1,0 +1,88 @@
+task_id: design-corner-brain-0901
+gear: 2
+l_level: L1
+gate_class: opus
+objective: |
+  The other half of Zero's 2026-09-01 order to open a /design corner ("salva tutto in un nuovo
+  corner /design che casomai vai a unire cn altre skill/corner"): the SKILL.md brain, the
+  front-page build chain, and the .claude/skills symlink that makes the corner loadable. The
+  calibrated probes are the sibling PR, which is serialized BEFORE this one because SKILL.md's
+  file inventory names its directory.
+
+  SKILL.md carries four things a future session cannot re-derive from the code: the north star
+  (deliver the product's promise before claiming anything — on a visa surface that means an
+  answer in ten seconds, because knowing the answer is the only trust signal a copycat cannot
+  reproduce); the doctrine rules, of which the load-bearing one is that your own server renders
+  decoration while a registrar renders evidence; LIVE STATE naming what is still Zero's and not
+  a session's; and nine blood-bought rules that each cost a real defect during the rebuild. §7
+  names the merge seams with bali-zero-brand, wr2 and visaoracle instead of duplicating them,
+  because Zero's order explicitly anticipated consolidation.
+
+  prima-pagina/ is the 2026-09-01 front page, rebuildable from repo sources. Nothing
+  images-shaped is copied in on purpose: the mark, the hero and the six staff cards are
+  re-encoded on demand from apps/mouth/public by assets.py. A second copy of a staff photograph
+  is a second thing to keep in sync and a second place it can leak from.
+
+  Two portability fixes travel with the build chain: assets.py pointed at a throwaway worktree
+  and a session scratchpad and now takes <repo-root> and <out-dir>, and it now FAILS LOUDLY if
+  a staff card is missing rather than shipping a page with dead images — which is precisely the
+  defect that motivated verify_images.py existing at all.
+constraints:
+  - "Additive only: 9 new files under .agents/skills/design/ plus one symlink at
+    .claude/skills/design. Touches zero existing file, no workflow, no product code."
+  - "Serialized after the sibling strumenti PR. If this one landed first, SKILL.md §4 would
+    name a directory that does not yet exist — a transient false claim in a docs file, not a
+    broken gate, but disclosed rather than discovered."
+  - "Fresh worktree cut from origin/main after PR #5505 (the unsplit version) was closed."
+  - "No PII and no image bytes: home.tpl.html carries __LOGO__/__HERO__/__SURYA__ tokens, never
+    encoded image data. The photographs live in apps/mouth/public and are read at build time."
+  - "Asserts no visa verdict. The front page's widget says 'orientation, not a determination'
+    and links to the Oracle — visaoracle owns the RulePack and the ENFORCE gate, and this
+    corner must never move that boundary."
+acceptance:
+  - "The corner rebuilds end-to-end from a clean directory on repo sources alone: assets.py ->
+    159 KB inline, build.py -> home.html 240,998 bytes, verify_images 8/8 decoded, verify_copy
+    7/7 widget branches, measure.py 0 mechanical failures across 6 states, defects.py 'probe
+    trusted' and clean on all six classes. Observed 2026-09-01."
+  - "The symlink resolves: .claude/skills/design -> ../../.agents/skills/design, and SKILL.md
+    is readable through it. Verified by an independent reader, not by the author."
+  - "Every file SKILL.md §4 names exists, and no file exists in this half that §4 fails to
+    account for. Checked in both directions."
+  - "Every script's argv arity matches the command block in §5 — checked by reading each
+    script's sys.argv handling rather than by running the block."
+consumer_map:
+  - "A session invoking /design. The Skill tool reads .claude/skills/design/SKILL.md, which is
+    the symlink this PR creates; without it the corner is files on disk that nothing loads."
+  - "The sibling strumenti PR (#5509), whose files SKILL.md §4 inventories and whose command
+    block §5 documents. That PR must land first."
+  - "apps/mouth/public/static/team/*.jpg and news/perfect-storm-bali.jpg — read by assets.py at
+    build time, never copied. A rename there breaks the rebuild loudly (assets.py raises)
+    rather than silently shipping a page with dead images."
+risks:
+  - "SKILL.md §1 LIVE STATE is a dated snapshot and will rot. Its own header says so; the
+    honest mitigation is the instruction to update it, not a mechanism, because nothing in CI
+    can know whether a claim about an unmerged contest vote is still true."
+  - "The design dossier this corner summarises is NOT in git — 29MB under ~/Desktop, on a
+    TCC-denied path. §1 records that and tells the reader to open files by explicit path rather
+    than glob. Committing it was rejected as 29MB of PNG renders for a vote still pending."
+  - "One claim was removed rather than corrected during review: a 'since 2019 vs since 2020,
+    10 vs 14 occurrences' count that an independent verifier could not reproduce under any
+    scoping. The contradiction it pointed at is real and is retained with full paths; the
+    number is gone, because a corrected-looking figure with no method behind it is the same
+    defect with a friendlier face."
+grader: |
+  Generator != grader held, and it bit. This session wrote the corner; an independent subagent
+  on fresh context checked SKILL.md's claims against disk rather than against the description.
+  It confirmed the symlink, the inventory in both directions, the argv arities, and defects.py's
+  actual main() contract — and it caught the unreproducible occurrence count described under
+  risks, which was removed in a follow-up commit before this PR was opened. A second, earlier
+  adversarial dispatch against the front page itself found three regulatory errors in the
+  widget's visa mappings (a C2 branch carrying D2's facts, an E33F missing its mandatory
+  sponsor, an E28A asking for shares where the hard filter is a management role); each was
+  re-verified by this session against research/visa/2026-07-24-w2-factbase-*.md before being
+  fixed, and the episode is rule 1 of SKILL.md §3.
+budget: |
+  Gear 2, solo-orchestrator, 2 independent verification dispatches (one adversarial against the
+  page, one against the corner's own claims). No council: the divergent-priors test does not
+  fire on a docs artifact whose factual claims are each individually checkable on disk.
+pii: none


### PR DESCRIPTION
The other half of Zero's 2026-09-01 order to open a `/design` corner. The calibrated probes are **#5509, which must land first** — this PR's `SKILL.md` §4 inventories its directory. Churn 1,040, floor 2, `evidence/brief.yml` declares gear 2.

## What `SKILL.md` carries that code cannot

- **The north star.** Deliver the product's promise before claiming anything. On a visa surface that means an answer in ten seconds, because *knowing the answer is the only trust signal a copycat cannot reproduce* — a website is an afternoon's work, knowing which permit someone needs is not.
- **Four doctrine rules**, of which the load-bearing one is R2: your own server renders decoration, a registrar renders evidence. That is why the front page links `oss.go.id` / `ahu.go.id` / `sikop.kemenkeu.go.id` instead of showing a self-issued badge.
- **LIVE STATE** naming what is still Zero's and not a session's: the registry numbers, the August filing count (a shape, not a measurement), the `since 2019`/`since 2020` contradiction, the five live `#1` claims, the pending contest vote.
- **Nine blood-bought rules**, each of which cost a real defect during the rebuild. Rule 1: a mechanical gate cannot be wrong about a regulation — twelve green gates sat on a widget that named the wrong visa code with confident specificity. Rule 2: a broken `<img>` passes every layout gate, because it still has a box, an alt string, a contrast ratio and a tap target.

§7 names the merge seams with `bali-zero-brand`, `wr2` and `visaoracle` rather than duplicating them, since Zero's order explicitly anticipated consolidation (*"casomai vai a unire cn altre skill/corner"*).

## `prima-pagina/`

The front page, rebuildable from repo sources. **Nothing images-shaped is copied in**: the mark, the hero and the six staff cards are re-encoded on demand from `apps/mouth/public`. A second copy of a staff photograph is a second thing to keep in sync and a second place it can leak from.

Two portability fixes travel with it: `assets.py` pointed at a throwaway worktree and a session scratchpad and now takes `<repo-root>` and `<out-dir>`, and it **fails loudly** when a staff card is missing rather than shipping a page with dead images — exactly the defect that motivated `verify_images.py` existing.

## Bites

**Consumer:** a session invoking `/design`. The Skill tool reads `.claude/skills/design/SKILL.md`, which is the symlink this PR creates; without it the corner is files on disk that nothing loads. **Observed on this branch** — the symlink resolves, and the chain runs from the corner into an empty directory:

```
assets.py     -> 159 KB inline (mark + hero + 6 staff cards)
build.py      -> home.html, 240,998 bytes
verify_images -> 8/8 decoded (guilt control fires)
verify_copy   -> 7/7 widget branches answer
measure.py    -> 0 mechanical failures across 6 states
defects.py    -> "probe trusted" + clean on all six classes
```

## One claim was removed rather than corrected

An independent verifier could not reproduce a `since 2019` / `since 2020` occurrence count under any scoping. The contradiction it pointed at is real and is retained with full paths; **the number is gone**, because a corrected-looking figure with no method behind it is the same defect with a friendlier face. An earlier adversarial dispatch against the page itself found three regulatory errors in the widget's visa mappings — each was re-verified against `research/visa/2026-07-24-w2-factbase-*.md` before being fixed, and that episode is rule 1 of §3.

## Scope

Docs/skill only. No product code, no workflow, no deploy, no image bytes in the diff, no PII. The corner asserts **no visa verdict** — the widget says "orientation, not a determination" and links to the Oracle; `visaoracle` keeps the RulePack and the ENFORCE gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
