### PR TITLE
fix(kbli): render kewenangan arrays with a separator on /kbli/[code]

### DIFF
--- a/apps/mouth/src/components/kbli/KBLIDivergence.test.tsx
+++ b/apps/mouth/src/components/kbli/KBLIDivergence.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { KBLIDivergence, authorityLabel } from "./KBLIDivergence";
+
+describe("authorityLabel helper", () => {
+  it("returns null for undefined", () => {
+    expect(authorityLabel(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string ''", () => {
+    expect(authorityLabel("")).toBeNull();
+  });
+
+  it("returns trimmed string for single non-empty string 'OSS'", () => {
+    expect(authorityLabel("OSS")).toBe("OSS");
+  });
+
+  it("returns null for empty array []", () => {
+    expect(authorityLabel([])).toBeNull();
+  });
+
+  it("returns single element string for array ['Gubernur']", () => {
+    expect(authorityLabel(["Gubernur"])).toBe("Gubernur");
+  });
+
+  it("joins multiple array elements with comma-space", () => {
+    expect(authorityLabel(["Bupati/Walikota", "Menteri", "Gubernur"])).toBe(
+      "Bupati/Walikota, Menteri, Gubernur",
+    );
+  });
+
+  it("filters out empty and whitespace-only elements inside array", () => {
+    expect(authorityLabel(["", "   "])).toBeNull();
+    expect(authorityLabel(["Gubernur", "", "  ", "Menteri"])).toBe(
+      "Gubernur, Menteri",
+    );
+  });
+});
+
+describe("KBLIDivergence component rendering", () => {
+  const baseProvenance = {
+    state: "not_classifiable" as const,
+    definition: { locator: null, assembly: null },
+    licensing: {
+      status: "detached" as const,
+      locator: null,
+      vintage: null,
+      noOssScope: false,
+      contentInheritedFrom: null,
+    },
+    pma: {
+      source: null,
+      vintage: null,
+      status: "declared_gap" as const,
+      locator: null,
+    },
+    dataNote: "Test correction note",
+  };
+
+  it("does not render Authority line when kewenangan is empty array []", () => {
+    const provenance = {
+      ...baseProvenance,
+      disputed: {
+        key: "per_skala_disputed_pp28_test",
+        rows: [
+          {
+            skala_usaha: ["Mikro" as const],
+            kategori_risiko: "Rendah",
+            kewenangan: [],
+          },
+        ],
+      },
+    };
+
+    render(<KBLIDivergence code="12345" provenance={provenance} />);
+    expect(screen.queryByText(/Authority:/)).toBeNull();
+  });
+
+  it("renders joined Authority line when kewenangan is an array of strings", () => {
+    const provenance = {
+      ...baseProvenance,
+      disputed: {
+        key: "per_skala_disputed_pp28_test",
+        rows: [
+          {
+            skala_usaha: ["Mikro" as const],
+            kategori_risiko: "Rendah",
+            kewenangan: ["Bupati/Walikota", "Menteri", "Gubernur"],
+          },
+        ],
+      },
+    };
+
+    render(<KBLIDivergence code="12345" provenance={provenance} />);
+    expect(
+      screen.getByText("Authority: Bupati/Walikota, Menteri, Gubernur"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/components/kbli/KBLIDivergence.tsx
+++ b/apps/mouth/src/components/kbli/KBLIDivergence.tsx
@@ -24,6 +24,19 @@ function licenseLabel(perizinan: string | string[] | undefined): string {
   return perizinan;
 }
 
+/** `kewenangan` is a string on legacy rows, an array elsewhere. Returns null if empty. */
+export function authorityLabel(
+  kewenangan: string | string[] | undefined,
+): string | null {
+  if (!kewenangan) return null;
+  if (Array.isArray(kewenangan)) {
+    const filtered = kewenangan.filter((k) => k.trim().length > 0);
+    return filtered.length > 0 ? filtered.join(", ") : null;
+  }
+  const trimmed = kewenangan.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export function KBLIDivergence({ code, provenance }: KBLIDivergenceProps) {
   const { dataNote, disputed } = provenance;
   if (!dataNote && !disputed) return null;
@@ -120,38 +133,41 @@ export function KBLIDivergence({ code, provenance }: KBLIDivergenceProps) {
               page describes. They are preserved here as the audit trail of the
               divergence.
             </p>
-            {disputed.rows.map((row, i) => (
-              <div
-                key={i}
-                className="rounded-lg border border-[var(--border)] px-4 py-3"
-                style={{ background: "var(--kbli-bg-elevated)" }}
-              >
-                <div className="flex flex-wrap items-center gap-2.5">
-                  {Array.isArray(row.skala_usaha) &&
-                    row.skala_usaha.length > 0 && (
-                      <span className="text-xs font-semibold text-[var(--foreground)]">
-                        {row.skala_usaha.join(", ")}
+            {disputed.rows.map((row, i) => {
+              const authority = authorityLabel(row.kewenangan);
+              return (
+                <div
+                  key={i}
+                  className="rounded-lg border border-[var(--border)] px-4 py-3"
+                  style={{ background: "var(--kbli-bg-elevated)" }}
+                >
+                  <div className="flex flex-wrap items-center gap-2.5">
+                    {Array.isArray(row.skala_usaha) &&
+                      row.skala_usaha.length > 0 && (
+                        <span className="text-xs font-semibold text-[var(--foreground)]">
+                          {row.skala_usaha.join(", ")}
+                        </span>
+                      )}
+                    {row.kategori_risiko && (
+                      <RiskBadge category={row.kategori_risiko} size="sm" />
+                    )}
+                    <span className="text-xs text-[var(--foreground-muted)]">
+                      {licenseLabel(row.perizinan)}
+                    </span>
+                    {authority && (
+                      <span className="ml-auto text-[11px] text-[var(--foreground-muted)]">
+                        Authority: {authority}
                       </span>
                     )}
-                  {row.kategori_risiko && (
-                    <RiskBadge category={row.kategori_risiko} size="sm" />
-                  )}
-                  <span className="text-xs text-[var(--foreground-muted)]">
-                    {licenseLabel(row.perizinan)}
-                  </span>
-                  {row.kewenangan && (
-                    <span className="ml-auto text-[11px] text-[var(--foreground-muted)]">
-                      Authority: {row.kewenangan}
-                    </span>
+                  </div>
+                  {row.scope_uraian && (
+                    <p className="mt-1.5 text-[11px] italic text-[var(--foreground-muted)]">
+                      Source-row scope: {row.scope_uraian}
+                    </p>
                   )}
                 </div>
-                {row.scope_uraian && (
-                  <p className="mt-1.5 text-[11px] italic text-[var(--foreground-muted)]">
-                    Source-row scope: {row.scope_uraian}
-                  </p>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         </details>
       )}

--- a/apps/mouth/src/lib/kbli-types.ts
+++ b/apps/mouth/src/lib/kbli-types.ts
@@ -55,7 +55,7 @@ export interface KBLIDisputedScaleRow {
   skala_usaha?: KBLIBusinessScale[];
   kategori_risiko?: string;
   perizinan?: string | string[];
-  kewenangan?: string;
+  kewenangan?: string | string[];
   jangka_waktu?: string;
   scope_uraian?: string;
   [key: string]: unknown;


### PR DESCRIPTION
## 1. Insight

`/kbli/[code]` showed a run-together string where an issuing authority should be:

    Bupati/WalikotaMenteri/Kepala BadanMenteri/Kepala BadanGubernur

`KBLIDivergence` rendered `row.kewenangan` straight into JSX. The value is an array on almost every row, and React joins array children with no separator. The page has been showing this to users.

## 2. Studio

**WHAT:** In the "disputed source rows" audit trail on `/kbli/[code]`, the `Authority:` line now reads as a separated list (`Bupati/Walikota, Menteri/Kepala Badan, Gubernur`) instead of one run-together string. Rows whose authority list is empty show no `Authority:` line at all — the same as rows where the value was absent before.

**WHERE:** `apps/mouth/src/components/kbli/KBLIDivergence.tsx` — zone VERDE.

Why: the line stated a concatenation of several authorities as if it were the name of one.

## 3. Source

    apps/mouth/src/components/kbli/KBLIDivergence.tsx       | 72 ++++++++++---------
    apps/mouth/src/lib/kbli-types.ts                        |  2 +-
    apps/mouth/src/components/kbli/KBLIDivergence.test.tsx  | new file

The commit is 144 insertions / 29 deletions across the three files. Most of the churn in `KBLIDivergence.tsx` is re-indentation from converting the `.map()` callback to a block body.

Decision basis:

- `apps/mouth/src/app/kbli/[code]/page.tsx:994` — where `KBLIDivergence` is mounted.
- `apps/mouth/src/lib/kbli-provenance.ts` — `getDisputedLicensing` / `normalizeDisputedRows`, which build `provenance.disputed.rows`.
- `apps/mouth/src/lib/kbli-types.ts:58` — `KBLIDisputedScaleRow.kewenangan`.
- `apps/mouth/data/KBLI_2025_FINAL_CLEAN.json` — measured for the real shape of the field.
- `apps/mouth/src/components/kbli/KBLIDivergence.tsx:20-24` — the existing `licenseLabel()` helper, which this change mirrors.

## 4. Methodology

Fix the render site and correct the type that let it compile, and nothing else.

A helper `authorityLabel()` is added directly alongside `licenseLabel()` in the same file, with the same shape: it takes `string | string[] | undefined` and returns a display string, or `null` when there is nothing to show. The `.map()` callback computes the label once and the guard tests the label rather than the raw value.

The type `KBLIDisputedScaleRow.kewenangan` becomes `string | string[]`, which is what the JSON actually contains. It is **not** normalised here — normalising the raw type is a separate concern that belongs with the producer-side work described in §8.

## 5. Raw Observations

### 5a. Reachability

`KBLIDivergence` is rendered at `apps/mouth/src/app/kbli/[code]/page.tsx:994`, on the public `/kbli/[code]` route. No feature flag, no env gate, no `NODE_ENV` branch, no noindex. The defect was user-visible.

### 5b. Field shape, measured at the path the code actually reads

`per_skala[].kewenangan` in `KBLI_2025_FINAL_CLEAN.json`:

| | count |
|---|---|
| total elements | 9095 |
| arrays | 9090 |
| strings | 5 |
| null | 0 |
| key absent | 0 |

Array length: minimum **0**, maximum **7**. Empty arrays exist, which is why the fix cannot rely on a truthiness guard — `[]` is truthy, so a bare `row.kewenangan &&` guard would have started rendering `Authority:` with nothing after it on rows that previously rendered no line at all.

Across `per_skala` plus every `per_skala_disputed_*` (9118 arrays): **0** empty-string elements and **0** whitespace-only elements. The helper still filters blank entries, but it is defence, not a fix for observed data.

Of 183 disputed rows, **4** carry an empty authority array.

An earlier count of 11,983 / 9,118 / 2,865 came from a recursive walk over every `kewenangan` key at any depth, including `per_skala_legacy`, which the code never parses. Those numbers do not describe this field and are not used here.

### 5c. Why the defect survived review

The first inventory pass used a case-sensitive grep for `authority`. The render site reads `Authority:` with a capital A, so it did not appear in that inventory's 70 results. A case-insensitive pass returns 103, and the missing 33 include the one line that produces the defect. The remaining 32 are the Visa Oracle module, comments, a hardcoded agency-name map, and `class-variance-authority` imports — no other user-facing consumer.

## 6. Reasoning Path

The type said `string`, so the compiler had no reason to object to interpolating the value directly, React joined the array's elements with no separator, and the page presented several authorities as one name. The same file already solved this exact problem for `perizinan` via `licenseLabel()`, so the fix follows that helper rather than inventing a pattern: `", "` as the separator, matching every other multi-value join in the KBLI components (`skala_usaha`, licensing sources, tier scales).

Empty is treated as absent rather than as an em dash. Rendering a dash where there was previously no line would be a visible change to a live page that nobody asked for; this PR fixes a defect and changes nothing else.

## 7. Risk

Blast radius is one component on one route. `packages/core` untouched, backend untouched, data untouched. Nothing else reads `KBLIDisputedScaleRow.kewenangan`.

Measured on this branch, based on `c4d48071a` (`origin/main`):

| Gate | Result |
|---|---|
| `npm run build -w apps/mouth` | RC=0 — 1766 static pages, `/kbli/sectors/[id]` still 21 paths |
| `npm run lint -w apps/mouth` | RC=0 — 177 problems, 0 errors |
| Lint attributable to this change | **0** — none of the three files appears in ESLint's output, and ESLint only prints files with problems |
| `npx prettier --check` (3 files) | RC=0 |

Not measured here: vitest does not run on this machine (the `@/` alias fails to resolve), so the new unit tests are added but unexecuted locally. Their verification is CI.

## 8. Implication

The type lie behind this defect exists in a second, wider place that this PR deliberately leaves alone: `KBLILicenseByScale.authority` is declared `string` in `kbli-types.ts:299` and `types/kbli.ts:69`, and both producers (`kbli-data.ts:359`, `kbli-data.server.ts:346`) pass the raw array straight through. That one is **latent** — no component currently renders it, because `LicensingSection` hardcodes a fixed authority string — and fixing it means normalising at the producer and updating fixtures, which is a different change with a different blast radius. Filed separately.

Test coverage before this PR: **0** fixtures used an array for this field. Every one used a string, which is why the array path was never exercised.

## 9. Recommendation

Merge once CI is green. The change is confined to one component and one type, follows a helper that already existed beside it, and preserves current behaviour for every input that previously rendered nothing. The wider type-lie fix should land as its own PR rather than be folded in.

## 10. Next Action

1. Land the `KBLILicenseByScale.authority` normalisation as a separate PR: normalise at both producers to an array, correct the two type declarations, update the string fixtures in `kbli-search.test.ts` and `kbli-meta.test.ts`, and add transform-layer tests.
2. Consider whether the hardcoded authority string in `LicensingSection` should be reading the real authority once the type is honest — it is currently the reason the latent defect is invisible.
