### PR TITLE
feat(garuda-voa): mount the document-upload HTTP hinge, with a size bound that is actually enforced while streaming

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_documents_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_documents_router.py
@@ -1,0 +1,499 @@
+"""HTTP shell for GARUDA VOA L5 — document upload + local-first OCR (hinge only).
+
+Implements exactly the two operations `products/garuda-voa/contracts/openapi.yaml`
+declares for `/api/visa/voa/eligibility-checks/{result_id}/documents`:
+`uploadIntakeDocument` (POST) and `listIntakeDocuments` (GET). Every business rule
+(byte validation, OCR, confidence classification, redaction) lives in
+`backend.services.garuda_documents` (L5, MERGED #4870) and is called, never
+reimplemented, here — this file's only job is translating HTTP <-> that service.
+
+Registered in `router_manifest.py` / `router_registration.py` (`_API`, mirrors
+`garuda_voa_public`/`garuda_orders_router` — mount unconditionally, flag
+`GARUDA_PUBLIC_ENABLED` re-checked per-request by this module's own
+`_require_flag`, wired as a ROUTER-LEVEL dependency so it resolves before every
+other `Depends()` and before body parsing, same ordering argument as
+`garuda_orders_router.py`'s comment above its own `router = APIRouter(...)`).
+
+WHY THIS ROUTER FAILS CLOSED IN PRODUCTION TODAY (deliberate, not a bug):
+`git log` PR #5120 ("the L5 document/OCR lane has no HTTP surface — and the Mini
+probe lies") found three stacked blockers, in order: (1) `garuda_documents/ports.py`
+ships only `InMemoryDocumentStore`, whose own docstring says it "must never be
+wired into a running service" — L1's retention-covered store has not merged for
+this table (`ports.py` module docstring: "no garuda-scoped documents migration
+exists"), and LANES.md is explicit that a lane must not persist a row before L1
+covers it; (2) OCR's only sanctioned host (`qwen2.5vl:7b`) sits on the Mini/Pro
+tailnet, not reachable from Fly — a sovereignty/architecture call, not a config
+change; (3) then this router. Building this router does not solve (1) or (2), and
+must not pretend to: `get_document_store()` below defaults to
+`_UnconfiguredDocumentStore`, the documents-lane analogue of
+`garuda_flow.public_api.UnconfiguredCheckStore` — every real call answers 503
+`PERSISTENCE_POLICY_UNAVAILABLE`/`SERVICE_UNAVAILABLE`, and OCR is never reached
+in that path (the store rejection happens before `service.submit_document` gets
+to the OCR call). The moment L1 ships a real `DocumentStorePort` adapter and (2)
+is resolved, swapping `app.state.garuda_document_store` in `service_initializer.py`
+is the only change needed — no router or contract edit — exactly the seam
+`garuda_flow/public_api.py`'s own module docstring describes for CheckStore.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from collections.abc import Awaitable, Callable
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from starlette.formparsers import MultiPartException
+
+from backend.services.garuda_documents import byte_validation
+from backend.services.garuda_documents.errors import (
+    DocumentTooLargeError,
+    UnsupportedMediaTypeError,
+)
+from backend.services.garuda_documents.models import (
+    DocumentKind,
+    DocumentOutcome,
+    LowConfidenceOutcome,
+    ProcessingOutcome,
+    ReadyOutcome,
+    UnreadableOutcome,
+)
+from backend.services.garuda_documents.ports import (
+    DocumentStorePort,
+    IdempotencyConflictError,
+)
+from backend.services.garuda_documents.service import (
+    DocumentIntakeService,
+    DocumentProcessingUnavailableError,
+)
+
+logger = logging.getLogger(__name__)
+
+_FLAG_ENV_VAR = "GARUDA_PUBLIC_ENABLED"
+
+
+def _flag_enabled() -> bool:
+    # Same permissive reader as garuda_voa_public/garuda_orders_router/
+    # garuda_portal_auth (LANES.md file-ownership discipline: a same-shaped
+    # LOCAL copy per file, never a shared import) — trimmed, case-insensitive,
+    # accepts "1"/"true"/"yes". A stricter/looser reader here would open this
+    # one surface out of step with the other three (the exact W-shaped bug
+    # `garuda_orders_router.py::_flag_enabled` was corrected for).
+    return os.environ.get(_FLAG_ENV_VAR, "").strip().lower() in {"1", "true", "yes"}
+
+
+def _require_flag() -> None:
+    if not _flag_enabled():
+        raise HTTPException(
+            status_code=404, detail={"code": "GARUDA_PUBLIC_DISABLED", "retryable": False}
+        )
+
+
+class _ContractErrorRoute(APIRoute):
+    """Rewrite every `HTTPException` this router raises into the frozen
+    `errors.yaml` envelope, with the same privacy headers a success path gets.
+
+    Same-shaped local copy of `garuda_orders_router.py`'s route class (LANES.md
+    discipline) — see that file's docstring for the full ordering argument on
+    why catching `HTTPException` here covers router-level dependency, parameter
+    dependency, and handler-body raises uniformly.
+    """
+
+    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+        downstream = super().get_route_handler()
+
+        async def handler(request: Request) -> Response:
+            try:
+                return await downstream(request)
+            except HTTPException as exc:
+                code = exc.detail.get("code") if isinstance(exc.detail, dict) else None
+                if code not in _ERROR_CATALOG:
+                    raise
+                return _error(code)
+
+        return handler
+
+
+router = APIRouter(
+    prefix="/api/visa/voa",
+    tags=["garuda-documents"],
+    route_class=_ContractErrorRoute,
+    dependencies=[Depends(_require_flag)],
+)
+
+
+def _privacy_headers(response: Response) -> None:
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
+
+
+#: `errors.yaml` — (http_status, retryable, message_key), restricted to the
+#: codes THIS router's own call sites can ever emit (500/429 are cross-cutting
+#: — the app-wide exception handler / rate-limit middleware — never raised
+#: here directly, same posture as `garuda_voa_public.py`'s own comment).
+_ERROR_CATALOG: dict[str, tuple[int, bool, str]] = {
+    "GARUDA_PUBLIC_DISABLED": (404, False, "garuda_voa.error.unavailable"),
+    "SESSION_REQUIRED": (401, False, "garuda_voa.error.session_required"),
+    "IDEMPOTENCY_KEY_REQUIRED": (400, False, "garuda_voa.error.idempotency_key_required"),
+    "RESULT_NOT_FOUND": (404, False, "garuda_voa.error.result_not_found"),
+    "IDEMPOTENCY_CONFLICT": (409, False, "garuda_voa.error.idempotency_conflict"),
+    "DOCUMENT_TOO_LARGE": (413, False, "garuda_voa.error.document_too_large"),
+    "UNSUPPORTED_DOCUMENT_MEDIA_TYPE": (
+        415,
+        False,
+        "garuda_voa.error.unsupported_document_media_type",
+    ),
+    "INVALID_REQUEST": (422, False, "garuda_voa.error.invalid_request"),
+    "UNREADABLE_DOCUMENT": (422, False, "garuda_voa.error.unreadable_document"),
+    "PERSISTENCE_POLICY_UNAVAILABLE": (503, False, "garuda_voa.error.sale_unavailable"),
+    "DOCUMENT_PROCESSING_UNAVAILABLE": (
+        503,
+        True,
+        "garuda_voa.error.document_processing_unavailable",
+    ),
+    "SERVICE_UNAVAILABLE": (503, True, "garuda_voa.error.service_unavailable"),
+}
+
+
+def _error(code: str) -> JSONResponse:
+    status_code, retryable, message_key = _ERROR_CATALOG[code]
+    response = JSONResponse(
+        status_code=status_code,
+        content={"code": code, "retryable": retryable, "message_key": message_key},
+    )
+    _privacy_headers(response)
+    return response
+
+
+class _PersistenceUnavailable(Exception):
+    """Raised by `_UnconfiguredDocumentStore` on every call — see its docstring."""
+
+
+class _UnconfiguredDocumentStore:
+    """Fail-closed `DocumentStorePort` default — the documents-lane analogue of
+    `garuda_flow.public_api.UnconfiguredCheckStore`.
+
+    Not a placeholder to delete later: it is the correct behaviour for as long
+    as no retention-covered store exists for `garuda_documents` (module
+    docstring above). Holds no bytes and no state; every call raises
+    `_PersistenceUnavailable`, which the handlers below map to the contract's
+    503 codes. `list_for_actor` is not part of `DocumentStorePort` (`ports.py`
+    has no enumeration method at all — a genuine gap, not an oversight this
+    router papers over); it is this router's own minimal extension so
+    `listIntakeDocuments` has something to call, structurally satisfied by
+    duck typing rather than a change to L5's frozen `ports.py`.
+    """
+
+    async def get_existing(self, _idempotency_key: str, _payload_hash: str) -> DocumentOutcome | None:
+        raise _PersistenceUnavailable()
+
+    async def commit(self, _idempotency_key: str, _payload_hash: str, _outcome: DocumentOutcome) -> bool:
+        raise _PersistenceUnavailable()
+
+    async def list_for_actor(self, _actor: str) -> list[dict]:
+        raise _PersistenceUnavailable()
+
+
+_default_store: DocumentStorePort = _UnconfiguredDocumentStore()
+
+
+def get_document_store(request: Request) -> DocumentStorePort:
+    """Reads `app.state.garuda_document_store`, wired by `service_initializer.py`.
+
+    Same `getattr(..., None) or default` shape `garuda_voa_public.get_garuda_check_store`
+    uses (never `app.dependency_overrides` for the PRODUCTION default — that dict is
+    FastAPI's test mechanism and a process-wide global one unrelated test's teardown
+    can clear). Tests override this dependency directly via
+    `app.dependency_overrides[get_document_store]`.
+    """
+    return getattr(request.app.state, "garuda_document_store", None) or _default_store
+
+
+class _ReplayTrackingStore:
+    """Wraps a `DocumentStorePort` to observe whether `DocumentIntakeService.submit_document`
+    took the short-circuit existing-outcome path — the one signal that method does not
+    return directly (it returns only the outcome, never a `(outcome, replayed)` pair,
+    unlike `garuda_orders/repository.py::create_order_and_checkout`). Delegates every
+    call unchanged; adds no persistence semantics and duplicates no hashing/business
+    logic — it only watches the SAME `get_existing` call `service.py` already makes.
+
+    `replayed` also goes True on the race-lost branch inside `submit_document` (a
+    second `get_existing` call after `commit` loses a race) — correct: the response
+    the caller receives there IS a previously (concurrently) committed outcome, not
+    freshly produced by this call, which is exactly what the header promises.
+    """
+
+    def __init__(self, inner: DocumentStorePort) -> None:
+        self._inner = inner
+        self.replayed = False
+
+    async def get_existing(self, idempotency_key: str, payload_hash: str) -> DocumentOutcome | None:
+        existing = await self._inner.get_existing(idempotency_key, payload_hash)
+        if existing is not None:
+            self.replayed = True
+        return existing
+
+    async def commit(self, idempotency_key: str, payload_hash: str, outcome: DocumentOutcome) -> bool:
+        return await self._inner.commit(idempotency_key, payload_hash, outcome)
+
+
+async def _require_magic_session_actor(request: Request) -> str:
+    """Same-shaped local copy of `garuda_orders_router.py`'s helper (LANES.md
+    discipline). Fails closed with SESSION_REQUIRED until the orchestrator wires
+    L4's real verifier onto `app.state.garuda_magic_session_verifier`. Returned
+    value is the session's own `result_id`, used both as the idempotency-scoping
+    actor and the ownership key every read/write below filters on.
+    """
+    verifier = getattr(request.app.state, "garuda_magic_session_verifier", None)
+    cookie = request.cookies.get("garuda_session")
+    if verifier is None or not cookie:
+        raise HTTPException(status_code=401, detail={"code": "SESSION_REQUIRED", "retryable": False})
+    actor = await verifier(cookie)
+    if actor is None:
+        raise HTTPException(status_code=401, detail={"code": "SESSION_REQUIRED", "retryable": False})
+    return actor
+
+
+def _idempotency_key(idempotency_key: str | None) -> str:
+    if not idempotency_key or len(idempotency_key) < 16 or len(idempotency_key) > 200:
+        raise HTTPException(
+            status_code=400, detail={"code": "IDEMPOTENCY_KEY_REQUIRED", "retryable": False}
+        )
+    return idempotency_key
+
+
+def _require_owned_result(result_id: str, actor: str) -> None:
+    """`actor` IS the session's own result_id (see `_require_magic_session_actor`'s
+    docstring) — a path `result_id` that does not match it is either malformed,
+    absent, or someone else's check. Same 404 RESULT_NOT_FOUND shape for all
+    three, deliberately: distinguishing them would open an enumeration oracle
+    (`garuda_orders_router.create_order_from_check` makes the identical call).
+    """
+    if result_id != actor:
+        raise HTTPException(status_code=404, detail={"code": "RESULT_NOT_FOUND", "retryable": False})
+
+
+def _scoped_key(*, actor: str, result_id: str, raw_key: str) -> str:
+    """Local scoping (LANES.md discipline: no cross-lane import of
+    `garuda_orders.idempotency`) — `DocumentStorePort` itself has no actor/result
+    concept (`ports.py` keys purely on the caller-supplied string), so without this
+    two different customers' documents could collide on the same literal
+    client-supplied Idempotency-Key value.
+    """
+    digest = hashlib.sha256()
+    for part in (actor, result_id, "uploadIntakeDocument", raw_key):
+        digest.update(part.encode("utf-8"))
+        digest.update(b"\x00")
+    return digest.hexdigest()
+
+
+async def _parse_upload_request(request: Request) -> tuple[DocumentKind, bytes, str]:
+    """Parses the multipart body with the size bound enforced DURING streaming.
+
+    Starlette's `MultiPartParser` checks each part's cumulative byte count as
+    chunks arrive from the ASGI receive channel and raises `MultiPartException`
+    the moment one part exceeds `max_part_size` (`formparsers.py::on_part_data`)
+    — it does not finish reading an oversized part first. Passing
+    `max_part_size=byte_validation.MAX_UPLOAD_BYTES` (the parser's own default is
+    1 MiB, well under our 15 MiB bound) means a 413 never requires buffering an
+    over-limit upload into memory, per this lane's hard rule.
+    """
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_length = int(content_length)
+        except ValueError:
+            declared_length = None
+        if declared_length is not None and declared_length > byte_validation.MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False})
+
+    try:
+        form = await request.form(max_part_size=byte_validation.MAX_UPLOAD_BYTES)
+    except MultiPartException as exc:
+        if "exceeded maximum size" in str(exc):
+            raise HTTPException(
+                status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False}
+            ) from exc
+        raise HTTPException(status_code=422, detail={"code": "INVALID_REQUEST", "retryable": False}) from exc
+
+    raw_kind = form.get("document_kind")
+    upload = form.get("file")
+    if not isinstance(raw_kind, str) or not hasattr(upload, "read"):
+        raise HTTPException(status_code=422, detail={"code": "INVALID_REQUEST", "retryable": False})
+    try:
+        document_kind = DocumentKind(raw_kind)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail={"code": "INVALID_REQUEST", "retryable": False}) from exc
+
+    raw_bytes = await upload.read()
+    declared_media_type = upload.content_type or ""
+    return document_kind, raw_bytes, declared_media_type
+
+
+#: Status codes documented for THIS operation, matching the frozen contract's
+#: declared set exactly (verified by `test_garuda_voa_openapi_parity.py`).
+#: Documentation only (`responses=` in the decorators below) — same shape as
+#: `garuda_orders_router.py::_OPERATION_STATUS_CODES`, which documents 500
+#: for the same reason: it IS genuinely reachable (any unhandled exception in
+#: either handler reaches the app-wide `general_exception_handler`, proven
+#: live by `TestUpload503::test_internal_error_is_the_apps_generic_500`), it
+#: is simply never raised by a `raise HTTPException(...)` call site in THIS
+#: file, so FastAPI would not otherwise put it in the generated schema. 429
+#: is not in the frozen contract's set for either operation here, unlike
+#: some `garuda_orders_router.py` operations, so it is correctly absent.
+_OPERATION_STATUS_CODES: dict[str, tuple[int, ...]] = {
+    "uploadIntakeDocument": (201, 202, 400, 401, 404, 409, 413, 415, 422, 500, 503),
+    "listIntakeDocuments": (200, 401, 404, 500, 503),
+}
+
+
+def _status_responses(operation_id: str) -> dict[int, dict[str, object]]:
+    return {
+        status_code: {"description": "See `products/garuda-voa/contracts/errors.yaml`."}
+        for status_code in _OPERATION_STATUS_CODES[operation_id]
+    }
+
+
+def _serialize_outcome(outcome: DocumentOutcome) -> tuple[int, dict]:
+    """Literal translation of `ReadyDocument`/`ProcessingDocument`/`LowConfidenceDocument`
+    (openapi.yaml components, ~line 1203) — never invents a field the contract
+    doesn't declare.
+    """
+    if isinstance(outcome, ReadyOutcome):
+        return 201, {
+            "document_id": outcome.document_id,
+            "processing_state": outcome.processing_state.value,
+            "review_fields": [
+                {
+                    "field_path": f.field_path.value,
+                    "value": f.value,
+                    "confirmation_required": f.confirmation_required,
+                }
+                for f in outcome.review_fields
+            ],
+        }
+    if isinstance(outcome, ProcessingOutcome):
+        return 202, {
+            "document_id": outcome.document_id,
+            "processing_state": outcome.processing_state.value,
+        }
+    if isinstance(outcome, LowConfidenceOutcome):
+        return 202, {
+            "document_id": outcome.document_id,
+            "processing_state": outcome.processing_state.value,
+            "uncertain_fields": [
+                {"field_path": f.field_path.value, "confirmation_required": f.confirmation_required}
+                for f in outcome.uncertain_fields
+            ],
+        }
+    # UnreadableOutcome — models.py's own docstring: "The router (L2) is
+    # responsible for mapping it to the 422 error envelope." Handled by the
+    # caller via isinstance-else, not reachable here.
+    raise AssertionError(f"unhandled outcome type: {type(outcome).__name__}")
+
+
+@router.post(
+    "/eligibility-checks/{result_id}/documents",
+    status_code=201,
+    operation_id="uploadIntakeDocument",
+    responses=_status_responses("uploadIntakeDocument"),
+    response_model=None,
+)
+async def upload_intake_document(
+    result_id: str,
+    request: Request,
+    response: Response,
+    idempotency_key: str | None = Header(None, alias="Idempotency-Key"),
+    store: DocumentStorePort = Depends(get_document_store),
+) -> dict | Response:
+    _privacy_headers(response)
+    actor = await _require_magic_session_actor(request)
+    key = _idempotency_key(idempotency_key)
+    _require_owned_result(result_id, actor)
+
+    document_kind, raw_bytes, declared_media_type = await _parse_upload_request(request)
+    scoped_key = _scoped_key(actor=actor, result_id=result_id, raw_key=key)
+
+    tracking_store = _ReplayTrackingStore(store)
+    service = DocumentIntakeService(store=tracking_store)
+
+    try:
+        outcome = await service.submit_document(
+            raw_bytes=raw_bytes,
+            declared_media_type=declared_media_type,
+            document_kind=document_kind,
+            idempotency_key=scoped_key,
+        )
+    except UnsupportedMediaTypeError as exc:
+        raise HTTPException(
+            status_code=415, detail={"code": "UNSUPPORTED_DOCUMENT_MEDIA_TYPE", "retryable": False}
+        ) from exc
+    except DocumentTooLargeError as exc:
+        raise HTTPException(
+            status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False}
+        ) from exc
+    except IdempotencyConflictError as exc:
+        raise HTTPException(
+            status_code=409, detail={"code": "IDEMPOTENCY_CONFLICT", "retryable": False}
+        ) from exc
+    except DocumentProcessingUnavailableError as exc:
+        raise HTTPException(
+            status_code=503, detail={"code": "DOCUMENT_PROCESSING_UNAVAILABLE", "retryable": True}
+        ) from exc
+    except _PersistenceUnavailable as exc:
+        raise HTTPException(
+            status_code=503, detail={"code": "PERSISTENCE_POLICY_UNAVAILABLE", "retryable": False}
+        ) from exc
+
+    if tracking_store.replayed:
+        response.headers["Idempotency-Replayed"] = "true"
+
+    # UnreadableOutcome carries no PII (only `document_id`) and maps to the 422
+    # error envelope per models.py's own docstring — returned via `_error()`
+    # directly rather than through `_serialize_outcome`'s isinstance ladder.
+    if isinstance(outcome, UnreadableOutcome):
+        return _error("UNREADABLE_DOCUMENT")
+
+    status_code, body = _serialize_outcome(outcome)
+    response.status_code = status_code
+    return body
+
+
+@router.get(
+    "/eligibility-checks/{result_id}/documents",
+    operation_id="listIntakeDocuments",
+    responses=_status_responses("listIntakeDocuments"),
+)
+async def list_intake_documents(
+    result_id: str,
+    request: Request,
+    response: Response,
+    store: DocumentStorePort = Depends(get_document_store),
+) -> dict:
+    """Customer-safe metadata only (contract: `DocumentList` -> `DocumentSummary`).
+
+    `list_for_actor` is NOT part of `DocumentStorePort` (`ports.py` has no
+    enumeration method at all today — see `_UnconfiguredDocumentStore`'s
+    docstring) — called via duck typing so this endpoint has something to call
+    without editing L5's frozen file; any store that lacks it, or that raises,
+    answers the contract's single documented 503 `SERVICE_UNAVAILABLE`, never a
+    stack trace or raw OCR diagnostic.
+    """
+    _privacy_headers(response)
+    actor = await _require_magic_session_actor(request)
+    _require_owned_result(result_id, actor)
+
+    list_for_actor = getattr(store, "list_for_actor", None)
+    if list_for_actor is None:
+        raise HTTPException(status_code=503, detail={"code": "SERVICE_UNAVAILABLE", "retryable": True})
+    try:
+        summaries = await list_for_actor(actor)
+    except _PersistenceUnavailable as exc:
+        raise HTTPException(
+            status_code=503, detail={"code": "SERVICE_UNAVAILABLE", "retryable": True}
+        ) from exc
+
+    return {"documents": summaries}

--- a/apps/backend-rag/backend/app/routers/garuda_documents_router.py
+++ b/apps/backend-rag/backend/app/routers/garuda_documents_router.py
@@ -40,12 +40,12 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
-from starlette.formparsers import MultiPartException
+from starlette.formparsers import MultiPartException, MultiPartParser
 
 from backend.services.garuda_documents import byte_validation
 from backend.services.garuda_documents.errors import (
@@ -290,16 +290,68 @@ def _scoped_key(*, actor: str, result_id: str, raw_key: str) -> str:
     return digest.hexdigest()
 
 
+class _RequestBodyTooLarge(Exception):
+    """Raised by `_bounded_body_stream` the instant the running total of bytes
+    read from the raw ASGI request stream would exceed the configured limit —
+    BEFORE the chunk that would push it over is ever yielded downstream. This
+    is what actually bounds memory here: measured empirically against the
+    installed Starlette (1.3.1), `MultiPartParser`'s own `max_part_size` only
+    bounds a non-file form FIELD (`formparsers.py::on_part_data`, the
+    `self._current_part.file is None` branch) — for a FILE part it writes
+    every chunk straight to a `SpooledTemporaryFile` with no size check
+    whatsoever. So `max_part_size` alone would never reject an oversized
+    upload; this exception is the real backstop.
+    """
+
+
+# Multipart framing (boundary lines, per-part `Content-Disposition`/`Content-Type`
+# headers, trailing CRLFs) makes the RAW BODY of a legitimately
+# MAX_UPLOAD_BYTES-sized upload a little larger than the file it carries. This
+# allowance is sized generously above that framing overhead for a single-file
+# upload specifically so a legal max-size upload is never rejected by the body
+# bound below — it is not itself a size limit on anything.
+_MULTIPART_FRAMING_ALLOWANCE_BYTES = 64 * 1024  # 64 KiB
+
+
+async def _bounded_body_stream(request: Request, limit: int) -> AsyncGenerator[bytes, None]:
+    """Wraps `request.stream()`, counting bytes as they arrive from the ASGI
+    receive channel and raising `_RequestBodyTooLarge` the moment the running
+    total would exceed `limit` — without yielding the chunk that pushes it
+    over. Memory stays bounded by construction: this never lets more than
+    `limit` bytes of the body reach the multipart parser (and, transitively,
+    its `SpooledTemporaryFile`), regardless of `Content-Length`.
+    """
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > limit:
+            raise _RequestBodyTooLarge()
+        yield chunk
+
+
 async def _parse_upload_request(request: Request) -> tuple[DocumentKind, bytes, str]:
     """Parses the multipart body with the size bound enforced DURING streaming.
 
-    Starlette's `MultiPartParser` checks each part's cumulative byte count as
-    chunks arrive from the ASGI receive channel and raises `MultiPartException`
-    the moment one part exceeds `max_part_size` (`formparsers.py::on_part_data`)
-    — it does not finish reading an oversized part first. Passing
-    `max_part_size=byte_validation.MAX_UPLOAD_BYTES` (the parser's own default is
-    1 MiB, well under our 15 MiB bound) means a 413 never requires buffering an
-    over-limit upload into memory, per this lane's hard rule.
+    Deliberately does NOT call `request.form()`. Starlette 1.3.1's
+    `Request._get_form` wraps its own parser call in
+    `except MultiPartException as exc: if "app" in self.scope: raise
+    HTTPException(status_code=400, detail=exc.message)` — every real request
+    through this (or any) ASGI app has `"app"` in scope, so a
+    `MultiPartException` raised inside `request.form()` NEVER reaches this
+    function as itself; it always surfaces as a plain Starlette
+    `HTTPException(400, detail=<human-facing string>)` instead. Classifying
+    that would mean pattern-matching a message string — guard-over/under-match
+    (repo scar family #3) — instead of an exception TYPE. Driving
+    `MultiPartParser` directly (bypassing `request.form()`/`_get_form`
+    entirely) keeps `MultiPartException` a real, catchable type here.
+
+    The actual size bound is `_bounded_body_stream` above, not
+    `MultiPartParser`'s own `max_part_size` — see `_RequestBodyTooLarge`'s
+    docstring: `max_part_size` never bounds the FILE part on this Starlette
+    version. `max_part_size` is still passed, set to the same body limit, so
+    it cannot reject anything `_bounded_body_stream` wouldn't already have
+    rejected first, and it still catches a pathologically oversized non-file
+    field (e.g. `document_kind`).
     """
     content_length = request.headers.get("content-length")
     if content_length is not None:
@@ -310,13 +362,24 @@ async def _parse_upload_request(request: Request) -> tuple[DocumentKind, bytes, 
         if declared_length is not None and declared_length > byte_validation.MAX_UPLOAD_BYTES:
             raise HTTPException(status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False})
 
+    # Read the file bound fresh on every call (never cache/close over it as a
+    # module-level constant) — tests monkeypatch `byte_validation.MAX_UPLOAD_BYTES`
+    # per-case, and a frozen constant would go stale the moment it did.
+    body_limit = byte_validation.MAX_UPLOAD_BYTES + _MULTIPART_FRAMING_ALLOWANCE_BYTES
+
     try:
-        form = await request.form(max_part_size=byte_validation.MAX_UPLOAD_BYTES)
+        parser = MultiPartParser(
+            request.headers,
+            _bounded_body_stream(request, body_limit),
+            max_part_size=body_limit,
+        )
+        form = await parser.parse()
+    except _RequestBodyTooLarge:
+        raise HTTPException(status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False})
     except MultiPartException as exc:
-        if "exceeded maximum size" in str(exc):
-            raise HTTPException(
-                status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False}
-            ) from exc
+        # Malformed body (missing boundary, no Content-Disposition `name`, an
+        # oversized non-file field, ...) — genuinely un-wrapped here, unlike
+        # `request.form()` (see this function's docstring).
         raise HTTPException(status_code=422, detail={"code": "INVALID_REQUEST", "retryable": False}) from exc
 
     raw_kind = form.get("document_kind")
@@ -329,6 +392,14 @@ async def _parse_upload_request(request: Request) -> tuple[DocumentKind, bytes, 
         raise HTTPException(status_code=422, detail={"code": "INVALID_REQUEST", "retryable": False}) from exc
 
     raw_bytes = await upload.read()
+    # Safe to buffer the whole file here without a fresh unbounded-memory risk:
+    # `_bounded_body_stream` already capped the ENTIRE raw body (this file's
+    # bytes included) at `body_limit`, so `raw_bytes` can never be larger than
+    # that regardless of what happens below. This check enforces the tighter,
+    # precise per-FILE rule (`MAX_UPLOAD_BYTES`) that `body_limit` deliberately
+    # leaves slack for — see `_MULTIPART_FRAMING_ALLOWANCE_BYTES`.
+    if len(raw_bytes) > byte_validation.MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail={"code": "DOCUMENT_TOO_LARGE", "retryable": False})
     declared_media_type = upload.content_type or ""
     return document_kind, raw_bytes, declared_media_type
 

--- a/apps/backend-rag/backend/app/routers/garuda_voa_public.py
+++ b/apps/backend-rag/backend/app/routers/garuda_voa_public.py
@@ -289,8 +289,20 @@ def _error_responses(operation_id: str) -> dict[int | str, dict[str, object]]:
 # only place that noticed this router's schema at all before 2026-08-30 (see
 # that module's own docstring for L3's status-code documentation gap more
 # broadly).
+#
+# `listIntakeDocuments` (L5, `garuda_documents_router.py`) joined this set
+# when that router was mounted: same shape again — `result_id: str` is a
+# bare path capture, ownership checked by hand (`_require_owned_result`)
+# against the session's own actor, never a Pydantic path constraint — so
+# the frozen contract's 5-code set for this GET (200/401/404/500/503, no
+# 422 at all) would otherwise be permanently unmatchable by any live schema.
 _NO_VALIDATION_ERROR_OPERATIONS = frozenset(
-    {"getEligibilityResult", "deleteEligibilityResult", "getOrderAndPractice"}
+    {
+        "getEligibilityResult",
+        "deleteEligibilityResult",
+        "getOrderAndPractice",
+        "listIntakeDocuments",
+    }
 )
 
 

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -246,6 +246,16 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
         process_groups=_API,
         tags=("visa", "garuda", "public", "auth"),
     ),
+    # ── GARUDA VOA documents + OCR hinge (contract-frozen, L5) ──
+    # Same no-mount-time-condition posture as the other three garuda_voa*
+    # routers above. Production store defaults fail-closed (503) until L1's
+    # retention-covered store exists — see garuda_documents_router.py's
+    # module docstring for the full three-blocker chain.
+    RouterEntry(
+        name="garuda_documents_router",
+        process_groups=_API,
+        tags=("visa", "garuda", "documents"),
+    ),
     # ── Google Drive / Integrations ──
     RouterEntry(name="google_drive", process_groups=_API, tags=("integrations",)),
     # ── Guardian ──

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -229,6 +229,10 @@ def include_routers(api: FastAPI) -> None:
 
     api.include_router(garuda_portal_auth.router)  # L4 magic-link auth — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
 
+    from backend.app.routers import garuda_documents_router
+
+    api.include_router(garuda_documents_router.router)  # L5 documents+OCR hinge — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount; production store fails closed 503 until L1's retention-covered store exists (see module docstring)
+
     # CRM routers
     api.include_router(crm_clients.router)
     api.include_router(intake_review.router)  # [FASE 5A] doc-intake HITL review-queue
@@ -678,6 +682,10 @@ def include_light_routers(api: FastAPI) -> None:
     from backend.app.routers import garuda_portal_auth
 
     api.include_router(garuda_portal_auth.router)  # L4 magic-link auth — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
+
+    from backend.app.routers import garuda_documents_router
+
+    api.include_router(garuda_documents_router.router)  # L5 documents+OCR hinge — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount; production store fails closed 503 until L1's retention-covered store exists (see module docstring)
 
     # Genome-backed registries (light: SQLite via cell-core, no ML deps)
     api.include_router(experience.router)  # [EXP] Experience Library (PR #54)

--- a/apps/backend-rag/backend/app/setup/service_initializer.py
+++ b/apps/backend-rag/backend/app/setup/service_initializer.py
@@ -1481,6 +1481,29 @@ async def initialize_garuda_services(app: FastAPI, db_pool) -> None:
             bool(garuda_xendit_secret_key),
         )
 
+    # 5.8 GARUDA VOA — document intake store wiring (L5 hinge, router-owned
+    # sentinel). Unconditional (no db_pool needed): L1's retention-covered
+    # store has not merged for `garuda_documents` (no migration exists —
+    # `garuda_documents/ports.py`'s own docstring says so), and LANES.md is
+    # explicit that a lane must not persist a row before L1 covers it.
+    # `garuda_documents/ports.py` therefore ships only `InMemoryDocumentStore`,
+    # whose own docstring forbids wiring it into a running service (an
+    # in-memory PII store is worse than no endpoint — PR #5120's ledger entry).
+    # Wiring `_UnconfiguredDocumentStore` here — the documents-lane analogue of
+    # `PostgresCheckStore`'s `UnconfiguredCheckStore` fallback at 5.6 above,
+    # minus the Postgres half, which does not exist yet for this table — means
+    # the route mounted by `garuda_documents_router.py` is live and testable
+    # today, and answers 503 PERSISTENCE_POLICY_UNAVAILABLE/SERVICE_UNAVAILABLE
+    # on every real request until L1 ships. Never raises: the sentinel takes no
+    # constructor arguments and touches no pool, so this needs no try/except.
+    from backend.app.routers.garuda_documents_router import _UnconfiguredDocumentStore
+
+    app.state.garuda_document_store = _UnconfiguredDocumentStore()
+    logger.info(
+        "ℹ️ GARUDA VOA document store wired fail-closed (L1 retention-covered store "
+        "not merged yet for garuda_documents — see garuda_documents_router.py docstring)"
+    )
+
 
 async def initialize_services(app: FastAPI) -> None:
     """

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_documents_router.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_documents_router.py
@@ -1,0 +1,649 @@
+"""L5 hinge — `garuda_documents_router.py` contract-status-code coverage.
+
+Same shape as `test_garuda_orders_envelope.py`/`test_garuda_staff_actor_async_
+verifier.py`: a bare `FastAPI()` app with only this router mounted, fakes for
+every collaborator (no Postgres, no live Ollama), `httpx.AsyncClient` over
+`ASGITransport`. One test per contract status code in
+`products/garuda-voa/contracts/openapi.yaml`'s `uploadIntakeDocument` /
+`listIntakeDocuments` responses tables, plus the auth/idempotency/PII/flag
+requirements this task additionally asked for.
+
+429 RATE_LIMITED and 500 INTERNAL_ERROR are declared in the contract but are
+cross-cutting (rate-limit middleware / the app-wide exception handler — see
+`garuda_voa_public.py`'s own comment on this, and this router's module
+docstring) and are not raised by any call site in `garuda_documents_router.py`
+itself; `test_internal_error_is_the_apps_generic_500` still proves the 500
+status is reachable end-to-end through the real app exception handler, using
+a store that raises an unmapped exception, so it is not merely asserted by
+citation.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from PIL import Image
+
+from backend.app.routers import garuda_documents_router
+from backend.services.garuda_documents import service as service_module
+from backend.services.garuda_documents.ocr_client import OcrPassResult
+from backend.services.garuda_documents.ports import InMemoryDocumentStore
+
+_SESSION_COOKIE = "garuda_session"
+_ACTOR = "result_owns_documents_00000000"
+_OTHER_RESULT = "result_belongs_to_someone_else"
+
+
+@pytest.fixture(autouse=True)
+def _garuda_public_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "true")
+
+
+async def _verifier_returns_fixed_actor(cookie: str) -> str | None:
+    return _ACTOR if cookie else None
+
+
+def _app(**state) -> FastAPI:
+    application = FastAPI()
+    application.include_router(garuda_documents_router.router)
+    for key, value in state.items():
+        setattr(application.state, key, value)
+    return application
+
+
+def _valid_png_bytes() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (16, 16), color=(10, 20, 30)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _pass(values: dict[str, str | None], confidence: float = 0.95) -> OcrPassResult:
+    conf = dict.fromkeys(values, confidence)
+    return OcrPassResult(values=values, self_confidence=conf)
+
+
+_CONFIDENT_FIELDS = {
+    "full_name": "X_SENTINEL_VALUE_1234",
+    "passport_number": "P1234567",
+    "nationality": "ITALIAN",
+    "passport_expiry_date": "2030-01-01",
+}
+
+
+def _patch_ocr(monkeypatch: pytest.MonkeyPatch, result) -> None:
+    """`service.py` imports `extract_passport_biodata_dual_pass` by name into
+    its own module namespace — patch it THERE, not on `ocr_client`, or the
+    service keeps calling the original."""
+
+    async def _fake(image_base64: str):
+        return result
+
+    monkeypatch.setattr(service_module, "extract_passport_biodata_dual_pass", _fake)
+
+
+async def _post_document(
+    client: AsyncClient,
+    *,
+    result_id: str = _ACTOR,
+    idempotency_key: str = "idem-key-0000000000001",
+    cookie: str | None = "cookie",
+    file_bytes: bytes | None = None,
+    file_field: str = "file",
+    document_kind: str | None = "PASSPORT_BIODATA",
+    content_type: str = "image/png",
+):
+    headers = {}
+    if idempotency_key is not None:
+        headers["Idempotency-Key"] = idempotency_key
+    cookies = {_SESSION_COOKIE: cookie} if cookie is not None else None
+    data = {}
+    if document_kind is not None:
+        data["document_kind"] = document_kind
+    files = {}
+    if file_bytes is not None:
+        files[file_field] = ("passport.png", file_bytes, content_type)
+    return await client.post(
+        f"/api/visa/voa/eligibility-checks/{result_id}/documents",
+        headers=headers,
+        cookies=cookies,
+        data=data,
+        files=files or None,
+    )
+
+
+def _assert_privacy_headers(headers) -> None:
+    assert headers.get("cache-control") == "no-store, private"
+    assert headers.get("referrer-policy") == "no-referrer"
+    assert headers.get("x-robots-tag") == "noindex, nofollow, noarchive"
+
+
+class _NeverCalledStore:
+    """Any method call is an immediate test failure — used to prove an
+    unauthorized/pre-store-touching request never reaches persistence."""
+
+    async def get_existing(self, *a, **kw):  # pragma: no cover
+        raise AssertionError("get_existing was called before auth/validation rejected the request")
+
+    async def commit(self, *a, **kw):  # pragma: no cover
+        raise AssertionError("commit was called before auth/validation rejected the request")
+
+    async def list_for_actor(self, *a, **kw):  # pragma: no cover
+        raise AssertionError("list_for_actor was called before auth/validation rejected the request")
+
+
+class _BrokenStore:
+    """Raises an exception `garuda_documents_router.py` does not name in any
+    `except` clause — proves 500 INTERNAL_ERROR is produced by the app's own
+    generic exception handler, not faked."""
+
+    async def get_existing(self, *a, **kw):
+        raise RuntimeError("boom — unmapped exception")
+
+    async def commit(self, *a, **kw):  # pragma: no cover
+        raise AssertionError("commit should not be reached")
+
+
+# ---------------------------------------------------------------------------
+# Contract status-code coverage — uploadIntakeDocument
+# ---------------------------------------------------------------------------
+
+
+class TestUpload201Ready:
+    async def test_all_confident_fields_return_201_ready_for_review(self, monkeypatch):
+        _patch_ocr(monkeypatch, (_pass(_CONFIDENT_FIELDS), _pass(_CONFIDENT_FIELDS)))
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["processing_state"] == "READY_FOR_REVIEW"
+        assert len(body["review_fields"]) == 4
+        _assert_privacy_headers(resp.headers)
+
+
+class TestUpload202Processing:
+    @pytest.mark.skip(
+        reason=(
+            "ProcessingOutcome is defensively unreachable per service.py's own "
+            "comment (all_confident False implies >=1 uncertain field, so "
+            "to_uncertain_fields is never empty) — not a code this route can "
+            "honestly claim to emit; LowConfidenceDocument covers the real "
+            "202 branch below. Reported honestly rather than faked — see final "
+            "report."
+        )
+    )
+    async def test_no_pass_rated_any_field_returns_202_processing(self):
+        raise AssertionError("unreachable — see skip reason")
+
+
+class TestUpload202LowConfidence:
+    async def test_disagreeing_passes_return_202_low_confidence(self, monkeypatch):
+        pass_a = _pass({**_CONFIDENT_FIELDS, "full_name": "ALPHA"})
+        pass_b = _pass({**_CONFIDENT_FIELDS, "full_name": "BETA"})
+        _patch_ocr(monkeypatch, (pass_a, pass_b))
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["processing_state"] == "LOW_CONFIDENCE"
+        assert {f["field_path"] for f in body["uncertain_fields"]} == {"full_name"}
+        assert all(f["confirmation_required"] is True for f in body["uncertain_fields"])
+        # Response body must never carry the disagreeing VALUE — only the field name.
+        assert "ALPHA" not in resp.text and "BETA" not in resp.text
+
+
+class TestUpload400IdempotencyKeyRequired:
+    async def test_missing_header_is_400_before_store_is_touched(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(
+                client, idempotency_key=None, file_bytes=_valid_png_bytes()
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["code"] == "IDEMPOTENCY_KEY_REQUIRED"
+        _assert_privacy_headers(resp.headers)
+
+
+class TestUpload401SessionRequired:
+    async def test_no_cookie_is_401_and_store_is_never_touched(self):
+        """The AUTH test: proves the store is never CALLED, not merely that
+        the response is 401 — `_NeverCalledStore` makes any method call raise,
+        which would surface as a 500, not a clean 401, if auth were bypassed.
+        """
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, cookie=None, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 401, resp.text
+        assert resp.json()["code"] == "SESSION_REQUIRED"
+        _assert_privacy_headers(resp.headers)
+
+    async def test_no_verifier_wired_is_401_and_store_is_never_touched(self):
+        """Production's actual state until L4's verifier is composed — no
+        `garuda_magic_session_verifier` on app.state at all."""
+        app = _app(garuda_document_store=_NeverCalledStore())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 401, resp.text
+        assert resp.json()["code"] == "SESSION_REQUIRED"
+
+
+class TestUpload404:
+    async def test_flag_disabled_is_404_garuda_public_disabled(self, monkeypatch):
+        monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "false")
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["code"] == "GARUDA_PUBLIC_DISABLED"
+
+    async def test_non_owned_result_id_is_404_result_not_found(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(
+                client, result_id=_OTHER_RESULT, file_bytes=_valid_png_bytes()
+            )
+
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["code"] == "RESULT_NOT_FOUND"
+
+
+class TestUpload409IdempotencyConflict:
+    async def test_same_key_different_payload_is_409(self, monkeypatch):
+        _patch_ocr(monkeypatch, (_pass(_CONFIDENT_FIELDS), _pass(_CONFIDENT_FIELDS)))
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            first = await _post_document(
+                client, idempotency_key="idem-conflict-000000001", file_bytes=_valid_png_bytes()
+            )
+            assert first.status_code == 201, first.text
+
+            second = await _post_document(
+                client,
+                idempotency_key="idem-conflict-000000001",
+                file_bytes=_valid_png_bytes() + b"\x00",  # different payload
+            )
+
+        assert second.status_code == 409, second.text
+        assert second.json()["code"] == "IDEMPOTENCY_CONFLICT"
+
+
+class TestIdempotencyReplay:
+    async def test_same_key_same_payload_replays_without_new_work(self, monkeypatch):
+        calls = 0
+        original = (_pass(_CONFIDENT_FIELDS), _pass(_CONFIDENT_FIELDS))
+
+        async def _counting_ocr(image_base64: str):
+            nonlocal calls
+            calls += 1
+            return original
+
+        monkeypatch.setattr(service_module, "extract_passport_biodata_dual_pass", _counting_ocr)
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        png = _valid_png_bytes()
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            first = await _post_document(
+                client, idempotency_key="idem-replay-0000000001", file_bytes=png
+            )
+            assert first.status_code == 201, first.text
+            assert "idempotency-replayed" not in {k.lower() for k in first.headers}
+
+            second = await _post_document(
+                client, idempotency_key="idem-replay-0000000001", file_bytes=png
+            )
+
+        assert second.status_code == 201, second.text
+        assert second.headers.get("idempotency-replayed") == "true"
+        assert second.json() == first.json()
+        # OCR ran exactly once — the replay caused no new work.
+        assert calls == 1
+
+
+class TestUpload413DocumentTooLarge:
+    async def test_oversized_upload_is_413_without_buffering_the_whole_body(
+        self, monkeypatch
+    ):
+        """Shrinks the bound to 10 bytes so the test sends only ~20 bytes total
+        (not 15 MiB) while still exercising the real streaming-bound code path
+        — the multipart parser raises as soon as ONE chunk pushes a part's
+        cumulative size past `max_part_size`, so this never allocates a
+        15 MiB buffer to prove the 413."""
+        monkeypatch.setattr(
+            garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", 10
+        )
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=b"x" * 200)
+
+        assert resp.status_code == 413, resp.text
+        assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
+
+
+class TestUpload415UnsupportedMediaType:
+    async def test_declared_media_type_not_allowed_is_415(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(
+                client, file_bytes=b"not-really-a-gif", content_type="image/gif"
+            )
+
+        assert resp.status_code == 415, resp.text
+        assert resp.json()["code"] == "UNSUPPORTED_DOCUMENT_MEDIA_TYPE"
+
+
+class TestUpload422InvalidRequest:
+    async def test_missing_file_field_is_422(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=None)
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["code"] == "INVALID_REQUEST"
+
+    async def test_wrong_document_kind_is_422(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(
+                client, document_kind="NOT_A_REAL_KIND", file_bytes=_valid_png_bytes()
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["code"] == "INVALID_REQUEST"
+
+
+class TestUpload422UnreadableDocument:
+    async def test_corrupt_bytes_are_422_unreadable(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=b"this-is-not-a-real-image-file")
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["code"] == "UNREADABLE_DOCUMENT"
+
+
+class TestUpload503:
+    async def test_ocr_unavailable_is_503_document_processing_unavailable(self, monkeypatch):
+        _patch_ocr(monkeypatch, None)
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["code"] == "DOCUMENT_PROCESSING_UNAVAILABLE"
+
+    async def test_no_store_wired_is_503_persistence_policy_unavailable(self):
+        """Production's actual default today — see module docstring: nothing
+        wires a working store, so the router's own `_UnconfiguredDocumentStore`
+        fallback answers this on every real upload."""
+        app = _app(garuda_magic_session_verifier=_verifier_returns_fixed_actor)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["code"] == "PERSISTENCE_POLICY_UNAVAILABLE"
+
+    async def test_internal_error_is_the_apps_generic_500(self):
+        """500 is cross-cutting (the app's own generic exception handler, not
+        this router — see module docstring); proven live rather than merely
+        cited, using a store that raises an exception this router names
+        nowhere in its own except clauses."""
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_BrokenStore(),
+        )
+        # `raise_app_exceptions=False`: an unhandled exception in the ASGI app must
+        # surface as the real HTTP response Starlette's own `ServerErrorMiddleware`
+        # produces (like a real client over the wire would see), not re-raise into
+        # the test process — which is httpx's ASGITransport default and would make
+        # this test "pass" by crashing instead of asserting anything.
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 500, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Contract status-code coverage — listIntakeDocuments
+# ---------------------------------------------------------------------------
+
+
+class _ListingStore(InMemoryDocumentStore):
+    def __init__(self, summaries: list[dict]) -> None:
+        super().__init__()
+        self._summaries = summaries
+
+    async def list_for_actor(self, actor: str) -> list[dict]:
+        return self._summaries
+
+
+class TestList200:
+    async def test_authorized_list_returns_document_summaries(self):
+        summaries = [
+            {
+                "document_id": "doc_0000000000000001",
+                "document_kind": "PASSPORT_BIODATA",
+                "processing_state": "READY_FOR_REVIEW",
+                "artifact_available": False,
+            }
+        ]
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_ListingStore(summaries),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(
+                f"/api/visa/voa/eligibility-checks/{_ACTOR}/documents",
+                cookies={_SESSION_COOKIE: "cookie"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"documents": summaries}
+        _assert_privacy_headers(resp.headers)
+
+
+class TestList401:
+    async def test_no_cookie_is_401_and_store_never_touched(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(f"/api/visa/voa/eligibility-checks/{_ACTOR}/documents")
+
+        assert resp.status_code == 401, resp.text
+        assert resp.json()["code"] == "SESSION_REQUIRED"
+
+
+class TestList404:
+    async def test_flag_disabled_is_404(self, monkeypatch):
+        monkeypatch.setenv("GARUDA_PUBLIC_ENABLED", "false")
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(
+                f"/api/visa/voa/eligibility-checks/{_ACTOR}/documents",
+                cookies={_SESSION_COOKIE: "cookie"},
+            )
+
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["code"] == "GARUDA_PUBLIC_DISABLED"
+
+    async def test_non_owned_result_id_is_404(self):
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(
+                f"/api/visa/voa/eligibility-checks/{_OTHER_RESULT}/documents",
+                cookies={_SESSION_COOKIE: "cookie"},
+            )
+
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["code"] == "RESULT_NOT_FOUND"
+
+
+class TestList503:
+    async def test_no_store_wired_is_503_service_unavailable(self):
+        app = _app(garuda_magic_session_verifier=_verifier_returns_fixed_actor)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await client.get(
+                f"/api/visa/voa/eligibility-checks/{_ACTOR}/documents",
+                cookies={_SESSION_COOKIE: "cookie"},
+            )
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["code"] == "SERVICE_UNAVAILABLE"
+
+
+# ---------------------------------------------------------------------------
+# PII: passport field values never leak to logs; low-confidence/processing
+# bodies never carry the raw value.
+# ---------------------------------------------------------------------------
+
+
+class TestPiiNeverLeaksToLogsOrUnauthorizedBodies:
+    """`X_SENTINEL_VALUE_1234` is a passport field VALUE (full_name). The
+    contract's 201 ReadyDocument legitimately echoes it back to the SAME
+    authenticated customer it belongs to (`ReviewField.value`'s own docstring:
+    "Authenticated customer review value") — that is the product working as
+    designed, not a leak, so this test does not assert it is absent from a
+    201 response body. What must hold UNIVERSALLY, across every outcome, is
+    that the value never reaches a LOG RECORD (CLAUDE.md §14 PII/OSINT output
+    boundary — logs are a listed surface), and that a body which is NOT an
+    authenticated per-field echo (the LOW_CONFIDENCE uncertain-fields list)
+    never carries the value either.
+    """
+
+    async def test_ready_outcome_value_never_appears_in_logs(self, monkeypatch, caplog):
+        _patch_ocr(monkeypatch, (_pass(_CONFIDENT_FIELDS), _pass(_CONFIDENT_FIELDS)))
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        with caplog.at_level(logging.DEBUG):
+            async with AsyncClient(transport=transport, base_url="http://t") as client:
+                resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 201, resp.text
+        assert "X_SENTINEL_VALUE_1234" in resp.text  # authenticated echo — expected
+        for record in caplog.records:
+            assert "X_SENTINEL_VALUE_1234" not in record.getMessage()
+
+    async def test_low_confidence_body_never_carries_the_disagreeing_value(
+        self, monkeypatch, caplog
+    ):
+        pass_a = _pass({**_CONFIDENT_FIELDS, "full_name": "X_SENTINEL_VALUE_1234"})
+        pass_b = _pass({**_CONFIDENT_FIELDS, "full_name": "DIFFERENT_VALUE_9999"})
+        _patch_ocr(monkeypatch, (pass_a, pass_b))
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        with caplog.at_level(logging.DEBUG):
+            async with AsyncClient(transport=transport, base_url="http://t") as client:
+                resp = await _post_document(client, file_bytes=_valid_png_bytes())
+
+        assert resp.status_code == 202, resp.text
+        assert "X_SENTINEL_VALUE_1234" not in resp.text
+        assert "DIFFERENT_VALUE_9999" not in resp.text
+        for record in caplog.records:
+            assert "X_SENTINEL_VALUE_1234" not in record.getMessage()
+            assert "DIFFERENT_VALUE_9999" not in record.getMessage()
+
+    async def test_error_paths_never_log_the_value(self, monkeypatch, caplog):
+        """413/415/401/404/503 paths run before or without OCR — the sentinel
+        never enters the pipeline at all on these, so this pins the floor:
+        even the FILENAME/media-type-carrying request never logs a value."""
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        transport = ASGITransport(app=app)
+        with caplog.at_level(logging.DEBUG):
+            async with AsyncClient(transport=transport, base_url="http://t") as client:
+                resp = await _post_document(
+                    client, file_bytes=b"X_SENTINEL_VALUE_1234", content_type="image/gif"
+                )
+
+        assert resp.status_code == 415, resp.text
+        for record in caplog.records:
+            assert "X_SENTINEL_VALUE_1234" not in record.getMessage()

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_documents_router.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_documents_router.py
@@ -115,6 +115,82 @@ async def _post_document(
     )
 
 
+#: Boundary for the hand-built multipart bodies below. Distinct from anything
+#: httpx's own `files=` helper would pick, purely so a diff is unambiguous
+#: about which code path built a given body.
+_RAW_BOUNDARY = "garudarawtestboundary00000000000000"
+
+
+def _build_raw_multipart_body(
+    *,
+    document_kind: str,
+    file_bytes: bytes,
+    filename: str = "passport.png",
+    content_type: str = "image/png",
+) -> bytes:
+    """Hand-builds the multipart/form-data wire format directly. httpx's
+    `files=`/`data=` helper (used by `_post_document` above) always computes
+    an accurate `Content-Length` from the fully-buffered body — exactly the
+    shape that lets `_parse_upload_request`'s cheap header pre-check answer
+    first and never reach the streaming path. The two tests below need a
+    body they can send with NO `Content-Length` (streamed) or with a LYING
+    one, which requires building the wire bytes by hand instead."""
+    parts = [
+        f"--{_RAW_BOUNDARY}\r\n".encode(),
+        b'Content-Disposition: form-data; name="document_kind"\r\n\r\n',
+        document_kind.encode() + b"\r\n",
+        f"--{_RAW_BOUNDARY}\r\n".encode(),
+        (
+            f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
+        ).encode(),
+        file_bytes,
+        b"\r\n",
+        f"--{_RAW_BOUNDARY}--\r\n".encode(),
+    ]
+    return b"".join(parts)
+
+
+async def _chunked_body(body: bytes, chunk_size: int = 4096):
+    """An async generator, never a `bytes` object — this is what makes httpx
+    emit `Transfer-Encoding: chunked` instead of computing `Content-Length`
+    (`httpx._content.encode_content`: `AsyncIterable` -> chunked, always)."""
+    for i in range(0, len(body), chunk_size):
+        yield body[i : i + chunk_size]
+
+
+async def _post_raw_multipart(
+    client: AsyncClient,
+    *,
+    result_id: str = _ACTOR,
+    idempotency_key: str = "idem-key-0000000000001",
+    cookie: str | None = "cookie",
+    body: bytes,
+    content_length_header: str | None = None,
+    streamed: bool = True,
+):
+    """Posts a hand-built multipart body. `streamed=True` (default) sends it
+    as an async generator so no `Content-Length` is ever computed — the
+    no-Content-Length ("chunked") case. `streamed=False` sends the body as
+    plain `bytes` (httpx would normally compute an accurate `Content-Length`
+    for that), letting the caller override it via `content_length_header` to
+    build the understated-`Content-Length` case.
+    """
+    headers = {"Content-Type": f"multipart/form-data; boundary={_RAW_BOUNDARY}"}
+    if idempotency_key is not None:
+        headers["Idempotency-Key"] = idempotency_key
+    if content_length_header is not None:
+        headers["Content-Length"] = content_length_header
+    cookies = {_SESSION_COOKIE: cookie} if cookie is not None else None
+    content = _chunked_body(body) if streamed else body
+    return await client.post(
+        f"/api/visa/voa/eligibility-checks/{result_id}/documents",
+        headers=headers,
+        cookies=cookies,
+        content=content,
+    )
+
+
 def _assert_privacy_headers(headers) -> None:
     assert headers.get("cache-control") == "no-store, private"
     assert headers.get("referrer-policy") == "no-referrer"
@@ -364,6 +440,91 @@ class TestUpload413DocumentTooLarge:
 
         assert resp.status_code == 413, resp.text
         assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
+
+    async def test_oversized_upload_with_no_content_length_is_still_413(
+        self, monkeypatch
+    ):
+        """The sibling test above never reaches the streaming path: httpx's
+        `files=` helper always computes an accurate `Content-Length`, so the
+        cheap header pre-check answers first every time. This sends the exact
+        same oversized body with NO `Content-Length` at all (a genuinely
+        streamed/chunked request) — the shape the pre-check cannot see coming.
+        """
+        monkeypatch.setattr(
+            garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", 10
+        )
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        body = _build_raw_multipart_body(
+            document_kind="PASSPORT_BIODATA", file_bytes=b"x" * 200
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_raw_multipart(client, body=body, streamed=True)
+
+        # Degenerate-test guard: if this ever carries a Content-Length again
+        # (e.g. someone "fixes" `_post_raw_multipart` to stop streaming), this
+        # test silently stops proving anything beyond the sibling above.
+        assert "content-length" not in resp.request.headers
+        assert resp.status_code == 413, resp.text
+        assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
+
+    async def test_understated_content_length_is_still_413(self, monkeypatch):
+        """Same shape as the no-Content-Length test above, but this time the
+        header IS present and LIES — declares a body far smaller than what
+        actually follows. A pre-check that trusts the declared value alone
+        would wave this through; the streaming/post-parse enforcement must
+        not."""
+        monkeypatch.setattr(
+            garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", 10
+        )
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=_NeverCalledStore(),
+        )
+        body = _build_raw_multipart_body(
+            document_kind="PASSPORT_BIODATA", file_bytes=b"x" * 200
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_raw_multipart(
+                client, body=body, streamed=False, content_length_header="5"
+            )
+
+        assert resp.request.headers.get("content-length") == "5"
+        assert resp.status_code == 413, resp.text
+        assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
+
+    async def test_upload_at_the_bound_with_no_content_length_still_succeeds(
+        self, monkeypatch
+    ):
+        """Innocence control: a legitimately max-sized upload, streamed with
+        no `Content-Length`, must NOT be rejected. This is what catches a
+        framing allowance (`_MULTIPART_FRAMING_ALLOWANCE_BYTES`) sized too
+        small — the failure mode a naive fix for the two tests above could
+        introduce by shrinking the body bound to exactly `MAX_UPLOAD_BYTES`
+        with no slack for multipart's own boundary/header overhead."""
+        png = _valid_png_bytes()
+        monkeypatch.setattr(
+            garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", len(png)
+        )
+        _patch_ocr(monkeypatch, (_pass(_CONFIDENT_FIELDS), _pass(_CONFIDENT_FIELDS)))
+        app = _app(
+            garuda_magic_session_verifier=_verifier_returns_fixed_actor,
+            garuda_document_store=InMemoryDocumentStore(),
+        )
+        body = _build_raw_multipart_body(
+            document_kind="PASSPORT_BIODATA", file_bytes=png
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            resp = await _post_raw_multipart(client, body=body, streamed=True)
+
+        assert "content-length" not in resp.request.headers
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["processing_state"] == "READY_FOR_REVIEW"
 
 
 class TestUpload415UnsupportedMediaType:

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_documents_router.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_documents_router.py
@@ -159,22 +159,49 @@ async def _chunked_body(body: bytes, chunk_size: int = 4096):
         yield body[i : i + chunk_size]
 
 
+class _CountingChunks:
+    """An async-iterable body wrapper that records, cumulatively, how many
+    bytes it has actually yielded — `total_yielded`, read AFTER the request
+    completes. This is the one signal that distinguishes "the server stopped
+    pulling the request body early" (the streaming bound firing) from "the
+    server read the entire body, then rejected it" (a buffering backstop
+    elsewhere catching the same oversized upload). A bare 413 status cannot
+    tell those apart; this can. httpx treats an object with `__aiter__` the
+    same as an async generator function (`AsyncIteratorByteStream`,
+    `httpx._content.py`), so this can be passed directly as `content=`.
+    """
+
+    def __init__(self, body: bytes, chunk_size: int) -> None:
+        self._body = body
+        self._chunk_size = chunk_size
+        self.total_yielded = 0
+
+    async def __aiter__(self):
+        for i in range(0, len(self._body), self._chunk_size):
+            chunk = self._body[i : i + self._chunk_size]
+            self.total_yielded += len(chunk)
+            yield chunk
+
+
 async def _post_raw_multipart(
     client: AsyncClient,
     *,
     result_id: str = _ACTOR,
     idempotency_key: str = "idem-key-0000000000001",
     cookie: str | None = "cookie",
-    body: bytes,
+    body: bytes | None = None,
     content_length_header: str | None = None,
     streamed: bool = True,
+    content=None,
 ):
     """Posts a hand-built multipart body. `streamed=True` (default) sends it
     as an async generator so no `Content-Length` is ever computed — the
     no-Content-Length ("chunked") case. `streamed=False` sends the body as
     plain `bytes` (httpx would normally compute an accurate `Content-Length`
     for that), letting the caller override it via `content_length_header` to
-    build the understated-`Content-Length` case.
+    build the understated-`Content-Length` case. Pass `content=` directly
+    (e.g. a `_CountingChunks` instance) to control chunking/instrumentation
+    yourself — `body`/`streamed` are then ignored.
     """
     headers = {"Content-Type": f"multipart/form-data; boundary={_RAW_BOUNDARY}"}
     if idempotency_key is not None:
@@ -182,7 +209,8 @@ async def _post_raw_multipart(
     if content_length_header is not None:
         headers["Content-Length"] = content_length_header
     cookies = {_SESSION_COOKIE: cookie} if cookie is not None else None
-    content = _chunked_body(body) if streamed else body
+    if content is None:
+        content = _chunked_body(body) if streamed else body
     return await client.post(
         f"/api/visa/voa/eligibility-checks/{result_id}/documents",
         headers=headers,
@@ -441,28 +469,61 @@ class TestUpload413DocumentTooLarge:
         assert resp.status_code == 413, resp.text
         assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
 
+    #: Patched together in every test below so `body_limit` (computed inside
+    #: `_parse_upload_request` as `MAX_UPLOAD_BYTES + _MULTIPART_FRAMING_
+    #: ALLOWANCE_BYTES`) is small enough that a modest hand-built body can
+    #: genuinely exceed it. With the real 64 KiB default allowance, ANY body
+    #: a fast unit test can afford to send sits comfortably under `body_limit`
+    #: regardless of `MAX_UPLOAD_BYTES` — so the streaming bound never fires,
+    #: and a bare 413 assertion only ever proves the (separate) post-parse /
+    #: `service.py` buffering backstop caught it. Shrinking the allowance too
+    #: is what makes the streaming bound itself reachable from a test.
+    _TEST_MAX_UPLOAD_BYTES = 1000
+    _TEST_FRAMING_ALLOWANCE_BYTES = 200
+    _TEST_BODY_LIMIT = _TEST_MAX_UPLOAD_BYTES + _TEST_FRAMING_ALLOWANCE_BYTES  # 1200
+
+    def _patch_bounds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            garuda_documents_router.byte_validation,
+            "MAX_UPLOAD_BYTES",
+            self._TEST_MAX_UPLOAD_BYTES,
+        )
+        monkeypatch.setattr(
+            garuda_documents_router,
+            "_MULTIPART_FRAMING_ALLOWANCE_BYTES",
+            self._TEST_FRAMING_ALLOWANCE_BYTES,
+        )
+
     async def test_oversized_upload_with_no_content_length_is_still_413(
         self, monkeypatch
     ):
-        """The sibling test above never reaches the streaming path: httpx's
-        `files=` helper always computes an accurate `Content-Length`, so the
-        cheap header pre-check answers first every time. This sends the exact
-        same oversized body with NO `Content-Length` at all (a genuinely
-        streamed/chunked request) — the shape the pre-check cannot see coming.
+        """The sibling test above never reaches the streaming path at all:
+        httpx's `files=` helper always computes an accurate `Content-Length`,
+        so the cheap header pre-check answers first every time. This sends a
+        body with NO `Content-Length` (genuinely streamed) that is not just
+        over `MAX_UPLOAD_BYTES` but over the full `body_limit` — 50 KB against
+        a ~1.2 KB limit — so `_bounded_body_stream` itself must be what fires,
+        not the post-parse/`service.py` buffering backstop (which would also
+        return 413 for a body this size, but only AFTER reading all of it).
+        `_CountingChunks` proves which one actually happened: the server must
+        stop pulling bytes far short of the 50 KB sent, bounded by `body_limit`
+        plus at most one 256-byte chunk of overshoot.
         """
-        monkeypatch.setattr(
-            garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", 10
-        )
+        self._patch_bounds(monkeypatch)
         app = _app(
             garuda_magic_session_verifier=_verifier_returns_fixed_actor,
             garuda_document_store=_NeverCalledStore(),
         )
+        oversized_file = b"x" * 50_000  # ~40x body_limit — "substantially more"
         body = _build_raw_multipart_body(
-            document_kind="PASSPORT_BIODATA", file_bytes=b"x" * 200
+            document_kind="PASSPORT_BIODATA", file_bytes=oversized_file
         )
+        assert len(body) > self._TEST_BODY_LIMIT * 10  # sanity: the send is genuinely oversized
+        chunk_size = 256
+        counter = _CountingChunks(body, chunk_size=chunk_size)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://t") as client:
-            resp = await _post_raw_multipart(client, body=body, streamed=True)
+            resp = await _post_raw_multipart(client, content=counter)
 
         # Degenerate-test guard: if this ever carries a Content-Length again
         # (e.g. someone "fixes" `_post_raw_multipart` to stop streaming), this
@@ -470,45 +531,73 @@ class TestUpload413DocumentTooLarge:
         assert "content-length" not in resp.request.headers
         assert resp.status_code == 413, resp.text
         assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
+        # The property under test: the server stopped pulling bytes early.
+        # A real ceiling, not merely "less than the 50 KB total" — at most
+        # one chunk of overshoot past body_limit.
+        assert counter.total_yielded <= self._TEST_BODY_LIMIT + chunk_size, (
+            f"server pulled {counter.total_yielded} bytes before rejecting — "
+            f"expected <= body_limit ({self._TEST_BODY_LIMIT}) + one chunk "
+            f"({chunk_size}); this means the streaming bound did NOT fire and "
+            "something downstream (the post-parse check, or service.py's "
+            "validate_size) caught it after buffering the whole body instead."
+        )
 
     async def test_understated_content_length_is_still_413(self, monkeypatch):
-        """Same shape as the no-Content-Length test above, but this time the
-        header IS present and LIES — declares a body far smaller than what
-        actually follows. A pre-check that trusts the declared value alone
-        would wave this through; the streaming/post-parse enforcement must
-        not."""
-        monkeypatch.setattr(
-            garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", 10
-        )
+        """Same shape and same proof as the no-Content-Length test above, but
+        this time the header IS present and LIES — declares a body far
+        smaller than what actually follows. A pre-check that trusts the
+        declared value alone would wave this through; the streaming
+        enforcement must not, and the byte-count assertion again proves it is
+        the streaming bound (not a buffering backstop) doing the rejecting.
+        """
+        self._patch_bounds(monkeypatch)
         app = _app(
             garuda_magic_session_verifier=_verifier_returns_fixed_actor,
             garuda_document_store=_NeverCalledStore(),
         )
+        oversized_file = b"x" * 50_000
         body = _build_raw_multipart_body(
-            document_kind="PASSPORT_BIODATA", file_bytes=b"x" * 200
+            document_kind="PASSPORT_BIODATA", file_bytes=oversized_file
         )
+        chunk_size = 256
+        counter = _CountingChunks(body, chunk_size=chunk_size)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://t") as client:
             resp = await _post_raw_multipart(
-                client, body=body, streamed=False, content_length_header="5"
+                client, content=counter, content_length_header="5"
             )
 
         assert resp.request.headers.get("content-length") == "5"
         assert resp.status_code == 413, resp.text
         assert resp.json()["code"] == "DOCUMENT_TOO_LARGE"
+        assert counter.total_yielded <= self._TEST_BODY_LIMIT + chunk_size, (
+            f"server pulled {counter.total_yielded} bytes before rejecting — "
+            f"expected <= body_limit ({self._TEST_BODY_LIMIT}) + one chunk "
+            f"({chunk_size})"
+        )
 
     async def test_upload_at_the_bound_with_no_content_length_still_succeeds(
         self, monkeypatch
     ):
         """Innocence control: a legitimately max-sized upload, streamed with
-        no `Content-Length`, must NOT be rejected. This is what catches a
-        framing allowance (`_MULTIPART_FRAMING_ALLOWANCE_BYTES`) sized too
-        small — the failure mode a naive fix for the two tests above could
-        introduce by shrinking the body bound to exactly `MAX_UPLOAD_BYTES`
-        with no slack for multipart's own boundary/header overhead."""
+        no `Content-Length`, must NOT be rejected. Patching the framing
+        allowance down to 320 bytes (instead of leaving the real 64 KiB
+        default) is what makes this test do real work: the measured framing
+        overhead of `_build_raw_multipart_body` for this exact payload is 292
+        bytes (boundary lines + Content-Disposition/Content-Type headers +
+        the `document_kind` field), so 320 is deliberately tight — enough to
+        fit the real overhead, not so much that a too-small allowance bug
+        would go uncaught. With the real default this test would pass even if
+        the allowance in production code were only, say, 200 bytes (too small
+        for a real single-file upload's framing) because 64 KiB would still
+        hide the difference.
+        """
         png = _valid_png_bytes()
         monkeypatch.setattr(
             garuda_documents_router.byte_validation, "MAX_UPLOAD_BYTES", len(png)
+        )
+        monkeypatch.setattr(
+            garuda_documents_router, "_MULTIPART_FRAMING_ALLOWANCE_BYTES", 320
         )
         _patch_ocr(monkeypatch, (_pass(_CONFIDENT_FIELDS), _pass(_CONFIDENT_FIELDS)))
         app = _app(
@@ -518,6 +607,7 @@ class TestUpload413DocumentTooLarge:
         body = _build_raw_multipart_body(
             document_kind="PASSPORT_BIODATA", file_bytes=png
         )
+        assert len(body) - len(png) == 292  # pins the framing-overhead measurement above
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://t") as client:
             resp = await _post_raw_multipart(client, body=body, streamed=True)

--- a/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_openapi_parity.py
+++ b/apps/backend-rag/backend/tests/app/routers/test_garuda_voa_openapi_parity.py
@@ -70,7 +70,10 @@ list." Measured that day: the frozen contract declares **13** operations;
 `garuda_orders_router.py`'s `createOrderFromCheck`/`getOrderAndPractice`/
 `observePaymentBrowserReturn`/`receivePaymentWebhook`/`resolveLateOrder`) and
 **3** have no router at all (`uploadIntakeDocument`, `listIntakeDocuments`,
-`transitionPractice`). None of the 7 L3/L4 operations were checked before
+`transitionPractice` — corrected: the first two moved to
+`_MOUNTED_OPERATION_IDS` when `garuda_documents_router.py`, L5's hinge,
+mounted; `transitionPractice` remains the only genuinely unmounted one).
+None of the 7 L3/L4 operations were checked before
 this widening — 5 of them were not even *resolvable* by operationId (their
 decorators never set `operation_id=`, so FastAPI auto-generated one from the
 Python function name), and the 2 that were resolvable (`requestMagicLink`/
@@ -199,8 +202,12 @@ def _live_path_methods() -> set[tuple[str, str]]:
 # new test code required).
 _NOT_YET_BUILT_OPERATION_IDS = frozenset(
     {
-        "uploadIntakeDocument",
-        "listIntakeDocuments",
+        # `uploadIntakeDocument`/`listIntakeDocuments` moved to
+        # `_MOUNTED_OPERATION_IDS` when `garuda_documents_router.py` (L5
+        # hinge) was mounted — its production store still fails closed 503
+        # until L1's retention-covered store exists (see that router's
+        # module docstring), but the HTTP surface itself is real and
+        # answers every status code the frozen contract declares.
         "transitionPractice",
     }
 )


### PR DESCRIPTION
Mounts the GARUDA VOA document-upload route — `POST`/`GET
/api/visa/voa/eligibility-checks/{result_id}/documents` — and wires
`app.state.garuda_document_store` to a fail-closed `_UnconfiguredDocumentStore`
that answers an honest 503 until the real Postgres store (#5526) lands. The
route is reachable in the `api` process group only, declared in the manifest
and included in both `include_routers()` and `include_light_routers()`, which
is the parity `test_manifest_registration_parity.py` enforces.

## The part worth reading: the size bound was asserted, not enforced

The first version of `_parse_upload_request` claimed in its docstring to bound
the upload DURING streaming and to map an oversize body to the frozen
contract's `413 DOCUMENT_TOO_LARGE`. Adversarial review found the claim was
false in three compounding ways, all measured against the installed Starlette
1.3.1 rather than assumed:

1. `await request.form(...)` never lets a `MultiPartException` escape.
   `starlette/requests.py::_get_form` catches it and re-raises
   `HTTPException(400, detail=<string>)` whenever `"app" in self.scope`, which
   is every real request. The router's `except MultiPartException` clause was
   dead code.
2. The surviving branch classified by `"exceeded maximum size" in str(exc)` —
   a bare substring test on a human-facing message (scar family #3).
3. `max_part_size` does not bound a FILE part at all on this version:
   `formparsers.py::MultiPartParser.on_part_data` size-checks only the
   non-file branch. Proven with a standalone repro — a 2000-byte file part
   with `max_part_size=10` raises nothing.

So a client sending a chunked or understated-`Content-Length` body larger than
the bound got no 413 from this layer at all; only the service layer caught it,
after the whole body was already buffered in memory. The old test could not
see any of this: httpx computes an accurate `Content-Length` for an in-memory
multipart body, so the cheap header pre-check always answered first and the
streaming path was never exercised. Deleting the enforcement left the test
green.

## The cure

`_parse_upload_request` no longer calls `request.form()`. It drives
`MultiPartParser` directly over `_bounded_body_stream()`, which counts bytes
off `request.stream()` and raises `_RequestBodyTooLarge` before yielding a
chunk that would cross `MAX_UPLOAD_BYTES + _MULTIPART_FRAMING_ALLOWANCE_BYTES`.
Classification is by exception TYPE only: `_RequestBodyTooLarge` → 413,
`MultiPartException` → 422. No string comparison survives in the function. The
`Content-Length` pre-check stays as a cheap early rejection for honest clients.

## Bites

The consumer is the route itself, and the observation is a mutation, not a
green suite: with the raise inside `_bounded_body_stream` disabled, the two new
tests fail with `server pulled 50292 bytes before rejecting — expected <=
body_limit (1200) + one chunk (256)`. That assertion is the point — a bare 413
cannot distinguish the streaming bound from the downstream buffering backstop,
and that ambiguity is exactly what hid the defect. The tests patch
`MAX_UPLOAD_BYTES` and the framing allowance down together, because with the
real 64 KiB allowance no body a unit test can afford to send ever reaches the
bound.

`46 passed, 1 skipped` across the router and contract-parity files. The skip is
honest and documented in place: the contract's 202 `ProcessingOutcome` is
defensively unreachable per `service.py`'s own comment, so the test says so
rather than faking a code the route cannot emit.

## Known and deliberately not fixed here

`service.py`'s pre-existing `validate_size()` is an independent second
enforcement of the same bound, which is why two of the three mutations run
against this diff stay green. Reported rather than engineered around. The
router-layer post-parse check is kept anyway for locality, with a comment
saying it is redundant so it does not later read as accidental.