### PR TITLE
fix(mouth/i18n): translate the English frontmatter of the six FR/RU Second Home articles

### DIFF
--- a/apps/mouth/src/content/articles/immigration/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.fr.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+title: "Visa Second Home Indonésie 2026 : l’essentiel pour expatriés aisés"
 slug: "indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now"
-excerpt: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+excerpt: "Visa Second Home Indonésie 2026 : l’essentiel pour expatriés aisés"
 coverImage: "/static/news/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.jpg"
-coverImageAlt: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+coverImageAlt: "Visa Second Home Indonésie 2026 : l’essentiel pour expatriés aisés"
 category: "immigration"
 noIndex: true
 tags: ["immigration", "second home visa"]
@@ -13,8 +13,8 @@ trending: true
 featured: false
 readingTime: 3
 difficulty: "intermediate"
-seoTitle: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
-seoDescription: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+seoTitle: "Visa Second Home Indonésie 2026 : l’essentiel pour expatriés aisés"
+seoDescription: "Visa Second Home Indonésie 2026 : les informations essentielles pour les expatriés aisés."
 locale: "fr"
 source_sha256: "0c724010b1d3cdd90f8d6369c4cc620327a1b9a8bde1493169786d9bd896d78f"
 ---

--- a/apps/mouth/src/content/articles/immigration/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.ru.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+title: "Виза Second Home в Индонезии 2026: главное для состоятельных экспатов"
 slug: "indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now"
-excerpt: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+excerpt: "Виза Second Home в Индонезии 2026: главное для состоятельных экспатов"
 coverImage: "/static/news/indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.jpg"
-coverImageAlt: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+coverImageAlt: "Виза Second Home в Индонезии 2026: главное для состоятельных экспатов"
 category: "immigration"
 noIndex: true
 tags: ["immigration", "second home visa"]
@@ -13,8 +13,8 @@ trending: true
 featured: false
 readingTime: 3
 difficulty: "intermediate"
-seoTitle: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
-seoDescription: "Indonesia Second Home Visa 2026: What Wealthy Expats Need to Know Now"
+seoTitle: "Виза Second Home в Индонезии 2026: главное для состоятельных экспатов"
+seoDescription: "Виза Second Home в Индонезии 2026: главное, что нужно знать состоятельным экспатам."
 locale: "ru"
 source_sha256: "0c724010b1d3cdd90f8d6369c4cc620327a1b9a8bde1493169786d9bd896d78f"
 ---

--- a/apps/mouth/src/content/articles/immigration/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.fr.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+title: "Séjourner durablement en Indonésie | Second Home et Golden Visa - PNB Immigration Law Firm"
 slug: "live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm"
-excerpt: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+excerpt: "Séjourner durablement en Indonésie | Second Home et Golden Visa - PNB Immigration Law Firm"
 coverImage: "/static/news/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.jpg"
-coverImageAlt: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+coverImageAlt: "Séjourner durablement en Indonésie | Second Home et Golden Visa - PNB Immigration Law Firm"
 category: "immigration"
 noIndex: true
 tags: ["immigration", "second home visa", "golden visa"]
@@ -13,8 +13,8 @@ trending: false
 featured: false
 readingTime: 3
 difficulty: "intermediate"
-seoTitle: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
-seoDescription: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+seoTitle: "Séjourner durablement en Indonésie | Second Home et Golden Visa - PNB Immigration Law Firm"
+seoDescription: "Séjourner durablement en Indonésie avec le visa Second Home ou le Golden Visa, par PNB Immigration Law Firm."
 locale: "fr"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.ru.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+title: "Долгосрочное проживание в Индонезии | Second Home и Golden Visa - PNB Immigration Law Firm"
 slug: "live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm"
-excerpt: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+excerpt: "Долгосрочное проживание в Индонезии | Second Home и Golden Visa - PNB Immigration Law Firm"
 coverImage: "/static/news/live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.jpg"
-coverImageAlt: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+coverImageAlt: "Долгосрочное проживание в Индонезии | Second Home и Golden Visa - PNB Immigration Law Firm"
 category: "immigration"
 noIndex: true
 tags: ["immigration", "second home visa", "golden visa"]
@@ -13,8 +13,8 @@ trending: false
 featured: false
 readingTime: 3
 difficulty: "intermediate"
-seoTitle: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
-seoDescription: "Live Long-Term in Indonesia | Second Home & Golden Visa - PNB Immigration Law Firm"
+seoTitle: "Долгосрочное проживание в Индонезии | Second Home и Golden Visa - PNB Immigration Law Firm"
+seoDescription: "Долгосрочное проживание в Индонезии по визе Second Home или Golden Visa от PNB Immigration Law Firm."
 locale: "ru"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.fr.mdx
@@ -1,12 +1,12 @@
 ---
 id: "second-home-visa-indonesia"
 slug: "second-home-visa-indonesia"
-title: "Second Home Visa Indonesia 2026: Complete Guide to the 5-Year Stay Permit"
-subtitle: "Everything about Indonesia's Second Home Visa for property owners and high-net-worth individuals"
-description: "Complete guide to Indonesia's Second Home Visa (SHV) 2026. IDR 2B bank balance or property ownership, 5-year stay, application process, rights, and limitations."
-excerpt: "Indonesia's Second Home Visa grants 5-year residency for those with IDR 2B savings or Indonesian property. Full guide to requirements, application, rights, and comparison with KITAP."
+title: "Visa Second Home Indonésie 2026 : guide du séjour de 5 ans"
+subtitle: "Tout savoir sur le visa Second Home d’Indonésie pour les propriétaires et les personnes fortunées"
+description: "Guide du visa Second Home (SHV) 2026 en Indonésie : 2 milliards IDR en banque ou un bien immobilier, séjour de 5 ans, démarches, droits et limites."
+excerpt: "Le visa Second Home d’Indonésie accorde un séjour de 5 ans aux détenteurs de 2 milliards IDR d’épargne ou d’un bien immobilier indonésien. Guide des conditions, démarches, droits et comparaison avec le KITAP."
 coverImage: "/static/insights/immigration/second-home-visa-indonesia.jpg"
-coverImageAlt: "Bali Zero cover graphic for the Indonesia Second Home Visa guide"
+coverImageAlt: "Visuel de couverture Bali Zero pour le guide du visa Second Home d’Indonésie"
 category: "immigration"
 tags:
   [
@@ -29,7 +29,7 @@ author:
   id: "zantara-ai"
   name: "Zantara AI"
   avatar: "/static/zantara-avatar.png"
-  role: "AI Immigration Advisor"
+  role: "Conseiller IA en immigration"
   isAI: true
 readingTime: 13
 aiGenerated: true
@@ -37,11 +37,11 @@ aiConfidenceScore: 0.92
 featured: false
 trending: false
 status: "published"
-seoTitle: "Second Home Visa Indonesia 2026: 5-Year Residency Guide"
-seoDescription: "Indonesia Second Home Visa: IDR 2B savings or property grants 5-year residency. Requirements, application process, work rights, KITAP comparison."
+seoTitle: "Visa Second Home Indonésie 2026 : guide de résidence de 5 ans"
+seoDescription: "Visa Second Home Indonésie : 2 milliards IDR d’épargne ou un bien immobilier pour 5 ans. Conditions, démarches, travail et KITAP."
 aiOptimization:
-  primaryQuestion: "What is the Second Home Visa for Indonesia and how do I qualify?"
-  answerSnippet: "Indonesia's Second Home Visa (SHV) is a 5-year stay permit for high-net-worth foreigners. You qualify by proving USD 130,000 (approximately IDR 2 billion) in bank savings OR ownership of property in Indonesia. See our service page for current pricing. It does not require a sponsoring company, and can be renewed for another 5 years."
+  primaryQuestion: "Qu’est-ce que le visa Second Home d’Indonésie et comment y être éligible ?"
+  answerSnippet: "Le visa Second Home d’Indonésie (SHV) est un titre de séjour de 5 ans destiné aux étrangers fortunés. Vous êtes éligible en prouvant USD 130,000 (environ 2 milliards IDR) d’épargne bancaire OU la propriété d’un bien immobilier en Indonésie. Consultez notre page de services pour les tarifs à jour. Il ne requiert pas d’entreprise sponsor et peut être renouvelé pour 5 ans supplémentaires."
   entityMentions:
     - type: "GovernmentOrganization"
       name: "Direktorat Jenderal Imigrasi"
@@ -50,12 +50,12 @@ aiOptimization:
       name: "Kementerian Hukum dan HAM"
       sameAs: "https://www.kemenkumham.go.id"
 faq:
-  - question: "Can I work on a Second Home Visa in Indonesia?"
-    answer: "The Second Home Visa does not include work authorization. You cannot be employed by an Indonesian company or operate a business. However, passive income activities (investment returns, rental income from overseas properties, pension) are permitted. Remote work for foreign clients exists in a similar gray area as the B211A visa. For legal work rights, you need a KITAS with RPTKA."
-  - question: "Do I need to keep IDR 2B in an Indonesian bank account?"
-    answer: "Yes. The funds must be held in your own name at a state-owned Indonesian (BUMN) bank — statements from foreign or international banks are not accepted as proof. The requirement is USD 130,000 (approximately IDR 2 billion). Alternatively, the requirement can be met with qualifying property worth at least USD 1,000,000."
-  - question: "Can the Second Home Visa be converted to KITAP (permanent residence)?"
-    answer: "Currently, time spent on the Second Home Visa does not count toward the 3-year consecutive KITAS requirement for KITAP eligibility. To pursue KITAP, you would need to switch to a KITAS category (such as E25B Director or E28A Investor) and complete 3 consecutive years on KITAS. The SHV and KITAP are separate immigration pathways."
+  - question: "Puis-je travailler avec un visa Second Home en Indonésie ?"
+    answer: "Le visa Second Home ne donne pas d’autorisation de travail. Vous ne pouvez pas être salarié d’une entreprise indonésienne ni exercer une activité commerciale. Les activités générant des revenus passifs (rendements d’investissement, revenus locatifs de biens à l’étranger, pension) sont toutefois autorisées. Le télétravail pour des clients étrangers se situe dans une zone grise comparable à celle du visa B211A. Pour travailler légalement, vous avez besoin d’un KITAS avec RPTKA."
+  - question: "Dois-je conserver 2 milliards IDR sur un compte bancaire indonésien ?"
+    answer: "Oui. Les fonds doivent être détenus à votre nom auprès d’une banque publique indonésienne (BUMN) ; les relevés de banques étrangères ou internationales ne sont pas acceptés comme preuve. L’exigence est de USD 130,000 (environ 2 milliards IDR). Elle peut aussi être satisfaite par un bien immobilier éligible d’une valeur minimale de USD 1,000,000."
+  - question: "Le visa Second Home peut-il être converti en KITAP (résidence permanente) ?"
+    answer: "À ce jour, la période passée avec un visa Second Home ne compte pas dans l’exigence de 3 années consécutives de KITAS pour être éligible au KITAP. Pour obtenir un KITAP, il faudrait passer à une catégorie de KITAS, telle qu’E25B Director ou E28A Investor, puis totaliser 3 années consécutives de KITAS. Le SHV et le KITAP sont deux parcours d’immigration distincts."
 contentStructure:
   hasHowTo: true
   hasFAQ: true

--- a/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.ru.mdx
@@ -1,12 +1,12 @@
 ---
 id: "second-home-visa-indonesia"
 slug: "second-home-visa-indonesia"
-title: "Second Home Visa Indonesia 2026: Complete Guide to the 5-Year Stay Permit"
-subtitle: "Everything about Indonesia's Second Home Visa for property owners and high-net-worth individuals"
-description: "Complete guide to Indonesia's Second Home Visa (SHV) 2026. IDR 2B bank balance or property ownership, 5-year stay, application process, rights, and limitations."
-excerpt: "Indonesia's Second Home Visa grants 5-year residency for those with IDR 2B savings or Indonesian property. Full guide to requirements, application, rights, and comparison with KITAP."
+title: "Виза Second Home в Индонезии 2026: гид по 5-летнему ВНЖ"
+subtitle: "Всё о визе Second Home в Индонезии для владельцев недвижимости и состоятельных лиц"
+description: "Полный гид по визе Second Home (SHV) в Индонезии на 2026 год: 2 млрд IDR на счёте или недвижимость, 5-летнее пребывание, подача, права и ограничения."
+excerpt: "Виза Second Home в Индонезии даёт 5-летний ВНЖ при наличии сбережений в 2 млрд IDR или индонезийской недвижимости. Условия, подача, права и сравнение с KITAP."
 coverImage: "/static/insights/immigration/second-home-visa-indonesia.jpg"
-coverImageAlt: "Bali Zero cover graphic for the Indonesia Second Home Visa guide"
+coverImageAlt: "Обложка Bali Zero для гида по визе Second Home в Индонезии"
 category: "immigration"
 tags:
   [
@@ -29,7 +29,7 @@ author:
   id: "zantara-ai"
   name: "Zantara AI"
   avatar: "/static/zantara-avatar.png"
-  role: "AI Immigration Advisor"
+  role: "ИИ-консультант по иммиграции"
   isAI: true
 readingTime: 13
 aiGenerated: true
@@ -37,11 +37,11 @@ aiConfidenceScore: 0.92
 featured: false
 trending: false
 status: "published"
-seoTitle: "Second Home Visa Indonesia 2026: 5-Year Residency Guide"
-seoDescription: "Indonesia Second Home Visa: IDR 2B savings or property grants 5-year residency. Requirements, application process, work rights, KITAP comparison."
+seoTitle: "Виза Second Home в Индонезии 2026: гид по 5-летнему ВНЖ"
+seoDescription: "Виза Second Home в Индонезии: сбережения 2 млрд IDR или недвижимость для 5-летнего ВНЖ. Условия, подача, право на работу и сравнение с KITAP."
 aiOptimization:
-  primaryQuestion: "What is the Second Home Visa for Indonesia and how do I qualify?"
-  answerSnippet: "Indonesia's Second Home Visa (SHV) is a 5-year stay permit for high-net-worth foreigners. You qualify by proving USD 130,000 (approximately IDR 2 billion) in bank savings OR ownership of property in Indonesia. See our service page for current pricing. It does not require a sponsoring company, and can be renewed for another 5 years."
+  primaryQuestion: "Что такое виза Second Home в Индонезии и как её получить?"
+  answerSnippet: "Виза Second Home в Индонезии (SHV) — это 5-летний вид на жительство для состоятельных иностранцев. Чтобы получить визу, необходимо подтвердить USD 130,000 (около 2 млрд IDR) на банковском счёте ИЛИ право собственности на недвижимость в Индонезии. Актуальные цены указаны на странице услуг. Виза не требует компании-спонсора и может быть продлена ещё на 5 лет."
   entityMentions:
     - type: "GovernmentOrganization"
       name: "Direktorat Jenderal Imigrasi"
@@ -50,12 +50,12 @@ aiOptimization:
       name: "Kementerian Hukum dan HAM"
       sameAs: "https://www.kemenkumham.go.id"
 faq:
-  - question: "Can I work on a Second Home Visa in Indonesia?"
-    answer: "The Second Home Visa does not include work authorization. You cannot be employed by an Indonesian company or operate a business. However, passive income activities (investment returns, rental income from overseas properties, pension) are permitted. Remote work for foreign clients exists in a similar gray area as the B211A visa. For legal work rights, you need a KITAS with RPTKA."
-  - question: "Do I need to keep IDR 2B in an Indonesian bank account?"
-    answer: "Yes. The funds must be held in your own name at a state-owned Indonesian (BUMN) bank — statements from foreign or international banks are not accepted as proof. The requirement is USD 130,000 (approximately IDR 2 billion). Alternatively, the requirement can be met with qualifying property worth at least USD 1,000,000."
-  - question: "Can the Second Home Visa be converted to KITAP (permanent residence)?"
-    answer: "Currently, time spent on the Second Home Visa does not count toward the 3-year consecutive KITAS requirement for KITAP eligibility. To pursue KITAP, you would need to switch to a KITAS category (such as E25B Director or E28A Investor) and complete 3 consecutive years on KITAS. The SHV and KITAP are separate immigration pathways."
+  - question: "Можно ли работать по визе Second Home в Индонезии?"
+    answer: "Виза Second Home не даёт права на работу. Нельзя быть сотрудником индонезийской компании или вести бизнес. Однако допустимы источники пассивного дохода: доход от инвестиций, аренды зарубежной недвижимости или пенсия. Удалённая работа для иностранных клиентов остаётся в той же серой зоне, что и по визе B211A. Для законного права на работу требуется KITAS с RPTKA."
+  - question: "Нужно ли хранить 2 млрд IDR на счёте в индонезийском банке?"
+    answer: "Да. Средства должны находиться на вашем счёте в государственном индонезийском банке (BUMN); выписки из зарубежных или международных банков не принимаются как подтверждение. Требование составляет USD 130,000 (около 2 млрд IDR). В качестве альтернативы подойдёт соответствующая требованиям недвижимость стоимостью не менее USD 1,000,000."
+  - question: "Можно ли перейти с визы Second Home на KITAP (постоянный вид на жительство)?"
+    answer: "Сейчас период проживания по визе Second Home не засчитывается в требование 3 последовательных лет с KITAS для получения KITAP. Чтобы оформить KITAP, нужно перейти на категорию KITAS, например E25B Director или E28A Investor, и провести на KITAS 3 последовательных года. SHV и KITAP — разные иммиграционные пути."
 contentStructure:
   hasHowTo: true
   hasFAQ: true


### PR DESCRIPTION
## Why

The six FR/RU Second Home articles had translated bodies but **verbatim English YAML frontmatter** — `title`, `description`, `excerpt`, `seoTitle`, `seoDescription`, `answerSnippet` and the whole `faq:` block. Those are the fields Google and the FAQ rich result read, so the FR and RU locales were effectively published in English where it counts (PENDING-ARMS row opened 2026-08-31; proof `grep -c "Do I need to keep IDR 2B"` = 1 in both `second-home-visa-indonesia.{fr,ru}.mdx`, now 0).

## What

Frontmatter string values only, in `apps/mouth/src/content/articles/immigration/`:
- `second-home-visa-indonesia.{fr,ru}.mdx` (31 keys, 3 FAQ entries each)
- `indonesia-second-home-visa-2026-what-wealthy-expats-need-to-know-now.{fr,ru}.mdx`
- `live-long-term-in-indonesia-second-home-golden-visa-pnb-immigration-law-firm.{fr,ru}.mdx`

Key trees, list lengths, `tags`/`category`/`locale`/`slug`/`id` and the bodies after the closing `---` are byte-identical to `main` (verified per file). Program names/codes and all amounts preserved.

## Verification (generator ≠ grader)

- Built on the codex seat (`gpt-5.6-terra`, effort high) from a written task file.
- Cross-family language QA: Gemini 3.1 Pro (`agy`) — 6 items; 4 wording fixes applied (FR *entreprise marraine* → *entreprise sponsor*, *ou le Golden Visa, par*; RU *как ей соответствовать* → *как её получить*, *Для соответствия* → *Чтобы получить визу*); 2 are inherited overflows (the EN base title of the `live-long-term` article is already 82 chars).
- Independent adversarial grade (sonnet, fresh context) on the final tree: **PASS** — bodies byte-identical, YAML parses, key trees identical, no meaning drift on negations / amounts / visa codes, no stray English, scope = the six files.
- `vitest run src/content/description-fields-integrity.test.ts`: 4 passed. Harness floor: Gear 1.

Pre-existing, NOT fixed here (one PR, one concern): the canonical EN `second-home-visa-indonesia.mdx` `answerSnippet` (line 44) is truncated mid-sentence ("…sponsoring…"); the `live-long-term` EN title is 82 chars.

Prove-live after the Vercel deploy: `/fr/…second-home-visa-indonesia` and `/ru/…` pages serve the translated `<title>` and FAQ JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jne5CZvgNcjcy2D3hFYmE
