### PR TITLE
fix(kbli): point JTBD entry cards at the anchor that exists

### DIFF
--- a/apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx
+++ b/apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx
@@ -46,7 +46,7 @@ export function KBLIPersonaDoors() {
         {DOORS.map(({ id, icon: Icon, label, subtext }) => (
           <a
             key={id}
-            href="#kbli-search"
+            href="#search"
             onClick={() => handleDoorClick(id)}
             className="block p-4 rounded-xl transition-all duration-200 cursor-pointer no-underline bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.07)] hover:bg-[rgba(255,255,255,0.06)] hover:border-[rgba(255,255,255,0.12)]"
           >


### PR DESCRIPTION
The three JTBD entry cards on /kbli link to an anchor that does not exist.

# Insight
`DOORS.map()` renders all three cards from one `href`, so a single dead anchor
disables all three entry points at once. The working hero CTA on the same page
already points at the correct id, which is what made the defect invisible in review.

# Studio
## Source / Reference
apps/mouth/src/components/kbli/KBLIPersonaDoors.tsx:49
Measured on origin/main 6262b65ba, 2026-09-02.

## Methodology
DOM scan on the served page, then `git grep` against origin/main for both the
referenced id and the one that exists.

## Raw Observations
Served page: `id="search"` present — `<div id="search" class="sticky top-14 z-40 ...">`.
`id="kbli-search"` absent; a case-insensitive scan for `[id*="kbli"]` returned zero.
Positive control: the same scan returned `id="search"`, so the selector can return non-zero.
Hero CTA `<a href="#search">` works: scrollY 0 -> 998, hash "#search".
origin/main: one `href="#kbli-search"` on disk, not three. The other three matches
are not anchors — two className values in KbliSearchBox.tsx:25-26 and one module
import in kbli-search.test.ts:2. Left untouched.

## Reasoning Path
The task described three dead anchors. The repository holds one, rendered three
times through a map. Measuring the class rather than the instances changed the
size of the fix but not its effect.

## Risk / Implication
One href value. No data model, no migration, no API surface. Zone VERDE.
Build RC=0, lint RC=0 (183 warnings, 0 errors, pre-existing), prettier RC=0.

# Recommendation
Point the cards at the id that exists rather than adding a new one, so the page
keeps a single scroll target shared with the hero CTA.

# Next Action
Click each of the three cards on the served page after /api/health reports this
commit, and confirm scrollY changes from 0 and location.hash becomes "#search".
Production currently trails main, so this cannot be verified as live until promote.
