### PR TITLE
fix(core): give CTAHandoff a stacking context and a 44px tap target

### DIFF
--- a/packages/core/components/CTAHandoff.test.tsx
+++ b/packages/core/components/CTAHandoff.test.tsx
@@ -25,4 +25,13 @@ describe("CTAHandoff", () => {
     expect(links).toHaveLength(1);
     expect(links[0].getAttribute("href")).toMatch(/wa\.me/);
   });
+
+  it("gives the WA anchor a 44px minimum tap target", () => {
+    const { getAllByRole } = render(
+      <CTAHandoff source="kbli" sessionId="xyz" />,
+    );
+    const wa = getAllByRole("link")[0];
+    expect(wa.style.minHeight).toBe("44px");
+    expect(wa.style.display).toBe("inline-flex");
+  });
 });

--- a/packages/core/components/CTAHandoff.tsx
+++ b/packages/core/components/CTAHandoff.tsx
@@ -11,6 +11,19 @@ export interface CTAHandoffProps {
   payload?: Record<string, unknown>;
 }
 
+/** WCAG 2.5.5 (Level AAA) minimum target size. The `.btn` classes on the
+ *  three children are undefined in every stylesheet in this monorepo —
+ *  measured 2026-09-02 on origin/main, `git grep "\.btn"` over *.css, *.ts
+ *  and *.tsx returns zero — so the size has to live here. `inline-flex` is
+ *  required alongside `minHeight`: an anchor is an inline box by default,
+ *  and minimum height does not apply to non-replaced inline boxes. */
+const tapTarget = {
+  minHeight: 44,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+} as const;
+
 export const CTAHandoff: FC<CTAHandoffProps> = ({
   source,
   sessionId,
@@ -26,16 +39,18 @@ export const CTAHandoff: FC<CTAHandoffProps> = ({
       aria-label="Next actions"
       style={{
         display: "flex",
+        alignItems: "center",
         gap: "var(--space-3)",
-        padding: "var(--space-4)",
+        padding: "var(--space-2) var(--space-4)",
         position: "sticky",
+        zIndex: 40,
         bottom: 0,
         background: "var(--surface-base)",
         borderTop: "1px solid var(--color-border-subtle)",
       }}
     >
       {pdfHref ? (
-        <a href={pdfHref} className="btn btn-tertiary">
+        <a href={pdfHref} className="btn btn-tertiary" style={tapTarget}>
           Scarica report
         </a>
       ) : null}
@@ -44,6 +59,7 @@ export const CTAHandoff: FC<CTAHandoffProps> = ({
           type="button"
           onClick={onZantaraClick}
           className="btn btn-secondary"
+          style={tapTarget}
         >
           Chat with Zantara
         </button>
@@ -54,6 +70,7 @@ export const CTAHandoff: FC<CTAHandoffProps> = ({
         className="btn btn-primary"
         target="_blank"
         rel="noreferrer"
+        style={tapTarget}
       >
         Talk on WhatsApp
       </a>


### PR DESCRIPTION
## Insight
`CTAHandoff` is a shared core component rendered on five routes, and both of its defects live in the same element — a sticky wrapper whose children are bare anchors. One is a stacking-context bug that makes the button unclickable; the other is a target-size bug. Fixing either alone would touch the same lines twice.

## Studio
Frontend / shared components. `packages/core/components/CTAHandoff.tsx`. Written GO from Antonello on 2 September 2026 for this file, one PR covering both defects.

## Source
Defect 1 measured 2 September 2026 on served commit `3339a8d40` via `elementFromPoint` at the centre of the button's rect at scrollY 0 / middle / bottom: the button was covered in 2 of 3 positions. Positive control: the selector returned 2 elements, not zero.

Defect 2: the button measured 147×24 px. WCAG 2.5.5 (Level AAA) asks for 44 px. Note that WCAG 2.2's Level AA criterion is 2.5.8 at 24 px minimum, which 147×24 passes at the threshold — this PR targets the AAA criterion.

## Methodology
All figures below were measured in a single session on 2 September 2026 against `origin/main` after `#5583`, `#5586` and `#5588` landed (`ef8f4c4f8`).

- Blast radius: `git grep -n "CTAHandoff"` plus `git grep -n "FunnelFrame" -- apps`, then reading `FunnelFrame.tsx:48` to confirm the render is unconditional.
- `.btn` definition: `git grep "\.btn" -- "*.css" "*.tsx" "*.ts"`. Positive control: `git grep -c "\.card" -- "*.css"` returned a non-zero file.
- Spacing tokens: `git grep -nE "^\s*--space-[0-9]+:" -- packages/core/tokens/primitives.css`, plus `git grep -n -- "--space-4" -- "*.ts" "*.tsx"` to rule out a TypeScript redefinition.
- Neighbour z-index: `git grep -n "sticky" -- apps/mouth/src/app/kbli`.
- Rendered tiers per route: `git grep -n -e "pdfHref" -e "onZantaraClick" -e "handoff" -- apps/mouth/src/app`. Positive controls: the same patterns return 8 hits in `CTAHandoff.tsx` and 2 in its test file.

## Raw Observations
- `CTAHandoff` renders on 5 routes: `/kbli`, `/kbli/[code]`, `/tax-calendar`, `/property/eligibility` (all four via `FunnelFrame`, unconditionally, `FunnelFrame.tsx:48`) and `/prime/proposal/[token]` (direct, `page.tsx:147`).
- `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-tertiary`: zero definitions across `*.css`, `*.ts`, `*.tsx` in both `packages/core` and `apps/mouth`.
- `--space-4` = `1rem`, `--space-2` = `0.5rem` (`packages/core/tokens/primitives.css:80` and `:78`). Single definition; no TypeScript redefinition. The ladder is 1·2·3·4·6·8·12·16·24 — there is no 6 px step.
- The sticky search on the same route is `z-40` with `backdrop-blur-2xl` (`apps/mouth/src/app/kbli/page.tsx:232`). That one element is both the nearest z-index neighbour and the source of the covering stacking context.
- `display` appeared once in `CTAHandoff.tsx` before this change — on the wrapper only. All three children were inline boxes.
- Zero call sites pass `pdfHref` or `onZantaraClick`. In production all five routes render exactly one button; the other two tiers exist in code and are covered by tests, but no consumer uses them today.
- Test baseline before this change: 37 files, 166 tests, green.

## Reasoning Path
`minHeight` alone would have been silently inert: an anchor is a non-replaced inline box, and minimum height does not apply to it. `display: inline-flex` has to travel with it, which is why the size lives in one shared constant rather than three separate style objects that could drift apart.

The wrapper is `display: flex` with no `alignItems`, so its effective cross-axis value was `stretch`. Raising one child's minimum height would have stretched its siblings to match, with their text pinned to the top. `alignItems: "center"` on the wrapper prevents that for any consumer that turns the other two tiers on.

Vertical padding drops from `--space-4` to `--space-2` so the row's total height grows by 4 px instead of 20. There is no 6 px token, so an exact-height-preserving change was not available on the existing ladder; `--space-2` is the nearest step that keeps the growth small. Horizontal padding is unchanged at `--space-4`.

`z-index: 40` is not a new number: it equals the sticky search on the same route.

## Risk
Low, and presentational only — no logic, no data, no migration. Rollback is a one-step PR revert.

The height change is arithmetic from source values (16 + 24 + 16 = 56 px before, 8 + 44 + 8 = 60 px after), not a `getBoundingClientRect` reading on a served page. Served-page verification is not possible before promote, so the 4 px figure should be treated as arithmetic until then.

`packages/design-system/brand-api/components.json` records `CTAHandoff` and its usage example, and the P8 Brand-API gate runs against it. Props are unchanged, so the gate should stay quiet, but it does touch this file.

## Implication
Both defects sat in a core component, so patching them from `apps/mouth/src/app/globals.css` via `:has([data-funnel])` was available and deliberately not taken: it would have fixed a core component from application CSS and left the defect live for any other consumer of `CTAHandoff`.

The `.btn` finding is wider than this PR. Four class names are referenced and none is defined anywhere in the monorepo, which means every element carrying them renders unstyled. This PR only addresses the three inside `CTAHandoff`; the rest is logged separately.

## Recommendation
Merge. The change is confined to one file plus its test, and both defects are in the same element.

## Next Action
Gates measured locally on 2 September 2026, branch `fix/cta-handoff-zindex-tap-target`, commit `1b89dd36a`:

- `npm run typecheck` — exit 0.
- `npx prettier --check` on both changed files — exit 0, both conform.
- `npm test -w @balizero/core` — 37 files, 167 tests, green. `CTAHandoff.test.tsx` went from 2 to 3 tests; the new one asserts both `minHeight` and `display` on the WA anchor, since the first without the second would pass while having no effect in a browser.
- `npm run build -w apps/mouth` — exit 0.
- Diff: 2 files, 28 insertions, 2 deletions.

Not measured: the local pre-push hook skipped the backend suite by default (`PREPUSH_RUN_BACKEND=0`); CI is the real gate for it. Served-page verification of the 44 px target and the click-through at three scroll positions is not possible before promote.
