### PR TITLE
fix(tests): stop leaking a real practices row into whichever suite runs next

### DIFF
--- a/apps/backend-rag/backend/tests/db/test_migration_303_voa_price_roundtrip.py
+++ b/apps/backend-rag/backend/tests/db/test_migration_303_voa_price_roundtrip.py
@@ -86,7 +86,28 @@ async def _seed(conn: asyncpg.Connection, price: int | None) -> None:
 
     CREATE TABLE IF NOT EXISTS rather than assuming the schema: this suite runs
     both against CI's freshly-migrated database and against developer machines
-    whose local copy is behind.
+    whose local copy is behind. In CI that CREATE is a silent no-op — the real
+    migration-221-seeded table (an `id serial` PK, `practices.practice_type_id`
+    FK-ing onto it) already exists under this exact name, so every statement
+    below actually lands on the shared catalogue row, not a private fixture.
+
+    For a KNOWN price, upsert rather than delete-then-insert: `UPDATE` never
+    trips `practices_practice_type_id_fkey` because it does not touch the `id`
+    a `practices` row references, so this path is safe even when another
+    suite's leaked row (or a genuinely concurrent xdist worker's live one) is
+    pointed at 'visa_b1_voa' right now. This is the exact path
+    `test_forward_moves_the_superseded_price_to_the_ruled_one` exercises, and
+    the one whose `DELETE` was observed to hit that FK in CI.
+
+    The `price is None` branch is unavoidably still a real DELETE: that
+    branch's entire point (`test_an_absent_row_raises_instead_of_recording_
+    success`) is to prove migration 303 raises when the row is genuinely
+    absent, which cannot be simulated without removing it. It therefore keeps
+    the same exposure this whole function used to have. A full cure needs this
+    suite to own a private schema (`CREATE SCHEMA` + `search_path`) rather than
+    aliasing the shared one — deliberately not done here: that changes how
+    every statement in this file resolves `practice_types`, which is a second
+    concern, not a fix to the one FK violation actually seen in CI.
     """
     await conn.execute(
         "CREATE TABLE IF NOT EXISTS practice_types ("
@@ -95,11 +116,13 @@ async def _seed(conn: asyncpg.Connection, price: int | None) -> None:
         "  base_price numeric,"
         "  updated_at timestamptz DEFAULT now())"
     )
-    await conn.execute("DELETE FROM practice_types WHERE code = 'visa_b1_voa'")
-    if price is not None:
+    if price is None:
+        await conn.execute("DELETE FROM practice_types WHERE code = 'visa_b1_voa'")
+    else:
         await conn.execute(
             "INSERT INTO practice_types (code, name, base_price) "
-            "VALUES ('visa_b1_voa', 'B1 - VOA', $1)",
+            "VALUES ('visa_b1_voa', 'B1 - VOA', $1) "
+            "ON CONFLICT (code) DO UPDATE SET base_price = EXCLUDED.base_price",
             price,
         )
 

--- a/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
+++ b/apps/backend-rag/backend/tests/services/garuda_orders/test_outbox_handlers.py
@@ -41,12 +41,23 @@ from backend.services.garuda_orders.outbox_handlers import (
 )
 from backend.tests.fixtures.prod_shaped_pool import create_prod_shaped_pool
 
-# `_seed_full_case` is imported rather than re-implemented ON PURPOSE. Seeding a
-# usable case means check -> order -> journal -> practice PLUS an active
-# GARUDA_CHECK retention policy, because `garuda_voa_check_results` is
-# fail-closed by trigger. A second copy of that would drift from the first, and
-# this suite would start proving something the adapter suite no longer does.
-from backend.tests.services.garuda_ops.test_adapters_pg import _seed_full_case
+# `_seed_full_case` and `_reset_suite_rows` are imported rather than
+# re-implemented ON PURPOSE. Seeding a usable case means check -> order ->
+# journal -> practice PLUS an active GARUDA_CHECK retention policy, because
+# `garuda_voa_check_results` is fail-closed by trigger. A second copy of
+# either would drift from the first, and this suite would start proving
+# something the adapter suite no longer does — which is exactly what had
+# already happened to the cleanup half: this file's `pool` fixture used to
+# carry its own hand-copied TRUNCATE/DELETE block with no post-yield call,
+# so the release-job tests below (which mint real `practices` rows keyed to
+# `visa_b1_voa` via `PostgresCrmWriter`) could leave the LAST such row
+# committed for whatever runs next on this worker. See `_reset_suite_rows`'s
+# docstring for the cross-file FK violation that caused
+# (`test_migration_303_voa_price_roundtrip.py`'s DELETE on the same code).
+from backend.tests.services.garuda_ops.test_adapters_pg import (
+    _reset_suite_rows,
+    _seed_full_case,
+)
 
 _DSN = (
     os.environ.get("GARUDA_L3_TEST_DSN")
@@ -78,26 +89,17 @@ async def pool():
         # connection error if that assumption ever stops being true.
         raise
     try:
-        async with p.acquire() as conn:
-            await conn.execute(
-                "TRUNCATE garuda_practices, garuda_order_outbox, "
-                "garuda_order_journal, garuda_orders, garuda_voa_check_results "
-                "CASCADE"
-            )
-            # The weld tests below write real CRM rows, so this fixture has to
-            # clean the CRM side too. Order matters and the second delete is
-            # not redundant: the first clears what the adapter wrote (every
-            # such row carries a key), the second clears any NULL-key row the
-            # first cannot see, and both must precede the client delete or
-            # `practices_client_id_fkey` rejects it — the same teardown trap
-            # `test_adapters_pg.py`'s fixture documents.
-            await conn.execute("DELETE FROM practices WHERE source_idempotency_key IS NOT NULL")
-            await conn.execute(
-                "DELETE FROM practices WHERE client_id IN "
-                "(SELECT id FROM clients WHERE email LIKE '%@example.invalid')"
-            )
-            await conn.execute("DELETE FROM clients WHERE email LIKE '%@example.invalid'")
+        # The weld tests below write real CRM rows (via `PostgresCrmWriter`,
+        # every such row carries a key), so cleanup has to reach the CRM side
+        # too, not just this file's own garuda_* tables — exactly what
+        # `_reset_suite_rows` already does for `test_adapters_pg.py`. Called
+        # both before AND after the yield: the second call is what closes the
+        # cross-file leak (see that function's docstring) — without it, the
+        # LAST release-job test in this file left a `practices` row keyed to
+        # `visa_b1_voa` committed for whatever ran next on this worker.
+        await _reset_suite_rows(p)
         yield p
+        await _reset_suite_rows(p)
     finally:
         await p.close()
 


### PR DESCRIPTION
An intermittent red on the shared backend suite:

```
FAILED backend/tests/db/test_migration_303_voa_price_roundtrip.py::test_forward_moves_the_superseded_price_to_the_ruled_one
  asyncpg.exceptions.ForeignKeyViolationError
  DETAIL:  Key (id)=(41) is still referenced from table "practices".
```

It is not a defect in migration 303 and not a defect in whichever PR happens to
be carrying it — it is one suite leaving a row behind for another.

`test_outbox_handlers.py` writes a real `practices` row tied to `visa_b1_voa`
and its `pool` fixture cleaned up only BEFORE each test, never after. Its
last-run test therefore left the row live in that worker's database.
`test_migration_303_voa_price_roundtrip.py`'s `_seed()` then does
`DELETE FROM practice_types WHERE code = 'visa_b1_voa'` and hits
`practices_practice_type_id_fkey`.

The repo already diagnosed and cured a PRIOR instance of exactly this, in
`test_adapters_pg.py`, whose `_reset_suite_rows` docstring tells the story and
warns that "ANY new test file added to the corpus can shift this file onto the
same shard/worker". The cure there was before-AND-after cleanup. Its sibling
never got it.

## Two fixes

**Primary** — `test_outbox_handlers.py` now imports and calls
`_reset_suite_rows` both before and after `yield p`. Its old inline block was
byte-for-byte the same body minus the post-yield call, so this is also a dedup.

**Secondary** — `_seed()` in the 303 test believed it was creating its own
sandbox: `CREATE TABLE IF NOT EXISTS practice_types` is a silent no-op in CI,
where the real migrated table exists (the stub it defines has no `id` column at
all), so the helper was mutating the shared schema while reading as if it were
isolated. Its concrete-price path is now an idempotent
`INSERT ... ON CONFLICT (code) DO UPDATE`, which never touches the referenced
`id` and therefore cannot trip the FK no matter who references the row.

Two options were considered and deliberately rejected, both recorded in the
code: asserting when the real table is found would fail always, because running
against CI's migrated database is the test's documented normal case; and giving
the test its own schema is correct but expands the diff past this one concern —
filed as a follow-up. The `price is None` path keeps a real DELETE, because
proving the migration raises on a genuinely absent row is its entire purpose;
that residual exposure is documented in the docstring rather than hidden.

## Bites

The consumer is CI's shared Postgres, and the observation is a reproduction and
a mutation, not a green suite.

Reproduced deliberately, against a local database confirmed to hold the real
migration-221-seeded row (`id=41`, `code=visa_b1_voa`): running one of the two
weld tests that writes a `practices` row left `practice_type_id=41` behind
after teardown (0 → 1, checked in psql), and migration-303's test against that
polluted database then produced the reported error verbatim.

Mutation, both directions:
- Revert the primary fix, keep `_seed()`'s: the leak still happens, and 4 of 5
  tests in the 303 file now pass anyway — only the `price is None` one fails,
  exactly as its comment predicts. The upsert has independent protective value.
- Revert both: the FK violation reproduces identically.
- Restore: 57 passed across the three files together, zero leftover rows.

Note on why this is intermittent rather than constant: CI runs with
`pytest-randomly`, so which test lands last in the leaking file decides whether
a row survives to end-of-file. In definition order it does not leak, which is
why running the files together locally will not show the bug by default.