### PR TITLE
fix(mouth/content): complete the truncated EN answerSnippet of the Second Home Visa guide

### DIFF
--- a/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx
+++ b/apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx
@@ -41,7 +41,7 @@ seoTitle: "Second Home Visa Indonesia 2026: 5-Year Residency Guide"
 seoDescription: "Indonesia Second Home Visa: IDR 2B savings or property grants 5-year residency. Requirements, application process, work rights, KITAP comparison."
 aiOptimization:
   primaryQuestion: "What is the Second Home Visa for Indonesia and how do I qualify?"
-  answerSnippet: "Indonesia's Second Home Visa (SHV) is a 5-year stay permit for high-net-worth foreigners. You qualify by proving USD 130,000 (approximately IDR 2 billion) in bank savings OR ownership of property in Indonesia. See our service page for current pricing. It does not require a sponsoring..."
+  answerSnippet: "Indonesia's Second Home Visa (SHV) is a 5-year stay permit for high-net-worth foreigners. You qualify by proving USD 130,000 (approximately IDR 2 billion) in bank savings OR ownership of property in Indonesia. See our service page for current pricing. It does not require a sponsoring company, and can be renewed for another 5 years."
   entityMentions:
     - type: "GovernmentOrganization"
       name: "Direktorat Jenderal Imigrasi"


### PR DESCRIPTION
## Why

The canonical English Second Home Visa guide's `aiOptimization.answerSnippet` (the text AI answer engines and the FAQ rich result quote) ended mid-sentence: *"…It does not require a sponsoring..."*. Surfaced by the adversarial grader of #5552 as a pre-existing defect outside that PR's scope.

## What

One string value in `apps/mouth/src/content/articles/immigration/second-home-visa-indonesia.mdx`: the sentence is completed as *"…It does not require a sponsoring company, and can be renewed for another 5 years."* — the exact English the FR/RU copies of the file carried before their frontmatter was translated, and what the article body states (no company sponsorship; 5-year renewal). YAML re-parsed; keys, body and every other field byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jne5CZvgNcjcy2D3hFYmE
