### PR TITLE
fix(news-room): render excerpt and SEO fallbacks as plain prose, cut at a word

### DIFF
--- a/apps/backend-rag/backend/app/routers/article_composer.py
+++ b/apps/backend-rag/backend/app/routers/article_composer.py
@@ -21,6 +21,7 @@ For marketing team to create articles manually with:
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from datetime import datetime, timezone
@@ -607,10 +608,48 @@ def generate_slug(headline: str) -> str:
     return slug[:120]  # Limit slug length
 
 
+# Article headings here (## Facts, ## Summary, ## Bali Zero Take, ...) are
+# generic structural section labels, never prose worth keeping in a
+# preview/SEO snippet, so the whole heading LINE is dropped — not just the
+# leading "#" marks.
+_MD_HEADING_RE = re.compile(r"(?m)^\s{0,3}#{1,6}[^\n]*\n?")
+_MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_MD_EMPHASIS_RE = re.compile(r"(\*\*\*|\*\*|\*|___|__|_)(.+?)\1")
+_MD_INLINE_CODE_RE = re.compile(r"`([^`]*)`")
+_MD_LIST_BULLET_RE = re.compile(r"(?m)^\s{0,3}(?:[-*+]|\d+[.)])\s+")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _plain_text_snippet(text: str, limit: int) -> str:
+    """Render markdown as plain prose and truncate to a word boundary.
+
+    Drops whole heading lines (``## Facts``), bold/italic markers,
+    ``[text](url)`` links (kept as ``text``), inline code, and list
+    bullets, then collapses whitespace. The result is truncated to at
+    most ``limit`` characters, cutting only at a space so no word is
+    split, and an ellipsis (``…``) is appended only when truncation
+    actually occurred.
+    """
+    plain = str(text)
+    plain = _MD_HEADING_RE.sub("", plain)
+    plain = _MD_LINK_RE.sub(r"\1", plain)
+    plain = _MD_EMPHASIS_RE.sub(r"\2", plain)
+    plain = _MD_INLINE_CODE_RE.sub(r"\1", plain)
+    plain = _MD_LIST_BULLET_RE.sub("", plain)
+    plain = _WHITESPACE_RE.sub(" ", plain).strip()
+
+    if len(plain) <= limit:
+        return plain
+
+    truncated = plain[:limit]
+    if " " in truncated:
+        truncated = truncated.rsplit(" ", 1)[0]
+    return truncated.rstrip(" .,;:!?-") + "…"
+
+
 def generate_mdx_content(article: EnrichedArticle, slug: str, cover_image_path: str | None) -> str:
     """Generate MDX file content from enriched article"""
     import json as json_module
-    import re
 
     # Map category to URL-friendly format
     category_map = {
@@ -721,9 +760,18 @@ def generate_mdx_content(article: EnrichedArticle, slug: str, cover_image_path: 
         return s
 
     safe_headline = yaml_safe(article.headline, 200)
-    safe_excerpt = yaml_safe(article.ai_summary, 280)
-    safe_seo_desc = yaml_safe(article.seo_description or article.ai_summary, 155)
-    safe_seo_title = yaml_safe(article.seo_title or article.headline, 60)
+    # excerpt/seoDescription/seoTitle can fall back to raw markdown content
+    # (e.g. a "## Facts" heading) when no dedicated summary/SEO field was
+    # generated — render as plain prose, word-boundary truncated, before the
+    # YAML quote-escaping pass below (generous max_len so yaml_safe's own
+    # truncation never re-fires on an already-bounded string).
+    safe_excerpt = yaml_safe(_plain_text_snippet(article.ai_summary, 280), 320)
+    safe_seo_desc = yaml_safe(
+        _plain_text_snippet(article.seo_description or article.ai_summary, 155), 190
+    )
+    safe_seo_title = yaml_safe(
+        _plain_text_snippet(article.seo_title or article.headline, 70), 100
+    )
     safe_cover_alt = yaml_safe(article.cover_image_alt or article.headline, 160)
     safe_answer = yaml_safe(answer_snippet, 300)
     safe_question = yaml_safe(primary_question, 150)

--- a/apps/backend-rag/backend/tests/unit/routers/test_article_composer.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_article_composer.py
@@ -27,6 +27,7 @@ from backend.app.routers.article_composer import (
     NextSteps,
     PublishRequest,
     TLDRSection,
+    _plain_text_snippet,
     build_enrichment_prompt,
     generate_mdx_content,
     generate_slug,
@@ -781,6 +782,101 @@ def test_generate_mdx_content_reading_time(sample_enriched_article):
     assert match
     reading_time = int(match.group(1))
     assert reading_time >= 3
+
+
+def test_plain_text_snippet_strips_heading_markdown():
+    """A '## Facts' heading and inline markdown must render as plain prose."""
+    raw = "## Facts\n\nIndonesia is **moving forward** with a [sweeping reform](https://x.io)."
+    snippet = _plain_text_snippet(raw, 280)
+
+    assert "#" not in snippet
+    assert "**" not in snippet
+    assert "[" not in snippet and "](" not in snippet
+    assert snippet.startswith("Indonesia is moving forward")
+
+
+def test_plain_text_snippet_truncates_at_word_boundary():
+    """Truncation never splits a word and only appends an ellipsis when cut."""
+    raw = "Indonesia is moving forward with a sweeping set of Usaha Menengah reforms today"
+    snippet = _plain_text_snippet(raw, 40)
+
+    assert len(snippet) <= 41  # 40 chars + the ellipsis character
+    assert snippet.endswith("…")
+    body = snippet[:-1].rstrip()
+    assert raw.startswith(body)
+    # The character right after the kept text in the source is a word
+    # boundary (space), proving no word was cut mid-way.
+    assert raw[len(body) : len(body) + 1] in (" ", "")
+
+
+def test_plain_text_snippet_no_ellipsis_when_untruncated():
+    """Short input is returned as-is — no trailing ellipsis added."""
+    snippet = _plain_text_snippet("Short headline", 70)
+    assert snippet == "Short headline"
+    assert not snippet.endswith("…")
+
+
+def test_generate_mdx_content_excerpt_and_seo_description_strip_markdown_fallback(
+    sample_enriched_article,
+):
+    """excerpt/seoDescription must be plain prose even when the only
+
+    available source is raw markdown content (e.g. the intel staging
+    conversion falling back to ``content[:280]`` when no '## Summary'
+    section exists — see backend/app/routers/intel_scraper.py
+    ``convert_staging_to_enriched_article``).
+    """
+    sample_enriched_article.ai_summary = (
+        "## Facts\n\nIndonesia is moving forward with a sweeping set of Usaha "
+        "Menengah reforms that will change how small and medium businesses "
+        "register for a KBLI code across the archipelago starting in Ma"
+    )
+    sample_enriched_article.seo_title = None
+    sample_enriched_article.seo_description = None
+
+    mdx = generate_mdx_content(sample_enriched_article, "seo-fallback-plain", None)
+
+    import yaml
+
+    frontmatter = yaml.safe_load(mdx.split("---", 2)[1])
+
+    expected_excerpt = _plain_text_snippet(sample_enriched_article.ai_summary, 280)
+    expected_seo_desc = _plain_text_snippet(sample_enriched_article.ai_summary, 155)
+    expected_seo_title = _plain_text_snippet(sample_enriched_article.headline, 70)
+
+    assert frontmatter["excerpt"] == expected_excerpt
+    assert frontmatter["seoDescription"] == expected_seo_desc
+    assert frontmatter["seoTitle"] == expected_seo_title
+
+    for field, value in (
+        ("excerpt", frontmatter["excerpt"]),
+        ("seoDescription", frontmatter["seoDescription"]),
+        ("seoTitle", frontmatter["seoTitle"]),
+    ):
+        assert "#" not in value, f"{field} still carries a markdown heading: {value!r}"
+        assert "\n" not in value
+        if value.endswith("…"):
+            # Whatever precedes the ellipsis must end at a real word — in
+            # the fully markdown-stripped source, the character right after
+            # the kept text is a space (or the kept text runs to the end),
+            # never mid-word.
+            body = value[:-1].rstrip()
+            plain_source = _plain_text_snippet(
+                sample_enriched_article.ai_summary, len(sample_enriched_article.ai_summary) + 10
+            )
+            assert plain_source[len(body) : len(body) + 1] in (" ", "")
+
+
+def test_generate_mdx_content_seo_title_prefers_short_headline_untruncated(
+    sample_enriched_article,
+):
+    """A headline at or under 70 chars is used verbatim — no ellipsis added."""
+    sample_enriched_article.headline = "Indonesia Tightens Visa Rules for Expats"
+    sample_enriched_article.seo_title = None
+
+    mdx = generate_mdx_content(sample_enriched_article, "seo-title-short", None)
+
+    assert 'seoTitle: "Indonesia Tightens Visa Rules for Expats"' in mdx
 
 
 def test_build_enrichment_prompt_truncates_content():


### PR DESCRIPTION
## Why

The KBLI 2025 article published today through the News Room (PR #5657) carries this frontmatter:

```
excerpt: "## Facts  Indonesia is moving forward with a sweeping reclassification …"
seoDescription: "## Facts  Indonesia is moving forward with … Lapangan Usaha..."
seoTitle: "Indonesia's KBLI 2025 Shake-Up: The Transition Rules Every..."
```

Raw markdown and mid-word cuts in the text Google, social cards and the homepage show. Cause: with no summary/SEO fields the composer renders the article content as is; the staging fallback (`content[:280]`) starts with the `## Facts` heading.

## What

- `article_composer.py`: one helper, `_plain_text_snippet(text, limit)`, strips markdown (heading lines, emphasis, links, inline code, bullets), collapses whitespace and truncates at a word boundary, appending `…` only when it actually cut. Used for `excerpt` (≤280), `seoDescription` (≤155) and `seoTitle` (≤70, verbatim when shorter).
- Which source is preferred (seo fields → ai_summary → headline) is unchanged; only the rendering.

## Verification

- `test_article_composer.py` + `test_intel_scraper_router.py` + `test_workspace_marketing_bridge.py`: 102 passed (new: helper unit tests; end-to-end `## Facts\n\n…` content yields frontmatter with no `#`, no newline, no mid-word cut; short headline used verbatim). ruff clean. Code by a Sonnet builder, verified by the session.

Bites: the next News Room publish on Fly (auto-deploy on merge) — observation: the article PR's MDX frontmatter `excerpt`/`seoDescription` contain no `#` and end on a whole word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
