### PR TITLE
fix(mouth): route GARUDA VOA customer funnel clients through the same-origin /api proxy

### DIFF
--- a/apps/mouth/src/app/visa/voa/orders/api-client.test.ts
+++ b/apps/mouth/src/app/visa/voa/orders/api-client.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test, same shape as the GARUDA VOA staff client (PR #5605,
+ * 2026-09-03): `NEXT_PUBLIC_API_URL` is baked to the Fly backend host
+ * (`https://nuzantara-rag.fly.dev`) in production. The order/checkout lane
+ * authenticates with the `garuda_session` cookie, `Domain=.balizero.com`
+ * (`get_cookie_domain()`, `garuda_portal_auth.py`) — a request built from
+ * that env var goes cross-origin and the browser never attaches a cookie
+ * scoped to `.balizero.com` to a `nuzantara-rag.fly.dev` request, same class
+ * of live 401 as the staff client. The fix hardcodes the same-origin `/api`
+ * base, so the client must never read `NEXT_PUBLIC_API_URL` again, even when
+ * it is set.
+ */
+describe("garuda-voa orders api-client base URL", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://nuzantara-rag.fly.dev");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("routes createOrder through the same-origin /api proxy, not NEXT_PUBLIC_API_URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          order_id: "o1",
+          state: "awaiting_payment",
+          checkout_url: "https://pay.example/checkout/o1",
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { createOrder } = await import("./api-client");
+    await createOrder({
+      request: {
+        result_id: "r1",
+        applicant: {
+          full_name: "Jane Doe",
+          email: "jane@example.com",
+          phone: "+6281234567890",
+          passport_number: "X1234567",
+        },
+        review_confirmed: true,
+      },
+      idempotencyKey: "key-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("/api/visa/voa/orders");
+    expect(calledUrl).not.toContain("nuzantara-rag.fly.dev");
+    expect((calledInit as RequestInit).credentials).toBe("same-origin");
+  });
+
+  it("routes getOrderAndPractice through the same-origin /api proxy", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ order_id: "o1", state: "paid", practice: null }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { getOrderAndPractice } = await import("./api-client");
+    await getOrderAndPractice({ orderId: "o1" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("/api/visa/voa/orders/o1");
+    expect(calledUrl).not.toContain("nuzantara-rag.fly.dev");
+    expect((calledInit as RequestInit).credentials).toBe("same-origin");
+  });
+});

--- a/apps/mouth/src/app/visa/voa/orders/api-client.ts
+++ b/apps/mouth/src/app/visa/voa/orders/api-client.ts
@@ -7,8 +7,13 @@
  *  - `GET  /api/visa/voa/orders/{order_id}` (getOrderAndPractice)
  *
  * Auth is the contract's `MagicSession` — the same `garuda_session` Secure, HttpOnly
- * cookie `upload/api-client.ts` documents. `fetch` sends same-origin cookies by default,
- * so no token handling belongs here; same `NEXT_PUBLIC_API_URL || "/api"` convention.
+ * cookie `upload/api-client.ts` documents, `Domain` set by the backend's
+ * `get_cookie_domain()` (`.balizero.com` in production, `garuda_portal_auth.py`'s
+ * `_set_account_session_cookie`) — never sent to a request that goes directly to
+ * `nuzantara-rag.fly.dev`. `fetch` sends same-origin cookies by default, so no token
+ * handling belongs here, but the base URL MUST stay same-origin `/api` (2026-09-03:
+ * `NEXT_PUBLIC_API_URL` pointing at the Fly host directly 401'd the sibling staff
+ * lane's cookie-session calls the same way — see `(workspace)/garuda-voa/api-client.ts`).
  */
 
 import type {
@@ -20,7 +25,7 @@ import type {
   OrderView,
 } from "./types";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
+const API_BASE_URL = "/api";
 
 export class GarudaOrderError extends Error {
   constructor(

--- a/apps/mouth/src/app/visa/voa/upload/api-client.test.ts
+++ b/apps/mouth/src/app/visa/voa/upload/api-client.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression test, same shape as the GARUDA VOA staff client (PR #5605,
+ * 2026-09-03): `NEXT_PUBLIC_API_URL` is baked to the Fly backend host
+ * (`https://nuzantara-rag.fly.dev`) in production. This upload lane
+ * authenticates with the `garuda_session` cookie, `Domain=.balizero.com`
+ * (`get_cookie_domain()`, `garuda_portal_auth.py`) — a request built from
+ * that env var goes cross-origin and the browser never attaches a cookie
+ * scoped to `.balizero.com` to a `nuzantara-rag.fly.dev` request, same class
+ * of live 401 as the staff client. The fix hardcodes the same-origin `/api`
+ * base, so the client must never read `NEXT_PUBLIC_API_URL` again, even when
+ * it is set.
+ */
+describe("garuda-voa upload api-client base URL", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://nuzantara-rag.fly.dev");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("routes uploadIntakeDocument through the same-origin /api proxy, not NEXT_PUBLIC_API_URL", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ status: "PROCESSING", document_id: "d1" }),
+          { status: 202, headers: { "content-type": "application/json" } },
+        ),
+      );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { uploadIntakeDocument } = await import("./api-client");
+    const file = new File(["fake-bytes"], "passport.jpg", {
+      type: "image/jpeg",
+    });
+    await uploadIntakeDocument({
+      resultId: "r1",
+      file,
+      idempotencyKey: "key-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe("/api/visa/voa/eligibility-checks/r1/documents");
+    expect(calledUrl).not.toContain("nuzantara-rag.fly.dev");
+    expect((calledInit as RequestInit).credentials).toBe("same-origin");
+  });
+});

--- a/apps/mouth/src/app/visa/voa/upload/api-client.ts
+++ b/apps/mouth/src/app/visa/voa/upload/api-client.ts
@@ -3,9 +3,13 @@
  * `POST /api/visa/voa/eligibility-checks/{result_id}/documents`.
  *
  * Auth is the contract's `MagicSession` — a Secure, HttpOnly `garuda_session` cookie set
- * by L4's magic-link exchange. `fetch` sends same-origin cookies by default, so no token
- * handling belongs here; this call is same-origin under `/api` per the repo's existing
- * `NEXT_PUBLIC_API_URL || "/api"` convention (see `src/lib/api/articles.api.ts`).
+ * by L4's magic-link exchange, `Domain` set by the backend's `get_cookie_domain()`
+ * (`.balizero.com` in production, `garuda_portal_auth.py`'s `_set_account_session_cookie`)
+ * — never sent to a request that goes directly to `nuzantara-rag.fly.dev`. `fetch` sends
+ * same-origin cookies by default, so no token handling belongs here, but the base URL
+ * MUST stay same-origin `/api` (2026-09-03: `NEXT_PUBLIC_API_URL` pointing at the Fly host
+ * directly 401'd the sibling staff lane's cookie-session calls the same way — see
+ * `(workspace)/garuda-voa/api-client.ts`).
  */
 
 import {
@@ -16,7 +20,7 @@ import {
   type UploadSuccessBody,
 } from "./types";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
+const API_BASE_URL = "/api";
 
 export class GarudaUploadError extends Error {
   constructor(


### PR DESCRIPTION
## Symptom

Same class as PR #5605 (staff client, merged and proven live — the staff list now hits `/api/visa/voa/staff/practices` → 200). Both `apps/mouth/src/app/visa/voa/orders/api-client.ts` and `apps/mouth/src/app/visa/voa/upload/api-client.ts` were still doing:

```ts
const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "/api";
```

## Auth check performed before touching anything

Both lanes authenticate with the customer-side `MagicSession`: a Secure, HttpOnly `garuda_session` cookie, set by `apps/mouth/src/app/visa/voa/auth/exchange/route.ts` (which itself deliberately calls the backend **through this app's own `/api` proxy**, never the Fly host directly — see that file's header comment).

- Backend: `apps/backend-rag/backend/app/routers/garuda_portal_auth.py:409-418` (`_set_account_session_cookie`) sets `domain=get_cookie_domain()`.
- `get_cookie_domain()` (`apps/backend-rag/backend/app/utils/cookie_auth.py:24-33`) returns the configured `settings.cookie_domain` — `.balizero.com` in production, same domain used by the staff session's `nz_access_token`.

A `Domain=.balizero.com` cookie is **never** attached by the browser to a request whose host is `nuzantara-rag.fly.dev` — that host doesn't match the domain or any of its subdomains, regardless of `credentials` setting. So `NEXT_PUBLIC_API_URL` pointing directly at the Fly host would 401 every order/upload call exactly like it did the staff calls.

**Proxy forwarding confirmed safe**: `apps/mouth/src/app/api/[...path]/route.ts` builds its outgoing `headers` as `new Headers(req.headers)` — a full copy of the incoming request, including the raw `Cookie` header. None of the proxy's cookie-mutation branches (lines ~128-179) touch `garuda_session` — they only conditionally strip/re-add `nz_access_token` and promote `nz_csrf_token` into `X-CSRF-Token` for mutating methods (a CRM/staff-session mechanism these customer-funnel endpoints don't use — grepped, no CSRF handling exists anywhere in `visa/voa/orders`, `visa/voa/upload`, or the corresponding backend routers). So `garuda_session` passes through the proxy unmodified, and multipart/form-data (used by the upload endpoint) is already handled generically by the proxy (`contentType.includes("multipart/form-data")` branch). **Nothing the proxy does NOT forward** — no STOP condition found.

## Fix

Both `orders/api-client.ts` and `upload/api-client.ts`: `API_BASE_URL` hardcoded to `"/api"`, no longer reads `NEXT_PUBLIC_API_URL`. Comments updated to document the `garuda_session` cookie-domain reasoning and point at the sibling staff-client fix. `credentials: "same-origin"` was already set on every request in both files — untouched.

## Verification

```
$ npx vitest run 'src/app/visa/voa/orders' 'src/app/visa/voa/upload'
 Test Files  6 passed (6)
      Tests  27 passed (27)

$ npx tsc --noEmit -p tsconfig.json
(no output — clean)

$ npx eslint 'src/app/visa/voa/orders/api-client.ts' 'src/app/visa/voa/upload/api-client.ts'
(no output — clean; *.test.ts files are eslint-ignored per eslint.config, same as every other test in this app)
```

Two new tests (`orders/api-client.test.ts`: `createOrder` + `getOrderAndPractice`; `upload/api-client.test.ts`: `uploadIntakeDocument`) assert the fetch URL is `/api/visa/voa/...` — never `nuzantara-rag.fly.dev` — with `credentials: "same-origin"`, even with `NEXT_PUBLIC_API_URL` stubbed to the Fly host via `vi.stubEnv` + `vi.resetModules()`.

## Bites

Consumer: the GARUDA VOA customer funnel (`/visa/voa/upload/[resultId]`, `/visa/voa/orders/[orderId]`) — every magic-link customer who reaches checkout or document upload after this deploys through the same-origin proxy instead of 401ing cross-origin, same observation class as #5605's staff-list 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiLWB7iiEoV8gknZqgPfm6
