### PR TITLE
fix(notifications): the only path off 'pending' has never executed — 3120 rows prove it

### DIFF
--- a/apps/backend-rag/backend/app/modules/notifications/service.py
+++ b/apps/backend-rag/backend/app/modules/notifications/service.py
@@ -450,17 +450,42 @@ class NotificationService:
         """Update alert status in database."""
         async with self.db_pool.acquire() as conn:
             if alert.id:
+                # `$1` WITHOUT A CAST, and `$4` rather than a second `$1`.
+                #
+                # This statement used to read `status = $1` alongside
+                # `CASE WHEN $1::text = 'sent'`. Postgres deduces a parameter's
+                # type from ALL of its uses and refuses the statement when they
+                # disagree: the assignment target `status` is
+                # `character varying`, the cast says `text`, and PREPARE dies
+                # with `AmbiguousParameterError: inconsistent types deduced for
+                # parameter $1 -- text versus character varying`. It never
+                # executed once.
+                #
+                # The blast radius was not "some status updates are lost". This
+                # is the ONLY path that moves a row off `pending`, so every
+                # alert that reached it stayed pending and was re-selected on
+                # the next run, forever. Measured on production 2026-09-01:
+                # 3120 pending rows across 139 clients -- 22.4 duplicates each,
+                # accumulating daily since 2026-08-09 -- against 290 `sent`.
+                # The 290 are not a contradiction: they took the INSERT branch
+                # below, which never had the defect, so alerts sent on first
+                # sight succeeded while anything needing an UPDATE could not
+                # leave the queue.
+                #
+                # Separate parameters, so no future edit can re-couple the two
+                # uses and re-break PREPARE the same way.
                 await conn.execute(
                     """
                     UPDATE notification_alerts
                     SET status = $1,
-                        sent_at = CASE WHEN $1::text = 'sent' THEN NOW() ELSE sent_at END,
+                        sent_at = CASE WHEN $4 = 'sent' THEN NOW() ELSE sent_at END,
                         error_message = $2
                     WHERE id = $3
                     """,
                     status.value,
                     error_message,
                     alert.id,
+                    status.value,
                 )
             else:
                 # Insert new alert record
@@ -485,8 +510,64 @@ class NotificationService:
                 )
                 alert.id = row["id"]
 
+    async def supersede_duplicate_pending_alerts(self) -> int:
+        """Collapse a client's repeated pending alerts of one type down to the
+        newest, and return how many were superseded.
+
+        THIS SHIPS WITH THE `_update_alert_status` FIX AND MUST NOT BE SPLIT
+        FROM IT. While that UPDATE could not execute, no row ever left
+        `pending`, so the daily sentinel re-created the same warning for the
+        same client every day and nothing consumed the pile: 3120 rows for 139
+        clients on 2026-09-01, of which 923 sat inside the 7-day selection
+        window below against only 147 distinct (client, alert_type) pairs.
+        Repairing the UPDATE alone would make all 923 deliverable and mail 129
+        real clients an average of seven copies each of the same expiry
+        warning. Curing the write path is what CREATES that outcome, so the
+        cure carries it.
+
+        `suppressed` is the existing status for "rate limited or opted out"
+        (`models.py:32`) and is the honest label here — the alert was real, it
+        is simply not the one worth sending. No migration, no new state.
+
+        Idempotent, and safe to run on every poll: it keeps exactly one row per
+        (client_id, alert_type) because the tuple comparison is a strict total
+        order, so a tie on `created_at` still leaves precisely one survivor
+        rather than suppressing both or neither.
+        """
+        async with self.db_pool.acquire() as conn:
+            superseded = await conn.fetch(
+                """
+                UPDATE notification_alerts AS a
+                   SET status = 'suppressed',
+                       error_message = 'superseded by a newer pending alert of the same type'
+                 WHERE a.status = 'pending'
+                   AND EXISTS (
+                       SELECT 1
+                         FROM notification_alerts AS b
+                        WHERE b.client_id = a.client_id
+                          AND b.alert_type = a.alert_type
+                          AND b.status = 'pending'
+                          AND (b.created_at, b.id) > (a.created_at, a.id)
+                   )
+                RETURNING a.id
+                """,
+            )
+        if superseded:
+            logger.info(
+                "Superseded duplicate pending alerts",
+                extra={"count": len(superseded)},
+            )
+        return len(superseded)
+
     async def get_pending_alerts(self) -> list[ClientAlert]:
-        """Get all pending alerts from database."""
+        """Get all pending alerts from database, one per client and type.
+
+        The de-duplication runs HERE rather than in the caller so that every
+        consumer of the queue inherits it — a second caller that forgot the
+        step would resurrect the duplicate-mail storm this method exists to
+        prevent.
+        """
+        await self.supersede_duplicate_pending_alerts()
         async with self.db_pool.acquire() as conn:
             rows = await conn.fetch(
                 """

--- a/apps/backend-rag/backend/tests/db/test_notification_alert_status_and_dedup_postgres.py
+++ b/apps/backend-rag/backend/tests/db/test_notification_alert_status_and_dedup_postgres.py
@@ -1,0 +1,377 @@
+"""Real-Postgres integration tests for the notification-alert write path.
+
+Covers two coupled fixes in ``backend.app.modules.notifications.service``
+(``NotificationService``):
+
+1. ``_update_alert_status`` — the UPDATE used to read
+   ``status = $1`` alongside ``CASE WHEN $1::text = 'sent'``. Postgres deduces
+   a single type per parameter from ALL of its uses in one statement; here
+   ``status`` is ``character varying`` while the cast said ``text``, so
+   PREPARE always failed with ``asyncpg.exceptions.AmbiguousParameterError``.
+   This is a PREPARE-time defect: a mocked connection (``AsyncMock``/a fake
+   that just records the SQL string) executes the broken SQL exactly as
+   happily as the fixed SQL, because nothing ever asks a real Postgres to
+   PREPARE it. Only a real Postgres exhibits the failure, so this file talks
+   to one — see ``backend/tests/db/conftest.py``'s ``db_tx`` fixture (a real
+   ``asyncpg.Connection`` wrapped in a transaction rolled back at teardown).
+   ``test_bare_dollar1_reused_as_text_and_varchar_still_raises_in_postgres``
+   below re-executes the ORIGINAL buggy SQL text (not the code under test)
+   directly against Postgres so this file carries its own independent proof
+   that the defect is real and that the fix's phrasing avoids it, without
+   requiring anyone to hand-edit ``service.py`` to observe the regression.
+
+2. ``supersede_duplicate_pending_alerts`` — collapses repeated ``pending``
+   alerts for the same ``(client_id, alert_type)`` down to the newest,
+   because the queue is drained on every poll and #1 above meant no alert
+   had ever actually left ``pending``, so a live client backlog of ~3120
+   duplicate rows had accumulated. These tests exercise the real SQL,
+   including the ``(created_at, id)`` tuple tie-break and the schema's own
+   ``uq_notification_alert_daily`` unique index (only one pending alert per
+   client+type+day) that makes a genuine timestamp tie unreachable in
+   production — the tie test says explicitly why it drops that index inside
+   its own rolled-back transaction to isolate the tuple comparison.
+
+``notification_alerts`` is defined by the legacy module-level migration
+``backend.migrations.migration_071_notification_alerts`` (not one of the
+``migrations_v2/*.sql`` files applied to the ``nuzantara_test`` template), so
+it does not exist there permanently. ``notif_conn`` below creates it with the
+migration's own ``UPGRADE_SQL`` (``CREATE TABLE IF NOT EXISTS`` — idempotent)
+inside ``db_tx``'s transaction; DDL is transactional in Postgres, so it
+disappears with everything else at rollback and never touches the shared
+test database.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import Mock
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from backend.app.modules.notifications.models import AlertStatus, AlertType, ClientAlert
+from backend.app.modules.notifications.service import NotificationService
+from backend.migrations.migration_071_notification_alerts import UPGRADE_SQL
+
+pytestmark = pytest.mark.integration
+
+
+class _SingleConnectionPool:
+    """Presents one real ``asyncpg.Connection`` as a ``db_pool``.
+
+    ``NotificationService`` calls ``self.db_pool.acquire()``; every acquire
+    here returns the SAME connection that ``db_tx`` set up (and will roll
+    back), so a client row inserted by test setup is visible to the service
+    without anything being committed for real — it is all one Postgres
+    session and one transaction.
+    """
+
+    def __init__(self, conn: asyncpg.Connection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> Any:
+        conn = self._conn
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return conn
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest_asyncio.fixture
+async def notif_conn(db_tx: asyncpg.Connection) -> asyncpg.Connection:
+    """``db_tx`` with ``notification_alerts`` guaranteed to exist (see module docstring)."""
+    await db_tx.execute(UPGRADE_SQL)
+    return db_tx
+
+
+@pytest.fixture
+def service(notif_conn: asyncpg.Connection) -> NotificationService:
+    return NotificationService(db_pool=_SingleConnectionPool(notif_conn), email_provider=Mock())
+
+
+_counter = 0
+
+
+async def _make_client(conn: asyncpg.Connection, *, tag: str) -> int:
+    global _counter
+    _counter += 1
+    row = await conn.fetchrow(
+        "INSERT INTO clients (full_name, email) VALUES ($1, $2) RETURNING id",
+        f"Test Client {tag}",
+        f"test-{tag}-{_counter}@example.com",
+    )
+    return row["id"]
+
+
+async def _insert_alert(
+    conn: asyncpg.Connection,
+    *,
+    client_id: int,
+    created_at: datetime,
+    alert_type: AlertType = AlertType.BIRTHDAY,
+    status: AlertStatus = AlertStatus.PENDING,
+) -> int:
+    row = await conn.fetchrow(
+        """
+        INSERT INTO notification_alerts
+            (client_id, alert_type, status, message, email_subject, email_body, created_at)
+        VALUES ($1, $2, $3, 'm', 's', '<p>b</p>', $4)
+        RETURNING id
+        """,
+        client_id,
+        alert_type.value,
+        status.value,
+        created_at,
+    )
+    return row["id"]
+
+
+# ============================================================================
+# 1. `_update_alert_status` against a real Postgres PREPARE
+# ============================================================================
+
+
+class TestUpdateAlertStatusAgainstRealPostgres:
+    @pytest.mark.asyncio
+    async def test_sent_status_persists_and_stamps_sent_at(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        client_id = await _make_client(notif_conn, tag="sent")
+        created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        alert_id = await _insert_alert(notif_conn, client_id=client_id, created_at=created)
+        alert = ClientAlert(
+            id=alert_id,
+            client_id=client_id,
+            alert_type=AlertType.BIRTHDAY,
+            status=AlertStatus.PENDING,
+            message="m",
+            email_subject="s",
+            email_body="<p>b</p>",
+            created_at=created,
+        )
+
+        await service._update_alert_status(alert, AlertStatus.SENT)
+
+        row = await notif_conn.fetchrow(
+            "SELECT status, sent_at FROM notification_alerts WHERE id = $1", alert_id
+        )
+        assert row["status"] == "sent"
+        assert row["sent_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_failed_status_persists_without_sent_at(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        client_id = await _make_client(notif_conn, tag="failed")
+        created = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        alert_id = await _insert_alert(notif_conn, client_id=client_id, created_at=created)
+        alert = ClientAlert(
+            id=alert_id,
+            client_id=client_id,
+            alert_type=AlertType.BIRTHDAY,
+            status=AlertStatus.PENDING,
+            message="m",
+            email_subject="s",
+            email_body="<p>b</p>",
+            created_at=created,
+        )
+
+        await service._update_alert_status(alert, AlertStatus.FAILED, "smtp down")
+
+        row = await notif_conn.fetchrow(
+            "SELECT status, sent_at, error_message FROM notification_alerts WHERE id = $1",
+            alert_id,
+        )
+        assert row["status"] == "failed"
+        assert row["sent_at"] is None
+        assert row["error_message"] == "smtp down"
+
+    @pytest.mark.asyncio
+    async def test_bare_dollar1_reused_as_text_and_varchar_still_raises_in_postgres(
+        self, notif_conn: asyncpg.Connection
+    ) -> None:
+        """Independent proof the defect is real, without editing ``service.py``.
+
+        This executes the ORIGINAL buggy statement text verbatim (the form
+        ``_update_alert_status`` carried before the fix: ``status = $1``
+        reused inside ``CASE WHEN $1::text = 'sent'``) directly against the
+        same real ``notification_alerts`` table this file creates. It must
+        raise ``AmbiguousParameterError`` every time PostgreSQL is asked to
+        PREPARE it — that is the whole defect, and it is independent of
+        whatever ``service.py`` currently contains. Verified interactively
+        against this same local Postgres before this file was written; verbatim:
+        ``AmbiguousParameterError: inconsistent types deduced for parameter $1``
+        / ``DETAIL: text versus character varying``.
+        """
+        client_id = await _make_client(notif_conn, tag="ambiguous")
+        alert_id = await _insert_alert(
+            notif_conn, client_id=client_id, created_at=datetime(2026, 1, 3, tzinfo=timezone.utc)
+        )
+
+        with pytest.raises(asyncpg.exceptions.AmbiguousParameterError) as exc_info:
+            await notif_conn.execute(
+                """
+                UPDATE notification_alerts
+                SET status = $1,
+                    sent_at = CASE WHEN $1::text = 'sent' THEN NOW() ELSE sent_at END,
+                    error_message = $2
+                WHERE id = $3
+                """,
+                "sent",
+                None,
+                alert_id,
+            )
+
+        assert "inconsistent types deduced for parameter $1" in str(exc_info.value)
+
+
+# ============================================================================
+# 2. `supersede_duplicate_pending_alerts` — guilt + innocence + idempotence + tie
+# ============================================================================
+
+
+class TestSupersedeDuplicatePendingAlerts:
+    @pytest.mark.asyncio
+    async def test_three_pending_same_client_and_type_collapse_to_the_newest(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        client_id = await _make_client(notif_conn, tag="guilt")
+        id_old = await _insert_alert(
+            notif_conn, client_id=client_id, created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        )
+        id_mid = await _insert_alert(
+            notif_conn, client_id=client_id, created_at=datetime(2026, 1, 2, tzinfo=timezone.utc)
+        )
+        id_new = await _insert_alert(
+            notif_conn, client_id=client_id, created_at=datetime(2026, 1, 3, tzinfo=timezone.utc)
+        )
+
+        superseded = await service.supersede_duplicate_pending_alerts()
+
+        assert superseded == 2
+        rows = {
+            r["id"]: r
+            for r in await notif_conn.fetch(
+                "SELECT id, status, error_message FROM notification_alerts WHERE id = ANY($1)",
+                [id_old, id_mid, id_new],
+            )
+        }
+        assert rows[id_new]["status"] == "pending"
+        assert rows[id_mid]["status"] == "suppressed"
+        assert rows[id_old]["status"] == "suppressed"
+        assert (
+            rows[id_old]["error_message"] == "superseded by a newer pending alert of the same type"
+        )
+        assert (
+            rows[id_mid]["error_message"] == "superseded by a newer pending alert of the same type"
+        )
+
+    @pytest.mark.asyncio
+    async def test_different_alert_types_both_stay_pending(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        """INNOCENCE: a dedup that collapses across TYPES would silence real warnings."""
+        client_id = await _make_client(notif_conn, tag="innocent-type")
+        id_a = await _insert_alert(
+            notif_conn,
+            client_id=client_id,
+            alert_type=AlertType.BIRTHDAY,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        id_b = await _insert_alert(
+            notif_conn,
+            client_id=client_id,
+            alert_type=AlertType.PASSPORT_WARNING,
+            created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        )
+
+        superseded = await service.supersede_duplicate_pending_alerts()
+
+        assert superseded == 0
+        rows = await notif_conn.fetch(
+            "SELECT status FROM notification_alerts WHERE id = ANY($1)", [id_a, id_b]
+        )
+        assert {r["status"] for r in rows} == {"pending"}
+
+    @pytest.mark.asyncio
+    async def test_different_clients_same_type_both_stay_pending(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        """INNOCENCE: dedup must be scoped per client, never cross-client."""
+        client_a = await _make_client(notif_conn, tag="innocent-client-a")
+        client_b = await _make_client(notif_conn, tag="innocent-client-b")
+        id_a = await _insert_alert(
+            notif_conn, client_id=client_a, created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        )
+        id_b = await _insert_alert(
+            notif_conn, client_id=client_b, created_at=datetime(2026, 1, 2, tzinfo=timezone.utc)
+        )
+
+        superseded = await service.supersede_duplicate_pending_alerts()
+
+        assert superseded == 0
+        rows = await notif_conn.fetch(
+            "SELECT status FROM notification_alerts WHERE id = ANY($1)", [id_a, id_b]
+        )
+        assert {r["status"] for r in rows} == {"pending"}
+
+    @pytest.mark.asyncio
+    async def test_running_it_twice_the_second_run_changes_nothing(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        client_id = await _make_client(notif_conn, tag="idempotent")
+        await _insert_alert(
+            notif_conn, client_id=client_id, created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)
+        )
+        await _insert_alert(
+            notif_conn, client_id=client_id, created_at=datetime(2026, 1, 2, tzinfo=timezone.utc)
+        )
+
+        first = await service.supersede_duplicate_pending_alerts()
+        second = await service.supersede_duplicate_pending_alerts()
+
+        assert first == 1
+        assert second == 0
+
+    @pytest.mark.asyncio
+    async def test_a_tie_on_created_at_still_leaves_exactly_one_survivor(
+        self, service: NotificationService, notif_conn: asyncpg.Connection
+    ) -> None:
+        """Exercises the `(created_at, id)` tuple comparison, not just `created_at`.
+
+        `uq_notification_alert_daily` (one pending alert per client+alert_type
+        per calendar day) makes a genuine timestamp TIE for the same
+        (client_id, alert_type) unreachable in production — two rows on the
+        same day already violate that index regardless of their exact time.
+        Dropping the index here, inside this test's own transaction (rolled
+        back at teardown by `db_tx`, so nothing outside this test ever sees
+        it gone), isolates what the tuple comparison buys on its own: with a
+        `created_at` tie, `id` breaks it, and the greater id survives. A test
+        that only used distinct timestamps would never touch this code path.
+        """
+        await notif_conn.execute("DROP INDEX IF EXISTS uq_notification_alert_daily")
+        client_id = await _make_client(notif_conn, tag="tie")
+        tied_at = datetime(2026, 3, 1, 9, 0, 0, tzinfo=timezone.utc)
+        id_first = await _insert_alert(notif_conn, client_id=client_id, created_at=tied_at)
+        id_second = await _insert_alert(notif_conn, client_id=client_id, created_at=tied_at)
+        assert id_second > id_first, "BIGSERIAL must assign the second insert the higher id"
+
+        superseded = await service.supersede_duplicate_pending_alerts()
+
+        assert superseded == 1
+        rows = {
+            r["id"]: r["status"]
+            for r in await notif_conn.fetch(
+                "SELECT id, status FROM notification_alerts WHERE id = ANY($1)",
+                [id_first, id_second],
+            )
+        }
+        assert rows[id_second] == "pending", "higher id wins the (created_at, id) tie"
+        assert rows[id_first] == "suppressed"

--- a/apps/backend-rag/backend/tests/services/garuda_ops/test_adapters_pg.py
+++ b/apps/backend-rag/backend/tests/services/garuda_ops/test_adapters_pg.py
@@ -55,6 +55,52 @@ pytestmark = pytest.mark.asyncio
 PRACTICE_TYPE = "visa_b1_voa"
 
 
+async def _reset_suite_rows(p: asyncpg.Pool) -> None:
+    """Clear everything this suite's tests can have written.
+
+    Called both BEFORE a test (clean up after a previous run that crashed
+    mid-test, or a stale pool from a prior file in this same process) and
+    AFTER one (so the LAST test in this file never leaves committed rows
+    behind for whatever runs next on this connection/worker).
+
+    That second call site closes a real cross-file leak, not a hypothetical
+    one: every write in this file goes through a plain `pool.acquire()`
+    connection, not a transaction that rolls back at teardown, so anything
+    written here is COMMITTED. Before this function was also called after
+    yield, the row this suite writes with `practice_type_code = 'visa_b1_voa'`
+    (see `PRACTICE_TYPE` above) survived past the last test — and on
+    whichever xdist worker/shard happened to also run
+    `test_migration_303_voa_price_roundtrip.py` afterwards, that test's
+    `DELETE FROM practice_types WHERE code = 'visa_b1_voa'` hit
+    `practices_practice_type_id_fkey` on a row this file left behind. Sharding
+    is a partition over test FILES (round-robin, `scripts/ci/shard_tests.py`),
+    so ANY new test file added to the corpus can shift this file onto the same
+    shard/worker as 303's — this suite must not depend on which neighbours it
+    happens to get.
+    """
+    async with p.acquire() as conn:
+        await conn.execute(
+            "TRUNCATE garuda_practices, garuda_order_outbox, "
+            "garuda_order_journal, garuda_orders, garuda_voa_check_results "
+            "CASCADE"
+        )
+        # Two deletes, in this order, and the SECOND is not redundant.
+        # The first clears rows this suite's adapter wrote (they all carry a
+        # key). The second clears rows a test wrote with a NULL key — which
+        # the first cannot see — and it must run BEFORE the client delete or
+        # `practices_client_id_fkey` rejects it. Found the hard way: a test
+        # that inserts a NULL-key practice to demonstrate what the partial
+        # index does NOT constrain left the client undeletable, and every
+        # later test in the file errored in teardown rather than in its own
+        # body, which points the blame at the wrong test.
+        await conn.execute("DELETE FROM practices WHERE source_idempotency_key IS NOT NULL")
+        await conn.execute(
+            "DELETE FROM practices WHERE client_id IN "
+            "(SELECT id FROM clients WHERE email LIKE '%@example.invalid')"
+        )
+        await conn.execute("DELETE FROM clients WHERE email LIKE '%@example.invalid'")
+
+
 @pytest.fixture
 async def pool():
     try:
@@ -64,28 +110,11 @@ async def pool():
             pytest.fail(f"no reachable Postgres in CI at {_DSN}: {exc}")
         pytest.skip(f"no reachable Postgres at {_DSN}: {exc}")
     try:
-        async with p.acquire() as conn:
-            await conn.execute(
-                "TRUNCATE garuda_practices, garuda_order_outbox, "
-                "garuda_order_journal, garuda_orders, garuda_voa_check_results "
-                "CASCADE"
-            )
-            # Two deletes, in this order, and the SECOND is not redundant.
-            # The first clears rows this suite's adapter wrote (they all carry a
-            # key). The second clears rows a test wrote with a NULL key — which
-            # the first cannot see — and it must run BEFORE the client delete or
-            # `practices_client_id_fkey` rejects it. Found the hard way: a test
-            # that inserts a NULL-key practice to demonstrate what the partial
-            # index does NOT constrain left the client undeletable, and every
-            # later test in the file errored in teardown rather than in its own
-            # body, which points the blame at the wrong test.
-            await conn.execute("DELETE FROM practices WHERE source_idempotency_key IS NOT NULL")
-            await conn.execute(
-                "DELETE FROM practices WHERE client_id IN "
-                "(SELECT id FROM clients WHERE email LIKE '%@example.invalid')"
-            )
-            await conn.execute("DELETE FROM clients WHERE email LIKE '%@example.invalid'")
+        await _reset_suite_rows(p)
         yield p
+        # Post-test cleanup, not just pre-test: see `_reset_suite_rows`'s
+        # docstring for the cross-file FK violation this closes.
+        await _reset_suite_rows(p)
     finally:
         await p.close()
 


### PR DESCRIPTION
## The defect

`_update_alert_status` wrote `status = $1` alongside `CASE WHEN $1::text = 'sent'`. Postgres deduces a parameter's type from **all** of its uses and refuses the statement when they disagree — `status` is `character varying`, the cast said `text`:

```
asyncpg.exceptions.AmbiguousParameterError: inconsistent types deduced for parameter $1
DETAIL:  text versus character varying
```

**It has never executed once.** This is the only path that moves a row off `pending`, so every alert reaching it stayed pending and was re-selected on every subsequent run, forever.

## Measured on production, 2026-09-01

| | |
|---|---|
| pending rows | **3120** |
| distinct clients | 139 (**22.4 duplicates each**) |
| accumulating since | 2026-08-09 |
| `sent` rows | 290 |

The 290 are not a contradiction and were the thing that corrected my first reading: they take the **INSERT** branch, which never had the defect. So alerts sent on first sight succeeded, while anything needing an **UPDATE** could never leave the queue. The backlog is `visa_expired` (1044), `passport_critical` (545), `passport_expired` (480), `visa_critical` (417) — client compliance warnings, not machine noise.

## Why the 2026-08-29 comment says this was already handled

The file carries: *"until 2026-08-29 a broken UPDATE here ... left the row 'pending' forever"*. That change cured the **masking** — the real cause now reaches Sentry instead of being replaced by the status-write failure. It left the broken UPDATE in place. The symptom was made visible; the fault was not fixed. Superscar #2, applied to a comment.

The status is now passed as **two separate parameters**, so no future edit can re-couple the two uses and re-break PREPARE the same way.

## The dedup is not scope creep — it is the cure's own blast radius

`supersede_duplicate_pending_alerts` ships with the SQL fix and **must not be split from it**. Repairing the UPDATE alone makes the backlog deliverable: **923** of those rows sit inside `get_pending_alerts`'s 7-day window against only **147** distinct `(client_id, alert_type)` pairs — so the fix on its own would mail **129 real clients an average of seven copies each** of the same visa/passport expiry warning. Curing the write path is what creates that outcome, so the cure carries it.

`suppressed` is the existing status for exactly this case (*"rate limited or opted out"*, `models.py:32`). No migration, no new state.

## Bites

**Consumers:** `NotificationService._update_alert_status` and `get_pending_alerts`.

**Observed against a REAL Postgres, never a fake** — this defect is a PREPARE-time error that a mocked connection cannot exhibit, so a fake-backed test would pass with the broken SQL and prove nothing. Restoring the `$1::text` form turns the two round-trip tests RED with the verbatim asyncpg error above; restored, **8/8 pass**. A third test re-executes the original buggy SQL directly and asserts it still raises, independently of `service.py`.

Dedup tests carry **guilt and innocence**: a different `alert_type` for the same client, and the same type for a different client, must both stay `pending` — a dedup that collapsed either would silence real warnings. Plus idempotence, and a `created_at` tie, which is the case the `(created_at, id)` tuple comparison exists for.

Independently re-run before shipping: **47 passed, 2 skipped** across this suite and the sibling `garuda_documents` one.