### PR TITLE
test(context): tighten the context-budget ratchet to the post-diet surface — 12,500 est. tokens, rules 8,192B

### DIFF
--- a/scripts/tests/test_context_budget_audit.py
+++ b/scripts/tests/test_context_budget_audit.py
@@ -2,11 +2,12 @@
 rollup). Module loaded via importlib (scripts/ is a flat bag, not a
 package — mirrors test_adversarial_review_gate.py's convention).
 
-REPO_SCOPE_TOKEN_CEILING is a RATCHET, not the diet's eventual 15,000-token
-target: measured 2026-09-04 (ratio 2.04) the real total was ~15,553 est.
-tokens. Tighten toward 15,000 once the superscar 8KB PR (#5639) and the
-root CLAUDE.md trim land — the assertion message always prints the
-measured breakdown, so tightening is a one-line, evidence-backed edit.
+REPO_SCOPE_TOKEN_CEILING is a RATCHET: measured 2026-09-04 evening (ratio
+2.04) after #5639 (superscar 8,189B) and #5642 (root CLAUDE.md 7,468B)
+landed, the repo-scope total is 12,135 est. tokens; the ceiling sits ~3%
+above that. UNSCOPED_RULES_BYTE_CEILING mirrors test_superscar_budget.py's
+8,192-byte cap. The assertion message prints the measured breakdown, so any
+further tightening stays a one-line, evidence-backed edit.
 """
 
 from __future__ import annotations
@@ -31,9 +32,9 @@ def _load_module() -> ModuleType:
 
 cba = _load_module()
 
-REPO_SCOPE_TOKEN_CEILING = 16_000
+REPO_SCOPE_TOKEN_CEILING = 12_500
 # Matches test_superscar_budget.py's BYTE_BUDGET on cicatrix-superscar.md.
-UNSCOPED_RULES_BYTE_CEILING = 14_000
+UNSCOPED_RULES_BYTE_CEILING = 8_192
 
 
 def _write(path: Path, content: str) -> None:


### PR DESCRIPTION
## What

Follow-up to #5648. With #5639 (superscar 8,189B) and #5642 (root CLAUDE.md 7,468B) on main, `python3 scripts/context_budget_audit.py` measures 12,135 est. tokens for the repo-scope always-injected surface (was 15,553). The provisional 16,000 ceiling drops to 12,500 (~3% headroom) and the unscoped-rules byte ceiling aligns with `test_superscar_budget.py`'s 8,192.

## Verification

`python3 -m pytest -q scripts/tests/test_context_budget_audit.py` → 5 passed (worktree on origin/main 33b335acf6). Diff: one test file, two constants + docstring.

## Bites

Consumer: CI runs `scripts/tests/test_context_budget_audit.py` on every PR. Observation: green on main with the measured breakdown printed in the assertion message; red the moment any always-injected repo file regrows past the post-diet surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4