### PR TITLE
fix(evidence-pack-lint): give R9 council-less fixtures a real council_run

### DIFF
--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -3344,11 +3344,35 @@ def selftest() -> int:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(yaml.safe_dump(obj, sort_keys=False), encoding="utf-8")
 
+    def write_journal(p: Path, entries: list[dict]) -> None:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8"
+        )
+
     good_receipt = {"claim": "tests pass", "cmd": "pytest -q", "exit": 0,
                      "ts": "2026-08-10T00:00:00Z", "seat": "sonnet-5"}
 
+    #: R9 quorum fixture — 2 DISTINCT COUNCIL_REVIEW_SEATS, role:review,
+    #: ok:true, ts present. Written once and reused by every Gear-3
+    #: innocence fixture below THAT ISN'T ITSELF TESTING R9 (dissent-shape,
+    #: hotzone-floor, ceiling gear_override): those fixtures need R9
+    #: satisfied like any real Gear-3 pack would, not bypassed — R9's own
+    #: `seat_override` escape is reserved for a genuine "we skipped the
+    #: council, here's why" human call (_r9_r11_verdict's docstring), which
+    #: none of these synthetic packs has, so a real journal is the honest
+    #: cure (added post-2026-09-02 R9_R11_ENFORCEMENT_DATE flip — see the
+    #: comment above that constant).
+    good_council_journal = [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True,
+         "ts": "2026-09-01T00:00:00Z"},
+        {"seat": "kimi-code/k3", "role": "review", "ok": True,
+         "ts": "2026-09-01T00:00:00Z"},
+    ]
+
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
+        write_journal(root / "evidence" / "council.jsonl", good_council_journal)
 
         # ---- unit-level: compute_floor is pure, test directly -------------
         check("compute_floor: hotzone hit -> 3",
@@ -3422,6 +3446,7 @@ def selftest() -> int:
             "receipts": [good_receipt],
             "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
             "pii_scan": "clean",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, None)
         check("innocence: non-empty dissent on gear-3 passes", rc == 0 and viol == [])
@@ -3516,6 +3541,7 @@ def selftest() -> int:
             "receipts": [good_receipt],
             "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
             "pii_scan": "clean",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, hotzone_changed)
         check("innocence: gear 3 on hotzone diff passes", rc == 0 and viol == [])
@@ -3554,6 +3580,7 @@ def selftest() -> int:
             "pii_scan": "clean",
             "council": True,
             "gear_override": "hotfix under active incident, verified live",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, ["docs/x.md"])
         check("innocence: gear_override on the same diff passes (ceiling reports, not fails)",
@@ -3603,6 +3630,7 @@ def selftest() -> int:
             "receipts": [good_receipt],
             "dissent": [{"seat": "codex-sol", "objection": "x", "status": "CONFIRMED"}],
             "pii_scan": "clean",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, None)
         check("innocence: fully-structured dissent entry passes", rc == 0 and viol == [])

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -73,6 +73,19 @@ GOOD_RECEIPT = {
     "ts": "2026-08-10T00:00:00Z", "seat": "sonnet-5",
 }
 
+#: R9 quorum fixture — 2 DISTINCT COUNCIL_REVIEW_SEATS, role:review, ok:true,
+#: ts present. Used by end-to-end Gear-3 fixtures below that test something
+#: OTHER than R9 itself (net-lines ceiling override, CLI flags) and need a
+#: real council_run journal, not `seat_override` — none of them carries a
+#: genuine "we skipped the council, here's why" human call, so a real
+#: journal is the honest cure post-2026-09-02 R9_R11_ENFORCEMENT_DATE flip.
+GOOD_COUNCIL_QUORUM = [
+    {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True,
+     "ts": "2026-09-01T00:00:00Z"},
+    {"seat": "kimi-code/k3", "role": "review", "ok": True,
+     "ts": "2026-09-01T00:00:00Z"},
+]
+
 
 @pytest.fixture()
 def tmp_repo(tmp_path):
@@ -535,10 +548,12 @@ def test_lint_end_to_end_measured_net_lines_overrides_pack_lie(tmp_repo):
     measured_net_lines parameter — no false ceiling."""
     root, write_brief, write_pack = tmp_repo
     write_brief(gear=3)
+    _write_journal(root / "evidence", "council.jsonl", GOOD_COUNCIL_QUORUM)
     pack_path = write_pack(
         dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
         council=True,
         net_lines=10,
+        council_run="council.jsonl",
     )
     diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
     rc, violations = lint(pack_path, root, diff, measured_net_lines=400)
@@ -1000,10 +1015,12 @@ def test_lint_end_to_end_innocence_ceiling_override_reports_not_fails(tmp_repo):
     to violations, so the pack passes clean."""
     root, write_brief, write_pack = tmp_repo
     write_brief(gear=3)
+    _write_journal(root / "evidence", "council.jsonl", GOOD_COUNCIL_QUORUM)
     pack_path = write_pack(
         dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
         council=True,
         gear_override="verified live, one-off",
+        council_run="council.jsonl",
     )
     rc, violations = lint(pack_path, root, ["docs/notes.md"])
     assert rc == 0
@@ -1139,8 +1156,10 @@ def test_net_lines_cli_flag_overrides_pack_lie_end_to_end(tmp_path):
     """--net-lines, given a diff shaped like predicate (b), wins over the
     pack's own (lying) net_lines field — reaching compute_ceiling() through
     the full CLI entry point, not just lint() called in-process."""
+    _write_journal(tmp_path / "evidence", "council.jsonl", GOOD_COUNCIL_QUORUM)
     pack_path = _write_full_tree(
-        tmp_path, gear=3, pack_overrides={"council": True, "net_lines": 10}
+        tmp_path, gear=3,
+        pack_overrides={"council": True, "net_lines": 10, "council_run": "council.jsonl"},
     )
     changed = tmp_path / "changed.txt"
     changed.write_text(


### PR DESCRIPTION
## What broke, and why it is a date crossing, not a commit

`R9_R11_ENFORCEMENT_DATE = datetime.date(2026, 9, 2)` in `scripts/evidence_pack_lint.py`
crossed at 00:00 UTC today. Before it, `check_council_run_gear3` (R9) gave a Gear-3 pack
with no `council_run` a NOTICE; from that instant it is a hard violation.

Pinned-clock proof (same fixture, same code, only `today` changes):

```
2026-09-01 (pre-flip):  viol= []  notice= council_run: gear:3 pack declares no council_run journal ...
2026-09-02 (post-flip): viol= ["council_run: gear:3 pack declares no council_run journal ..."]  notice= None
```

`date -u '+%Y-%m-%dT%H:%M:%SZ'` at repro time: `2026-09-02T00:09:47Z` — 9 minutes past the flip.

Four `--selftest` fixtures (dissent-shape / hotzone-floor / ceiling `gear_override` innocence
tests) and three `test_evidence_pack_lint.py` end-to-end fixtures are Gear-3-shaped packs that
predate `council_run` entirely — collateral, not a regression in what they were written to test.

## The cure

Read `check_council_run_gear3`, `_read_council_journal_seats`, `_r9_r11_verdict`. R9 requires
either (a) `council_run: <path>` resolving to a journal with ≥2 distinct `COUNCIL_REVIEW_SEATS`
each posting `{seat, role:"review", ok:true, ts}`, or (b) a `seat_override: <reason>` — but that
key is documented as a deliberate, named **human** call ("we skipped the council, here's why"),
never a silent pass. None of these seven fixtures carries a genuine reason to skip the council —
they're testing something else entirely (net-lines ceiling, dissent shape, hotzone floor, CLI
flags). Faking a `seat_override` reason to make them pass would misrepresent what happened and
quietly retire R9's own reporting signal (X3's override-frequency count) for these paths.

So the fix gives each fixture a **real** council journal (`council.jsonl`, 2 distinct seats:
`codex-gpt-5.6-sol` + `kimi-code/k3`, `ok:true`, `role:review`, `ts` set) — the same thing a real
Gear-3 PR now has to produce. This keeps every fixture testing what it always tested, and keeps
R9 fully enforced (these are packs proving compliance, not packs dodging the rule).

## Forbidden things NOT done

- `R9_R11_ENFORCEMENT_DATE` is untouched — no move, no raise, no defer.
- No fixture/assertion deleted, skipped, weakened, or `xfail`ed.
- No exemption/allowlist added that makes `council_run` not apply to selftest/test packs.
- Nothing outside these seven fixtures (+ 2 small test-scoped helpers) touched.

## Proof

1. **`--selftest` exits 0, PASS** (was exit 1 with 4 named FAILs).
2. **Guilt arm still bites** — called `check_council_run_gear3` directly against a council-less
   Gear-3 pack with `today=None` (real clock, i.e. today): still returns a `council_run`
   violation. Mutation check: deleting `council_run` from one fixture reddens exactly that
   fixture (`FAIL innocence: non-empty dissent on gear-3 passes`); restoring the file returns
   to PASS.
3. **`pytest scripts/tests/test_evidence_pack_lint.py -q`: 344 passed** (was 341 passed / 3
   failed on the same date-crossing collateral, in fixtures the CI job also runs — see below).

## Why the 3 pytest fixtures are in scope too

The CI job step this PR fixes runs **both** commands, in order:
```
python3 -m pytest scripts/tests/test_evidence_pack_lint.py -q
python3 scripts/evidence_pack_lint.py --selftest
```
(`.github/workflows/guard-conformance.yml`, step "Evidence Pack lint guilt+innocence"). Fixing
only `--selftest` would leave the same CI check red on the pytest half — same root cause
(`R9_R11_ENFORCEMENT_DATE` flip), same fixture shape (Gear-3, no `council_run`), same cure.
Confirmed pre-existing on unmodified `origin/main` via `git stash`: 4 failures there
(`test_selftest_corpus_passes` + 3 named end-to-end tests), not introduced by this branch.

**Bites:** `.github/workflows/guard-conformance.yml`'s "Every guard proves guilt AND innocence"
job, step "Evidence Pack lint guilt+innocence (evidence_pack_lint.py)" — currently red on
`origin/main` from the date crossing alone, blocking every PR that touches
`scripts/evidence_pack_lint.py` or its test corpus. Observation proving it's in force: this PR's
own required-check run of that step goes green, and re-running
`python3 scripts/evidence_pack_lint.py --selftest` plus
`pytest scripts/tests/test_evidence_pack_lint.py -q` on `origin/main` post-merge both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)