### PR TITLE
docs(evidence): the queue_unstick sender cron runs on Mini, not Pro (#5561 brief)

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-mailbox-retract-stale-035ce205/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-mailbox-retract-stale-035ce205/brief.yml
@@ -65,7 +65,7 @@ risks:
   - "The first live queue_unstick_cron.sh tick against a real resolved PR on Pro is the actual
     proof-of-armed for the retraction path — everything above is local simulation with a mocked
     _run(). No live dispatch was run as part of this PR (queue_unstick_cron.sh is a 10-min cron
-    already installed and armed on Pro per PENDING-ARMS; its next natural tick against a real
+    already installed and armed on Mini per PENDING-ARMS; its next natural tick against a real
     MERGED/CLOSED PR still in dirty_seen state is the receipt, observable via
     dirty_retracted=N in its own summary line and *.retracted-* files in the mailbox)."
   - "queue_stall_notify.py's broadcast surface is unmeasured for staleness (0 samples) — the TTL


### PR DESCRIPTION
## What

One-line correction to the merged brief for PR #5561: `queue_unstick_cron.sh` is installed and armed on **Mini**, not Pro.

## Why

Measured post-merge (2026-09-01 23:4x UTC): `ssh mini crontab -l` shows the entry
```
*/10 * * * * /bin/bash /Users/nuzantara/scripts/cron-runner.sh /Users/nuzantara/nuzantara/scripts/queue_unstick_cron.sh >> /Users/nuzantara/logs/cron-tmp/queue-unstick.log 2>&1
```
Mini's checkout was clean, on `main`, 0 commits behind `origin/main` pre-merge. Pro was not checked as the cron host by the original brief; the claim "already installed and armed on Pro per PENDING-ARMS" was incorrect and is corrected here so future readers don't chase the wrong machine when looking for live-tick evidence.

## Scope

Single line in `evidence/2026-09/agent-air-m5-infra-mailbox-retract-stale-035ce205/brief.yml`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)