### PR TITLE
fix(kbli): derive the visible KBLI code count from the dataset

### DIFF
--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -34,6 +34,7 @@ export default async function KBLIHomePage({
   const initialQuery = q ? decodeURIComponent(q) : "";
   const sections = getSections().filter((s) => s.codeCount > 0);
   const allCodes = getAllCodes();
+  const codeCount = allCodes.length.toLocaleString("en-US");
   const baliBlockedPct = Math.round(
     (allCodes.filter((c) => c.baliL4?.blocked).length / allCodes.length) * 100,
   );
@@ -122,8 +123,8 @@ export default async function KBLIHomePage({
 
               {/* Inline stats */}
               <p className="mt-3 text-sm text-zinc-500 tracking-wide">
-                1,559 codes&ensp;&middot;&ensp;22 sectors&ensp;&middot;&ensp;PMA
-                rules
+                {codeCount} codes&ensp;&middot;&ensp;22
+                sectors&ensp;&middot;&ensp;PMA rules
               </p>
 
               {/* CTA — glassmorphism button */}
@@ -202,7 +203,7 @@ export default async function KBLIHomePage({
         {/* ── TRUST BAR ── */}
         <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6 -mt-4">
           {[
-            { num: "1,559", label: "KBLI Codes" },
+            { num: codeCount, label: "KBLI Codes" },
             { num: "22", label: "Industry Sectors" },
             {
               num: `~${baliBlockedPct}%`,


### PR DESCRIPTION
## 1. Insight

SCOPE — derive the KBLI code count on /kbli

1. GOAL        : the code count shown on balizero.com/kbli comes from the 
dataset at render time, not from a hand-typed string.
2. NON-GOAL    : does not touch the KBLI data model, kbli-data.ts, 
packages/core, the "22 sectors" figure, or the 46 occurrences of the same 
literal in other files.
3. FILES       : apps/mouth/src/app/kbli/page.tsx only.
4. MEASURED BY : git grep -co "1,559" on this file drops from 4 to 2, with 
the origin/main count run as a separate call.
5. ROLLBACK    : revert the PR. Presentational only, no migration, no data 
change.
6. DONE WHEN   : state 6 — /api/health serves this commit and the page 
still renders 1,559 in both places.

## 2. Studio

A visitor sees no change. The hero paragraph and the trust bar on 
balizero.com/kbli both still read 1,559 KBLI Codes, because the dataset 
genuinely holds 1,559 rows today. What changed is where that number comes 
from: the hero copy at apps/mouth/src/app/kbli/page.tsx:125 and the stat 
tile at :206 now read a value derived from allCodes.length inside the page 
component (zone VERDE), instead of two separate hand-typed strings. If the 
dataset ever changes size, both places follow it; previously they would 
have silently kept showing a stale figure.

Two other copies of the same number, in the page metadata at :16 and :20, 
are unchanged and still hand-typed. Those render into the document title 
and description rather than the visible page body.

## 3. Source

Todoist 6hP5pWJH5JWq99F6 — /kbli Phase 2 UX audit, layer 6 (claims). 
Read-only audit run 2026-09-02 against served commit 
21b684ca99703b6b4675285a78f8dcf2b7894f25.

## 4. Methodology

Read-only measurement first: locate every occurrence of the literal, trace 
where the number could be derived from, and check whether each occurrence 
sits in a scope that can reach that source. Only then edit. The scope of 
the change was cut down after measurement showed two of the four 
occurrences are unreachable from the derived value.

## 5. Raw Observations

Dataset length, read without touching any entry:

    cd ~/Teman2/apps/mouth && node -e 'const fs=require("fs"); const 
raw=JSON.parse(fs.readFileSync("data/KBLI_2025_FINAL_CLEAN.json","utf-8")); 
console.log(raw.data.length)'
    1559

Occurrence counts, run as two separate calls:

    git grep -co "1,559" origin/main -- apps/mouth/src/app/kbli/page.tsx
    4

    git grep -co "1,559" -- apps/mouth/src/app/kbli/page.tsx
    2

Local gates:

    npm run build -w apps/mouth                                  exit 0
    npm run lint  -w apps/mouth                                  exit 0, 0 
errors, 183 pre-existing warnings
    npx prettier --check apps/mouth/src/app/kbli/page.tsx        exit 0
    git diff --stat                                              1 file 
changed, 4 insertions(+), 3 deletions(-)

## 6. Reasoning Path

getAllCodes() at kbli-data.ts:500 calls loadData() at :431, which reads 
apps/mouth/data/KBLI_2025_FINAL_CLEAN.json, and :462 maps over raw.data 
with no filter. So allCodes.length equals raw.data.length exactly. The 
page already binds allCodes at :36 and already computes other statistics 
from it at :38 — the source was present and unused.

The two metadata occurrences cannot use it. export const metadata at 
:13-25 evaluates in module scope, while allCodes is bound inside the page 
function. Reaching them would mean restructuring the file, which is a 
different change with a different risk profile.

## 7. Risk

Two of four literals remain. export const metadata at :13-25 runs in 
module scope and cannot read allCodes, which is bound inside the page 
function at :36. Reaching them would require restructuring the file; that 
is not in this PR. Measured 2026-09-02: 4 occurrences in this file before, 
2 after.

The figure 1,559 is CORRECT as of 2026-09-02 — raw.data.length = 1559, and 
getAllCodes() is a plain .map over it. This PR does not fix a wrong fact; 
it removes the possibility of drift.

Out of scope, tracked separately: 46 occurrences of "1,559" in other files 
(Todoist 6hQCvFwp4gvF9376). Also noted but untouched: the docstring at 
kbli-data.ts:498 still reads "Get all 1,563 KBLI codes", stale against a 
1559-row dataset (Todoist 6hQCvFwWvqfqmrv6).

Prettier reformatted the file after the first check failed on manual JSX 
reflow; the committed content is the reformatted version, re-checked at 
exit 0.

## 8. Implication

A closed-form count that is hand-typed is wrong every day after the data 
moves, and nothing turns red when it does. Deriving it removes that class 
of failure for this page. It does not remove it for the other 46 copies, 
and this PR should not be read as closing that class.

## 9. Recommendation

Rekomendasi: Tinggi. Merge as a small VERDE change. No decision needed 
from the owner beyond the usual review.

## 10. Next Action

Stops at gh pr ready per item 60 — no arming, no merge, no promote. After 
this commit is served, confirm via /api/health and check that both figures 
still render as 1,559. The remaining two metadata literals and the 46 
occurrences elsewhere are tracked as separate Todoist lines and are not 
carried by this PR.
