### PR TITLE
fix(evidence-lint): exclude pip-compile lockfiles from the size term, like every other lockfile

### DIFF
--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -828,6 +828,37 @@ SIZE_TERM_EXCLUDE_FILENAMES: tuple[str, ...] = (
     "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock",
     "Cargo.lock", "uv.lock", "Gemfile.lock", "composer.lock",
 )
+#: Exact repo-relative PATHS (never a basename, never a glob) for this
+#: repo's own pip-compile-style, hash-pinned, machine-derived lockfiles —
+#: added 2026-09-02 after measurement on PR #5530 (a routine 55-package pip
+#: dependabot bump, `gh api repos/Bali-Zero/Teman2/pulls/5530/files`): the
+#: two files carried 3570 of 3672 total churned lines (97%); the remaining
+#: 102 lines, spread across 5 human-reviewable `requirements*.txt` files,
+#: still count in full.
+#:
+#: Went through TWO adversarial rounds on this same PR before landing here:
+#: (1) a glob `requirements*.lock.txt` matched any basename in that shape,
+#: including a hand-added `requirements-backdoor.lock.txt` nobody's tooling
+#: produced; (2) fixing that to two exact LITERALS still matched by
+#: basename only (`PurePosixPath(path).name`), so the same fabricated
+#: content at `docs/requirements.lock.txt` or any other directory still
+#: exempted itself — the well-known package-manager names above accept
+#: that basename-only risk because they are unambiguous, single-ecosystem
+#: conventions; "requirements.lock.txt" is generic enough that a decoy
+#: elsewhere in the tree is a real, not hypothetical, shape. This repo
+#: already treats exactly that shape as suspicious in the OTHER direction
+#: (`scripts/prepush_classify.py`'s `NEVER_INNOCENT_BASENAMES`, proven by
+#: `test_guilt_requirements_family_under_an_allowlisted_prefix_forces_full`
+#: in `scripts/tests/test_prepush_classify.py`: a requirements manifest
+#: under an allowlisted prefix it doesn't really live under must force
+#: full attention, never read as innocent) — matching that discipline here
+#: means exempting by FULL PATH, not name. Only these two exact,
+#: currently-real paths are exempted; a genuine future sibling (e.g. a
+#: split requirements-dev.lock.txt) needs its own literal added here.
+SIZE_TERM_EXCLUDE_EXACT_PATHS: tuple[str, ...] = (
+    "apps/backend-rag/requirements.lock.txt",
+    "apps/backend-rag/requirements-prod.lock.txt",
+)
 SIZE_TERM_EXCLUDE_SUFFIXES: tuple[str, ...] = (
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".bmp",
     ".pdf", ".zip", ".gz", ".woff", ".woff2", ".ttf", ".otf", ".eot",
@@ -839,15 +870,25 @@ def _is_size_term_excluded(path: str) -> bool:
     """True when `path` should NOT count toward the size term (S1):
     generated/vendored output, well-known lockfiles, minified bundles, and
     binary/image assets. See the SIZE_TERM_EXCLUDE_* tuples above for what
-    and why. Deliberately NOT a blanket `*.lock` suffix match (adversarial
-    review, PR #5049): the mandate's "lockfiles" meant the well-known
-    package-manager ones enumerated above, not every file a script happens
-    to name `*.lock` — this repo's own coordination primitives use that
-    suffix for real hand-written state (CLAUDE.md's `agent_lock:<resource>`
-    Redis keys), and a blanket suffix match would have let a diff touching
-    real lock-coordination code hide behind the same exemption."""
+    and why. Deliberately NOT a blanket `*.lock`/`*.lock.txt` suffix or glob
+    match (adversarial review, PR #5049 and again PR #5531): the mandate's
+    "lockfiles" meant the well-known, actually-produced ones enumerated
+    above, not every file a script happens to name that way — this repo's
+    own coordination primitives use `*.lock` for real hand-written state
+    (CLAUDE.md's `agent_lock:<resource>` Redis keys), and a blanket
+    suffix/glob match would let a diff touching real lock-coordination
+    code — or a fabricated file chosen to LOOK like a lockfile — hide
+    behind the same exemption (superscar #3, W98-class). The well-known
+    package-manager names in SIZE_TERM_EXCLUDE_FILENAMES match by BASENAME
+    (any directory) because each is an unambiguous single-ecosystem
+    convention; SIZE_TERM_EXCLUDE_EXACT_PATHS matches by FULL repo-relative
+    PATH ONLY (PR #5531 round 2) because "requirements.lock.txt" is a
+    generic enough name that a same-named decoy elsewhere in the tree is a
+    real risk, not a hypothetical one."""
     p = PurePosixPath(path)
     if any(part in SIZE_TERM_EXCLUDE_DIR_NAMES for part in p.parts[:-1]):
+        return True
+    if p.as_posix() in SIZE_TERM_EXCLUDE_EXACT_PATHS:
         return True
     name = p.name
     if name in SIZE_TERM_EXCLUDE_FILENAMES:
@@ -876,11 +917,21 @@ def _size_term_net_lines(numstat: str) -> int:
     excludes generated/vendored/binary paths (_is_size_term_excluded) that
     inflate churn without inflating review burden. Binary rows
     ("-\\t-\\tpath") and malformed lines are skipped, same as
-    sum_numstat()."""
+    sum_numstat(). CORRECTED again 2026-09-02 (adversarial review, codex-sol,
+    PR #5531, round 3): the blankness check used to be `line = line.strip()`
+    on the WHOLE line before splitting, which silently strips leading/
+    trailing whitespace off the PATH field too — git permits a trailing
+    space in a real filename, so a decoy committed as
+    "apps/backend-rag/requirements.lock.txt " (note the space) numstat's as
+    that literal string, gets stripped to the real lockfile's exact name,
+    and its churn vanishes from the size term entirely. `sum_numstat()`
+    above does the identical whole-line strip but is safe from this class —
+    it never looks at `path` for a decision, only at the two numeric
+    fields. Here, where `path` gates an exclusion, blankness is checked
+    without mutating the line the path is sliced from."""
     net = 0
     for line in numstat.splitlines():
-        line = line.strip()
-        if not line:
+        if not line.strip():
             continue
         parts = line.split("\t")
         if len(parts) < 3:

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -660,6 +660,47 @@ def test_compute_floor_hotzone_hit_wins_over_small_size():
     assert compute_floor(["fly.toml"], numstat) == 3
 
 
+def test_compute_floor_innocence_pip_compile_lockfile_churn_does_not_floor_2026_09_02():
+    """INNOCENCE (2026-09-02): a diff whose churn is almost entirely inside
+    the pip-compile-generated `.lock.txt` files, with a small human-authored
+    `requirements*.txt` diff underneath, must NOT floor at Gear 3 on size.
+    This is the ACTUAL numstat of dependabot PR #5530 (verified via
+    `gh api repos/Bali-Zero/Teman2/pulls/5530/files`, not a hand-picked
+    approximation): 55-package minor-and-patch bump, 3672 raw lines total,
+    102 of them in the 5 human-reviewable `requirements*.txt` files, 3570
+    (97%) inside the two `.lock.txt` files this exemption targets."""
+    changed = [
+        "apps/backend-rag/requirements-ci-tools.txt",
+        "apps/backend-rag/requirements-livekit-worker.txt",
+        "apps/backend-rag/requirements-prod.lock.txt",
+        "apps/backend-rag/requirements-prod.txt",
+        "apps/backend-rag/requirements-test.txt",
+        "apps/backend-rag/requirements.lock.txt",
+        "apps/backend-rag/requirements.txt",
+    ]
+    numstat = (
+        "1\t1\tapps/backend-rag/requirements-ci-tools.txt\n"
+        "1\t1\tapps/backend-rag/requirements-livekit-worker.txt\n"
+        "827\t784\tapps/backend-rag/requirements-prod.lock.txt\n"
+        "21\t21\tapps/backend-rag/requirements-prod.txt\n"
+        "1\t1\tapps/backend-rag/requirements-test.txt\n"
+        "1001\t958\tapps/backend-rag/requirements.lock.txt\n"
+        "27\t27\tapps/backend-rag/requirements.txt\n"
+    )
+    assert compute_floor(changed, numstat) == 1
+
+
+def test_compute_floor_guilt_large_requirements_txt_source_diff_still_floors_2026_09_02():
+    """GUILT (2026-09-02): the exemption narrows the *counted* churn, it does
+    not exempt the PR from the floor outright — a diff that churns
+    SIZE_GEAR2_THRESHOLD lines in the human-authored `requirements.txt`
+    itself (not the generated lock file) must still floor at Gear 2, exactly
+    as any other ordinary source file would."""
+    changed = ["apps/backend-rag/requirements.txt"]
+    numstat = f"{SIZE_GEAR2_THRESHOLD}\t0\tapps/backend-rag/requirements.txt\n"
+    assert compute_floor(changed, numstat) == 2
+
+
 # --------------------------------------------------------- compute_floor_source (S2)
 # S2, 2026-08-27 (Gear-3 gate review round 2, PR #5049): compute_floor_source()
 # exposes WHY the floor is what it is, so harness-floor.yml's Step 5b can grant
@@ -815,6 +856,117 @@ def test_size_term_net_lines_innocence_not_fixtures_directory_not_excluded():
     is NOT excluded — only a genuine `fixtures/` component is."""
     numstat = "100\t0\tapps/x/not_fixtures/real.py\n"
     assert _size_term_net_lines(numstat) == 100
+
+
+def test_size_term_net_lines_pip_compile_lockfile_excluded_2026_09_02():
+    """GUILT->INNOCENCE (2026-09-02): this repo's pip-compile lockfiles
+    (`requirements.lock.txt`, `requirements-prod.lock.txt`) are the SAME
+    machine-derived object `poetry.lock`/`uv.lock` already are above, under
+    a naming convention the exact-name tuple previously could not match.
+    This is the ACTUAL, complete numstat of dependabot PR #5530 (verified
+    via `gh api repos/Bali-Zero/Teman2/pulls/5530/files`): the two
+    `.lock.txt` files carried 3570 of 3672 total churned lines (97%); the
+    remaining 102 lines are spread across 5 human-reviewable
+    `requirements*.txt` files and all still count."""
+    numstat = (
+        "1\t1\tapps/backend-rag/requirements-ci-tools.txt\n"
+        "1\t1\tapps/backend-rag/requirements-livekit-worker.txt\n"
+        "827\t784\tapps/backend-rag/requirements-prod.lock.txt\n"
+        "21\t21\tapps/backend-rag/requirements-prod.txt\n"
+        "1\t1\tapps/backend-rag/requirements-test.txt\n"
+        "1001\t958\tapps/backend-rag/requirements.lock.txt\n"
+        "27\t27\tapps/backend-rag/requirements.txt\n"
+    )
+    # only the 5 human-authored requirements*.txt files count:
+    # 2 + 2 + 42 + 2 + 54 = 102 (the two .lock.txt files, 3570, are excluded)
+    assert _size_term_net_lines(numstat) == 102
+
+
+def test_size_term_net_lines_innocence_similarly_named_file_not_matched():
+    """INNOCENCE (guard-over-match, superscar #3): the exemption is two
+    EXACT literals, not a `requirements*` prefix or `.lock.txt` suffix
+    match — a file that merely shares the `.lock.txt` suffix without being
+    one of the two names this repo's tooling actually writes (e.g. a
+    future hand-written lock-coordination file choosing a similar name) is
+    NOT exempted. Mirrors the existing named-lockfile-vs-custom.lock test
+    above for the same discipline."""
+    numstat = "50\t10\tinfra/coordination/myrequirements.lock.txt\n"
+    assert _size_term_net_lines(numstat) == 60
+
+
+def test_size_term_net_lines_guilt_glob_shaped_fabricated_lockfile_not_excluded_2026_09_02():
+    """GUILT (2026-09-02, adversarial finding from a codex-sol refuter on
+    this same PR): the FIRST cut of this exemption used an fnmatch glob
+    `requirements*.lock.txt`, which would have exempted ANY basename
+    matching that shape regardless of whether this repo's tooling actually
+    produces it — e.g. a hand-added `requirements-backdoor.lock.txt` could
+    smuggle arbitrary churn past the size term by name alone (W98-class:
+    content-based never name-speculative). The fix (exact-literal matching)
+    closes that hole: only the two lockfiles this repo's dependency
+    tooling actually writes are exempted; anything else sharing the naming
+    SHAPE — however lockfile-like — still counts in full."""
+    numstat = (
+        "2000\t0\tapps/backend-rag/requirements-backdoor.lock.txt\n"
+        "50\t0\tapps/backend-rag/requirements-handwritten.lock.txt\n"
+        "30\t0\tapps/backend-rag/requirementsfoo.lock.txt\n"
+    )
+    assert _size_term_net_lines(numstat) == 2080
+
+
+def test_size_term_net_lines_guilt_same_basename_wrong_directory_not_excluded_2026_09_02():
+    """GUILT (2026-09-02, round-2 adversarial finding from a codex-sol
+    refuter on this same PR): the ROUND-1 fix matched the two lockfiles by
+    BASENAME only (`PurePosixPath(path).name`) — same mechanism the
+    well-known package-manager names already use above. That is fine for
+    `poetry.lock`/`Cargo.lock`/etc (unambiguous single-ecosystem names),
+    but "requirements.lock.txt" is generic enough that a decoy at
+    `docs/requirements.lock.txt` or `research/requirements-prod.lock.txt`
+    would ALSO have matched by basename, exempting fabricated churn at a
+    path this repo's tooling never writes to. This repo already treats
+    exactly that shape as suspicious in the opposite direction — see
+    `test_guilt_requirements_family_under_an_allowlisted_prefix_forces_full`
+    in test_prepush_classify.py, which forces FULL attention on a
+    requirements manifest under an allowlisted-but-wrong prefix. The fix
+    (SIZE_TERM_EXCLUDE_EXACT_PATHS, matched by full repo-relative path, not
+    basename) closes this: only the two real paths are exempted."""
+    numstat = (
+        "2000\t0\tdocs/requirements.lock.txt\n"
+        "1500\t0\tresearch/requirements-prod.lock.txt\n"
+    )
+    assert _size_term_net_lines(numstat) == 3500
+
+
+def test_size_term_net_lines_innocence_real_lockfile_paths_still_excluded_2026_09_02():
+    """INNOCENCE companion to the guilt test above: the two REAL paths this
+    repo's pip-compile tooling actually writes to must still be excluded —
+    the round-2 fix narrows the match from basename to full path, it does
+    not accidentally stop matching the real files."""
+    numstat = (
+        "827\t784\tapps/backend-rag/requirements-prod.lock.txt\n"
+        "1001\t958\tapps/backend-rag/requirements.lock.txt\n"
+    )
+    assert _size_term_net_lines(numstat) == 0
+
+
+def test_size_term_net_lines_guilt_trailing_space_decoy_not_excluded_2026_09_02():
+    """GUILT (2026-09-02, round-3 adversarial finding from a codex-sol
+    refuter on this same PR): `_size_term_net_lines` used to call
+    `line.strip()` on the WHOLE numstat line before splitting it, silently
+    dropping a trailing space that is part of the actual filename. Git
+    permits a trailing space in a real committed filename, so a decoy
+    committed as `apps/backend-rag/requirements.lock.txt ` (note the
+    trailing space — a DIFFERENT file from the real lockfile) would
+    numstat as that literal string, get stripped down to the real
+    lockfile's exact name by the old code, and match
+    SIZE_TERM_EXCLUDE_EXACT_PATHS despite being a different file entirely
+    — hiding its churn from the floor. This is orthogonal to round 1/2
+    (it is a parsing bug in the shared numstat loop, not in the exclusion
+    tuples) but was demonstrated against these exact two new paths, so it
+    is pinned here. Verified empirically before the fix: this fixture's
+    net was 0 (fully hidden); after the fix (blankness checked without
+    mutating the line the path is sliced from) it must be 2000."""
+    numstat = "2000\t0\tapps/backend-rag/requirements.lock.txt \n"
+    assert _size_term_net_lines(numstat) == 2000
 
 
 # --------------------------------------------------------- end-to-end lint()


### PR DESCRIPTION
## Cosa cambia

`apps/backend-rag/requirements.lock.txt` / `requirements-prod.lock.txt` (pip-compile, hash-pinned, machine-derivati) vengono ora esclusi dal SIZE term del gear-classifier `scripts/evidence_pack_lint.py`, con lo stesso trattamento già riservato a `poetry.lock`/`uv.lock`/`package-lock.json`.

**Motivo misurato**: dependabot #5530 (55 pacchetti, minor-and-patch) falliva "Harness floor recompute" a floor=3/source=size perché 3570 delle 3672 righe churnate vivevano nei due `.lock.txt` generati; il diff umano (`requirements*.txt`) era 102 righe — ben sotto la soglia Gear-2 (400).

## Tre round adversariali (codex-sol, foreground, read-only sandbox)

1. **Round 1**: primo cut con glob fnmatch `requirements*.lock.txt` — rotto: matcha qualsiasi basename in quella forma, incluso un `requirements-backdoor.lock.txt` fabbricato a mano.
2. **Round 2**: fix a due literal esatti (filename) — ancora rotto: il match per basename lascia passare un decoy con lo stesso nome in QUALSIASI directory (`docs/requirements.lock.txt`). Questo repo tratta già quella stessa forma come sospetta nella direzione opposta (`prepush_classify.py`'s `NEVER_INNOCENT_BASENAMES` forza full-attention su un manifest requirements sotto un prefix sbagliato) — coerentemente, l'esenzione qui va per PATH completo, non per nome (`SIZE_TERM_EXCLUDE_EXACT_PATHS`).
3. **Round 3**: trovato un bug ORTOGONALE e PREESISTENTE nel parser condiviso `_size_term_net_lines`: faceva `line.strip()` sull'intera riga numstat PRIMA di splittarla, cancellando uno spazio finale che è parte legittima di un nome file git — un decoy `requirements.lock.txt ` (spazio finale) si normalizzava nel path reale e nascondeva il suo churn. Il bug preesisteva (valeva anche per `poetry.lock`/`uv.lock`) ma è stato dimostrato esattamente sul codice toccato da questa PR, quindi corretto qui.

**Round 4 (finale)**: verdetto **SAFE TO MERGE**, nessun finding residuo.

## Test

Guilt+innocence per tutte e tre le classi di attacco chiuse, più la coppia `compute_floor`/`_size_term_net_lines` sul numstat REALE di PR #5530 (verificato via `gh api repos/Bali-Zero/Teman2/pulls/5530/files`). 340 → 344 test, tutti verdi.

**Bites**: dependabot #5530 (o il suo successore) — dopo il merge, "Harness floor recompute" deve passare a floor=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)