### PR TITLE
fix(home): give the desktop hero a height floor so the tagline clears the nav

### DIFF
--- a/apps/mouth/src/app/globals.css
+++ b/apps/mouth/src/app/globals.css
@@ -974,7 +974,7 @@ main,
 @media (min-width: 768px) {
   .hero-aspect {
     aspect-ratio: 21 / 9;
-    min-height: 0;
+    min-height: 560px;
     max-height: none;
   }
   .hero-gradient {


### PR DESCRIPTION
The desktop hero loses its height floor at ≥768px, so the centred text stack overflows upward and hides the tagline behind the fixed nav.

# Insight
Between 768px and ~1148px the hero box is shorter than the text it holds. The overlay centres that stack, so half the overflow lands above y=0 — behind a 56px fixed nav. The eyebrow line "Bali Zero · Dispatch" and the tagline "Your Bali, from Zero." are the lines that disappear.

# Studio

## Source / Reference
- `apps/mouth/src/app/globals.css:957-961` — mobile hero: `aspect-ratio: 4/5`, `min-height: 560px`, `max-height: 90vh`
- `apps/mouth/src/app/globals.css:974-979` — `@media (min-width: 768px)`: `aspect-ratio: 21/9`, `min-height: 0`, `max-height: none`
- `apps/mouth/src/app/v2/_components/HeroBlueprint.tsx:25` — the only `.hero-aspect` call site
- `apps/mouth/src/app/v2/_components/HeroBlueprint.tsx:62` — overlay `absolute inset-0 flex items-end md:items-center pb-8 md:pb-0 pt-14`
- `packages/core/components/NavShell.tsx:46-58` — `position: fixed`, `h-14` (56px), `zIndex: 300`

## Methodology
Read every declaration of `.hero-aspect` at `origin/main` and confirmed there is no third breakpoint. Counted call sites repo-wide, not only under `apps/mouth`. Derived the affected viewport band from the aspect ratio, then measured the rendered DOM on two live pages side by side: production (unfixed) as the positive control, and this PR's Vercel preview (fixed).

## Raw Observations
- `.hero-aspect` has exactly 2 definitions and 1 call site.
- Desktop box height = viewport width × 9/21. The overflow threshold is a box of 492px, i.e. a viewport of ~1148px. Above that width the bug disappears on its own.
- Production, unfixed: at 921px the box is 388px tall and the stack top sits at y=0; at 955px the box is 403px and the stack top sits at y=6. Nav bottom is y=56 in both. Both readings are occluded.
- This PR's preview: at 921px and 955px the box is 560px and the stack top sits at y=86 and y=84 respectively — 30px and 28px clear of the nav.
- Stack height measured 445px and 448px, well under the 504px of room a 560px box leaves after the 56px offset.
- `--nav-h: 3.5rem` is defined at `globals.css:947` with a comment naming this exact use case, and has zero consumers repo-wide.

## Reasoning Path
The trigger is not the centring and not `pt-14` — mobile uses the same overlay and is fine, because mobile keeps `min-height: 560px`. Desktop drops the floor to `0` and leaves the aspect ratio as the only thing setting height. Restoring the floor removes the overflow, and centring then behaves as designed.

The model predicts stack top as `56 + (box − 56 − stack) / 2` when the stack fits, and `56 − (stack − (box − 56)) / 2` when it overflows. It matched all four readings — two pages, two widths — to within 1px, which is what makes a two-width sample informative rather than anecdotal.

## Risk / Implication
Between 768px and 1307px the box is now taller than 21/9 would make it, so the photo crop changes on tablets and small laptops. That is a deliberate trade: 560px is the value the mobile hero already uses, so the floor is consistent with the design system rather than a new magic number. Above 1307px the aspect ratio takes over again and nothing changes.

Widths 768 / 900 / 987 / 1100 / 1280 were not reachable in the measuring tool and remain computed rather than measured. The computation is that the floor wins over 21/9 across that whole band, and the text stack is width-independent because its container is capped at `max-w-[640px]` and reaches that cap from about 720px up.

Not addressed here, on purpose: `max-height: none` at `:978` also removes the `90vh` cap, so on very wide screens the hero can exceed the viewport. Separate defect, separate PR.

# Recommendation
Restore the floor in CSS. Do not move the offset to `items-start` — that would push the same overflow downward into the bottom fade and the next section, which is worse at 768px.

# Next Action
After promote, confirm on the live page at 768 / 900 / 987 / 1100 / 1280 that the stack top sits below y=56 at every width, with the hero CTAs still inside the box.
