### PR TITLE
THROWAWAY: guilt-fixture proof for voa-probe-tests.yml (never merge)

### DIFF
--- a/infra/launchagents/wrappers/voa-probe-wrapper.sh
+++ b/infra/launchagents/wrappers/voa-probe-wrapper.sh
@@ -221,7 +221,7 @@ if zmodload zsh/system 2>/dev/null; then
     fi
     case "$lock_rc" in
         0) LOCK_ACQUIRED=0 ;;
-        2)
+        99)
             echo "[voa-probe] overlapping run detected (lock busy: $LOCKFILE) — skipping this tick" >> "$LOG"
             heartbeat "warning" "skipped: overlapping run held the advisory lock"
             exit 0


### PR DESCRIPTION
Deliberate guilt fixture (case 2 -> 99 in voa-probe-wrapper.sh) to observe `voa-probe-tests.yml` go red in real CI, closing the proof-of-armed bar in PENDING-ARMS L1702. Will be closed without merging.