### PR TITLE
fix(mouth): route GARUDA VOA staff client through the same-origin /api proxy

### DIFF
--- a/apps/mouth/src/app/(workspace)/garuda-voa/api-client.test.ts
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/api-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test for the live defect measured on kita.balizero.com
+ * 2026-09-03: `NEXT_PUBLIC_API_URL` is baked to the Fly backend host
+ * (`https://nuzantara-rag.fly.dev`) in production. When the staff client
+ * built its URL from that env var, every request went cross-origin —
+ * bypassing the Next.js same-origin proxy (`app/api/[...path]/route.ts`)
+ * that forwards the `nz_access_token` httpOnly session cookie and promotes
+ * `nz_csrf_token` into the `X-CSRF-Token` header for mutating calls — and
+ * 401'd. The fix hardcodes the same-origin `/api` base (matching
+ * `lib/api/index.ts`'s `API_BASE_URL = ""` and the literal `/api/...` fetch
+ * in `(workspace)/review/page.tsx`), so the client must never read
+ * `NEXT_PUBLIC_API_URL` again, even when it is set.
+ */
+describe("garuda-voa staff api-client base URL", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://nuzantara-rag.fly.dev");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("routes listStaffPractices through the same-origin /api proxy, not NEXT_PUBLIC_API_URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ items: [], next_cursor: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { listStaffPractices } = await import("./api-client");
+    await listStaffPractices({ assigned: "all" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("/api/visa/voa/staff/practices?assigned=all");
+    expect(calledUrl).not.toContain("nuzantara-rag.fly.dev");
+    expect((calledInit as RequestInit).credentials).toBe("same-origin");
+  });
+
+  it("routes transitionPractice (mutating call) through the same-origin /api proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          practice_id: "p1",
+          state: "assigned",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { transitionPractice } = await import("./api-client");
+    await transitionPractice({
+      practiceId: "p1",
+      request: { transition_id: "PR-02" },
+      idempotencyKey: "key-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("/api/visa/voa/staff/practices/p1/transitions");
+    expect(calledUrl).not.toContain("nuzantara-rag.fly.dev");
+    expect((calledInit as RequestInit).credentials).toBe("same-origin");
+  });
+});

--- a/apps/mouth/src/app/(workspace)/garuda-voa/api-client.ts
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/api-client.ts
@@ -10,8 +10,17 @@
  * Auth: the CRM cookie session (`HybridAuthMiddleware`, see
  * `deps/auth.py::get_current_user`) the rest of the `(workspace)` surface
  * already relies on — same `fetch(..., { credentials: "same-origin" })`
- * pattern as `visa/voa/orders/api-client.ts`, no bearer token handling here.
- * `NEXT_PUBLIC_API_URL || "/api"` matches every other lane in this app.
+ * pattern used elsewhere. The base URL is deliberately hardcoded same-origin
+ * (`lib/api/index.ts`'s `API_BASE_URL = ""`, and the literal `/api/...` fetch
+ * in `(workspace)/review/page.tsx`, are the established convention for
+ * cookie-session-authenticated `(workspace)` calls): every request MUST go
+ * through the Next.js same-origin proxy (`app/api/[...path]/route.ts`),
+ * which is also the only place that promotes the `nz_csrf_token` cookie into
+ * the `X-CSRF-Token` header for mutating methods. `NEXT_PUBLIC_API_URL`
+ * points at the Fly backend host directly in production — using it here sent
+ * requests cross-origin, without the proxy's CSRF promotion and without the
+ * httpOnly session cookie (scoped to `.balizero.com`, never sent to
+ * `nuzantara-rag.fly.dev`), which 401'd every staff call live.
  */
 
 import type {
@@ -25,7 +34,7 @@ import type {
   StaffPracticeView,
 } from "./types";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
+const API_BASE_URL = "/api";
 
 export class GarudaStaffError extends Error {
   constructor(


### PR DESCRIPTION
## Symptom (measured)

On `kita.balizero.com/garuda-voa` with an admin session (2026-09-03), the page shows "Failed to load GARUDA VOA practices". The browser issued `GET https://nuzantara-rag.fly.dev/visa/voa/staff/practices?assigned=all` → **401**.

## Root cause

`apps/mouth/src/app/(workspace)/garuda-voa/api-client.ts:28` did:

```ts
const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
```

Vercel bakes `NEXT_PUBLIC_API_URL=https://nuzantara-rag.fly.dev` in production, so every staff request (list/detail/assign/transition) went **cross-origin**, bypassing the Next.js same-origin proxy (`apps/mouth/src/app/api/[...path]/route.ts`) that:
- forwards the httpOnly `nz_access_token` session cookie (scoped to `.balizero.com`, never sent to `nuzantara-rag.fly.dev`)
- promotes the `nz_csrf_token` cookie into the `X-CSRF-Token` header for mutating methods

Result: 401 on every staff call, live.

The same-origin proxy path `GET /api/visa/voa/staff/practices` returns 200 with the admin session — that's the path the client must use.

## Convention found

Grepped `NEXT_PUBLIC_API_URL` / literal `"/api` usage under `apps/mouth/src/lib` and `apps/mouth/src/app/(workspace)`:

- `apps/mouth/src/lib/api/index.ts:59` hardcodes `API_BASE_URL = ""` for the app-wide authenticated singleton (`export const api = new ApiClient(API_BASE_URL)`) — always same-origin.
- `apps/mouth/src/app/(workspace)/review/page.tsx:747` fetches a literal `/api/intake/review/${id}/blob` with `credentials: "include"`.

Established convention: cookie-session-authenticated `(workspace)` calls are **always same-origin**, never `NEXT_PUBLIC_API_URL`. (`visa/voa/orders/api-client.ts` and `visa/voa/upload/api-client.ts` share the same `NEXT_PUBLIC_API_URL || "/api"` pattern and are latently exposed to the same bug, but are out of this PR's scope — team-lead mandate was staff client only.)

## Fix

`apps/mouth/src/app/(workspace)/garuda-voa/api-client.ts`:
- `API_BASE_URL` hardcoded to `"/api"` (same-origin), no longer reads `NEXT_PUBLIC_API_URL`.
- Updated the file's top comment to document the convention and why the old code broke.
- `credentials: "same-origin"` was already set on every request (`fetchJson` for list/detail/assign, explicit on `transitionPractice`) — no change needed there.

## Verification

```
$ npx vitest run 'src/app/(workspace)/garuda-voa/api-client.test.ts'
 Test Files  1 passed (1)
      Tests  2 passed (2)

$ npx vitest run 'src/app/(workspace)/garuda-voa'
 Test Files  4 passed (4)
      Tests  14 passed (14)

$ npx tsc --noEmit -p tsconfig.json
(no output — clean)

$ npx eslint 'src/app/(workspace)/garuda-voa/api-client.ts'
(no output — clean; the new .test.ts is intentionally eslint-ignored per eslint.config, same as every other *.test.ts in this app)
```

New test `api-client.test.ts` asserts `listStaffPractices` and `transitionPractice` hit `/api/visa/voa/staff/practices...` (never `nuzantara-rag.fly.dev`) with `credentials: "same-origin"`, even with `NEXT_PUBLIC_API_URL` stubbed to the Fly host via `vi.stubEnv` + `vi.resetModules()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiLWB7iiEoV8gknZqgPfm6
