### PR TITLE
ci(dependabot): group the three codeql-action steps — they are one contract

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -170,3 +170,23 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      # The three github/codeql-action/* steps are ONE contract, not three
+      # dependencies: `init` writes the CodeQL config that `autobuild` reads,
+      # and `analyze` consumes what autobuild produced. Ungrouped, Dependabot
+      # opens a separate PR per step, so the refs diverge the moment one lands
+      # without the others — security.yml then runs init at one version and
+      # autobuild at another. That happened: PR #5444 carried only the
+      # `autobuild` half of 4.37.7 -> 4.37.9, and its CodeQL jobs failed for
+      # exactly that reason (cured out-of-band by PR #5517, which moved all
+      # three refs in one commit; #5444 was closed as superseded).
+      #
+      # Deliberately NARROW. A catch-all group over this whole ecosystem would
+      # be a poison-batch risk: one bad action bump would block every other
+      # action update behind it, with no way to merge the innocent ones
+      # separately. That is the same reasoning the `openai-stack` comment
+      # records for pip above, and it is why this groups a single coupled
+      # family rather than "all github-actions minor+patch".
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"


### PR DESCRIPTION
## What

The `github-actions` ecosystem block in `.github/dependabot.yml` carried **no
`groups:` at all** (pip and npm both have them — this ecosystem was the gap). So
Dependabot opens one PR per action step, including one per `github/codeql-action/*`
step.

Those three are **one contract, not three dependencies**: `init` writes the CodeQL
config that `autobuild` reads, and `analyze` consumes what autobuild produced. The
refs diverge the instant one lands without the others.

## Why now

Not hypothetical. **#5444** carried only the `autobuild` half of 4.37.7 → 4.37.9.
Its CodeQL jobs failed for exactly that reason — and the failure stayed invisible
for two days behind a separate defect (a concurrency group that cancelled its runs
before any job started, removed in #5519). Cured out-of-band by **#5517**, which
moved all three refs in one commit; #5444 is closed as superseded.

## Deliberately narrow

One coupled family, **not** a catch-all over the ecosystem. A group spanning all
`github-actions` updates would be a poison-batch risk: one bad action bump holds
every innocent update behind it, with no way to merge them separately.

This is not a new insight — it is already this file's own doctrine in another
ecosystem. The `openai-stack` group's comment records it verbatim: *"a breaking
bump ... only fails a small, individually-mergeable PR instead of the whole batch
(see closed PR #935: 60-pkg group failed 4 required checks as a unit)"*. This PR
applies that lesson to the one ecosystem that had no grouping at all.

## What this does not do

It does **not** reduce Dependabot's alerting surface. Grouping changes how many PRs
carry the same updates, never which vulnerabilities are reported. (Relevant because
"just disable Dependabot" was on the table tonight: the repo's default branch
currently reports 1 high + 2 moderate vulnerabilities, and this config is the only
thing watching for them.)

## Bites

**Consumer:** Dependabot's own config parser, which reads this file on push.

**Observable now:** the file resolves under the schema Dependabot enforces —
`yaml.safe_load` gives the `github-actions` entry
`groups: {codeql-action: {patterns: ["github/codeql-action*"]}}` — and GitHub
reports no configuration error against it.

**Stated plainly rather than overclaimed:** the *behavioural* proof — three refs
arriving in a single PR — cannot be observed until the next `codeql-action`
release, and is not claimed here. All three refs are currently aligned at v4.37.9,
so there is nothing pending for it to group today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
