### PR TITLE
docs(research): context engineering SOTA study — Karpathy, Anthropic, OSS repos vs Nuzantara

### DIFF
--- a/evidence/2026-09/agent-air-m5-ops-context-engineering-sota-eecdde90/brief.yml
+++ b/evidence/2026-09/agent-air-m5-ops-context-engineering-sota-eecdde90/brief.yml
@@ -1,0 +1,34 @@
+task_id: context-engineering-sota-0904
+gear: 2
+l_level: L2
+gate_class: opus
+objective: |
+  Deep-research capture ordered by Zero on 2026-09-04: "verifica come i migliori al mondo
+  gestiscono questo contesto, controlla i repo migliori e i migliori dev come Karpathy, e così
+  studiamo il report". Trigger: the /context panel of an M5 session at 60% (297.6k/500k) with
+  ~137k of fixed per-session overhead, 52k of it memory files.
+
+  Three parallel research lanes (Karpathy/thought-leaders · official Anthropic guidance · SOTA
+  open-source agents) synthesized into research/operations/2026-09-04-context-engineering-sota.md,
+  with the three lane raw files landed beside it for audit. The report compares the SOTA consensus
+  against the measured Nuzantara panel and ranks recommendations R1-R7 (CLAUDE.md diet + CI-armed
+  byte budget being the dominant lever). STUDY-ONLY: no recommendation is executed in this PR;
+  Zero decides on R1-R6 (doctrine surface, Legge 5).
+
+  Gear 2 by SIZE: 4 new markdown files, +511 net lines, no code, no hot zone, no consumer surface.
+  The floor recompute reached 2 via the SIZE term alone; this brief declares it.
+constraints:
+  - "Docs-only diff: research/operations/*.md plus this evidence dir. No code, no config, no
+    doctrine file is touched — the report RECOMMENDS a CLAUDE.md diet, it does not perform one."
+  - "Anti-hallucination: every lane was instructed to report only what fetched pages actually say
+    and to flag unreachable sources; the flagged limits (X/Twitter HTTP 402, OpenAI/Google sections
+    aggregated-only, single-source compaction table) are carried verbatim into the report's
+    'Limiti' section rather than laundered."
+  - "Generator != grader: the synthesis author is the conducting Claude session; the adversarial
+    review seat is codex (GPT-5.6, cross-family), probed live (PONG ~39s) before dispatch."
+acceptance:
+  - "Report exists at research/operations/2026-09-04-context-engineering-sota.md with frontmatter
+    (date/domain/client_case/sources) per CLAUDE.md §15."
+  - "The three lane raw files sit beside it with the -lane-* suffix."
+  - "R1 gate satisfied: adversarial_review seat declared, ## Adversarial review section present
+    with the disposition of codex's findings."

--- a/research/operations/2026-09-04-context-engineering-sota-lane-anthropic.md
+++ b/research/operations/2026-09-04-context-engineering-sota-lane-anthropic.md
@@ -1,3 +1,10 @@
+---
+date: 2026-09-04
+domain: operations
+client_case: none — raw lane capture for 2026-09-04-context-engineering-sota.md
+adversarial_review: exempt-raw-lane-capture-reviewed-via-synthesis
+---
+
 # Guidance ufficiale su context management per agenti (Anthropic + confronto OpenAI/Google)
 (lane research-anthropic, 2026-09-04)
 

--- a/research/operations/2026-09-04-context-engineering-sota-lane-anthropic.md
+++ b/research/operations/2026-09-04-context-engineering-sota-lane-anthropic.md
@@ -1,0 +1,115 @@
+# Guidance ufficiale su context management per agenti (Anthropic + confronto OpenAI/Google)
+(lane research-anthropic, 2026-09-04)
+
+## 1. Anthropic — "Effective context engineering for AI agents"
+Fonte: https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+
+**Framing**: context engineering è l'evoluzione del prompt engineering — non "trovare le parole giuste" ma "quale configurazione di contesto è più probabile che generi il comportamento desiderato". Principio guida (testuale): **"the smallest possible set of high-signal tokens that maximize the likelihood of your desired outcome"**.
+
+**Attention budget / context rot**: gli LLM hanno un "attention budget" limitato che si esaurisce a ogni token aggiunto. "Context rot" = la capacità di recuperare accuratamente informazioni degrada al crescere dei token. Causa architetturale: relazioni n² tra token nel Transformer → tensione naturale tra dimensione del contesto e focus dell'attenzione.
+
+**System prompt — "right altitude"**: zona Riccioli d'oro tra (a) troppo **brittle** (logica fragile hardcodata) e (b) troppo **vago** (guida alto-livello senza segnali concreti). Operativo: partire da un prompt minimalista sul modello migliore, aggiungere istruzioni SOLO in risposta a fallimenti osservati, mai preventivamente.
+
+**Retrieval: just-in-time vs pre-loading**: JIT = identificatori leggeri (path, query, link) + caricamento dinamico via tool, invece di pre-caricare tutto. Ibrido consigliato: alcuni dati anticipati per velocità + libertà di esplorazione autonoma.
+
+**Tre tecniche per task long-horizon**:
+1. **Compaction**: riassumere la cronologia e reinizializzare. L'arte è nella selezione — prima massimizzare il recall, poi iterare sulla precisione. Tecnica leggera: "clearing tool results" (eliminare output grezzi dei tool consumati).
+2. **Structured note-taking**: note persistenti fuori dalla window (Claude Code to-do list; "Claude Pokémon" tally su migliaia di step). Memory tool in beta pubblica.
+3. **Sub-agent architectures**: agenti con context puliti per task focali; ogni subagente esplora decine di migliaia di token ma restituisce **1.000-2.000 token** di riassunto.
+
+## 2. Anthropic — "Best practices for Claude Code" (versione corrente 2026)
+Fonte: https://code.claude.com/docs/en/best-practices (redirect 308 dal post aprile 2025)
+
+**Vincolo fondante (testuale)**: "Most best practices are based on one constraint: Claude's context window fills up fast, and performance degrades as it fills." Un singolo debugging può generare "tens of thousands of tokens". Usare `/context` per ispezionare, status line per tracciare.
+
+**CLAUDE.md — raccomandazioni esatte**:
+- Generato con `/init`, raffinato nel tempo. "Keep it short and human-readable".
+- **Test di inclusione riga per riga**: *"Would removing this cause Claude to make mistakes? If not, cut it."*
+- ✅ Include: bash command non indovinabili, code style non-standard, istruzioni testing, repo etiquette, decisioni architetturali specifiche, quirk env, gotcha non ovvi.
+- ❌ Exclude: derivabile dal codice, convenzioni standard, doc API dettagliata (linkare), info che cambiano spesso, tutorial lunghi, descrizioni file-per-file, pratiche ovvie.
+- **Diagnostica**: Claude ignora una regola presente → file troppo lungo, la regola si perde nel rumore. Claude chiede cose già scritte → fraseggio ambiguo.
+- Enfasi "IMPORTANT" SOLO su una riga alla volta: "If you emphasize many lines, none of them stands out".
+- Trattato come codice: "review it when things go wrong, prune it regularly, test changes by observing whether Claude's behavior actually shifts". `/doctor` propone tagli per contenuto derivabile.
+- Import con `@path/to/import`.
+- **Anti-pattern nominato**: "The over-specified CLAUDE.md" — troppo lungo ⇒ Claude ignora metà del contenuto. Fix: "Ruthlessly prune. If Claude already does something correctly without the instruction, delete it or convert it to a hook."
+
+**Skills vs CLAUDE.md**: CLAUDE.md caricato OGNI sessione → solo cose sempre applicabili. Conoscenza di dominio/workflow occasionali → skills on-demand.
+
+**/clear e /compact**:
+- Auto-compact vicino ai limiti, preservando codice e decisioni.
+- `/clear` **frequente tra task non correlati**.
+- `/compact <istruzioni>` per controllo fine. `Esc+Esc`/`/rewind` per riassumere solo una parte.
+- CLAUDE.md può istruire la compaction (es. "When compacting, always preserve the full list of modified files and any test commands").
+- `/btw` per domande usa-e-getta fuori cronologia.
+- **>2 correzioni fallite sullo stesso problema → contesto "polluted"** → `/clear` + riprompt. "A clean session with a better prompt almost always outperforms a long session with accumulated corrections."
+
+**Subagents**: "Since context is your fundamental constraint, use subagents to keep research out of it." Riportano solo riassunti. Anche per adversarial review (reviewer fresh-context vede solo diff + criteri).
+
+**Multi-Claude workflow**: worktree paralleli; cross-session messaging; Writer/Reviewer su due sessioni (context fresco = review non biased); `/batch` fan-out 5-30 subagent con worktree+PR ciascuno.
+
+**Anti-pattern elencati**: kitchen sink session · correcting over and over (>2 → /clear) · over-specified CLAUDE.md · trust-then-verify gap · infinite exploration (→ scope narrow o subagent).
+
+## 3. Anthropic — "How we built our multi-agent research system"
+Fonte: https://www.anthropic.com/engineering/built-multi-agent-research-system
+
+**Orchestrator-worker**: lead coordina, delega a subagenti paralleli con istruzioni dettagliate (obiettivo, formato output, guida tool/fonti, confini).
+
+**Token economics**:
+- Single-agent: **~4×** token di una chat. Multi-agente: **~15×**.
+- **"token usage alone explains 80% of the variance in performance"**.
+- Multi-agente (Opus 4 lead + Sonnet 4 subagenti) **supera un singolo Opus 4 del 90.2%** (su research eval).
+
+**Quando conviene**: breadth-first parallelizzabile, alto valore, ricerche oltre una singola window. **Quando NO**: contesto condiviso/dipendenze forti — "most coding tasks involve fewer truly parallelizable tasks than research."
+
+## 4. Anthropic — Memory tool e Context editing (docs API)
+Fonte: https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool
+
+**Memory tool** (Claude 4+): client-side, operazioni file (`view`, `create`, `str_replace`, `insert`, `delete`, `rename`) sotto `/memories`. JIT context retrieval: l'agente registra ciò che apprende e lo rilegge on-demand. Con memory tool attivo l'API inietta: "IMPORTANT: ALWAYS VIEW YOUR MEMORY DIRECTORY BEFORE DOING ANYTHING ELSE."
+
+**Context editing vs compaction**: context editing ripulisce tool result client-side; compaction riassume l'intera conversazione server-side. Per agenti long-running: entrambi — "compaction keeps the active context small without client-side bookkeeping, and memory preserves the information that must survive summarization."
+
+**Pattern "Multisession software development"**: sessione initializer scrive progress log + feature checklist PRIMA del lavoro; ogni sessione successiva riparte leggendo quei file; "completa" solo dopo verifica end-to-end.
+
+(Caveat: soglie di context editing citate da fonti terze — 60% window, ultimi 5 tool use — NON ri-verificate su fonte primaria.)
+
+## 5. Claude Code — Agent Skills / progressive disclosure (docs ufficiali)
+Fonte: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+
+| Livello | Quando caricato | Costo token | Contenuto |
+|---|---|---|---|
+| 1: Metadata | Sempre, all'avvio | **~100 token per Skill** | `name`+`description` YAML |
+| 2: Instructions | Al trigger | **<5k token** | corpo SKILL.md |
+| 3+: Resources | Solo se referenziati | 0 finché non acceduti | file bundlati, script (solo l'OUTPUT entra in context) |
+
+La `description` deve dire **cosa fa E quando usarla** — è il testo di matching. Vincoli: name max 64 char; description max 1024 char.
+
+## 6. Confronto — OpenAI (AGENTS.md) e Google (GEMINI.md)
+(Caveat: ricerca aggregata, fonti primarie NON fetchate direttamente.)
+
+**OpenAI AGENTS.md**: "the most important context management tool for Codex". Governance passata alla **Agentic AI Foundation sotto Linux Foundation** — standard cross-tool multi-vendor. Regole di team obbligatorie in AGENTS.md checked-in; memorie conversazionali come layer di recall locale, non fonte unica.
+
+**Google GEMINI.md**: gerarchia 3 livelli (`~/.gemini/GEMINI.md` globale → `./GEMINI.md` progetto → `./src/GEMINI.md` subdirectory). Tutti i file trovati **concatenati eager a OGNI prompt** — nessun lazy load nativo. `/memory show` e `/memory reload`. Import modulari `@file.md`.
+
+**Differenza chiave**: solo Anthropic Skills = progressive disclosure vera (lazy, ~100 token finché non triggerata); GEMINI.md = concatenazione eager; AGENTS.md = standardizzazione cross-vendor più che caricamento incrementale.
+
+## 7. Materiale 2026
+
+- Prompt caching (fetch diretto platform.claude.com): minimo cacheable **512 token per Fable 5.1/Mythos 5.1/Opus 5/Fable 5/Mythos 5** (1.024 per Opus 4.8 e Sonnet 5/4.6/4.5; 4.096 per Opus 4.6/4.5 e Haiku 4.5). Max 4 cache breakpoint (400 oltre). TTL default 5 min (reset a ogni hit); TTL 1h a 2× cache-write (vs 1.25× per 5 min). Cache read **0.1× input base** (0.025× per Fable 5.1/Mythos 5.1). Lookback window 20 blocchi → su conversazioni lunghe servono 2 breakpoint.
+- "Best practices" 2026 include: plan mode Shift+Tab, checkpoint/rewind Esc+Esc, `/goal` gate deterministico via evaluator separato, Stop hook (override dopo 8 blocchi), auto mode con classifier, `/batch` 5-30 subagent, Agent teams (sperimentale).
+
+## Principi operativi estraibili
+
+- **Test del taglio-riga su CLAUDE.md**: "la sua rimozione causerebbe errori?" — se no, tagliare. [best-practices]
+- **Niente in CLAUDE.md di derivabile dal codice o che cambia spesso** — skill on-demand invece. [best-practices]
+- **"IMPORTANT" solo su UNA riga** — enfasi diffusa = zero enfasi. [best-practices]
+- **`/clear` tra task non correlati, sempre**. [best-practices]
+- **>2 correzioni fallite → `/clear` + riprompt specifico**. [best-practices]
+- **Esplorazione delegata a subagent** (riassunto 1-2k token vs decine di migliaia esplorati). [effective-context-engineering; multi-agent-research]
+- **Review adversariale in context fresco** (solo diff + criteri). [best-practices]
+- **Multi-agente SOLO per breadth-first ad alto valore** (~15× token; il coding parallelizza poco). [multi-agent-research]
+- **Compaction: recall prima, precisione poi**. [effective-context-engineering]
+- **Memory tool / pattern initializer-session** per stato che sopravvive a compaction/reset. [memory-tool docs]
+- **Skill description = cosa + quando** (unico costo ~100 token finché non triggera). [agent-skills docs]
+- **Caching: statico prima del dinamico**, `cache_control` sull'ultimo blocco statico. [prompt-caching docs]
+- **System prompt "right altitude"**: minimale, poi regole solo su fallimenti osservati. [effective-context-engineering]
+- **Cross-vendor**: Skills Anthropic = lazy (più efficiente all'avvio); GEMINI.md = eager; AGENTS.md = standard cross-tool. [aggregato, da verificare]

--- a/research/operations/2026-09-04-context-engineering-sota-lane-karpathy.md
+++ b/research/operations/2026-09-04-context-engineering-sota-lane-karpathy.md
@@ -1,3 +1,10 @@
+---
+date: 2026-09-04
+domain: operations
+client_case: none — raw lane capture for 2026-09-04-context-engineering-sota.md
+adversarial_review: exempt-raw-lane-capture-reviewed-via-synthesis
+---
+
 # Report: Context Engineering secondo Karpathy e i thought-leader del settore
 
 ## 1. Andrej Karpathy

--- a/research/operations/2026-09-04-context-engineering-sota-lane-karpathy.md
+++ b/research/operations/2026-09-04-context-engineering-sota-lane-karpathy.md
@@ -1,0 +1,103 @@
+# Report: Context Engineering secondo Karpathy e i thought-leader del settore
+
+## 1. Andrej Karpathy
+
+**Origine del termine (giugno 2025).** Il 27 giugno 2025 Karpathy pubblica su X il tweet che ha coniato/consacrato il termine "context engineering", proponendolo come sostituto di "prompt engineering". La sua tesi: "prompt" evoca nell'immaginario comune una breve istruzione digitata in una chat, mentre nelle applicazioni LLM industriali il vero lavoro è l'arte e scienza delicata di riempire la finestra di contesto con esattamente le informazioni giuste per il passo successivo — includendo descrizioni del task, few-shot examples, RAG, dati multimodali, tool e cronologia. ([x.com/karpathy](https://x.com/karpathy/status/1937902205765607626); ricostruzione via [MindStudio](https://www.mindstudio.ai/blog/software-3-0-explained-karpathy-context-window-ram-model-weights-cpu), [thecontextgraph.co](https://thecontextgraph.co/memos/context-engineering-2026-from-tweet-to-infrastructure))
+
+**LLM come CPU / "LLM OS".** Nel framework più ampio di Karpathy (elaborato nel talk "Software 3.0", presentato in varie sedi nel 2025 e ripreso a Y Combinator/Latent Space) l'LLM non è un'applicazione ma un nuovo tipo di sistema operativo: i pesi del modello funzionano come CPU/processore fisso, il context window funge da RAM/working memory, e tutto ciò che sta fuori dal contesto (vector store, documenti, cronologia) è "disco" — storage passivo che richiede un'operazione esplicita di load per influenzare il ragionamento. Il prompting diventa quindi "programmazione": il context window è il "codice" scritto in linguaggio naturale che governa il computer neurale. ([Latent Space "Software 3.0"](https://www.latent.space/p/s3); [MindStudio](https://www.mindstudio.ai/blog/software-3-0-explained-karpathy-context-window-ram-model-weights-cpu); [aibuilderclub](https://www.aibuilderclub.com/blog/karpathy-software-3-0))
+
+**"Anterograde amnesia".** Karpathy descrive gli agenti attuali come affetti da un problema simile all'amnesia anterograda: nessun consolidamento di conoscenza a lungo termine dopo il training, solo una memoria a breve termine limitata (il context window). Paragona questa condizione a un collega che non accumula mai competenze durature — un limite strutturale che rende la context window l'unico "luogo" dove l'agente può "ricordare" qualcosa entro una sessione. ([thegenios.com](https://thegenios.com/blog/karpathy-on-memory-and-context/))
+
+**Sequoia Ascent 2026 (30 aprile 2026, dal suo blog personale).** Qui Karpathy formalizza la distinzione tra **vibe coding** ("alza il floor" — chiunque può costruire software senza capire la sintassi, modalità "prompt and pray") e **agentic engineering** ("alza il ceiling" — i professionisti vanno più veloci senza sacrificare qualità: spec design, diff review, eval loop, guardrail espliciti, gestione permessi). Sul contesto, la sua ricetta operativa condensata è: definire il contesto, definire gli strumenti, definire il feedback loop, definire i guardrail, e solo allora lasciare lavorare l'agente. Immagina anche uno scenario futuro di "computer completamente neurali" dove la rete neurale è il processo host e le CPU tradizionali diventano coprocessori. Nello stesso talk cita "context builders" come Gitingest e DeepWiki (Cognition) come strumenti che strutturano informazioni leggibili dagli agenti, e nota che l'HTML è poco parsabile per gli LLM — da cui l'emergere di formati alternativi tipo `llms.txt`. ([karpathy.bearblog.dev/sequoia-ascent-2026](https://karpathy.bearblog.dev/sequoia-ascent-2026/); riassunto [MindStudio](https://www.mindstudio.ai/blog/karpathy-sequoia-talk-5-predictions-agentic-engineering))
+
+**Sviluppo recente (maggio 2026).** Il 19 maggio 2026 Karpathy ha annunciato di essersi unito al team di pre-training di Anthropic, guidato da Nicholas Joseph, con l'obiettivo dichiarato di costruire un gruppo che usi Claude per accelerare la ricerca sul pre-training stesso. Non risulta, nelle fonti raccolte, un nuovo scritto pubblico specifico sul context engineering datato dopo questo passaggio. ([TechCrunch](https://techcrunch.com/2026/05/19/openai-co-founder-andrej-karpathy-joins-anthropics-pre-training-team/); [Let's Data Science](https://letsdatascience.com/blog/karpathy-joins-anthropic-pretraining-team-may-19-2026))
+
+**Autonomy slider.** Concetto correlato: dare agli utenti un cursore di autonomia variabile invece di un binario "manuale/automatico" — esempi citati sono Cursor (Tab → Cmd+K → Agent mode), Perplexity (search → research → deep research) e Tesla Autopilot (livelli 1-4). La logica: una demo richiede solo che *una* traiettoria funzioni, un prodotto richiede che funzionino *tutte*. ([MindStudio](https://www.mindstudio.ai/blog/karpathy-sequoia-talk-5-predictions-agentic-engineering))
+
+---
+
+## 2. Drew Breunig — tassonomia dei fallimenti del contesto
+
+Fonte primaria: "How Long Contexts Fail" (22 giugno 2025) di Drew Breunig. ([dbreunig.com](https://www.dbreunig.com/2025/06/22/how-contexts-fail-and-how-to-fix-them.html))
+
+| Fallimento | Definizione | Esempio empirico citato |
+|---|---|---|
+| **Context Poisoning** | Un'allucinazione o un errore entra nel contesto e viene ripetutamente ri-referenziato | Nel playthrough di Pokémon con Gemini 2.5, l'agente allucinava durante il gioco contaminando la sezione "goals" con stato di gioco errato, producendo strategie insensate ripetute verso un obiettivo irraggiungibile |
+| **Context Distraction** | Il contesto diventa così lungo che il modello se ne sovra-affida, trascurando ciò che ha appreso durante il training | Gemini 2.5 Pro (1M+ token) oltre i 100k token tendeva a ripetere azioni dalla cronologia invece di sintetizzare nuovi piani; uno studio Databricks trova che la correttezza cala già intorno ai 32k token per Llama 3.1 405B, e prima ancora per modelli più piccoli |
+| **Context Confusion** | Contenuto superfluo nel contesto viene usato dal modello e degrada la qualità della risposta | Berkeley Function-Calling Leaderboard: ogni modello testato peggiora quando riceve più di un tool disponibile; su GeoEngine (46 tool) un Llama 3.1 8B quantizzato fallisce con tutti i 46 tool ma riesce con solo 19 |
+| **Context Clash** | Nuove informazioni/tool accumulati nel contesto entrano in conflitto con informazioni già presenti | Studio Microsoft/Salesforce su prompt "sharded" (distribuiti su più turni): calo medio del 39% nelle prestazioni; il modello o3 crolla da un punteggio di 98,1 a 64,1. I modelli fanno assunzioni premature nei primi turni e non si riprendono se imboccano la strada sbagliata |
+
+**Mitigazioni** (elaborate nel seguito, "How to Fix Your Context", ripreso e sistematizzato anche da Simon Willison):
+- **RAG (retrieval selettivo)** — invece di stipare tutto, recuperare dinamicamente solo ciò che serve
+- **Tool loadout** — selezionare un sottoinsieme di tool attivi per il task corrente: la ricerca citata mostra che oltre ~20 tool disponibili confonde alcuni modelli
+- **Context quarantine** — isolare sotto-contesti in thread dedicati separati (pattern usato da Claude Code e dal sistema multi-agente di ricerca di Anthropic)
+- **Context pruning** — rimuovere attivamente informazioni superflue accumulate
+- **Context summarization** — condensare un contesto lungo in un riassunto quando si avvicina ai limiti
+- **Context offloading** — spostare informazioni fuori dal context window verso storage esterno (note tool, file `plan.md` negli agenti di coding)
+
+Fonti: [dbreunig.com/2025/06/22](https://www.dbreunig.com/2025/06/22/how-contexts-fail-and-how-to-fix-them.html), [simonwillison.net/2025/Jun/29](https://simonwillison.net/2025/Jun/29/how-to-fix-your-context/)
+
+---
+
+## 3. Simon Willison e swyx/Latent Space
+
+**Simon Willison** (27 giugno 2025, "Context engineering") sostiene che "context engineering" è un termine migliore di "prompt engineering" perché la sua definizione inferita è molto più vicina al lavoro reale — costruire con cura e competenza il contesto giusto per ottenere buoni risultati da un LLM — mentre "prompt engineering" nell'opinione pubblica è ridotto a "digitare cose in una chatbot". Willison cita anche Tobi Lutke (CEO Shopify), che descrive la pratica come l'arte di fornire tutto il contesto necessario perché il task sia plausibilmente risolvibile dall'LLM, e riprende la definizione di Karpathy. Nel post successivo "How to Fix Your Context" (29 giugno 2025) Willison sistematizza le mitigazioni di Breunig (vedi tabella sopra) e conclude che il contesto non è gratuito: ogni token influenza il comportamento del modello, e finestre di contesto ampie non giustificano negligenza nella gestione. ([simonwillison.net/2025/jun/27](https://simonwillison.net/2025/jun/27/context-engineering/), [simonwillison.net/2025/Jun/29](https://simonwillison.net/2025/Jun/29/how-to-fix-your-context/))
+
+**swyx / Latent Space.** Non ho trovato un post/episodio dedicato esclusivamente a una posizione originale di swyx sul tema (le fonti indicano soprattutto il ruolo di Latent Space come piattaforma che ospita la discussione). Un episodio del podcast Latent Space (settembre 2025, con Alessio Fanelli e swyx come host) ha ospitato Lance Martin (LangChain) proprio su "Context Engineering for Agents", discutendo la distinzione prompt engineering vs context engineering e le sfide di gestire il contesto generato dalle tool call negli agenti — ma il contenuto specifico delle affermazioni di Martin non è stato recuperato in questa ricerca (fonte trovata solo come metadato di episodio, non fetchata). swyx descrive comunque il 2025 come "l'anno dei coding agent" e il 2026 come l'anno in cui i coding agent "rompono il contenimento" per fare tutto il resto, nel quadro più ampio "Software 3.0" che Latent Space ha adottato come cornice editoriale. ([podwise.ai — episodio](https://podwise.ai/dashboard/episodes/5181174), [latent.space/p/2026](https://www.latent.space/p/2026))
+
+---
+
+## 4. Manus — "Context Engineering for AI Agents: Lessons from Building Manus" (Yichao "Peak" Ji, 18 luglio 2025)
+
+Fonte: [manus.im/blog](https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus)
+
+- **KV-cache hit rate = metrica #1.** Nel profilo computazionale di un agente in produzione il rapporto token input:output è ~100:1 in Manus. Con Claude Sonnet, i token in cache costano 0,30 USD/MTok contro 3 USD/MTok per quelli non cachati — un differenziale di **10x**. Pratiche per massimizzare il cache hit: prefix del prompt stabile, contesto **append-only** (mai modificare azioni/osservazioni passate), serializzazione deterministica dell'output (es. ordinamento stabile delle chiavi JSON), evitare timestamp nel system prompt.
+- **Mask, don't remove.** Rimuovere dinamicamente dei tool a runtime invalida la KV-cache e può generare violazioni di schema quando azioni passate referenziano tool non più definiti. Manus mantiene stabile la definizione dei tool e maschera invece i logit dei token candidati durante il decoding, tramite una state machine context-aware con response prefill, per vincolare quali azioni sono disponibili senza toccare la cache.
+- **Filesystem come contesto esterno.** Il filesystem è trattato come il "contesto definitivo": illimitato in dimensione, persistente per natura, direttamente operabile dal modello stesso (lettura/scrittura). Le strategie di compressione applicate al contesto in-memory restano reversibili — ad esempio si può scartare il contenuto di una pagina web mantenendone l'URL, in modo che possa essere ri-recuperato se necessario.
+- **Recitation (todo.md).** Manus crea e aggiorna continuamente un file `todo.md` durante task complessi, "recitando" il piano/obiettivo verso la parte finale (più recente) del contesto. Questo contrasta il problema "lost-in-the-middle" e riduce il goal drift mantenendo il piano nell'area di massima attenzione del modello.
+- **Keep the errors in.** Conservare errori e tracce fallite nel contesto (invece di ripulirle) permette al modello di aggiornare le proprie "credenze" interne e migliora la capacità di recovery — considerata un indicatore chiave di comportamento agentivo robusto.
+- **Few-shot rut.** Contesti troppo uniformi (esempi ripetitivi, stessa struttura) inducono il modello a ripetere pattern ciecamente, causando drift o allucinazioni; la mitigazione è introdurre variazione strutturata controllata nella serializzazione, fraseologia e ordinamento.
+- Nota di processo: Manus ha ricostruito il proprio framework agentico **quattro volte**, ogni volta scoprendo un modo migliore di plasmare il contesto — un dato che sottolinea quanto questa disciplina sia empirica e iterativa più che teorica.
+
+---
+
+## 5. Cognition — "Don't Build Multi-Agents" (Walden Yan, giugno 2025)
+
+Fonte: [cognition.com/blog/dont-build-multi-agents](https://cognition.com/blog/dont-build-multi-agents) (redirect da cognition.ai)
+
+Il principio cardine di Yan, riassunto senza citazione diretta estesa (nel rispetto del limite di una sola citazione breve per risposta): al centro dell'affidabilità di un agente sta il context engineering, e questo implica condividere non solo i messaggi individuali ma le tracce complete dell'agente tra sotto-agenti.
+
+- **Il rischio dei sub-agenti a contesto parziale.** Yan illustra il problema con un esempio concreto: costruendo un clone di Flappy Bird tramite sub-agenti paralleli, un sub-agente fraintende il proprio sotto-task e inizia a costruire uno sfondo in stile Super Mario Bros invece che coerente col resto del gioco — perché non vede il contesto/le decisioni implicite prese dagli altri sub-agenti in parallelo.
+- **Decisioni implicite in conflitto.** La formulazione chiave: azioni distinte portano con sé decisioni implicite, e decisioni in conflitto tra loro producono risultati scadenti (`"actions carry implicit decisions, and conflicting decisions carry bad results"` — questa è l'unica citazione diretta riportata in questo report, sotto le 15 parole, attribuita a Walden Yan/Cognition). Anche condividendo un contesto iniziale identico, sub-agenti che lavorano in parallelo senza visibilità reciproca sulle azioni altrui producono output visivamente/logicamente incoerenti (nell'esempio, uno stile grafico disomogeneo nel gioco).
+- **Context compression con modelli dedicati.** Per task molto lunghi che eccedono comunque la finestra di contesto, Yan propone un LLM specializzato che comprima la storia di azioni e conversazione in dettagli chiave, eventi e decisioni — segnalando però esplicitamente che questo è difficile da ottenere bene, al punto da suggerire il fine-tuning di modelli più piccoli dedicati a questa sola funzione.
+
+Il contrasto editoriale notato dalle fonti secondarie: Cognition pubblica "Don't Build Multi-Agents" più o meno nello stesso periodo in cui Anthropic dettaglia il proprio sistema di ricerca multi-agente — due filosofie architetturali opposte pubblicate in parallelo, entrambe però convergenti sul punto che il context engineering è la leva decisiva per l'affidabilità. ([Medium — recap del dibattito](https://medium.com/@maureesewilliams/the-agent-architecture-wars-why-two-ai-giants-completely-disagree-on-multi-agent-systems-d19a53364200))
+
+---
+
+## 6. Materiale 2026 più recente
+
+- **Karpathy → Anthropic pretraining team (19 maggio 2026)**, già coperto sopra: passaggio di ruolo datato e verificato, non ancora accompagnato (nelle fonti raccolte) da un nuovo scritto pubblico dedicato al context engineering.
+- **Karpathy, Sequoia Ascent (30 aprile 2026)**: la sintesi più recente e organica del suo pensiero su agentic engineering, con la formalizzazione vibe-coding/agentic-engineering e la ricetta "definisci contesto → tool → feedback loop → guardrail → lascia lavorare l'agente". ([karpathy.bearblog.dev](https://karpathy.bearblog.dev/sequoia-ascent-2026/))
+- **Evoluzione del paradigma 2022-2026**: una fonte secondaria (bits-bytes-nn, aprile 2026) descrive una progressione in tre fasi — Prompt Engineering → Context Engineering → **Harness Engineering** — come lettura dello stato dell'arte più recente, dove l'attenzione si sposta dal "cosa mettere nel contesto" al "che impalcatura di strumenti/loop circonda l'agente". Non è chiaro dalle fonti se questo termine sia stato coniato o solo ripreso da Karpathy stesso. ([bits-bytes-nn.github.io](https://bits-bytes-nn.github.io/insights/agentic-ai/2026/04/05/evolution-of-ai-agentic-patterns-en.html))
+- Un paper accademico del 2026, "Context Engineering 2.0: The Context of Context Engineering" (arXiv, ottobre 2025/2026), segnala che il campo sta già producendo tentativi di sistematizzazione teorica del termine coniato da Karpathy — non ho fetchato il full text, solo il titolo/abstract dai risultati di ricerca. ([arxiv.org/pdf/2510.26493](https://arxiv.org/pdf/2510.26493))
+
+**Pagine non raggiungibili**: il fetch diretto del tweet originale di Karpathy (x.com) ha restituito HTTP 402 (Payment Required) — il testo del tweet è stato ricostruito solo tramite gli estratti riportati nei risultati di ricerca, non da lettura diretta della pagina.
+
+---
+
+## Principi operativi estraibili
+
+- **Trattare il context window come RAM scarsa, non come un buffer infinito** — riempirlo solo con ciò che serve al passo successivo, non con tutto ciò che è disponibile (Karpathy).
+- **Ottimizzare per il KV-cache hit rate come prima metrica di costo/latenza**: contesto append-only, prefix stabile, niente timestamp nel system prompt, serializzazione deterministica — differenziale di costo osservato 10x tra token cachati e non (Manus/Yichao Ji).
+- **Mascherare i tool invece di rimuoverli dinamicamente**, per non invalidare la cache e non rompere la coerenza schema/azioni passate (Manus).
+- **Usare il filesystem (o altro storage esterno persistente) come estensione del contesto**, mantenendo riferimenti recuperabili (es. URL) anche quando si scarta il contenuto pieno (Manus).
+- **"Recitare" periodicamente l'obiettivo/piano** (es. un file todo.md aggiornato) per contrastare il "lost-in-the-middle" e il goal drift nei task lunghi (Manus).
+- **Non ripulire gli errori dal contesto**: le tracce fallite sono segnale utile per la recovery del modello (Manus).
+- **Evitare la monotonia strutturale (few-shot rut)** introducendo variazione controllata nella forma degli esempi, per prevenire drift da imitazione cieca del pattern (Manus).
+- **Limitare il numero di tool attivi contemporaneamente** — oltre ~20 il degrado di performance è misurato empiricamente su più benchmark (Breunig/Willison).
+- **Isolare sotto-contesti in thread dedicati (context quarantine)** quando i task sono davvero indipendenti, invece di sovraccaricare un unico contesto condiviso (Breunig, pattern usato da Claude Code).
+- **Potare, riassumere e scaricare (pruning/summarization/offloading)** attivamente il contesto man mano che cresce, anche con finestre molto ampie — perché la correttezza cala ben prima del limite tecnico dichiarato (già a ~32k token su alcuni modelli, secondo lo studio Databricks citato da Breunig).
+- **Nel multi-agente, condividere tracce complete, non solo messaggi**: le decisioni implicite di un agente devono essere visibili agli altri, o si generano incoerenze/conflitti (Cognition/Walden Yan).
+- **Se serve comprimere una storia lunga per un sub-agente, farlo con un modello dedicato a quel solo compito**, accettando che è un problema difficile da risolvere bene, non una funzione banale (Cognition).
+- **Distinguere "vibe coding" da "agentic engineering"**: la seconda richiede spec design esplicito, diff review, eval loop verificabili e guardrail — non semplice delega cieca all'agente (Karpathy, Sequoia Ascent 2026).

--- a/research/operations/2026-09-04-context-engineering-sota-lane-repos.md
+++ b/research/operations/2026-09-04-context-engineering-sota-lane-repos.md
@@ -1,0 +1,145 @@
+# Context management nei coding agent open-source — meccanismi concreti
+(lane research-repos, 2026-09-04)
+
+## 1. Aider — repomap tree-sitter + PageRank
+
+**Meccanismo**: aider parsa ogni file sorgente con tree-sitter (AST language-specific), estrae tag `def` (definizioni: funzioni/classi/metodi) e `ref` (usi/riferimenti). Costruisce un grafo dove i file sono nodi e le dipendenze (chi referenzia chi) sono archi, poi esegue un **PageRank personalizzato** con restart-vector "biased" verso i simboli presenti nella chat corrente — un simbolo chiamato da 20 funzioni pesa più di un helper privato chiamato una volta. Il risultato: la repomap mostra solo *signatures* (non file interi), scelte per densità informativa/token.
+
+**Numeri**: token budget default **1.000 token** (`--map-tokens`), fitting via **binary search** su `get_ranked_tags_map()` per restare entro ~15% del budget target (`max_map_tokens` default 1.024).
+
+**Trade-off dichiarato**: anche solo la repomap può eccedere la context window per repo molto grandi → serve filtering selettivo, non inclusione comprensiva.
+
+Fonti: aider.chat/2023/10/22/repomap.html · anishgandhi.com/aider-pagerank-codebase-ranking/ · agentpatterns.ai/context-engineering/repository-map-pattern/
+
+## 2. Cline / Roo Code — Memory Bank + .clinerules
+
+**Meccanismo**: "Memory Bank" = sistema di file markdown strutturati (`activeContext.md`, `progress.md`, ecc.) che **devono essere letti a inizio di OGNI task** — trasforma un agente stateless in uno con continuità cross-sessione. `.clinerules` è trattato come codice (versionabile, condivisibile) e può contenere sia istruzioni di memory-bank sia configurazioni custom.
+
+**Auto-compaction**: "Auto Compact" agisce da buffer quando la window si riempie; il comando `/smol` o `/compact` fa la stessa compressione ma triggerabile manualmente dentro lo stesso task (utile in debugging profondo per non rompere il flow).
+
+**Trade-off**: nessun numero di token esplicito nelle fonti trovate — il pattern è dichiarativo (istruzioni scritte dall'utente), non algoritmico come la repomap di aider.
+
+Fonti: cline.bot/blog/how-to-think-about-context-engineering-in-cline · docs.cline.bot/features/memory-bank · github.com/cline/prompts/blob/main/.clinerules/memory-bank.md
+
+## 3. OpenHands (ex OpenDevin) — Condenser + Event Stream + Microagents
+
+**Architettura**: la history è uno **event stream** append-only (azioni + osservazioni). Un **EventLog persistente** consente replay completo anche dopo compressione.
+
+**Condenser** (famiglia di classi): `NoOpCondenser` (pass-through) · `LLMSummarizingCondenser` (usa un LLM, spesso più economico del reasoning LLM, per riassumere) · `PipelineCondenser` (concatena più condenser) · `RollingCondenser` (classe base con trigger a soglia).
+
+**Numeri concreti**: trigger automatico quando il conteggio eventi supera `max_size` = **120 eventi** (default); trigger manuale via evento `CondensationRequest` su context-error. Pattern "rolling window": preserva i primi `keep_first`=**4** eventi, riassume la porzione centrale, preserva la coda recente; target output ≈ **60 eventi** (`max_size // 2`) post-condensazione. Il riassunto viene inserito come testo a un `summary_offset` specifico e gli eventi "dimenticati" restano tracciati (`forgotten_event_ids`) — mai cancellati fisicamente dal log.
+
+**Microagents**: convenzioni/knowledge di progetto che si caricano **automaticamente su trigger** (l'agente "conosce" il repo appena atterra) — pattern di context injection selettiva, non sempre-caricato.
+
+**Trade-off dichiarato**: senza condensazione, la gestione del contesto scala **quadraticamente** nel tempo; con condensazione scala **linearmente**.
+
+Fonti: docs.openhands.dev/sdk/arch/condenser · openhands.dev/blog/openhands-context-condensensation-for-more-efficient-ai-agents · github.com/OpenHands/OpenHands/pull/7311
+
+## 4. SWE-agent (Princeton) — Agent-Computer Interface (ACI)
+
+**Tesi centrale**: l'interfaccia con cui l'agente vede/manipola il computer è determinante quanto il prompt — un agente senza ACI ben tarata (baseline shell-only) fa molto peggio dello stesso modello con ACI dedicata.
+
+**File viewer a finestra**: comando `open` mostra **100 righe per turno** con numeri di riga + statistiche file; navigazione con `scroll up/down` o `goto <linea>`. Trovato empiricamente che 100 righe è il punto ottimale (non "tutto il file").
+
+**Altri elementi ACI**: linter automatico sui comandi di edit (blocca codice sintatticamente errato prima del submit); search directory che elenca **solo i file con match** (dettagli per-match "troppo confusi per il modello" — scelta deliberata di compattezza su completezza); messaggi espliciti su output vuoto ("comando riuscito, nessun output").
+
+**Risultati**: SWE-agent + GPT-4 Turbo → 12.47% pass@1 su SWE-bench full, 18.00% su SWE-bench Lite, +64% relativo rispetto a un agente shell-only su Lite (SOTA all'epoca).
+
+**Principi**: simplicity, compactness, concise feedback, error guardrails — ottimizzati per l'interazione LM, non umana.
+
+Fonti: swe-agent.com/latest/background/aci/ · paper NeurIPS 2024 (arXiv 2405.15793)
+
+## 5. MemGPT / Letta — Virtual context management (OS-like paging)
+
+**Architettura a 3 livelli**, ispirata alla memoria virtuale OS (l'LLM è il proprio "memory manager"):
+- **Core memory**: analoga alla RAM — persona + contesto critico sempre nella context window, editabile dall'agente stesso (self-editing).
+- **Recall memory**: storico completo delle interazioni, ricercabile ma fuori dalla finestra attiva; in Letta salva su disco automaticamente.
+- **Archival memory**: knowledge esplicitamente elaborata, indicizzata su vector DB esterno — a differenza della recall (raw), contenuto processato/strutturato.
+
+**Meccanismo**: l'agente sposta dati tra core memory (in-context) e archival/recall (esterne) tramite **tool call espliciti** — illusione di memoria illimitata dentro un limite fisso di token.
+
+Fonti: letta.com/blog/agent-memory/ · vectorize.io/articles/mem0-vs-letta · vectorize.io/articles/hindsight-vs-letta
+
+## 6. Gemini CLI — GEMINI.md hierarchy + compressione a soglia
+
+**Hierarchy di caricamento**: `~/.gemini/GEMINI.md` (globale) → risalita da cwd fino a project root → scansione sub-directory per istruzioni component-specific; più specifico sovrascrive più generale.
+
+**Compressione**: `/compress` sostituisce l'INTERA chat history con un summary. Soglia configurabile `chatCompression` come % della finestra (es. 0.6 = trigger a 60%). La compressione NON salva in memoria a lungo termine — è locale alla conversazione — mentre le voci in GEMINI.md sopravvivono perché vivono fuori dal chat context.
+
+**Checkpointing**: `/restore` cattura stato working directory + workspace; il restore sovrascrive i file E resetta la conversazione a quello snapshot (rollback combinato codice+contesto).
+
+Fonti: geminicli.com/docs/cli/gemini-md/ · aipositive.substack.com/p/a-look-at-context-engineering-in · google-gemini.github.io/gemini-cli/docs/cli/commands.html
+
+## 7. Codex CLI (OpenAI) — AGENTS.md + compaction a doppio percorso
+
+**AGENTS.md**: concatenato nella context window all'inizio di OGNI sessione — la prima cosa che Codex legge. Costruito camminando il filesystem (hierarchy), pensato come "README per agenti".
+
+**Compaction a due percorsi**: per modelli NON-Codex, summarization locale via LLM con compaction-prompt visibile nel codice (summary con prefisso `_summary` anti-loop). Per i modelli Codex, endpoint remoto `POST /v1/responses/compact` → blob AES-encrypted la cui chiave resta sui server OpenAI; al turno successivo il server decripta e antepone un "handoff prompt".
+
+Fonti: codex.danielvaughan.com/2026/03/31/codex-cli-context-compaction-architecture/ · thepromptshelf.dev/blog/agents-md-codex-setup-guide-2026/
+
+## 8. Claude Code — CLAUDE.md hierarchy + skills progressive disclosure + subagent
+
+**CLAUDE.md come "table of contents"**: root file = indice, skill = capitoli, agent guide = appendici — l'agente carica solo ciò che serve.
+
+**Skills — progressive disclosure a 3 livelli** (fonte Anthropic engineering):
+1. **Livello 1 (metadata)**: `name` + `description` di ogni skill pre-caricati nel system prompt — pochi token, Claude sa che esiste senza pagarne il body.
+2. **Livello 2 (core content)**: su rilevanza, legge il `SKILL.md` completo via tool call.
+3. **Livello 3+ (risorse bundled)**: file referenziati dentro SKILL.md caricati SOLO quando servono.
+"Il contenuto bundlabile in una skill è di fatto illimitato" — con filesystem access l'agente evita di caricare tutto. Design: separare i path quando i contesti sono "mutuamente esclusivi o usati raramente insieme".
+
+**Subagent**: "spawna un agente nel momento in cui un task inquinerebbe il context principale"; anti-pattern: 20 file-read + 12 grep nella sessione principale e poi pianificare col rumore caricato — meglio: subagent di ricerca → report pulito → planning pulito.
+
+**Auto-compact**: "il modello è al suo punto meno intelligente proprio durante l'auto-compact" — gestirlo proattivamente, non subirlo.
+
+**Confronto soglie di compaction (7 agenti, fonte comparativa 2026-04)**:
+| Agent | Soglia trigger | Formula |
+|---|---|---|
+| Gemini CLI | ~50% | default, configurabile |
+| Roo Code | ~86–92% | `contextWindow × 0.9 − maxOutputTokens` |
+| Claude Code | ~89% | `contextWindow − min(maxOutput, 20k) − 13k` |
+| Codex CLI | ~90% | hard ceiling, configurabile solo al ribasso |
+| Pi | ~92% | `contextTokens > window − 16.384` |
+| OpenCode | ~96–99% | `contextTokens ≥ context − reserved` |
+| OpenHands | event-based | 120 eventi o trigger manuale |
+
+Claude Code usa **5 meccanismi di difesa**: microcompact (senza LLM), clearing output tool, summarization LLM completa, cache reuse, compact guidato dall'utente. Gemini CLI: two-pass summarization con self-critique, preserva verbatim il 30% finale. OpenCode: protegge gli ultimi 40.000 token (soglia minima prunable 20.000).
+
+**Costo nascosto (KV cache)**: una compaction su 125.000 token ≈ $0.40 — ~21 turni cache-hit ($0.019 vs $0.23 per 60k token). Checklist pre-compaction su 7 categorie (path, decisioni, errori, firme, test, env var, task) → +49% qualità summary a costo trascurabile ($0.013).
+
+Fonti: anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills · alexop.dev/posts/stop-bloating-your-claude-md-progressive-disclosure-ai-coding-tools/ · codex.danielvaughan.com/2026/04/10/context-compaction-showdown-coding-agents/
+
+## 9. LangChain/LangGraph — framework "Write / Select / Compress / Isolate"
+
+**Definizione**: context engineering = "l'arte e la scienza di riempire la context window con esattamente l'informazione giusta a ogni step della traiettoria dell'agente".
+
+**4 strategie**:
+- **Write**: salvare contesto FUORI dalla window per uso futuro — pattern "scratchpad".
+- **Select**: tirare DENTRO ciò che serve (retrieval mirato).
+- **Compress**: mantenere solo i token necessari al task.
+- **Isolate**: dividere il contesto (sub-agenti con contesti separati) per evitare cross-contamination.
+
+LangGraph implementa via **checkpointing di stato** (thread-scoped memory) + long-term memory esterna.
+
+Fonti: langchain.com/blog/context-engineering-for-agents · github.com/langchain-ai/context_engineering · deepwiki.com/langchain-ai/context_engineering/2-context-engineering-strategies
+
+## 9bis. Tendenze 2026
+
+- Context engineering = "successore del prompt engineering": gli agenti falliscono per **state-management failure**, non per prompt failure.
+- 4 failure mode ricorrenti: **context poisoning**, **context distraction**, **context confusion**, **context clash**.
+- Ecosistema memoria agentica: ~21 framework, ~20 vector store, 3 modelli hosting — disciplina matura.
+
+Fonti: mem0.ai/blog/state-of-ai-agent-memory-2026 · sourcegraph.com/blog/context-engineering · jobsbyculture.com/blog/context-engineering-guide-2026
+
+---
+
+## Principi operativi estraibili
+
+- **Rank, don't dump** (Aider): grafo riferimenti + PageRank battono "includi tutto" — signatures pesate per centralità.
+- **Memory esterna leggibile a inizio task, non nel prompt system** (Cline Memory Bank, MemGPT): persistenza cross-sessione in file/DB letti ESPLICITAMENTE all'avvio, mai stipata nel context permanente.
+- **Mai cancellare, sempre marcare "dimenticato"** (OpenHands `forgotten_event_ids`): history compressa recuperabile — event sourcing, non distruzione.
+- **Interfaccia > prompt** (SWE-agent ACI): finestre fisse (100 righe), search compatta, messaggi espliciti su output nullo.
+- **Soglia di trigger esplicita e misurabile** (tabella 7 agenti): formula percentuale/evento-based dichiarata, mai "quando si riempie".
+- **Progressive disclosure a 3 livelli = standard** (Claude Skills, GEMINI.md hierarchy, repomap): metadata sempre in context, corpo su match, risorse profonde solo se referenziate.
+- **La compaction ha costo economico misurabile e non lineare** (KV cache): checklist pre-compaction 7 categorie = +49% qualità a costo trascurabile.
+- **Isolamento per sotto-task > contesto condiviso grande** (LangGraph Isolate, subagent pattern, microagents): "fan-out a contesto pulito, poi report sintetico".

--- a/research/operations/2026-09-04-context-engineering-sota-lane-repos.md
+++ b/research/operations/2026-09-04-context-engineering-sota-lane-repos.md
@@ -1,3 +1,10 @@
+---
+date: 2026-09-04
+domain: operations
+client_case: none — raw lane capture for 2026-09-04-context-engineering-sota.md
+adversarial_review: exempt-raw-lane-capture-reviewed-via-synthesis
+---
+
 # Context management nei coding agent open-source — meccanismi concreti
 (lane research-repos, 2026-09-04)
 

--- a/research/operations/2026-09-04-context-engineering-sota.md
+++ b/research/operations/2026-09-04-context-engineering-sota.md
@@ -2,6 +2,7 @@
 date: 2026-09-04
 domain: operations
 client_case: none — internal context-engineering study (sessione M5, mandato Zero)
+adversarial_review: codex
 sources: 3 lane di ricerca parallele (Karpathy/thought-leader · Anthropic ufficiale · repo SOTA), ~30 fonti primarie/secondarie fetchate; raw delle lane accanto a questo file (suffissi -lane-karpathy/-lane-anthropic/-lane-repos)
 ---
 
@@ -17,14 +18,14 @@ sources: 3 lane di ricerca parallele (Karpathy/thought-leader · Anthropic uffic
 
 1. **Il campo ha un consenso, ed è quasi unanime**: il context window è RAM scarsa (Karpathy), l'attention budget degrada al crescere dei token ("context rot", Anthropic), e la regola d'oro è *"the smallest possible set of high-signal tokens"*. Nessuna fonte SOTA difende il pattern "carica tutto sempre".
 2. **Nuzantara è già SOTA su architettura** (skills progressive-disclosure, memoria index+corpi tipo Letta, subagent fan-out, stato durevole su file, budget armati da test) **ma anti-SOTA su un punto preciso**: i due CLAUDE.md. Sono l'anti-pattern che Anthropic chiama per nome — *"The over-specified CLAUDE.md"* — con il sintomo diagnostico esatto che documentiamo da mesi nelle cicatrici: *"se Claude ignora una regola presente, il file è troppo lungo e la regola si perde nel rumore"*.
-3. **La leva più grande è una sola**: dieta dei due CLAUDE.md (oggi la parte dominante dei 52k token di memory files) spostando storia/rulings superati in file on-demand, con un budget armato da test come già facciamo per superscar (≤14KB) e MEMORY.md (≤24,4KB). Il resto (system tools 40k, MCP 18k) è harness o loadout, leve minori.
+3. **La leva più grande è una sola**: dieta dei due CLAUDE.md (misurati su disco: 78,7KB ≈ ~20-25k token stimati, circa metà dei 52k di memory files; il resto è superscar, MEMORY.md e corpi iniettati) spostando storia/rulings superati in file on-demand, con un budget armato da test come già facciamo per superscar (≤14KB) e MEMORY.md (≤24,4KB). Il resto (system tools 40k, MCP 18k) è harness o loadout, leve minori.
 4. La disciplina delle sessioni corte con stato su file — che abbiamo già scoperto a nostre spese (scar 💸: 8 sessioni >24h = 48,6% della spesa) — è esattamente la best practice ufficiale: *"A clean session with a better prompt almost always outperforms a long session with accumulated corrections."*
 
 ---
 
-## 1. Il consenso SOTA — i principi su cui TUTTE le fonti convergono
+## 1. Il consenso SOTA — i principi ad ampia convergenza
 
-Tre corpi di evidenza indipendenti (thought-leader, vendor ufficiale, repo open-source) arrivano agli stessi principi. Quando tre tradizioni diverse convergono, il principio è probabilmente reale.
+Tre corpi di evidenza (thought-leader, vendor ufficiale, repo open-source — con parziale sovrapposizione di fonti tra le lane) arrivano agli stessi principi di base; i disaccordi reali sono elencati sotto, non nascosti.
 
 | Principio | Karpathy / thought-leader | Anthropic ufficiale | Repo SOTA |
 |---|---|---|---|
@@ -33,7 +34,7 @@ Tre corpi di evidenza indipendenti (thought-leader, vendor ufficiale, repo open-
 | **Progressive disclosure / lazy load** | context builders (Gitingest, DeepWiki) | Skills: ~100 token finché non triggerate, <5k al trigger, risorse a costo 0 | OpenHands microagents trigger-based; SKILL.md a 3 livelli |
 | **Stato durevole su FILE, non in window** | — | memory tool, pattern "initializer session" | Manus filesystem-as-context; Cline Memory Bank; MemGPT core/recall/archival |
 | **Isolamento sub-task (quarantine)** | Breunig: context quarantine | subagent = riassunto 1-2k token contro decine di migliaia esplorati | LangGraph "Isolate"; pattern universale "fan-out pulito → report sintetico" |
-| **Compaction gestita, mai subita** | pruning/summarization/offloading attivi | "il recall prima, la precisione poi"; /clear tra task | 7 agent, 7 formule di soglia esplicite (50%→99%); checklist pre-compaction = +49% qualità summary |
+| **Compaction gestita, mai subita** | pruning/summarization/offloading attivi | "il recall prima, la precisione poi"; /clear tra task | 7 agent, 7 formule di soglia esplicite (50%→99%); checklist pre-compaction = +49% copertura del summary (misurata come lunghezza, 1.643→2.455 token — non qualità end-task) |
 | **Cache-stability del prefix** | Manus: KV-cache hit rate = metrica #1 (10x costo cached/uncached) | statico prima del dinamico, cache_control sull'ultimo blocco statico | Codex `_summary` anti-loop; append-only context |
 
 ### I 4 modi in cui il contesto fallisce (tassonomia Breunig, ormai canonica)
@@ -45,7 +46,9 @@ Tre corpi di evidenza indipendenti (thought-leader, vendor ufficiale, repo open-
 
 ### I punti di disaccordo (unico vero dibattito)
 
-**Multi-agente sì/no.** Anthropic (multi-agent research system): orchestrator-worker batte il singolo Opus del 90,2% sulle ricerche breadth-first, MA costa ~15× i token e *"most coding tasks involve fewer truly parallelizable tasks than research"*. Cognition (Walden Yan, "Don't Build Multi-Agents"): sub-agenti a contesto parziale prendono decisioni implicite in conflitto — *"actions carry implicit decisions, and conflicting decisions carry bad results"*. La sintesi onesta: **fan-out per LETTURE indipendenti, mai per scritture accoppiate** — che è esattamente la regola modus "fan-out for READS, funnel-in for WRITES". Su questo siamo già allineati al punto di equilibrio del dibattito.
+**Multi-agente sì/no.** Anthropic (multi-agent research system): orchestrator-worker batte il singolo Opus del 90,2% sulle ricerche breadth-first, MA costa ~15× i token e *"most coding tasks involve fewer truly parallelizable tasks than research"*. Cognition (Walden Yan, "Don't Build Multi-Agents"): sub-agenti a contesto parziale prendono decisioni implicite in conflitto — *"actions carry implicit decisions, and conflicting decisions carry bad results"*. La sintesi onesta: **fan-out per LETTURE indipendenti; scritture parallele solo se disaccoppiate e isolate (worktree/ownership), mai accoppiate sullo stesso stato condiviso** — che è esattamente la regola modus "fan-out for READS, funnel-in for WRITES". Su questo siamo già allineati al punto di equilibrio del dibattito.
+
+Seconda tensione, minore: Manus dice "keep the errors in" (le tracce fallite migliorano la recovery), Anthropic dice `/clear` dopo >2 correzioni fallite. Si concilia distinguendo l'errore-segnale DENTRO un tentativo (tienilo) dagli approcci falliti accumulati TRA tentativi (pulisci e riprompta).
 
 ---
 
@@ -77,7 +80,7 @@ Tre corpi di evidenza indipendenti (thought-leader, vendor ufficiale, repo open-
 - **OpenHands**: event stream append-only + Condenser — trigger a **120 eventi**, preserva i primi 4, target 60 post-condensazione, eventi "dimenticati" tracciati (`forgotten_event_ids`), mai cancellati. Senza condenser il costo scala quadraticamente, con condenser linearmente.
 - **MemGPT/Letta**: core memory (sempre in window, self-editing) / recall (storico ricercabile) / archival (knowledge strutturata su vector DB) — paging OS-like via tool call. **La nostra MEMORY.md (indice) + corpi .md è questo pattern.**
 - **Soglie di auto-compact a confronto** (7 agent): Gemini CLI ~50% · Roo ~86-92% · **Claude Code ~89%** (`window − min(maxOutput,20k) − 13k`) · Codex ~90% · OpenCode ~96-99% · OpenHands event-based. Claude Code ha 5 difese (microcompact, clearing tool output, summarization, cache reuse, compact manuale).
-- **Costo compaction misurato**: ~$0.40 su 125k token (≈21 turni cache-hit); checklist pre-compaction su 7 categorie (path, decisioni, errori, firme, test, env var, task) = **+49% qualità del summary** a costo trascurabile. "Il modello è al suo punto meno intelligente proprio durante l'auto-compact" — gestirla prima, mai subirla.
+- **Costo compaction misurato**: ~$0.40 su 125k token (≈21 turni cache-hit); checklist pre-compaction su 7 categorie (path, decisioni, errori, firme, test, env var, task) = **summary +49% più ricco** (misurato come lunghezza/copertura, non qualità end-task) a costo trascurabile. "Il modello è al suo punto meno intelligente proprio durante l'auto-compact" — gestirla prima, mai subirla.
 - **Cline Memory Bank**: file markdown letti a inizio di OGNI task (activeContext.md, progress.md) — persistenza dichiarativa cross-sessione.
 
 ---
@@ -86,13 +89,13 @@ Tre corpi di evidenza indipendenti (thought-leader, vendor ufficiale, repo open-
 
 Pannello misurato (sessione M5, 500k window): overhead fisso ~137k (27,5%) = system prompt 7k + system tools 40k + MCP 18k + custom agents 10,3k + **memory files 52k** + skills 10k; messages 161k; autocompact buffer 33k.
 
-### Dove siamo GIÀ al livello dei migliori (o oltre)
+### Dove siamo GIÀ allineati alle pratiche documentate dalle fonti
 
 | Pratica SOTA | Implementazione Nuzantara | Giudizio |
 |---|---|---|
 | Progressive disclosure | skills corner (`/bot`, `/kbli-navigator`, …), skill-catalog on-demand | ✅ pattern Skills fatto bene |
 | Memoria a livelli (Letta) | MEMORY.md indice ≤24,4KB + corpi .md + MEMORY_ARCHIVE | ✅ core/recall/archival de facto |
-| **Budget armato da TEST** | superscar ≤14KB (`test_superscar_budget.py`), MEMORY.md cap misurato | ✅ **oltre SOTA**: nessuna fonte impone il budget via CI |
+| **Budget armato da TEST** | superscar ≤14KB (`test_superscar_budget.py`), MEMORY.md cap misurato | ✅ pratica assente in TUTTE le fonti esaminate (nessuna impone il budget via CI) |
 | Stato durevole su file | PENDING-ARMS ledger, spec su disco, handoff via file (ruling 💸) | ✅ = memory tool pattern |
 | Quarantine/subagent | fan-out READS, funnel-in WRITES; worktree per agent | ✅ = punto di equilibrio Anthropic/Cognition |
 | Recitation (Manus) | recap-on-wake, dense recap block di modus | ✅ |
@@ -115,12 +118,12 @@ Pannello misurato (sessione M5, 500k window): overhead fisso ~137k (27,5%) = sys
 
 | # | Azione | Leva | Effort | Note |
 |---|---|---|---|---|
-| R1 | **Dieta dei due CLAUDE.md** col test ufficiale riga-per-riga ("la rimozione causerebbe errori?"). Storia/ruling superseded → un file `RULINGS.md` (o memory files) on-demand; nel CLAUDE.md resta solo lo stato VIGENTE in 1 riga + puntatore. Target: −50-60% (52k → ~20-25k) | ~30k token/sessione, × ogni subagent | Medio (1 sessione dedicata, Gear 3: tocca doctrine) | Il precedente interno esiste già: superscar è nato così (99 scar → 10 famiglie ponte). Stesso gesto, applicato ai CLAUDE.md |
-| R2 | **Budget armato da test sui CLAUDE.md** (pattern `test_superscar_budget.py`): cap in byte, CI rossa se sfora | Impedisce la ricrescita — la dieta senza budget si rimangia | Basso | Senza R2, R1 dura 3 mesi |
-| R3 | **De-duplicare i blocchi gemelli** globale↔repo (quirk famiglia 5, roster, cost constraint): una sola casa + puntatore | ~5-8k | Basso | Attenzione: il globale è un HOME-fork dichiarato (3 copie, scar 📄🍴) — la cura va applicata a tutte le copie |
-| R4 | **Istruzioni di compaction in CLAUDE.md** ("When compacting, always preserve: file modificati, comandi test, decisioni, PENDING-ARMS aperti") | +49% qualità summary misurato altrove, costo ~0 | Minimo | Una riga |
+| R1 | **Dieta dei due CLAUDE.md** col test ufficiale riga-per-riga ("la rimozione causerebbe errori?"). Storia/ruling superseded → un file `RULINGS.md` (o memory files) on-demand; nel CLAUDE.md resta solo lo stato VIGENTE in 1 riga + puntatore. Target: −50-60% dei due file (misurati 78,7KB ≈ ~20-25k token) | ~10-15k token/sessione stimati, × ogni subagent | Medio (1 sessione dedicata, Gear 3: tocca doctrine) | Il precedente interno esiste già: superscar è nato così (99 scar → 10 famiglie ponte). Stesso gesto, applicato ai CLAUDE.md |
+| R2 | **Budget armato da test sui CLAUDE.md** (pattern `test_superscar_budget.py`): cap in byte, CI rossa se sfora | Impedisce la ricrescita — la dieta senza budget si rimangia | Basso | Senza R2 la dieta si rimangia (precedente interno: MEMORY.md ha un cap perché la coda veniva scartata in silenzio quando cresceva) |
+| R3 | **De-duplicare i blocchi gemelli** globale↔repo (quirk famiglia 5, roster, cost constraint): una sola casa + puntatore | ~5-8k (stima, non misurata) | Basso | Attenzione: il globale è un HOME-fork dichiarato (3 copie, scar 📄🍴) — la cura va applicata a tutte le copie |
+| R4 | **Istruzioni di compaction in CLAUDE.md** ("When compacting, always preserve: file modificati, comandi test, decisioni, PENDING-ARMS aperti") | summary più ricco (+49% copertura misurata altrove; proxy di lunghezza, non di qualità), costo ~0 | Minimo | Una riga |
 | R5 | **Razionalizzare l'enfasi**: 🔴 riservato alle sole righe che governano azioni distruttive (la regola c'è già in MEMORY.md ma non è applicata ai CLAUDE.md) | Restituisce significato all'enfasi residua | Basso | |
-| R6 | **MCP loadout per-sessione**: valutare quali dei 4 server servono di default su M5 (Drive? context7?) e spostare gli altri su attivazione esplicita | ~8-12k | Basso | Deferred tools già mitigano; qui si taglia la definizione |
+| R6 | **MCP loadout per-sessione**: valutare quali dei 4 server servono di default su M5 (Drive? context7?) e spostare gli altri su attivazione esplicita | ~8-12k (stima sui 18k MCP del pannello; il benchmark sul degrado riguarda il numero di TOOL attivi, non di server) | Basso | Deferred tools già mitigano; qui si taglia la definizione |
 | R7 | Mantenere e rinforzare ciò che è già SOTA: sessioni corte + stato via file, fan-out READS, budget armati. **Nessun cambio.** | — | — | Il report conferma le scelte, non le smentisce |
 
 **Ordine consigliato**: R2 prima di R1 (arma il budget, poi dimagrisci dentro il budget — altrimenti è una dieta senza bilancia). R3-R5 dentro la stessa PR di R1. R6 indipendente.
@@ -146,3 +149,21 @@ Pannello misurato (sessione M5, 500k window): overhead fisso ~137k (27,5%) = sys
 - Repo: aider.chat/2023/10/22/repomap.html · swe-agent.com/latest/background/aci · docs.openhands.dev/sdk/arch/condenser · letta.com/blog/agent-memory · langchain.com/blog/context-engineering-for-agents · codex.danielvaughan.com/2026/04/10/context-compaction-showdown-coding-agents/
 
 *Raw completi delle 3 lane: file gemelli `2026-09-04-context-engineering-sota-lane-{karpathy,anthropic,repos}.md` in questa directory.*
+
+## Adversarial review
+
+Seat: **codex** (GPT-5.6, cross-family, sonda live PONG ~39s prima del dispatch; sandbox read-only, effort high). 9 finding, disposizione:
+
+| # | Finding | Verdetto | Disposizione |
+|---|---|---|---|
+| 1 | "+49% qualità summary" — la fonte misura LUNGHEZZA (1.643→2.455 token), non qualità | CONFERMATO | Rietichettato in tutte le occorrenze come copertura/lunghezza |
+| 2 | Target "52k→20-25k / −30k a sessione" non derivato | CONFERMATO | Misurato su disco: i due CLAUDE.md = 78.741B ≈ ~20-25k token (≈ metà dei 52k); leva corretta a ~10-15k stimati |
+| 3 | R3 ~5-8k senza provenance (quote del finding imprecisa, punto valido) | PARZIALE | Etichettato "stima, non misurata" |
+| 4 | Attribuzione "IMPORTANT su una riga sola" sarebbe falsa | **REFUTATO con prova** | La frase "If you emphasize many lines, none of them stands out" esiste VERBATIM nella pagina Anthropic, ri-fetchata in questo turno dal gate. Il refuter ha allucinato un negativo (classe W65) |
+| 5 | "TUTTE le fonti convergono" contraddetto dal testo stesso | CONFERMATO | Header ammorbidito; aggiunta la seconda tensione (errors-in vs /clear) con conciliazione |
+| 6 | Stima MCP ~8-12k: il benchmark riguarda i TOOL, non i server | CONFERMATO | Etichettata stima + scope del benchmark precisato |
+| 7 | "Senza R2, R1 dura 3 mesi" fabbricato | CONFERMATO | Sostituito con il precedente interno non numerico (cap MEMORY.md) |
+| 8 | "mai scritture accoppiate" sovra-esteso | CONFERMATO | Precisato: scritture parallele ok se disaccoppiate/isolate (worktree), mai sullo stesso stato condiviso |
+| 9 | "SOTA/oltre SOTA" senza benchmark esterno | CONFERMATO | Riformulato come "allineato alle pratiche documentate dalle fonti esaminate" / "pratica assente in tutte le fonti" |
+
+Bilancio: 7 confermati (curati nel testo), 1 parziale, 1 refutato con prova indipendente. Il round dimostra entrambe le metà della disciplina: il generator sbaglia (etichette e stime non marcate), e anche il refuter allucina (finding 4) — la verifica indipendente del gate resta non delegabile.

--- a/research/operations/2026-09-04-context-engineering-sota.md
+++ b/research/operations/2026-09-04-context-engineering-sota.md
@@ -1,0 +1,148 @@
+---
+date: 2026-09-04
+domain: operations
+client_case: none — internal context-engineering study (sessione M5, mandato Zero)
+sources: 3 lane di ricerca parallele (Karpathy/thought-leader · Anthropic ufficiale · repo SOTA), ~30 fonti primarie/secondarie fetchate; raw delle lane accanto a questo file (suffissi -lane-karpathy/-lane-anthropic/-lane-repos)
+---
+
+# Context Engineering SOTA — come i migliori gestiscono il contesto, e dove sta Nuzantara
+
+> Mandato: Zero, 2026-09-04 — "verifica come i migliori al mondo gestiscono questo contesto,
+> controlla i repo migliori e i migliori dev come Karpathy, e così studiamo il report".
+> Innesco: pannello `/context` di una sessione M5 al 60% (297.6k/500k), overhead fisso ~137k.
+
+---
+
+## 0. Executive summary
+
+1. **Il campo ha un consenso, ed è quasi unanime**: il context window è RAM scarsa (Karpathy), l'attention budget degrada al crescere dei token ("context rot", Anthropic), e la regola d'oro è *"the smallest possible set of high-signal tokens"*. Nessuna fonte SOTA difende il pattern "carica tutto sempre".
+2. **Nuzantara è già SOTA su architettura** (skills progressive-disclosure, memoria index+corpi tipo Letta, subagent fan-out, stato durevole su file, budget armati da test) **ma anti-SOTA su un punto preciso**: i due CLAUDE.md. Sono l'anti-pattern che Anthropic chiama per nome — *"The over-specified CLAUDE.md"* — con il sintomo diagnostico esatto che documentiamo da mesi nelle cicatrici: *"se Claude ignora una regola presente, il file è troppo lungo e la regola si perde nel rumore"*.
+3. **La leva più grande è una sola**: dieta dei due CLAUDE.md (oggi la parte dominante dei 52k token di memory files) spostando storia/rulings superati in file on-demand, con un budget armato da test come già facciamo per superscar (≤14KB) e MEMORY.md (≤24,4KB). Il resto (system tools 40k, MCP 18k) è harness o loadout, leve minori.
+4. La disciplina delle sessioni corte con stato su file — che abbiamo già scoperto a nostre spese (scar 💸: 8 sessioni >24h = 48,6% della spesa) — è esattamente la best practice ufficiale: *"A clean session with a better prompt almost always outperforms a long session with accumulated corrections."*
+
+---
+
+## 1. Il consenso SOTA — i principi su cui TUTTE le fonti convergono
+
+Tre corpi di evidenza indipendenti (thought-leader, vendor ufficiale, repo open-source) arrivano agli stessi principi. Quando tre tradizioni diverse convergono, il principio è probabilmente reale.
+
+| Principio | Karpathy / thought-leader | Anthropic ufficiale | Repo SOTA |
+|---|---|---|---|
+| **Contesto = RAM scarsa, non buffer infinito** | LLM OS: pesi=CPU, window=RAM, resto=disco | attention budget, context rot (n² del Transformer) | correttezza cala già a ~32k token su alcuni modelli (Databricks via Breunig) |
+| **Minimo set di token ad alto segnale** | "esattamente le informazioni giuste per il passo successivo" (tweet fondativo) | "smallest possible set of high-signal tokens" (testuale) | Aider: repomap 1k token di signatures, mai file interi |
+| **Progressive disclosure / lazy load** | context builders (Gitingest, DeepWiki) | Skills: ~100 token finché non triggerate, <5k al trigger, risorse a costo 0 | OpenHands microagents trigger-based; SKILL.md a 3 livelli |
+| **Stato durevole su FILE, non in window** | — | memory tool, pattern "initializer session" | Manus filesystem-as-context; Cline Memory Bank; MemGPT core/recall/archival |
+| **Isolamento sub-task (quarantine)** | Breunig: context quarantine | subagent = riassunto 1-2k token contro decine di migliaia esplorati | LangGraph "Isolate"; pattern universale "fan-out pulito → report sintetico" |
+| **Compaction gestita, mai subita** | pruning/summarization/offloading attivi | "il recall prima, la precisione poi"; /clear tra task | 7 agent, 7 formule di soglia esplicite (50%→99%); checklist pre-compaction = +49% qualità summary |
+| **Cache-stability del prefix** | Manus: KV-cache hit rate = metrica #1 (10x costo cached/uncached) | statico prima del dinamico, cache_control sull'ultimo blocco statico | Codex `_summary` anti-loop; append-only context |
+
+### I 4 modi in cui il contesto fallisce (tassonomia Breunig, ormai canonica)
+
+- **Poisoning**: un'allucinazione entra nel contesto e viene ri-referenziata (il nostro equivalente: famiglia scar #6 phantom citations).
+- **Distraction**: il contesto lungo fa sovra-affidare il modello alla cronologia invece che al ragionamento (Gemini 2.5 oltre 100k ripeteva azioni invece di pianificare).
+- **Confusion**: contenuto superfluo degrada la risposta — **ogni modello testato peggiora con >1 tool disponibile**; oltre ~20 tool il degrado è misurato (Berkeley FCL).
+- **Clash**: informazioni accumulate in conflitto — prompt "sharded" su più turni: −39% medio, o3 crolla da 98,1 a 64,1.
+
+### I punti di disaccordo (unico vero dibattito)
+
+**Multi-agente sì/no.** Anthropic (multi-agent research system): orchestrator-worker batte il singolo Opus del 90,2% sulle ricerche breadth-first, MA costa ~15× i token e *"most coding tasks involve fewer truly parallelizable tasks than research"*. Cognition (Walden Yan, "Don't Build Multi-Agents"): sub-agenti a contesto parziale prendono decisioni implicite in conflitto — *"actions carry implicit decisions, and conflicting decisions carry bad results"*. La sintesi onesta: **fan-out per LETTURE indipendenti, mai per scritture accoppiate** — che è esattamente la regola modus "fan-out for READS, funnel-in for WRITES". Su questo siamo già allineati al punto di equilibrio del dibattito.
+
+---
+
+## 2. I tre corpi di evidenza (sintesi; raw nei file di lane accanto)
+
+### 2a. Karpathy (e la traiettoria 2025→2026)
+
+- **27 giu 2025**: tweet fondativo — "context engineering" sostituisce "prompt engineering"; l'arte di riempire la finestra con esattamente ciò che serve al passo successivo.
+- **Software 3.0 / LLM OS**: window=RAM, pesi=CPU, storage esterno=disco che richiede load esplicito. Gli agenti soffrono di "anterograde amnesia": la window è l'unico luogo dove ricordare entro la sessione.
+- **Sequoia Ascent (30 apr 2026)**: distinzione **vibe coding** (alza il floor, "prompt and pray") vs **agentic engineering** (alza il ceiling: spec design, diff review, eval loop, guardrail, permessi). Ricetta: definisci contesto → tool → feedback loop → guardrail → poi lascia lavorare l'agente. Autonomy slider, non binario.
+- **19 mag 2026**: Karpathy entra nel team pre-training di Anthropic. Nessun nuovo scritto pubblico sul context engineering dopo questa data (verificato dalla lane).
+- Tendenza 2026 segnalata (fonte secondaria): Prompt Engineering → Context Engineering → **Harness Engineering** — l'attenzione si sposta all'impalcatura di strumenti/loop attorno all'agente.
+- **Manus (Yichao Ji)** — il post più operativo del campo: KV-cache hit rate metrica #1 (input:output ~100:1, 10x il differenziale cached/uncached); append-only, mai modificare il passato; **mask don't remove** (mascherare i logit dei tool, mai rimuoverli — invalida la cache); filesystem come contesto esterno reversibile (scarta il contenuto, tieni l'URL); **recitation** (todo.md ri-scritto verso la coda del contesto contro il lost-in-the-middle); **keep the errors in** (le tracce fallite migliorano la recovery); evitare il few-shot rut. Manus ha ricostruito il framework 4 volte — disciplina empirica, non teorica.
+
+### 2b. Anthropic ufficiale (fetch diretto delle pagine, 2026)
+
+- **CLAUDE.md**: test riga per riga — *"Would removing this cause Claude to make mistakes? If not, cut it."* Escludere: tutto ciò che è derivabile dal codice, info che cambiano spesso, tutorial, descrizioni file-per-file. **"IMPORTANT" su UNA sola riga** — enfasi diffusa = zero enfasi. Anti-pattern nominato: over-specified CLAUDE.md → *"Ruthlessly prune… or convert it to a hook."* (Il principio "hooks enforce what prompts cannot" ce l'abbiamo già — CLAUDE.md §7.)
+- **Skills vs CLAUDE.md**: CLAUDE.md è pagato OGNI sessione → solo regole sempre applicabili; il resto in skill on-demand (~100 token/skill finché non triggera, <5k al trigger, risorse a costo 0).
+- **Sessioni**: `/clear` tra task non correlati; >2 correzioni fallite sullo stesso tema = contesto avvelenato → `/clear` + riprompt. `/compact <istruzioni>` per controllo fine; CLAUDE.md può istruire la compaction ("preserva sempre la lista dei file modificati e i comandi di test"). `/btw` per domande usa-e-getta.
+- **Subagent**: "context is your fundamental constraint, use subagents to keep research out of it"; review adversariale in contesto fresco (solo diff + criteri, mai il ragionamento che ha prodotto la modifica) — il nostro generator≠grader.
+- **Memory tool** (API): pattern initializer-session — scrivi progress-log + checklist PRIMA del lavoro, ogni sessione riparte da lì; compaction server-side + memory client-side insieme.
+- **Caching 2026** (fetch diretto): minimo cacheable 512 token su Opus 5/Fable 5 (0.1× input alla lettura); max 4 breakpoint; TTL 5min/1h; lookback 20 blocchi.
+- Caveat dichiarato dalla lane: sezione OpenAI/Google solo da ricerca aggregata (AGENTS.md ora sotto Linux Foundation/Agentic AI Foundation; GEMINI.md = concatenazione eager gerarchica, NON lazy).
+
+### 2c. Repo SOTA (meccanismi, con numeri)
+
+- **Aider**: repomap tree-sitter + PageRank biased sulla chat — solo signatures, budget default **1.000 token**, fitting per binary search. (Il nostro `build_repomap.sh` dichiara la stessa strategia.)
+- **SWE-agent (Princeton, NeurIPS 2024)**: l'interfaccia conta quanto il prompt (ACI). File viewer a **100 righe** (ottimo empirico, non "tutto il file"); search che elenca solo i file con match; messaggi espliciti su output vuoto. +64% relativo vs shell-only.
+- **OpenHands**: event stream append-only + Condenser — trigger a **120 eventi**, preserva i primi 4, target 60 post-condensazione, eventi "dimenticati" tracciati (`forgotten_event_ids`), mai cancellati. Senza condenser il costo scala quadraticamente, con condenser linearmente.
+- **MemGPT/Letta**: core memory (sempre in window, self-editing) / recall (storico ricercabile) / archival (knowledge strutturata su vector DB) — paging OS-like via tool call. **La nostra MEMORY.md (indice) + corpi .md è questo pattern.**
+- **Soglie di auto-compact a confronto** (7 agent): Gemini CLI ~50% · Roo ~86-92% · **Claude Code ~89%** (`window − min(maxOutput,20k) − 13k`) · Codex ~90% · OpenCode ~96-99% · OpenHands event-based. Claude Code ha 5 difese (microcompact, clearing tool output, summarization, cache reuse, compact manuale).
+- **Costo compaction misurato**: ~$0.40 su 125k token (≈21 turni cache-hit); checklist pre-compaction su 7 categorie (path, decisioni, errori, firme, test, env var, task) = **+49% qualità del summary** a costo trascurabile. "Il modello è al suo punto meno intelligente proprio durante l'auto-compact" — gestirla prima, mai subirla.
+- **Cline Memory Bank**: file markdown letti a inizio di OGNI task (activeContext.md, progress.md) — persistenza dichiarativa cross-sessione.
+
+---
+
+## 3. Nuzantara vs SOTA — la diagnosi sul pannello reale
+
+Pannello misurato (sessione M5, 500k window): overhead fisso ~137k (27,5%) = system prompt 7k + system tools 40k + MCP 18k + custom agents 10,3k + **memory files 52k** + skills 10k; messages 161k; autocompact buffer 33k.
+
+### Dove siamo GIÀ al livello dei migliori (o oltre)
+
+| Pratica SOTA | Implementazione Nuzantara | Giudizio |
+|---|---|---|
+| Progressive disclosure | skills corner (`/bot`, `/kbli-navigator`, …), skill-catalog on-demand | ✅ pattern Skills fatto bene |
+| Memoria a livelli (Letta) | MEMORY.md indice ≤24,4KB + corpi .md + MEMORY_ARCHIVE | ✅ core/recall/archival de facto |
+| **Budget armato da TEST** | superscar ≤14KB (`test_superscar_budget.py`), MEMORY.md cap misurato | ✅ **oltre SOTA**: nessuna fonte impone il budget via CI |
+| Stato durevole su file | PENDING-ARMS ledger, spec su disco, handoff via file (ruling 💸) | ✅ = memory tool pattern |
+| Quarantine/subagent | fan-out READS, funnel-in WRITES; worktree per agent | ✅ = punto di equilibrio Anthropic/Cognition |
+| Recitation (Manus) | recap-on-wake, dense recap block di modus | ✅ |
+| Keep the errors in | cicatrici/scar system — gli errori sono LA memoria | ✅ filosoficamente identico |
+| Hooks > prompt | CLAUDE.md §7 "hooks enforce what prompts cannot" | ✅ = "convert it to a hook" ufficiale |
+| Repomap | `build_repomap.sh` tree-sitter, inject se <30min | ✅ = Aider |
+| Sessioni corte + stato via file | scar 💸 (ginocchio ~200 richieste, splitta) | ✅ già pagato col sangue, ora confermato ufficiale |
+
+### Dove DIVERGIAMO dal consenso
+
+1. **I due CLAUDE.md violano il test del taglio-riga.** Sono la parte dominante dei 52k di memory files e contengono esattamente ciò che la guida ufficiale esclude: **storia** (catene di ruling superseded tenute inline: 2026-07-25 → 08-19 → 08-20 sul modello del gate, tre blocchi per dire "oggi è Opus 5 xhigh"), **duplicazioni** (i quirk della famiglia 5 compaiono sia nel CLAUDE.md globale sia in quello repo, quasi verbatim), **info che cambiano spesso** (roster seats, stati "PENDING/probation", snapshot datati), **narrativa lunga** dove servirebbe una riga + puntatore. Il sintomo previsto dalla diagnostica ufficiale — regole ignorate perché sepolte nel rumore — è documentato nelle nostre stesse cicatrici.
+2. **L'enfasi è satura.** Decine di righe 🔴/HARD RULE/⚡ in entrambi i file: per la guida ufficiale questo equivale a zero enfasi ("if you emphasize many lines, none of them stands out").
+3. **Ogni subagent ri-paga l'iniezione.** Superscar lo dice da solo ("ciò che aggiungi lo paga tutta la flotta, per sempre") — ma il principio vale per TUTTO il blocco iniettato, non solo superscar: 52k × ogni subagent × ogni sessione.
+4. **Tool loadout non gestito.** 40k system tools + 18k MCP sempre caricati; la ricerca misura degrado oltre ~20 tool attivi. I deferred tools mitigano già in parte; i 4 MCP server (Drive, Chrome, knowledge, context7) pesano anche quando la sessione non li usa.
+5. **Compaction subita, non istruita.** Nessuna istruzione di compaction nei CLAUDE.md; la checklist pre-compaction (7 categorie) è un +49% di qualità misurato a costo quasi nullo.
+
+---
+
+## 4. Raccomandazioni (in ordine di leva, da studiare — nessuna eseguita)
+
+| # | Azione | Leva | Effort | Note |
+|---|---|---|---|---|
+| R1 | **Dieta dei due CLAUDE.md** col test ufficiale riga-per-riga ("la rimozione causerebbe errori?"). Storia/ruling superseded → un file `RULINGS.md` (o memory files) on-demand; nel CLAUDE.md resta solo lo stato VIGENTE in 1 riga + puntatore. Target: −50-60% (52k → ~20-25k) | ~30k token/sessione, × ogni subagent | Medio (1 sessione dedicata, Gear 3: tocca doctrine) | Il precedente interno esiste già: superscar è nato così (99 scar → 10 famiglie ponte). Stesso gesto, applicato ai CLAUDE.md |
+| R2 | **Budget armato da test sui CLAUDE.md** (pattern `test_superscar_budget.py`): cap in byte, CI rossa se sfora | Impedisce la ricrescita — la dieta senza budget si rimangia | Basso | Senza R2, R1 dura 3 mesi |
+| R3 | **De-duplicare i blocchi gemelli** globale↔repo (quirk famiglia 5, roster, cost constraint): una sola casa + puntatore | ~5-8k | Basso | Attenzione: il globale è un HOME-fork dichiarato (3 copie, scar 📄🍴) — la cura va applicata a tutte le copie |
+| R4 | **Istruzioni di compaction in CLAUDE.md** ("When compacting, always preserve: file modificati, comandi test, decisioni, PENDING-ARMS aperti") | +49% qualità summary misurato altrove, costo ~0 | Minimo | Una riga |
+| R5 | **Razionalizzare l'enfasi**: 🔴 riservato alle sole righe che governano azioni distruttive (la regola c'è già in MEMORY.md ma non è applicata ai CLAUDE.md) | Restituisce significato all'enfasi residua | Basso | |
+| R6 | **MCP loadout per-sessione**: valutare quali dei 4 server servono di default su M5 (Drive? context7?) e spostare gli altri su attivazione esplicita | ~8-12k | Basso | Deferred tools già mitigano; qui si taglia la definizione |
+| R7 | Mantenere e rinforzare ciò che è già SOTA: sessioni corte + stato via file, fan-out READS, budget armati. **Nessun cambio.** | — | — | Il report conferma le scelte, non le smentisce |
+
+**Ordine consigliato**: R2 prima di R1 (arma il budget, poi dimagrisci dentro il budget — altrimenti è una dieta senza bilancia). R3-R5 dentro la stessa PR di R1. R6 indipendente.
+
+## §Solo-operatore
+
+- Decidere SE e QUANDO eseguire R1-R6 (tocca doctrine = Legge 5; R1 è un cambio di CLAUDE.md, self-doctrine → PR con review, mai auto-merge disinvolto).
+- Il CLAUDE.md globale (`~/.claude/CLAUDE.md`) è fuori repo e HOME-fork su 3 macchine: l'allineamento delle copie è gesto di flotta da pianificare.
+
+## Limiti di questo report
+
+- Le sezioni OpenAI/Google della lane Anthropic derivano da ricerca aggregata, non da fetch delle pagine primarie (dichiarato dalla lane).
+- Il tweet originale di Karpathy non è fetchabile direttamente (X → HTTP 402); testo ricostruito da fonti secondarie concordi.
+- I numeri delle soglie di compaction dei 7 agent provengono da un'unica fonte comparativa (codex.danielvaughan.com, apr 2026) — buona ma singola.
+
+## Fonti principali
+
+- Karpathy: x.com/karpathy/status/1937902205765607626 · karpathy.bearblog.dev/sequoia-ascent-2026 · latent.space/p/s3
+- Breunig: dbreunig.com/2025/06/22/how-contexts-fail-and-how-to-fix-them.html · simonwillison.net/2025/Jun/29/how-to-fix-your-context/
+- Manus: manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus
+- Cognition: cognition.com/blog/dont-build-multi-agents
+- Anthropic: anthropic.com/engineering/effective-context-engineering-for-ai-agents · code.claude.com/docs/en/best-practices · anthropic.com/engineering/built-multi-agent-research-system · platform.claude.com/docs (memory-tool, agent-skills, prompt-caching)
+- Repo: aider.chat/2023/10/22/repomap.html · swe-agent.com/latest/background/aci · docs.openhands.dev/sdk/arch/condenser · letta.com/blog/agent-memory · langchain.com/blog/context-engineering-for-agents · codex.danielvaughan.com/2026/04/10/context-compaction-showdown-coding-agents/
+
+*Raw completi delle 3 lane: file gemelli `2026-09-04-context-engineering-sota-lane-{karpathy,anthropic,repos}.md` in questa directory.*


### PR DESCRIPTION
## What

Deep-research capture (Zero's mandate, 2026-09-04): how the best in the field manage LLM/agent context — three parallel research lanes (Karpathy + thought-leaders · official Anthropic guidance · SOTA open-source agents), synthesized into `research/operations/2026-09-04-context-engineering-sota.md` with the three lane raw files beside it.

## Key findings

- Unanimous SOTA consensus: smallest set of high-signal tokens; progressive disclosure; durable state on files; sub-task quarantine; managed (never suffered) compaction; cache-stable prefixes.
- Nuzantara measured against its own `/context` panel (137k fixed overhead / 52k memory files): architecture already SOTA (skills, memory tiers, CI-armed budgets), the two CLAUDE.md files are the one anti-SOTA surface (the officially-named "over-specified CLAUDE.md" anti-pattern).
- R1-R7 recommendations ranked by leverage — study-only, nothing executed in this PR.

## Bites

Zero reads the report to decide on R1-R6 (context diet). Docs-only diff: no code, no consumer, no deploy surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)