### PR TITLE
feat(bot): refuse, at ingest, any corpus row that states a government-fee figure

### DIFF
--- a/apps/backend-rag/backend/services/misc/curated_qa_government_fee_detector.py
+++ b/apps/backend-rag/backend/services/misc/curated_qa_government_fee_detector.py
@@ -1,0 +1,135 @@
+"""Pre-ingest FACT-scan: does this answer state a GOVERNMENT FEE FIGURE to a client?
+
+WHY (cycle 359, measured on real WhatsApp delivery 2026-09-01)
+--------------------------------------------------------------
+Zero's standing ruling (2026-07-17, re-ruled 2026-09-01) is **one all-inclusive
+client-facing price** — never a PNBP-versus-service-fee split. The bot broke it
+on questions 11 and 14 of the cycle-359 battery, and the cause was not the
+prompt: **the corpus teaches the split.** Two live `curated_qa` points answered
+"how much does the Investor KITAS cost" with the government fee alone, and one
+of them stated the doctrine outright — *"We always keep these two costs
+distinct"*. Their source file has never existed in this repo, so deleting the
+points fixes today and nothing else: the next harvest can regenerate them.
+
+This module is the thing that survives the deletion.
+
+WHAT IT SCANS FOR — the FACT, never a phrasing
+-----------------------------------------------
+The overnight sweep that preceded this gate reported "5 offenders, 808 scanned,
+1 residual" and was falsely reassuring: it searched the phrasings someone had
+catalogued (*"we always show the two figures separately"*) and missed *"We
+always keep these two costs distinct"* — the same teaching, different words.
+W82, under-match. So this scans for the FACT: **a government-fee token and a
+money figure in the same answer.** A rewording cannot escape it, because the
+fee and the figure are what the offence is made of.
+
+WHAT IT DELIBERATELY DOES NOT DO — decide
+------------------------------------------
+Measured on the live collection (808 points, 2026-09-03):
+
+| shape | count | verdict |
+|---|---|---|
+| no government-fee token | 758 | passes, untouched |
+| government-fee token, **no** money figure | 27 | passes — and these are the model answers: *"rather than quote a figure that may age, ask our team"* |
+| government-fee token **and** a money figure | 23 | **refused unless reviewed** |
+
+Of those 23, **9 are genuine offenders** and 14 are compliant answers that
+happen to name a figure — *"one all-inclusive price that already contains the
+statutory PNBP, so you will never be asked to pay a government fee on top"*.
+
+A proximity rule was calibrated against those 9 and **rejected on its numbers**:
+at every window from 40 to 160 characters it caught at most 8 of 9 while
+blocking 11 to 13 compliant rows. There is no lexical rule that separates
+"the government charges X, we charge Y" from "our X already includes the
+government charge" — the difference is semantic. So this gate does not pretend
+to: it is **high-recall (9 of 9) and refuse-by-default**, and a row that
+genuinely must state a government figure carries an explicit per-row marker
+saying a human looked at it. One field, once, on 2.8% of the corpus, in
+exchange for making the silent regeneration of the offence impossible.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from backend.services.misc.curated_qa_pricing_detector import has_price_content
+
+# Government-fee vocabulary, in the four languages this corpus is written in.
+# Every term names the SAME entity — a charge levied by the Indonesian state —
+# which is what makes this a fact scan and not a phrase list: an author who
+# rewords the sentence still has to name the fee.
+_GOVERNMENT_FEE_RE = re.compile(
+    r"""
+      \bPNBP\b
+    | penerimaan\s+negara\s+bukan\s+pajak
+    | government\s+(?:issuance\s+|processing\s+)?fee
+    | governmental\s+fee
+    | government\s+(?:tariff|charge)
+    | official\s+government
+    | official\s+fee
+    | state\s+fee
+    | biaya\s+(?:pemerintah|negara|resmi|imigrasi|visa)
+    | tarif\s+(?:resmi|pemerintah)
+    | immigration\s+fee
+    | visa\s+fee
+    | tassa\s+governativa
+    | spese\s+governative
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# The per-row escape hatch. A corpus row that must state a government figure —
+# the all-inclusive explainers do, legitimately — sets this to True AND gives a
+# note. Both are required: a bare boolean is a checkbox, a note is a claim
+# someone made and can be held to.
+REVIEW_FLAG_FIELD = "government_fee_reviewed"
+REVIEW_NOTE_FIELD = "government_fee_review_note"
+
+
+@dataclass(frozen=True)
+class GovernmentFeeFinding:
+    """What the scan saw. `states_a_figure` is the gating fact."""
+
+    tokens: tuple[str, ...]
+    states_a_figure: bool
+
+
+def scan_government_fee(answer: str | None) -> GovernmentFeeFinding | None:
+    """Return what the answer says about government fees, or None if nothing.
+
+    Pure, no I/O. `None` means the text names no government fee at all — the
+    overwhelming majority (758 of 808 measured).
+    """
+    if not answer:
+        return None
+    tokens = tuple(sorted({m.group(0).lower() for m in _GOVERNMENT_FEE_RE.finditer(answer)}))
+    if not tokens:
+        return None
+    return GovernmentFeeFinding(tokens=tokens, states_a_figure=has_price_content(answer))
+
+
+def row_is_refused(row: dict) -> str | None:
+    """Return the refusal reason for a corpus row, or None to let it through.
+
+    The gate: an answer that names a government fee AND states a money figure
+    is refused, unless the row carries BOTH the review flag and a non-empty
+    review note.
+    """
+    answer = row.get("answer")
+    finding = scan_government_fee(answer if isinstance(answer, str) else None)
+    if finding is None or not finding.states_a_figure:
+        return None
+
+    reviewed = row.get(REVIEW_FLAG_FIELD) is True
+    note = row.get(REVIEW_NOTE_FIELD)
+    if reviewed and isinstance(note, str) and note.strip():
+        return None
+
+    return (
+        "states a government-fee figure to a client "
+        f"(tokens: {', '.join(finding.tokens)}) without "
+        f"{REVIEW_FLAG_FIELD}=true and a non-empty {REVIEW_NOTE_FIELD}. "
+        "Zero's ruling is ONE all-inclusive client-facing price — never a "
+        "PNBP-versus-service-fee split (2026-07-17, re-ruled 2026-09-01)."
+    )

--- a/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_harvest.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_harvest.py
@@ -1232,3 +1232,78 @@ async def test_load_batch_dry_run_never_persists_commit_markers(tmp_path: Path) 
     assert manifest["qdrant_committed"] is False
     assert manifest["faq_committed"] is False
     assert not manifest_path.exists()
+
+
+# ── the government-fee pre-ingest gate (cycle 359) ─────────────────────────
+
+
+def test_a_row_stating_a_government_fee_figure_is_refused_from_BOTH_sinks(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """GUILT — the exact live text of curated_qa point 59da08d9, the row that
+    taught the split as doctrine ("We always keep these two costs distinct").
+
+    The assertion that matters is that the row never reaches `valid_rows`, so
+    it is refused from the FAQ sink AND the Qdrant sink together: the two are
+    loaded separately downstream, and a gate that guards only one is not a
+    gate. Removing the `government_fee_row_is_refused` call in
+    `_load_and_gate_batches` makes this test go green with the offending row
+    ingested, which is what makes it evidence."""
+    monkeypatch.setattr(harvest, "_DEFAULT_DATA_DIR", tmp_path)
+    offender = _row(
+        question="Is the PNBP the same as your fee?",
+        answer=(
+            "No — the PNBP figures (Rp 7,000,000 for 1 year, Rp 9,500,000 for 2 "
+            "years) are the government's own fees; they are not Bali Zero's "
+            "service fee. We always keep these two costs distinct."
+        ),
+        confidence_class="JELAS",
+    )
+    clean = _row(
+        question="What does the government fee depend on?",
+        answer=(
+            "The government fee (PNBP) is set by immigration and can change over "
+            "time — rather than quote a figure that may age, ask our team."
+        ),
+        confidence_class="JELAS",
+    )
+    path = _write_jsonl(tmp_path / "batch.jsonl", [offender, clean])
+    harvest.write_batch_manifest(path, dry_run=False)
+    stats = harvest.HarvestStats()
+
+    batches = harvest._load_and_gate_batches([path], stats)
+
+    assert stats.government_fee_refused == 1
+    assert len(batches) == 1
+    surviving = batches[0][3]
+    assert [r["question"] for r in surviving] == [
+        "What does the government fee depend on?"
+    ], "the compliant row must survive; only the figure-bearing one is refused"
+
+
+def test_the_review_marker_lets_an_all_inclusive_explainer_through(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """INNOCENCE — 17 of the live collection's government-fee rows state a
+    figure legitimately, saying our price ALREADY contains it. They are
+    ingestable, with an explicit per-row note."""
+    monkeypatch.setattr(harvest, "_DEFAULT_DATA_DIR", tmp_path)
+    reviewed = _row(
+        question="Are government fees included?",
+        answer=(
+            "Yes — our E33 price is one all-inclusive figure of Rp 20.000.000 "
+            "that already contains the statutory PNBP, so you will never be "
+            "asked to pay a government fee on top."
+        ),
+        confidence_class="JELAS",
+        government_fee_reviewed=True,
+        government_fee_review_note="all-inclusive explainer; the figure IS our price",
+    )
+    path = _write_jsonl(tmp_path / "batch.jsonl", [reviewed])
+    harvest.write_batch_manifest(path, dry_run=False)
+    stats = harvest.HarvestStats()
+
+    batches = harvest._load_and_gate_batches([path], stats)
+
+    assert stats.government_fee_refused == 0
+    assert len(batches) == 1 and len(batches[0][3]) == 1

--- a/apps/backend-rag/backend/tests/unit/services/test_curated_qa_government_fee_gate.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_curated_qa_government_fee_gate.py
@@ -1,0 +1,203 @@
+"""The pre-ingest gate that stops the corpus teaching the price split.
+
+Every string below is REAL corpus text, copied from the live `curated_qa`
+collection on 2026-09-03. They are corpus, not client data — no PII.
+
+The guilt set is the nine rows the FACT-scan found offending. The innocence
+set is the model answers: rows that name a government fee and deliberately
+refuse to quote a figure. Both halves are load-bearing — a gate that refuses
+the whole 50-row government-fee population would take the good answers with
+the bad, and the good ones are the behaviour the ruling wants.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.misc.curated_qa_government_fee_detector import (
+    REVIEW_FLAG_FIELD,
+    REVIEW_NOTE_FIELD,
+    row_is_refused,
+    scan_government_fee,
+)
+
+# --- GUILT: the nine offenders, verbatim from the live collection ----------
+
+OFFENDERS: dict[str, str] = {
+    # 57deb254 — answers "how much does the Investor KITAS cost" with the
+    # government fee ONLY. Cycle 359 Q11.
+    "e28a_q5": (
+        "The government fee (PNBP) totals Rp 7,000,000 for a 1-year Investor "
+        "KITAS, or Rp 9,500,000 for 2 years — both cover the visa, the ITAS, "
+        "the bundled re-entry permit, and the verification fee."
+    ),
+    # 59da08d9 — the split as written DOCTRINE. This is the one the earlier
+    # phrase-based sweep missed (it looked for "we always show the two figures
+    # separately"; the corpus says "keep these two costs distinct"). W82.
+    "e28a_q6": (
+        "No — the PNBP figures (Rp 7,000,000 for 1 year, Rp 9,500,000 for 2 "
+        "years) are the Indonesian government's own visa and stay-permit fees; "
+        "they are not Bali Zero's service fee. Our fee is separate and quoted "
+        "individually by our team. We always keep these two costs distinct so "
+        "you know exactly what's going to the government and what's going to us."
+    ),
+    # 8b520434
+    "e33e_q13": (
+        "The official government fee (PNBP) to issue an E33E totals "
+        "Rp 13,000,000, broken down as: visa Rp 500,000 + verification "
+        "Rp 2,000,000 + ITAS Rp 7,000,000 + re-entry permit Rp 3,500,000. "
+        "This is the government fee only — it does not include Bali Zero's "
+        "service fee, which we quote separately."
+    ),
+    # eacec21f — a bare PNBP figure volunteered inside an ELIGIBILITY answer.
+    "final_q11": (
+        "Government fee (PNBP): Rp 12,000,000 for 5 years, Rp 18,500,000 for "
+        "10 years. The investment commitment is at least USD 30,000."
+    ),
+    # 8ebf681f
+    "final_q13": (
+        "All three KITAP routes share the same official government fee (PNBP) "
+        "structure, tiered by validity period: roughly Rp 7,000,000 for the "
+        "standard 5-year ITAP, a Rp 12,000,000 tier, and a Rp 15,000,000 tier."
+    ),
+    # The four this gate found that the corner had not yet named.
+    "finalv2_q8": (
+        "Official government PNBP fees for ITAP were revised under PP 45/2024 "
+        "and are tiered by validity period: roughly Rp 7,000,000 for a 5-year."
+    ),
+    "c1_q19": (
+        "The government issuance fee (PNBP) for the C1 is Rp 1,000,000, "
+        "covering the initial 60-day stay — this is a fixed, official figure."
+    ),
+    "kitap_q7": (
+        "Under the current official fee schedule (PP 45/2024), the government "
+        "tariff (PNBP) for an ITAP is Rp 7,000,000 for the 5-year duration."
+    ),
+    "finalv2_q12": (
+        "For the Golden Visa family, the official government PNBP structure is: "
+        "IDR 13,000,000 total for the 5-year tier (residence permit "
+        "IDR 7,000,000 + visa IDR 500,000 + verification IDR 2,000,000)."
+    ),
+}
+
+# --- INNOCENCE: the model answers, also verbatim -------------------------
+
+COMPLIANT_NO_FIGURE: dict[str, str] = {
+    "defers_to_the_team": (
+        "The government fee (PNBP) is set by immigration, varies by code and "
+        "by how many years you choose, and can change over time — so rather "
+        "than quote a figure that may age, ask our team for the current one."
+    ),
+    "d12_defers": (
+        "The government fee (PNBP) for a D12 depends on whether you choose the "
+        "1-year or 2-year validity, and it is set by immigration and can "
+        "change over time."
+    ),
+    "non_refundable": (
+        "Government fees (PNBP) paid to Indonesian Immigration are, in "
+        "practice, treated as non-refundable once your application has been "
+        "reviewed and a decision issued."
+    ),
+    "reentry_bundled": (
+        "Yes — you can travel in and out of Indonesia during your Investor "
+        "KITAS's validity. A re-entry permit is bundled directly into your "
+        "permit, and its government fee is part of what you already paid."
+    ),
+}
+
+NO_GOVERNMENT_FEE_AT_ALL: dict[str, str] = {
+    "our_price": "Bali Zero quotes the Investor KITAS at Rp 20.000.000, all inclusive.",
+    "no_money": "An Investor KITAS is granted for either 1 or 2 years, at your choice.",
+    "empty": "",
+}
+
+
+class TestGuilt:
+    @pytest.mark.parametrize("name", sorted(OFFENDERS))
+    def test_every_known_offender_is_refused(self, name: str) -> None:
+        """Recall measured at 9 of 9 against the live collection, 2026-09-03."""
+        refusal = row_is_refused({"answer": OFFENDERS[name]})
+        assert refusal is not None, f"{name} states a government-fee figure and must be refused"
+        assert "all-inclusive" in refusal, "the refusal must name the ruling it enforces"
+
+    def test_the_doctrine_row_is_caught_by_the_FACT_not_the_phrasing(self) -> None:
+        """W82. The predecessor sweep searched "we always show the two figures
+        separately" and missed "We always keep these two costs distinct" — the
+        same teaching, different words. Rewording must not buy an escape."""
+        for reworded in (
+            "We always keep these two costs distinct: PNBP Rp 9,500,000 is the "
+            "government's, our service fee is ours.",
+            "Teniamo sempre separate le due voci: la tassa governativa è "
+            "Rp 9.500.000, il nostro onorario è a parte.",
+            "Kami selalu memisahkan dua biaya ini: biaya pemerintah "
+            "Rp 9.500.000 dan jasa kami terpisah.",
+        ):
+            assert row_is_refused({"answer": reworded}) is not None, reworded
+
+
+class TestInnocence:
+    @pytest.mark.parametrize("name", sorted(COMPLIANT_NO_FIGURE))
+    def test_naming_a_government_fee_without_a_figure_passes(self, name: str) -> None:
+        """These are the answers the ruling WANTS: they explain that a
+        government charge exists and refuse to quote it. 27 of the 50
+        government-fee rows in the live collection are this shape."""
+        text = COMPLIANT_NO_FIGURE[name]
+        assert scan_government_fee(text) is not None, "the token IS present"
+        assert row_is_refused({"answer": text}) is None, "but no figure — must pass"
+
+    @pytest.mark.parametrize("name", sorted(NO_GOVERNMENT_FEE_AT_ALL))
+    def test_a_row_that_names_no_government_fee_is_never_touched(self, name: str) -> None:
+        """758 of 808. Our own all-inclusive price is not a government fee."""
+        text = NO_GOVERNMENT_FEE_AT_ALL[name]
+        assert scan_government_fee(text) is None
+        assert row_is_refused({"answer": text}) is None
+
+
+class TestTheReviewMarker:
+    """The escape hatch for the 17 compliant rows that DO name a figure.
+
+    No lexical rule separates "the government charges X, we charge Y" from
+    "our X already includes the government charge" — a proximity rule was
+    calibrated against the nine offenders and rejected on its numbers (at
+    every window from 40 to 160 chars it caught at most 8 of 9 while blocking
+    11 to 13 compliant rows). So the gate refuses by default and a human says
+    otherwise, per row, in writing.
+    """
+
+    ALL_INCLUSIVE = (
+        "Government immigration fees are included: our E33 Second Home price is "
+        "one all-inclusive figure of Rp 20.000.000 that already contains the "
+        "statutory PNBP, so you will never be asked to pay a government fee on top."
+    )
+
+    def test_a_compliant_figure_bearing_row_is_refused_without_the_marker(self) -> None:
+        assert row_is_refused({"answer": self.ALL_INCLUSIVE}) is not None
+
+    def test_the_marker_plus_a_note_releases_it(self) -> None:
+        row = {
+            "answer": self.ALL_INCLUSIVE,
+            REVIEW_FLAG_FIELD: True,
+            REVIEW_NOTE_FIELD: "all-inclusive explainer; the figure IS our price",
+        }
+        assert row_is_refused(row) is None
+
+    def test_the_flag_alone_is_not_enough(self) -> None:
+        """A bare boolean is a checkbox. A note is a claim someone can be held to."""
+        for note in (None, "", "   "):
+            row = {
+                "answer": self.ALL_INCLUSIVE,
+                REVIEW_FLAG_FIELD: True,
+                REVIEW_NOTE_FIELD: note,
+            }
+            assert row_is_refused(row) is not None, f"note={note!r} must not release the row"
+
+    def test_a_truthy_non_true_flag_is_not_enough(self) -> None:
+        """`is True`, not truthiness: "no", "false" and 1 are all truthy strings
+        or ints someone could put in a JSONL by accident."""
+        for flag in ("false", "no", 1, "yes"):
+            row = {
+                "answer": self.ALL_INCLUSIVE,
+                REVIEW_FLAG_FIELD: flag,
+                REVIEW_NOTE_FIELD: "reviewed",
+            }
+            assert row_is_refused(row) is not None, f"flag={flag!r} must not release the row"

--- a/apps/backend-rag/scripts/curated_qa_harvest.py
+++ b/apps/backend-rag/scripts/curated_qa_harvest.py
@@ -151,6 +151,7 @@ class HarvestStats:
 
     faq_written: int = 0
     faq_answerless_skipped: int = 0
+    government_fee_refused: int = 0
     faq_collision_refused: int = 0
     faq_failed: int = 0
     faq_ineligible_skipped: int = 0
@@ -188,6 +189,11 @@ class HarvestStats:
                 f"ineligible_skipped={self.faq_ineligible_skipped} "
                 f"price_rejected={self.faq_price_rejected} "
                 f"failed={self.faq_failed}",
+            )
+        if self.government_fee_refused:
+            lines.append(
+                f"Government-fee gate: refused={self.government_fee_refused} "
+                "(states a government-fee figure without an explicit review marker)"
             )
         if self.qdrant_written or self.qdrant_answerless_skipped or self.qdrant_failed:
             lines.append(
@@ -847,6 +853,12 @@ def _load_and_gate_batches(
     source_file_sha256 matches the file's CURRENT content. Returns the list
     of gate-passing (batch_id, manifest_path, manifest, rows) groups.
     """
+    # Lazy, like every other backend import in this script: the module is
+    # importable (and --help works) without the backend package present.
+    from backend.services.misc.curated_qa_government_fee_detector import (
+        row_is_refused as government_fee_row_is_refused,
+    )
+
     batches: list[tuple[str, Path, dict[str, Any], list[dict]]] = []
 
     for p in paths:
@@ -861,6 +873,27 @@ def _load_and_gate_batches(
                 stats.invalid_rows += 1
                 logger.error("Invalid row %r: %s", row.get("question", "<unknown>"), error)
                 continue
+            # Pre-ingest FACT-scan (cycle 359): a row that states a
+            # GOVERNMENT-FEE FIGURE to a client is refused from BOTH sinks
+            # unless it carries an explicit per-row review marker. Placed
+            # here, in the shared validation loop, so it is impossible to
+            # reach Qdrant through the FAQ sink's absence or vice versa —
+            # the two sinks are loaded separately downstream, and a gate
+            # that guards only one is not a gate.
+            #
+            # This is the thing that survives deleting the offending points:
+            # their source file has never existed in this repo, so a
+            # deletion alone leaves the next harvest free to write them back.
+            fee_refusal = government_fee_row_is_refused(row)
+            if fee_refusal:
+                stats.government_fee_refused += 1
+                logger.error(
+                    "REFUSED %r: %s",
+                    str(row.get("question", "<unknown>"))[:120],
+                    fee_refusal,
+                )
+                continue
+
             valid_rows.append(row)
             confidence_class = str(row.get("confidence_class"))
             stats.confidence_class_counts[confidence_class] = (

--- a/evidence/2026-09/agent-nuzantara-ops-bot-wa-corpus-a7726b90/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-bot-wa-corpus-a7726b90/brief.yml
@@ -1,0 +1,22 @@
+task_id: lane-e-bot-wa-corpus-government-fee-gate
+gear: 2
+l_level: L2
+gate_class: client-facing
+objective: >-
+  Refuse, at ingest, any curated_qa row that states a government-fee figure to a
+  client without an explicit per-row review marker. Cycle 359 questions 11 and 14
+  volunteered "PNBP Rp 9.500.000" beside the Bali Zero price against Zero's
+  standing one-all-inclusive-price ruling; the cause is the corpus, not the
+  prompt, and the offending points' source file has never existed in this repo,
+  so deleting them alone leaves the next harvest free to write them back.
+grader: codex-sol
+pii: none
+notes: >-
+  Recall measured 9/9 against the live 808-point collection; cost measured at 26
+  refusals, of which 17 are compliant rows that now need a written note. A
+  proximity rule was built as the alternative and REJECTED on its numbers (at
+  every window from 40 to 160 chars it caught at most 8 of 9 while blocking 11
+  to 13 compliant rows) — recorded in the module docstring so it is not
+  re-derived. Mutation-verified: replacing the gate call with `fee_refusal =
+  None` turns the wiring test red. The data half (two prod Qdrant deletions) was
+  snapshotted with vectors to a 0600 file outside the repo before execution.


### PR DESCRIPTION
## The defect

Cycle 359 questions 11 and 14 volunteered **`PNBP Rp 9.500.000`** beside the Bali Zero price,
against Zero's standing ruling of **ONE all-inclusive client-facing price** (2026-07-17, re-ruled
2026-09-01). The cause is not the prompt — **the corpus teaches the split.**

Deleting the offending Qdrant points fixes today and nothing else: their source file
(`GARUDA-E28A-DEFINITIVE-CHATKB-2026-07-18.md`) has never existed in this repo, and
`apps/backend-rag/data/curated_qa/` is gitignored, so the next harvest can write them straight
back from a local staging file nobody can review. **This PR is the part that survives the deletion.**

## The scan is on the FACT, never a phrasing

The sweep that preceded this gate reported "5 offenders, 808 scanned, 1 residual" and was **falsely
reassuring**: it searched the phrasings someone had catalogued (*"we always show the two figures
separately"*) and missed *"We always keep these two costs distinct"* — the same teaching, different
words. W82, under-match.

So the scan is: **a government-fee token and a money figure in the same answer.** A rewording
cannot escape it, because the fee and the figure are what the offence is made of. Pinned by three
rewordings in three languages.

## Measured against the live collection, 808 points, 2026-09-03

| shape | count | verdict |
|---|---:|---|
| no government-fee token | 758 | untouched |
| token, **no** money figure | 27 | **passes** — and these are the model answers: *"rather than quote a figure that may age, ask our team"* |
| token **and** a money figure | 26 | **refused unless reviewed** |

Of those 26, **9 are genuine offenders — recall 9 of 9** — and 17 are compliant answers that name a
figure legitimately (*"one all-inclusive figure that already contains the statutory PNBP, so you
will never be asked to pay a government fee on top"*).

## It does not pretend to decide, and the numbers say why

A **proximity rule** (a money figure within N characters of the fee token) was calibrated against
the nine offenders and **rejected on its own numbers**:

```
W= 40  caught=7/9  extra_blocked=8
W= 60  caught=7/9  extra_blocked=10
W= 80  caught=7/9  extra_blocked=11
W=120  caught=8/9  extra_blocked=13
W=160  caught=8/9  extra_blocked=13
```

No lexical rule separates *"the government charges X, we charge Y"* from *"our X already includes
the government charge"* — that difference is semantic. So the gate is **high-recall and
refuse-by-default**, with a per-row escape costing one flag **and** a written note. `is True`, not
truthiness: a bare boolean is a checkbox, a note is a claim someone can be held to.

## Wiring

`_load_and_gate_batches` — the **shared** validation loop, so a refused row is kept out of the FAQ
sink **and** the Qdrant sink together. The two are loaded separately downstream, and a gate that
guards only one is not a gate.

## Bites

**Consumer: `scripts/curated_qa_harvest.py`, the only writer of the `curated_qa` collection that
grounds every client answer.** The observation is a **mutation**, not a passing test — replacing the
call with `fee_refusal = None` turns the wiring test red:

```
$ # gate call removed
FAILED test_a_row_stating_a_government_fee_figure_is_refused_from_BOTH_sinks - assert 0 == 1
$ # restored
97 passed
```

**Data side, already executed (restorable):** the two points the lane mandate names — the Investor
KITAS cost answered with the government fee alone, and *"We always keep these two costs distinct"* —
were snapshotted **with their vectors** to a 0600 file outside the repo and deleted from prod:

```
delete: completed
points_count 808 -> 806   still-present: 0
Investor-KITAS answers still carrying a PNBP figure: 0   (re-scanned all 806)
```

End-to-end prove-live on the real WhatsApp thread is cycle 360's job, in its battery table.

## Deliberately NOT in this PR — named, measured, not narrowed away

1. **Seven further `curated_qa` offenders are still live.** The three the mandate asked me to
   *review* (`8b520434` E33E#Q13 "which we quote separately", `eacec21f` FINAL#Q11, `8ebf681f`
   FINAL#Q13) are all offenders under the ruling, and the FACT-scan found **four more the corner had
   not named**: `11b7e26d`, `12d804e9`, `1b53de60`, `e407d532`. All seven are snapshotted and ready.
   Deleting them applies a standing ruling — but it more than triples an explicit two-row order on
   **production client-facing data**, so it is surfaced rather than taken.

2. **A worse carrier exists in a different collection.** `training_conversations_hybrid` holds
   **8 points** teaching the split, and **6 of them model a consultant giving an itemised PT PMA
   quote** — *"Jasa Pendirian: IDR 20.000.000 / Biaya PNBP (Negara): IDR 5.000.000"* — in Indonesian,
   Javanese and English, on the single most common pricing question. That is not a mention of the
   split; it is a worked example of performing it.

3. **The training-data file has four occurrences, not one.** The mandate named
   `visa_011_notebooklm_session2.md:123`; it is fixed (backed up first). Lines 315, 547 and 711 of
   the same file carry it too, and `grep -rc PNBP` over `training-data/` returns **36 lines across
   5 files**. Rewriting 36 lines of a client-facing corpus by hand, unreviewed, in a gitignored
   staging directory is not a thing to do quietly. `scripts/reingest_training_data.py` is the
   ingest path and is where the same detector belongs — its own PR.

## Scope

+1 module, +1 test file, harvester wiring, harvester tests. No migration, no config, no secret.