### PR TITLE
fix(visa-oracle): the two date fixtures went off at midnight, not the engine

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -27,14 +27,31 @@ function expectQuestion(state: FlowState, questionId: string): void {
   });
 }
 
+/** `today` is optional and defaults to undefined, so every existing caller is
+ * unchanged. Pass it ONLY on a transition whose next node depends on a date
+ * comparison — `shouldAskRenewalPaid` is the one that does. The reducer
+ * forwards it to `computeNextNode` (flow.ts), so this is the clock the engine
+ * actually READS; freezing anything else would leave the forward build on the
+ * real wall clock, which is precisely how the two fixtures below went off. */
 function answer(
   state: FlowState,
   questionId: string,
   value: string,
+  today?: Date,
 ): FlowState {
   expectQuestion(state, questionId);
-  return reduce(state, { type: "ANSWER", questionId, value });
+  return reduce(state, { type: "ANSWER", questionId, value, today });
 }
+
+/** The date the two date-sensitive tests below were WRITTEN on. Their fixture
+ * `permit_expiry: "2026-09-01"` was picked as "8 days out" from here, so the
+ * `renewal_paid` gate skipped and the chain reached `overstay_days`. Judged
+ * against the real wall clock that stopped being true at 00:00 UTC on
+ * 2026-09-02, and both went red with no code change behind them. The sibling
+ * `renewal_paid gating` block never had this fault: its fixtures are
+ * 2020-01-01 and 2099-01-01, far enough out on both sides that no clock
+ * reaches them. Those tests are deliberately left alone. */
+const PERMIT_STILL_CURRENT = new Date("2026-08-24T00:00:00Z");
 
 function startOffshore(category?: string): FlowState {
   let state = initialFlowState("en");
@@ -349,7 +366,7 @@ describe("onshore/offshore canonical fact collection", () => {
     expectQuestion(state, "permit_expiry");
     state = answer(state, "permit_expiry", "2026-09-01");
     expectQuestion(state, "stay_permit_code");
-    state = answer(state, "stay_permit_code", "E28A");
+    state = answer(state, "stay_permit_code", "E28A", PERMIT_STILL_CURRENT);
     expectQuestion(state, "overstay_days");
     state = answer(state, "overstay_days", "0");
     expectQuestion(state, "nationalities");
@@ -916,7 +933,7 @@ describe("resume snapshot validation", () => {
     state = answer(state, "in_indonesia", "yes");
     state = answer(state, "permit_expiry", "2026-09-01");
     state = answer(state, "holds_stay_permit", "yes");
-    state = answer(state, "stay_permit_code", "E28A");
+    state = answer(state, "stay_permit_code", "E28A", PERMIT_STILL_CURRENT);
     // At save-time (2026-08-24) the permit is still 8 days from expiry, so
     // the gate skips `renewal_paid` and goes straight to `overstay_days`.
     expectQuestion(state, "overstay_days");


### PR DESCRIPTION
## What

`main` is RED on the REQUIRED check `Frontend Tests (Next.js) (mouth, true)`, which blocks
**every PR in the repo**, merge queue included. This unblocks it. One file, test-only, +20/−3.

## It broke on the clock, not on a diff

| | run | when | SHA |
|---|---|---|---|
| last green | `33559071784` | 2026-09-01T21:05Z | `63e4c5dc` |
| first red | `33574723838` | 2026-09-02T00:17Z | `5f724ce1` |

The 19 commits in between touch only `.mdx` articles — `flow.ts`, `flow.test.ts` and `tree.ts`
are byte-identical across the boundary. The boundary is **00:00 UTC on 2026-09-02**.

## The engine is correct; the fixtures are the defect

Both failing tests pin `permit_expiry: "2026-09-01"`, picked as *"8 days out"* when they were
written on 2026-08-24 — their own comment says so. `shouldAskRenewalPaid` (`flow.ts:441`) fires
when `daysRemaining < 0`. From today that is true, so the chain reaches `renewal_paid` where the
tests expected `overstay_days`.

**Asking someone whose permit expired yesterday whether they paid the renewal is the right
question.** There is no user-facing defect here. The sibling `renewal_paid gating` block proves
the intended contract with fixtures no clock reaches (`2020-01-01` / `2099-01-01`) and is
deliberately left untouched.

## The cure, and the trap it avoids

`today` is forwarded through the `answer()` helper on the **two** date-sensitive transitions.
That is the clock the engine *actually reads* — the reducer hands `action.today` to
`computeNextNode` (`flow.ts:780`), and `today?: Date` is already on the `ANSWER` action
(`flow.ts:106`). Every other caller passes `undefined` and is unchanged.

This is the distinction that matters: the two tests already froze the clock on
`createInterviewSnapshot`/`restoreInterviewSnapshot` and left the **forward build** on the real
wall clock. Freezing a clock the code under test never consults is exactly how they went off, and
it is a failure this repo already has on record. Bumping the fixture date would merely re-arm the
fuse; `2099-01-01` would destroy the second test's thesis, which *requires* save-before-expiry and
resume-after.

## Bites

**Consumer:** the required `Frontend Tests (Next.js) (mouth, true)` job.

**Observation:** `npx vitest run flow.test.ts` → **78 passed (78)**, from `2 failed | 76 passed`
before.

**And the guard is re-armed, not silenced — proven by mutation.** The P1 regression test was not
merely red: it failed at its *first* assertion and never reached the restore assertions it exists
to protect, so the save-time-replay invariant has been **unguarded since 2026-09-02**. Mutating
`flow.ts:316` so replay uses the resume-time clock instead of `savedAt` turns **exactly that one
test red (1 failed | 77 passed)**; restoring the file returns it byte-identical (sha256
`33e6d974b5af1944`) and 78/78 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
