### PR TITLE
fix(notifications): a login link is not correspondence — stop copying it to staff

### DIFF
--- a/apps/backend-rag/backend/app/modules/notifications/router.py
+++ b/apps/backend-rag/backend/app/modules/notifications/router.py
@@ -326,24 +326,70 @@ async def send_pending_alerts(
 _ACCOUNTING_CC = "asya@balizero.com"
 _INVOICE_EMAIL_TYPES = frozenset({"invoice_client", "invoice", "invoice_team"})
 
+#: RULED by Antonello 2026-09-02, scoped in his own words to "solo per le
+#: pratiche del garuda voa": VOA practice mail copies these three. Nothing
+#: else moves -- every other practice keeps the assigned-lead rule below.
+#: A tuple rather than one address because this is the single email family
+#: with a STANDING copy list instead of one contextual reader.
+_GARUDA_VOA_CC: tuple[str, ...] = (
+    "surya@balizero.com",
+    "vino@balizero.com",
+    "zero@balizero.com",
+)
+
+#: Credential deliveries are NOT correspondence. The body of one of these IS
+#: the recipient's single-use key to their own account, so a copy is not an
+#: audit trail -- it is a second person who can sign in as the customer.
+#: They therefore carry NO Bali Zero copy at all, and any cc/bcc a caller
+#: supplied is STRIPPED rather than merely left un-augmented.
+#:
+#: Membership is a fixed set decided HERE, never a boolean the caller passes:
+#: a bypass anyone can set is not a rule (superscar #3 -- match the entity,
+#: not a flag). An email_type that is absent, misspelled or unknown is NOT a
+#: credential delivery and keeps its copy, so the failure mode of a typo is
+#: an unwanted copy, never a leaked credential.
+_CREDENTIAL_DELIVERY_EMAIL_TYPES = frozenset({"garuda_magic_link"})
+
 
 def _is_balizero(addr: str) -> bool:
     """True iff ``addr`` is on the @balizero.com domain (suffix match,
-    case-insensitive). Never a bare substring — superscar #3: match the
+    case-insensitive). Never a bare substring -- superscar #3: match the
     entity, not the text. So ``x@balizero.com.evil.com`` is NOT a match."""
     return addr.strip().lower().endswith("@balizero.com")
 
 
-def _pick_balizero_cc(email_type: str | None, assigned_to: str | None) -> str:
-    """Choose WHICH Bali Zero address to copy, per Antonello's rule
-    (2026-06-17): invoices → accounting (asya@); everything else → the
-    practice's assigned lead; if no assigned lead is known, fall back to
-    accounting so a client mail is never sent with nobody copied."""
-    if email_type and email_type.strip().lower() in _INVOICE_EMAIL_TYPES:
-        return _ACCOUNTING_CC
+def _normalise_email_type(email_type: str | None) -> str:
+    return (email_type or "").strip().lower()
+
+
+def _is_garuda_voa(email_type: str) -> bool:
+    """True for the GARUDA VOA practice email family.
+
+    A PREFIX test on a controlled internal field, not a substring search of
+    free text: ``garuda_voa`` exactly, or ``garuda_voa_`` followed by the
+    specific message name. ``garuda_voa_order_confirmed`` matches;
+    ``not_garuda_voa`` does not.
+    """
+    return email_type == "garuda_voa" or email_type.startswith("garuda_voa_")
+
+
+def _pick_balizero_cc(email_type: str, assigned_to: str | None) -> list[str]:
+    """Choose WHICH Bali Zero address(es) to copy.
+
+    The order is a precedence, not a preference:
+    - GARUDA VOA practice -> the standing three (Antonello 2026-09-02)
+    - invoices            -> accounting (Antonello 2026-06-17)
+    - otherwise           -> the practice's assigned lead
+    - no assigned lead    -> accounting, so a client mail is never sent
+      with nobody copied.
+    """
+    if _is_garuda_voa(email_type):
+        return list(_GARUDA_VOA_CC)
+    if email_type in _INVOICE_EMAIL_TYPES:
+        return [_ACCOUNTING_CC]
     if assigned_to and _is_balizero(assigned_to):
-        return assigned_to.strip()
-    return _ACCOUNTING_CC
+        return [assigned_to.strip()]
+    return [_ACCOUNTING_CC]
 
 
 def _enforce_balizero_cc(
@@ -352,41 +398,73 @@ def _enforce_balizero_cc(
     bcc_list: list[str] | None,
     email_type: str | None = None,
     assigned_to: str | None = None,
-) -> list[str] | None:
-    """Guarantee at least one @balizero.com address is in the loop.
+) -> tuple[list[str] | None, list[str] | None]:
+    """Decide who else is in the loop on an outbound email.
 
-    HARD RULE (Antonello 2026-06-17): a client must never receive an
-    email without a Bali Zero address copied in. Structural enforcement
-    at the single send choke-point.
+    HARD RULE (Antonello 2026-06-17): a client must never receive an email
+    without a Bali Zero address copied in. Structural enforcement at the
+    single send choke-point.
 
-    Logic:
-    - If the recipient (``to``) is itself ``@balizero.com`` → intra-team
-      mail, nothing to add.
-    - If any existing cc/bcc is already ``@balizero.com`` → compliant,
-      leave untouched (respects the caller's explicit choice).
-    - Otherwise (external recipient, nobody from Bali Zero copied) →
-      append the contextual address from :func:`_pick_balizero_cc`
-      (invoice → asya@, else assigned lead, else asya@) and log it.
+    ONE CATEGORY IS EXEMPT, and the exemption is the point rather than a
+    hole in the rule: a credential delivery (see
+    ``_CREDENTIAL_DELIVERY_EMAIL_TYPES``) has exactly one legitimate
+    recipient, because its body is the key to that recipient's account.
+    Those are stripped of cc AND bcc.
 
-    Returns the (possibly augmented) cc_list.
+    Returns the (possibly rewritten) ``(cc_list, bcc_list)`` pair. It returns
+    BOTH -- an earlier version returned only cc, which left no way to drop a
+    bcc, and a bcc'd login link leaks exactly as much as a cc'd one.
     """
-    if _is_balizero(to):
-        return cc_list
-    existing = (cc_list or []) + (bcc_list or [])
-    if any(_is_balizero(a) for a in existing):
-        return cc_list
+    etype = _normalise_email_type(email_type)
 
-    chosen = _pick_balizero_cc(email_type, assigned_to)
+    if etype in _CREDENTIAL_DELIVERY_EMAIL_TYPES:
+        if cc_list or bcc_list:
+            logger.warning(
+                "send-email: %s is a credential delivery -- dropping %d cc and "
+                "%d bcc recipient(s); a login link has one recipient by design",
+                etype,
+                len(cc_list or []),
+                len(bcc_list or []),
+            )
+        return None, None
+
+    if _is_balizero(to):
+        return cc_list, bcc_list
+
+    existing = (cc_list or []) + (bcc_list or [])
+
+    if _is_garuda_voa(etype):
+        # Deliberately NOT "add one if nobody is copied". The three are a
+        # STANDING list, so they are unioned in even when another Bali Zero
+        # address is already present -- which is what "in cc vanno surya,
+        # vino e zero" asks for. Scoped to this one family on purpose.
+        already = {a.strip().lower() for a in existing}
+        missing = [a for a in _GARUDA_VOA_CC if a.lower() not in already]
+        if not missing:
+            return cc_list, bcc_list
+        augmented = list(cc_list or [])
+        augmented.extend(missing)
+        logger.info(
+            "send-email: GARUDA VOA practice mail (email_type=%s) -- adding %d "
+            "standing recipient(s) to CC",
+            etype,
+            len(missing),
+        )
+        return augmented, bcc_list
+
+    if any(_is_balizero(a) for a in existing):
+        return cc_list, bcc_list
+
+    chosen = _pick_balizero_cc(etype, assigned_to)
     augmented = list(cc_list or [])
-    augmented.append(chosen)
+    augmented.extend(chosen)
     logger.warning(
-        "send-email: no @balizero.com in to/cc/bcc for external recipient %s "
-        "(email_type=%s) — forcing %s into CC (hard rule)",
-        to,
-        email_type,
-        chosen,
+        "send-email: no @balizero.com in to/cc/bcc for external recipient "
+        "(email_type=%s) -- forcing %d address(es) into CC (hard rule)",
+        etype,
+        len(chosen),
     )
-    return augmented
+    return augmented, bcc_list
 
 
 @router.post("/send-email", response_model=SendEmailResponse)
@@ -411,8 +489,11 @@ async def send_direct_email(
     # HARD RULE (Antonello 2026-06-17): a client never receives an email
     # without at least one @balizero.com address in the loop. Enforced
     # here — the single send choke-point — so no caller can bypass it.
-    # Contextual CC: invoice → asya@, else the assigned lead, else asya@.
-    cc_list = _enforce_balizero_cc(
+    # Contextual CC: GARUDA VOA → the standing three, invoice → asya@,
+    # else the assigned lead, else asya@. One exemption, and it is not a
+    # bypass: a credential delivery (magic link) has one recipient by
+    # design, so it is stripped of cc AND bcc.
+    cc_list, bcc_list = _enforce_balizero_cc(
         request.to, cc_list, bcc_list, request.email_type, request.assigned_to
     )
 

--- a/apps/backend-rag/backend/services/garuda_portal/magic_link_store.py
+++ b/apps/backend-rag/backend/services/garuda_portal/magic_link_store.py
@@ -161,7 +161,20 @@ async def _default_send_magic_link_email(*, email: str, result_id: str, raw_toke
             resp = await client.post(
                 api_url,
                 headers={"X-API-Key": api_key},
-                json={"to": email, "subject": "Your Bali Zero VOA result link", "body": html_body},
+                json={
+                    "to": email,
+                    "subject": "Your Bali Zero VOA result link",
+                    "body": html_body,
+                    # DECLARED, not incidental. Without this the send
+                    # choke-point classifies the mail as ordinary client
+                    # correspondence and copies a Bali Zero address in --
+                    # which on THIS message means handing a staff member a
+                    # working login for the customer's own application.
+                    # `garuda_magic_link` is in the notifications router's
+                    # `_CREDENTIAL_DELIVERY_EMAIL_TYPES`, the set that gets
+                    # cc AND bcc stripped.
+                    "email_type": "garuda_magic_link",
+                },
             )
             resp.raise_for_status()
         logger.info("garuda_magic_link: email dispatched via Brevo")

--- a/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_send_email_chain.py
+++ b/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_send_email_chain.py
@@ -21,6 +21,19 @@ from backend.app.modules.notifications.router import (
 )
 
 
+def _cc_of(*args, **kwargs):
+    """The CC half of `_enforce_balizero_cc`'s ``(cc, bcc)`` pair.
+
+    The function grew a second return value when credential deliveries had
+    to be stripped of bcc as well as cc (a bcc'd login link leaks exactly as
+    much as a cc'd one). The assertions in `TestEnforceBalizeroCc` below are
+    about the CC half and are UNCHANGED from when the function returned it
+    alone -- this helper keeps them that way instead of restating them.
+    Tests that care about the bcc half call the real function directly.
+    """
+    return _enforce_balizero_cc(*args, **kwargs)[0]
+
+
 class TestEnforceBalizeroCc:
     """Hard rule (Antonello 2026-06-17): a client never gets an email
     without a @balizero.com address copied in. Contextual CC:
@@ -33,18 +46,18 @@ class TestEnforceBalizeroCc:
     # --- GUILT: external recipient, no balizero anywhere → inject CC ---
     def test_external_no_context_falls_back_to_accounting(self):
         # no email_type, no assigned → fallback asya@ (never silently void)
-        assert _enforce_balizero_cc("alice@example.com", None, None) == [
+        assert _cc_of("alice@example.com", None, None) == [
             "asya@balizero.com"
         ]
 
     def test_invoice_forces_accounting_cc(self):
-        out = _enforce_balizero_cc(
+        out = _cc_of(
             "alice@example.com", None, None, email_type="invoice_client"
         )
         assert out == ["asya@balizero.com"]
 
     def test_non_invoice_forces_assigned_lead(self):
-        out = _enforce_balizero_cc(
+        out = _cc_of(
             "alice@example.com",
             None,
             None,
@@ -54,14 +67,14 @@ class TestEnforceBalizeroCc:
         assert out == ["krisna@balizero.com"]
 
     def test_non_invoice_no_assigned_falls_back_to_accounting(self):
-        out = _enforce_balizero_cc(
+        out = _cc_of(
             "alice@example.com", None, None, email_type="waiting_docs_client"
         )
         assert out == ["asya@balizero.com"]
 
     def test_invoice_ignores_assigned_and_uses_accounting(self):
         # even with an assigned lead, an invoice goes to accounting
-        out = _enforce_balizero_cc(
+        out = _cc_of(
             "alice@example.com",
             None,
             None,
@@ -71,7 +84,7 @@ class TestEnforceBalizeroCc:
         assert out == ["asya@balizero.com"]
 
     def test_external_with_other_cc_appends_balizero(self):
-        out = _enforce_balizero_cc(
+        out = _cc_of(
             "alice@example.com", ["bob@gmail.com"], None, email_type="welcome",
             assigned_to="krisna@balizero.com",
         )
@@ -81,14 +94,14 @@ class TestEnforceBalizeroCc:
     # --- INNOCENCE: already compliant → leave untouched ---
     def test_intra_domain_recipient_untouched(self):
         # to is @balizero.com → intra-team, no injection
-        assert _enforce_balizero_cc("bob@balizero.com", None, None) is None
+        assert _cc_of("bob@balizero.com", None, None) is None
 
     def test_existing_balizero_cc_untouched(self):
         # caller already copied a balizero address → respect their choice,
         # do NOT also add the contextual one
         cc = ["asya@balizero.com", "client@gmail.com"]
         assert (
-            _enforce_balizero_cc(
+            _cc_of(
                 "alice@example.com", cc, None, email_type="welcome",
                 assigned_to="krisna@balizero.com",
             )
@@ -98,20 +111,20 @@ class TestEnforceBalizeroCc:
     def test_balizero_in_bcc_counts_as_compliant(self):
         # team copied via BCC → rule satisfied, cc not mutated
         assert (
-            _enforce_balizero_cc("alice@example.com", None, ["zero@balizero.com"])
+            _cc_of("alice@example.com", None, ["zero@balizero.com"])
             is None
         )
 
     def test_case_insensitive_domain_match(self):
         assert (
-            _enforce_balizero_cc("alice@example.com", ["Asya@BaliZero.com"], None)
+            _cc_of("alice@example.com", ["Asya@BaliZero.com"], None)
             == ["Asya@BaliZero.com"]
         )
 
     def test_no_bare_substring_false_match(self):
         # 'balizero.com.evil.com' must NOT be treated as a balizero address
         # → guard fires, injects the fallback accounting address
-        out = _enforce_balizero_cc(
+        out = _cc_of(
             "alice@example.com", ["x@balizero.com.evil.com"], None,
             email_type="invoice_client",
         )
@@ -257,3 +270,150 @@ async def test_intra_domain_does_not_use_resend(req_intra):
     zoho.assert_called_once()
     brevo.assert_called_once()
     resend.assert_not_called()
+
+
+class TestGarudaVoaStandingCc:
+    """RULED by Antonello 2026-09-02: "in cc questi 3 solo per le pratiche
+    del garuda voa". A STANDING list scoped to one email family -- unlike
+    every other rule here, which picks ONE contextual reader.
+
+    Superscar #3 discipline: guilt AND innocence, and the innocence cases
+    are the ones that keep this from becoming an over-match."""
+
+    THREE = ["surya@balizero.com", "vino@balizero.com", "zero@balizero.com"]
+
+    # --- GUILT ---
+    def test_voa_practice_mail_copies_all_three(self):
+        cc, bcc = _enforce_balizero_cc(
+            "alice@example.com", None, None, email_type="garuda_voa_order_confirmed"
+        )
+        assert cc == self.THREE
+        assert bcc is None
+
+    def test_bare_family_name_also_matches(self):
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com", None, None, email_type="garuda_voa"
+        )
+        assert cc == self.THREE
+
+    def test_case_and_whitespace_do_not_defeat_it(self):
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com", None, None, email_type="  GARUDA_VOA_Status  "
+        )
+        assert cc == self.THREE
+
+    def test_standing_list_is_added_even_when_someone_is_already_copied(self):
+        # Deliberately DIFFERENT from the generic rule, which leaves an
+        # already-compliant mail untouched. "In cc vanno questi tre" is not
+        # "in cc va qualcuno".
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com",
+            ["krisna@balizero.com"],
+            None,
+            email_type="garuda_voa_status",
+        )
+        assert cc[0] == "krisna@balizero.com"
+        for addr in self.THREE:
+            assert addr in cc
+
+    def test_no_duplicate_when_one_is_already_there(self):
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com", ["zero@balizero.com"], None, email_type="garuda_voa"
+        )
+        assert cc.count("zero@balizero.com") == 1
+        assert len(cc) == 3
+
+    # --- INNOCENCE ---
+    def test_a_neighbouring_email_type_does_NOT_get_the_three(self):
+        # The classifier is a PREFIX on a controlled field, not a substring
+        # search: a type that merely CONTAINS the family name is not it.
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com",
+            None,
+            None,
+            email_type="not_garuda_voa",
+            assigned_to="krisna@balizero.com",
+        )
+        assert cc == ["krisna@balizero.com"]
+
+    def test_ordinary_practice_mail_is_unchanged_by_this_rule(self):
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com",
+            None,
+            None,
+            email_type="welcome",
+            assigned_to="krisna@balizero.com",
+        )
+        assert cc == ["krisna@balizero.com"]
+        assert "surya@balizero.com" not in cc
+
+    def test_intra_team_voa_mail_gets_nothing_forced(self):
+        cc, bcc = _enforce_balizero_cc(
+            "bob@balizero.com", None, None, email_type="garuda_voa_status"
+        )
+        assert cc is None and bcc is None
+
+
+class TestCredentialDeliveryIsNeverCopied:
+    """A magic link's body IS the recipient's key to their own account, so a
+    copy is not an audit trail -- it is a second person able to sign in as
+    the customer. Before 2026-09-02 the magic-link sender passed no
+    email_type at all, so it fell through to the accounting fallback and
+    every customer login link was copied to a staff mailbox."""
+
+    LINK = "garuda_magic_link"
+
+    # --- GUILT ---
+    def test_no_address_is_injected(self):
+        cc, bcc = _enforce_balizero_cc(
+            "alice@example.com", None, None, email_type=self.LINK
+        )
+        assert cc is None
+        assert bcc is None
+
+    def test_a_caller_supplied_cc_is_STRIPPED_not_merely_left_alone(self):
+        cc, bcc = _enforce_balizero_cc(
+            "alice@example.com",
+            ["asya@balizero.com", "someone@example.com"],
+            None,
+            email_type=self.LINK,
+        )
+        assert cc is None and bcc is None
+
+    def test_bcc_is_stripped_too(self):
+        # A bcc'd login link leaks exactly as much as a cc'd one; the
+        # function returns both halves precisely so this is expressible.
+        cc, bcc = _enforce_balizero_cc(
+            "alice@example.com", None, ["zero@balizero.com"], email_type=self.LINK
+        )
+        assert cc is None and bcc is None
+
+    def test_the_assigned_lead_does_not_override_it(self):
+        cc, bcc = _enforce_balizero_cc(
+            "alice@example.com",
+            None,
+            None,
+            email_type=self.LINK,
+            assigned_to="krisna@balizero.com",
+        )
+        assert cc is None and bcc is None
+
+    # --- INNOCENCE: the exemption must not widen ---
+    def test_an_unknown_email_type_is_NOT_exempt(self):
+        # The failure mode of a typo must be an unwanted copy, never a
+        # leaked credential. `_CREDENTIAL_DELIVERY_EMAIL_TYPES` is a fixed
+        # membership list, not a pattern.
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com", None, None, email_type="garuda_magic_lnk"
+        )
+        assert cc == ["asya@balizero.com"]
+
+    def test_a_type_merely_containing_the_name_is_NOT_exempt(self):
+        cc, _ = _enforce_balizero_cc(
+            "alice@example.com", None, None, email_type="about_garuda_magic_link"
+        )
+        assert cc == ["asya@balizero.com"]
+
+    def test_absent_email_type_is_NOT_exempt(self):
+        cc, _ = _enforce_balizero_cc("alice@example.com", None, None)
+        assert cc == ["asya@balizero.com"]


### PR DESCRIPTION
Two changes to the send choke-point's CC rule, one ruled and one a leak the
ruling uncovered.

RULED (Antonello 2026-09-02, "in cc questi 3 solo per le pratiche del garuda
voa"): GARUDA VOA practice mail now copies surya@, vino@ and zero@ as a
STANDING list. Deliberately unlike every other rule in this function, which
picks ONE contextual reader and leaves an already-compliant mail untouched:
"in cc vanno questi tre" is not "in cc va qualcuno", so the three are unioned
in even when another Bali Zero address is already present. Scoped to this one
family — no other practice changes.

THE LEAK: `_default_send_magic_link_email` posts {to, subject, body} with no
`email_type`, so the hard rule classified a customer's magic link as ordinary
client correspondence and forced the accounting address into CC. That mail's
body IS the recipient's single-use key to their own application: the copy was
not an audit trail, it was a staff mailbox holding a working login for every
customer. Credential deliveries now carry no Bali Zero copy at all, and a
caller-supplied cc/bcc is STRIPPED rather than left un-augmented.

The exemption is a fixed membership set decided in the router, never a boolean
a caller passes — a bypass anyone can set is not a rule (superscar #3). An
email_type that is absent, misspelled or merely CONTAINING the name is not
exempt, so a typo's failure mode is an unwanted copy, never a leaked
credential; three innocence tests pin that direction.

`_enforce_balizero_cc` now returns (cc, bcc). It returned cc alone, which left
no way to drop a bcc — and a bcc'd login link leaks exactly as much as a cc'd
one. The 11 existing assertions are unchanged, routed through a `_cc_of`
helper rather than restated.

Bites: `send_direct_email` in this same file is the single choke-point every
outbound mail passes through, and `magic_link_store._default_send_magic_link_email`
is the caller that now declares its type. Observed: 31 passed, and four
mutations each go red on their own test — deleting the credential exemption
(4 red), making the VOA classifier never match (5 red), reducing VOA to
"only if nobody is copied" (2 red), and stripping cc while forgetting bcc
(1 red, the test written for it).

Not cured here, inherited and out of this diff's scope: `send_direct_email`
logs the recipient address at info level on every successful send.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>