### PR TITLE
fix(workspace-marketing): the fact gate killed every real NotebookLM answer at 75 s

### DIFF
--- a/apps/nuzantara-mcp/nuzantara_mcp/tools/workspace_marketing.py
+++ b/apps/nuzantara-mcp/nuzantara_mcp/tools/workspace_marketing.py
@@ -793,6 +793,14 @@ async def _run_public_subprocess(
     except TimeoutError:
         process.kill()
         await process.wait()
+        # The public message stays constant; the Pro log says WHICH provider and
+        # what budget it blew (a 121 s NotebookLM answer hid behind a 75 s cap on
+        # 2026-09-04 with nothing in the log to say so).
+        logger.warning(
+            "Editorial verification provider %s timed out after %ss",
+            Path(argv[0]).name,
+            timeout_seconds,
+        )
         raise RuntimeError("Editorial verification timed out") from None
     if process.returncode != 0:
         # The exit code alone hid a "Not logged in" for two days (2026-09-01..02).
@@ -876,6 +884,8 @@ def _secrets_file_value(name: str, path: Path | None = None) -> str:
 # The question is therefore built per PART, each under this byte budget.
 _NOTEBOOKLM_QUESTION_BUDGET = 4_000
 _NOTEBOOKLM_MAX_PARTS = 8
+_NOTEBOOKLM_QUERY_TIMEOUT_SECONDS = 240
+_NOTEBOOKLM_CONCURRENCY = 4
 _NOTEBOOKLM_QUESTION_PREAMBLE = (
     "Verify the material legal, regulatory, tax, immigration, company or property "
     "claims in this public-intended Bali Zero article. Identify unsupported, outdated, "
@@ -967,14 +977,30 @@ async def _query_notebooklm(article: dict[str, Any], notebook_id: str) -> str:
             f"{_NOTEBOOKLM_MAX_PARTS} parts of about {_NOTEBOOKLM_QUESTION_BUDGET} "
             "characters"
         )
-    notes: list[str] = []
-    for index, part_text in enumerate(parts, start=1):
+    # A grounded answer from a 250-source notebook took 121 s on Pro (2026-09-04);
+    # the old 75 s cap killed every real query while a 5 s "ping" passed. Parts
+    # run concurrently so the gate's wall time is one answer, not one per part.
+    # `--timeout` is nlm's own per-request budget; it did not stop the 121 s
+    # answer, so the outer cap is what actually bounds the call.
+    env = _verification_env("notebooklm")
+    limiter = asyncio.Semaphore(_NOTEBOOKLM_CONCURRENCY)
+
+    async def query_part(index: int, part_text: str) -> str:
         question = _notebooklm_question(article, part_text, index, len(parts))
-        output = await _run_public_subprocess(
-            [binary, "query", "notebook", notebook_id, question, "--timeout", "60"],
-            timeout_seconds=75,
-            env=_verification_env("notebooklm"),
-        )
+        async with limiter:
+            output = await _run_public_subprocess(
+                [
+                    binary,
+                    "query",
+                    "notebook",
+                    notebook_id,
+                    question,
+                    "--timeout",
+                    str(_NOTEBOOKLM_QUERY_TIMEOUT_SECONDS),
+                ],
+                timeout_seconds=_NOTEBOOKLM_QUERY_TIMEOUT_SECONDS + 30,
+                env=env,
+            )
         try:
             payload = json.loads(output)
         except json.JSONDecodeError:
@@ -984,9 +1010,11 @@ async def _query_notebooklm(article: dict[str, Any], notebook_id: str) -> str:
         cleaned = _clean_text(answer, limit=8_000)
         if not cleaned:
             raise RuntimeError("NotebookLM verifier returned no usable evidence")
-        notes.append(
-            cleaned if len(parts) == 1 else f"[part {index}/{len(parts)}] {cleaned}"
-        )
+        return cleaned if len(parts) == 1 else f"[part {index}/{len(parts)}] {cleaned}"
+
+    notes = await asyncio.gather(
+        *(query_part(index, part_text) for index, part_text in enumerate(parts, start=1))
+    )
     return "\n\n".join(notes)
 
 

--- a/apps/nuzantara-mcp/tests/test_workspace_marketing_bridge.py
+++ b/apps/nuzantara-mcp/tests/test_workspace_marketing_bridge.py
@@ -2123,3 +2123,59 @@ async def test_query_notebooklm_refuses_an_article_beyond_the_part_cap(
         await marketing._query_notebooklm(
             {"title": "t", "content": body, "source_url": ""}, "nb-id"
         )
+
+
+async def test_notebooklm_parts_run_concurrently_under_a_real_answer_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A grounded NotebookLM answer took 121 s on Pro (2026-09-04); the old 75 s
+    cap killed every real query. Parts must carry a budget above that and run
+    concurrently so the gate waits for one answer, not one per part."""
+
+    in_flight = 0
+    peak = 0
+    budgets: list[tuple[str, int]] = []
+
+    async def fake_subprocess(argv: list[str], *, timeout_seconds: int, **_: Any) -> str:
+        nonlocal in_flight, peak
+        budgets.append((argv[argv.index("--timeout") + 1], timeout_seconds))
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+        return json.dumps({"answer": "evidence"})
+
+    monkeypatch.setattr(marketing, "_run_public_subprocess", fake_subprocess)
+    monkeypatch.setattr(marketing.shutil, "which", lambda *_a, **_k: "/usr/bin/nlm")
+
+    body = "Claim sentence number one about LKPM reporting. " * 400
+    evidence = await marketing._query_notebooklm(
+        {"title": "t", "content": body, "source_url": ""}, "nb-id"
+    )
+
+    assert len(budgets) >= 3
+    assert peak > 1, "parts ran one after another"
+    assert peak <= marketing._NOTEBOOKLM_CONCURRENCY
+    for cli_timeout, outer_timeout in budgets:
+        assert int(cli_timeout) >= 200
+        assert outer_timeout > int(cli_timeout)
+    # Order is preserved even though the parts finish independently.
+    assert evidence.startswith("[part 1/")
+    assert evidence.index("[part 2/") > evidence.index("[part 1/")
+
+
+async def test_timed_out_verifier_names_the_provider_in_the_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import sys as _sys
+
+    caplog.set_level("WARNING", logger="nuzantara_mcp.tools.workspace_marketing")
+    with pytest.raises(RuntimeError, match="timed out"):
+        await marketing._run_public_subprocess(
+            [_sys.executable, "-c", "import time; time.sleep(5)"],
+            timeout_seconds=1,
+            env={"PATH": "/usr/bin:/bin"},
+        )
+    record = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "timed out after 1s" in record
+    assert Path(_sys.executable).name in record


### PR DESCRIPTION
## Why

A grounded answer from a 253-source notebook took 121 s on Pro (2026-09-04, `nlm query notebook 85207af3-… "<3.6k-char question>"`), while `_query_notebooklm` capped each call at 75 s (`--timeout 60`). A 5 s "ping" passed, so the cap looked fine and every real fact gate raised "Editorial verification timed out" — with no log line naming the provider, so the cause was invisible from the tunnel log.

## What

- Per-part budget 240 s (`--timeout 240`, outer cap 270 s); nlm's own `--timeout` did not stop the 121 s answer, the outer cap is what bounds the call.
- Parts run concurrently (semaphore 4) so the gate waits for one answer, not one per part; evidence order is preserved.
- The timeout branch of `_run_public_subprocess` logs the provider name and the budget it blew, the way the non-zero-exit branch already does.

## Verification

- `pytest tests/test_workspace_marketing_bridge.py -q` → 64 passed.
- `ruff check` on both changed files → clean.
- Timing measured on Pro (2026-09-04): `nlm query notebook 85207af3-… "<3.6k-char question>"` → 121 s wall time against a 253-source notebook.

Bites: `newsroom_fact_gate` on Pro (LaunchAgent com.nuzantara.chatgpt-marketing-tunnel) on pending draft news_20260903_173431_b5405cf4 — observation: a verdict dict instead of "Editorial verification timed out", and any future timeout lands in ~/Library/Logs/chatgpt-marketing-tunnel.err.log as "provider nlm timed out after 270s".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
