### PR TITLE
chore(context-diet): repo agent descriptions to one sentence + MCP→CLI tools index

### DIFF
--- a/.claude/agents/frontend-browser.md
+++ b/.claude/agents/frontend-browser.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-browser
-description: Use when need to QA frontend after deploy — screenshot kita.balizero.com / my / prime / mouth / web, verify colors/logo/no broken elements. Browser automation via mcp__claude-in-chrome (or mcp__playwright if explicitly instructed).
+description: Use when need to QA frontend after deploy — screenshot kita.balizero.com / my / prime / mouth / web, verify colors/logo/no broken elements.
 tools: Bash, Read, Grep, Glob, WebFetch, mcp__claude-in-chrome
 disallowedTools: Edit, Write, MultiEdit, NotebookEdit
 model: sonnet

--- a/.claude/agents/wr2-design-architect.md
+++ b/.claude/agents/wr2-design-architect.md
@@ -1,6 +1,6 @@
 ---
 name: wr2-design-architect
-description: 'MUST BE USED for every Bali Zero WR2 editorial carousel. Use IMMEDIATELY when user says "design a carousel for [topic]", "draft a WR2 brief", or invokes the WR2 pipeline. Orchestrator-only: fans out to 4 specialist subagents, never writes JSON/HTML inline.'
+description: 'MUST BE USED for every Bali Zero WR2 editorial carousel. Use IMMEDIATELY when user says "design a carousel for [topic]", "draft a WR2 brief", or invokes the WR2 pipeline.'
 tools: Read, Write, Edit, Glob, Grep, Bash, Skill, Agent, WebFetch
 model: opus
 isolation: worktree

--- a/.claude/agents/wr2-storyboarder.md
+++ b/.claude/agents/wr2-storyboarder.md
@@ -1,6 +1,6 @@
 ---
 name: wr2-storyboarder
-description: "MUST BE USED by wr2-design-architect at Step 3 of every carousel run. Use IMMEDIATELY when brief-interpreter returns its brief. Returns 4-10 slide narrative spec. ENFORCES bullet-promise rule (Article 6.3). No HTML, no rendering."
+description: "MUST BE USED by wr2-design-architect at Step 3 of every carousel run. Use IMMEDIATELY when brief-interpreter returns its brief."
 tools: Read, Glob, Grep, Bash
 model: sonnet
 color: purple

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,18 @@ Quick start: `python scripts/agent_start.py --lane <X> --task-id <Y>` → cd out
 - **Anti-hallucination**: mai citare output di un tool senza averlo eseguito in QUESTO turn. 4-LLM panel + workflow generator≠grader: `docs/rules/operations.md`.
 - **Off-limits files** (top-level hard boundary): `zantara_core.py`, `fly.toml`, `.env*`, `apps/bali-intel-scraper/backend/db/migrations/env.py`. Correzione 2026-08-21 (il vecchio `alembic/env.py` non esiste in questo repo) + dettaglio: `docs/rules/RULINGS.md`.
 
+## Strumenti (MCP→CLI, dieta 2026-09-04)
+
+Il server MCP `nuzantara-knowledge` è staccato dal contesto di default (~−5k token/sessione) — stessi dati via API; `.mcp.json` locale tiene `mcpServers` vuoto (backup `.mcp.json.bak-diet-20260904`).
+
+| Serve | Usa |
+|---|---|
+| Prezzi / KBLI / visa / legal (PII-free) | `curl https://nuzantara-rag.fly.dev/...` — è il backend che l'MCP wrappava (`apps/nuzantara-mcp/nuzantara_mcp/server_knowledge.py`); per una sessione che vuole i tool MCP: ripristina il backup di `.mcp.json` |
+| Docs librerie/framework | WebFetch / WebSearch (plugin context7 disinstallato) |
+| GitHub · Fly · Postgres | `gh` · `fly` · `scripts/pg.sh` |
+| Browser QA post-deploy | MCP `claude-in-chrome` (resta, deferred) |
+| Google Drive | connector claude.ai on-demand (`operator[gui]`) |
+
 ## 3. Memory (MOS — Memory Operating System)
 
 SessionStart hook auto-loads last 5 memories (importance ≥7). Manual CLI `~/.claude/scripts/mem`:


### PR DESCRIPTION
## Summary
- Trim repo `.claude/agents/*.md` `description:` frontmatter fields over 230 chars to a single sentence (3 files exceeded the cap: `frontend-browser.md`, `wr2-design-architect.md`, `wr2-storyboarder.md`) — fixes a script bug in the provided trim snippet that dropped the closing YAML quote on 2 of the 3 quoted-scalar files, verified with `yaml.safe_load` on every touched frontmatter.
- Adds a `## Strumenti (MCP→CLI, dieta 2026-09-04)` section to root `CLAUDE.md` between "Regole sempre-applicabili" and "3. Memory", documenting the `nuzantara-knowledge` MCP detach (~−5k token/session) and its CLI/API replacements.
- Part of the 2026-09-04 context-diet mandate, follows PR #5628 / #5631.

## Bites
Every M5 session loads the root index + agent descriptions at boot — observed via `scripts/tests/test_claude_md_budget.py` green (15/15, pointer integrity) and the description byte-count printed by the trim script (repo agent description: 4108B -> 3826B before the manual YAML fix; final per-file description lengths verified with `yaml.safe_load`: frontend-browser.md 139B, wr2-design-architect.md 170B, wr2-storyboarder.md 127B).

## Test plan
- [x] `python3 -m pytest scripts/tests/test_claude_md_budget.py -q` → 15/15 passed
- [x] `wc -c CLAUDE.md` → 10571B (≤16384B budget)
- [x] `yaml.safe_load` on all 3 touched agent frontmatters → valid (2 had broken YAML from the original trim script — closing quote missing — fixed by hand before commit)
- [x] `git diff` confirms only the `description:` field changed per agent file (no body/tool/model changes)
- [x] Evidence floor measured 1 (source: none) via `scripts/evidence_pack_lint.py --print-floor` — below the ≥2 threshold that requires `evidence/brief.yml`, so none was created

## Deviation from instructions
Step 4 (evidence/brief.yml) was skipped — measured floor is 1, not ≥2 as assumed in the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuWdQmAMJzUXQqMo7FmGMD