### PR TITLE
docs(agents): restore the "draft a WR2 brief" trigger in wr2-design-architect

### DIFF
--- a/.claude/agents/wr2-design-architect.md
+++ b/.claude/agents/wr2-design-architect.md
@@ -1,6 +1,6 @@
 ---
 name: wr2-design-architect
-description: 'MUST BE USED for every Bali Zero WR2 editorial carousel. Use IMMEDIATELY when user says "design a carousel for [topic]" or invokes the WR2 pipeline. Orchestrator-only: fans out to 4 specialist subagents, never writes JSON/HTML inline.'
+description: 'MUST BE USED for every Bali Zero WR2 editorial carousel. Use IMMEDIATELY when user says "design a carousel for [topic]", "draft a WR2 brief", or invokes the WR2 pipeline. Orchestrator-only: fans out to 4 specialist subagents, never writes JSON/HTML inline.'
 tools: Read, Write, Edit, Glob, Grep, Bash, Skill, Agent, WebFetch
 model: opus
 isolation: worktree


### PR DESCRIPTION
## Why

The independent grade of #5560 (agent/skill description trims) found exactly one lost dispatcher trigger: the quoted user phrase `"draft a WR2 brief"` for `wr2-design-architect` survived only in the body Notes, which the agent selector does not read.

## What

One line in `.claude/agents/wr2-design-architect.md`: the phrase is back in `description:` (234 → 256 chars, inside the 280-char budget enforced by `scripts/tests/test_startup_tax_budget.py`). Budget + model-pin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
