### PR TITLE
feat(evidence): journal a council seat at dispatch, because it cannot be journaled after

### DIFF
--- a/scripts/council_journal.py
+++ b/scripts/council_journal.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""council_journal.py — record a council seat AT DISPATCH, because it cannot be recorded
+afterwards without inventing a timestamp.
+
+WHY THIS EXISTS (measured 2026-09-02 while shipping PR #5519). R9
+(`scripts/evidence_pack_lint.py::check_council_run_gear3`) counts a journal line only when it
+carries `role == "review"` AND `ok is True` AND a non-empty `ts` —
+`_read_council_journal_seats` `continue`s on anything else, its own comment saying "the declared
+minimal schema requires 'ts' too". A qualifying line is therefore UNWRITEABLE without a
+timestamp, and after the fact the only timestamp available is one you make up.
+
+That is not hypothetical. On #5519 the two seats that really did review the diff appeared in
+`lanes[]` and in `dissent[]` with their actual objections, but in no journal — and the only
+dispatch line on disk named a DIFFERENT roster, so reusing its timestamp would have asserted
+those seats took part in a dispatch that the line itself says they did not. There was no honest
+journal left to write, so that pack declared `seat_override` instead. An override is legitimate
+once; it should not become how this repo passes R9.
+
+Twenty-five `council-journal.jsonl` files already exist under `evidence/2026-08/`, all
+hand-authored, with no tool and no documented procedure anywhere in `docs/`, `.claude/skills/`
+or `research/`. So the gap this fills is not "nobody journals" — it is that journaling correctly
+depends entirely on remembering, at the right moment, a schema written down only inside the
+linter that reads it. This makes the honest path the easy one.
+
+WHAT IT DELIBERATELY WILL NOT DO:
+
+  * It will not backdate. `ts` is always `datetime.now(timezone.utc)` at the moment of the call.
+    There is no `--ts` flag, on purpose: a flag that accepts a timestamp is a flag that accepts
+    an invented one, and inventing it is the exact failure this file exists to prevent.
+  * It will not write `ok: true` without a `--note`. A qualifying line CLAIMS a seat returned a
+    judgement; a claim with nothing behind it is the "receipt without a command" shape the
+    evidence-pack contract already rejects.
+  * It will not reimplement R9. `check` imports the real `check_council_run_gear3` and reports
+    what THAT says, inheriting its path confinement and seat validation. A second copy of a rule
+    is a second rule, and the two drift.
+  * It will not write outside the pack directory, nor onto `pack.yml` / `brief.yml` — mirroring
+    the confinement `scripts/ci/stage_council_journal.py` enforces on the CI side.
+
+A seat that times out or refuses is recorded with `--outcome non-judgement`. That line does NOT
+count toward quorum (R9 requires `ok is True`) and is not meant to — a silence is not an
+agreement. Recording it still matters: it is the difference between "this seat was never asked"
+and "this seat was asked and could not answer", which is precisely what a later reader needs in
+order to judge whether a `seat_override` is honest.
+
+Usage:
+    python3 scripts/council_journal.py append \\
+        --pack-dir evidence/2026-09/<task-slug>-<8hex> \\
+        --seat codex-gpt-5.6-sol --outcome ok \\
+        --note "one round on the finished diff, --sandbox read-only, effort=high"
+
+    python3 scripts/council_journal.py check --pack-dir evidence/2026-09/<task-slug>-<8hex>
+
+Exit codes:
+    append: 0 = written; 2 = refused (unknown seat is a NOTE not a refusal; refusals are a
+            missing note on `ok`, a path escape, a reserved name, or a missing pack dir)
+    check:  0 = R9 satisfied on and after its enforcement date (or pack is not Gear-3);
+            1 = R9 would fail on/after that date; 2 = could not evaluate
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+#: The filename every one of the 25 existing journals uses. Matching it is not cosmetic: a pack
+#: declares `council_run: council-journal.jsonl` as a bare relative name, and a different
+#: filename here would silently produce a journal R9 never looks at.
+DEFAULT_JOURNAL_NAME = "council-journal.jsonl"
+
+#: Names harness-floor.yml stages the pack and brief under. A journal must never land on one.
+RESERVED_NAMES = frozenset({"pack.yml", "brief.yml"})
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_lint_module() -> Any:
+    """Import evidence_pack_lint without requiring it on sys.path.
+
+    Deliberately imports the REAL module rather than copying its constants: COUNCIL_REVIEW_SEATS
+    is a moving list — `kimi-code/k3` was quota-dead for a whole week on 2026-09-01 — and a local
+    copy would keep validating against a roster that no longer matches the rule.
+    """
+    path = _REPO_ROOT / "scripts" / "evidence_pack_lint.py"
+    spec = importlib.util.spec_from_file_location("_council_journal_lint", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - import plumbing
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _resolve_journal(pack_dir: Path, name: str) -> tuple[Path | None, str | None]:
+    """Resolve `name` inside `pack_dir`, refusing escapes and reserved names.
+
+    Mirrors R9's own confinement — it resolves `council_run:` against the pack's OWN directory
+    and rejects anything leaving it — so a journal written elsewhere would be invisible to the
+    very rule meant to read it.
+    """
+    if not name or not name.strip():
+        return None, "journal name is empty"
+    if Path(name).is_absolute() or name.startswith("//"):
+        return None, f"journal name {name!r} must be relative to the pack dir, not absolute"
+    if Path(name).name in RESERVED_NAMES:
+        return None, f"journal name {name!r} would collide with a staged {Path(name).name}"
+    pack_resolved = pack_dir.resolve()
+    journal = (pack_resolved / name).resolve()
+    if pack_resolved not in (journal, *journal.parents):
+        return None, f"journal name {name!r} escapes the pack directory"
+    return journal, None
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    pack_dir = Path(args.pack_dir)
+    if not pack_dir.is_dir():
+        print(f"council_journal: {pack_dir} is not a directory", file=sys.stderr)
+        return 2
+
+    seat = args.seat.strip()
+    if not seat:
+        print("council_journal: --seat is empty", file=sys.stderr)
+        return 2
+
+    ok = args.outcome == "ok"
+    if ok and not (args.note and args.note.strip()):
+        print(
+            "council_journal: --outcome ok requires --note. A qualifying line asserts this seat "
+            "returned a judgement; record what it said, or use --outcome non-judgement.",
+            file=sys.stderr,
+        )
+        return 2
+
+    journal, err = _resolve_journal(pack_dir, args.journal)
+    if journal is None:
+        print(f"council_journal: {err}", file=sys.stderr)
+        return 2
+
+    # Field order matches every existing journal in the tree: seat, role, ok, ts, then extras.
+    entry: dict[str, Any] = {
+        "seat": seat,
+        "role": "review",
+        "ok": ok,
+        # Never a parameter — see the module docstring.
+        "ts": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if args.note and args.note.strip():
+        entry["note"] = args.note.strip()
+
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    with journal.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    print(f"council_journal: appended seat={seat} ok={ok} ts={entry['ts']} -> {journal}")
+
+    if ok:
+        qualifying = set(getattr(_load_lint_module(), "COUNCIL_REVIEW_SEATS", ()))
+        if seat not in qualifying:
+            # A NOTE, not a refusal: a council may legitimately include seats R9 does not count
+            # (agy/Gemini gave the single most plan-changing objection on #5519). Recording them
+            # is right; letting the author believe they counted toward quorum is not.
+            print(
+                f"council_journal: NOTE — {seat!r} is not one of R9's qualifying seats "
+                f"({', '.join(sorted(qualifying))}), so this line is recorded but does NOT "
+                "count toward quorum.",
+            )
+
+    rel = journal.relative_to(pack_dir.resolve())
+    print(f"council_journal: the pack must declare  council_run: {rel}")
+    return 0
+
+
+def _resolve_gear(pack: dict[str, Any], pack_dir: Path) -> tuple[int | None, str]:
+    """Find the pack's gear, looking in the SIBLING BRIEF when the pack does not carry it.
+
+    Measured 2026-09-02 across the 40 real evidence packs in this tree: **zero** declare `gear`
+    in `pack.yml`; 37 declare it only in the sibling `brief.yml`, and 3 in neither. A checker
+    that reads `pack.yml` alone therefore answers "not Gear-3, nothing to check" on every real
+    pack in the repo — green on everything, which is worse than no checker at all. (`pack.yml`'s
+    `brief_ref:` is the CI-staging literal `evidence/brief.yml`, not a path to the real sibling,
+    so it cannot be followed from here; the sibling is found by name.)
+    """
+    if isinstance(pack.get("gear"), int):
+        return pack["gear"], "pack.yml"
+
+    import yaml
+
+    brief = pack_dir / "brief.yml"
+    if brief.is_file():
+        try:
+            data = yaml.safe_load(brief.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            return None, "brief.yml (unparseable)"
+        if isinstance(data, dict) and isinstance(data.get("gear"), int):
+            return data["gear"], "brief.yml"
+    return None, "nowhere"
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    import yaml  # local import so `append` still works where PyYAML is absent
+
+    pack_dir = Path(args.pack_dir)
+    pack_path = pack_dir / "pack.yml"
+    if not pack_path.is_file():
+        print(f"council_journal: no pack.yml under {pack_dir}", file=sys.stderr)
+        return 2
+    try:
+        pack = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        print(f"council_journal: {pack_path} does not parse: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(pack, dict):
+        print(f"council_journal: {pack_path} did not parse to a mapping", file=sys.stderr)
+        return 2
+
+    gear, gear_src = _resolve_gear(pack, pack_dir)
+    if gear is None:
+        # NEVER a silent pass. "I could not find the gear" and "this is not Gear-3" are different
+        # answers, and collapsing them is how a checker reports green on everything.
+        print(
+            f"council_journal: cannot determine gear — absent from {pack_dir/'pack.yml'} and from "
+            f"the sibling brief.yml. Refusing to report a verdict rather than assume not-Gear-3.",
+            file=sys.stderr,
+        )
+        return 2
+    if gear != 3:
+        print(f"council_journal: gear={gear!r} (from {gear_src}) — R9 is Gear-3 only, nothing to check")
+        return 0
+
+    lint = _load_lint_module()
+    flip: datetime.date = getattr(lint, "R9_R11_ENFORCEMENT_DATE")
+    before = flip - datetime.timedelta(days=1)
+
+    # Asked on BOTH sides of its own enforcement date. Reporting only today's verdict is exactly
+    # how a pack sails into a dated cliff: before the flip R9 is a NOTICE, after it the identical
+    # finding fails a required check.
+    results: dict[str, tuple[list[str], str | None]] = {}
+    for label, day in (("before", before), ("on/after", flip)):
+        violations, notice = lint.check_council_run_gear3(
+            pack, pack_dir=pack_dir, gear=3, today=day
+        )
+        results[label] = (list(violations or []), notice)
+
+    if pack.get("seat_override"):
+        print("council_journal: pack declares seat_override — R9 is reported, never failed.")
+    print(f"council_journal: council_run = {pack.get('council_run')!r}")
+    for label, day in (("before", before), ("on/after", flip)):
+        violations, notice = results[label]
+        if violations:
+            state = f"VIOLATION — {violations[0]}"
+        elif notice:
+            state = f"notice — {notice}"
+        else:
+            state = "OK"
+        print(f"  {label} the flip ({day.isoformat()}): {state}")
+
+    return 1 if results["on/after"][0] else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Record a council seat at dispatch; check R9 quorum using the real rule."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    ap = sub.add_parser("append", help="append one seat's outcome, stamped with the real clock")
+    ap.add_argument("--pack-dir", required=True)
+    ap.add_argument("--seat", required=True)
+    ap.add_argument("--outcome", required=True, choices=("ok", "non-judgement"))
+    ap.add_argument("--note", default="", help="what the seat returned; required for --outcome ok")
+    ap.add_argument("--journal", default=DEFAULT_JOURNAL_NAME)
+    ap.set_defaults(func=cmd_append)
+
+    cp = sub.add_parser(
+        "check", help="report what R9 says about this pack, before and after its flip date"
+    )
+    cp.add_argument("--pack-dir", required=True)
+    cp.set_defaults(func=cmd_check)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_council_journal.py
+++ b/scripts/tests/test_council_journal.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tests for scripts/council_journal.py.
+
+Every guard here is exercised for GUILT and INNOCENCE. The load-bearing pair is the one about
+backdating: the innocence test proves a written line is accepted by the REAL R9 reader, and the
+guilt test proves there is no door through which a timestamp can be supplied. If a future change
+adds a `--ts` flag "for tests", `test_no_backdating_door_exists` goes red — which is the whole
+point, because the reason this script exists is that a qualifying journal line cannot be written
+after the fact without inventing one.
+
+The quorum assertions never reimplement R9. They import `check_council_run_gear3` and
+`_read_council_journal_seats` from `scripts/evidence_pack_lint.py` and assert on what THOSE
+return, so a change to the rule surfaces here instead of drifting past a private copy.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cj = _load("_cj_under_test", "council_journal.py")
+lint = _load("_cj_lint", "evidence_pack_lint.py")
+
+QUALIFYING = list(lint.COUNCIL_REVIEW_SEATS)
+FLIP = lint.R9_R11_ENFORCEMENT_DATE
+
+
+def _pack_dir(tmp_path: Path, *, gear: int | None = 3, council_run: str | None = None,
+              seat_override: str | None = None, gear_in: str = "pack") -> Path:
+    """Build a pack dir. `gear_in` selects where the gear is declared.
+
+    `gear_in="brief"` is the shape EVERY real pack in this repo uses (measured 2026-09-02:
+    0 of 40 declare gear in pack.yml, 37 declare it only in the sibling brief). `gear_in="pack"`
+    is the shape the tool was first written against. Both must work.
+    """
+    import yaml
+
+    d = tmp_path / "evidence" / "2026-09" / "task-slug-deadbeef"
+    d.mkdir(parents=True)
+    pack: dict = {"brief_ref": "evidence/brief.yml"}
+    brief: dict = {"task": "a test pack"}
+    if gear is not None:
+        (pack if gear_in == "pack" else brief)["gear"] = gear
+    if council_run is not None:
+        pack["council_run"] = council_run
+    if seat_override is not None:
+        pack["seat_override"] = seat_override
+    (d / "pack.yml").write_text(yaml.safe_dump(pack, sort_keys=False), encoding="utf-8")
+    (d / "brief.yml").write_text(yaml.safe_dump(brief, sort_keys=False), encoding="utf-8")
+    return d
+
+
+def _append(pack_dir: Path, seat: str, outcome: str = "ok", note: str = "said a thing",
+            journal: str | None = None) -> int:
+    argv = ["append", "--pack-dir", str(pack_dir), "--seat", seat, "--outcome", outcome]
+    if note:
+        argv += ["--note", note]
+    if journal is not None:
+        argv += ["--journal", journal]
+    return cj.main(argv)
+
+
+# --------------------------------------------------------------------------- INNOCENCE
+
+
+def test_a_written_line_is_accepted_by_the_real_r9_reader(tmp_path: Path) -> None:
+    """INNOCENCE: what this script writes is what R9 counts — asserted through R9's own reader."""
+    d = _pack_dir(tmp_path)
+    assert _append(d, QUALIFYING[0]) == 0
+    seats = lint._read_council_journal_seats(d, cj.DEFAULT_JOURNAL_NAME)
+    assert seats == {QUALIFYING[0]}
+
+
+def test_two_qualifying_seats_satisfy_r9_after_the_flip(tmp_path: Path) -> None:
+    """INNOCENCE: quorum reached -> no violation even on/after the enforcement date."""
+    d = _pack_dir(tmp_path, council_run=cj.DEFAULT_JOURNAL_NAME)
+    assert _append(d, QUALIFYING[0]) == 0
+    assert _append(d, QUALIFYING[1]) == 0
+    import yaml
+
+    pack = yaml.safe_load((d / "pack.yml").read_text(encoding="utf-8"))
+    violations, _ = lint.check_council_run_gear3(pack, pack_dir=d, gear=3, today=FLIP)
+    assert violations == []
+
+
+def test_written_timestamp_is_now_and_parses(tmp_path: Path) -> None:
+    """INNOCENCE: `ts` is a real, current, parseable UTC stamp — not a placeholder."""
+    d = _pack_dir(tmp_path)
+    before = datetime.datetime.now(datetime.timezone.utc)
+    assert _append(d, QUALIFYING[0]) == 0
+    after = datetime.datetime.now(datetime.timezone.utc)
+    entry = json.loads((d / cj.DEFAULT_JOURNAL_NAME).read_text(encoding="utf-8").strip())
+    stamped = datetime.datetime.strptime(entry["ts"], "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=datetime.timezone.utc
+    )
+    # one second of slack each way: the script truncates to whole seconds
+    assert before - datetime.timedelta(seconds=1) <= stamped <= after + datetime.timedelta(seconds=1)
+
+
+def test_line_field_order_matches_the_existing_journals(tmp_path: Path) -> None:
+    """INNOCENCE: the on-disk shape matches the 25 journals already in the tree."""
+    d = _pack_dir(tmp_path)
+    assert _append(d, QUALIFYING[0], note="a note") == 0
+    entry = json.loads((d / cj.DEFAULT_JOURNAL_NAME).read_text(encoding="utf-8").strip())
+    assert list(entry) == ["seat", "role", "ok", "ts", "note"]
+    assert entry["role"] == "review" and entry["ok"] is True
+
+
+def test_check_reports_zero_when_quorum_is_met(tmp_path: Path) -> None:
+    """INNOCENCE: `check` exits 0 once the pack genuinely satisfies R9."""
+    d = _pack_dir(tmp_path, council_run=cj.DEFAULT_JOURNAL_NAME)
+    _append(d, QUALIFYING[0])
+    _append(d, QUALIFYING[1])
+    assert cj.main(["check", "--pack-dir", str(d)]) == 0
+
+
+def test_check_is_silent_on_non_gear3_packs(tmp_path: Path) -> None:
+    """INNOCENCE: R9 is Gear-3 only; a Gear-2 pack must not be failed by this tool."""
+    d = _pack_dir(tmp_path, gear=2)
+    assert cj.main(["check", "--pack-dir", str(d)]) == 0
+
+
+# --------------------------------------------------------------------------- GUILT
+
+
+def test_no_backdating_door_exists(tmp_path: Path) -> None:
+    """GUILT: there is no way to supply a timestamp. This is the reason the script exists.
+
+    If someone adds `--ts` (even "just for tests"), this goes red on purpose.
+    """
+    d = _pack_dir(tmp_path)
+    with pytest.raises(SystemExit) as excinfo:
+        cj.main([
+            "append", "--pack-dir", str(d), "--seat", QUALIFYING[0],
+            "--outcome", "ok", "--note", "x", "--ts", "2020-01-01T00:00:00Z",
+        ])
+    assert excinfo.value.code != 0
+    assert not (d / cj.DEFAULT_JOURNAL_NAME).exists()
+
+
+def test_ok_without_a_note_is_refused_and_writes_nothing(tmp_path: Path) -> None:
+    """GUILT: a qualifying line is a claim; a claim with nothing behind it is refused."""
+    d = _pack_dir(tmp_path)
+    assert _append(d, QUALIFYING[0], note="") == 2
+    assert not (d / cj.DEFAULT_JOURNAL_NAME).exists()
+
+
+@pytest.mark.parametrize("bad", ["../escaped.jsonl", "/tmp/absolute.jsonl", "pack.yml", "brief.yml"])
+def test_journal_path_escapes_and_reserved_names_are_refused(tmp_path: Path, bad: str) -> None:
+    """GUILT: a journal outside the pack dir is invisible to R9; one over pack.yml is worse."""
+    d = _pack_dir(tmp_path)
+    assert _append(d, QUALIFYING[0], journal=bad) == 2
+    assert list(d.glob("*.jsonl")) == []
+
+
+def test_a_non_judgement_is_recorded_but_does_not_count(tmp_path: Path) -> None:
+    """GUILT: a seat that timed out must never reach quorum — silence is not agreement."""
+    d = _pack_dir(tmp_path, council_run=cj.DEFAULT_JOURNAL_NAME)
+    assert _append(d, QUALIFYING[0]) == 0
+    assert _append(d, QUALIFYING[1], outcome="non-judgement", note="TP1 timeout") == 0
+    # the line IS on disk — that is the point of recording it
+    lines = (d / cj.DEFAULT_JOURNAL_NAME).read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[1])["ok"] is False
+    # ...but it does not count toward quorum
+    assert lint._read_council_journal_seats(d, cj.DEFAULT_JOURNAL_NAME) == {QUALIFYING[0]}
+    assert cj.main(["check", "--pack-dir", str(d)]) == 1
+
+
+def test_a_single_qualifying_seat_fails_check_after_the_flip(tmp_path: Path) -> None:
+    """GUILT: one seat is not a council. `check` must say so, and exit non-zero."""
+    d = _pack_dir(tmp_path, council_run=cj.DEFAULT_JOURNAL_NAME)
+    _append(d, QUALIFYING[0])
+    assert cj.main(["check", "--pack-dir", str(d)]) == 1
+
+
+def test_unknown_seat_is_recorded_but_not_counted(tmp_path: Path, capsys) -> None:
+    """GUILT: a non-qualifying seat must not silently look like quorum.
+
+    Recording it is correct — a council may include seats R9 does not count. Letting the author
+    believe it counted is not, so the tool says so out loud.
+    """
+    d = _pack_dir(tmp_path, council_run=cj.DEFAULT_JOURNAL_NAME)
+    assert _append(d, "agy-gemini-3.1-pro", note="constructive width") == 0
+    assert "does NOT" in capsys.readouterr().out
+    assert lint._read_council_journal_seats(d, cj.DEFAULT_JOURNAL_NAME) == set()
+
+
+def test_gear_declared_only_in_the_sibling_brief_is_still_checked(tmp_path: Path) -> None:
+    """GUILT: the shape EVERY real pack uses must not read as "not Gear-3, nothing to check".
+
+    Measured 2026-09-02: 0 of 40 real packs declare `gear` in pack.yml; 37 declare it only in the
+    sibling brief. Reading pack.yml alone made this tool answer green on the entire repo — the
+    exact "instrument answered a neighbouring question" failure it exists to prevent. Without the
+    brief fallback this returns 0 (a false pass); with it, 1 (no quorum, correctly refused).
+    """
+    d = _pack_dir(tmp_path, council_run=cj.DEFAULT_JOURNAL_NAME, gear_in="brief")
+    assert "gear" not in (d / "pack.yml").read_text(encoding="utf-8")
+    assert cj.main(["check", "--pack-dir", str(d)]) == 1
+
+
+def test_gear_nowhere_refuses_instead_of_passing_silently(tmp_path: Path) -> None:
+    """GUILT: "I cannot find the gear" and "this is not Gear-3" are different answers.
+
+    Collapsing them into 0 is how a checker reports green on everything it cannot parse.
+    """
+    d = _pack_dir(tmp_path, gear=None)
+    assert cj.main(["check", "--pack-dir", str(d)]) == 2
+
+
+def test_gear_in_pack_still_wins_when_present(tmp_path: Path) -> None:
+    """INNOCENCE: the fallback must not shadow a gear the pack does declare."""
+    d = _pack_dir(tmp_path, gear=2, gear_in="pack")
+    assert cj.main(["check", "--pack-dir", str(d)]) == 0  # gear 2 -> R9 not applicable
+
+
+def test_missing_pack_dir_is_refused(tmp_path: Path) -> None:
+    """GUILT: never create a pack directory as a side effect of journaling into it."""
+    missing = tmp_path / "nope"
+    assert _append(missing, QUALIFYING[0]) == 2
+    assert not missing.exists()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## The one fact this is built on

R9 (`evidence_pack_lint.py::check_council_run_gear3`) counts a journal line only when it carries
`role == "review"` **and** `ok is True` **and a non-empty `ts`** — `_read_council_journal_seats`
`continue`s otherwise, its own comment saying *"the declared minimal schema requires 'ts' too"*.

So **a qualifying line is unwriteable without a timestamp**, and after the fact the only timestamp
available is one you invent.

## Why now

On #5519 the two seats that genuinely reviewed the diff appeared in `lanes[]` and `dissent[]` with
their real objections — but in no journal. The only dispatch line on disk named a **different**
roster, so borrowing its timestamp would have asserted those seats took part in a dispatch that the
line itself denies. There was no honest journal left to write, so that pack declared
`seat_override`.

The independent gate lane accepted the override *and then asked for exactly this*: land the tooling,
so the next Gear-3 pack satisfies R9 **by record** instead of by escape. An override is legitimate
once; it should not become how this repo passes R9.

Twenty-five journals already exist under `evidence/2026-08/`, all hand-authored, with **no tool and
no documented procedure** anywhere in `docs/`, `.claude/skills/` or `research/`. The gap is not that
nobody journals — it is that journaling correctly depends on remembering, at the right moment, a
schema written down only inside the linter that reads it.

## What it refuses to do, deliberately

| refusal | why |
|---|---|
| **No `--ts` flag** | A flag that accepts a timestamp accepts an invented one — the whole failure. `test_no_backdating_door_exists` goes red if anyone adds one "just for tests". |
| **No `ok: true` without `--note`** | A qualifying line *claims* a seat returned a judgement. A claim with nothing behind it is the "receipt without a command" shape the pack contract already rejects. |
| **No reimplementation of R9** | `check` imports the real function and reports what THAT says, inheriting its path confinement and seat validation. A second copy of a rule is a second rule. |
| **No writing outside the pack dir**, nor onto `pack.yml`/`brief.yml` | Mirrors the confinement `scripts/ci/stage_council_journal.py` enforces CI-side. A journal written elsewhere is invisible to the rule meant to read it. |

A seat that times out is recorded with `--outcome non-judgement`. It does **not** count toward
quorum — silence is not agreement — but recording it is the difference between *"never asked"* and
*"asked and could not answer"*, which is exactly what a later reader needs in order to judge whether
a `seat_override` is honest.

## A defect found by USING it, not by reading it

`check` first read `gear` from `pack.yml` alone. Measured across the 40 real packs in this tree:
**zero** declare gear there, **37** declare it only in the sibling `brief.yml`. So the tool answered
*"not Gear-3, nothing to check"* on every real pack in the repo — green on everything, which is worse
than no checker at all. Fixed with a brief fallback; and gear found in **neither** now exits 2 rather
than collapsing into a silent pass, because *"I cannot determine the gear"* and *"this is not Gear-3"*
are different answers.

## Bites

**Consumer:** the tool itself, run against the 40 real evidence packs already in this tree.

**Observation:** it discriminates rather than rubber-stamps — **16 OK, 21 missing quorum, 3
unevaluable** — and returns the same verdict the linter does on a pack with a genuine two-seat
journal (`evidence/2026-08/agent-air-m5-backend-rag-xendit-quarantine-alarm-cbc3fbd2`: OK on both
sides of the flip date; a pack with no `council_run` reports `notice` before the flip and
`VIOLATION` after it).

**Failure-capable, not merely green:** 19 tests pass, and three mutations — drop the note
requirement, allow a path escape out of the pack dir, make a non-judgement count toward quorum —
each redden exactly one test, with the file restoring byte-identical afterwards. A fourth mutation
(remove the `brief.yml` gear fallback) reddens the regression test above.

## Note for whoever reviews

`scripts/ci/stage_council_journal.py` is pinned in `CODEOWNERS` with the comment *"added on a point
it is already the thing deciding whether R9 sees a council journal at all"*. This script writes what
that one stages, so it is plausibly the same tier — flagging it rather than self-adding, since
pinning one's own file is not the author's call.

Floor is 1 (`--print-floor` → `1`, source `none`): `scripts/**` is not a hot zone, so no evidence
pack is required for this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
