### PR TITLE
fix(kbli): render the shared footer across the KBLI route tree

### DIFF
--- a/apps/mouth/src/app/kbli/layout.tsx
+++ b/apps/mouth/src/app/kbli/layout.tsx
@@ -5,6 +5,7 @@ import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
 import { getFunnelNavItems } from "@/components/funnel/funnel-nav";
 import { MobileNav } from "@/app/v2/_components/MobileNav";
+import { Footer } from "@/app/v2/_components/Footer";
 
 export default function KBLILayout({
   children,
@@ -44,6 +45,7 @@ export default function KBLILayout({
       <div className="mx-auto max-w-6xl px-4 pt-14 pb-8 sm:px-6 lg:px-8">
         {children}
       </div>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## 1. Insight

/kbli renders no footer. Measured on production 2026-09-02, served commit
21b684ca9 (read from /api/health in the same session as the curl below), with
age: 0 and x-vercel-cache: MISS on both pages and a positive control of
`<title>` = 1 on each:

    "All rights reserved"    /kbli = 0     / = 1

The homepage value is non-zero, so this is not a promote gap — /kbli genuinely
never rendered one. A page with no footer has no outbound internal links, which
is a structural SEO failure rather than a content oversight.

## 2. Studio

Visitors on /kbli and every page beneath it now see the same site footer they
see everywhere else: the Visas / Business / Taxes / Property / Living link
columns, About and Team, the Get in Touch block, the copyright line, and the
Privacy Policy and Terms links. Nothing above the footer moves or changes. The
footer is rendered from apps/mouth/src/app/kbli/layout.tsx, using the existing
Footer component at apps/mouth/src/app/v2/_components/Footer.tsx. Both files
are in apps/mouth, which is the VERDE zone. No component in packages/core is
touched, so the brand-api generator gate does not apply.

## 3. Source

apps/mouth/src/app/layout.tsx:259-277 — the root layout's `<body>` renders
providers only (QueryProvider, ThemeProvider, WebVitalsMonitor, ErrorBoundary,
children). A grep for `Footer` across that file returns 0 matches, and it
renders no navigation either.
apps/mouth/src/app/(marketing)/layout.tsx:1-12 — deliberately empty; its own
docstring says "No shared header/footer".
apps/mouth/src/app/(marketing)/page.tsx — the homepage assembles its own shell:
NavShell imported at :2 and used at :83, Footer imported at :13 and used at
:121.
apps/mouth/src/app/kbli/layout.tsx — before this change it returned a `<div>` at
:16, rendered NavShell at :23 and SessionInit at :43, and contained zero
occurrences of Footer.
packages/core/tokens/themes/editorial.css:39 — `--footer-bg: #162d50`.

## 4. Methodology

There is no global shell to inherit. Every route group assembles its own, and
the homepage is the reference implementation. The smallest correct change is
therefore to import the same Footer component the homepage uses and render it
as a sibling of the content container, matching the homepage's structure rather
than introducing a new wrapper. Two lines, one file. No new component, no copy
of Footer, no refactor of NavShell.

The import is written as `@/app/v2/_components/Footer` rather than the relative
`../v2/_components/Footer` the homepage uses, to match `MobileNav` on the line
directly above it in this same file. The two forms resolve to the same module —
`@/*` maps to `./src/*` in apps/mouth/tsconfig.json:23 — so this is a
consistency choice inside one file, not a resolution change.

## 5. Raw Observations

A Phase 1 read-only pass disproved two starting hypotheses before any edit was
made. kbli/layout.tsx does not return `<html>`, so it never replaced the root
layout; and the root layout renders no shell, so "delete the layout and inherit"
was mechanically impossible and would have removed the navigation /kbli already
has.

The same pass found that zero of the four L1 funnel layouts render a footer.
visa-oracle, tax-calendar and property have no layout file at all; kbli had one
with no Footer.

Contrast was measured rather than eyeballed. Footer reads --footer-bg and
--text-primary/secondary/tertiary — not the tokens the initial hypothesis named.
The remap block at globals.css:244 sits on a bare `:root` selector, so it is
global rather than /kbli-scoped, and it maps --background/--foreground, not the
--text-* roles the footer actually uses. The theme is decided by the data-theme
attribute set by the pre-paint script in the root layout. Both the homepage and
/kbli resolve to editorial, and kbli-theme.css overrides none of the --text-*
tokens.

Against --footer-bg #162d50, every text element is below 18pt and below 14pt
bold, so the threshold is 4.5 throughout. Alpha values are composited over the
footer background before the ratio is taken:

| element        | token                        | size          | ratio | verdict |
|----------------|------------------------------|---------------|-------|---------|
| column link    | --text-secondary rgba(…,.68) | 13px          |  7.18 | PASS    |
| column heading | --text-tertiary  rgba(…,.80) | 11px bold     |  9.34 | PASS    |
| copyright      | --text-tertiary  rgba(…,.80) | 11px          |  9.34 | PASS    |
| contact value  | --text-primary   rgba(…,.96) | 12px semibold | 12.80 | PASS    |

Positive controls computed by the same function: black on white 21.00, white on
white 1.00, #767676 on white 4.54. All three returned their known values, so the
table above is a measurement rather than an assertion.

## 6. Reasoning Path

The footer is absent from the served page; the homepage proves the component
works and is already themed for this palette; the only thing missing on /kbli is
the call site. Since the theme resolves identically on both pages, adding the
call site cannot change how the footer looks — which is what the contrast table
confirms rather than assumes. Navigation is excluded because funnel-nav.ts's
docstring at :1-13 states the reduced funnel set is intentional and
`getFunnelNavItems` at :32-38 implements exactly that, so changing it would be a
product decision smuggled in as a bug fix.

## 7. Risk

Blast radius is six routes, not one. kbli/layout.tsx wraps /kbli, /kbli/[code],
/kbli/builder, /kbli/decoder, /kbli/sectors and /kbli/sectors/[id] — confirmed
by enumerating page.tsx under apps/mouth/src/app/kbli, which returns exactly
those six.

Footer.tsx is a client component (`"use client"` on line 1), so those six routes
each ship its JavaScript. The bundle delta has not been measured.

Rollback is a revert of a two-line diff. No data, no migration, no token change.

## 8. Implication

/kbli becomes the only L1 funnel with a footer, which is an inconsistency in the
opposite direction from the one this PR fixes. The other three funnels are
tracked as a separate line of work and are deliberately outside this PR, so that
if this shape turns out to be wrong it has not already been copied three times.

main is 2 commits ahead of the served commit (21b684ca9 -> origin/main),
measured 2026-09-02, with a positive control of `21b684ca9..21b684ca9`
returning 0 and `git merge-base --is-ancestor` confirming the served commit is
on main's history. Merged is not live.

Note on a superseded number: an earlier measurement this morning reported a gap
of 5 against a served commit of 98f627a16. /api/health now reports 21b684ca9, so
that reading described a deploy that has since been replaced. The 5 is not
wrong about what it measured; it is wrong about what is being served.

## 9. Recommendation

Rekomendasi: Sangat Tinggi — merge as is.

The defect is measured at layer 3 with a positive control, the fix reuses an
existing component with no new surface area, the contrast gate passes with
margin on all four text roles, and rollback is one revert of two lines. The
scope was deliberately held to one file even though the same defect exists on
three sibling funnels.

Local gates on this branch: `npm run build -w apps/mouth` PASS, `npm run lint -w
apps/mouth` 0 errors (183 pre-existing warnings, none of them in this file — a
grep of the lint output for `kbli/layout.tsx` returns 0), `npx prettier --check`
PASS, and the pre-commit `tsc --noEmit` typecheck PASS.

## 10. Next Action

After merge and promote, re-measure on the served page and confirm the commit
first:

    curl -s <origin>/api/health        # must report this PR's commit
    curl -sS <origin>/kbli | sed 's/<!-- -->//g' | grep -o 'All rights reserved' | wc -l

Expected 1, against a before value of 0. Run the `<title>` positive control as a
separate command, so a zero produced by a failed fetch cannot be read as a pass.
Until /api/health reports this commit, the after value is not measured and must
not be described as fixed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dNNBXSqHvKZPVSqg1PnZC
