### PR TITLE
fix(bot): answer a bare greeting from a script instead of the 7m45s retry ladder

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
+++ b/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
@@ -427,6 +427,13 @@ class CodexLegResult:
     stand_down: bool = False
     fail: str = ""
     reason: str = ""
+    # Which path produced `text`. "codex" is the broker completion; the
+    # deterministic greeting turn sets "scripted_greeting" so the worker's
+    # log line does not claim a broker round-trip that never happened
+    # (cross-family refuter finding 4, 2026-09-03 — `generation_route` stays
+    # NULL on that row, so a log saying "codex leg served" was the only
+    # record of it and it was false).
+    served_by: str = "codex"
 
 
 async def attempt(
@@ -545,7 +552,7 @@ async def _attempt(
             outbox_id,
             greeting.language,
         )
-        return CodexLegResult(text=greeting.text)
+        return CodexLegResult(text=greeting.text, served_by="scripted_greeting")
 
     epoch = int(thread["handling_version"])
 

--- a/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
+++ b/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
@@ -119,6 +119,7 @@ from backend.services.integrations.wa_finalize import (
     FinalizeOutcome,
     finalize_wa_answer,
 )
+from backend.services.integrations.wa_greeting import match_greeting
 
 # Same-package deliberate reuse of the bot leg's lazy-singleton RAG client,
 # thread-context loader, notifier and kill switch: ONE persistent HTTP
@@ -510,6 +511,41 @@ async def _attempt(
         # — the worker turns it into SilentStandingCondition, same as
         # autoreply_disabled above.
         return CodexLegResult(reason="no_customer_message")
+
+    # Deterministic greeting turn — BEFORE the package build, which is the
+    # first step that can retrieve anything. A bare "halo" classifies as
+    # QueryDomain.GREETING, whose collection list is empty by design, so the
+    # builder refuses with PackageUnbuildable("greeting_domain") and (since
+    # the Gemini cut) the row takes the full five-attempt retry ladder to
+    # arrive at an English error stub ~7m45s later. Measured on the real
+    # thread, cycle 359. `match_greeting` is a pure function with no I/O and
+    # answers None for anything that is not a BARE greeting — "halo, berapa
+    # harga PT PMA?" still goes down the normal route untouched.
+    #
+    # Placed here rather than in the worker because this is where the query
+    # actually exists (one DB read, already done above), and here rather
+    # than in the package builder because a greeting is not an unbuildable
+    # package — it is a turn with a scripted answer.
+    #
+    # Deliberately does NOT run wa_finalize: that pipeline exists to police
+    # GENERATED text (abstain labels, monologue leaks, KG scaffold, pricing
+    # veto, secret egress). This text is a module constant — nothing in it
+    # came from a model, from retrieval, or from the client.
+    #
+    # Known gap, declared: `wa_outbox.generation_route` stays NULL on these
+    # rows, because that column is one half of the codex OFFER's CAS fence
+    # and this row is never offered. A scripted greeting is therefore not
+    # yet countable in SQL; the log line below is the only marker. Same
+    # ledger family as "an abstain leaves no record" — a column, and its own
+    # PR.
+    greeting = match_greeting(query)
+    if greeting is not None:
+        logger.info(
+            "wa_codex_leg: scripted greeting served outbox=%s lang=%s",
+            outbox_id,
+            greeting.language,
+        )
+        return CodexLegResult(text=greeting.text)
 
     epoch = int(thread["handling_version"])
 

--- a/apps/backend-rag/backend/services/integrations/wa_greeting.py
+++ b/apps/backend-rag/backend/services/integrations/wa_greeting.py
@@ -38,6 +38,26 @@ CONTRACT
 - **No citation, no price, no client data.** Per ZERO-DECISIONS item 3 case
   (b), a courtesy turn carries no source line; prices come from PricingTool on
   the answering path, never from a canned string.
+
+WHY THE CALL SITE IS INSIDE THE CODEX LEG (refuter finding 3, adjudicated)
+--------------------------------------------------------------------------
+A greeting is not a generation, so gating it on ``WA_GENERATION_PROVIDER``
+looks wrong. It is not an exposure: when that switch is not ``codex`` the
+worker raises ``BotStandingCondition`` before the leg is ever entered and the
+product generates **nothing at all** — there is no state in which questions
+are answered and greetings are not. The alternative, hoisting the check into
+``wa_outbox_worker``, buys nothing and costs a second thread-context read plus
+a second owner of "what the query is" — the exact drift ``_load_thread_context``
+exists to prevent (W114). When a second generation route is added, this call
+moves to whatever becomes the common pre-generation point, and the two
+integration tests in ``test_wa_codex_leg.py`` move with it.
+
+The short-circuit also returns before ``epoch = thread["handling_version"]``
+is read, which the normal route uses for the broker's drift verdict. That
+verdict exists because a broker round-trip takes seconds to minutes and a human
+may take the thread over inside that window; a scripted constant takes
+microseconds. The worker's own fenced re-read of ``human_handling`` and the
+24h-window check still run before the send, unchanged.
 """
 
 from __future__ import annotations
@@ -84,8 +104,10 @@ _GREETING_TOKENS: dict[str, str] = {
     "вітаю": "uk",
 }
 
-# Multi-word greetings, matched against the WHOLE normalized message before
-# the token pass. Keys are already normalized.
+# Multi-word greetings. Keyed on the normalized token TUPLE, not on the whole
+# message, so "selamat pagi kak" and "good morning Zantara" are recognised —
+# a whole-message match missed both (refuter finding 2). Longest phrase first
+# is guaranteed by _MAX_PHRASE_TOKENS below.
 _GREETING_PHRASES: dict[str, str] = {
     "selamat pagi": "id",
     "selamat siang": "id",
@@ -104,39 +126,49 @@ _GREETING_PHRASES: dict[str, str] = {
     "доброе утро": "ru",
     "доброго дня": "uk",
     "добрий день": "uk",
+    # Apostrophes are stripped by _normalize, so the common transliteration
+    # "Assalamu'alaikum" arrives here as two tokens (refuter finding 2).
+    "assalamu alaikum": "id",
+    "assalamualaikum warahmatullahi": "id",
+    "salam sejahtera": "id",
 }
+
+_MAX_PHRASE_TOKENS = max(len(phrase.split()) for phrase in _GREETING_PHRASES)
 
 # Tokens allowed to keep a message a greeting when at least one real greeting
 # token is present: a vocative or an intensifier. "halo zantara" and "hi hi"
 # are greetings; "bali zero" alone is not (no greeting token → no match).
-_VOCATIVE_TOKENS: frozenset[str] = frozenset(
-    {
-        "zantara",
-        "bali",
-        "zero",
-        "balizero",
-        "admin",
-        "min",
-        "kak",
-        "pak",
-        "bu",
-        "ibu",
-        "bapak",
-        "mas",
-        "mbak",
-        "team",
-        "tim",
-        "there",
-        "everyone",
-        "all",
-    }
-)
+_VOCATIVE_TOKENS: dict[str, str | None] = {
+    # Neutral / brand — no language signal.
+    "zantara": None,
+    "bali": None,
+    "zero": None,
+    "balizero": None,
+    "there": None,
+    # Indonesian honorifics — these DO carry a language signal, used below to
+    # break the tie when the greeting token itself is English ("hi kak").
+    "kak": "id",
+    "pak": "id",
+    "bu": "id",
+    "ibu": "id",
+    "bapak": "id",
+    "mas": "id",
+    "mbak": "id",
+    "min": "id",
+}
+
+# DELIBERATELY NOT vocatives: "admin", "team", "tim", "everyone", "all".
+# Cross-family refuter (Codex GPT-5.6 Sol, 2026-09-03, BLOCK finding 1) on the
+# exact string "Halo admin?": those words are not politeness, they are a
+# request for a PERSON. Answering them with a capability list is the same
+# class of defect this module exists to cure, pointed the other way — so they
+# fall through to the normal route, which has the human-notification wiring.
 
 # A greeting is short. The cap is a second, independent brake on over-match:
 # whatever slips past the token rules, a long message is never answered from a
 # canned string.
-_MAX_GREETING_TOKENS = 4
-_MAX_GREETING_CHARS = 40
+_MAX_GREETING_TOKENS = 5
+_MAX_GREETING_CHARS = 48
 
 _PUNCT_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
 _WS_RE = re.compile(r"\s+", flags=re.UNICODE)
@@ -220,6 +252,13 @@ def match_greeting(text: str | None) -> GreetingTurn | None:
 
     Never raises, never performs I/O. `None` is the safe answer and means
     "not my business" — the caller runs the normal generation route.
+
+    The message is consumed left to right: a multi-word greeting phrase, then
+    a single-word greeting, then an allowed vocative. ANY token that is none
+    of those ends the match immediately, and at least one real greeting must
+    have been consumed. So "selamat pagi kak" is a greeting, "bali zero" is
+    not (no greeting token), and "halo, berapa harga PT PMA?" is not (the
+    remaining tokens are a question).
     """
     if not text:
         return None
@@ -230,22 +269,50 @@ def match_greeting(text: str | None) -> GreetingTurn | None:
     if not normalized:
         return None
 
-    language = _GREETING_PHRASES.get(normalized)
-    if language is None:
-        tokens = normalized.split()
-        if not tokens or len(tokens) > _MAX_GREETING_TOKENS:
-            return None
-        languages = [_GREETING_TOKENS.get(tok) for tok in tokens]
-        # Every token must be either a greeting or an allowed vocative, and at
-        # least one must be an actual greeting. A message carrying any other
-        # word carries a question, and questions are not answered from here.
-        for tok, lang in zip(tokens, languages, strict=True):
-            if lang is None and tok not in _VOCATIVE_TOKENS:
+    tokens = normalized.split()
+    if not tokens or len(tokens) > _MAX_GREETING_TOKENS:
+        return None
+
+    greeting_langs: list[str] = []
+    vocative_langs: list[str] = []
+    i = 0
+    while i < len(tokens):
+        # Longest phrase first, so "assalamu alaikum" is not consumed as an
+        # unknown single token.
+        for span in range(min(_MAX_PHRASE_TOKENS, len(tokens) - i), 1, -1):
+            phrase = " ".join(tokens[i : i + span])
+            phrase_lang = _GREETING_PHRASES.get(phrase)
+            if phrase_lang is not None:
+                greeting_langs.append(phrase_lang)
+                i += span
+                break
+        else:
+            token = tokens[i]
+            token_lang = _GREETING_TOKENS.get(token)
+            if token_lang is not None:
+                greeting_langs.append(token_lang)
+            elif token in _VOCATIVE_TOKENS:
+                vocative_lang = _VOCATIVE_TOKENS[token]
+                if vocative_lang is not None:
+                    vocative_langs.append(vocative_lang)
+            else:
+                # A word that is neither a greeting nor a vocative is content,
+                # and content is answered by the retrieval route.
                 return None
-        greeting_langs = [lang for lang in languages if lang is not None]
-        if not greeting_langs:
-            return None
-        language = greeting_langs[0]
+            i += 1
+
+    if not greeting_langs:
+        return None
+
+    language = greeting_langs[0]
+    if language == _FALLBACK_LANG and vocative_langs:
+        # "hi kak" (refuter finding 5). An Indonesian honorific beside an
+        # English greeting is stronger evidence of the client's language than
+        # the greeting is: "hi" is used in every language on this number,
+        # "kak" is not. The override is deliberately one-directional — a
+        # vocative may displace the FALLBACK language, never an explicit
+        # non-English one ("ciao kak" stays Italian).
+        language = vocative_langs[0]
 
     reply = _GREETING_REPLIES.get(language) or _GREETING_REPLIES[_FALLBACK_LANG]
     return GreetingTurn(language=language, text=reply)

--- a/apps/backend-rag/backend/services/integrations/wa_greeting.py
+++ b/apps/backend-rag/backend/services/integrations/wa_greeting.py
@@ -1,0 +1,251 @@
+"""Deterministic scripted greeting turn for the WhatsApp product.
+
+WHY THIS EXISTS (measured, cycle 359, 2026-09-01, WhatsApp thread 30)
+---------------------------------------------------------------------
+A bare ``halo`` — the single most likely first message a real client ever
+sends — took **7m45s** and answered an English technical-error stub to an
+Indonesian greeting. The chain, all of it working as written:
+
+``QueryPlanner`` classifies the message correctly as ``QueryDomain.GREETING``;
+``_DOMAIN_COLLECTIONS[GREETING]`` is ``[]`` by design (there is nothing to
+retrieve for "hello"); ``wa_package_builder.build_context_package`` therefore
+raises ``PackageUnbuildable("greeting_domain")``; the codex leg falls off; and
+since the Gemini leg was cut for WhatsApp on 2026-08-27 there is no second
+generator to hand it to, so the row takes the full retry ladder — five
+attempts, ~7 minutes of backoff — and terminalizes as ``failed`` with the
+localized apology (English whenever ``detect_language`` returns ``'auto'``,
+which it does for most ordinary phrasings).
+
+Nothing in that chain is a bug. The missing piece is that a greeting has an
+answer and it is not a retrieval answer. Published practice says the same:
+Google Dialogflow CX and Rasa both reach a scripted greeting/capability turn
+BEFORE any retrieval or generation, never a generation attempt with no topic.
+
+CONTRACT
+--------
+- **No LLM, no retrieval, no I/O.** Pure function over the message text.
+- **Whole-message only.** ``halo`` is a greeting; ``halo, berapa harga PT
+  PMA?`` is a pricing question that happens to open politely, and it MUST fall
+  through to the normal route untouched. Guilt without innocence is how a
+  guard eats the traffic it was meant to let past (scar family #3).
+- **Conservative by construction.** Anything this module is not sure about
+  returns ``None`` and costs nothing — the normal route still runs.
+- **The greeting token decides the language**, not ``detect_language``. That
+  detector returns ``'auto'`` for ordinary phrasings (measured 6 of 9 on
+  2026-08-11) and its consumers then fall back to English. Here the entire
+  input IS the greeting, so the token itself is the strongest available
+  signal and there is nothing else to weigh.
+- **No citation, no price, no client data.** Per ZERO-DECISIONS item 3 case
+  (b), a courtesy turn carries no source line; prices come from PricingTool on
+  the answering path, never from a canned string.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+
+# Single-word greetings → the language they are written in. One language per
+# token on purpose: a token that would need a coin-flip (e.g. "hallo", read as
+# German, Dutch or Indonesian) is assigned the reading most likely on THIS
+# number's traffic, and being wrong costs a greeting in the wrong language,
+# never a wrong fact.
+_GREETING_TOKENS: dict[str, str] = {
+    # Indonesian
+    "halo": "id",
+    "hallo": "id",
+    "hai": "id",
+    "pagi": "id",
+    "siang": "id",
+    "sore": "id",
+    "malam": "id",
+    "permisi": "id",
+    "assalamualaikum": "id",
+    "assalamualaykum": "id",
+    # English
+    "hi": "en",
+    "hello": "en",
+    "hey": "en",
+    "hiya": "en",
+    "greetings": "en",
+    # Italian
+    "ciao": "it",
+    "buongiorno": "it",
+    "buonasera": "it",
+    "salve": "it",
+    # Russian
+    "привет": "ru",
+    "здравствуйте": "ru",
+    "здравствуй": "ru",
+    "приветствую": "ru",
+    # Ukrainian
+    "привіт": "uk",
+    "вітаю": "uk",
+}
+
+# Multi-word greetings, matched against the WHOLE normalized message before
+# the token pass. Keys are already normalized.
+_GREETING_PHRASES: dict[str, str] = {
+    "selamat pagi": "id",
+    "selamat siang": "id",
+    "selamat sore": "id",
+    "selamat malam": "id",
+    "selamat datang": "id",
+    "apa kabar": "id",
+    "good morning": "en",
+    "good afternoon": "en",
+    "good evening": "en",
+    "good day": "en",
+    "buon giorno": "it",
+    "buona sera": "it",
+    "добрый день": "ru",
+    "добрый вечер": "ru",
+    "доброе утро": "ru",
+    "доброго дня": "uk",
+    "добрий день": "uk",
+}
+
+# Tokens allowed to keep a message a greeting when at least one real greeting
+# token is present: a vocative or an intensifier. "halo zantara" and "hi hi"
+# are greetings; "bali zero" alone is not (no greeting token → no match).
+_VOCATIVE_TOKENS: frozenset[str] = frozenset(
+    {
+        "zantara",
+        "bali",
+        "zero",
+        "balizero",
+        "admin",
+        "min",
+        "kak",
+        "pak",
+        "bu",
+        "ibu",
+        "bapak",
+        "mas",
+        "mbak",
+        "team",
+        "tim",
+        "there",
+        "everyone",
+        "all",
+    }
+)
+
+# A greeting is short. The cap is a second, independent brake on over-match:
+# whatever slips past the token rules, a long message is never answered from a
+# canned string.
+_MAX_GREETING_TOKENS = 4
+_MAX_GREETING_CHARS = 40
+
+_PUNCT_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
+_WS_RE = re.compile(r"\s+", flags=re.UNICODE)
+
+# Scripted greeting + capability turn, one per supported language. Deliberately
+# names service FAMILIES and never a price: what the client may ask about, so
+# the next turn lands on the answering path with a topic. English is the
+# fallback for a language we recognise but do not script.
+_GREETING_REPLIES: dict[str, str] = {
+    "id": (
+        "Halo! Saya Zantara, asisten Bali Zero.\n\n"
+        "Saya bisa bantu soal:\n"
+        "• Visa & izin tinggal (KITAS, KITAP, visa kunjungan)\n"
+        "• Pendirian perusahaan & perizinan (PT PMA, NIB, OSS, KBLI)\n"
+        "• Pajak & pelaporan (NPWP, SPT, LKPM)\n"
+        "• Properti & sertifikat tanah\n\n"
+        "Silakan tulis pertanyaan Anda — makin spesifik, makin tepat jawabannya."
+    ),
+    "en": (
+        "Hello! I'm Zantara, the Bali Zero assistant.\n\n"
+        "I can help you with:\n"
+        "• Visas & stay permits (KITAS, KITAP, visit visas)\n"
+        "• Company setup & licensing (PT PMA, NIB, OSS, KBLI)\n"
+        "• Tax & reporting (NPWP, SPT, LKPM)\n"
+        "• Property & land titles\n\n"
+        "Just write your question — the more specific, the better the answer."
+    ),
+    "it": (
+        "Ciao! Sono Zantara, l'assistente di Bali Zero.\n\n"
+        "Posso aiutarti con:\n"
+        "• Visti e permessi di soggiorno (KITAS, KITAP, visti turistici)\n"
+        "• Apertura società e licenze (PT PMA, NIB, OSS, KBLI)\n"
+        "• Tasse e adempimenti (NPWP, SPT, LKPM)\n"
+        "• Immobili e titoli di proprietà\n\n"
+        "Scrivimi pure la tua domanda — più è precisa, più la risposta sarà utile."
+    ),
+    "ru": (
+        "Здравствуйте! Я Зантара, ассистент Bali Zero.\n\n"
+        "Я могу помочь с:\n"
+        "• Визами и видами на жительство (KITAS, KITAP, гостевые визы)\n"
+        "• Регистрацией компании и лицензиями (PT PMA, NIB, OSS, KBLI)\n"
+        "• Налогами и отчётностью (NPWP, SPT, LKPM)\n"
+        "• Недвижимостью и правами на землю\n\n"
+        "Напишите ваш вопрос — чем конкретнее, тем точнее ответ."
+    ),
+    "uk": (
+        "Вітаю! Я Зантара, асистент Bali Zero.\n\n"
+        "Я можу допомогти з:\n"
+        "• Візами та дозволами на проживання (KITAS, KITAP, гостьові візи)\n"
+        "• Реєстрацією компанії та ліцензіями (PT PMA, NIB, OSS, KBLI)\n"
+        "• Податками та звітністю (NPWP, SPT, LKPM)\n"
+        "• Нерухомістю та правами на землю\n\n"
+        "Напишіть ваше запитання — що конкретніше, то точніша відповідь."
+    ),
+}
+
+_FALLBACK_LANG = "en"
+
+
+@dataclass(frozen=True)
+class GreetingTurn:
+    """A matched greeting and the scripted answer for it."""
+
+    language: str
+    text: str
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, strip punctuation and emoji, collapse whitespace.
+
+    NFKC first so a full-width or decomposed form normalizes to the same
+    tokens as the plain one.
+    """
+    folded = unicodedata.normalize("NFKC", text).casefold()
+    stripped = _PUNCT_RE.sub(" ", folded)
+    return _WS_RE.sub(" ", stripped).strip()
+
+
+def match_greeting(text: str | None) -> GreetingTurn | None:
+    """Return the scripted turn when `text` is a bare greeting, else None.
+
+    Never raises, never performs I/O. `None` is the safe answer and means
+    "not my business" — the caller runs the normal generation route.
+    """
+    if not text:
+        return None
+    if len(text) > _MAX_GREETING_CHARS:
+        return None
+
+    normalized = _normalize(text)
+    if not normalized:
+        return None
+
+    language = _GREETING_PHRASES.get(normalized)
+    if language is None:
+        tokens = normalized.split()
+        if not tokens or len(tokens) > _MAX_GREETING_TOKENS:
+            return None
+        languages = [_GREETING_TOKENS.get(tok) for tok in tokens]
+        # Every token must be either a greeting or an allowed vocative, and at
+        # least one must be an actual greeting. A message carrying any other
+        # word carries a question, and questions are not answered from here.
+        for tok, lang in zip(tokens, languages, strict=True):
+            if lang is None and tok not in _VOCATIVE_TOKENS:
+                return None
+        greeting_langs = [lang for lang in languages if lang is not None]
+        if not greeting_langs:
+            return None
+        language = greeting_langs[0]
+
+    reply = _GREETING_REPLIES.get(language) or _GREETING_REPLIES[_FALLBACK_LANG]
+    return GreetingTurn(language=language, text=reply)

--- a/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
+++ b/apps/backend-rag/backend/services/integrations/wa_outbox_worker.py
@@ -1013,7 +1013,7 @@ async def _process_claimed_row(
             elif leg.text is not None:
                 body_text = leg.text
                 logger.info(
-                    "wa_outbox: codex leg served outbox=%s", outbox_id
+                    "wa_outbox: %s served outbox=%s", leg.served_by, outbox_id
                 )
             elif leg.reason in _CODEX_LEG_STANDING_REASONS:
                 # SilentStandingCondition, not the plain BotStandingCondition:

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
@@ -303,6 +303,46 @@ async def test_window_never_opened_falls_off(
     stubs.offer_job.assert_not_awaited()
 
 
+# ── gate 2b: the scripted greeting turn ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_bare_greeting_is_served_from_the_script_before_any_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cycle 359, measured on real delivery: a bare "halo" reached the package
+    builder, was refused as `greeting_domain` (GREETING maps to zero
+    collections by design), and — with the Gemini leg cut — took the full
+    five-attempt retry ladder, ~7m45s, to arrive at an English error stub.
+
+    The cure returns the scripted turn here, and the assertions that matter
+    are the NEGATIVE ones: no build request, no broker offer, nothing
+    generated. If the short-circuit is removed, `rag_client.post` is awaited
+    and this test fails."""
+    stubs = _wire_stubs(monkeypatch, query="halo")
+    result = await _run()
+
+    assert result.text is not None
+    assert "Zantara" in result.text
+    assert result.reason == "" and not result.stand_down and not result.fail
+    stubs.rag_client.post.assert_not_awaited()
+    stubs.offer_job.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_question_that_merely_opens_with_a_greeting_takes_the_normal_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Innocence, and the expensive half: "halo, berapa harga PT PMA?" is a
+    pricing question wearing a polite hat. It must reach the package build
+    exactly as before — a greeting guard that eats real questions is a worse
+    defect than the one it cures (scar family #3)."""
+    stubs = _wire_stubs(monkeypatch, query="halo, berapa harga PT PMA?")
+    await _run()
+
+    stubs.rag_client.post.assert_awaited()
+
+
 # ── gate 3: the package build ───────────────────────────────────────────────
 
 

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_greeting.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_greeting.py
@@ -1,0 +1,147 @@
+"""Guilt AND innocence for the scripted greeting turn.
+
+The defect this cures (cycle 359, real delivery): a bare "halo" fell off the
+package builder and took ~7m45s to answer an English error stub.
+
+The defect a careless cure would INTRODUCE: swallowing "halo, berapa harga PT
+PMA?" — a real pricing question that opens politely — into a canned capability
+message. Scar family #3 is over-match, and it is the more expensive half here,
+so the innocence set below is deliberately larger than the guilt set.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from backend.services.integrations.wa_greeting import (
+    _GREETING_REPLIES,
+    GreetingTurn,
+    match_greeting,
+)
+
+
+class TestGuilt:
+    """Bare greetings MUST be answered from the script, in their language."""
+
+    @pytest.mark.parametrize(
+        ("message", "language"),
+        [
+            # The four the mandate names.
+            ("halo", "id"),
+            ("hi", "en"),
+            ("ciao", "it"),
+            ("привет", "ru"),
+            # The rest of the front door, per language.
+            ("Halo", "id"),
+            ("HALO!", "id"),
+            ("halo 👋", "id"),
+            ("hai", "id"),
+            ("Selamat pagi", "id"),
+            ("selamat sore", "id"),
+            ("assalamualaikum", "id"),
+            ("hello", "en"),
+            ("Hello!", "en"),
+            ("hey", "en"),
+            ("Good morning", "en"),
+            ("good evening", "en"),
+            ("Ciao!", "it"),
+            ("buongiorno", "it"),
+            ("Buonasera", "it"),
+            ("salve", "it"),
+            ("Привет!", "ru"),
+            ("здравствуйте", "ru"),
+            ("добрый день", "ru"),
+            ("привіт", "uk"),
+            ("доброго дня", "uk"),
+        ],
+    )
+    def test_a_bare_greeting_is_answered_from_the_script(
+        self, message: str, language: str
+    ) -> None:
+        turn = match_greeting(message)
+        assert turn is not None, f"{message!r} must be recognised as a greeting"
+        assert turn.language == language
+        assert turn.text == _GREETING_REPLIES[language]
+
+    @pytest.mark.parametrize(
+        "message",
+        ["halo zantara", "hi there", "ciao Bali Zero", "halo halo", "halo kak"],
+    )
+    def test_a_greeting_with_a_vocative_is_still_a_greeting(self, message: str) -> None:
+        assert match_greeting(message) is not None
+
+    def test_the_answer_names_what_the_bot_can_do(self) -> None:
+        """A greeting turn that only greets sends the client back to square one.
+
+        The measured shape (Dialogflow CX / Rasa) is greeting + capability, so
+        the NEXT turn arrives with a topic the retrieval path can serve.
+        """
+        for language, reply in _GREETING_REPLIES.items():
+            assert reply.count("•") >= 4, f"{language} reply lists no capabilities"
+            assert "KITAS" in reply and "PT PMA" in reply
+
+    def test_the_answer_carries_no_citation_and_no_price(self) -> None:
+        """ZERO-DECISIONS item 3 case (b): a courtesy turn cites nothing.
+
+        And prices come from PricingTool on the answering path — never from a
+        canned string (Golden Rule 11, and Zero's single-price ruling).
+        """
+        for reply in _GREETING_REPLIES.values():
+            assert "📜" not in reply
+            assert "Sumber:" not in reply and "Source:" not in reply
+            assert "Rp" not in reply
+            assert "IDR" not in reply
+
+
+class TestInnocence:
+    """A question that merely OPENS with a greeting is not a greeting."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # The exact shape the cure must not eat, in four languages.
+            "halo, berapa harga PT PMA?",
+            "Halo saya mau tanya soal visa",
+            "hi, my KITAS expired last week",
+            "Hello, how much is a PT PMA?",
+            "ciao, quanto costa aprire una PT PMA?",
+            "Buongiorno, ho bisogno di rinnovare il KITAS",
+            "привет, сколько стоит KITAS?",
+            "Здравствуйте, я хочу открыть компанию",
+            # Not greetings at all.
+            "berapa harga PT PMA?",
+            "What is the minimum paid-up capital for a PT PMA?",
+            "posso pagare con bonifico?",
+            # A vocative with no greeting in it is not a greeting.
+            "bali zero",
+            "zantara",
+            "admin",
+            # Nonsense must fall through, not be greeted.
+            "xyzabc123",
+            "?",
+            "👍",
+        ],
+    )
+    def test_a_message_carrying_a_question_falls_through(self, message: str) -> None:
+        assert match_greeting(message) is None, (
+            f"{message!r} was swallowed by the greeting path — it carries content "
+            "the retrieval route must answer"
+        )
+
+    @pytest.mark.parametrize("message", ["", "   ", None])
+    def test_empty_input_falls_through(self, message: str | None) -> None:
+        assert match_greeting(message) is None
+
+    def test_a_long_message_is_never_greeted(self) -> None:
+        """The character cap is a second, independent brake on over-match."""
+        assert match_greeting("halo " * 20) is None
+
+
+def test_the_return_type_is_frozen() -> None:
+    """The turn is a value, not a mutable bag the caller can edit."""
+    turn = match_greeting("halo")
+    assert isinstance(turn, GreetingTurn)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        turn.text = "something else"  # type: ignore[misc]

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_greeting.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_greeting.py
@@ -55,6 +55,16 @@ class TestGuilt:
             ("добрый день", "ru"),
             ("привіт", "uk"),
             ("доброго дня", "uk"),
+            # Cross-family refuter (Codex GPT-5.6 Sol, 2026-09-03) finding 2:
+            # both of these were MISSED by the first draft and therefore still
+            # cost the full 7m45s. The apostrophe is stripped by _normalize, so
+            # the transliteration arrives as two tokens; and a multi-word
+            # greeting followed by an honorific was not matchable at all while
+            # phrases were keyed on the whole message.
+            ("Assalamu'alaikum", "id"),
+            ("Selamat pagi, Kak", "id"),
+            ("selamat malam pak", "id"),
+            ("good morning zantara", "en"),
         ],
     )
     def test_a_bare_greeting_is_answered_from_the_script(
@@ -71,6 +81,19 @@ class TestGuilt:
     )
     def test_a_greeting_with_a_vocative_is_still_a_greeting(self, message: str) -> None:
         assert match_greeting(message) is not None
+
+    def test_an_indonesian_honorific_outranks_an_english_greeting(self) -> None:
+        """Refuter finding 5: "Hi kak" answered in English.
+
+        "hi" is used on this number in every language; "kak" is not. The
+        override is one-directional — a vocative may displace the FALLBACK
+        language, never an explicit non-English one.
+        """
+        hi_kak = match_greeting("Hi kak")
+        assert hi_kak is not None and hi_kak.language == "id"
+
+        ciao_kak = match_greeting("ciao kak")
+        assert ciao_kak is not None and ciao_kak.language == "it"
 
     def test_the_answer_names_what_the_bot_can_do(self) -> None:
         """A greeting turn that only greets sends the client back to square one.
@@ -117,7 +140,17 @@ class TestInnocence:
             # A vocative with no greeting in it is not a greeting.
             "bali zero",
             "zantara",
+            # Refuter finding 1, the BLOCKING one. "admin"/"team" are not
+            # politeness — they are a request for a PERSON, and answering them
+            # with a capability list is this module's own defect pointed the
+            # other way. They must reach the normal route, which carries the
+            # human-notification wiring.
             "admin",
+            "Halo admin?",
+            "Hi, admin?",
+            "Ciao, admin?",
+            "halo team",
+            "hi everyone",
             # Nonsense must fall through, not be greeted.
             "xyzabc123",
             "?",

--- a/evidence/2026-09/agent-nuzantara-ops-bot-wa-greeting-c7320b94/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-bot-wa-greeting-c7320b94/brief.yml
@@ -1,0 +1,20 @@
+task_id: lane-e-bot-wa-greeting
+gear: 2
+l_level: L2
+gate_class: client-facing
+objective: >-
+  Answer a bare greeting on WhatsApp from a deterministic script instead of the
+  five-attempt retry ladder. Measured on real delivery, cycle 359: a bare "halo"
+  cost 7m45s and answered an English technical-error stub to an Indonesian
+  greeting, because QueryDomain.GREETING maps to zero collections by design and
+  the Gemini leg was cut on 2026-08-27, leaving no second generator.
+grader: codex-sol
+pii: none
+notes: >-
+  Floor 2 is reached via the SIZE term alone (474 net lines), and most of that
+  size is the guilt+innocence corpus, not the cure: the matcher is 250 lines of
+  which the vocabulary tables are the bulk, and the tests are 185. Adversarial
+  gate ran BEFORE this brief existed — Codex GPT-5.6 Sol at effort high, on the
+  frozen diff, returned BLOCK with six findings; four cured in code (over-match
+  on "Halo admin?", two under-matches, a language tie-break) and two answered in
+  prose in the module docstring. Generator never graded its own diff.


### PR DESCRIPTION
## The defect, measured on real delivery

Cycle 359, WhatsApp thread 30, 2026-09-01. A bare **`halo`** — the likeliest first message a real
client ever sends — took **7 minutes 45 seconds** and answered an **English technical-error stub**
to an Indonesian greeting.

Nothing in that chain was broken:

1. `QueryPlanner` classifies the message correctly as `QueryDomain.GREETING`.
2. `_DOMAIN_COLLECTIONS[GREETING]` is `[]` **by design** — there is nothing to retrieve for "hello".
3. `build_context_package` therefore raises `PackageUnbuildable("greeting_domain")`.
4. The Gemini leg was cut for WhatsApp on 2026-08-27, so there is no second generator to hand the
   row to — it takes the full five-attempt retry ladder and terminalizes as `failed`.
5. The apology is English whenever `detect_language` returns `'auto'`, which it does for most
   ordinary phrasings (measured 6 of 9, 2026-08-11).

The missing piece is that **a greeting has an answer and it is not a retrieval answer**. That is
also the published shape: Dialogflow CX and Rasa both reach a scripted greeting/capability turn
BEFORE retrieval, never a generation attempt with no topic.

## The cure

`wa_greeting.match_greeting` — a pure function, no LLM, no retrieval, no I/O — wired into
`wa_codex_leg._attempt` immediately after the thread-context load and **before the package build**,
the first step that can retrieve anything. A match returns a scripted greeting + capability turn in
the client's language, so the next turn arrives with a topic the retrieval path can serve.

The greeting token decides the language, not `detect_language`: when the whole input IS the
greeting, the token is the strongest signal available, and the detector's `'auto'` → English
fallback is precisely the defect being cured.

## Innocence is the expensive half

`halo, berapa harga PT PMA?` is a pricing question wearing a polite hat. A greeting guard that eats
real questions is a worse defect than the one it cures (scar family #3). Whole-message consumption
only, a 5-token / 48-char cap, at least one real greeting token required — a vocative alone
(`bali zero`) is not a greeting. **24 innocence cases against 30 guilt cases.**

## Adversarial gate (generator≠grader)

**Codex GPT-5.6 Sol, effort high, not the author — returned BLOCK on the frozen diff.** All six
findings adjudicated, four cured in code, two answered in prose:

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | BLOCKER | over-match on `"Halo admin?"` — `admin`/`team`/`everyone` were vocatives, so a client asking for a **person** got a capability list | **CURED** — those five tokens removed from the allowlist; four innocence cases pinned |
| 2 | HIGH | under-match: `"Assalamu'alaikum"` (apostrophe → two unknown tokens) and `"Selamat pagi, Kak"` (phrases were keyed on the whole message) still cost 7m45s | **CURED** — left-to-right consumption: longest phrase, then single greeting, then vocative |
| 5 | MEDIUM | `"Hi kak"` answered in English | **CURED** — an Indonesian honorific may displace the FALLBACK language, never an explicit non-English one (`ciao kak` stays `it`) |
| 4 | LOW | the worker logged `"codex leg served"` for a row no broker ever saw, and `generation_route` stays NULL, so that log was the only record and it was false | **CURED** — `CodexLegResult.served_by` |
| 3 | MEDIUM | the call site is inside the codex leg, so it is gated on `WA_GENERATION_PROVIDER` | **ANSWERED** — when that switch is not `codex` the worker raises `BotStandingCondition` before the leg is entered and the product generates **nothing at all**; there is no state where questions are answered and greetings are not. Hoisting it costs a second thread-context read and a second owner of "what the query is" (W114). Recorded in the module docstring, with the epoch/drift analysis |
| 6 | HIGH | the innocence set only proved the easy zero-overlap case | **ANSWERED** — every string the refuter named is now in the corpus |

## Bites

**Consumer: `wa_codex_leg._attempt`, the only live WhatsApp generation route**
(`wa_outbox.generation_route='codex'` on all 58 rows since 2026-08-27, re-measured on prod today —
the Gemini leg is cut). The observation that proves the change is in force is a **mutation**, not a
passing test: replacing `greeting = match_greeting(query)` with `greeting = None` turns
`test_a_bare_greeting_is_served_from_the_script_before_any_io` **red**.

```
$ # short-circuit removed
1 failed, 2 passed  — AssertionError: assert None is not None
$ # short-circuit restored
3 passed
```

The integration test's load-bearing assertions are the negative ones — `rag_client.post` and
`offer_job` are **never awaited** on a greeting, i.e. no build, no broker, no generation.

```
169 passed   (test_wa_greeting.py + test_wa_codex_leg.py + test_wa_outbox_worker.py)
2070 passed  (the whole WA + agentic batch, 30 skipped, 6 xfailed)
```

Prove-live on the real thread is cycle 360's job, in its battery table.

## Declared gap

`wa_outbox.generation_route` stays NULL on a scripted greeting, because that column is one half of
the codex **offer's** CAS fence and this row is never offered — so a scripted greeting is not yet
countable in SQL, and `served_by` in the log line is its only marker. Same ledger family as "an
abstain leaves no record". A column, and its own PR.

## Scope

+3 files changed, 1 new module, 1 new test file. No migration, no config, no secret, no prompt.