### PR TITLE
feat(kbli): --licensing-only — sync the PP 28/2025 tuple on the 25 hand-written rows without touching prose

### DIFF
--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -62,6 +62,18 @@ SCOPE DISCIPLINE (mirrors `kg_kbli_license_fix.py`): `--only` is MANDATORY
 unless `--all-quarantined` is passed explicitly — this script NEVER sweeps
 the full ~1,559-row table.
 
+TWO NARROW MODES, for the rows the gate protects (2026-09-01). `--pma-only`
+and `--licensing-only` each sync ONE tuple inside `metadata` — the PMA
+evidence tuple (`PMA_METADATA_KEYS`) or the licensing tuple
+(`LICENSING_METADATA_KEYS`) — through a server-side jsonb merge that binds
+only those keys; `judul`, `content` and every other key stay byte-identical.
+Both require `--only`, refuse every `--all-*` selector and refuse each other
+(two tuples, two cure runs). `--licensing-only` is one-directional: a code
+whose canonical `per_skala` is empty is REFUSED, never emptied — that is the
+quarantine class. These modes exist because since v34 the channel reads the
+structured metadata and never the prose, so on a hand-written row the tuple
+is the only thing a client can still be told wrong.
+
 `--only` DOES NOT GET THE CONTENT-PRESERVATION GATE. That gate is scoped to
 `--all-licensing-absent`, so passing the same population as a hand-written
 `--only` list cures every code the gate would have REFUSED — on 2026-08-02
@@ -301,6 +313,21 @@ class DocumentCurePlan:
     # `judul` and `content` are left byte-identical by construction (see
     # `plan_pma_only`), so the apply path must not rewrite them either.
     pma_only: bool = False
+    # Same contract for the licensing tuple (`plan_licensing_only`). The two
+    # flags are exclusive by construction: `validate_args` refuses both.
+    licensing_only: bool = False
+
+    @property
+    def partial_keys(self) -> tuple[str, ...] | None:
+        """The metadata keys a NARROW plan binds to its server-side merge —
+        or None when the plan is a full rebuild (judul + content + whole
+        metadata). Single dispatch point for the apply path: a mode that is
+        not listed here rewrites the row wholesale, loudly, never by accident."""
+        if self.pma_only:
+            return PMA_METADATA_KEYS
+        if self.licensing_only:
+            return LICENSING_METADATA_KEYS
+        return None
 
 
 # The PMA evidence tuple `build_cured_metadata` writes — and the ONLY keys a
@@ -316,6 +343,19 @@ PMA_METADATA_KEYS: tuple[str, ...] = (
     "pma_source_vintage",
     "pma_cap_special",
     "pma_cap_verified",
+)
+
+# The licensing tuple `build_cured_metadata` writes — and the ONLY keys a
+# `--licensing-only` plan may touch. `per_skala` is the PP 28/2025 per-scale
+# row-set the conformance detector measures (`jsonb_array_length(metadata->
+# 'per_skala')` vs the canonical rows); `pp28_sources` is its provenance and
+# moves with it; `licensing_status` follows the SAME rule the full rebuild
+# applies (gap marker on an empty set, otherwise carried over — this script
+# makes no independent claim about it).
+LICENSING_METADATA_KEYS: tuple[str, ...] = (
+    "per_skala",
+    "pp28_sources",
+    "licensing_status",
 )
 
 _ABSENT = object()  # a key that is not there is not the same as a key holding null
@@ -335,8 +375,8 @@ def _json_differs(a: object, b: object) -> bool:
     )
 
 
-def pma_metadata_patch(new_metadata: dict) -> dict:
-    """Pure. The ONLY keys a `--pma-only` apply binds to its UPDATE.
+def metadata_patch(new_metadata: dict, keys: tuple[str, ...]) -> dict:
+    """Pure. The ONLY keys a narrow apply binds to its UPDATE.
 
     The write is a server-side merge (`metadata || $2::jsonb`), never a
     replacement of the whole column: the row's other keys are not
@@ -344,7 +384,39 @@ def pma_metadata_patch(new_metadata: dict) -> dict:
     plan to touch) and a write landing on some other key between our SELECT
     and our UPDATE is not clobbered.
     """
-    return {key: new_metadata[key] for key in PMA_METADATA_KEYS}
+    return {key: new_metadata[key] for key in keys}
+
+
+def pma_metadata_patch(new_metadata: dict) -> dict:
+    """Pure. The seven PMA keys a `--pma-only` apply binds — see `metadata_patch`."""
+    return metadata_patch(new_metadata, PMA_METADATA_KEYS)
+
+
+def licensing_metadata_patch(new_metadata: dict) -> dict:
+    """Pure. The three licensing keys a `--licensing-only` apply binds — see `metadata_patch`."""
+    return metadata_patch(new_metadata, LICENSING_METADATA_KEYS)
+
+
+def licensing_metadata_from_canonical(record: dict, old_metadata: dict | None) -> dict:
+    """Pure. The licensing tuple exactly as `build_cured_metadata` writes it —
+    ONE derivation shared by the full rebuild and the narrow sync, so the two
+    paths cannot disagree about the same three keys (W105).
+
+    `per_skala` is the CURRENT canonical row-set (`[]` for an honest gap);
+    `pp28_sources` is whatever canonical records as its provenance;
+    `licensing_status` gets the KG cure's `PENDING_REGULATION` marker on an
+    empty set and is otherwise carried over unchanged (`N/A` when the row
+    never had one) — the rebuild has always declined to assert it, and the
+    narrow mode inherits that restraint rather than inventing a value."""
+    old = old_metadata or {}
+    per_skala = record.get("per_skala") or []
+    return {
+        "per_skala": per_skala,
+        "pp28_sources": record.get("pp28_sources"),
+        "licensing_status": "PENDING_REGULATION"
+        if per_skala == []
+        else old.get("licensing_status", "N/A"),
+    }
 
 
 def quarantined_codes(dataset: list[dict]) -> list[str]:
@@ -741,11 +813,11 @@ def build_cured_metadata(code: str, record: dict, old_metadata: dict | None) -> 
     non-gap/restored code's existing value is left untouched — this script
     makes no independent claim about it."""
     old = dict(old_metadata or {})
-    per_skala = record.get("per_skala") or []
+    licensing = licensing_metadata_from_canonical(record, old)
     pma = disclose_pma(record)
     new_meta: dict = {
         "judul": record.get("judul"),
-        "per_skala": per_skala,
+        "per_skala": licensing["per_skala"],
         "sektor_id": record.get("sektor_id"),
         "pma_status": pma["pma_status"],
         "pma_max_asing": pma["pma_max_asing"],
@@ -754,12 +826,10 @@ def build_cured_metadata(code: str, record: dict, old_metadata: dict | None) -> 
         "pma_source_vintage": pma["pma_source_vintage"],
         "pma_cap_special": pma["pma_cap_special"],
         "pma_cap_verified": pma["pma_cap_verified"],
-        "pp28_sources": record.get("pp28_sources"),
+        "pp28_sources": licensing["pp28_sources"],
         "kode_kbli_2025": code,
         "status_mapping": record.get("status_mapping"),
-        "licensing_status": "PENDING_REGULATION"
-        if per_skala == []
-        else old.get("licensing_status", "N/A"),
+        "licensing_status": licensing["licensing_status"],
     }
     data_note = record.get("_data_note") if pma_claims_verified(record) else None
     if data_note:
@@ -891,9 +961,101 @@ def plan_pma_only(code: str, record: dict | None, current_row: dict | None) -> D
     )
 
 
-def pma_tuple_delta(old_metadata: dict | None, new_metadata: dict | None) -> str:
-    """Pure. `key: old -> new` for every PMA key a `--pma-only` plan changes —
-    the run report must say WHAT moved, not just that a row was touched."""
+def plan_licensing_only(
+    code: str, record: dict | None, current_row: dict | None
+) -> DocumentCurePlan:
+    """Pure decision function for `--licensing-only` — no I/O.
+
+    Syncs the licensing tuple in `metadata` from canonical and NOTHING else:
+    `judul`, `content` and every other metadata key (the PMA tuple included)
+    are carried over unchanged. Same reason `--pma-only` exists: the rows the
+    detector reports as "canonical holds PP 28/2025 rows, the table serves
+    none" are hand-written prose the content-preservation gate refuses to
+    rebuild, and since v34 the structured metadata is the only thing the
+    channel still reads from them.
+
+    ONE DIRECTION, like `licensing_absent_codes`: this mode only ever REPLACES
+    an empty or stale row-set with canonical's non-empty one. A code whose
+    canonical `per_skala` is `[]` is refused, not emptied — a table row-set
+    that canonical has since detached is the QUARANTINE class
+    (`--all-quarantined`, which archives and rebuilds because that prose is
+    fabricated by definition). Emptying it from here would destroy a row-set
+    while reporting a cure.
+    """
+    if record is None:
+        return DocumentCurePlan(
+            code=code,
+            found_in_canonical=False,
+            found_in_table=current_row is not None,
+            is_gap=None,
+            new_judul=None,
+            new_content=None,
+            new_metadata=None,
+            update_row=False,
+            skip_reason="not in canonical dataset",
+            licensing_only=True,
+        )
+    if current_row is None:
+        return DocumentCurePlan(
+            code=code,
+            found_in_canonical=True,
+            found_in_table=False,
+            is_gap=None,
+            new_judul=None,
+            new_content=None,
+            new_metadata=None,
+            update_row=False,
+            skip_reason="not in kbli_documents table",
+            licensing_only=True,
+        )
+    if not (record.get("per_skala") or []):
+        return DocumentCurePlan(
+            code=code,
+            found_in_canonical=True,
+            found_in_table=True,
+            is_gap=True,
+            new_judul=None,
+            new_content=None,
+            new_metadata=None,
+            update_row=False,
+            skip_reason=(
+                "canonical holds no licensing rows for this code — refusing to empty the "
+                "stored row-set under --licensing-only (a detached row-set is the "
+                "--all-quarantined class)"
+            ),
+            licensing_only=True,
+        )
+
+    old_metadata = dict(current_row.get("metadata") or {})
+    new_metadata = dict(old_metadata)
+    new_metadata.update(licensing_metadata_from_canonical(record, old_metadata))
+    # Type-strict for the same reason as `plan_pma_only`: `[]` vs `null` vs a
+    # JSON string holding "[]" are three different things to jsonb and to
+    # `jsonb_array_length`, and Python's `==` would call some of them equal.
+    update_row = _json_differs(new_metadata, old_metadata)
+    return DocumentCurePlan(
+        code=code,
+        found_in_canonical=True,
+        found_in_table=True,
+        is_gap=False,
+        new_judul=None,
+        new_content=None,
+        new_metadata=new_metadata if update_row else None,
+        update_row=update_row,
+        skip_reason=None
+        if update_row
+        else "already cured (metadata licensing tuple matches canonical)",
+        licensing_only=True,
+    )
+
+
+def _tuple_delta(
+    old_metadata: dict | None, new_metadata: dict | None, keys: tuple[str, ...]
+) -> str:
+    """Pure. `key: old -> new` for every key of the tuple that moves — the run
+    report must say WHAT moved, not just that a row was touched. A list value
+    is shown by its length (a 60-row `per_skala` is a measurement, not a log
+    line); every other value by its repr."""
     old = old_metadata or {}
     new = new_metadata or {}
 
@@ -903,13 +1065,27 @@ def pma_tuple_delta(old_metadata: dict | None, new_metadata: dict | None) -> str
         return _json_differs(o, n)
 
     def _show(v: object) -> str:
-        return "<absent>" if v is _ABSENT else repr(v)
+        if v is _ABSENT:
+            return "<absent>"
+        if isinstance(v, list):
+            return f"<{len(v)} rows>"
+        return repr(v)
 
     return ", ".join(
         f"{key}: {_show(old.get(key, _ABSENT))} -> {_show(new.get(key, _ABSENT))}"
-        for key in PMA_METADATA_KEYS
+        for key in keys
         if _moved(old.get(key, _ABSENT), new.get(key, _ABSENT))
     )
+
+
+def pma_tuple_delta(old_metadata: dict | None, new_metadata: dict | None) -> str:
+    """Pure. The PMA tuple's moves — see `_tuple_delta`."""
+    return _tuple_delta(old_metadata, new_metadata, PMA_METADATA_KEYS)
+
+
+def licensing_tuple_delta(old_metadata: dict | None, new_metadata: dict | None) -> str:
+    """Pure. The licensing tuple's moves — see `_tuple_delta`."""
+    return _tuple_delta(old_metadata, new_metadata, LICENSING_METADATA_KEYS)
 
 
 def archive_params(code: str, current_row: dict) -> tuple:
@@ -972,6 +1148,15 @@ def build_parser() -> argparse.ArgumentParser:
         "`content` and every other metadata key are left byte-identical — the cure for rows "
         "whose hand-written prose the full rebuild would destroy. Refuses to combine with any "
         "--all-* selector.",
+    )
+    ap.add_argument(
+        "--licensing-only",
+        action="store_true",
+        help="with --only: sync ONLY the licensing tuple inside `metadata` from canonical "
+        "(per_skala, pp28_sources, licensing_status). `judul`, `content` and every other "
+        "metadata key are left byte-identical. One direction only: a code whose canonical "
+        "per_skala is empty is refused, never emptied (that is --all-quarantined's class). "
+        "Refuses to combine with any --all-* selector or with --pma-only.",
     )
     ap.add_argument(
         "--all-quarantined",
@@ -1047,10 +1232,24 @@ def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> 
         parser.error(
             "--cure-run is REQUIRED when --apply is passed — each cure pass declares its own stable id"
         )
-    # --pma-only is a NARROWER write on an operator-named scope, never a sweep:
-    # the --all-* selectors each justify a WHOLESALE rebuild (marker / detector /
-    # stored text), and none of them says anything about the PMA tuple alone.
-    if getattr(args, "pma_only", False):
+    # --pma-only / --licensing-only are NARROWER writes on an operator-named
+    # scope, never a sweep: the --all-* selectors each justify a WHOLESALE
+    # rebuild (marker / detector / stored text), and none of them says anything
+    # about one tuple alone.
+    narrow = [
+        name
+        for name, on in (
+            ("--pma-only", getattr(args, "pma_only", False)),
+            ("--licensing-only", getattr(args, "licensing_only", False)),
+        )
+        if on
+    ]
+    if len(narrow) > 1:
+        parser.error(
+            "--pma-only and --licensing-only are two tuples and two cure runs — run them separately"
+        )
+    if narrow:
+        (mode,) = narrow
         sweep = [
             name
             for name, on in (
@@ -1062,10 +1261,10 @@ def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> 
         ]
         if sweep:
             parser.error(
-                f"--pma-only cannot be combined with {' or '.join(sweep)} — name the codes with --only"
+                f"{mode} cannot be combined with {' or '.join(sweep)} — name the codes with --only"
             )
         if not args.only:
-            parser.error("--pma-only requires --only <codes> — it never guesses scope")
+            parser.error(f"{mode} requires --only <codes> — it never guesses scope")
     if not args.cure_run:
         return "dry-run"
     cure_run = args.cure_run.strip()
@@ -1214,8 +1413,8 @@ async def main() -> int | None:
             if not codes:
                 logger.warning("gate refused every selected row — nothing to do")
                 return
-        elif not args.all_quarantined and not args.pma_only:
-            # (`--pma-only` is exempt: it rewrites no prose, so the warning
+        elif not args.all_quarantined and not (args.pma_only or args.licensing_only):
+            # (the narrow modes are exempt: they rewrite no prose, so the warning
             # below would be a false alarm about an overwrite that cannot happen.)
             # `--only` BYPASSES the gate above, and that is the trap this block
             # exists to make loud. The gate cannot run here: a hand-written
@@ -1270,6 +1469,8 @@ async def main() -> int | None:
                 }
             if args.pma_only:
                 plan = plan_pma_only(code, by_code.get(code), current_row)
+            elif args.licensing_only:
+                plan = plan_licensing_only(code, by_code.get(code), current_row)
             else:
                 plan = plan_cure(code, by_code.get(code), current_row)
             plans.append(plan)
@@ -1278,13 +1479,14 @@ async def main() -> int | None:
                 logger.info("SKIP %s: %s", code, plan.skip_reason)
                 continue
 
-            if plan.pma_only:
+            if plan.partial_keys is not None:
                 assert current_row is not None
                 logger.info(
-                    "  %s: %s metadata PMA tuple only (judul/content byte-identical): %s",
+                    "  %s: %s metadata %s tuple only (judul/content byte-identical): %s",
                     code,
                     "syncing" if args.apply else "would sync",
-                    pma_tuple_delta(current_row.get("metadata"), plan.new_metadata),
+                    "PMA" if plan.pma_only else "licensing",
+                    _tuple_delta(current_row.get("metadata"), plan.new_metadata, plan.partial_keys),
                 )
             else:
                 logger.info(
@@ -1302,8 +1504,8 @@ async def main() -> int | None:
                 # precedent): bind the pre-serialized json.dumps() string to a
                 # $N::text::jsonb placeholder so the server casts text->jsonb
                 # exactly once.
-                if plan.pma_only:
-                    # Server-side merge of the tuple ONLY: `||` overwrites the 7
+                if plan.partial_keys is not None:
+                    # Server-side merge of the tuple ONLY: `||` overwrites the
                     # bound keys (a JSON null value still overwrites, it does not
                     # delete) and leaves every other key exactly as stored.
                     # The CASE guards the LEFT operand: `NULL || x` is NULL (a
@@ -1318,7 +1520,10 @@ async def main() -> int | None:
                         "THEN metadata ELSE '{}'::jsonb END) || $2::text::jsonb, "
                         "updated_at = now() WHERE kode_kbli = $1",
                         code,
-                        json.dumps(pma_metadata_patch(plan.new_metadata), ensure_ascii=False),
+                        json.dumps(
+                            metadata_patch(plan.new_metadata, plan.partial_keys),
+                            ensure_ascii=False,
+                        ),
                     )
                 else:
                     await conn.execute(

--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -415,11 +415,20 @@ def licensing_metadata_from_canonical(record: dict, old_metadata: dict | None) -
     paths cannot disagree about the same three keys (W105).
 
     `per_skala` is the CURRENT canonical row-set (`[]` for an honest gap);
-    `pp28_sources` is whatever canonical records as its provenance;
+    `pp28_sources` is whatever canonical records as its provenance — verbatim,
+    and JSON `null` when canonical carries none, which the jsonb merge writes
+    OVER any stored array (parity with the rebuild, and the dry-run delta line
+    shows it as `<n rows> -> None`: a code with rows and no provenance is a
+    canonical defect to fix upstream, not one to paper over here);
     `licensing_status` gets the KG cure's `PENDING_REGULATION` marker on an
     empty set and is otherwise carried over unchanged (`N/A` when the row
     never had one) — the rebuild has always declined to assert it, and the
-    narrow mode inherits that restraint rather than inventing a value."""
+    narrow mode inherits that restraint rather than inventing a value. Declared
+    consequence (refuter 2026-09-01): a cured row can hold real rows beside
+    `licensing_status: "N/A"`. Nothing reads that key off this table; the
+    public verdict comes from `kg_nodes`, whose convention (`REGULATED`
+    default / `PENDING_REGULATION` gap) is a cross-store contract this script
+    has no mandate to set — spec it, do not improvise it per row."""
     old = old_metadata or {}
     per_skala = record.get("per_skala") or []
     return {
@@ -1023,18 +1032,26 @@ def plan_licensing_only(
             skip_reason="not in kbli_documents table",
             licensing_only=True,
         )
-    if not (record.get("per_skala") or []):
+    canonical_rows = record.get("per_skala")
+    if not isinstance(canonical_rows, list) or not canonical_rows:
+        # Shape is checked, not just truthiness: a non-empty string or object
+        # under `per_skala` is truthy, would be written as the row-set, and
+        # would then fail `jsonb_array_length` at the detector — refuse it.
+        malformed = canonical_rows is not None and not isinstance(canonical_rows, list)
         return DocumentCurePlan(
             code=code,
             found_in_canonical=True,
             found_in_table=True,
-            is_gap=True,
+            is_gap=None if malformed else True,
             new_judul=None,
             new_content=None,
             new_metadata=None,
             update_row=False,
             skip_reason=(
-                "canonical holds no licensing rows for this code — refusing to empty the "
+                f"canonical per_skala is a {type(canonical_rows).__name__}, not a list — "
+                "refusing to write a malformed row-set"
+                if malformed
+                else "canonical holds no licensing rows for this code — refusing to empty the "
                 "stored row-set under --licensing-only (a detached row-set is the "
                 "--all-quarantined class)"
             ),
@@ -1555,7 +1572,11 @@ async def main() -> int | None:
     mode = "APPLIED" if args.apply else "DRY-RUN"
     acted = [p for p in plans if p.update_row]
     skipped = [p for p in plans if not p.update_row]
-    logger.info("%s: %d code(s) cured | %d skipped", mode, len(acted), len(skipped))
+    # N of M (W97): the denominator is every code the run was asked about, so
+    # "23 cured" can never be read as "all of them".
+    logger.info(
+        "%s: %d of %d code(s) cured | %d skipped", mode, len(acted), len(plans), len(skipped)
+    )
     for p in skipped:
         logger.info("  skipped %s: %s", p.code, p.skip_reason)
     if not args.apply and acted:

--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -13,7 +13,8 @@ cure pathway (Fase 1 collision detach, `kg_kbli_license_fix.py`,
 (`POST /api/v1/kbli-notebook/chat`, `backend/app/routers/kbli_notebook_chat.py`)
 injected `kbli_documents.content` VERBATIM into the LLM context until v34
 (2026-08-15 — since then its direct path selects `judul, metadata` only and
-reads just the PMA tuple; see TWO NARROW MODES below) — via the
+reads off it the PMA tuple plus `official_description`/`uraian` via
+`_official_scope`, nothing else; see TWO NARROW MODES below) — via the
 direct 5-digit-code lookup path (`kbli_notebook_chat.py:699`) and via
 `_fetch_parent_documents_from_kbli_table()` (`kbli_notebook_chat.py:635`,
 used for every result the search/explanation step returns). For a
@@ -73,9 +74,11 @@ Both require `--only`, refuse every `--all-*` selector and refuse each other
 (two tuples, two cure runs). `--licensing-only` is one-directional: a code
 whose canonical `per_skala` is empty is REFUSED, never emptied — that is the
 quarantine class. They exist because since v34 the channel never injects the
-prose: `chat_kbli`'s direct path selects `judul, metadata` and reads ONLY the
-PMA tuple off it (`_pma_disclosure_fields`), so on a hand-written row the PMA
-tuple is the one thing a client can still be told wrong FROM THIS TABLE.
+prose: `chat_kbli`'s direct path selects `judul, metadata` and reads off it
+only the PMA tuple (`_pma_disclosure_fields`) and the official description
+(`_official_scope`: `official_description` / `uraian`), so on a hand-written
+row the PMA tuple is the one VERDICT a client can still be told wrong FROM
+THIS TABLE.
 The licensing tuple, by contrast, has NO runtime reader on this table
 (measured 2026-09-01: `per_skala`/`licensing_status`/`pp28_sources` reach a
 client from the canonical file, from the Qdrant point text via
@@ -365,8 +368,8 @@ PMA_METADATA_KEYS: tuple[str, ...] = (
 # moves with it; `licensing_status` follows the SAME rule the full rebuild
 # applies (gap marker on an empty set, otherwise carried over — this script
 # makes no independent claim about it). No runtime consumer reads these three
-# keys off THIS table (measured 2026-09-01 — module docstring); the PMA tuple
-# above is the one the channel reads.
+# keys off THIS table (measured 2026-09-01 — module docstring); the channel
+# reads the PMA tuple above and `official_description`/`uraian`, nothing else.
 LICENSING_METADATA_KEYS: tuple[str, ...] = (
     "per_skala",
     "pp28_sources",

--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -11,7 +11,9 @@ anywhere in the repo — a datastore entirely outside the canonical dataset's
 cure pathway (Fase 1 collision detach, `kg_kbli_license_fix.py`,
 `kbli_qdrant_risk_clear.py`, the gold cure). `chat_kbli`
 (`POST /api/v1/kbli-notebook/chat`, `backend/app/routers/kbli_notebook_chat.py`)
-injects `kbli_documents.content` VERBATIM into the LLM context — via the
+injected `kbli_documents.content` VERBATIM into the LLM context until v34
+(2026-08-15 — since then its direct path selects `judul, metadata` only and
+reads just the PMA tuple; see TWO NARROW MODES below) — via the
 direct 5-digit-code lookup path (`kbli_notebook_chat.py:699`) and via
 `_fetch_parent_documents_from_kbli_table()` (`kbli_notebook_chat.py:635`,
 used for every result the search/explanation step returns). For a
@@ -118,9 +120,10 @@ and no `pma_official_basis` does NOT, and curing it merely propagates an
 unsourced verdict to a second surface (2026-08-01: `02101` and `03120` were
 held back for exactly this reason, while six sibling divergences were cured).
 
-SIZE IS PART OF SCOPE on this table, unlike the others: `chat_kbli` injects
-`content` VERBATIM into the LLM context, so a code with a large `per_skala`
-renders a document that competes for that context. Measured on the live table
+SIZE IS PART OF SCOPE on this table, unlike the others: `chat_kbli` injected
+`content` VERBATIM into the LLM context until v34 (the row is still stored,
+archived and served whole to any future reader), so a code with a large
+`per_skala` renders a document that competes for that context. Measured on the live table
 2026-08-01: median 2,458 chars, p99 13,272, max 25,483. `03110` (69 canonical
 rows) computes to 48,008 — ~2x the largest row that has ever existed there —
 and was held back pending a channel-appropriate rendering. Read the dry-run's
@@ -1033,24 +1036,28 @@ def plan_licensing_only(
             licensing_only=True,
         )
     canonical_rows = record.get("per_skala")
-    if not isinstance(canonical_rows, list) or not canonical_rows:
-        # Shape is checked, not just truthiness: a non-empty string or object
-        # under `per_skala` is truthy, would be written as the row-set, and
-        # would then fail `jsonb_array_length` at the detector — refuse it.
-        malformed = canonical_rows is not None and not isinstance(canonical_rows, list)
+    # Shape is checked, not just truthiness: a non-empty string or object
+    # under `per_skala` is truthy and would be written as the row-set; a list
+    # of primitives would pass `jsonb_array_length` at the detector and then
+    # crash every renderer that does `entry.get(...)`. Both are refused, named.
+    shape_defect: str | None = None
+    if canonical_rows is not None and not isinstance(canonical_rows, list):
+        shape_defect = f"canonical per_skala is a {type(canonical_rows).__name__}, not a list"
+    elif canonical_rows and not all(isinstance(entry, dict) for entry in canonical_rows):
+        shape_defect = "canonical per_skala holds non-object entries"
+    if shape_defect or not canonical_rows:
         return DocumentCurePlan(
             code=code,
             found_in_canonical=True,
             found_in_table=True,
-            is_gap=None if malformed else True,
+            is_gap=None if shape_defect else True,
             new_judul=None,
             new_content=None,
             new_metadata=None,
             update_row=False,
             skip_reason=(
-                f"canonical per_skala is a {type(canonical_rows).__name__}, not a list — "
-                "refusing to write a malformed row-set"
-                if malformed
+                f"{shape_defect} — refusing to write a malformed row-set"
+                if shape_defect
                 else "canonical holds no licensing rows for this code — refusing to empty the "
                 "stored row-set under --licensing-only (a detached row-set is the "
                 "--all-quarantined class)"
@@ -1392,6 +1399,10 @@ async def main() -> int | None:
             )
         }
 
+        # W97 denominator for the final summary: taken BEFORE any gate narrows
+        # `codes`, so "N of M" keeps the M the operator actually asked about.
+        asked = len(codes)
+
         # Content-preservation gate — state-selected scope ONLY. The quarantine
         # population is deliberately exempt: there the stored content is
         # FABRICATED by definition (invented risk tiers, a capital figure from a
@@ -1572,10 +1583,17 @@ async def main() -> int | None:
     mode = "APPLIED" if args.apply else "DRY-RUN"
     acted = [p for p in plans if p.update_row]
     skipped = [p for p in plans if not p.update_row]
-    # N of M (W97): the denominator is every code the run was asked about, so
-    # "23 cured" can never be read as "all of them".
+    # N of M (W97): the denominator is every code the run was asked about —
+    # BEFORE the scope gates narrowed the list — so "23 cured" can never be
+    # read as "all of them", and a gate that dropped rows shows up here too,
+    # not only in its own earlier log line.
     logger.info(
-        "%s: %d of %d code(s) cured | %d skipped", mode, len(acted), len(plans), len(skipped)
+        "%s: %d of %d code(s) asked cured | %d skipped | %d narrowed out by the scope gate",
+        mode,
+        len(acted),
+        asked,
+        len(skipped),
+        asked - len(plans),
     )
     for p in skipped:
         logger.info("  skipped %s: %s", p.code, p.skip_reason)

--- a/apps/backend-rag/backend/scripts/kbli_documents_cure.py
+++ b/apps/backend-rag/backend/scripts/kbli_documents_cure.py
@@ -70,9 +70,19 @@ only those keys; `judul`, `content` and every other key stay byte-identical.
 Both require `--only`, refuse every `--all-*` selector and refuse each other
 (two tuples, two cure runs). `--licensing-only` is one-directional: a code
 whose canonical `per_skala` is empty is REFUSED, never emptied — that is the
-quarantine class. These modes exist because since v34 the channel reads the
-structured metadata and never the prose, so on a hand-written row the tuple
-is the only thing a client can still be told wrong.
+quarantine class. They exist because since v34 the channel never injects the
+prose: `chat_kbli`'s direct path selects `judul, metadata` and reads ONLY the
+PMA tuple off it (`_pma_disclosure_fields`), so on a hand-written row the PMA
+tuple is the one thing a client can still be told wrong FROM THIS TABLE.
+The licensing tuple, by contrast, has NO runtime reader on this table
+(measured 2026-09-01: `per_skala`/`licensing_status`/`pp28_sources` reach a
+client from the canonical file, from the Qdrant point text via
+`sanitize_kbli_search_result`, and from `kg_nodes` via `inspect_kbli` —
+never from `kbli_documents`). `--licensing-only` therefore buys table↔canonical
+agreement — the detector's `licensing presence disagrees` class closes and any
+future reader of the row finds government rows instead of `[]` — and does
+NOT, by itself, change what a client is told about licensing. Report it as
+exactly that.
 
 `--only` DOES NOT GET THE CONTENT-PRESERVATION GATE. That gate is scoped to
 `--all-licensing-absent`, so passing the same population as a hand-written
@@ -351,7 +361,9 @@ PMA_METADATA_KEYS: tuple[str, ...] = (
 # 'per_skala')` vs the canonical rows); `pp28_sources` is its provenance and
 # moves with it; `licensing_status` follows the SAME rule the full rebuild
 # applies (gap marker on an empty set, otherwise carried over — this script
-# makes no independent claim about it).
+# makes no independent claim about it). No runtime consumer reads these three
+# keys off THIS table (measured 2026-09-01 — module docstring); the PMA tuple
+# above is the one the channel reads.
 LICENSING_METADATA_KEYS: tuple[str, ...] = (
     "per_skala",
     "pp28_sources",
@@ -968,11 +980,14 @@ def plan_licensing_only(
 
     Syncs the licensing tuple in `metadata` from canonical and NOTHING else:
     `judul`, `content` and every other metadata key (the PMA tuple included)
-    are carried over unchanged. Same reason `--pma-only` exists: the rows the
-    detector reports as "canonical holds PP 28/2025 rows, the table serves
-    none" are hand-written prose the content-preservation gate refuses to
-    rebuild, and since v34 the structured metadata is the only thing the
-    channel still reads from them.
+    are carried over unchanged. Same shape as `--pma-only`, narrower stakes:
+    the rows the detector reports as "canonical holds PP 28/2025 rows, the
+    table serves none" are hand-written prose the content-preservation gate
+    refuses to rebuild — but unlike the PMA tuple, this tuple has no runtime
+    reader on this table today (module docstring, "TWO NARROW MODES"). What
+    this cure buys is table↔canonical agreement: the detector class closes
+    and a future reader finds rows, not `[]`. It does not change what the
+    channel serves; do not report it as if it did.
 
     ONE DIRECTION, like `licensing_absent_codes`: this mode only ever REPLACES
     an empty or stale row-set with canonical's non-empty one. A code whose

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -4,7 +4,8 @@ No DB, no network — `plan_cure`, `build_cured_content`, `build_cured_metadata`
 `quarantined_codes`, and `archive_params` take plain dicts/lists and return
 plain dicts/dataclasses. These tests pin the 4th-consumer-surface cure
 (2026-07-19): `chat_kbli` injected `kbli_documents.content` verbatim (until v34,
-2026-08-15 — its direct path now reads only the PMA tuple off `metadata`) into the
+2026-08-15 — its direct path now reads only the PMA tuple and
+`official_description`/`uraian` off `metadata`) into the
 LLM context (see module docstring in
 `backend/scripts/kbli_documents_cure.py`), and this script must never
 synthesize a new licensing/risk/capital assertion for a code the canonical

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -1878,7 +1878,10 @@ def test_main_full_only_apply_still_rewrites_judul_and_content(monkeypatch):
 # `per_skala: []`, `licensing_status: "N/A"` and a seed-era `pp28_sources`
 # array, while canonical holds real PP 28/2025 rows. The full rebuild would
 # have replaced all 25 documents (up to 20k chars each); the content-
-# preservation gate refuses exactly that. The tuple is what the channel reads.
+# preservation gate refuses exactly that. NOTE (grounded 2026-09-01): unlike the
+# PMA tuple, NO runtime consumer reads these three keys off this table — the
+# channel serves licensing from Qdrant text and `kg_nodes`. This mode buys
+# table<->canonical agreement (detector class closes), not a channel change.
 from backend.scripts.kbli_documents_cure import (  # noqa: E402
     LICENSING_METADATA_KEYS,
     licensing_metadata_from_canonical,
@@ -2212,3 +2215,68 @@ def test_main_pma_only_apply_still_binds_only_the_pma_tuple_after_the_generalisa
     bound = _json_obl.loads(args[1])
     assert set(bound) == set(PMA_METADATA_KEYS)
     assert "per_skala" not in bound
+
+
+# --- refuter round 1 (Codex sol, 2026-09-01) on --licensing-only: folded ------
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    ["NIB dan Sertifikat Standar", {"skala": "Mikro"}, 3],
+    ids=["str", "dict", "int"],
+)
+def test_licensing_only_refuses_a_malformed_canonical_row_set(malformed):
+    """MAJOR #3a. Truthiness alone would have WRITTEN a non-empty string or
+    object as `per_skala` (and `jsonb_array_length` would then fail at the
+    detector). Shape is refused, named, and never reaches the UPDATE."""
+    record = {**RECORD_85510_SOURCED, "per_skala": malformed}
+    plan = plan_licensing_only("85510", record, HAND_WRITTEN_ROW_85510)
+    assert plan.update_row is False
+    assert plan.new_metadata is None
+    assert plan.is_gap is None
+    assert "not a list" in (plan.skip_reason or "")
+
+
+def test_main_licensing_only_malformed_canonical_binds_nothing(monkeypatch, caplog):
+    record = {**RECORD_85510_SOURCED, "per_skala": "NIB"}
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, _LICENSING_ONLY_APPLY_ARGV, [_ROW_85510_IN_TABLE], [record]
+        )
+    assert not rc
+    assert conn.updates() == [] and archive_calls == []
+    assert any("not a list" in r.getMessage() for r in caplog.records)
+
+
+def test_main_licensing_only_second_run_on_string_metadata_is_a_no_op(monkeypatch, caplog):
+    """MINOR #5. asyncpg can hand `metadata` back as a JSON STRING; `main()`
+    decodes it before planning. A cured row re-read that way must be a
+    declared no-op — no snapshot, no UPDATE — or the mode is not idempotent
+    against the real driver. (The mutant that drops the `json.loads` branch
+    is what this catches: a str has no `.get`.)"""
+    cured = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510).new_metadata
+    row = {**_ROW_85510_IN_TABLE, "metadata": _json_obl.dumps(cured, ensure_ascii=False)}
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, _LICENSING_ONLY_APPLY_ARGV, [row], [RECORD_85510_SOURCED]
+        )
+    assert not rc
+    assert conn.updates() == [] and archive_calls == []
+    assert any(
+        "SKIP 85510" in r.getMessage() and "already cured" in r.getMessage() for r in caplog.records
+    )
+
+
+def test_main_summary_states_n_of_m(monkeypatch, caplog):
+    """MINOR #6 (W97). Two codes asked, one cured, one not in the table: the
+    summary must carry the denominator, not a bare count."""
+    argv = [a if a != "85510" else "85510,03231" for a in _LICENSING_ONLY_APPLY_ARGV]
+    record_03231 = {**RECORD_85510_SOURCED, "kode_kbli_2025": "03231"}
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, _ = _drive_apply(
+            monkeypatch, argv, [_ROW_85510_IN_TABLE], [RECORD_85510_SOURCED, record_03231]
+        )
+    assert not rc
+    assert len(conn.updates()) == 1
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("APPLIED: 1 of 2 code(s) cured | 1 skipped" in m for m in messages), messages

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -1869,3 +1869,346 @@ def test_main_full_only_apply_still_rewrites_judul_and_content(monkeypatch):
     assert "||" not in sql
     assert sql.rstrip().endswith("WHERE kode_kbli = $1")
     assert args[1] is not None and args[2] is not None
+
+
+# ---------------------------------------------------------------------------
+# --licensing-only (2026-09-01, second narrow mode). Measured on prod that day:
+# the detector's `licensing presence disagrees` class held 25 codes, every one
+# a hand-written row (257-1,124 chars of prose) whose metadata carried
+# `per_skala: []`, `licensing_status: "N/A"` and a seed-era `pp28_sources`
+# array, while canonical holds real PP 28/2025 rows. The full rebuild would
+# have replaced all 25 documents (up to 20k chars each); the content-
+# preservation gate refuses exactly that. The tuple is what the channel reads.
+from backend.scripts.kbli_documents_cure import (  # noqa: E402
+    LICENSING_METADATA_KEYS,
+    licensing_metadata_from_canonical,
+    licensing_metadata_patch,
+    licensing_tuple_delta,
+    metadata_patch,
+    plan_licensing_only,
+)
+
+# The measured shape of the 25 rows: rows present-but-empty, a seed-era
+# provenance list, no verdict — under hand-written prose.
+HAND_WRITTEN_ROW_85510 = {
+    "judul": "PENDIDIKAN OLAHRAGA DAN REKREASI",
+    "content": (
+        "KBLI 85510: PENDIDIKAN OLAHRAGA DAN REKREASI\n\nWHAT IT MEANS:\n"
+        "Yoga studios, surf schools, dive instruction, retreat teaching.\n\n"
+        "BALI CONTEXT:\nCanggu and Ubud are dense with them."
+    ),
+    "metadata": {
+        "judul": "PENDIDIKAN OLAHRAGA DAN REKREASI",
+        "kode_kbli_2025": "85510",
+        "licensing_status": "N/A",
+        "per_skala": [],
+        "pma_status": "TERBUKA",
+        "pp28_sources": ["seed-2026-02-18"],
+        "sektor_id": "P",
+        "status_mapping": "MATCH_LANGSUNG",
+    },
+}
+
+RECORD_85510_SOURCED = {
+    "kode_kbli_2025": "85510",
+    "judul": "Pendidikan Olahraga dan Rekreasi",
+    "uraian": "Kelompok ini mencakup kegiatan pendidikan olahraga dan rekreasi.",
+    # Deliberately DIFFERENT from the row's PMA tuple: a licensing-only plan
+    # must not touch it even when canonical disagrees — that is --pma-only's job.
+    "pma_status": "TERBATAS",
+    "pma_max_asing": 49,
+    "pma_verification_status": "located",
+    "pma_official_basis": "Perpres 10/2021 Lampiran III fixture",
+    "pma_source_vintage": "2021-03-02",
+    "pma_cap_verified": True,
+    "per_skala": [
+        {
+            "skala": "Mikro",
+            "kategori_risiko": "Rendah",
+            "perizinan": "NIB",
+            "kewenangan": "Bupati/Wali Kota",
+        },
+        {
+            "skala": "Kecil",
+            "kategori_risiko": "Menengah Rendah",
+            "perizinan": "NIB dan Sertifikat Standar",
+            "kewenangan": "Bupati/Wali Kota",
+        },
+    ],
+    "pp28_sources": ["PP 28/2025 Lampiran I Sektor Pendidikan", "OSS RBA 2025"],
+}
+
+
+def test_licensing_only_guilt_syncs_the_tuple_and_nothing_else():
+    plan = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510)
+    assert plan.licensing_only is True and plan.pma_only is False
+    assert plan.partial_keys == LICENSING_METADATA_KEYS
+    assert plan.update_row is True
+    assert plan.new_judul is None and plan.new_content is None
+    old = HAND_WRITTEN_ROW_85510["metadata"]
+    new = plan.new_metadata
+    assert new["per_skala"] == RECORD_85510_SOURCED["per_skala"]
+    assert new["pp28_sources"] == RECORD_85510_SOURCED["pp28_sources"]
+    # Non-empty canonical rows: the verdict is CARRIED OVER, never asserted.
+    assert new["licensing_status"] == "N/A"
+    # The PMA tuple canonical disagrees with is left exactly as stored.
+    assert new["pma_status"] == "TERBUKA"
+    assert "pma_official_basis" not in new
+    for key, value in old.items():
+        if key not in LICENSING_METADATA_KEYS:
+            assert new[key] == value, key
+    assert set(new) - set(old) <= set(LICENSING_METADATA_KEYS)
+
+
+def test_licensing_only_writes_the_same_tuple_the_full_rebuild_would():
+    """Two paths, one row-set (W105): the narrow sync and `build_cured_metadata`
+    share ONE derivation, so they cannot disagree about these three keys."""
+    narrow = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510).new_metadata
+    full = build_cured_metadata("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510["metadata"])
+    assert {k: narrow[k] for k in LICENSING_METADATA_KEYS} == {
+        k: full[k] for k in LICENSING_METADATA_KEYS
+    }
+    # and the shared derivation itself keeps the rebuild's gap rule
+    gap = licensing_metadata_from_canonical({"per_skala": []}, {"licensing_status": "N/A"})
+    assert gap == {"per_skala": [], "pp28_sources": None, "licensing_status": "PENDING_REGULATION"}
+
+
+def test_licensing_only_really_differs_from_the_full_rebuild_on_a_hand_written_row():
+    full = plan_cure("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510)
+    assert full.update_row is True
+    assert full.new_content != HAND_WRITTEN_ROW_85510["content"]
+    assert full.new_metadata["pma_status"] == "TERBATAS"  # the rebuild moves the PMA tuple too
+    narrow = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510)
+    assert narrow.new_content is None
+    assert narrow.new_metadata["pma_status"] == "TERBUKA"
+
+
+def test_licensing_only_innocence_is_idempotent():
+    first = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510)
+    cured_row = {**HAND_WRITTEN_ROW_85510, "metadata": first.new_metadata}
+    second = plan_licensing_only("85510", RECORD_85510_SOURCED, cured_row)
+    assert second.update_row is False
+    assert second.new_metadata is None
+    assert "already cured" in (second.skip_reason or "")
+
+
+def test_licensing_only_compares_row_content_not_row_count():
+    """The detector measures `jsonb_array_length`; a same-length row-set with
+    different content would satisfy it and still be stale. The plan compares
+    the rows themselves."""
+    same_count_other_rows = [
+        {**row, "kategori_risiko": "Tinggi"} for row in RECORD_85510_SOURCED["per_skala"]
+    ]
+    row = {
+        **HAND_WRITTEN_ROW_85510,
+        "metadata": {
+            **HAND_WRITTEN_ROW_85510["metadata"],
+            "per_skala": same_count_other_rows,
+            "pp28_sources": RECORD_85510_SOURCED["pp28_sources"],
+        },
+    }
+    plan = plan_licensing_only("85510", RECORD_85510_SOURCED, row)
+    assert plan.update_row is True
+    assert plan.new_metadata["per_skala"] == RECORD_85510_SOURCED["per_skala"]
+
+
+def test_licensing_only_refuses_to_empty_a_stored_row_set():
+    """GUILT for the one-direction rule: canonical detached the rows (the
+    quarantine class) while the table still serves them. Emptying them here
+    would destroy a row-set while reporting a cure — the plan REFUSES."""
+    detached = {**RECORD_85510_SOURCED, "per_skala": []}
+    served = {
+        **HAND_WRITTEN_ROW_85510,
+        "metadata": {
+            **HAND_WRITTEN_ROW_85510["metadata"],
+            "per_skala": RECORD_85510_SOURCED["per_skala"],
+        },
+    }
+    plan = plan_licensing_only("85510", detached, served)
+    assert plan.update_row is False
+    assert plan.new_metadata is None
+    assert plan.licensing_only is True
+    assert "--all-quarantined" in (plan.skip_reason or "")
+    # and an honest gap on BOTH sides is equally not this mode's business —
+    # no PENDING_REGULATION write sneaks in through the narrow door
+    both_empty = plan_licensing_only("85510", detached, HAND_WRITTEN_ROW_85510)
+    assert both_empty.update_row is False
+    # INNOCENCE: a record whose per_skala key is missing entirely reads as
+    # empty too — refused, not crashed, not emptied.
+    no_key = {k: v for k, v in RECORD_85510_SOURCED.items() if k != "per_skala"}
+    assert plan_licensing_only("85510", no_key, served).update_row is False
+
+
+def test_licensing_only_skips_when_canonical_or_table_is_missing():
+    no_record = plan_licensing_only("85510", None, HAND_WRITTEN_ROW_85510)
+    assert no_record.update_row is False
+    assert no_record.licensing_only is True
+    assert no_record.skip_reason == "not in canonical dataset"
+    no_row = plan_licensing_only("85510", RECORD_85510_SOURCED, None)
+    assert no_row.update_row is False
+    assert no_row.licensing_only is True
+    assert no_row.skip_reason == "not in kbli_documents table"
+
+
+def test_licensing_tuple_delta_shows_row_counts_not_the_blob():
+    old = HAND_WRITTEN_ROW_85510["metadata"]
+    new = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510).new_metadata
+    delta = licensing_tuple_delta(old, new)
+    assert delta == "per_skala: <0 rows> -> <2 rows>, pp28_sources: <1 rows> -> <2 rows>"
+    assert "Bupati" not in delta  # the rows themselves never reach the log line
+    assert licensing_tuple_delta(new, dict(new)) == ""
+    # the PMA delta helper is untouched by the generalisation
+    assert pma_tuple_delta(old, new) == ""
+
+
+def test_licensing_metadata_patch_binds_the_tuple_and_nothing_else():
+    new = plan_licensing_only("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510).new_metadata
+    patch = licensing_metadata_patch(new)
+    assert set(patch) == set(LICENSING_METADATA_KEYS)
+    assert "pma_status" not in patch and "judul" not in patch
+    assert patch == metadata_patch(new, LICENSING_METADATA_KEYS)
+    # a full-rebuild plan has no partial keys: the apply path must take the other branch
+    assert plan_cure("85510", RECORD_85510_SOURCED, HAND_WRITTEN_ROW_85510).partial_keys is None
+
+
+def test_parser_licensing_only_requires_an_only_scope():
+    ap = _cure_build_parser()
+    args = ap.parse_args(["--licensing-only"])
+    with pytest.raises(SystemExit):
+        _cure_validate_args(ap, args)
+
+
+@pytest.mark.parametrize(
+    "sweep", ["--all-quarantined", "--all-licensing-absent", "--all-machine-template"]
+)
+def test_parser_licensing_only_refuses_every_sweep_selector(sweep):
+    ap = _cure_build_parser()
+    args = ap.parse_args(["--licensing-only", "--only", "85510", sweep])
+    with pytest.raises(SystemExit):
+        _cure_validate_args(ap, args)
+
+
+def test_parser_refuses_both_narrow_modes_at_once():
+    ap = _cure_build_parser()
+    args = ap.parse_args(["--licensing-only", "--pma-only", "--only", "85510"])
+    with pytest.raises(SystemExit):
+        _cure_validate_args(ap, args)
+
+
+def test_parser_licensing_only_with_only_is_accepted_in_both_modes():
+    ap = _cure_build_parser()
+    dry = ap.parse_args(["--licensing-only", "--only", "85510,03231"])
+    assert _cure_validate_args(ap, dry) == "dry-run"
+    live = ap.parse_args(
+        [
+            "--licensing-only",
+            "--only",
+            "85510",
+            "--apply",
+            "--cure-run",
+            "kbli_cure:2026-09-01-licensing-only",
+        ]
+    )
+    assert _cure_validate_args(ap, live) == "kbli_cure:2026-09-01-licensing-only"
+
+
+_ROW_85510_IN_TABLE = {
+    "kode_kbli": "85510",
+    "created_at": None,
+    "updated_at": None,
+    **HAND_WRITTEN_ROW_85510,
+}
+_LICENSING_ONLY_APPLY_ARGV = [
+    "cure",
+    "--licensing-only",
+    "--only",
+    "85510",
+    "--apply",
+    "--cure-run",
+    "kbli_cure:2026-09-01-licensing-only",
+]
+
+
+def test_main_licensing_only_apply_merges_the_tuple_and_never_binds_judul_or_content(
+    monkeypatch, caplog
+):
+    """GUILT, driven through main(): the dispatch `elif args.licensing_only`
+    and the `partial_keys` branch of the apply path are what keep a hand-
+    written row's judul/content out of the UPDATE."""
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, _LICENSING_ONLY_APPLY_ARGV, [_ROW_85510_IN_TABLE], [RECORD_85510_SOURCED]
+        )
+    assert not rc
+    updates = conn.updates()
+    assert len(updates) == 1, [q for q, _ in conn.executes]
+    sql, args = updates[0]
+    assert (
+        "(CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END) "
+        "|| $2::text::jsonb"
+    ) in sql
+    assert "judul" not in sql and "content" not in sql
+    assert sql.rstrip().endswith("WHERE kode_kbli = $1")
+    assert args[0] == "85510"
+    bound = _json_obl.loads(args[1])
+    assert set(bound) == set(LICENSING_METADATA_KEYS)
+    assert bound["per_skala"] == RECORD_85510_SOURCED["per_skala"]
+    assert bound["pp28_sources"] == RECORD_85510_SOURCED["pp28_sources"]
+    assert bound["licensing_status"] == "N/A"
+    assert [c["cure_run"] for c in archive_calls] == ["kbli_cure:2026-09-01-licensing-only"]
+    assert archive_calls[0]["params"][2] == HAND_WRITTEN_ROW_85510["content"]
+    messages = [r.getMessage() for r in caplog.records]
+    assert not [m for m in messages if "content-preservation gate" in m], messages
+    assert not [m for m in messages if "OVERWRITE" in m], messages
+    assert any(
+        "syncing metadata licensing tuple only" in m and "per_skala: <0 rows> -> <2 rows>" in m
+        for m in messages
+    ), messages
+
+
+def test_main_licensing_only_dry_run_binds_no_update_and_takes_no_snapshot(monkeypatch, caplog):
+    argv = [
+        a
+        for a in _LICENSING_ONLY_APPLY_ARGV
+        if a not in ("--apply", "--cure-run", "kbli_cure:2026-09-01-licensing-only")
+    ]
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, argv, [_ROW_85510_IN_TABLE], [RECORD_85510_SOURCED]
+        )
+    assert not rc
+    assert conn.updates() == []
+    assert archive_calls == []
+    assert any("would sync metadata licensing tuple only" in r.getMessage() for r in caplog.records)
+
+
+def test_main_licensing_only_refusal_on_a_detached_code_binds_nothing(monkeypatch, caplog):
+    """The one-direction rule survives the drive: a detached canonical record
+    under --apply produces no UPDATE, no snapshot, and a named SKIP."""
+    detached = {**RECORD_85510_SOURCED, "per_skala": []}
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, _LICENSING_ONLY_APPLY_ARGV, [_ROW_85510_IN_TABLE], [detached]
+        )
+    assert not rc
+    assert conn.updates() == []
+    assert archive_calls == []
+    assert any(
+        "SKIP 85510" in r.getMessage() and "--all-quarantined" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_main_pma_only_apply_still_binds_only_the_pma_tuple_after_the_generalisation(
+    monkeypatch,
+):
+    """INNOCENCE for the shared apply branch: `partial_keys` must resolve to
+    the SEVEN PMA keys under --pma-only, never to the licensing tuple."""
+    rc, conn, _ = _drive_apply(
+        monkeypatch, _PMA_ONLY_APPLY_ARGV, [_ROW_96210_IN_TABLE], [RECORD_96210_LOCATED]
+    )
+    assert not rc
+    ((_, args),) = conn.updates()
+    bound = _json_obl.loads(args[1])
+    assert set(bound) == set(PMA_METADATA_KEYS)
+    assert "per_skala" not in bound

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_documents_cure.py
@@ -3,7 +3,8 @@
 No DB, no network — `plan_cure`, `build_cured_content`, `build_cured_metadata`,
 `quarantined_codes`, and `archive_params` take plain dicts/lists and return
 plain dicts/dataclasses. These tests pin the 4th-consumer-surface cure
-(2026-07-19): `chat_kbli` injects `kbli_documents.content` verbatim into the
+(2026-07-19): `chat_kbli` injected `kbli_documents.content` verbatim (until v34,
+2026-08-15 — its direct path now reads only the PMA tuple off `metadata`) into the
 LLM context (see module docstring in
 `backend/scripts/kbli_documents_cure.py`), and this script must never
 synthesize a new licensing/risk/capital assertion for a code the canonical
@@ -1209,7 +1210,7 @@ def test_a_hand_added_section_is_still_refused():
 
 
 def test_the_obligations_are_actually_wired_into_the_document_the_channel_reads():
-    """`chat_kbli` injects `content` verbatim — so the section being CORRECT is
+    """`chat_kbli` injected `content` verbatim (until v34) — so the section being CORRECT is
     worth nothing unless `build_cured_content` emits it.
 
     Added because mutation testing killed five of six mutants and this one
@@ -2279,4 +2280,82 @@ def test_main_summary_states_n_of_m(monkeypatch, caplog):
     assert not rc
     assert len(conn.updates()) == 1
     messages = [r.getMessage() for r in caplog.records]
-    assert any("APPLIED: 1 of 2 code(s) cured | 1 skipped" in m for m in messages), messages
+    assert any(
+        "APPLIED: 1 of 2 code(s) asked cured | 1 skipped | 0 narrowed out" in m for m in messages
+    ), messages
+
+
+# --- refuter round 2 (Codex sol, 2026-09-01): folded ---------------------------
+
+
+@pytest.mark.parametrize("falsey", ["", {}, 0], ids=["empty-str", "empty-dict", "zero"])
+def test_licensing_only_names_a_falsey_non_list_as_malformed_not_as_a_gap(falsey):
+    """Round-2 surviving mutant: `bool(rows) and not isinstance(...)` would
+    have filed `""`/`{}`/`0` under "honest gap" (is_gap True). A wrong TYPE is
+    a shape defect whatever its truthiness."""
+    record = {**RECORD_85510_SOURCED, "per_skala": falsey}
+    plan = plan_licensing_only("85510", record, HAND_WRITTEN_ROW_85510)
+    assert plan.update_row is False
+    assert plan.is_gap is None
+    assert "not a list" in (plan.skip_reason or "")
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [[1], ["NIB"], [{"skala": "Mikro"}, "NIB"]],
+    ids=["int-entries", "str-entries", "mixed"],
+)
+def test_licensing_only_refuses_a_row_set_with_non_object_entries(rows):
+    """Round-2 MINOR 3: a list of primitives passes `jsonb_array_length` at
+    the detector and crashes every renderer that does `entry.get(...)`."""
+    record = {**RECORD_85510_SOURCED, "per_skala": rows}
+    plan = plan_licensing_only("85510", record, HAND_WRITTEN_ROW_85510)
+    assert plan.update_row is False
+    assert plan.new_metadata is None
+    assert plan.is_gap is None
+    assert "non-object entries" in (plan.skip_reason or "")
+
+
+def test_main_licensing_only_non_object_entries_bind_nothing(monkeypatch, caplog):
+    record = {**RECORD_85510_SOURCED, "per_skala": [1, 2]}
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, archive_calls = _drive_apply(
+            monkeypatch, _LICENSING_ONLY_APPLY_ARGV, [_ROW_85510_IN_TABLE], [record]
+        )
+    assert not rc
+    assert conn.updates() == [] and archive_calls == []
+    assert any("non-object entries" in r.getMessage() for r in caplog.records)
+
+
+def test_main_summary_keeps_the_pre_gate_denominator_under_a_gated_sweep(monkeypatch, caplog):
+    """Round-2 MAJOR 2 (W97). The `--all-*` gates narrow `codes` BEFORE the
+    plans are built, so a summary that counts plans would say `1 of 1` for a
+    run that was asked about 2 and dropped one. The denominator is taken
+    before the gate; the narrowed-out count is stated."""
+    seed_row = {
+        "kode_kbli": "74191",
+        "created_at": None,
+        "updated_at": None,
+        "judul": "Aktivitas Konsultasi",
+        "content": _MACHINE_SEED,
+        "metadata": {"kode_kbli_2025": "74191", "per_skala": [], "licensing_status": "N/A"},
+    }
+    record_74191 = {
+        "kode_kbli_2025": "74191",
+        "judul": "Aktivitas Konsultasi",
+        "uraian": "Kelompok ini mencakup konsultasi.",
+        "per_skala": [],
+    }
+    argv = ["cure", "--all-machine-template", "--apply", "--cure-run", "kbli_cure:2026-09-01-mt"]
+    with caplog.at_level(_logging.INFO, logger=_cure.logger.name):
+        rc, conn, _ = _drive_apply(
+            monkeypatch, argv, [seed_row, _ROW_85510_IN_TABLE], [record_74191, RECORD_85510_SOURCED]
+        )
+    assert not rc
+    updates = conn.updates()
+    assert [a[0] for _, a in updates] == ["74191"]  # the hand-written row is never rebuilt
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "APPLIED: 1 of 2 code(s) asked cured | 0 skipped | 1 narrowed out by the scope gate" in m
+        for m in messages
+    ), messages


### PR DESCRIPTION
## What

Second narrow mode for `kbli_documents_cure.py`, twin of `--pma-only` (#5489): **`--licensing-only`** syncs ONLY the PP 28/2025 licensing tuple inside `kbli_documents.metadata` — `per_skala`, `pp28_sources`, `licensing_status` — from the canonical dataset, through the same server-side jsonb merge (`CASE WHEN jsonb_typeof(metadata)='object' … END || $2::text::jsonb`). `judul`, `content` and every other metadata key (the PMA tuple included) stay byte-identical.

## Why

The conformance detector's `licensing presence disagrees` class holds **25 codes on prod** (2026-09-01): `03231 03232 03233 56400 62900 65111 65121 74192 85102 85510 85520 85571 85572 85573 85574 85575 85579 85693 85694 90200 90310 91122 96230 96300 96400`. Measured this evening (read-only probe via `scripts/pg.sh`): every one is a hand-written row (257–1,124 chars of prose) whose metadata is a jsonb object with `per_skala: []` present, `licensing_status: "N/A"`, a seed-era `pp28_sources` array — while canonical holds real PP 28/2025 rows. The full rebuild dry-run (`--only <25>`, pinned dataset) reported **"25 of 25 selected row(s) carry hand-written prose this run will OVERWRITE"** (rebuilt documents up to 20,223 chars) — exactly what the content-preservation gate exists to refuse, and what `--only` only warns about. Since v34 the channel never injects `content`. **Grounded against origin/main during this PR (corrected before arming):** `chat_kbli`'s direct path selects `judul, metadata` and reads ONLY the PMA tuple off it (`_pma_disclosure_fields`, `kbli_notebook_chat.py:1103-1119`); `per_skala` / `licensing_status` / `pp28_sources` reach a client from the canonical file, the Qdrant point text (`sanitize_kbli_search_result`, `kbli_pma_disclosure.py:183-254`) and `kg_nodes` (`inspect_kbli`) — **never from `kbli_documents`**. So this cure buys table↔canonical agreement (the detector class closes; any future reader finds government rows instead of `[]`) and does NOT, by itself, change what a client is told about licensing. The docstrings say exactly that. Live probe during this PR: `inspect_kbli 85510` (KG) answers `licensing_status: PENDING_REGULATION`, `licenses: []` while canonical holds PP 28 rows — the client-facing exposure of the 25 is in KG/Qdrant and is being mapped as its own lane (ledger row).

## Design (mirrors `--pma-only`, three deliberate choices)

- **One derivation, two paths (W105):** `licensing_metadata_from_canonical()` is now what `build_cured_metadata` itself uses for the three keys, so the narrow sync can never disagree with the full rebuild. `licensing_status` therefore follows the rebuild's existing rule: `PENDING_REGULATION` on an empty set, otherwise **carried over** (`N/A` stays) — this script has never asserted that field and the narrow mode inherits the restraint.
- **One direction only:** a code whose canonical `per_skala` is empty is **REFUSED** (named SKIP, no snapshot, no write), never emptied — a table row-set canonical has detached is the `--all-quarantined` class (fabricated prose, archived + rebuilt there). Same asymmetry `licensing_absent_codes` already asserts.
- **Scope discipline:** requires `--only`; refuses every `--all-*` selector and `--pma-only` (two tuples, two cure runs). The apply path now dispatches on `DocumentCurePlan.partial_keys` (PMA keys / licensing keys / `None` = full rebuild); the PMA branch is unchanged and re-pinned by a new innocence test.

Type-strict comparison (`_json_differs`) as in `--pma-only`; the log line shows row COUNTS (`per_skala: <0 rows> -> <2 rows>`), never the blob.

## Tests

19 new in `test_kbli_documents_cure.py` (+14 from the two refuter rounds) — **149 passed** locally (`ruff` clean): guilt (tuple and nothing else, PMA tuple untouched even when canonical disagrees), parity with `build_cured_metadata`, row-content-vs-row-count staleness, one-direction refusal (detached / both-empty / missing key), idempotence, missing canonical/table, delta rendering, parser (requires `--only`, refuses each sweep, refuses both narrow modes), `licensing_metadata_patch` binds exactly three keys, and three `main()`-level drives with the UPDATE spy: apply binds the CASE-merge with exactly `{per_skala, pp28_sources, licensing_status}` and never `judul`/`content` (+ archive keyed by `--cure-run`, no gate line, no OVERWRITE warning), dry-run binds nothing, detached-code apply binds nothing; plus the PMA branch still binds exactly the seven PMA keys after the generalisation.

## Ship / prove-live plan (session-owned)

Merge = deploy (`fly-deploy.yml` on `apps/backend-rag/**`; no migration in this PR). Then, from Pro, inside the Fly container with the pinned dataset blob: dry-run `--licensing-only --only <25>` → read the 25 delta lines → `--apply --cure-run kbli_cure:2026-09-01-licensing-only` → md5(judul)/md5(content) of the 25 rows identical to the pre-apply baseline (`pre_apply_licensing_rows_20260901.txt`) → second run = 25 × "already cured" → detector re-run on Pro.

**Bites:** the conformance detector (`scripts/kbli_filiera/kbli_surface_conformance.py`, Pro) — `licensing presence disagrees` goes **25 → 0** after the apply, with `jsonb_array_length(metadata->'per_skala')` non-zero on all 25 rows and their `judul`/`content` md5 unchanged against the pre-apply baseline; a second `--apply` reports 25 × `already cured`. No runtime reader of these keys exists on this table (measured above), so no channel output is claimed to change — a claim to the contrary would be false.

## Declared, not hidden

- **Refuter round 3 (Codex sol, final): FIX-FIRST(1) — one MINOR, introduced, docs-only:** the inventory said the direct path reads "ONLY the PMA tuple"; it also reads `official_description`/`uraian` via `_official_scope` (`kbli_notebook.py:300-309`). The three sentences now name both; the licensing-tuple statement (no runtime reader) stands. The refuter re-confirmed: W97 denominator, shape refusals, narrow/full dispatch hold, named mutants killed, no surviving implementation mutant. The sibling wording in `build_cured_metadata`'s docstring predates this PR → ledger. **Three rounds closed; armed.**
- **Refuter round 2 (Codex sol): FIX-FIRST(3) → folded in `507086f193`, independently re-verified (149 passed):** the round-1 `N of M` summary lost its denominator under the `--all-*` gates (they narrow `codes` before plans are built) — now captured pre-gate and stated as `N of M asked cured | skipped | narrowed out by the scope gate`, driven through `main()` under `--all-machine-template`; the shape guard now also refuses lists with non-object entries and files falsey non-lists as shape defects; four pre-existing present-tense "injects `content` verbatim" sentences now read "until v34". Round 3 is the last (rule 8).
- **Refuter round 1 (Codex sol, refute stance): BLOCKED(1)/2 MAJOR/3 MINOR → folded.** The BLOCKER was the consumer claim above (cured before the verdict landed); MAJOR 3a (shape guard) + MINOR 5/6 cured with tests (141 passed); MAJOR 2 (`licensing_status` carried over as `N/A` beside real rows), MAJOR 3b (`pp28_sources` written verbatim — canonical has `[]` on 21 of the 25, so the seed-era array is replaced by `[]`; the archive keeps it) and MINOR 4 (archive round-trip) are INHERITED from `build_cured_metadata`/`archive_params` and declared in the docstrings, not changed (rule 8: cure what the diff introduces, spec what it inherits).
- **The client-facing licensing defect of these 25 is in the KG, not this table** (measured 2026-09-01, read-only): 22 of 25 `kbli:<code>` nodes serve `licensing_status: PENDING_REGULATION` with 0–1 `REQUIRES` edges while canonical holds 3–52 PP 28 rows each; only 03231/03232/03233 are `REGULATED` (6/8/9 edges vs 20/8/4 rows). No existing KG cure covers the class — `kg_kbli_license_fix.py` runs the opposite direction (canonical `per_skala == []`), `kg_kbli_resync.py` leaves `licensing_status` untouched by its own docstring. Ledgered as its own lane (spec first: what builds `REQUIRES` edges from `per_skala`, and the cross-store verdict convention).
- `kg_nodes` carries three entity-id spellings per code (`kbli:<code>` real; `kbli_<code>`, `kbli_kbli_<code>` empty duplicates) — noted, out of scope.
- `archive_params` still round-trips the pre-cure metadata through Python `json.dumps` (inherited debt, ledgered on #5489 — unchanged here).
- The 25 codes are named by hand from the detector JSON (`--only`), the same way #5489 did — the `--all-licensing-absent` selector needs the repo-side detector, which the Fly image does not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jne5CZvgNcjcy2D3hFYmE
