### PR TITLE
fix(news-room): an editor-attached cover becomes the slug-named hero and its own card

### DIFF
--- a/apps/backend-rag/backend/app/routers/article_composer.py
+++ b/apps/backend-rag/backend/app/routers/article_composer.py
@@ -24,6 +24,7 @@ import os
 import time
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -47,6 +48,7 @@ from backend.services.article_composer import (
     handle_json_error,
     log_error_with_context,
 )
+from backend.services.cover_images import _cover_as_jpeg, cover_card_as_jpeg
 
 router = APIRouter(prefix="/api/articles", tags=["Article Composer"])
 logger = logging.getLogger(__name__)
@@ -908,14 +910,16 @@ async def publish_article_internal(request: PublishRequest) -> PublishResponse:
             import base64
 
             # Decode base64 image
-            image_data = base64.b64decode(request.cover_image_base64)
+            image_data = _cover_as_jpeg(base64.b64decode(request.cover_image_base64))
 
             # Determine image path
-            image_filename = request.cover_image_filename or f"{slug}.jpg"
+            image_filename = f"{Path(request.cover_image_filename).stem}.jpg"
             image_git_path = f"apps/mouth/public/static/news/{image_filename}"
             cover_image_path = f"/static/news/{image_filename}"
+            card_git_path = f"apps/mouth/public/static/news/{Path(image_filename).stem}_card.jpg"
 
             files_to_commit.append({"path": image_git_path, "content": image_data})
+            files_to_commit.append({"path": card_git_path, "content": cover_card_as_jpeg(image_data)})
             logger.info("Will upload cover image: %s", image_git_path)
 
         # 2. Generate MDX content

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -40,6 +40,7 @@ from backend.app.utils.internal_api_auth import verify_internal_api_key
 from backend.app.utils.logging_utils import get_logger
 from backend.core.cache import invalidate_cache
 from backend.core.qdrant_db import QdrantClient
+from backend.services.cover_images import _cover_as_jpeg
 from backend.services.intel.intel_staging_service import assert_valid_item_id
 
 logger = get_logger(__name__)
@@ -798,6 +799,7 @@ async def _publish_staging_item(
                 NextSteps,
                 PublishRequest,
                 TLDRSection,
+                generate_slug,
             )
 
             # Convert staging item to EnrichedArticle
@@ -829,6 +831,7 @@ async def _publish_staging_item(
             # Prepare cover image if available
             cover_image_base64 = None
             cover_image_filename = None
+            cover_slug = (data.get("slug") or "").strip() or generate_slug(title)
 
             # Priority 1: Download from Google Drive (uploaded by scraper)
             if data.get("image_drive_file_id"):
@@ -843,9 +846,10 @@ async def _publish_staging_item(
                         # Download file content from Drive
                         request = drive_svc.service.files().get_media(fileId=file_id)
                         image_bytes = await asyncio.to_thread(request.execute)
-                        cover_image_base64 = base64.b64encode(image_bytes).decode("utf-8")
-                        file_ext = "png" if image_bytes[:4] == b"\x89PNG" else "jpg"
-                        cover_image_filename = f"{item_id}.{file_ext}"
+                        cover_image_base64 = base64.b64encode(_cover_as_jpeg(image_bytes)).decode(
+                            "utf-8"
+                        )
+                        cover_image_filename = f"{cover_slug}.jpg"
                         logger.info(
                             "Cover image downloaded from Drive",
                             extra={
@@ -877,10 +881,9 @@ async def _publish_staging_item(
                         cover_image_path = PathLib(cover_image_path)
 
                     if cover_image_path.exists():
-                        cover_image_base64 = base64.b64encode(cover_image_path.read_bytes()).decode(
-                            "utf-8",
-                        )
-                        cover_image_filename = cover_image_path.name
+                        image_bytes = cover_image_path.read_bytes()
+                        cover_image_base64 = base64.b64encode(_cover_as_jpeg(image_bytes)).decode("utf-8")
+                        cover_image_filename = f"{cover_slug}.jpg"
                         logger.info(
                             "Cover image found on local filesystem",
                             extra={

--- a/apps/backend-rag/backend/services/cover_images.py
+++ b/apps/backend-rag/backend/services/cover_images.py
@@ -1,0 +1,37 @@
+"""Canonical rendering helpers for public news cover images."""
+
+from io import BytesIO
+
+from PIL import Image
+
+
+def _cover_as_jpeg(image_bytes: bytes) -> bytes:
+    """Decode an image and return an RGB JPEG without changing its dimensions."""
+    with Image.open(BytesIO(image_bytes)) as image:
+        rgb_image = image.convert("RGB")
+        output = BytesIO()
+        rgb_image.save(output, format="JPEG", quality=90, optimize=True)
+    return output.getvalue()
+
+
+def cover_card_as_jpeg(hero_image_bytes: bytes) -> bytes:
+    """Return a centre-cropped 16:10 JPEG card derived from a hero image."""
+    with Image.open(BytesIO(hero_image_bytes)) as image:
+        rgb_image = image.convert("RGB")
+        width, height = rgb_image.size
+        target_ratio = 16 / 10
+        source_ratio = width / height
+
+        if source_ratio > target_ratio:
+            crop_width = int(height * target_ratio)
+            left = (width - crop_width) // 2
+            crop_box = (left, 0, left + crop_width, height)
+        else:
+            crop_height = int(width / target_ratio)
+            top = (height - crop_height) // 2
+            crop_box = (0, top, width, top + crop_height)
+
+        card_image = rgb_image.crop(crop_box)
+        output = BytesIO()
+        card_image.save(output, format="JPEG", quality=90, optimize=True)
+    return output.getvalue()

--- a/apps/backend-rag/backend/tests/unit/routers/test_article_composer.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_article_composer.py
@@ -13,10 +13,12 @@ Tests cover:
 import base64
 import json
 from datetime import datetime, timezone
+from io import BytesIO
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from PIL import Image
 
 from backend.app.routers.article_composer import (
     BaliZeroTake,
@@ -35,8 +37,34 @@ from backend.services.article_composer.claude_client import (
     _TextBlock,
     _Usage,
 )
+from backend.services.cover_images import _cover_as_jpeg, cover_card_as_jpeg
 
 # --- FIXTURES ---
+
+
+def _png_bytes(width: int = 64, height: int = 40) -> bytes:
+    """Create a valid RGB PNG for cover publication tests."""
+    output = BytesIO()
+    Image.new("RGB", (width, height), color="navy").save(output, format="PNG")
+    return output.getvalue()
+
+
+def test_cover_helper_converts_png_to_jpeg_and_crops_card_to_16_10() -> None:
+    """Covers stay full-size while cards are cropped, never stretched or padded."""
+    hero = _cover_as_jpeg(_png_bytes(width=2100, height=900))
+    card = cover_card_as_jpeg(hero)
+
+    with Image.open(BytesIO(hero)) as hero_image:
+        assert hero_image.format == "JPEG"
+        assert hero_image.mode == "RGB"
+        assert hero_image.size == (2100, 900)
+
+    with Image.open(BytesIO(card)) as card_image:
+        assert card_image.format == "JPEG"
+        assert card_image.mode == "RGB"
+        assert abs((card_image.width / card_image.height) - 1.6) < 0.01
+        assert card_image.width <= 2100
+        assert card_image.height <= 900
 
 
 @pytest.fixture
@@ -401,7 +429,7 @@ async def test_publish_article_with_cover_image(
     )
 
     # Create base64 image
-    image_data = b"fake-image-data"
+    image_data = _png_bytes()
     image_base64 = base64.b64encode(image_data).decode("utf-8")
 
     # Call endpoint
@@ -424,9 +452,18 @@ async def test_publish_article_with_cover_image(
     # Verify atomic commit was called via the pull-request path
     mock_publisher.create_commit_with_files.assert_called_once()
     call_args = mock_publisher.create_commit_with_files.call_args
-    assert len(call_args[1]["files"]) == 2  # MDX + image
+    files = call_args[1]["files"]
+    assert {entry["path"] for entry in files} == {
+        "apps/mouth/public/static/news/test-article.jpg",
+        "apps/mouth/public/static/news/test-article_card.jpg",
+        "apps/mouth/src/content/articles/immigration/indonesia-tightens-visa-rules-what-expats-need-to-know.mdx",
+    }
+    mdx = next(entry["content"] for entry in files if entry["path"].endswith(".mdx"))
+    assert 'cardImage: "/static/news/test-article_card.jpg"' in mdx
     assert call_args[1]["pull_request"] is True
-    assert call_args[1]["must_not_exist_paths"] == [call_args[1]["files"][1]["path"]]
+    assert call_args[1]["must_not_exist_paths"] == [
+        "apps/mouth/src/content/articles/immigration/indonesia-tightens-visa-rules-what-expats-need-to-know.mdx"
+    ]
 
 
 @pytest.mark.asyncio
@@ -486,7 +523,7 @@ async def test_hero_publication_commits_article_cover_and_layout_atomically(
             "auto_merge_enabled": True,
         }
     )
-    image_base64 = base64.b64encode(b"fake-image-data").decode("utf-8")
+    image_base64 = base64.b64encode(_png_bytes()).decode("utf-8")
     request = PublishRequest(
         article=sample_enriched_article,
         cover_image_base64=image_base64,
@@ -503,6 +540,7 @@ async def test_hero_publication_commits_article_cover_and_layout_atomically(
     paths = {entry["path"] for entry in files}
     assert paths == {
         "apps/mouth/public/static/news/hero.jpg",
+        "apps/mouth/public/static/news/hero_card.jpg",
         "apps/mouth/src/content/articles/immigration/new-hero-story.mdx",
     }
     assert mock_publisher.create_commit_with_files.await_args.kwargs[

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
@@ -10,9 +10,13 @@ Covers:
 - ingest_intel_to_qdrant (helper)
 """
 
+import base64
+from io import BytesIO
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from PIL import Image
 
 # ---------------------------------------------------------------------------
 # Helper: convert_staging_to_enriched_article
@@ -694,6 +698,64 @@ class TestSubmitFromScraper:
 
 
 class TestPublishStagingItem:
+    @pytest.mark.asyncio
+    async def test_workspace_cover_is_slug_named_jpeg_before_publish(self, tmp_path) -> None:
+        """A workspace PNG reaches the composer as the canonical slug-named JPEG."""
+        from backend.app.routers.article_composer import generate_slug
+        from backend.app.routers.intel_scraper import publish_staging_item_internal
+
+        title = "Indonesia Activates Global 15% Minimum Tax — Can DJP Deliver?"
+        item_id = "news_20260903_173409_3446a476"
+        cover_dir = tmp_path / "covers"
+        cover_dir.mkdir()
+        cover_path = cover_dir / f"{item_id}.png"
+        image_output = BytesIO()
+        Image.new("RGB", (2100, 900), color="navy").save(image_output, format="PNG")
+        cover_path.write_bytes(image_output.getvalue())
+
+        staging_data = {
+            "title": title,
+            "content": "## Summary\nTax update.\n## Facts\nDetails.\n## Bali Zero Take\nImpact.\n## Next Steps\nAct.",
+            "category": "tax",
+            "relevance_score": 80,
+            "cover_image": f"covers/{item_id}.png",
+        }
+        publish_response = SimpleNamespace(
+            success=True,
+            article_url="https://balizero.com/tax-legal/example",
+            commit_sha="abc123",
+            mdx_path="apps/mouth/src/content/articles/tax-legal/example.mdx",
+            pull_request_number=1,
+            auto_merge_enabled=True,
+            image_path=f"/static/news/{generate_slug(title)}.jpg",
+        )
+
+        with (
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_staging,
+            patch("backend.app.routers.intel_scraper.intel_user_actions_total") as mock_metric,
+            patch(
+                "backend.app.routers.intel_scraper.ingest_intel_to_qdrant",
+                new=AsyncMock(return_value=True),
+            ),
+            patch("backend.app.routers.intel_scraper.invalidate_cache", new=AsyncMock()),
+            patch(
+                "backend.app.routers.article_composer.publish_article_internal",
+                new=AsyncMock(return_value=publish_response),
+            ) as mock_publish,
+        ):
+            mock_staging.load_staging_item.return_value = staging_data
+            mock_staging.get_staging_dir.return_value = tmp_path
+            mock_metric.labels.return_value.inc = MagicMock()
+
+            result = await publish_staging_item_internal(
+                "news", item_id, actor="test", allow_generated_cover=False
+            )
+
+        assert result["success"] is True
+        request = mock_publish.await_args.args[0]
+        assert request.cover_image_filename == f"{generate_slug(title)}.jpg"
+        assert base64.b64decode(request.cover_image_base64).startswith(b"\xff\xd8")
+
     @pytest.mark.asyncio
     async def test_not_found(self) -> None:
         from fastapi import HTTPException

--- a/apps/backend-rag/backend/tests/unit/routers/test_workspace_marketing_bridge.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_workspace_marketing_bridge.py
@@ -507,7 +507,11 @@ async def test_failed_github_publish_remains_pending_and_retryable(
 ) -> None:
     item = _ready_news_item()
     item["cover_image"] = "cover.png"
-    (tmp_path / "cover.png").write_bytes(b"\x89PNG\r\n\x1a\n" + (b"x" * 5_100))
+    # A decodable image: the cover is re-encoded as JPEG at publish time, so a
+    # bare PNG header would be refused as unreadable before GitHub is reached.
+    cover_png = io.BytesIO()
+    Image.new("RGB", (1200, 630), color="navy").save(cover_png, format="PNG")
+    (tmp_path / "cover.png").write_bytes(cover_png.getvalue())
     staging_path = tmp_path / "news_1.json"
     staging_path.write_text(json.dumps(item), encoding="utf-8")
     monkeypatch.setattr(intel_scraper.staging_service, "load_staging_item", lambda *_: item)


### PR DESCRIPTION
## Why

Traced 2026-09-04 on the ChatGPT Business → News Room path. A cover attached by the editor was published under the staging item's name (`/static/news/news_2026…_xxx.png`), while the MDX frontmatter derived `cardImage` as `…_card.png` — a file nothing ever committed, so the homepage card was a broken image (`LatestNews.tsx` renders `cardImage` with no existence check, by design: Vercel excludes `public/static/**` from function tracing).

The post-publish poller on Pro then looked for `{slug}.jpg` / `{slug}_card.jpg`, found neither, generated two unrelated Codex images and pointed the DB `news` row at its own hero — so the article page (DB row first) and the homepage showed pictures the editor never approved.

## What

- `publish_staging_item_internal`: a cover read from staging (local file or Drive) is published as `{slug}.jpg`, the slug computed with the same `generate_slug` the composer uses (or the item's own `slug`).
- Every published cover is re-encoded as RGB JPEG q90 (`backend/services/cover_images.py`), whatever ImageGen sent (PNG/WebP).
- `publish_article_internal` commits `{stem}_card.jpg` — a 16:10 centre crop of the hero — in the SAME tree as the hero and the MDX, so `cardImage` points at a file that exists and the poller finds both and skips generation.
- Publishes without a cover are unchanged; `allow_generated_cover=False` semantics untouched.

## Verification

- `test_article_composer.py` + `test_intel_scraper_router.py`: 62 passed (new: helper converts PNG→JPEG and crops 16:10; workspace cover reaches the composer as `{slug}.jpg` JPEG; publish with cover commits hero AND card; publish without cover commits no images).
- ruff clean. Code written by the codex seat (gpt-5.6-terra, `scripts/seat_build.sh`), verified by the session.

Bites: Damar's next `newsroom_publish` on the Pro tunnel — observation: the publishing commit carries `apps/mouth/public/static/news/<slug>.jpg` AND `<slug>_card.jpg`, the homepage card renders, and the poller logs "Both covers already on GitHub" instead of generating replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
