### PR TITLE
fix(intel-scraper): the poller derives a missing card from the approved hero and never clobbers authored SEO

### DIFF
--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -596,6 +596,25 @@ def _image_exists_on_github(gh_path: str) -> bool:
         return False
 
 
+def _download_github_file(gh_path: str) -> bytes | None:
+    """Return a GitHub Contents API file's decoded bytes, if it is readable."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{GITHUB_OWNER}/{GITHUB_REPO}/contents/{gh_path}"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            _log_gh_failure(f"download {gh_path}", result)
+            return None
+        return base64.b64decode(json.loads(result.stdout)["content"])
+    except (KeyError, ValueError, TypeError) as e:
+        log(f"  ⚠ GitHub download decode error ({gh_path}): {e}")
+        return None
+    except Exception as e:
+        log(f"  ⚠ GitHub download error ({gh_path}): {e}")
+        return None
+
+
 def log(msg: str):
     line = f"[{datetime.now().strftime('%H:%M:%S')}] {msg}"
     print(line, flush=True)
@@ -706,6 +725,53 @@ def wait_for_ollama_free(max_wait: int = 60 * 15) -> bool:
 
 # ─── SEO/GEO ──────────────────────────────────────────────────────────────────
 
+SEO_PLACEHOLDER_STRINGS = (
+    "Check article for specific dates",
+    "mean for expats in Bali?",
+)
+
+
+def _frontmatter_field_value(frontmatter: str, key: str) -> str:
+    """Extract a simple one-line frontmatter value, without its quote wrapper."""
+    match = re.search(
+        rf"^{re.escape(key)}:\s*(?:[\"'](.*?)[\"']|(.*?))\s*$",
+        frontmatter,
+        re.MULTILINE,
+    )
+    if not match:
+        return ""
+    return (match.group(1) if match.group(1) is not None else match.group(2)).strip()
+
+
+def _seo_field_is_empty_or_placeholder(frontmatter: str, key: str) -> bool:
+    value = _frontmatter_field_value(frontmatter, key)
+    return not value or any(placeholder in value for placeholder in SEO_PLACEHOLDER_STRINGS)
+
+
+def _set_frontmatter_field(frontmatter: str, key: str, value: str) -> str:
+    value_escaped = value.replace('"', '\\"')
+    pattern = rf"^{re.escape(key)}:.*$"
+    replacement = f'{key}: "{value_escaped}"'
+    updated = re.sub(pattern, replacement, frontmatter, flags=re.MULTILINE)
+    if updated == frontmatter:
+        updated = frontmatter + f'\n{key}: "{value_escaped}"'
+    return updated
+
+
+def _set_ai_optimization_field(frontmatter: str, key: str, value: str) -> str:
+    """Set or add one scalar beneath the aiOptimization frontmatter mapping."""
+    value_escaped = value.replace('"', '\\"')
+    pattern = rf"^(\s*{re.escape(key)}:\s*).*?$"
+    if re.search(pattern, frontmatter, re.MULTILINE):
+        return re.sub(pattern, rf'\1"{value_escaped}"', frontmatter, flags=re.MULTILINE)
+
+    ai_optimization = re.search(r"^aiOptimization:\s*$", frontmatter, re.MULTILINE)
+    field = f'  {key}: "{value_escaped}"'
+    if ai_optimization:
+        insert_at = ai_optimization.end()
+        return f"{frontmatter[:insert_at]}\n{field}{frontmatter[insert_at:]}"
+    return f"{frontmatter}\naiOptimization:\n{field}"
+
 def run_seo(slug: str, category: str) -> bool:
     """Optimize SEO/GEO metadata of published MDX via agy (fallback: codex).
 
@@ -741,7 +807,7 @@ def run_seo(slug: str, category: str) -> bool:
     body = match.group(2)
 
     # Already optimized?
-    if "answerSnippet" in fm_raw and "Check article for specific dates" not in fm_raw and "mean for expats in Bali?" not in fm_raw:
+    if "answerSnippet" in fm_raw and not any(placeholder in fm_raw for placeholder in SEO_PLACEHOLDER_STRINGS):
             log("  ⏭ SEO already optimized")
             return True
 
@@ -778,25 +844,20 @@ Return this exact JSON structure:
         log(f"  ⚠ SEO: no JSON in {tool_used} response")
         return False
 
-    def set_fm_field(fm: str, key: str, value: str) -> str:
-        value_escaped = value.replace('"', '\\"')
-        pattern = rf'^{re.escape(key)}:.*$'
-        replacement = f'{key}: "{value_escaped}"'
-        new_fm = re.sub(pattern, replacement, fm, flags=re.MULTILINE)
-        if new_fm == fm:
-            new_fm = fm + f'\n{key}: "{value_escaped}"'
-        return new_fm
-
     ai_opt = seo.get("aiOptimization", {})
-    fm_raw = set_fm_field(fm_raw, "seoTitle", seo.get("seoTitle", ""))
-    fm_raw = set_fm_field(fm_raw, "seoDescription", seo.get("seoDescription", ""))
+    preserved_fields: list[str] = []
+    for key in ("seoTitle", "seoDescription"):
+        if _seo_field_is_empty_or_placeholder(fm_raw, key):
+            fm_raw = _set_frontmatter_field(fm_raw, key, seo.get(key, ""))
+        else:
+            preserved_fields.append(key)
+    if preserved_fields:
+        log(f"  ↳ Preserved authored SEO fields: {', '.join(preserved_fields)}")
 
     if ai_opt.get("answerSnippet"):
-        answer = ai_opt["answerSnippet"].replace('"', '\\"')
-        fm_raw = re.sub(r'(answerSnippet:\s*)["\']?.*?["\']?\s*$', f'\\1"{answer}"', fm_raw, flags=re.MULTILINE)
+        fm_raw = _set_ai_optimization_field(fm_raw, "answerSnippet", ai_opt["answerSnippet"])
     if ai_opt.get("primaryQuestion"):
-        question = ai_opt["primaryQuestion"].replace('"', '\\"')
-        fm_raw = re.sub(r'(primaryQuestion:\s*)["\']?.*?["\']?\s*$', f'\\1"{question}"', fm_raw, flags=re.MULTILINE)
+        fm_raw = _set_ai_optimization_field(fm_raw, "primaryQuestion", ai_opt["primaryQuestion"])
 
     new_content = f"---\n{fm_raw}\n---\n{body}"
 
@@ -907,6 +968,32 @@ def _fetch_mdx_meta(slug: str, category: str) -> tuple[str | None, str | None]:
     return title, summary
 
 
+def _derive_card_from_hero(hero_bytes: bytes) -> bytes | None:
+    """Centre-crop hero bytes to 16:10 and return an optimized JPEG card."""
+    try:
+        from io import BytesIO
+        from PIL import Image
+
+        with Image.open(BytesIO(hero_bytes)) as hero:
+            width, height = hero.size
+            target_ratio = 16 / 10
+            if width / height > target_ratio:
+                crop_width = round(height * target_ratio)
+                left = (width - crop_width) // 2
+                crop_box = (left, 0, left + crop_width, height)
+            else:
+                crop_height = round(width / target_ratio)
+                top = (height - crop_height) // 2
+                crop_box = (0, top, width, top + crop_height)
+            card = hero.crop(crop_box).convert("RGB")
+            output = BytesIO()
+            card.save(output, format="JPEG", quality=90)
+            return output.getvalue()
+    except Exception as e:
+        log(f"  ⚠ Card derivation failed: {e}")
+        return None
+
+
 def run_image(slug: str, category: str, title: str | None = None, article_id: str | None = None) -> bool:
     """Generate TWO cover images via Codex $imagegen (gpt-image-2), stage for GitHub.
 
@@ -929,6 +1016,20 @@ def run_image(slug: str, category: str, title: str | None = None, article_id: st
     card_done = _image_exists_on_github(card_gh_path)
     if hero_done and card_done:
         log("  ⏭ Both covers already on GitHub")
+        if article_id:
+            _update_news_image_url(article_id, f"/static/news/{slug}.jpg")
+        return True
+
+    if hero_done and not card_done:
+        hero_bytes = _download_github_file(hero_gh_path)
+        if hero_bytes is None:
+            return False
+        card_bytes = _derive_card_from_hero(hero_bytes)
+        if card_bytes is None:
+            return False
+        _stage_commit("image", card_gh_path, card_bytes,
+                      f"feat(image): derive card cover for '{slug[:50]}'")
+        log("  ▶ Card derived from existing hero")
         if article_id:
             _update_news_image_url(article_id, f"/static/news/{slug}.jpg")
         return True

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -8,11 +8,14 @@ once, per kind, into ONE bot branch + auto-merged PR.
 """
 
 import base64
+from io import BytesIO
 import json
+from pathlib import Path
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
+from PIL import Image
 
 from scripts import post_publish_poller as ppp
 
@@ -866,6 +869,99 @@ class TestRunSeo:
         assert ok is False
         assert [c for c in ppp._PENDING_COMMITS if c["kind"] == "seo"] == []
 
+    def test_run_seo_preserves_authored_seo_title_and_description(self):
+        content = (
+            "---\n"
+            'title: "Test Article"\n'
+            'seoTitle: "Authored title"\n'
+            'seoDescription: "Authored description"\n'
+            "---\n"
+            "Body text here.\n"
+        )
+        gh_payload = json.dumps({"content": base64.b64encode(content.encode()).decode("ascii")})
+        seo_json = (
+            '{"seoTitle": "Generated title", "seoDescription": "Generated description", '
+            '"aiOptimization": {"answerSnippet": "The answer.", '
+            '"primaryQuestion": "What is it?"}}'
+        )
+
+        with (
+            patch("scripts.post_publish_poller.subprocess.run", return_value=_res(stdout=gh_payload)),
+            patch.object(ppp, "_seo_llm_complete", return_value=(seo_json, "agy")),
+        ):
+            assert ppp.run_seo("test-slug", "business") is True
+
+        decoded = base64.b64decode(ppp._PENDING_COMMITS[0]["content_b64"]).decode()
+        assert 'seoTitle: "Authored title"' in decoded
+        assert 'seoDescription: "Authored description"' in decoded
+        assert 'answerSnippet: "The answer."' in decoded
+        assert 'primaryQuestion: "What is it?"' in decoded
+
+    def test_run_seo_fills_empty_seo_fields(self):
+        gh_payload = _mdx_frontmatter_payload()
+        seo_json = (
+            '{"seoTitle": "Generated title", "seoDescription": "Generated description", '
+            '"aiOptimization": {"answerSnippet": "The answer.", '
+            '"primaryQuestion": "What is it?"}}'
+        )
+
+        with (
+            patch("scripts.post_publish_poller.subprocess.run", return_value=_res(stdout=gh_payload)),
+            patch.object(ppp, "_seo_llm_complete", return_value=(seo_json, "agy")),
+        ):
+            assert ppp.run_seo("test-slug", "business") is True
+
+        decoded = base64.b64decode(ppp._PENDING_COMMITS[0]["content_b64"]).decode()
+        assert 'seoTitle: "Generated title"' in decoded
+        assert 'seoDescription: "Generated description"' in decoded
+
+
+class TestRunImage:
+    @staticmethod
+    def _hero_bytes() -> bytes:
+        image = Image.new("RGB", (2100, 900), "navy")
+        output = BytesIO()
+        image.save(output, format="JPEG")
+        return output.getvalue()
+
+    def test_run_image_derives_card_from_existing_hero_without_codex(self):
+        hero_bytes = self._hero_bytes()
+
+        with (
+            patch.object(ppp, "_image_exists_on_github", side_effect=[True, False]),
+            patch.object(ppp, "_download_github_file", return_value=hero_bytes),
+            patch.object(ppp, "codex_generate_image", side_effect=AssertionError("must not be called")),
+        ):
+            assert ppp.run_image("test-slug", "business") is True
+
+        assert len(ppp._PENDING_COMMITS) == 1
+        staged = ppp._PENDING_COMMITS[0]
+        assert staged["gh_path"].endswith("_card.jpg")
+        with Image.open(BytesIO(base64.b64decode(staged["content_b64"]))) as card:
+            assert card.format == "JPEG"
+            assert abs((card.width / card.height) - 1.6) < 0.01
+
+    def test_run_image_generates_both_when_hero_missing(self):
+        def generate_image(_: str, destination: Path) -> bool:
+            destination.write_bytes(self._hero_bytes())
+            return True
+
+        with (
+            patch.object(ppp, "_image_exists_on_github", side_effect=[False, False]),
+            patch.object(ppp, "_fetch_mdx_meta", return_value=("Test Article", None)),
+            patch.object(ppp, "codex_healthy", return_value=True),
+            patch.object(ppp, "codex_generate_image", side_effect=generate_image) as generate,
+        ):
+            assert ppp.run_image("test-slug", "business") is True
+
+        assert generate.call_count == 2
+        assert [commit["gh_path"] for commit in ppp._PENDING_COMMITS] == [
+            f"{ppp.IMAGE_GH_DIR}/test-slug.jpg",
+            f"{ppp.IMAGE_GH_DIR}/test-slug_card.jpg",
+        ]
+
+
+class TestAgyGenerateText:
     def test_agy_invocation_uses_configured_model_and_sandbox(self):
         """Regression pin for the actual CLI invocation shape (agy_swarm_
         commander.py convention: --model "Gemini 3.1 Pro (High)" --sandbox)."""


### PR DESCRIPTION
## Why

Traced 2026-09-04 on the post-publish poller (Pro):

- `run_image` treated a missing `{slug}_card.jpg` as "generate a new picture": with an editor-approved hero already on GitHub it produced an unrelated Codex card, so homepage and article showed different images.
- `run_seo` rewrote `seoTitle`/`seoDescription` unconditionally whenever `answerSnippet` was absent or placeholder, clobbering values an editor had set.

## What

- When the hero exists and only the card is missing, the card is now a 16:10 centre crop of that hero (Pillow, JPEG q90) staged in the same batch — no Codex call, one line "Card derived from existing hero". Hero missing → unchanged (both generated).
- `seoTitle`/`seoDescription` are now written only when empty or placeholder; `aiOptimization.answerSnippet`/`primaryQuestion` are still always written. Preserved fields are logged.

## Verification

44 passed in `tests/unit/test_post_publish_poller.py`, ruff clean. Written by the codex seat (gpt-5.6-terra via `scripts/seat_build.sh`), verified by the session.

Bites: com.balizero.post-publish-poller on Pro — observation: for a queue row whose hero is already on GitHub, post_publish_poller.err logs "Card derived from existing hero" and no "$imagegen" call for that slug; an article with an authored seoTitle keeps it after the SEO step and the log says "Preserved authored SEO fields: seoTitle, seoDescription".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
