### PR TITLE
fix(ci): break the main-red deadlock — carry both inherited cures on one queue ref

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -27,14 +27,31 @@ function expectQuestion(state: FlowState, questionId: string): void {
   });
 }
 
+/** `today` is optional and defaults to undefined, so every existing caller is
+ * unchanged. Pass it ONLY on a transition whose next node depends on a date
+ * comparison — `shouldAskRenewalPaid` is the one that does. The reducer
+ * forwards it to `computeNextNode` (flow.ts), so this is the clock the engine
+ * actually READS; freezing anything else would leave the forward build on the
+ * real wall clock, which is precisely how the two fixtures below went off. */
 function answer(
   state: FlowState,
   questionId: string,
   value: string,
+  today?: Date,
 ): FlowState {
   expectQuestion(state, questionId);
-  return reduce(state, { type: "ANSWER", questionId, value });
+  return reduce(state, { type: "ANSWER", questionId, value, today });
 }
+
+/** The date the two date-sensitive tests below were WRITTEN on. Their fixture
+ * `permit_expiry: "2026-09-01"` was picked as "8 days out" from here, so the
+ * `renewal_paid` gate skipped and the chain reached `overstay_days`. Judged
+ * against the real wall clock that stopped being true at 00:00 UTC on
+ * 2026-09-02, and both went red with no code change behind them. The sibling
+ * `renewal_paid gating` block never had this fault: its fixtures are
+ * 2020-01-01 and 2099-01-01, far enough out on both sides that no clock
+ * reaches them. Those tests are deliberately left alone. */
+const PERMIT_STILL_CURRENT = new Date("2026-08-24T00:00:00Z");
 
 function startOffshore(category?: string): FlowState {
   let state = initialFlowState("en");
@@ -349,7 +366,7 @@ describe("onshore/offshore canonical fact collection", () => {
     expectQuestion(state, "permit_expiry");
     state = answer(state, "permit_expiry", "2026-09-01");
     expectQuestion(state, "stay_permit_code");
-    state = answer(state, "stay_permit_code", "E28A");
+    state = answer(state, "stay_permit_code", "E28A", PERMIT_STILL_CURRENT);
     expectQuestion(state, "overstay_days");
     state = answer(state, "overstay_days", "0");
     expectQuestion(state, "nationalities");
@@ -916,7 +933,7 @@ describe("resume snapshot validation", () => {
     state = answer(state, "in_indonesia", "yes");
     state = answer(state, "permit_expiry", "2026-09-01");
     state = answer(state, "holds_stay_permit", "yes");
-    state = answer(state, "stay_permit_code", "E28A");
+    state = answer(state, "stay_permit_code", "E28A", PERMIT_STILL_CURRENT);
     // At save-time (2026-08-24) the permit is still 8 days from expiry, so
     // the gate skips `renewal_paid` and goes straight to `overstay_days`.
     expectQuestion(state, "overstay_days");

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -3344,11 +3344,35 @@ def selftest() -> int:
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(yaml.safe_dump(obj, sort_keys=False), encoding="utf-8")
 
+    def write_journal(p: Path, entries: list[dict]) -> None:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8"
+        )
+
     good_receipt = {"claim": "tests pass", "cmd": "pytest -q", "exit": 0,
                      "ts": "2026-08-10T00:00:00Z", "seat": "sonnet-5"}
 
+    #: R9 quorum fixture — 2 DISTINCT COUNCIL_REVIEW_SEATS, role:review,
+    #: ok:true, ts present. Written once and reused by every Gear-3
+    #: innocence fixture below THAT ISN'T ITSELF TESTING R9 (dissent-shape,
+    #: hotzone-floor, ceiling gear_override): those fixtures need R9
+    #: satisfied like any real Gear-3 pack would, not bypassed — R9's own
+    #: `seat_override` escape is reserved for a genuine "we skipped the
+    #: council, here's why" human call (_r9_r11_verdict's docstring), which
+    #: none of these synthetic packs has, so a real journal is the honest
+    #: cure (added post-2026-09-02 R9_R11_ENFORCEMENT_DATE flip — see the
+    #: comment above that constant).
+    good_council_journal = [
+        {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True,
+         "ts": "2026-09-01T00:00:00Z"},
+        {"seat": "kimi-code/k3", "role": "review", "ok": True,
+         "ts": "2026-09-01T00:00:00Z"},
+    ]
+
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
+        write_journal(root / "evidence" / "council.jsonl", good_council_journal)
 
         # ---- unit-level: compute_floor is pure, test directly -------------
         check("compute_floor: hotzone hit -> 3",
@@ -3422,6 +3446,7 @@ def selftest() -> int:
             "receipts": [good_receipt],
             "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
             "pii_scan": "clean",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, None)
         check("innocence: non-empty dissent on gear-3 passes", rc == 0 and viol == [])
@@ -3516,6 +3541,7 @@ def selftest() -> int:
             "receipts": [good_receipt],
             "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
             "pii_scan": "clean",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, hotzone_changed)
         check("innocence: gear 3 on hotzone diff passes", rc == 0 and viol == [])
@@ -3554,6 +3580,7 @@ def selftest() -> int:
             "pii_scan": "clean",
             "council": True,
             "gear_override": "hotfix under active incident, verified live",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, ["docs/x.md"])
         check("innocence: gear_override on the same diff passes (ceiling reports, not fails)",
@@ -3603,6 +3630,7 @@ def selftest() -> int:
             "receipts": [good_receipt],
             "dissent": [{"seat": "codex-sol", "objection": "x", "status": "CONFIRMED"}],
             "pii_scan": "clean",
+            "council_run": "council.jsonl",
         })
         rc, viol = lint(root / "evidence" / "pack.yml", root, None)
         check("innocence: fully-structured dissent entry passes", rc == 0 and viol == [])

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -73,6 +73,19 @@ GOOD_RECEIPT = {
     "ts": "2026-08-10T00:00:00Z", "seat": "sonnet-5",
 }
 
+#: R9 quorum fixture — 2 DISTINCT COUNCIL_REVIEW_SEATS, role:review, ok:true,
+#: ts present. Used by end-to-end Gear-3 fixtures below that test something
+#: OTHER than R9 itself (net-lines ceiling override, CLI flags) and need a
+#: real council_run journal, not `seat_override` — none of them carries a
+#: genuine "we skipped the council, here's why" human call, so a real
+#: journal is the honest cure post-2026-09-02 R9_R11_ENFORCEMENT_DATE flip.
+GOOD_COUNCIL_QUORUM = [
+    {"seat": "codex-gpt-5.6-sol", "role": "review", "ok": True,
+     "ts": "2026-09-01T00:00:00Z"},
+    {"seat": "kimi-code/k3", "role": "review", "ok": True,
+     "ts": "2026-09-01T00:00:00Z"},
+]
+
 
 @pytest.fixture()
 def tmp_repo(tmp_path):
@@ -535,10 +548,12 @@ def test_lint_end_to_end_measured_net_lines_overrides_pack_lie(tmp_repo):
     measured_net_lines parameter — no false ceiling."""
     root, write_brief, write_pack = tmp_repo
     write_brief(gear=3)
+    _write_journal(root / "evidence", "council.jsonl", GOOD_COUNCIL_QUORUM)
     pack_path = write_pack(
         dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
         council=True,
         net_lines=10,
+        council_run="council.jsonl",
     )
     diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
     rc, violations = lint(pack_path, root, diff, measured_net_lines=400)
@@ -1000,10 +1015,12 @@ def test_lint_end_to_end_innocence_ceiling_override_reports_not_fails(tmp_repo):
     to violations, so the pack passes clean."""
     root, write_brief, write_pack = tmp_repo
     write_brief(gear=3)
+    _write_journal(root / "evidence", "council.jsonl", GOOD_COUNCIL_QUORUM)
     pack_path = write_pack(
         dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
         council=True,
         gear_override="verified live, one-off",
+        council_run="council.jsonl",
     )
     rc, violations = lint(pack_path, root, ["docs/notes.md"])
     assert rc == 0
@@ -1139,8 +1156,10 @@ def test_net_lines_cli_flag_overrides_pack_lie_end_to_end(tmp_path):
     """--net-lines, given a diff shaped like predicate (b), wins over the
     pack's own (lying) net_lines field — reaching compute_ceiling() through
     the full CLI entry point, not just lint() called in-process."""
+    _write_journal(tmp_path / "evidence", "council.jsonl", GOOD_COUNCIL_QUORUM)
     pack_path = _write_full_tree(
-        tmp_path, gear=3, pack_overrides={"council": True, "net_lines": 10}
+        tmp_path, gear=3,
+        pack_overrides={"council": True, "net_lines": 10, "council_run": "council.jsonl"},
     )
     changed = tmp_path / "changed.txt"
     changed.write_text(


### PR DESCRIPTION
## What

`main` has been red on TWO required checks since 2026-09-02 00:00 UTC, and the two open cures block each other. This PR carries both cures, cherry-picked verbatim (authorship preserved) onto a fresh `origin/main`, so the queue can move again.

| inherited red | where it fails | open cure | why the cure cannot land alone |
|---|---|---|---|
| `Frontend Tests (Next.js) (mouth, true)` — `flow.test.ts` fixtures pinned `permit_expiry: "2026-09-01"`, expired at midnight UTC | every `pull_request` run since `2026-09-01T23:59Z`; `schedule` on main `33574723838` | #5580 (`fd9ffc7c`) | ejected from the merge queue twice (`failed_checks`, 01:25Z and 01:33Z) by the OTHER red below |
| `Guard conformance` — `scripts/tests/test_evidence_pack_lint.py`, 4 tests: R9 council-less fixtures vs the 3-seat quorum tuple | every `merge_group` run since `2026-09-02T00:08Z` (pr-5573, 5559, 5572, 5580) | #5575 (`e76c5c54`) | its own `pull_request` rollup is BLOCKED by the frontend red above |

Neither red is caused by a diff: `flow.ts`/`flow.test.ts` are byte-identical across the last-green/first-red boundary (#5580's body has the SHAs), and the evidence-pack fixtures went stale against the roster tuple already on main.

The `Security Scanning` red on the same merge_group runs is a consequence, not a cause: CodeQL reports `ref 'refs/heads/gh-readonly-queue/main/pr-5580-…' not found` because the queue tore the ref down after the Guard-conformance red.

## Measured on a worktree cut from `origin/main` @ `5f724ce1` [misurato]

```
baseline  pytest scripts/tests/test_evidence_pack_lint.py     4 failed, 340 passed
baseline  vitest flow.test.ts (origin/main fixture)            2 failed  (expected overstay_days, got renewal_paid)
cured     pytest scripts/tests/test_evidence_pack_lint.py     344 passed
cured     vitest flow.test.ts                                  78 passed
```

The vitest baseline is a positive control: the origin/main fixture was swapped back in on the cured tree and failed with the exact CI diff.

## Bites

`Bites:` the merge queue itself. Consumer = the next `merge_group` run on `main` after this lands: `Guard conformance` and `Tests & Coverage` both green on the SAME queue ref, and the first PR behind this one (#5574 or #5569, both armed) is dequeued by MERGE, not by `failed_checks`. Until then the queue has 0 successful merges since `2026-09-01T23:46Z`.

## After merge

#5580 and #5575 become content-already-on-main (verify by content: `git diff origin/main -- <file>` empty on each) and are closed by their owners. This PR is the deadlock breaker, not a replacement of their reasoning — read their bodies for the why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
