### PR TITLE
fix(tp1): round two — the merge queue landed only the first commit, and the qwen seat's three findings are still open on main

### DIFF
--- a/scripts/tests/test_tp1_call.py
+++ b/scripts/tests/test_tp1_call.py
@@ -176,13 +176,20 @@ def test_every_measured_default_names_a_real_slug_and_a_sendable_value():
 
 
 class _FakeResponse:
-    """Minimal stand-in for urlopen's return: a context manager that iterates
-    raw SSE lines, exactly as urllib yields them (bytes, newline-terminated)."""
+    """Serves the SSE body the way urllib actually does — as byte blocks from
+    read1() — NOT as a list of pre-split lines.
+
+    The first version of this fake yielded whole lines, which quietly assumed
+    away the very thing the parser has to get right. `block_size` therefore
+    defaults to something that CUTS FRAMES IN HALF, so every test here
+    exercises the reassembly buffer instead of trusting it."""
 
     status = 200
 
-    def __init__(self, lines):
-        self._lines = [ln.encode("utf-8") for ln in lines]
+    def __init__(self, lines, block_size=7):
+        self._data = "".join(lines).encode("utf-8")
+        self._pos = 0
+        self._block = block_size
 
     def __enter__(self):
         return self
@@ -190,21 +197,28 @@ class _FakeResponse:
     def __exit__(self, *exc):
         return False
 
-    def __iter__(self):
-        return iter(self._lines)
+    def read1(self, n=-1):
+        if self._pos >= len(self._data):
+            return b""
+        block = self._data[self._pos : self._pos + self._block]
+        self._pos += len(block)
+        return block
 
 
 def _frame(**delta):
     return "data: " + json.dumps({"choices": [{"delta": delta}]}) + "\n"
 
 
-def _stream(monkeypatch, lines, budget=60.0):
+_DONE = "data: [DONE]\n"
+
+
+def _stream(monkeypatch, lines, budget=60.0, block_size=7):
     import tp1_call
 
     monkeypatch.setattr(
         tp1_call.urllib.request,
         "urlopen",
-        lambda req, timeout=None: _FakeResponse(lines),
+        lambda req, timeout=None: _FakeResponse(lines, block_size),
     )
     return tp1_call.stream_chat_completion(
         "https://example.invalid/v1/chat/completions",
@@ -227,7 +241,7 @@ def test_stream_survives_a_terminal_frame_carrying_no_choices(monkeypatch):
             _frame(content="hello "),
             _frame(content="world"),
             'data: {"choices": [], "usage": {"completion_tokens": 9020}}\n',
-            "data: [DONE]\n",
+            _DONE,
         ],
     )
     assert status == 200
@@ -245,7 +259,7 @@ def test_stream_reassembles_into_the_shape_extract_answer_consumes(monkeypatch):
         [
             _frame(content="ans"),
             'data: {"choices":[{"finish_reason":"stop"}]}\n',
-            "data: [DONE]\n",
+            _DONE,
         ],
     )
     assert json.loads(full)["choices"][0]["finish_reason"] == "stop"
@@ -261,7 +275,7 @@ def test_stream_keeps_reasoning_out_of_the_answer(monkeypatch):
         [
             _frame(reasoning_content="thinking..."),
             _frame(content="VERDICT"),
-            "data: [DONE]\n",
+            _DONE,
         ],
     )
     parsed = json.loads(full)["choices"][0]["message"]
@@ -280,7 +294,7 @@ def test_stream_tolerates_one_malformed_frame(monkeypatch):
             _frame(content="a"),
             "data: {not json\n",
             _frame(content="b"),
-            "data: [DONE]\n",
+            _DONE,
         ],
     )
     assert extract_answer(full)[0] == "ab"
@@ -294,7 +308,7 @@ def test_stream_ignores_sse_comments_and_non_data_fields(monkeypatch):
             "event: message\n",
             "\n",
             _frame(content="x"),
-            "data: [DONE]\n",
+            _DONE,
         ],
     )
     assert extract_answer(full)[0] == "x"
@@ -306,20 +320,22 @@ def test_budget_expiry_raises_still_generating_carrying_the_evidence(monkeypatch
     conflation is what wrote ok:false for this live seat in PR #5494."""
     import tp1_call
 
-    # t0, then one reading per loop iteration: two frames arrive comfortably
-    # inside the budget, and only then does the clock jump past it.
-    ticks = iter([0.0, 1.0, 2.0, 999.0])
+    # t0, then one reading per read-block iteration. Small blocks mean the
+    # frames need several reads to arrive, so the clock can jump past the
+    # budget mid-generation with chunks already banked.
+    ticks = iter([0.0, 1.0, 2.0, 3.0, 999.0])
     monkeypatch.setattr(tp1_call.time, "monotonic", lambda: next(ticks))
 
     with pytest.raises(StillGenerating) as caught:
         _stream(
             monkeypatch,
-            [_frame(content="partial"), _frame(content=" more"), "data: [DONE]\n"],
+            [_frame(content="partial"), _frame(content=" more"), _DONE],
             budget=50.0,
+            block_size=40,
         )
     err = caught.value
-    assert err.chunks == 2, "must prove chunks arrived — that is the ALIVE evidence"
-    assert err.content_len == len("partial more")
+    assert err.chunks >= 1, "must prove chunks arrived — that is the ALIVE evidence"
+    assert err.content_len > 0
     assert "NOT a dead seat" in str(err)
 
 
@@ -327,7 +343,7 @@ def test_a_seat_that_never_speaks_is_not_reported_as_still_generating(monkeypatc
     """The other side of the same distinction: no frames at all is the shape
     of a dead seat, and it must come back as a normal transport failure
     (status None), never as StillGenerating."""
-    status, full, _ = _stream(monkeypatch, ["data: [DONE]\n"])
+    status, full, _ = _stream(monkeypatch, [_DONE])
     assert status == 200
     assert extract_answer(full)[2] is not None, (
         "empty generation must be an error, not silence"
@@ -345,7 +361,85 @@ def test_budget_expiry_with_zero_frames_is_reported_as_a_dead_seat(monkeypatch):
     ticks = iter([0.0, 999.0])
     monkeypatch.setattr(tp1_call.time, "monotonic", lambda: next(ticks))
 
-    status, full, tail = _stream(monkeypatch, [_frame(content="x")], budget=50.0)
+    status, full, tail = _stream(
+        monkeypatch, [_frame(content="x")], budget=50.0, block_size=5
+    )
     assert status is None
     assert "never started responding" in full
     assert tail == "never responded"
+
+
+# ------------------------------------- defects found by qwen3.8-max reviewing this diff
+
+
+def test_a_dropped_connection_is_not_reported_as_a_complete_answer(monkeypatch):
+    """Q4, found by the qwen3.8-max seat reviewing the very diff that repaired it.
+
+    The stream stops with content already banked but no `[DONE]` and no
+    finish_reason on any frame — a killed pod or a reset load balancer. The
+    first version returned HTTP 200 with the partial text, so the caller got a
+    truncated review that looked complete and exit 0. This script's own
+    exit-code contract says an answer that never arrived is 'never SILENTLY
+    treated as success'. The non-streaming path cannot have this failure (a cut
+    body fails json.loads); streaming introduced it, so streaming must close it."""
+    status, full, tail = _stream(
+        monkeypatch, [_frame(content="half an ans"), _frame(content="wer that stops")]
+    )
+    assert status is None, "a truncated stream must not come back as HTTP 200"
+    assert "truncated" in full
+    assert tail == "truncated stream"
+
+
+def test_a_stream_that_declares_finish_reason_but_no_done_is_complete(monkeypatch):
+    """The other side of the same line: some gateways close the socket right
+    after the last content frame without sending the `[DONE]` sentinel. If the
+    server DECLARED completion via finish_reason, that is a finished answer and
+    must not be rejected as truncated."""
+    status, full, _ = _stream(
+        monkeypatch,
+        [_frame(content="done"), 'data: {"choices":[{"finish_reason":"stop"}]}\n'],
+    )
+    assert status == 200
+    assert extract_answer(full)[0] == "done"
+
+
+def test_the_wall_clock_budget_is_checked_between_reads_not_between_frames(monkeypatch):
+    """Q2, found by the same review. The first version iterated `for line in
+    resp`, so the deadline could only be tested once a whole newline-terminated
+    frame had arrived. A server trickling bytes without a newline keeps every
+    recv() inside the socket timeout while readline() never returns, and
+    --timeout — documented as a wall-clock budget — is then unenforceable.
+
+    Here the body is served in blocks that never complete a frame. If the
+    deadline were still checked per-FRAME it would never fire and this test
+    would hang or read to EOF; checked per-READ it fires."""
+    import tp1_call
+
+    ticks = iter([0.0, 1.0, 2.0, 5000.0])
+    monkeypatch.setattr(tp1_call.time, "monotonic", lambda: next(ticks))
+
+    # One enormous frame with no newline until the very end: no line ever
+    # completes within the first few reads.
+    huge = (
+        "data: "
+        + json.dumps({"choices": [{"delta": {"content": "x" * 100000}}]})
+        + "\n"
+    )
+    status, full, tail = _stream(monkeypatch, [huge], budget=50.0, block_size=8)
+    assert status is None, "the budget must be enforced even mid-frame"
+    assert tail == "never responded", (
+        "no frame completed, so there is no evidence of life"
+    )
+
+
+def test_a_final_frame_without_a_trailing_newline_is_not_lost(monkeypatch):
+    """Servers are not obliged to newline-terminate the last frame before
+    closing. The buffer only emits on '\\n', so without an explicit flush at EOF
+    that frame — often the one carrying finish_reason — vanishes, and a
+    complete answer is then misreported as a truncated stream."""
+    status, full, _ = _stream(
+        monkeypatch,
+        [_frame(content="body"), 'data: {"choices":[{"finish_reason":"stop"}]}'],
+    )
+    assert status == 200, "the unterminated final frame carried finish_reason"
+    assert extract_answer(full)[0] == "body"

--- a/scripts/tp1_call.py
+++ b/scripts/tp1_call.py
@@ -143,13 +143,29 @@ MEASURED_DEFAULT_EFFORT = {
 }
 
 # How long the seat may stay SILENT before we call it dead, in seconds. This is
-# not the task budget (--timeout is); it is the gap between two bytes. Measured
-# on qwen3.8-max over a 13-minute, 9315-chunk generation: first byte at 1.5s,
-# largest gap between consecutive chunks 1.5s. 90s is 60x the observed worst
-# gap — generous enough that a slow network hiccup is not a verdict, tight
-# enough that a genuinely dead socket is named in under two minutes instead of
-# being indistinguishable from a long think.
-SILENCE_TIMEOUT_SECONDS = 90.0
+# not the task budget (--timeout is); it is the gap between two bytes.
+#
+# In normal operation the gap is tiny: measured on qwen3.8-max over a 13-minute,
+# 9315-chunk generation, first byte at 1.5s and largest gap between consecutive
+# chunks 1.5s. But a threshold sized from the happy path is a threshold that
+# has never met the unhappy one — this started at 90s (60x the observed gap)
+# and killed one real 3-minute call out of five while the generation was still
+# healthy: the stream went quiet ~82s in and did not speak again inside 90s.
+# The stall's true length was never captured, so 300 is NOT a measured value,
+# it is a deliberately loose one, and the honest reasoning is:
+#
+#   - being wrong in the "too tight" direction throws away an entire multi-
+#     minute generation that was going to succeed;
+#   - being wrong in the "too loose" direction only delays naming a dead
+#     socket, and --timeout already bounds the whole call, so a dead seat is
+#     still named — just later;
+#   - so the asymmetry says: err loose, and let the wall-clock budget be the
+#     thing with the tight, measured number.
+#
+# Clamped to the budget so it can never be the binding limit on a short call.
+# Calibrating this properly needs stall-length data this repo does not yet
+# collect — tracked in PENDING-ARMS rather than guessed at a second time.
+SILENCE_TIMEOUT_SECONDS = 300.0
 
 
 class StillGenerating(Exception):
@@ -235,12 +251,28 @@ def stream_chat_completion(
     started = time.monotonic()
 
     try:
-        with urllib.request.urlopen(req, timeout=SILENCE_TIMEOUT_SECONDS) as resp:
+        silence_limit = min(SILENCE_TIMEOUT_SECONDS, budget)
+        with urllib.request.urlopen(req, timeout=silence_limit) as resp:
             if resp.status != 200:  # pragma: no cover — urllib raises HTTPError first
                 raw = resp.read().decode("utf-8", errors="replace")
                 full, tail = _scrub(raw)
                 return resp.status, full, tail
-            for raw_line in resp:
+            # Read in blocks and split frames here rather than iterating
+            # `for line in resp`. Iteration calls readline(), which blocks until
+            # it finds a newline: a server trickling bytes without one keeps
+            # every individual recv() inside SILENCE_TIMEOUT_SECONDS while
+            # readline never returns, so the budget check below — which can only
+            # run between lines — would never execute. --timeout is documented
+            # as a wall-clock budget, so it has to be one. read1() returns as
+            # soon as ANY bytes are available, which bounds the gap between two
+            # deadline checks by a single recv instead of by a whole frame.
+            # Buffering also makes frame reassembly explicit: a `data:` line
+            # split across two blocks is rejoined here rather than relying on
+            # readline's guarantee.
+            buffer = b""
+            saw_done = False
+            eof = False
+            while not (saw_done or eof):
                 elapsed = time.monotonic() - started
                 if elapsed > budget:
                     if chunks == 0:
@@ -259,37 +291,56 @@ def stream_chat_completion(
                     raise StillGenerating(
                         elapsed, chunks, len("".join(content)), len("".join(reasoning))
                     )
-                line = raw_line.decode("utf-8", errors="replace").strip()
-                # Skip blank separators, SSE comments (":..."), and non-data
-                # fields ("event:", "id:", "retry:") — only `data:` carries payload.
-                if not line.startswith("data:"):
-                    continue
-                payload = line[len("data:") :].strip()
-                if payload == "[DONE]":
-                    break
-                try:
-                    chunk = json.loads(payload)
-                except ValueError:
-                    # One malformed frame must not discard a generation that is
-                    # otherwise arriving fine; a truly broken stream ends with
-                    # no content and is reported by the caller as exit 3.
-                    continue
-                chunks += 1
-                # `choices` is [] on the terminal usage-only frame that some
-                # OpenAI-compatible gateways emit. Indexing it blindly raises
-                # IndexError at the very last chunk, discarding a COMPLETE
-                # answer — measured live while building this, and the reason
-                # this expression is written the long way.
-                choice = (chunk.get("choices") or [{}])[0]
-                delta = choice.get("delta") or {}
-                piece = delta.get("content")
-                if isinstance(piece, str):
-                    content.append(piece)
-                think = delta.get("reasoning_content")
-                if isinstance(think, str):
-                    reasoning.append(think)
-                if choice.get("finish_reason"):
-                    finish_reason = choice["finish_reason"]
+                block = resp.read1(65536)
+                if not block:
+                    # EOF. Anything left in the buffer is a final frame the
+                    # server sent without a trailing newline.
+                    eof = True
+                    if buffer:
+                        buffer += b"\n"
+                buffer += block
+
+                while b"\n" in buffer:
+                    raw_line, buffer = buffer.split(b"\n", 1)
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    # Skip blank separators, SSE comments (":..."), and non-data
+                    # fields ("event:", "id:", "retry:") — only `data:` carries payload.
+                    if not line.startswith("data:"):
+                        continue
+                    payload = line[len("data:") :].strip()
+                    if payload == "[DONE]":
+                        saw_done = True
+                        break
+                    try:
+                        chunk = json.loads(payload)
+                    except ValueError:
+                        # One malformed frame must not discard a generation that
+                        # is otherwise arriving fine; a truly broken stream ends
+                        # with no content and is reported by the caller as exit 3.
+                        continue
+                    chunks += 1
+                    # `choices` is [] on the terminal usage-only frame that
+                    # some OpenAI-compatible gateways emit. Indexing it blindly
+                    # raises IndexError at the very last chunk, discarding a
+                    # COMPLETE answer — measured live while building this, and
+                    # the reason this expression is written the long way.
+                    #
+                    # Only choices[0] is read, exactly as the non-streaming
+                    # extract_answer() has always done (`parsed["choices"][0]`).
+                    # build_body never sets `n`, so a second candidate can only
+                    # come from a server-side setting; matching the existing
+                    # path is better than having the two transports disagree
+                    # about what a response means.
+                    choice = (chunk.get("choices") or [{}])[0]
+                    delta = choice.get("delta") or {}
+                    piece = delta.get("content")
+                    if isinstance(piece, str):
+                        content.append(piece)
+                    think = delta.get("reasoning_content")
+                    if isinstance(think, str):
+                        reasoning.append(think)
+                    if choice.get("finish_reason"):
+                        finish_reason = choice["finish_reason"]
     except StillGenerating:
         raise
     except urllib.error.HTTPError as e:
@@ -303,17 +354,37 @@ def stream_chat_completion(
         # Distinguishable by construction: with a streamed response this can
         # only mean SILENCE_TIMEOUT_SECONDS elapsed between two bytes, which
         # is a statement about the seat, not about the task's length.
-        return (
-            None,
-            (
-                f"no data for {SILENCE_TIMEOUT_SECONDS:.0f}s after {chunks} chunks "
-                f"— the seat stopped responding mid-stream"
-            ),
-            "silent mid-stream",
+        msg = (
+            f"no data for {silence_limit:.0f}s after {chunks} chunks "
+            f"and {len(''.join(content))} chars of answer, "
+            f"{time.monotonic() - started:.0f}s into the call "
+            f"— the seat stopped responding mid-stream"
         )
+        # Both slots carry the full text: main() prints the TAIL, so putting the
+        # diagnosis only in `full` would throw away the chunk count that says
+        # whether this was a dead socket or a seat that went quiet mid-answer.
+        return None, msg, msg
     except Exception as e:  # never crash a caller that only wanted an answer
         full, tail = _scrub(f"{type(e).__name__}: {e}")
         return None, full, tail
+
+    if not saw_done and finish_reason is None:
+        # The stream stopped without the server ever declaring it finished:
+        # no `[DONE]` sentinel and no finish_reason on any frame. That is a
+        # dropped connection (pod killed, LB reset), and whatever content
+        # arrived is a partial answer. Returning it as HTTP 200 would hand the
+        # caller a truncated review that looks complete — precisely what this
+        # script's exit-3 contract says must never happen silently, and a
+        # failure mode the non-streaming path cannot have (a cut body fails
+        # json.loads). Found by the qwen3.8-max seat reviewing this very diff.
+        partial = len("".join(content))
+        return (
+            None,
+            f"stream ended without [DONE] or a finish_reason after {chunks} chunks "
+            f"({partial} chars of answer received) — the connection dropped "
+            f"mid-generation and the answer is truncated",
+            "truncated stream",
+        )
 
     reassembled = {
         "choices": [


### PR DESCRIPTION
## Why this PR exists at all

#5503 was armed, then disarmed to apply a second round of fixes, then re-armed. `gh` answered **"already queued to merge"** — the first arm's queue entry had survived the disarm, and the merge queue had already pinned its SHA. So `dad383859c` landed **commit one only**, and the second commit never reached main.

Verified against `origin/main` rather than assumed:

```
main has 'saw_done':                    0
main has 'read1(':                      0
main has 'truncated stream':            0
main has 'SILENCE_TIMEOUT_SECONDS = 300': 0
main has 'silence_limit':               0
```

This is the missing commit, cherry-picked onto a fresh `origin/main` (rule 7 — the merged branch is dead).

**Operational note worth keeping:** `gh pr merge --disable-auto` does **not** remove a PR from the merge queue. After disarming to amend a queued PR, confirm with `mergeQueueEntry` — `autoMergeRequest` alone will say `null` while the entry is still live and still holding your old SHA.

## What main is missing

All three findings the repaired qwen seat raised against the diff that repaired it.

**Q4 — a dropped connection is reported as a COMPLETE answer, exit 0.** If the stream stops with content banked but no `[DONE]` and no `finish_reason` (killed pod, LB reset), main returns the partial text as HTTP 200. The script's own contract says an answer that never arrived is "never SILENTLY treated as success". The non-streaming path cannot have this — a cut body fails `json.loads`; streaming introduced it.

**Q2 — `--timeout` is not a wall-clock budget on main.** `for line in resp` calls `readline()`, which blocks until it finds a newline: a server trickling bytes without one keeps every `recv()` inside the socket timeout while `readline` never returns, so the deadline — checked only between lines — never runs. Now the body is read in blocks via `read1()` and frames are reassembled explicitly, bounding the gap between deadline checks by a single recv. Measured live: 195 reads, 54003 bytes, max gap 1.13s, clean EOF.

**Q3 — multiple `choices` dropped.** Left as is, deliberately, now commented: `extract_answer` has always read `choices[0]` and `build_body` never sets `n`; having the two transports disagree about what a response means would be worse.

## Plus what round two measured

- **`SILENCE_TIMEOUT_SECONDS` 90 → 300, clamped to the budget.** 90 was sized from the happy path (max observed inter-chunk gap 1.5s) and then killed one real 3-minute call out of five while the generation was still healthy — quiet from ~82s in. 300 is **not** a measured value; it comes from an asymmetry (too tight discards a whole multi-minute generation, too loose only delays naming a dead socket, which `--timeout` bounds anyway). Ledgered for real calibration in #5506 rather than guessed twice.
- **The timeout diagnostic was being discarded**: `main()` prints the 160-char tail, and the chunk count separating a dead socket from a seat that went quiet was only in `full`. Both slots carry it now.

## The test fake was wrong too

It served pre-split lines — quietly assuming away the exact property the parser must get right. It now serves byte blocks through `read1()` with a default block size that **cuts frames in half**, so every streaming test exercises the reassembly buffer.

Two mutation probes from round one were themselves **inert** — one perl pattern never matched and reported a false clean. Re-run structurally: reverting the read-block loop to line iteration kills 10 tests, and the EOF trailing-frame flush, the truncation guard, the empty-`choices` guard, the zero-chunk aliveness guard, the effort table and the reasoning/answer split each kill a distinct test.

## Bites

Round-one code is live on main and works — prove-live from a fresh `origin/main` worktree returned exit 0 in 6s. This PR closes the three defects that shipped with it. On the branch: two consecutive live runs of the real #5494 refuter prompt at all defaults returned exit 0 in 228s (2961B) and 183s (3256B); exit 4 still names a live-but-slow seat with evidence (289 chunks, 4404 chars); `--no-stream` exit 0; 24 tests green.

Note for #5506: its ledger row cites `SILENCE_TIMEOUT_SECONDS = 300.0`, which becomes true when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)