### PR TITLE
fix(ci): align every codeql-action step to v4.37.9

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -649,7 +649,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.RUN_THIS_LANGUAGE == 'true'
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -657,11 +657,11 @@ jobs:
 
       - name: Autobuild
         if: env.RUN_THIS_LANGUAGE == 'true'
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       - name: Perform CodeQL Analysis
         if: env.RUN_THIS_LANGUAGE == 'true'
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{matrix.language}}"
 


### PR DESCRIPTION
## What

`security.yml` carries **two versions of one action family**. #5442 moved the two
`upload-sarif` steps to `v4.37.9`; `init`, `autobuild` and `analyze` stayed at `v4.37.7`.
This moves the remaining three, bringing all five to one version.

| step | before | after |
|---|---|---|
| `upload-sarif` ×2 | v4.37.9 | v4.37.9 (untouched) |
| `init` | v4.37.7 | **v4.37.9** |
| `autobuild` | v4.37.7 | **v4.37.9** |
| `analyze` | v4.37.7 | **v4.37.9** |

## Why now

The mixed state is functional — `upload-sarif` runs after analysis and reads none of the
config `init` writes, which is why #5442 was green. But it is the state Dependabot cannot
escape: it proposes each action path as a separate PR, so **#5444** (which moves `autobuild`
alone) is red right now with

```
We were unable to automatically build your code.
Loaded a configuration file for version '4.37.7', but running version '4.37.9'
```

`init` writes the config `autobuild` reads — they must move together. This PR supersedes
**#5444**, which should be closed once this lands.

Worth recording how #5444 was found: it sat `BLOCKED` for two days with **zero failing
checks**, because four of its workflows were cancelled before any job started and no
check-run object was ever created. The block and the breakage were both invisible.

## SHA provenance

Both tags are **annotated**, so the commit is one dereference past the ref — reading
`.object.sha` off the tag ref yields the tag object, not the code:

```
v4.37.7 -> tag faaa5d804fc648d0fdb28822a8e36cf7d0a6132c -> commit ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd
v4.37.9 -> tag a35ac6e6798d72df5475948b28efb89edc2e19ca -> commit cdf488f595d80d6e07e03d4674febd5ab45fa938
```

Verified against `github/codeql-action`'s own tags, not taken from Dependabot's diff.
Each line keeps its existing pin style (SHA+comment here, bare tag on the `upload-sarif`
pair); only the version moves.

## Bites

**Consumer: `CodeQL Analysis (python)` and `CodeQL Analysis (javascript)`, running on this
PR.** Both fail today on #5444 with the version-mismatch error above. They must come back
green here — the workflow this diff edits is the workflow that proves it.

## Floor

Gear 1 by the path-term exemption merged in #5499 (first-party pin bump, all refs pinned,
minus and plus identical in sequence). Measured locally on this exact diff: floor **3**
without the exemption, **1** with it.