### PR TITLE
fix(garuda-voa): the failure page is not the failed state — expire the pending credential

### DIFF
--- a/apps/mouth/src/app/visa/voa/auth/contract.ts
+++ b/apps/mouth/src/app/visa/voa/auth/contract.ts
@@ -75,6 +75,31 @@ export const PENDING_COOKIE_MAX_AGE_SECONDS = 600;
  */
 export const PENDING_COOKIE_PATH = "/visa/voa/auth";
 
+/**
+ * Clears the pending cookie. Same Path, or the browser keeps the old one.
+ *
+ * Lives HERE, not in `exchange/route.ts` where it was born, because BOTH
+ * routes out of the landing GET have to emit it and only one of them did.
+ * The landing GET's `!usable` branch returned the failure redirect with no
+ * cookie argument at all, so a malformed second link left an ALREADY-LIVE
+ * pending credential from a previous good link usable for the rest of its
+ * `PENDING_COOKIE_MAX_AGE_SECONDS` — from another tab, or a direct
+ * same-origin POST — while the customer was looking at a failure page.
+ * Bounded by that Max-Age and the token's own server-side TTL, which is why
+ * it was ledgered LOW rather than fixed in the PR that found it; it is fixed
+ * here because the funnel is about to stop being dark.
+ */
+export function expirePending(secure: boolean): string {
+  return [
+    `${PENDING_COOKIE}=`,
+    "HttpOnly",
+    `Path=${PENDING_COOKIE_PATH}`,
+    "Max-Age=0",
+    "SameSite=Lax",
+    ...(secure ? ["Secure"] : []),
+  ].join("; ");
+}
+
 /** The account cookie the backend mints; this flow forwards it verbatim. */
 export const ACCOUNT_COOKIE_PREFIX = "garuda_session=";
 

--- a/apps/mouth/src/app/visa/voa/auth/exchange/route.ts
+++ b/apps/mouth/src/app/visa/voa/auth/exchange/route.ts
@@ -4,8 +4,8 @@ import { logger } from "@/lib/logger";
 import {
   FAILURE_LOCATION,
   PENDING_COOKIE,
-  PENDING_COOKIE_PATH,
   decodePending,
+  expirePending,
   hasAccountSession,
   isLoopback,
 } from "../contract";
@@ -49,18 +49,6 @@ import {
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-/** Clears the pending cookie. Same Path, or the browser keeps the old one. */
-function expirePending(secure: boolean): string {
-  return [
-    `${PENDING_COOKIE}=`,
-    "HttpOnly",
-    `Path=${PENDING_COOKIE_PATH}`,
-    "Max-Age=0",
-    "SameSite=Lax",
-    ...(secure ? ["Secure"] : []),
-  ].join("; ");
-}
 
 function seeOther(location: string, cookies: string[]): Response {
   const headers = new Headers({

--- a/apps/mouth/src/app/visa/voa/auth/route.test.ts
+++ b/apps/mouth/src/app/visa/voa/auth/route.test.ts
@@ -147,12 +147,47 @@ describe("GET /visa/voa/auth", () => {
     ["no parameters at all", ""],
     ["token only", `?magic_token=${TOKEN}`],
     ["result_id only", `?result_id=${RESULT_ID}`],
-  ])("rejects %s and sets no pending cookie", async (_label, query) => {
-    const { GET } = await import("./route");
-    const res = await GET(makeGet(query));
+  ])(
+    "rejects %s and EXPIRES any pending cookie instead of leaving it live",
+    async (_label, query) => {
+      const { GET } = await import("./route");
+      const res = await GET(makeGet(query));
 
-    expect(res.headers.get("location")).toBe(FAILURE);
-    expect(pendingCookie(res)).toBeUndefined();
-    expect(res.headers.get("location")).not.toContain(TOKEN);
+      expect(res.headers.get("location")).toBe(FAILURE);
+      expect(res.headers.get("location")).not.toContain(TOKEN);
+
+      // This assertion used to read `toBeUndefined()`, i.e. "no cookie at
+      // all". That was WEAKER than it looked: emitting nothing leaves a
+      // pending credential from a PREVIOUS good link alive in the browser
+      // for the rest of its Max-Age, redeemable from another tab while the
+      // customer is looking at the failure page. What has to be true is not
+      // "this response sets no cookie" but "no live pending credential
+      // survives this response" — so the expiry is now required, and its
+      // shape is pinned.
+      const cookie = pendingCookie(res);
+      expect(cookie).toBeDefined();
+      expect(cookie).toContain("Max-Age=0");
+      // Empty VALUE, not merely the right name: `garuda_magic_pending=x` with
+      // Max-Age=0 would still be a cookie carrying something.
+      expect(cookie?.startsWith(`${PENDING_COOKIE}=;`)).toBe(true);
+      // Same Path as the one that was set, or the browser keeps the old one
+      // and the "expiry" clears nothing.
+      expect(cookie).toContain("Path=/visa/voa/auth");
+      expect(cookie).not.toContain(TOKEN);
+    },
+  );
+
+  // INNOCENCE CONTROL for the guilt case above: the expiry must fire only on
+  // the failure branch. Without this, deleting the `usable` test entirely —
+  // and expiring the cookie unconditionally — would leave every guilt
+  // assertion green while breaking the whole flow.
+  it("does NOT expire the pending cookie on a well-formed link", async () => {
+    const { GET } = await import("./route");
+    const res = await GET(makeGet());
+
+    const cookie = pendingCookie(res);
+    expect(cookie).toBeDefined();
+    expect(cookie).not.toContain("Max-Age=0");
+    expect(cookie).toContain(`Max-Age=600`);
   });
 });

--- a/apps/mouth/src/app/visa/voa/auth/route.ts
+++ b/apps/mouth/src/app/visa/voa/auth/route.ts
@@ -9,6 +9,7 @@ import {
   TOKEN_MAX_LENGTH,
   TOKEN_MIN_LENGTH,
   encodePending,
+  expirePending,
   isLoopback,
 } from "./contract";
 
@@ -91,7 +92,11 @@ export async function GET(request: NextRequest): Promise<Response> {
     RESULT_ID_PATTERN.test(resultId);
 
   if (!usable) {
-    return seeOther(FAILURE_LOCATION);
+    // Clear any pending credential a PREVIOUS good link left behind. Without
+    // this the customer sees a failure page while link A stays redeemable
+    // from another tab for the rest of its Max-Age — the failure page is not
+    // the same thing as the failed state.
+    return seeOther(FAILURE_LOCATION, expirePending(!isLoopback(url.hostname)));
   }
 
   const cookie = [


### PR DESCRIPTION
## What

The GARUDA VOA magic-link landing GET (`apps/mouth/src/app/visa/voa/auth/route.ts:93`) returned its failure redirect with **no cookie argument**, so a malformed second link left an **already-live pending credential** from a previous good link redeemable for the rest of its 600s `Max-Age` — from another tab, or a direct same-origin POST — while the customer looked at a failure page.

Ledgered LOW on 2026-08-29 and deliberately *not* fixed in the PR that found it: PR #5196 was carrying a "no production code path differs from the version already measured sound" guarantee, and trading that for a small hardening was the wrong call at the time. It is fixed here because **the funnel is about to stop being dark**, and this is one of the three conditions the ledger names as blocking the `GARUDA_PUBLIC_ENABLED` flip.

## How

`expirePending` moves from `exchange/route.ts`, where it was private, into the shared `contract.ts` — the module whose own docstring says these constants live in one place because duplicating them "is a drift the next edit pays for". Both routes out of the landing now emit it.

## The test change is a strengthening, not an accommodation

The existing guilt test asserted `pendingCookie(res)` was `undefined`. That was **weaker than it read**: *"this response sets no cookie"* is not *"no live credential survives this response"* — emitting nothing is exactly the defect. The assertion now requires the expiry and pins its shape: empty value, `Max-Age=0`, and the **matching `Path`** (a different Path expires nothing and the browser keeps the old cookie).

Added an **innocence control** so a mutation that expires the cookie *unconditionally* — which would break the entire flow — cannot keep the guilt cases green.

## Bites

**Consumer:** `apps/mouth/src/app/visa/voa/auth/route.ts:93`, the landing GET's `!usable` branch.

**Observation:** reverting the `expirePending(...)` argument turns **6 of the 15** tests in `route.test.ts` RED. The mutation was verified non-inert by `diff` before trusting the result (W121 discipline). Restored: **61/61 pass** across `src/app/visa/voa/auth/`.

Frontend-only (`apps/mouth/**`) — this does not touch `apps/backend-rag/**` and therefore triggers no Fly deploy.