### PR TITLE
fix(hooks): SessionStart receptors cap their output at 1.5KB and stay quiet when green

### DIFF
--- a/scripts/hooks/escalations_alert_sessionstart.sh
+++ b/scripts/hooks/escalations_alert_sessionstart.sh
@@ -157,33 +157,79 @@ high = _dedup
 if not high and normal_pending == 0:
     sys.exit(0)
 
-lines = ["🚨 ESCALATIONS BOARD (injected by SessionStart receptor)"]
-if high:
-    lines.append(f"  — {len(high)} HIGH-priority open (act first):")
-    for src, job, summ in high[:12]:
-        tail = f" — {summ}" if summ else ""
-        lines.append(f"    🔴 [{src}] {job}{tail}")
-    if len(high) > 12:
-        lines.append(f"    … +{len(high) - 12} more HIGH")
-else:
-    lines.append("  — 0 HIGH-priority open.")
-if normal_pending:
-    lines.append(f"  — {normal_pending} NORMAL pending in escalations_pro.jsonl (context).")
-lines.append("")
-lines.append(
+# Output cap (2026-09-04): this receptor injects into EVERY session start on
+# every machine — a board with dozens of HIGH items must not itself become
+# the noise it exists to cut through. SESSIONSTART_HOOK_MAX_BYTES caps the
+# WHOLE stdout payload (the JSON envelope included, since that is what the
+# harness actually injects). Priority, most-detail-first: the HIGH count
+# line and HIGH items are never dropped; the long explanatory paragraph is
+# the first thing to go, then the HIGH item list itself shrinks (still
+# naming how many are hidden); the /escalations pointer always survives —
+# it is the shortest tail and the one line every stage keeps.
+MAX_BYTES = int(os.environ.get("SESSIONSTART_HOOK_MAX_BYTES", "1500"))
+SHORT_POINTER = "Run /escalations for the full board."
+LONG_EXPLANATION = (
     "Run /escalations for the full board. These are surfaced HIGH-first per "
     "CLAUDE.md §2/§14; the receptor is read-only — it never mutates the board. "
     "claude_tasks shown are HIGH within the last "
     f"{fresh_days}d only (the dir is a 500+ file graveyard; surfacing all would "
     "re-create the noise-blindness — SNAPSHOT, not graveyard)."
 )
-ctx = "\n".join(lines)
-print(json.dumps({
-    "hookSpecificOutput": {
-        "hookEventName": "SessionStart",
-        "additionalContext": ctx,
-    }
-}))
+
+
+def _payload(ctx: str) -> str:
+    return json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": ctx,
+        }
+    })
+
+
+def _build(show_n: int, tail_text: str) -> str:
+    lines = ["🚨 ESCALATIONS BOARD (injected by SessionStart receptor)"]
+    if high:
+        lines.append(f"  — {len(high)} HIGH-priority open (act first):")
+        for src, job, summ in high[:show_n]:
+            tail = f" — {summ}" if summ else ""
+            lines.append(f"    🔴 [{src}] {job}{tail}")
+        if len(high) > show_n:
+            lines.append(f"    … +{len(high) - show_n} more HIGH")
+    else:
+        lines.append("  — 0 HIGH-priority open.")
+    if normal_pending:
+        lines.append(f"  — {normal_pending} NORMAL pending in escalations_pro.jsonl (context).")
+    lines.append("")
+    lines.append(tail_text)
+    return "\n".join(lines)
+
+
+ctx = _build(12, LONG_EXPLANATION)
+if len(_payload(ctx).encode("utf-8")) > MAX_BYTES:
+    ctx = _build(12, SHORT_POINTER)
+show_n = 12
+while len(_payload(ctx).encode("utf-8")) > MAX_BYTES and show_n > 1:
+    show_n -= 1
+    ctx = _build(show_n, SHORT_POINTER)
+
+if len(_payload(ctx).encode("utf-8")) > MAX_BYTES:
+    # Defensive last resort (an unbounded `job` field can still overflow at
+    # show_n=1): hard-truncate at a line boundary and say so.
+    lines = ctx.split("\n")
+    kept: list[str] = []
+    running = 0
+    char_budget = max(MAX_BYTES - 300, 0)  # margin for the JSON envelope + trailer
+    for ln in lines:
+        running += len(ln) + 1
+        if running > char_budget:
+            break
+        kept.append(ln)
+    hidden_lines = len(lines) - len(kept)
+    if hidden_lines > 0:
+        kept.append(f"… (+{hidden_lines} lines, run /escalations for the full board)")
+    ctx = "\n".join(kept) if kept else lines[0]
+
+print(_payload(ctx))
 PYEOF
 
 exit 0

--- a/scripts/hooks/organism_digest_sessionstart.sh
+++ b/scripts/hooks/organism_digest_sessionstart.sh
@@ -68,6 +68,84 @@ fi
 OUT="$(python3 "$REPO_ROOT/scripts/organism_digest.py" 2>/dev/null)"
 RC=$?
 if [[ -n "$OUT" ]]; then
+  # Output cap (2026-09-04): reshape + cap WITHOUT touching organism_digest.py
+  # (768 lines, its own selftest asserts exact arsenal_card shape) — this is a
+  # post-filter over the already-rendered text. Two rules, always applied:
+  #   (a) the arsenal card's per-seat rollup line + provider "doors:" line
+  #       collapse into ONE line naming only the NOT-ok seats — the doors map
+  #       is reference material (the report has it in full), the all-seats
+  #       rollup is the single biggest line in a HEALTHY digest and names
+  #       nothing an operator acts on.
+  #   (b) if still over budget: drop low/unknown-severity regulatory lines,
+  #       then the main-landing line, then pending-arms detail lines, before
+  #       ever touching a red item (seat TIMEOUT/dead, silent organ,
+  #       medium+/high regulatory) — and if that alone is not enough, hard
+  #       line-boundary truncate with a trailer naming the real full command.
+  MAX_BYTES="${SESSIONSTART_HOOK_MAX_BYTES:-1500}"
+  CAPPED="$(python3 - "$OUT" "$MAX_BYTES" <<'PYEOF' 2>/dev/null
+import sys
+
+text, max_bytes = sys.argv[1], int(sys.argv[2])
+lines = text.split("\n")
+
+out = []
+i = 0
+while i < len(lines):
+    ln = lines[i]
+    if ln.lstrip().startswith("🔌 arsenal (probe"):
+        out.append(ln)
+        rollup = lines[i + 1] if i + 1 < len(lines) else ""
+        if "no seats" in rollup:
+            out.append("  (report has no seats)")
+        else:
+            not_ok = [tok for tok in rollup.split() if "✗" in tok]
+            out.append("  not ok: " + " ".join(not_ok) if not_ok else "  all seats ok")
+        i += 3  # skip the original rollup + doors lines — always collapsed
+        continue
+    out.append(ln)
+    i += 1
+
+
+def _bytes(ls: list[str]) -> int:
+    return len("\n".join(ls).encode("utf-8"))
+
+
+if _bytes(out) > max_bytes:
+    def _priority(ln: str):
+        s = ln.strip()
+        if s.startswith("⚖️") and ("[low]" in s or "[?]" in s):
+            return 1  # lowest severity regulatory: drop first
+        if s.startswith("⬆️") or s.startswith("🕰️"):
+            return 2  # main-landing / pending-arms detail: droppable second
+        return None  # never droppable here: seats, organs, high/medium reg, errors
+
+    trimmed = list(out)
+    while _bytes(trimmed) > max_bytes:
+        candidates = [(idx, _priority(ln)) for idx, ln in enumerate(trimmed)]
+        candidates = [(idx, p) for idx, p in candidates if p is not None]
+        if not candidates:
+            break
+        candidates.sort(key=lambda t: (-t[1], -t[0]))  # least-important, latest first
+        del trimmed[candidates[0][0]]
+
+    if _bytes(trimmed) > max_bytes:
+        kept, total, reserve = [], 0, 100
+        for ln in trimmed:
+            b = len((ln + "\n").encode("utf-8"))
+            if total + b > max_bytes - reserve:
+                break
+            kept.append(ln)
+            total += b
+        hidden = len(trimmed) - len(kept)
+        if hidden > 0:
+            kept.append(f"… (+{hidden} lines, run: python3 scripts/organism_digest.py)")
+        trimmed = kept
+    out = trimmed
+
+sys.stdout.write("\n".join(out))
+PYEOF
+)"
+  [[ -n "$CAPPED" ]] && OUT="$CAPPED"
   echo "$OUT"
 elif [[ $RC -ne 0 ]]; then
   echo "📰 organismo: receptor error (digest exit $RC) — run: python3 scripts/organism_digest.py"

--- a/scripts/hooks/proprioception_sessionstart.sh
+++ b/scripts/hooks/proprioception_sessionstart.sh
@@ -67,7 +67,7 @@ if not div:
     else:
         print(f"🧭 propriocezione: fresh ({age_h:.1f}h), all {n} probes reconciled{head_note}")
     sys.exit(0)
-print(f"🧭 PROPRIOCEZIONE: {len(div)} boundary divergence(s) ({len(unp)} unprobeable), report {age_h:.1f}h old{head_note}")
+out_lines = [f"🧭 PROPRIOCEZIONE: {len(div)} boundary divergence(s) ({len(unp)} unprobeable), report {age_h:.1f}h old{head_note}"]
 
 # #44 (2026-07-26): a report's per-item findings are snapshot assertions computed once at
 # {report_time}, not live facts — a home_fork_scripts DIVERGED was TRUE at snapshot time and
@@ -88,7 +88,11 @@ self_finding = next((p for p in div if p.get("id") == "guardian_freshness"), Non
 other_div = [p for p in div if p is not self_finding]
 
 
-def _print_finding(p: dict) -> None:
+FIX_HINT_MAX = 160  # output-cap budget (2026-09-04): a fix_hint this long already
+# eats a large share of the whole receptor byte cap on its own.
+
+
+def _finding_lines(p: dict) -> list[str]:
     # W97 again, one level DOWN from where it was cured. The [:4] probe cap above
     # was fixed on 2026-07-26 so a truncated list of PROBES could not read as
     # complete — but the single line each probe prints still truncated its own
@@ -108,19 +112,51 @@ def _print_finding(p: dict) -> None:
     n = p.get("n_findings")
     ev = p["evidence"][0] if p.get("evidence") else f"{n if n is not None else '?'} findings"
     more = f" [1 of {n}]" if p.get("evidence") and isinstance(n, int) and n > 1 else ""
-    print(f"  !! [{p.get('severity')}] {p.get('id')}{more} (as of {report_time}, {age_h:.1f}h ago — re-verify before acting): {ev}")
-    print(f"     fix: {p.get('fix_hint', '')}")
+    fix_hint = p.get("fix_hint", "") or ""
+    if len(fix_hint) > FIX_HINT_MAX:
+        fix_hint = fix_hint[: FIX_HINT_MAX - 1] + "…"
+    return [
+        f"  !! [{p.get('severity')}] {p.get('id')}{more} (as of {report_time}, {age_h:.1f}h ago — re-verify before acting): {ev}",
+        f"     fix: {fix_hint}",
+    ]
 
 
 if self_finding is not None:
-    _print_finding(self_finding)
-ranked = sorted(other_div, key=lambda x: x.get("severity", "P3"))
+    out_lines.extend(_finding_lines(self_finding))
+
+# P1 first, always in full (up to the top-4 cap); P2+ collapses to a single
+# count line whenever a P1 is present — a P1 is the thing to act on, a P2
+# alongside it is context, not a second thing to read in full at boot.
+p1 = [p for p in other_div if p.get("severity") == "P1"]
+p2plus = [p for p in other_div if p.get("severity") != "P1"]
+ranked = sorted(p1, key=lambda x: x.get("severity", "P3")) if p1 else \
+    sorted(other_div, key=lambda x: x.get("severity", "P3"))
 for p in ranked[:4]:
-    _print_finding(p)
+    out_lines.extend(_finding_lines(p))
 hidden = ranked[4:]
 if hidden:
     hidden_ids = ", ".join(p.get("id", "?") for p in hidden)
-    print(f"  … +{len(hidden)} more ({hidden_ids}) — cat ~/.nuzantara-proprioception/last.md")
+    out_lines.append(f"  … +{len(hidden)} more ({hidden_ids}) — cat ~/.nuzantara-proprioception/last.md")
+if p1 and p2plus:
+    out_lines.append(f"  … +{len(p2plus)} lower-severity finding(s) — cat ~/.nuzantara-proprioception/last.md")
+
+MAX_BYTES = int(os.environ.get("SESSIONSTART_HOOK_MAX_BYTES", "1500"))
+text = "\n".join(out_lines)
+if len(text.encode("utf-8")) > MAX_BYTES:
+    kept: list[str] = []
+    total = 0
+    reserve = 100  # room for the trailer line below
+    for ln in out_lines:
+        b = len((ln + "\n").encode("utf-8"))
+        if total + b > MAX_BYTES - reserve:
+            break
+        kept.append(ln)
+        total += b
+    hidden_lines = len(out_lines) - len(kept)
+    if hidden_lines > 0:
+        kept.append(f"… (+{hidden_lines} lines, run: cat ~/.nuzantara-proprioception/last.md for the full board)")
+    text = "\n".join(kept)
+print(text)
 PYEOF
 )"
 RC=$?

--- a/scripts/tests/test_escalations_alert_sessionstart.py
+++ b/scripts/tests/test_escalations_alert_sessionstart.py
@@ -139,3 +139,73 @@ class TestNetPending:
         assert out is not None
         ctx = out["hookSpecificOutput"]["additionalContext"]
         assert "1 NORMAL pending" in ctx
+
+
+class TestOutputCap:
+    """Output cap (2026-09-04): this receptor injects into EVERY session start
+    on every machine, so a board carrying dozens of HIGH items must not itself
+    become the noise CLAUDE.md §2/§14 asked it to cut through. The cap is on
+    the WHOLE stdout (JSON envelope included, since that is what the harness
+    actually injects), default 1500 bytes, overridable via
+    SESSIONSTART_HOOK_MAX_BYTES. Priority: HIGH count + HIGH items survive
+    first; the long explanatory paragraph is the first thing dropped; the
+    /escalations pointer survives every stage."""
+
+    def _raw_payload_bytes(self, esc_file: Path, tasks_dir: Path, extra_env=None) -> tuple[bytes, dict | None]:
+        env = dict(os.environ)
+        env["ESCALATIONS_FILE_OVERRIDE"] = str(esc_file)
+        env["CLAUDE_TASKS_DIR"] = str(tasks_dir)
+        env["ESCALATIONS_RECEPTOR_ENABLED"] = "true"
+        if extra_env:
+            env.update(extra_env)
+        result = subprocess.run(
+            ["bash", str(_SCRIPT)], env=env, capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, f"hook must always exit 0; stderr={result.stderr}"
+        raw = result.stdout.strip()
+        parsed = json.loads(raw) if raw else None
+        return raw.encode("utf-8"), parsed
+
+    def test_guilt_oversized_board_stays_under_cap_and_keeps_high_and_pointer(self, tmp_path, tasks_dir):
+        esc = tmp_path / "escalations_pro.jsonl"
+        records = [
+            {"job": f"job_{i}", "status": "pending", "priority": "HIGH",
+             "error_summary": "x" * 78, "ts": 100 + i}
+            for i in range(60)
+        ]
+        _write_jsonl(esc, records)
+        raw, out = self._raw_payload_bytes(esc, tasks_dir)
+        assert len(raw) <= 1500, f"payload must fit the default cap, got {len(raw)} bytes"
+        assert out is not None
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "HIGH-priority open" in ctx, "HIGH count line must survive the cap"
+        assert "🔴" in ctx, "at least one HIGH item must survive the cap"
+        assert "/escalations" in ctx, "the /escalations pointer must survive every cap stage"
+
+    def test_innocence_small_board_is_not_over_trimmed(self, tmp_path, tasks_dir):
+        esc = tmp_path / "escalations_pro.jsonl"
+        _write_jsonl(esc, [
+            {"job": "fly_backup", "status": "pending", "priority": "HIGH",
+             "error_summary": "exit 1", "ts": 100},
+        ])
+        raw, out = self._raw_payload_bytes(esc, tasks_dir)
+        assert len(raw) <= 1500
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "the receptor is read-only" in ctx, (
+            "a board well under budget must keep the full explanation — the "
+            "cap must not trim content that already fits"
+        )
+
+    def test_env_override_shrinks_the_cap(self, tmp_path, tasks_dir):
+        esc = tmp_path / "escalations_pro.jsonl"
+        records = [
+            {"job": f"job_{i}", "status": "pending", "priority": "HIGH",
+             "error_summary": "y" * 78, "ts": 100 + i}
+            for i in range(60)
+        ]
+        _write_jsonl(esc, records)
+        raw, out = self._raw_payload_bytes(esc, tasks_dir, extra_env={"SESSIONSTART_HOOK_MAX_BYTES": "500"})
+        assert len(raw) <= 500, f"SESSIONSTART_HOOK_MAX_BYTES=500 must be honored, got {len(raw)} bytes"
+        assert out is not None
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "HIGH-priority open" in ctx

--- a/scripts/tests/test_organism_digest_sessionstart_cap.sh
+++ b/scripts/tests/test_organism_digest_sessionstart_cap.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+# test_organism_digest_sessionstart_cap.sh — B4 output cap (2026-09-04, context diet).
+#
+# scripts/hooks/organism_digest_sessionstart.sh injects into EVERY session
+# start on every machine. Its content is entirely rendered by
+# scripts/organism_digest.py (768 lines, its own selftest asserts the exact
+# shape of arsenal_card()) — this cap is a POST-FILTER over that already-
+# rendered text, applied inside the .sh wrapper only, so organism_digest.py
+# and its existing test suite (test_organism_digest_pending_arms.py) are
+# untouched and stay green.
+#
+# Fixtures use organism_digest.py's own ORGANISM_DIGEST_HOME / _REPO env
+# overrides (the same mechanism its own _selftest() uses) so this drives the
+# REAL hook + the REAL renderer against a throwaway world, never the tracked
+# ~/.organism state or this repo's real regulatory deltas.
+#
+# Three rules under test:
+#   (a) the arsenal card's per-seat rollup + "doors:" line ALWAYS collapse
+#       into one "not ok: ..." (or "all seats ok") line — fixed reshape, not
+#       conditional on the cap.
+#   (b) under budget pressure, low/unknown-severity regulatory lines and the
+#       main-landing line drop before any red item (seat TIMEOUT/dead,
+#       silent organ, medium+/high regulatory) is touched.
+#   (c) SESSIONSTART_HOOK_MAX_BYTES caps the WHOLE stdout; when even (a) and
+#       (b) are not enough, a line-boundary truncation adds one trailer line
+#       naming the real full-board command.
+#
+# Run:  sh scripts/tests/test_organism_digest_sessionstart_cap.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/scripts/hooks/organism_digest_sessionstart.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+[ -f "$HOOK" ] || { echo "FAIL - hook not found at $HOOK"; exit 1; }
+
+byte_len() { printf '%s' "$1" | wc -c | tr -d ' '; }
+
+# build_world WORLD_DIR PY_SNIPPET — PY_SNIPPET receives `home` and `repo`
+# (both already created as directories) and populates them.
+build_world() {
+  world="$1"
+  home="$world/home"
+  repo="$world/repo"
+  mkdir -p "$home/.organism/arsenal" "$home/.organism/last_seen" \
+           "$repo/research/regulatory" "$repo/scripts"
+  python3 - "$home" "$repo" <<PYEOF
+import json, os, sys, time
+home, repo = sys.argv[1], sys.argv[2]
+$2
+PYEOF
+  # a real git repo with an origin/main ref, or merged_on_main() errors out
+  ( cd "$repo" && git init -q \
+      && git -c user.name=t -c user.email=t@e commit -q --allow-empty -m "seed" \
+      && git update-ref refs/remotes/origin/main HEAD ) >/dev/null 2>&1
+}
+
+run_hook() {
+  # $1=world dir, $2=max_bytes override (optional)
+  CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+    ORGANISM_DIGEST_ENABLED=true \
+    ORGANISM_ARSENAL_REFRESH_ENABLED=false \
+    ORGANISM_DIGEST_HOME="$1/home" \
+    ORGANISM_DIGEST_REPO="$1/repo" \
+    SESSIONSTART_HOOK_MAX_BYTES="${2:-1500}" \
+    bash "$HOOK"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 (guilt, stress): 30 synthetic seats all TIMEOUT (arsenal_seats() has
+# no internal cap — organism_digest.py prints one line per not-LIVE seat) +
+# 5 regulatory deltas spanning high/medium/low/unknown severity. Deliberately
+# past what even the priority-drop stage can absorb, to exercise BOTH (b) and
+# the hard line-boundary fallback (c) in one fixture.
+# ---------------------------------------------------------------------------
+w1="$TMPDIR/w1"
+build_world "$w1" '
+seats = [{"seat": f"synthetic_seat_{i}", "status": "TIMEOUT"} for i in range(30)]
+with open(os.path.join(home, ".organism", "arsenal", "last.json"), "w") as f:
+    json.dump({"seats": seats}, f)
+deltas = [
+    {"citation": "PMK 1/2026", "severity": "high", "service_line": "tax",
+     "title_en": "High severity change to tax filings and consultant registration procedure"},
+    {"citation": "PMK 2/2026", "severity": "medium", "service_line": "tax",
+     "title_en": "Medium severity change to reporting deadlines for corporate taxpayers"},
+    {"citation": "PMK 3/2026", "severity": "low", "service_line": "tax",
+     "title_en": "Low severity administrative clarification on invoice numbering formats"},
+    {"citation": "PMK 4/2026", "severity": "low", "service_line": "tax",
+     "title_en": "Another low severity clarification on filing portal navigation steps"},
+    {"citation": "PMK 5/2026", "severity": "?", "service_line": "tax",
+     "title_en": "Unclassified regulatory change pending severity triage"},
+]
+with open(os.path.join(repo, "research", "regulatory", "2026-09-01-delta.json"), "w") as f:
+    json.dump({"deltas": deltas}, f)
+'
+out1="$(run_hook "$w1")"
+n1="$(byte_len "$out1")"
+if [ "$n1" -le 1500 ]; then
+  note_pass "guilt/stress — 30 TIMEOUT seats + mixed-severity regulatory fits the default cap ($n1 bytes)"
+else
+  note_fail "guilt/stress — output exceeds 1500 bytes: $n1"
+fi
+if printf '%s\n' "$out1" | grep -q 'TIMEOUT'; then
+  note_pass "guilt/stress — red seat (TIMEOUT) lines survive"
+else
+  note_fail "guilt/stress — all red seat lines lost: $out1"
+fi
+if printf '%s\n' "$out1" | grep -q '\[high\]' && printf '%s\n' "$out1" | grep -q '\[medium\]'; then
+  note_pass "guilt/stress — high and medium severity regulatory lines survive"
+else
+  note_fail "guilt/stress — a medium/high regulatory line was lost: $out1"
+fi
+if printf '%s\n' "$out1" | grep -q '\[low\]' || printf '%s\n' "$out1" | grep -q '\[?\]'; then
+  note_fail "guilt/stress — a low/unknown severity regulatory line survived a budget crunch"
+else
+  note_pass "guilt/stress — low/unknown severity regulatory lines dropped first"
+fi
+if printf '%s\n' "$out1" | grep -q '^… (+[0-9]* lines, run: python3 scripts/organism_digest.py)$'; then
+  note_pass "guilt/stress — hard-truncation trailer present and names the real full-board command"
+else
+  note_fail "guilt/stress — expected a truncation trailer, got: $out1"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 (innocence): a small, mostly-healthy world — well under budget, no
+# truncation should occur, but the arsenal card's rollup+doors collapse is a
+# FIXED reshape (not conditional on the cap) so it must still collapse here.
+# ---------------------------------------------------------------------------
+w2="$TMPDIR/w2"
+build_world "$w2" '
+seats = [{"seat": "claude", "status": "LIVE"}, {"seat": "kimi", "status": "TIMEOUT"}]
+with open(os.path.join(home, ".organism", "arsenal", "last.json"), "w") as f:
+    json.dump({"seats": seats}, f)
+'
+out2="$(run_hook "$w2")"
+n2="$(byte_len "$out2")"
+if [ "$n2" -le 1500 ] && ! printf '%s\n' "$out2" | grep -q 'lines, run:'; then
+  note_pass "innocence — a small world fits comfortably, no truncation trailer ($n2 bytes)"
+else
+  note_fail "innocence — small world unexpectedly truncated: $out2"
+fi
+if printf '%s\n' "$out2" | grep -q '  doors: '; then
+  note_fail "innocence — the uncollapsed doors: line leaked through"
+else
+  note_pass "innocence — the doors: line never reaches the injected output"
+fi
+if printf '%s\n' "$out2" | grep -q 'not ok: kimi'; then
+  note_pass "innocence — the collapsed line names the one NOT-ok seat"
+else
+  note_fail "innocence — collapsed not-ok line missing or wrong: $out2"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 (env override): a tight SESSIONSTART_HOOK_MAX_BYTES must be honored
+# and the header + at least one red seat line must still make it through.
+# ---------------------------------------------------------------------------
+out3="$(run_hook "$w1" "500")"
+n3="$(byte_len "$out3")"
+if [ "$n3" -le 500 ]; then
+  note_pass "env override — SESSIONSTART_HOOK_MAX_BYTES=500 honored ($n3 bytes)"
+else
+  note_fail "env override — output exceeds the overridden cap: $n3 bytes"
+fi
+if printf '%s\n' "$out3" | grep -q '📰 ORGANISMO' && printf '%s\n' "$out3" | grep -q 'TIMEOUT'; then
+  note_pass "env override — header and at least one red seat line survive a tight cap"
+else
+  note_fail "env override — header or red line lost under a tight cap: $out3"
+fi
+
+echo ""
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test_proprioception_output_cap.sh
+++ b/scripts/tests/test_proprioception_output_cap.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+# test_proprioception_output_cap.sh — B4 output cap (2026-09-04, context diet).
+#
+# scripts/hooks/proprioception_sessionstart.sh injects into EVERY session
+# start on every machine. Before this cap, a report carrying several DIVERGED
+# P1s each with a long fix_hint, plus a mix of P1 and P2 findings, could push
+# the injected block well past a couple KB (measured live on Pro pre-fix:
+# 2261 bytes with just 4 findings — see git history of this file). Two rules
+# under test:
+#   (a) a fix_hint longer than 160 chars is truncated (with an ellipsis),
+#       never printed whole.
+#   (b) when at least one P1 finding is present, other-severity findings
+#       collapse into a single count line instead of printing in full.
+#   (c) SESSIONSTART_HOOK_MAX_BYTES caps the WHOLE stdout, truncating at a
+#       line boundary and naming the real full-board command when even (a)
+#       and (b) are not enough.
+#
+# Run:  sh scripts/tests/test_proprioception_output_cap.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$REPO_ROOT/scripts/hooks/proprioception_sessionstart.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+[ -f "$HOOK" ] || { echo "FAIL - hook not found at $HOOK"; exit 1; }
+
+build_report() {
+  # $1 = output path, $2 = python snippet defining `report` (ts/mtime
+  # injected relative to a FRESH "now", never a hardcoded date — W129).
+  python3 - "$1" <<PYEOF
+import json, os, sys, time
+out_path = sys.argv[1]
+now = time.time()
+report_ts = time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime(now))
+$2
+report["ts"] = report_ts
+with open(out_path, "w") as fh:
+    json.dump(report, fh)
+os.utime(out_path, (now, now))
+PYEOF
+}
+
+run_hook() {
+  PROPRIOCEPTION_REPORT_PATH="$1" PROPRIOCEPTION_RECEPTOR_ENABLED=true \
+    SESSIONSTART_HOOK_MAX_BYTES="${2:-1500}" bash "$HOOK"
+}
+
+byte_len() {
+  printf '%s' "$1" | wc -c | tr -d ' '
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 (guilt): 3 P1 findings each carrying a 400-char fix_hint, plus 1 P2.
+# Pre-fix this alone (4 findings, uncapped fix_hint) measured 2261 bytes live
+# with SHORTER hints than this fixture uses — this fixture is worse than the
+# live incident on purpose.
+# ---------------------------------------------------------------------------
+long_hint="$(python3 -c 'print("x" * 400)')"
+r1="$TMPDIR/case1.json"
+build_report "$r1" "
+report = {
+    \"schema\": 1, \"runner_version\": \"1.0.0\",
+    \"machine\": \"pro\", \"repo_head\": \"abc123\", \"config_source\": \"embedded\",
+    \"config_sha\": \"x\", \"probes_expected\": 4, \"probes_run\": 4,
+    \"unwatched_classes\": [],
+    \"summary\": \"s\",
+    \"probes\": [
+        {\"id\": \"probe_p1_a\", \"boundary\": \"b\", \"class\": \"a<->b\",
+         \"status\": \"DIVERGED\", \"severity\": \"P1\", \"n_findings\": 1,
+         \"evidence\": [\"evidence a\"], \"fix_hint\": \"$long_hint\", \"duration_ms\": 1},
+        {\"id\": \"probe_p1_b\", \"boundary\": \"b\", \"class\": \"a<->b\",
+         \"status\": \"DIVERGED\", \"severity\": \"P1\", \"n_findings\": 1,
+         \"evidence\": [\"evidence b\"], \"fix_hint\": \"$long_hint\", \"duration_ms\": 1},
+        {\"id\": \"probe_p1_c\", \"boundary\": \"b\", \"class\": \"a<->b\",
+         \"status\": \"DIVERGED\", \"severity\": \"P1\", \"n_findings\": 1,
+         \"evidence\": [\"evidence c\"], \"fix_hint\": \"$long_hint\", \"duration_ms\": 1},
+        {\"id\": \"probe_p2\", \"boundary\": \"b\", \"class\": \"a<->b\",
+         \"status\": \"DIVERGED\", \"severity\": \"P2\", \"n_findings\": 1,
+         \"evidence\": [\"evidence p2\"], \"fix_hint\": \"low priority context\", \"duration_ms\": 1},
+    ],
+}
+"
+out1="$(run_hook "$r1")"
+n1="$(byte_len "$out1")"
+if [ "$n1" -le 1500 ]; then
+  note_pass "guilt — output with 3 long-fix_hint P1s + 1 P2 fits the default cap ($n1 bytes)"
+else
+  note_fail "guilt — output exceeds 1500 bytes: $n1"
+fi
+if printf '%s\n' "$out1" | grep -q 'probe_p1_a' && printf '%s\n' "$out1" | grep -q 'probe_p1_b' && printf '%s\n' "$out1" | grep -q 'probe_p1_c'; then
+  note_pass "guilt — all 3 P1 findings survive the cap"
+else
+  note_fail "guilt — a P1 finding was lost to the cap: $out1"
+fi
+if printf '%s\n' "$out1" | grep -q 'probe_p2'; then
+  note_fail "guilt — the P2 finding printed in full instead of collapsing to a count line"
+else
+  note_pass "guilt — the P2 finding collapsed away (a P1 is present)"
+fi
+if printf '%s\n' "$out1" | grep -q '1 lower-severity finding'; then
+  note_pass "guilt — the collapsed P2 is named as a count, not silently dropped"
+else
+  note_fail "guilt — no lower-severity count line found: $out1"
+fi
+# No single fix: line may exceed FIX_HINT_MAX(160)+prefix by more than a
+# couple chars of slack for the ellipsis.
+long_fix_line="$(printf '%s\n' "$out1" | grep '     fix: xxx' | head -1)"
+if [ -n "$long_fix_line" ] && [ "$(byte_len "$long_fix_line")" -le 175 ]; then
+  note_pass "guilt — a 400-char fix_hint was truncated, not printed whole"
+else
+  note_fail "guilt — fix_hint truncation missing or too loose: '$long_fix_line'"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 (innocence): a single short P1, well under budget — the cap must
+# not trim content that already fits (mirrors the pre-existing behavioural
+# tests in test_proprioception_receptor_ranking.sh, kept green by this fix).
+# ---------------------------------------------------------------------------
+r2="$TMPDIR/case2.json"
+build_report "$r2" '
+report = {
+    "schema": 1, "runner_version": "1.0.0",
+    "machine": "pro", "repo_head": "abc123", "config_source": "embedded",
+    "config_sha": "x", "probes_expected": 1, "probes_run": 1,
+    "unwatched_classes": [],
+    "summary": "s",
+    "probes": [
+        {"id": "small_probe", "boundary": "b", "class": "a<->b",
+         "status": "DIVERGED", "severity": "P1", "n_findings": 1,
+         "evidence": ["short evidence"], "fix_hint": "short fix", "duration_ms": 1},
+    ],
+}
+'
+out2="$(run_hook "$r2")"
+if printf '%s\n' "$out2" | grep -q 'short fix' && ! printf '%s\n' "$out2" | grep -q 'lines,'; then
+  note_pass "innocence — a small report is not over-trimmed (no truncation trailer, hint intact)"
+else
+  note_fail "innocence — a small report was needlessly trimmed: $out2"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 (env override): a tight SESSIONSTART_HOOK_MAX_BYTES must be honored
+# and must still surface at least the header + one P1 line.
+# ---------------------------------------------------------------------------
+out3="$(run_hook "$r1" "300")"
+n3="$(byte_len "$out3")"
+if [ "$n3" -le 300 ]; then
+  note_pass "env override — SESSIONSTART_HOOK_MAX_BYTES=300 honored ($n3 bytes)"
+else
+  note_fail "env override — output exceeds the overridden cap: $n3 bytes"
+fi
+if printf '%s\n' "$out3" | grep -q 'PROPRIOCEZIONE'; then
+  note_pass "env override — the header line survives even a tight cap"
+else
+  note_fail "env override — header lost under a tight cap: $out3"
+fi
+
+echo ""
+echo "== $pass passed, $fail failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What
Task B4 of the context diet: cap the stdout of the three project SessionStart hooks (`.claude/settings.json` → `hooks.SessionStart`) so each injects <= 1,500 bytes into every new session, quiet when green, red items surviving first.

- `escalations_alert_sessionstart.sh` — HIGH count + HIGH items always kept; the long explanatory paragraph is the first thing dropped, then the HIGH item list itself shrinks (naming how many are hidden); the `/escalations` pointer survives every stage. Defensive line-boundary hard fallback for the (unbounded) `job` field.
- `proprioception_sessionstart.sh` — `fix_hint` truncated to 160 chars (was unbounded); when a P1 finding is present, other-severity findings collapse to one count line instead of printing in full; overall byte cap with a line-boundary truncation + trailer naming the real full-board command (`cat ~/.nuzantara-proprioception/last.md`).
- `organism_digest_sessionstart.sh` — a post-filter (organism_digest.py itself, 768 lines with its own selftest, is untouched) that always collapses the arsenal card's per-seat rollup + `doors:` lines into one `not ok: <seats>` line, then under budget pressure drops low/unknown-severity regulatory lines and the main-landing line before ever touching a red item (seat TIMEOUT/dead, silent organ, medium+/high regulatory), then hard-truncates at a line boundary as a last resort.

All three caps default to 1500 bytes, overridable via `SESSIONSTART_HOOK_MAX_BYTES`.

## Verification
Live before/after bytes (real state on this machine, same snapshot for the before/after pair):

| Hook | Before | After |
|---|---|---|
| escalations_alert_sessionstart.sh | 579 | 579 (already under cap) |
| proprioception_sessionstart.sh | 2261 | 1351 |
| organism_digest_sessionstart.sh | 1680 | 1173 |

`bash -n` clean on all three. `shellcheck` clean on all three (installed, ran with zero findings).

Pytest/shell suites, all green, 0 regressions:
```
test_escalations_alert_sessionstart.py .........  9 passed  (6 pre-existing + 3 new cap tests)
test_proprioception_finding_count.sh              14 passed (pre-existing, untouched)
test_proprioception_receptor_ranking.sh            7 passed (pre-existing, untouched)
test_proprioception_output_cap.sh (new)            8 passed
test_organism_digest_sessionstart_cap.sh (new)    10 passed
test_organism_digest_pending_arms.py              15 passed (pre-existing, untouched — organism_digest.py not modified)
7 other proprioception.py suites                 122 passed (pre-existing, untouched — proprioception.py not modified)
```

## Bites
Consumer: the SessionStart hooks wired in `.claude/settings.json` run at every session start in this repo. Observation: each script's live stdout is <= 1500 bytes on a run from this branch (numbers in the table above, captured against real on-disk state — escalations board, proprioception report, organism digest sources), and all 185 covering test cases (176 pre-existing + 9 new) are green.

No auto-merge armed — leaving review/merge to the coordinating session per the task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4