### PR TITLE
fix(nb-curator): write the spec line after the log directory exists

### DIFF
--- a/scripts/nb-curator-daily.sh
+++ b/scripts/nb-curator-daily.sh
@@ -38,23 +38,6 @@ TG_NOTIFY="$SCRIPT_DIR/tg_notify.py"
 # 04:00 cron on Pro (W96: tests must never touch production state).
 LOCK_FILE="${NB_CURATOR_LOCK_FILE:-/tmp/nb-curator.lock}"
 LOG="$HOME/logs/nb-curator.log"
-
-# The OPERATIVE SPEC is the git-tracked `.claude/agents/<name>.md`: reviewed, gated by
-# scripts/tests/test_agent_defs_model_pins.py, and identical on every checkout. It is named
-# by absolute path below rather than reached by cd: making the repo copy the one the HARNESS
-# loads would require the process cwd to be the repo, which drags the project CLAUDE.md,
-# .claude/settings.json hooks and git visibility into a headless cron -- two cross-family
-# reviewers independently showed that re-opens autonomous `git commit` against the main
-# checkout (the failure this repo already closed three times). Left to its own PR.
-# WHERE the checkout is absent (not yet pulled), fall back to the machine-local copy -- the
-# only spec that exists today -- and say so in the log, so a run is never silently spec-less.
-NUZ_ROOT="${NUZ_ROOT:-$HOME/nuzantara}"
-SPEC_PATH="$NUZ_ROOT/.claude/agents/nb-curator.md"
-if [ ! -f "$SPEC_PATH" ]; then
-  SPEC_PATH="$HOME/.claude/agents/nb-curator.md"
-  echo "[$(date)] WARN: $NUZ_ROOT/.claude/agents/nb-curator.md absent -- using the machine-local spec $SPEC_PATH instead" >> "$LOG"
-fi
-echo "[$(date)] spec: $SPEC_PATH" >> "$LOG"
 # G2_heartbeat — proof of life at ~/.organism/last_seen/<id>.json, which is what
 # organs_registry.yaml (bridge_source.path) and the stale-detector actually read.
 # The library is INVOKED under `bash`, never sourced: this wrapper is zsh, and
@@ -82,6 +65,23 @@ DAY=$(TZ=Asia/Makassar date +%-d)  # day-of-month
 # left behind here would read like a knob and change nothing when turned.)
 
 mkdir -p "$HOME/logs" "$OUTPUT_DIR"
+
+# The OPERATIVE SPEC is the git-tracked `.claude/agents/<name>.md`: reviewed, gated by
+# scripts/tests/test_agent_defs_model_pins.py, and identical on every checkout. It is named
+# by absolute path below rather than reached by cd: making the repo copy the one the HARNESS
+# loads would require the process cwd to be the repo, which drags the project CLAUDE.md,
+# .claude/settings.json hooks and git visibility into a headless cron -- two cross-family
+# reviewers independently showed that re-opens autonomous `git commit` against the main
+# checkout (the failure this repo already closed three times). Left to its own PR.
+# WHERE the checkout is absent (not yet pulled), fall back to the machine-local copy -- the
+# only spec that exists today -- and say so in the log, so a run is never silently spec-less.
+NUZ_ROOT="${NUZ_ROOT:-$HOME/nuzantara}"
+SPEC_PATH="$NUZ_ROOT/.claude/agents/nb-curator.md"
+if [ ! -f "$SPEC_PATH" ]; then
+  SPEC_PATH="$HOME/.claude/agents/nb-curator.md"
+  echo "[$(date)] WARN: $NUZ_ROOT/.claude/agents/nb-curator.md absent -- using the machine-local spec $SPEC_PATH instead" >> "$LOG"
+fi
+echo "[$(date)] spec: $SPEC_PATH" >> "$LOG"
 
 # The sidecar must carry the REAL outcome and must be written on EVERY exit
 # path. One unconditional write at the end would say "alive" for a run that


### PR DESCRIPTION
**GEAR 1**: pure statement move, 1 file, 17/17, `--print-floor` = 1. No council, no pack.

Condition 1 of the independent Gear-3 gate on #5638, which conditioned that merge on this follow-up from fresh `origin/main` (the branch was armed and therefore frozen).

## The defect

The `SPEC_PATH` block #5638 added sat **above** `mkdir -p "$HOME/logs"`, making it the first `$LOG` write in the script. On `origin/main` before #5638 the first was line 105, safely after the mkdir — so the ordering defect is *introduced*, not inherited.

With `~/logs` absent, both the WARN and the `spec:` line vanished onto stderr as `no such file or directory` and the run continued. The block lost its stated purpose — "a run is never silently spec-less" — in exactly the state where knowing which spec loaded matters most.

The asymmetry was the tell: `infra/launchagents/wrappers/competitor-monitor-run.sh` mkdirs at `:17`, **before** its identical block. Same block, two files, one ordering.

**Latent, not live**: `/Users/nuzantara/logs` exists on Pro today, verified over ssh.

## Bites

**Consumer:** `scripts/nb-curator-daily.sh`, invoked directly by `com.balizero.nb-curator.daily` on Pro (the plist names the repo path, so this goes live on the next pull with no home-fork resync).

**Observation, made before reporting this done** — the script's first 110 lines run with `HOME` pointed at a directory containing no `logs/`:

| | `spec:` lines in the log | `no such file` on stderr |
|---|---|---|
| `origin/main` (before) | **0** | 2 |
| this branch (after) | **1** | 0 |

Guilt and innocence from the same probe: the defect is reproducible on the parent commit and absent here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Wwxv1pr7FBwb2Uiqfh9XW