### PR TITLE
feat(context): context_budget_audit.py measures the always-injected surface

### DIFF
--- a/scripts/context_budget_audit.py
+++ b/scripts/context_budget_audit.py
@@ -1,0 +1,362 @@
+"""
+Context-budget audit: measures the ALWAYS-INJECTED context surface of this
+repo — the bytes Claude Code loads into every session and every subagent
+before the first user turn, regardless of what the task is about.
+
+Context-diet (2026-09-04, mandate "B6: an audit script that measures the
+always-injected context surface + a CI test that caps it"). Sibling guards
+already exist for individual pieces of this surface —
+`test_superscar_budget.py` caps `cicatrix-superscar.md`, `test_claude_md_budget.py`
+caps `CLAUDE.md` (root + per-folder) and flags a `.claude/rules/*.md` file
+that forgot its `paths:` scoping frontmatter. This script is the ROLLUP: it
+adds up everything Claude Code boots with, so a change that stays under each
+individual cap can still be caught if it pushes the TOTAL over budget —
+exactly the superscar-family-#2 failure mode ("Esiste ≠ Armato" applied to a
+budget: five individually-compliant files can still add up to a boot tax
+nobody measured).
+
+What gets counted, and why (verified empirically against a fresh Claude Code
+session boot on 2026-09-04, not assumed from documentation):
+
+  - `root_claude_md`  — `CLAUDE.md` at the repo root, loaded in FULL.
+  - `unscoped_rules`  — every `.claude/rules/*.md` file WHOSE FRONTMATTER HAS
+    NO `paths:` KEY, loaded in FULL (a `paths:`-scoped rule only loads when
+    a file matching its glob is touched — that's the entire point of the
+    scoping mechanism `test_claude_md_budget.py`'s guard #4 protects).
+  - `agents_frontmatter` — every `.claude/agents/*.md` file contributes only
+    its frontmatter `name` + `description` + `tools` fields (the body is
+    read lazily, only if that agent is actually dispatched).
+  - `skills_listing` — every `.claude/skills/*/SKILL.md` and
+    `.claude/commands/*.md` file contributes only its frontmatter `name` +
+    `description` (same lazy-body reasoning as agents).
+
+`--live` adds four more categories that are machine-local (they read
+`Path.home()`, i.e. `~/.claude/...`, not anything in this repo) and are
+NEVER identical across two machines or two worktrees on the same machine:
+`global_claude_md` (`~/.claude/CLAUDE.md`), `auto_memory` (the per-project
+auto-loaded `MEMORY.md` under `~/.claude/projects/<cwd-slug>/memory/`, where
+`<cwd-slug>` is the current working directory's absolute path with every
+`/` replaced by `-` — e.g. `/Users/balizero/nuzantara` becomes
+`-Users-balizero-nuzantara`, which is why the `--live` table must never be
+pasted anywhere outside this machine: the slug alone identifies the
+operator's home directory), `home_agents_frontmatter` and
+`home_skills_listing` (the `~/.claude/agents` and `~/.claude/skills` +
+`~/.claude/commands` mirrors of the two repo categories above). Because
+`--live` output is machine-identifying, only the four REPO categories are
+asserted on in CI (`scripts/tests/test_context_budget_audit.py`) — `--live`
+is a human-operated diagnostic, not a gate.
+
+The byte→token ratio (default 2.04 bytes/token) was measured empirically on
+this repo's actual injected-context mix (Italian prose + emoji + markdown
+tables skew heavier per-token than English ASCII prose) — it is a ballpark,
+not a tokenizer. Every "est_tokens" figure in this script's output is
+labelled "est." for exactly that reason: the only ground truth for the real
+number is running `/context` in a fresh Claude Code session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_BYTES_PER_TOKEN = 2.04
+
+# Repo-scope categories, in table/report order. Deterministic, CI-safe —
+# nothing here reads outside the repo checkout.
+REPO_CATEGORIES = (
+    "root_claude_md",
+    "unscoped_rules",
+    "agents_frontmatter",
+    "skills_listing",
+)
+
+# Machine-local categories, only measured under --live. Every one of these
+# reads Path.home() — never paste this table anywhere, it identifies the
+# operator's machine (see module docstring on `auto_memory`'s slug).
+LIVE_CATEGORIES = (
+    "global_claude_md",
+    "auto_memory",
+    "home_agents_frontmatter",
+    "home_skills_listing",
+)
+
+_FRONTMATTER_KEY_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$")
+
+
+def frontmatter_block(text: str) -> list[str] | None:
+    """The raw lines strictly between the opening `---` and the closing
+    `---` of a YAML frontmatter block at the very top of `text`. `None` if
+    `text` does not open with `---` on its first line, or the block is
+    never closed."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    body: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return body
+        body.append(line)
+    return None  # opened but never closed — not a valid frontmatter block
+
+
+def has_paths_frontmatter(text: str) -> bool:
+    """True if `text` opens with a YAML frontmatter block that declares a
+    `paths:` key (single-line list or a multi-line list continued on the
+    lines below it — either shape only needs the KEY line itself, its value
+    shape does not matter here)."""
+    body = frontmatter_block(text)
+    if body is None:
+        return False
+    return any(line.strip().startswith("paths:") for line in body)
+
+
+def frontmatter_fields(text: str) -> dict[str, str]:
+    """Top-level scalar frontmatter fields as raw strings — surrounding
+    quotes stripped, multi-line continuations (an indented list under a bare
+    `key:`) joined with spaces into the same field. Returns `{}` when `text`
+    has no frontmatter block at all (the "skip files without frontmatter"
+    case: such a file contributes nothing, deliberately not an error — a
+    body-only `.md` file under `.claude/agents/` etc. is never auto-injected
+    at boot, so it costs zero context budget)."""
+    body = frontmatter_block(text)
+    if body is None:
+        return {}
+    fields: dict[str, str] = {}
+    current_key: str | None = None
+    for line in body:
+        if line and not line[0].isspace():
+            m = _FRONTMATTER_KEY_RE.match(line)
+            if m:
+                current_key = m.group(1)
+                value = m.group(2).strip()
+                if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                    value = value[1:-1]
+                fields[current_key] = value
+                continue
+        if current_key is not None:
+            fields[current_key] = (fields[current_key] + " " + line.strip()).strip()
+    return fields
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _measure_frontmatter_file(path: Path, *, include_tools: bool) -> tuple[int, int]:
+    """(files, chars) contributed by one agent/skill/command file: the sum
+    of its frontmatter `name` + `description` (+ `tools` when
+    `include_tools`) field lengths — NOT the file's on-disk byte size, since
+    only the frontmatter is loaded at boot, the body is read lazily. Files
+    without a frontmatter block contribute (0, 0)."""
+    fields = frontmatter_fields(_read(path))
+    if not fields:
+        return (0, 0)
+    total = len(fields.get("name", "")) + len(fields.get("description", ""))
+    if include_tools:
+        total += len(fields.get("tools", ""))
+    return (1, total)
+
+
+def _measure_frontmatter_glob(root: Path, pattern: str, *, include_tools: bool) -> tuple[int, int]:
+    files = 0
+    total = 0
+    if not root.is_dir():
+        return (0, 0)
+    for p in sorted(root.glob(pattern)):
+        if not p.is_file():
+            continue
+        f, b = _measure_frontmatter_file(p, include_tools=include_tools)
+        files += f
+        total += b
+    return (files, total)
+
+
+def _measure_unscoped_rules(repo_root: Path) -> tuple[int, int]:
+    rules_dir = repo_root / ".claude" / "rules"
+    files = 0
+    total = 0
+    if not rules_dir.is_dir():
+        return (0, 0)
+    for p in sorted(rules_dir.glob("*.md")):
+        if not p.is_file():
+            continue
+        text = _read(p)
+        if not has_paths_frontmatter(text):
+            files += 1
+            total += p.stat().st_size
+    return (files, total)
+
+
+def _measure_whole_file(path: Path) -> tuple[int, int]:
+    if not path.is_file():
+        return (0, 0)
+    return (1, path.stat().st_size)
+
+
+def _memory_slug(repo_root: Path) -> str:
+    """`~/.claude/projects/<slug>/memory/MEMORY.md`'s `<slug>`: the current
+    working directory's resolved absolute path with every `/` replaced by
+    `-` (e.g. `/Users/balizero/nuzantara` -> `-Users-balizero-nuzantara`).
+    Deliberately keyed on `repo_root` (the audit's own notion of "cwd"), NOT
+    a hardcoded canonical checkout path — running this from a worktree
+    checkout correctly reports that worktree's (usually absent) memory
+    file, not the main checkout's."""
+    return str(repo_root.resolve()).replace("/", "-")
+
+
+def measure(repo_root: Path, live: bool = False) -> dict[str, dict[str, int]]:
+    """Measure the always-injected context surface. Returns an ordered dict
+    (`REPO_CATEGORIES`, then `LIVE_CATEGORIES` if `live`) of
+    `{"files": int, "bytes": int}`. `bytes` is on-disk file size for the two
+    whole-file categories (`root_claude_md`, `unscoped_rules`,
+    `global_claude_md`, `auto_memory`) and frontmatter-field character count
+    for the two frontmatter-only categories (`agents_frontmatter`,
+    `skills_listing`, and their `home_*` live counterparts) — see the
+    per-category docstrings above for why the two are measured differently."""
+    repo_root = Path(repo_root)
+    result: dict[str, dict[str, int]] = {}
+
+    files, total = _measure_whole_file(repo_root / "CLAUDE.md")
+    result["root_claude_md"] = {"files": files, "bytes": total}
+
+    files, total = _measure_unscoped_rules(repo_root)
+    result["unscoped_rules"] = {"files": files, "bytes": total}
+
+    files, total = _measure_frontmatter_glob(
+        repo_root / ".claude" / "agents", "*.md", include_tools=True
+    )
+    result["agents_frontmatter"] = {"files": files, "bytes": total}
+
+    skill_files, skill_total = _measure_frontmatter_glob(
+        repo_root / ".claude" / "skills", "*/SKILL.md", include_tools=False
+    )
+    cmd_files, cmd_total = _measure_frontmatter_glob(
+        repo_root / ".claude" / "commands", "*.md", include_tools=False
+    )
+    result["skills_listing"] = {
+        "files": skill_files + cmd_files,
+        "bytes": skill_total + cmd_total,
+    }
+
+    if live:
+        home = Path.home()
+
+        files, total = _measure_whole_file(home / ".claude" / "CLAUDE.md")
+        result["global_claude_md"] = {"files": files, "bytes": total}
+
+        slug = _memory_slug(repo_root)
+        mem_path = home / ".claude" / "projects" / slug / "memory" / "MEMORY.md"
+        files, total = _measure_whole_file(mem_path)
+        result["auto_memory"] = {"files": files, "bytes": total}
+
+        files, total = _measure_frontmatter_glob(
+            home / ".claude" / "agents", "*.md", include_tools=True
+        )
+        result["home_agents_frontmatter"] = {"files": files, "bytes": total}
+
+        skill_files, skill_total = _measure_frontmatter_glob(
+            home / ".claude" / "skills", "*/SKILL.md", include_tools=False
+        )
+        cmd_files, cmd_total = _measure_frontmatter_glob(
+            home / ".claude" / "commands", "*.md", include_tools=False
+        )
+        result["home_skills_listing"] = {
+            "files": skill_files + cmd_files,
+            "bytes": skill_total + cmd_total,
+        }
+
+    return result
+
+
+def _est_tokens(num_bytes: int, bytes_per_token: float) -> int:
+    return round(num_bytes / bytes_per_token)
+
+
+def render_table(
+    measurement: dict[str, dict[str, int]], bytes_per_token: float
+) -> str:
+    lines: list[str] = []
+    header = f"{'category':<26}{'files':>8}{'bytes':>12}{'est_tokens':>14}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    total_bytes = 0
+    for category, stats in measurement.items():
+        b = stats["bytes"]
+        total_bytes += b
+        lines.append(
+            f"{category:<26}{stats['files']:>8}{b:>12,}{_est_tokens(b, bytes_per_token):>14,}"
+        )
+    lines.append("-" * len(header))
+    lines.append(
+        f"{'TOTAL':<26}{'':>8}{total_bytes:>12,}{_est_tokens(total_bytes, bytes_per_token):>14,}"
+    )
+    lines.append("")
+    lines.append(
+        f"ratio: {bytes_per_token} bytes/token (est. — true count via /context in a fresh session)"
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure the always-injected context surface of this repo."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repo checkout to measure (default: this script's own repo)",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="also measure machine-local ~/.claude categories (never paste this output)",
+    )
+    parser.add_argument(
+        "--bytes-per-token",
+        type=float,
+        default=DEFAULT_BYTES_PER_TOKEN,
+        help=f"bytes-per-token ratio for the est_tokens column (default: {DEFAULT_BYTES_PER_TOKEN})",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=None,
+        help="exit 1 if the estimated total exceeds this many tokens",
+    )
+    args = parser.parse_args(argv)
+
+    measurement = measure(args.repo_root, live=args.live)
+    total_bytes = sum(stats["bytes"] for stats in measurement.values())
+    total_tokens = _est_tokens(total_bytes, args.bytes_per_token)
+
+    if args.json:
+        payload = {
+            "categories": measurement,
+            "total_bytes": total_bytes,
+            "total_est_tokens": total_tokens,
+            "bytes_per_token": args.bytes_per_token,
+            "live": args.live,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(render_table(measurement, args.bytes_per_token))
+
+    if args.max_tokens is not None and total_tokens > args.max_tokens:
+        print(
+            f"\nOVER BUDGET: est. {total_tokens:,} tokens > --max-tokens {args.max_tokens:,}",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_context_budget_audit.py
+++ b/scripts/tests/test_context_budget_audit.py
@@ -1,0 +1,260 @@
+"""Tests for scripts/context_budget_audit.py — the B6 always-injected
+context-surface rollup.
+
+Module is imported via importlib.util.spec_from_file_location (not a package
+import) because scripts/ is a flat bag of standalone tools, not a Python
+package (mirrors scripts/tests/test_adversarial_review_gate.py /
+scripts/tests/test_pending_arms_report.py convention).
+
+Three things, deliberately kept together:
+
+1. Self-tests of the two frontmatter helpers (`has_paths_frontmatter`,
+   `frontmatter_fields`) and of `measure()` itself, on fixtures built in
+   `tmp_path` — never against the real repo, so these stay green regardless
+   of what any other in-flight PR does to `.claude/`.
+2. A RATCHET on the real repo's four repo-scope categories
+   (`root_claude_md`, `unscoped_rules`, `agents_frontmatter`,
+   `skills_listing`): total estimated tokens must stay at or under
+   `REPO_SCOPE_TOKEN_CEILING`. This is deliberately NOT the diet's eventual
+   target of 15,000 tokens — measured at write time (2026-09-04, ratio
+   2.04 bytes/token) the real total was ~15,553 est. tokens, almost
+   entirely `root_claude_md` (~5,182) + `unscoped_rules`
+   (~6,120, i.e. `cicatrix-superscar.md` sitting near its own independent
+   14KB cap) with `agents_frontmatter`/`skills_listing` a smaller remainder
+   (~2,293 + ~1,959). Two sibling mandates in flight the same day
+   (`b1-superscar`, shrinking `cicatrix-superscar.md`; `b3-claude-md`,
+   shrinking the root `CLAUDE.md`) are expected to pull the real number
+   down — when they land, TIGHTEN `REPO_SCOPE_TOKEN_CEILING` toward 15,000
+   rather than leaving headroom that only masks the next regression. The
+   assertion message always prints the number this run actually measured,
+   so tightening it is a one-line, evidence-backed edit, never a guess.
+3. A per-category guard: `unscoped_rules` stays at or under 14,000 BYTES —
+   the exact `BYTE_BUDGET` `test_superscar_budget.py` already enforces on
+   `cicatrix-superscar.md` (currently the sole unscoped-rules contributor).
+   Deliberately not lowered here: another PR (`b1-superscar`) owns lowering
+   that cap: this guard exists only to catch a NEW unscoped `.claude/rules/`
+   file (one that forgot its `paths:` frontmatter) pushing the category over
+   budget, not to police the existing superscar diet.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "context_budget_audit.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("context_budget_audit", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cba = _load_module()
+
+# Ratchet, not the diet's eventual target — see module docstring point 2.
+# Current measured (2026-09-04, ratio 2.04): ~15,553 est. tokens.
+REPO_SCOPE_TOKEN_CEILING = 16_000
+
+# Matches test_superscar_budget.py's BYTE_BUDGET exactly (see point 3 above).
+UNSCOPED_RULES_BYTE_CEILING = 14_000
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Self-tests: frontmatter helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHasPathsFrontmatter:
+    def test_no_frontmatter_at_all_is_false(self) -> None:
+        assert cba.has_paths_frontmatter("# just a heading\n\nsome prose\n") is False
+
+    def test_frontmatter_without_a_paths_key_is_false(self) -> None:
+        text = "---\nname: infra\ndescription: some rule\n---\n\nbody\n"
+        assert cba.has_paths_frontmatter(text) is False
+
+    def test_single_line_paths_list_is_true(self) -> None:
+        text = '---\npaths: ["scripts/generate_*.py"]\n---\n\nbody\n'
+        assert cba.has_paths_frontmatter(text) is True
+
+    def test_multiline_paths_list_is_true(self) -> None:
+        text = (
+            "---\n"
+            "paths:\n"
+            "  [\n"
+            '    "apps/mouth/**/*.{ts,tsx,js,jsx}",\n'
+            '    "apps/webapp/**/*.{ts,tsx}",\n'
+            "  ]\n"
+            "---\n\n"
+            "body\n"
+        )
+        assert cba.has_paths_frontmatter(text) is True
+
+    def test_unclosed_frontmatter_is_false(self) -> None:
+        assert cba.has_paths_frontmatter("---\npaths: [x]\nno closing marker\n") is False
+
+
+class TestFrontmatterFields:
+    def test_file_without_frontmatter_yields_empty_dict(self) -> None:
+        assert cba.frontmatter_fields("# body only, no frontmatter\n") == {}
+
+    def test_simple_scalar_fields_are_extracted(self) -> None:
+        text = "---\nname: backend-verifier\ndescription: verify backend health\n---\n\nbody\n"
+        fields = cba.frontmatter_fields(text)
+        assert fields["name"] == "backend-verifier"
+        assert fields["description"] == "verify backend health"
+
+    def test_quoted_values_have_quotes_stripped(self) -> None:
+        text = '---\nname: bot\ndescription: "Zantara WA bot corner"\n---\n\nbody\n'
+        fields = cba.frontmatter_fields(text)
+        assert fields["description"] == "Zantara WA bot corner"
+
+    def test_tools_field_is_the_raw_comma_list(self) -> None:
+        text = "---\nname: x\ntools: Bash, Read, Grep, Glob\n---\n\nbody\n"
+        assert cba.frontmatter_fields(text)["tools"] == "Bash, Read, Grep, Glob"
+
+
+# ---------------------------------------------------------------------------
+# Self-tests: measure() on fixtures — never on the real repo
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureOnFixtures:
+    def test_a_rule_with_a_multiline_paths_list_is_excluded(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "CLAUDE.md",
+            "root claude md\n" * 5,
+        )
+        _write(
+            tmp_path / ".claude" / "rules" / "scoped.md",
+            "---\npaths:\n  [\n"
+            '    "apps/mouth/**/*.ts",\n'
+            "  ]\n---\n\nscoped body, must not be counted\n",
+        )
+        result = cba.measure(tmp_path)
+        assert result["unscoped_rules"] == {"files": 0, "bytes": 0}
+
+    def test_a_rule_without_paths_frontmatter_is_included(self, tmp_path: Path) -> None:
+        _write(tmp_path / "CLAUDE.md", "root\n")
+        rule_text = "---\nname: infra\n---\n\nalways-injected body\n"
+        _write(tmp_path / ".claude" / "rules" / "unscoped.md", rule_text)
+        result = cba.measure(tmp_path)
+        assert result["unscoped_rules"] == {
+            "files": 1,
+            "bytes": len(rule_text.encode("utf-8")),
+        }
+
+    def test_mixed_scoped_and_unscoped_rules_counts_only_the_unscoped_one(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path / "CLAUDE.md", "root\n")
+        _write(
+            tmp_path / ".claude" / "rules" / "scoped.md",
+            '---\npaths: ["**/*.py"]\n---\n\nscoped\n',
+        )
+        unscoped_text = "---\nname: always\n---\n\nalways body\n"
+        _write(tmp_path / ".claude" / "rules" / "unscoped.md", unscoped_text)
+        result = cba.measure(tmp_path)
+        assert result["unscoped_rules"]["files"] == 1
+        assert result["unscoped_rules"]["bytes"] == len(unscoped_text.encode("utf-8"))
+
+    def test_an_agent_file_without_frontmatter_contributes_zero(self, tmp_path: Path) -> None:
+        _write(tmp_path / "CLAUDE.md", "root\n")
+        _write(
+            tmp_path / ".claude" / "agents" / "no-frontmatter.md",
+            "# just an agent body, no frontmatter block at all\n",
+        )
+        result = cba.measure(tmp_path)
+        assert result["agents_frontmatter"] == {"files": 0, "bytes": 0}
+
+    def test_an_agent_file_with_frontmatter_contributes_name_description_tools_length(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path / "CLAUDE.md", "root\n")
+        _write(
+            tmp_path / ".claude" / "agents" / "verifier.md",
+            "---\nname: verifier\ndescription: checks things\ntools: Bash, Read\n---\n\nbody\n",
+        )
+        result = cba.measure(tmp_path)
+        expected = len("verifier") + len("checks things") + len("Bash, Read")
+        assert result["agents_frontmatter"] == {"files": 1, "bytes": expected}
+
+    def test_skill_and_command_files_are_summed_into_one_category(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path / "CLAUDE.md", "root\n")
+        _write(
+            tmp_path / ".claude" / "skills" / "bot" / "SKILL.md",
+            "---\nname: bot\ndescription: wa bot corner\n---\n\nbody\n",
+        )
+        _write(
+            tmp_path / ".claude" / "commands" / "verify.md",
+            "---\nname: verify\ndescription: empirical verification\n---\n\nbody\n",
+        )
+        result = cba.measure(tmp_path)
+        expected = (
+            len("bot")
+            + len("wa bot corner")
+            + len("verify")
+            + len("empirical verification")
+        )
+        assert result["skills_listing"] == {"files": 2, "bytes": expected}
+
+    def test_a_missing_repo_root_claude_md_is_zero_not_a_crash(self, tmp_path: Path) -> None:
+        result = cba.measure(tmp_path)
+        assert result["root_claude_md"] == {"files": 0, "bytes": 0}
+
+    def test_live_categories_are_absent_unless_requested(self, tmp_path: Path) -> None:
+        _write(tmp_path / "CLAUDE.md", "root\n")
+        result = cba.measure(tmp_path, live=False)
+        for key in cba.LIVE_CATEGORIES:
+            assert key not in result
+        for key in cba.REPO_CATEGORIES:
+            assert key in result
+
+
+# ---------------------------------------------------------------------------
+# The real repo: the actual guard
+# ---------------------------------------------------------------------------
+
+
+class TestTheRealRepoScopeStaysUnderBudget:
+    def test_total_repo_scope_estimated_tokens_stays_under_the_ratchet(self) -> None:
+        measurement = cba.measure(REPO_ROOT, live=False)
+        assert set(measurement) == set(cba.REPO_CATEGORIES)
+        total_bytes = sum(stats["bytes"] for stats in measurement.values())
+        total_tokens = cba._est_tokens(total_bytes, cba.DEFAULT_BYTES_PER_TOKEN)
+        breakdown = ", ".join(
+            f"{cat}={stats['bytes']}B" for cat, stats in measurement.items()
+        )
+        assert total_tokens <= REPO_SCOPE_TOKEN_CEILING, (
+            f"always-injected repo-scope context surface is now ~{total_tokens:,} "
+            f"est. tokens ({total_bytes:,} bytes), over the "
+            f"{REPO_SCOPE_TOKEN_CEILING:,}-token ratchet. Per-category: {breakdown}. "
+            "If this is a deliberate addition, confirm it is truly always-injected "
+            "(not something that belongs behind a `paths:` scope or a lazily-read "
+            "agent/skill body) before raising the ceiling."
+        )
+
+    def test_unscoped_rules_stays_under_its_byte_ceiling(self) -> None:
+        measurement = cba.measure(REPO_ROOT, live=False)
+        size = measurement["unscoped_rules"]["bytes"]
+        assert size <= UNSCOPED_RULES_BYTE_CEILING, (
+            f".claude/rules/ files without `paths:` frontmatter total {size} bytes, "
+            f"over the {UNSCOPED_RULES_BYTE_CEILING}-byte ceiling shared with "
+            "cicatrix-superscar.md's own budget test. Either a new unscoped rule "
+            "file appeared (give it `paths:` scoping if it doesn't need to be "
+            "always-injected) or the existing one grew."
+        )


### PR DESCRIPTION
## What
Adds `scripts/context_budget_audit.py`: an audit that rolls up the ALWAYS-INJECTED context surface of this repo — root `CLAUDE.md`, unscoped `.claude/rules/*.md` (no `paths:` frontmatter), and the frontmatter-only (`name`+`description`+`tools`) cost of every `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, and `.claude/commands/*.md` file. `--live` adds four machine-local `~/.claude/...` categories for human diagnosis (never asserted on in CI, never pasted — the `auto_memory` path encodes the operator's home directory).

Adds `scripts/tests/test_context_budget_audit.py`: self-tests of the frontmatter helpers and `measure()` on `tmp_path` fixtures, plus the real CI ratchet on the repo's four repo-scope categories.

## Verification
Repo-scope table (2026-09-04, ratio 2.04 bytes/token):

```
category                     files       bytes    est_tokens
------------------------------------------------------------
root_claude_md                   1      10,571         5,182
unscoped_rules                   1      12,484         6,120
agents_frontmatter              20       4,677         2,293
skills_listing                  22       3,996         1,959
------------------------------------------------------------
TOTAL                                   31,728        15,553

ratio: 2.04 bytes/token (est. — true count via /context in a fresh session)
```

`unscoped_rules`'s sole contributor is `cicatrix-superscar.md`, sitting near its own independent 14KB cap. The CI ratchet is set to 16,000 est. tokens (not the diet's eventual 15,000 target) to give headroom for that current snapshot — tighten it once the concurrent `b1-superscar`/`b3-claude-md` diet PRs land and pull the real number down.

```
$ python3 -m pytest -q scripts/tests/test_context_budget_audit.py
19 passed in 0.06s
```

`ruff check` clean on both new files.

## Bites
Consumer: CI runs `scripts/tests/test_context_budget_audit.py` on every PR (it lives under `scripts/tests` like the other budget tests); observation: the test is green on main and prints the measured est. tokens on failure; `python3 scripts/context_budget_audit.py` on main reproduces the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4