### PR TITLE
fix(migrations): pre-check the catalog and bound the DDL lock wait so a no-op migration 121 cannot hang the deploy

### DIFF
--- a/apps/backend-rag/backend/migrations/_lock_guard.py
+++ b/apps/backend-rag/backend/migrations/_lock_guard.py
@@ -1,0 +1,40 @@
+"""Retry DDL that cannot immediately acquire a PostgreSQL table lock."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Awaitable, Callable
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+_LOCK_TIMEOUT_PATTERN = re.compile(r"^\d+(ms|s|min)$")
+
+
+async def run_ddl_with_lock_timeout(
+    conn: asyncpg.Connection,
+    fn: Callable[[asyncpg.Connection], Awaitable[None]],
+    *,
+    lock_timeout: str = "5s",
+    attempts: int = 3,
+    sleep_seconds: float = 2.0,
+    sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> None:
+    """Run DDL with a bounded lock wait and retry on unavailable locks."""
+    if not _LOCK_TIMEOUT_PATTERN.fullmatch(lock_timeout):
+        raise ValueError(f"Invalid lock_timeout: {lock_timeout!r}")
+
+    await conn.execute(f"SET lock_timeout = '{lock_timeout}'")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            await fn(conn)
+            return
+        except asyncpg.exceptions.LockNotAvailableError:
+            logger.warning("DDL lock unavailable (attempt %d/%d)", attempt, attempts)
+            if attempt == attempts:
+                raise
+            await sleeper(sleep_seconds)

--- a/apps/backend-rag/backend/migrations/apply_migration_119.py
+++ b/apps/backend-rag/backend/migrations/apply_migration_119.py
@@ -24,6 +24,7 @@ import asyncpg
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from migrations._lock_guard import run_ddl_with_lock_timeout
 from migrations.migration_119_partners import apply
 
 logging.basicConfig(
@@ -57,7 +58,11 @@ async def main() -> None:
             "Applying migration 119: partners + partner_referrals + "
             "partner_commissions + partner_audit_log + team_members.partner_id column",
         )
-        await apply(conn)
+        try:
+            await run_ddl_with_lock_timeout(conn, apply)
+        except asyncpg.exceptions.LockNotAvailableError:
+            logger.error("Migration 119 failed: DDL lock unavailable after retries")
+            sys.exit(3)
 
         # Verify core tables exist
         tables = await conn.fetch(

--- a/apps/backend-rag/backend/migrations/apply_migration_120.py
+++ b/apps/backend-rag/backend/migrations/apply_migration_120.py
@@ -23,6 +23,7 @@ import asyncpg
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from migrations._lock_guard import run_ddl_with_lock_timeout
 from migrations.migration_120_partner_email_outbox import apply
 
 logging.basicConfig(
@@ -54,7 +55,11 @@ async def main() -> None:
             sys.exit(2)
 
         logger.info("Applying migration 120: partner_email_outbox")
-        await apply(conn)
+        try:
+            await run_ddl_with_lock_timeout(conn, apply)
+        except asyncpg.exceptions.LockNotAvailableError:
+            logger.error("Migration 120 failed: DDL lock unavailable after retries")
+            sys.exit(3)
 
         # Verify
         exists = await conn.fetchval(

--- a/apps/backend-rag/backend/migrations/apply_migration_121.py
+++ b/apps/backend-rag/backend/migrations/apply_migration_121.py
@@ -23,6 +23,7 @@ import asyncpg
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from migrations._lock_guard import run_ddl_with_lock_timeout
 from migrations.migration_121_practices_family_member import apply
 
 logging.basicConfig(
@@ -55,7 +56,11 @@ async def main() -> None:
                 sys.exit(2)
 
         logger.info("Applying migration 121: practices.family_member_id")
-        await apply(conn)
+        try:
+            await run_ddl_with_lock_timeout(conn, apply)
+        except asyncpg.exceptions.LockNotAvailableError:
+            logger.error("Migration 121 failed: DDL lock unavailable after retries")
+            sys.exit(3)
 
         # Verify column + FK
         col_exists = await conn.fetchval(

--- a/apps/backend-rag/backend/migrations/migration_121_practices_family_member.py
+++ b/apps/backend-rag/backend/migrations/migration_121_practices_family_member.py
@@ -24,17 +24,40 @@ logger = logging.getLogger(__name__)
 
 
 async def apply(conn: Any) -> None:
-    await conn.execute("""
-        ALTER TABLE practices
-        ADD COLUMN IF NOT EXISTS family_member_id BIGINT
-            REFERENCES client_family_members(id) ON DELETE SET NULL;
+    column_exists = await conn.fetchval("""
+        SELECT EXISTS (
+            SELECT FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'practices'
+              AND column_name = 'family_member_id'
+        )
+    """)
+    index_exists = await conn.fetchval("""
+        SELECT EXISTS (
+            SELECT FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'practices'
+              AND indexname = 'idx_practices_family_member_id'
+        )
     """)
 
-    await conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_practices_family_member_id "
-        "ON practices (family_member_id) "
-        "WHERE family_member_id IS NOT NULL;"
-    )
+    if column_exists and index_exists:
+        logger.info("Migration 121 already applied — no DDL, no lock")
+        return
+
+    if not column_exists:
+        await conn.execute("""
+            ALTER TABLE practices
+            ADD COLUMN IF NOT EXISTS family_member_id BIGINT
+                REFERENCES client_family_members(id) ON DELETE SET NULL;
+        """)
+
+    if not index_exists:
+        await conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_practices_family_member_id "
+            "ON practices (family_member_id) "
+            "WHERE family_member_id IS NOT NULL;"
+        )
 
     logger.info("Migration 121: practices.family_member_id + partial index applied")
 

--- a/apps/backend-rag/backend/tests/migrations/test_migration_121.py
+++ b/apps/backend-rag/backend/tests/migrations/test_migration_121.py
@@ -1,0 +1,133 @@
+"""Tests for migration 121 and its DDL lock guard."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+
+def _sql_calls(conn: AsyncMock) -> list[str]:
+    """Return SQL passed to the connection execute mock."""
+    return [call.args[0] for call in conn.execute.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_migration_121_noops_without_ddl_when_column_and_index_exist() -> None:
+    """Existing schema must never issue a lock-taking DDL statement."""
+    from backend.migrations.migration_121_practices_family_member import apply
+
+    conn = AsyncMock()
+    conn.fetchval.side_effect = [True, True]
+
+    await apply(conn)
+
+    assert conn.execute.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_migration_121_creates_missing_column_and_index_in_order() -> None:
+    """A new schema receives the column before its dependent index."""
+    from backend.migrations.migration_121_practices_family_member import apply
+
+    conn = AsyncMock()
+    conn.fetchval.side_effect = [False, False]
+
+    await apply(conn)
+
+    sql = _sql_calls(conn)
+    assert len(sql) == 2
+    assert "ALTER TABLE practices" in sql[0]
+    assert "CREATE INDEX IF NOT EXISTS idx_practices_family_member_id" in sql[1]
+
+
+@pytest.mark.asyncio
+async def test_migration_121_creates_only_missing_index() -> None:
+    """An existing column skips ALTER TABLE when only the index is absent."""
+    from backend.migrations.migration_121_practices_family_member import apply
+
+    conn = AsyncMock()
+    conn.fetchval.side_effect = [True, False]
+
+    await apply(conn)
+
+    sql = _sql_calls(conn)
+    assert sql == [
+        "CREATE INDEX IF NOT EXISTS idx_practices_family_member_id "
+        "ON practices (family_member_id) "
+        "WHERE family_member_id IS NOT NULL;"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lock_guard_sets_timeout_before_calling_ddl() -> None:
+    """The session lock timeout is set before invoking the DDL function."""
+    from backend.migrations._lock_guard import run_ddl_with_lock_timeout
+
+    conn = AsyncMock()
+    call_order: list[str] = []
+
+    async def fn(connection: asyncpg.Connection) -> None:
+        assert connection is conn
+        call_order.append("fn")
+
+    conn.execute.side_effect = lambda sql: call_order.append(sql)
+
+    await run_ddl_with_lock_timeout(conn, fn)
+
+    assert call_order == ["SET lock_timeout = '5s'", "fn"]
+
+
+@pytest.mark.asyncio
+async def test_lock_guard_retries_until_ddl_succeeds() -> None:
+    """Two unavailable locks retry twice before a successful third attempt."""
+    from backend.migrations._lock_guard import run_ddl_with_lock_timeout
+
+    conn = AsyncMock()
+    fn: Callable[[asyncpg.Connection], Awaitable[None]] = AsyncMock(
+        side_effect=[
+            asyncpg.exceptions.LockNotAvailableError("x"),
+            asyncpg.exceptions.LockNotAvailableError("x"),
+            None,
+        ]
+    )
+    sleeper = AsyncMock()
+
+    await run_ddl_with_lock_timeout(conn, fn, sleeper=sleeper)
+
+    assert fn.call_count == 3
+    assert sleeper.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_lock_guard_reraises_after_all_attempts() -> None:
+    """An unavailable lock after the final attempt remains visible to callers."""
+    from backend.migrations._lock_guard import run_ddl_with_lock_timeout
+
+    conn = AsyncMock()
+    fn: Callable[[asyncpg.Connection], Awaitable[None]] = AsyncMock(
+        side_effect=asyncpg.exceptions.LockNotAvailableError("x")
+    )
+    sleeper = AsyncMock()
+
+    with pytest.raises(asyncpg.exceptions.LockNotAvailableError):
+        await run_ddl_with_lock_timeout(conn, fn, attempts=3, sleeper=sleeper)
+
+    assert fn.call_count == 3
+    assert sleeper.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_lock_guard_rejects_invalid_timeout_before_execute() -> None:
+    """Timeout validation must prevent unsafe SQL interpolation."""
+    from backend.migrations._lock_guard import run_ddl_with_lock_timeout
+
+    conn = AsyncMock()
+    fn: Callable[[asyncpg.Connection], Awaitable[None]] = AsyncMock()
+
+    with pytest.raises(ValueError, match="Invalid lock_timeout"):
+        await run_ddl_with_lock_timeout(conn, fn, lock_timeout="5s; SELECT 1")
+
+    assert conn.execute.call_count == 0


### PR DESCRIPTION
## Why

Every deploy re-runs `apply_migration_121` post-deploy (`fly-deploy.yml`, step timeout 2 min). Its `ALTER TABLE practices ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` are no-ops in prod (both objects exist since 2026-09-02 13:08Z), but Postgres takes the ACCESS EXCLUSIVE / SHARE lock on `practices` **before** evaluating `IF NOT EXISTS`. During merge-queue batch deploys the statement queues behind live traffic without bound, the step hits its timeout, and the deploy workflow goes red on main on every push while prod is healthy (measured today: build `e83632f7b3` live and serving while the workflow reported failure).

## What

- `migration_121_practices_family_member.py::apply` reads `information_schema.columns` / `pg_indexes` first (no table lock) and returns with **zero** `execute` calls when both exist; otherwise runs only the missing statement(s). `rollback()` unchanged.
- New `backend/migrations/_lock_guard.py::run_ddl_with_lock_timeout`: `SET lock_timeout` (value validated against `^\d+(ms|s|min)$`), retries `LockNotAvailableError` up to 3× with an injectable sleeper, re-raises after.
- `apply_migration_119/120/121.py` call `apply()` through the guard and exit 3 with `DDL lock unavailable after retries` instead of timing out mute.
- `backend/tests/migrations/test_migration_121.py`: guilt (already applied → `execute.call_count == 0`), innocence (fresh schema → ALTER then CREATE INDEX), partial schema, guard order / retry / exhaustion / invalid timeout. Suite `backend/tests/migrations/`: 56 passed; ruff clean.

## Provenance

Built on the codex seat (`gpt-5.6-terra`, effort high) from a written task file; diff re-read and tests re-run by the conducting session; independent adversarial grade dispatched at PR-open (verdict will be posted here before merge). Harness floor for this diff: Gear 1.

Merging this PR deploys it (`fly-deploy.yml` on push to main); the wrappers run post-deploy — the first run after merge is the prove-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jne5CZvgNcjcy2D3hFYmE
