### PR TITLE
fix(brand): lock official anthracite to #363A3E

### DIFF
--- a/skills/bali-zero-brand/SKILL.md
+++ b/skills/bali-zero-brand/SKILL.md
@@ -60,13 +60,15 @@ Bali Zero is the Indonesian-business-services agency for expat founders, investo
 
 | Role                  | Token                 | Hex       |
 | --------------------- | --------------------- | --------- |
-| Background primary    | `color.bg.antracite`  | `#373D42` |
+| Background primary    | `color.bg.antracite`  | `#363A3E` |
 | Background secondary  | `color.bg.black`      | `#000000` |
 | Body text             | `color.text.white`    | `#FFFFFF` |
 | Accent data           | `color.accent.yellow` | `#F4C430` |
 | Status critico / logo | `color.status.red`    | `#C8102E` |
 
 NEVER green, blue, purple, pastel, beige.
+
+**Owner lock (2026-09-02):** `#363A3E` is the only official flat anthracite for Bali Zero editorial backgrounds and UI surfaces. Do not substitute a bluer blue-grey approximation. Hero-photo zones retain their natural cinematic grading under Article 2.3.
 
 ## Quick typography (full version in tokens.json)
 

--- a/skills/bali-zero-brand/_damar-anchor-ui.html
+++ b/skills/bali-zero-brand/_damar-anchor-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 Anchor Picker</title>
 <style>
   :root {
-    --color-bg-antracite: #373D42;
+    --color-bg-antracite: #363A3E;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_damar-inject-ui.html
+++ b/skills/bali-zero-brand/_damar-inject-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 — Manual Topic Injection</title>
 <style>
   :root {
-    --color-bg-antracite: #373D42;
+    --color-bg-antracite: #363A3E;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_damar-queue-ui.html
+++ b/skills/bali-zero-brand/_damar-queue-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 Damar Queue</title>
 <style>
   :root {
-    --color-bg-antracite: #373D42;
+    --color-bg-antracite: #363A3E;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_damar-tag-ui.html
+++ b/skills/bali-zero-brand/_damar-tag-ui.html
@@ -5,7 +5,7 @@
 <title>WR2 Past Carousel Tagging</title>
 <style>
   :root {
-    --color-bg-antracite: #373D42;
+    --color-bg-antracite: #363A3E;
     --color-bg-black: #000000;
     --color-text-white: #FFFFFF;
     --color-text-muted: #9CA3AF;

--- a/skills/bali-zero-brand/_render_smoke_test.py
+++ b/skills/bali-zero-brand/_render_smoke_test.py
@@ -30,7 +30,7 @@ TEST_SLIDE = {
 
 ALLOWED_HEX_IN_CSS = {
     # Palette tokens — these are OK in _base.css :root only
-    "#373D42", "#000000", "#FFFFFF", "#9CA3AF",
+    "#363A3E", "#000000", "#FFFFFF", "#9CA3AF",
     "#F4C430", "#C8102E",
 }
 

--- a/skills/bali-zero-brand/constitution.md
+++ b/skills/bali-zero-brand/constitution.md
@@ -2,7 +2,7 @@
 
 > Hard rules. Non-negotiable. The wr2-critic subagent enforces these. Violations = hard fail, route back to layout-composer.
 >
-> Last revision: 2026-05-08. Owner: Antonello Siano.
+> Last revision: 2026-09-02. Owner: Antonello Siano.
 
 ---
 
@@ -19,7 +19,7 @@
 
 | Token                 | Hex       | Role                                         |
 | --------------------- | --------- | -------------------------------------------- |
-| `color.bg.antracite`  | `#373D42` | Primary background                           |
+| `color.bg.antracite`  | `#363A3E` | Primary background                           |
 | `color.bg.black`      | `#000000` | Secondary background, hero overlay           |
 | `color.text.white`    | `#FFFFFF` | Body text, headlines                         |
 | `color.accent.yellow` | `#F4C430` | Data, sub-headlines, key numbers             |
@@ -27,6 +27,7 @@
 | `color.text.muted`    | `#9CA3AF` | Sources, captions, footer (rare use)         |
 
 2.2 **Banned colors in TEXT zones and UI elements**: green (any shade), blue (any shade), purple (any shade), pastels, beige, brown. Hard fail.
+2.2.1 **Owner-locked anthracite (amended 2026-09-02)**: the flat background represented by `color.bg.antracite` MUST resolve to exactly `#363A3E` (RGB 54, 58, 62). A bluer blue-grey approximation is not an acceptable alias. This lock applies to carousel text zones, flat editorial backgrounds and Bali Zero UI surfaces; it does not recolor natural hero-photo zones.
 2.3 **Region-aware pixel adherence**:
 
 - **TEXT zones** (heading, body, sub-headline, list items, captions, source footers, status badges): ≥95% of pixels in palette tokens (color.bg._ + color.text._ + color.accent._ + color.status._). Hard fail.
@@ -369,7 +370,7 @@ When `brief.primary_regulation_code` is non-empty, the cover slide MUST display 
 
 When `brief.primary_regulation_code` is empty, the cover MUST NOT display this badge (avoid false-authoritative signal).
 
-**Rationale**: FT, Kontan, Tempo signal "we are citing the primary source" before the body is read. Indonesian regulatory audience reads the code first. Yellow chosen 2026-05-13 after WCAG audit (research/wr2-design-sota/2026-05-13-best-bg-color-editorial-publisher.md) found red-as-text on the dark bg FAILS contrast; yellow passes. Recomputed 2026-07-08 on the corrected antracite `#373D42` (historic value `#373D42` read as blue-grey — palette fix by Zero): yellow `#F4C430` vs bg = 6.70:1 (AA, AAA for the large display text carousels use), white vs bg = 11.0:1 (AAA), muted `#9CA3AF` vs bg = 4.33:1 (large text/captions only), red `#C8102E` vs bg = 1.87:1 (never as text on bg — logo/badge fills only), black text on yellow = 12.79:1 (AAA inside).
+**Rationale**: FT, Kontan, Tempo signal "we are citing the primary source" before the body is read. Indonesian regulatory audience reads the code first. Yellow chosen 2026-05-13 after WCAG audit (research/wr2-design-sota/2026-05-13-best-bg-color-editorial-publisher.md) found red-as-text on the dark bg FAILS contrast; yellow passes. Recomputed 2026-09-02 on the owner-locked anthracite `#363A3E`: yellow `#F4C430` vs bg = 6.98:1 (AA, AAA for the large display text carousels use), white vs bg = 11.47:1 (AAA), muted `#9CA3AF` vs bg = 4.52:1 (AA), red `#C8102E` vs bg = 1.95:1 (never as text on bg — logo/badge fills only), black text on yellow = 12.79:1 (AAA inside).
 
 **Brand semantics (added 2026-05-13)**: yellow unifies regulation badge with Article 6.9 anchor highlights as the **family color for "verifiable facts"** — numbers, codes, regulations, dates. Red retained for: logo (3 ALI ZERO red glyph on black-circle bg, accessible by construction), red rule dividers (line not text, contrast n/a), and status critical alerts on white background only.
 

--- a/skills/bali-zero-brand/layouts/_base.css
+++ b/skills/bali-zero-brand/layouts/_base.css
@@ -9,7 +9,7 @@
 
 :root {
   /* Colors — derived from tokens.json color.* */
-  --color-bg-antracite: #373D42;
+  --color-bg-antracite: #363A3E;
   --color-bg-black: #000000;
   --color-text-white: #FFFFFF;
   --color-text-muted: #9CA3AF;
@@ -117,8 +117,9 @@ body {
  *
  * REVISED 2026-05-13: bg red → yellow, text white → black. Reason: WCAG audit
  * (research/wr2-design-sota/2026-05-13-best-bg-color-editorial-publisher.md)
- * found red #C8102E vs antracite #373D42 = 2.27:1 (FAIL). Yellow #F4C430 vs
- * antracite = 8.14:1 (AAA). Black text on yellow = 12.79:1 (AAA inside).
+ * recomputed 2026-09-02 against owner-locked antracite #363A3E:
+ * red #C8102E = 1.95:1 (FAIL); yellow #F4C430 = 6.98:1; black text on
+ * yellow = 12.79:1 (AAA inside).
  * Yellow now unifies regulation badge with Article 6.9 anchor highlights as
  * the family color for "verifiable facts" (numbers, codes, regulations).
  */

--- a/skills/bali-zero-brand/surfaces/email-template.md
+++ b/skills/bali-zero-brand/surfaces/email-template.md
@@ -41,7 +41,7 @@ Per constitution Article 12.2, every email inherits:
 
 ### Palette (subset — email rendering varies)
 
-- Background: `#FFFFFF` body OR `#373D42` antracite for "alert/regulatory" emails. NEVER pure black `#000000` (renders harshly on phone OLED).
+- Background: `#FFFFFF` body OR `#363A3E` antracite for "alert/regulatory" emails. NEVER pure black `#000000` (renders harshly on phone OLED).
 - Text on white: `#1A1A1A` (slightly off-black for readability).
 - Text on antracite: `#FFFFFF`.
 - Accent yellow: `#F4C430` for key data points and CTA buttons (sparingly).

--- a/skills/bali-zero-brand/surfaces/fb-community-post.md
+++ b/skills/bali-zero-brand/surfaces/fb-community-post.md
@@ -52,7 +52,7 @@ Same as `carousel-ig` surface for any text laid on image:
 
 Subset of full brand palette — FB feed crops dark images visually:
 
-- Background overlay: `#373D42` antracite at 70-85% opacity over photo OR `#FFFFFF` flat for "explainer" posts.
+- Background overlay: `#363A3E` antracite at 70-85% opacity over photo OR `#FFFFFF` flat for "explainer" posts.
 - Text on antracite overlay: `#FFFFFF`.
 - Text on white: `#1A1A1A`.
 - Accent yellow `#F4C430` for the regulation number / concrete data point.

--- a/skills/bali-zero-brand/surfaces/internal-print-a4/_template.css
+++ b/skills/bali-zero-brand/surfaces/internal-print-a4/_template.css
@@ -55,7 +55,7 @@ html, body {
 /* ========== COLOR TOKENS — bali-zero-brand constitution Article 2 ========== */
 :root {
   /* Brand-cortex official tokens */
-  --bz-bg-dark: #373D42;          /* color.bg.antracite */
+  --bz-bg-dark: #363A3E;          /* color.bg.antracite */
   --bz-bg-darker: #000000;        /* color.bg.black */
   --bz-text-light: #FFFFFF;       /* color.text.white */
   --bz-text-muted: #9CA3AF;       /* color.text.muted (sources, captions) */

--- a/skills/bali-zero-brand/surfaces/internal-print-a4/_template.css
+++ b/skills/bali-zero-brand/surfaces/internal-print-a4/_template.css
@@ -33,7 +33,7 @@
 
 @page cover {
   margin: 0;
-  background: #2a2d35;
+  background: #363A3E;
 }
 
 * {
@@ -522,7 +522,7 @@ table tbody tr:nth-child(even) td {
   font-weight: 600;
 }
 
-.tag.gold { background: var(--bz-gold); color: #2a2d35; }
+.tag.gold { background: var(--bz-gold); color: var(--bz-black); }
 .tag.red { background: var(--bz-red); color: #fff; }
 
 .divider {

--- a/skills/bali-zero-brand/tokens.json
+++ b/skills/bali-zero-brand/tokens.json
@@ -2,18 +2,18 @@
   "$schema": "https://design-tokens.org/schema.json",
   "meta": {
     "name": "bali-zero-brand-tokens",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "owner": "Antonello Siano",
-    "last_revised": "2026-05-08",
+    "last_revised": "2026-09-02",
     "namespace": "closed",
     "comment": "Closed namespace. wr2-design-architect references token names only, never hex codes."
   },
   "color": {
     "bg": {
       "antracite": {
-        "value": "#373D42",
+        "value": "#363A3E",
         "type": "color",
-        "role": "primary background"
+        "role": "owner-locked primary flat background; exact RGB 54,58,62; do not substitute blue-grey approximations"
       },
       "black": {
         "value": "#000000",
@@ -233,7 +233,7 @@
     "bg": {
       "value": "color.accent.yellow",
       "type": "tokenRef",
-      "role": "yellow rounded badge for regulation code top-right (revised 2026-05-13 — was red, WCAG 2.27:1 FAIL on antracite; yellow=8.14:1 AAA vs antracite + black text=12.79:1 AAA inside)"
+      "role": "yellow rounded badge for regulation code top-right (contrast recomputed 2026-09-02 — yellow=6.98:1 vs #363A3E; black text=12.79:1 AAA inside)"
     },
     "text": {
       "value": "color.bg.black",
@@ -254,7 +254,7 @@
       "value": "cover slide ONLY when brief.primary_regulation_code is present (added 2026-05-12, SOTA pattern #3, revised 2026-05-13 for WCAG AAA)"
     },
     "_revision_2026_05_13": {
-      "value": "Previous: red bg #C8102E + white text — WCAG audit found badge vs antracite bg = 2.27:1 (FAIL). Migration: bg → accent.yellow #F4C430 (8.14:1 AAA vs antracite), text → bg.black (12.79:1 AAA). Yellow becomes the family color for 'verifiable facts' (anchors Art 6.9 + regulation badge unified). Red retained for: logo, status critical alerts on white bg, red rule divider lines."
+      "value": "Previous: red bg #C8102E + white text failed against the dark background. Current: accent.yellow #F4C430 = 6.98:1 against owner-locked antracite #363A3E; bg.black text = 12.79:1. Yellow is the family color for verifiable facts. Red remains for logo, critical status on white and divider lines."
     }
   },
   "qr_closing": {


### PR DESCRIPTION
## Outcome

Locks `color.bg.antracite` to the owner-approved `#363A3E` across the Bali Zero brand cortex and every active downstream surface.

## Updated

- constitution, quick palette and machine-readable tokens
- WR2 base CSS and Damar editorial UIs
- email, Facebook and internal-print surfaces
- render smoke-test palette allowlist
- WCAG contrast figures recomputed against `#363A3E`

## Verification

- legacy `#373D42` absent from active brand files
- `tokens.json` valid and CSS/token parity confirmed
- `git diff --check` clean
- pre-commit and pre-push gates passed

Generator does not merge or deploy; independent Claude review remains required.