### PR TITLE
fix(intel-scraper): the cover visual director never found `claude` under launchd

### DIFF
--- a/apps/bali-intel-scraper/scripts/bz_image_style.py
+++ b/apps/bali-intel-scraper/scripts/bz_image_style.py
@@ -58,6 +58,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -495,6 +496,24 @@ _OAUTH_SCRUB_PREFIXES = (
 )
 
 
+# launchd hands the poller a PATH of /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin,
+# but the `claude` CLI on the fleet lives in ~/.local/bin. Measured on Pro
+# 2026-09-04: 113 × "claude CLI: not found in PATH" and 388 × "Using fallback
+# visual" — every cover came from the canned template, never from the visual
+# director. Same cure as the marketing bridge's _verification_env: a standard
+# PATH that includes the user-local bin, prepended, never replaced.
+_CLI_STANDARD_PATH = (
+    "/opt/homebrew/bin:{home}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+)
+
+
+def _cli_search_path(current: str | None = None) -> str:
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    standard = _CLI_STANDARD_PATH.format(home=home)
+    current = current if current is not None else os.environ.get("PATH", "")
+    return f"{standard}:{current}" if current else standard
+
+
 def _img_oauth_env(token: str) -> dict[str, str]:
     env = {
         key: value
@@ -502,6 +521,7 @@ def _img_oauth_env(token: str) -> dict[str, str]:
         if key not in _OAUTH_SCRUB_KEYS
         and not key.startswith(_OAUTH_SCRUB_PREFIXES)
     }
+    env["PATH"] = _cli_search_path(env.get("PATH"))
     if token:
         env["CLAUDE_CODE_OAUTH_TOKEN"] = token
     else:
@@ -578,11 +598,16 @@ def _prompt_via_claude(title: str, category: str, summary: str, mood: str) -> st
             break
         attempt_timeout = max(0.1, remaining / (len(chain) - position))
 
+        env = _img_oauth_env(token)
+        # Resolve against the child's PATH, not the parent's; a miss falls
+        # through to the bare name so the existing FileNotFoundError branch
+        # keeps reporting "not found in PATH".
+        claude_binary = shutil.which("claude", path=env["PATH"]) or "claude"
         try:
             result = _run_process_group(
-                ["claude", "--print", "--model", "claude-haiku-4-5-20251001", combined],
+                [claude_binary, "--print", "--model", "claude-haiku-4-5-20251001", combined],
                 timeout=attempt_timeout,
-                env=_img_oauth_env(token),
+                env=env,
             )
         except subprocess.TimeoutExpired:
             print(f"  claude CLI: {label} timed out", file=sys.stderr)

--- a/scripts/tests/test_bz_image_style_cli_path.py
+++ b/scripts/tests/test_bz_image_style_cli_path.py
@@ -1,0 +1,80 @@
+"""The cover visual director must find the `claude` CLI under launchd's PATH.
+
+Measured on Pro 2026-09-04: the post-publish poller runs with
+PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin while `claude` lives in
+~/.local/bin, so every cover prompt logged "claude CLI: not found in PATH" and
+fell back to the canned visual (388 times). The child PATH must include the
+user-local bin, and the binary must be resolved against THAT path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module() -> ModuleType:
+    path = REPO_ROOT / "apps/bali-intel-scraper/scripts/bz_image_style.py"
+    spec = importlib.util.spec_from_file_location("cli_path_bz_image_style", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cli_path_bz_image_style"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cli_search_path_prepends_user_local_bin_and_keeps_the_current_path(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    module = _load_module()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    path = module._cli_search_path("/usr/bin:/bin")
+
+    assert path.startswith(f"/opt/homebrew/bin:{tmp_path}/.local/bin:")
+    assert path.endswith(":/usr/bin:/bin")
+    # No current PATH at all (launchd minimal env): still a usable search path.
+    assert module._cli_search_path("") == module._CLI_STANDARD_PATH.format(home=tmp_path)
+
+
+def test_prompt_via_claude_resolves_the_binary_from_the_child_path(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    module = _load_module()
+    fake_bin = tmp_path / ".local" / "bin"
+    fake_bin.mkdir(parents=True)
+    fake_claude = fake_bin / "claude"
+    fake_claude.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IXUSR)
+
+    # The parent's PATH is launchd's: it cannot see ~/.local/bin.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    for slot in range(1, 7):
+        monkeypatch.delenv(f"CLAUDE_CODE_OAUTH_TOKEN_{slot}", raising=False)
+    module._IMG_EXHAUSTED_TOKENS.clear()
+
+    seen: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], *, timeout: float, env: dict[str, str]) -> Any:
+        seen["argv0"] = argv[0]
+        seen["path"] = env["PATH"]
+        return SimpleNamespace(
+            returncode=0, stdout="A grounded visual concept with enough detail.", stderr=""
+        )
+
+    monkeypatch.setattr(module, "_run_process_group", fake_run)
+
+    output = module._prompt_via_claude("Title", "tax", "Summary", "crisis")
+
+    assert output == "A grounded visual concept with enough detail."
+    assert seen["argv0"] == str(fake_claude)
+    assert seen["path"].split(os.pathsep)[1] == str(fake_bin)


### PR DESCRIPTION
## Why

The post-publish poller (LaunchAgent `com.balizero.post-publish-poller` on Pro) generates the News Room cover images. Its visual director asks Claude Haiku for a scene concept before calling `$imagegen`; under launchd the PATH is `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`, while the `claude` CLI lives in `~/.local/bin`. Result, measured 2026-09-04 in `~/.openclaw/workspace/logs/post_publish_poller.err`:

| log line | count |
|---|---|
| `claude CLI: not found in PATH` | 113 |
| `Using fallback visual for codex […]` | 388 |

Every cover ever produced by the poller came from the canned template, never from the visual director.

## What

- `_img_oauth_env` prepends a standard search path that includes `~/.local/bin` (same shape as the marketing bridge's `_verification_env`), never replacing the inherited PATH.
- `_prompt_via_claude` resolves the binary with `shutil.which` against the child's PATH; a miss falls through to the bare name so the existing "not found" branch still reports.

## Verification

- New `scripts/tests/test_bz_image_style_cli_path.py` (2 tests: search-path shape; the resolved absolute binary is what gets spawned when the parent PATH cannot see it).
- Existing `test_claude_oauth_runtime_fallback.py` image_style / consumer-isolation tests still pass. (`test_wr2_metrics_wrapper_reaches_slot_five` fails on a clean `origin/main` tree too — pre-existing, unrelated.)
- ruff clean.

Bites: the post-publish poller on Pro — observation: the next cover run logs the visual-director prompt path instead of "Using fallback visual for codex", and `post_publish_poller.err` stops accruing "claude CLI: not found in PATH".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
