### PR TITLE
fix(kbli): stop the search autofocus from scrolling the hero out of view

### DIFF
--- a/apps/mouth/src/components/kbli/KBLISearch.tsx
+++ b/apps/mouth/src/components/kbli/KBLISearch.tsx
@@ -53,6 +53,14 @@ export function KBLISearch({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Focus after hydration instead of via the HTML autofocus attribute. The
+  // attribute is present in the server-rendered markup, so the browser focuses
+  // the input while parsing and scrolls to it — which skipped the page hero on
+  // every first visit. preventScroll keeps the caret without moving the page.
+  React.useEffect(() => {
+    if (autoFocus) inputRef.current?.focus({ preventScroll: true });
+  }, [autoFocus]);
+
   // Close dropdown when clicking outside
   React.useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -175,7 +183,6 @@ export function KBLISearch({
           onFocus={() => query.length >= 2 && setIsOpen(true)}
           placeholder={placeholder}
           aria-label={placeholder || "Search KBLI"}
-          autoFocus={autoFocus}
           className={cn(
             "w-full pl-12 pr-10 py-4 bg-white/[0.04] backdrop-blur-xl border border-white/[0.08] rounded-2xl text-white placeholder-zinc-500",
             "shadow-[0_4px_20px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.04)]",


### PR DESCRIPTION
## 1. Insight

/kbli renders a search input with the HTML `autoFocus` attribute. Because that
attribute is present in the server-rendered markup, the browser focuses the
input while it is still parsing the document, and focusing scrolls the element
into view. The search box sits below the page hero, so the first thing a visitor
saw was a page already scrolled past its own opening. The autofocus was the
intended behaviour; the scroll it dragged along was not.

## 2. Studio

Visitors arriving on /kbli now land at the top of the page. The hero — the
heading and its supporting copy above the search box — stays visible on first
paint instead of being scrolled out of view before the visitor has done
anything. The search input still receives the caret, so typing immediately
works exactly as before; only the viewport position changes.

The change is in apps/mouth/src/components/kbli/KBLISearch.tsx, the search
component rendered by apps/mouth/src/app/kbli/page.tsx:234 inside the sticky
search container (`id="search"`, `sticky top-14`) that sits below the hero.
apps/mouth is the VERDE zone; no component in packages/core is touched.

The size of the eliminated jump has not been measured on the served page. What
is verified here is the mechanism, not a pixel count — no number is claimed.

## 3. Source

apps/mouth/src/components/kbli/KBLISearch.tsx:186 (before this change) — the
input carried `autoFocus={autoFocus}`, rendered into the server markup.
apps/mouth/src/app/kbli/page.tsx:232-242 — the only production call site, and
the only one that passes `autoFocus` (bare, so `true`).
apps/mouth/src/components/kbli/KBLISearch.tsx:46 — `inputRef`, an existing ref
already attached to the input; no new ref was introduced.
apps/mouth/src/components/kbli/KBLISearch.tsx:19 — `autoFocus?: boolean`,
defaulting to `false` at :34, so every other consumer is unaffected.

## 4. Methodology

Keep the behaviour, drop the side effect. `HTMLElement.focus()` accepts
`{ preventScroll: true }`, which sets focus without scrolling the element into
view — but it is only reachable from script, so the focus has to move out of the
markup and into an effect that runs after hydration. The attribute is removed
and replaced by a `useEffect` keyed on the `autoFocus` prop, reusing the ref the
component already has.

No new component, no new prop, no change to the public shape of `KBLISearch`.
Eight lines added, one removed, one file.

## 5. Raw Observations

`git show 09583edcf --stat` reports exactly one file changed, 8 insertions and
1 deletion.

A repo-wide grep for `KBLISearch` across apps/mouth/src returns 45 lines, but
they are two different identifiers. The *component* is imported in exactly two
places: apps/mouth/src/app/kbli/page.tsx:6 (production) and
apps/mouth/src/components/kbli/KBLISearch.quick-filters.test.tsx:3 (test).
Every other hit is the unrelated type `KBLISearchResult` or the analytics
function `trackKBLISearch`. The real blast radius is therefore one production
page, not forty-five call sites.

Positive control for that grep, run as a separate command:
`git grep -c 'export' -- apps/mouth/src/components/kbli/KBLISearch.tsx`
returned a non-zero count, so the grep was reading the file rather than silently
matching nothing.

Local gates, all run on this branch:

| gate                                          | result                        |
|-----------------------------------------------|-------------------------------|
| npm run build -w apps/mouth                    | PASS, full route table emitted|
| npm run lint -w apps/mouth                     | 0 errors, 183 warnings        |
| npx prettier --check …/KBLISearch.tsx          | PASS                          |

The 183 warnings are the pre-existing repo baseline. Grepping the lint output
for `KBLISearch.tsx` returns zero matches, so the changed file contributes none
of them.

## 6. Reasoning Path

The scroll is not a styling problem and not a hero problem — the hero is
correct and the sticky offset is correct. The scroll is what focus does by
definition, and the browser performs it during parse because the instruction is
baked into the markup. So the fix is not to fight the scroll after it happens
(no scroll restoration, no `scrollTo(0,0)` on mount, both of which would race
the browser and flicker) but to never ask for it: move the focus to a moment
where the API that suppresses scrolling is available, and use it. That is the
smallest change that removes the cause rather than compensating for the effect.

## 7. Risk

Blast radius is one route: /kbli. `KBLISearch` has exactly one production
consumer, and it is the only one that sets `autoFocus`.

Focus now depends on JavaScript. Before, the attribute focused the input even
without hydration; now, if the bundle fails to load, the input is not focused.
The page remains fully usable — the visitor clicks the field, as on every other
page on the site.

Focus now lands after hydration rather than during parse. On a slow connection
that is a later moment, so a visitor who starts interacting with something else
in that window could have the caret pulled into the search field. This is the
same window in which the old attribute-based focus also had not yet been
usurped by user action, but the delay is longer and it has not been measured.

`focus({ preventScroll })` is the load-bearing API. It is unsupported on
sufficiently old browsers, where the option is ignored and the scroll returns —
degrading to exactly today's behaviour, never worse.

Rollback is a revert of a 9-line diff in one file. No data, no migration, no
token change, no API change.

## 8. Implication

/kbli is the only page in the funnel that autofocuses a search input, so this
fix has no sibling pages to propagate to today. If another funnel page adopts
`KBLISearch` with `autoFocus`, it inherits the corrected behaviour for free,
because the fix lives in the component rather than at the call site.

main is 5 commits ahead of the served commit (98f627a16 -> 4044b75a7), measured
2026-09-02 with a positive control of `98f627a16..98f627a16` style self-range
returning 0. Merged is not live.

## 9. Recommendation

Rekomendasi: Sangat Tinggi — merge as is.

One file, nine lines, one consumer. The cause is understood rather than
compensated for, the replacement uses a standard DOM option rather than a
workaround, all three local gates are green with the changed file contributing
zero lint warnings, and rollback is a single revert. The two residual risks
(JS-dependency, later focus moment) are both strictly bounded and both degrade
to a usable page.

## 10. Next Action

After merge and promote, confirm the commit before believing the page, then
verify the attribute is gone from the served markup:

    curl -s <origin>/api/health        # must report this PR's commit
    curl -sS <origin>/kbli | grep -o 'autofocus' | wc -l

Expected 0, against a before value of 1. Run a `<title>` count as a separate
positive control so a zero from a failed fetch cannot be read as a pass. Until
/api/health reports this commit, the after value is not measured and must not be
described as fixed.

The remaining check is the one no curl can make: load /kbli in a browser and
confirm the hero is visible on first paint and the caret is in the search field.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dNNBXSqHvKZPVSqg1PnZC
