### PR TITLE
fix(news-room): staging summary fallback is complete sentences, not content[:280]

### DIFF
--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -61,6 +61,52 @@ def _require_publish_admin(user: dict[str, Any]) -> None:
 # --- CONVERSION FUNCTIONS ---
 
 
+def _summary_from_content(content: str, limit: int = 300) -> str:
+    """Extract a complete-sentence summary from the first prose paragraph."""
+    paragraph_lines: list[str] = []
+    for line in content.splitlines():
+        stripped_line = line.strip()
+        if not stripped_line:
+            if paragraph_lines:
+                break
+            continue
+        if re.match(r"^#{1,6}\s", stripped_line):
+            continue
+        paragraph_lines.append(stripped_line)
+
+    paragraph = " ".join(paragraph_lines)
+    paragraph = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", paragraph)
+    paragraph = re.sub(r"[*_`]", "", paragraph).strip()
+    if not paragraph:
+        return ""
+
+    sentences = re.split(r"(?<=[.!?])\s+", paragraph)
+    summary_sentences: list[str] = []
+    summary_length = 0
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        separator_length = 1 if summary_sentences else 0
+        if summary_length + separator_length + len(sentence) > limit:
+            break
+        summary_sentences.append(sentence)
+        summary_length += separator_length + len(sentence)
+
+    if summary_sentences:
+        return " ".join(summary_sentences).rstrip(" (—-,;:")
+
+    words = paragraph.split()
+    truncated_words: list[str] = []
+    for word in words:
+        candidate = " ".join([*truncated_words, word])
+        if len(candidate) + 1 > limit:
+            break
+        truncated_words.append(word)
+
+    return " ".join(truncated_words).rstrip(" (—-,;:") + "…"
+
+
 def convert_staging_to_enriched_article(staging_data: dict) -> dict:
     """
     Convert staging item (markdown simple) to EnrichedArticle format.
@@ -90,7 +136,9 @@ def convert_staging_to_enriched_article(staging_data: dict) -> dict:
         content,
         re.DOTALL | re.IGNORECASE,
     )
-    ai_summary = summary_match.group(1).strip() if summary_match else content[:280]
+    ai_summary = (
+        summary_match.group(1).strip()[:280] if summary_match else _summary_from_content(content)
+    )
 
     # Extract Facts section
     facts_match = re.search(r"## Facts\s*\n(.*?)(?=\n## |$)", content, re.DOTALL | re.IGNORECASE)
@@ -254,7 +302,7 @@ def convert_staging_to_enriched_article(staging_data: dict) -> dict:
         "category": category,
         "priority": priority,
         "relevance_score": relevance_score,
-        "ai_summary": ai_summary[:280],  # Limit to 280 chars
+        "ai_summary": ai_summary,
         "ai_tags": ai_tags[:5],  # Limit to 5 tags
         "suggested_components": suggested_components[:3],  # Limit to 3 components
         "cover_image": None,  # Will be set from staging_data if available

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
@@ -85,6 +85,44 @@ class TestConvertStagingToEnrichedArticle:
         assert result["ai_summary"]
         assert result["facts"]
 
+    def test_fallback_summary_uses_complete_sentences(self) -> None:
+        from backend.app.routers.intel_scraper import convert_staging_to_enriched_article
+
+        content = (
+            "## Facts\n\n"
+            "Indonesia is moving forward with a sweeping reclassification of its official "
+            "business activity codes — the Klasifikasi Baku Lapangan Usaha Indonesia "
+            "(KBLI) — updating the system to its 2025 edition. To manage the changeover, "
+            "the government has produced a Joint Circular Letter that sets out the rules.\n\n"
+            "Second paragraph."
+        )
+
+        result = convert_staging_to_enriched_article({"content": content})
+
+        assert "#" not in result["ai_summary"]
+        assert result["ai_summary"].endswith(".")
+        assert result["ai_summary"].count("(") == result["ai_summary"].count(")")
+        assert len(result["ai_summary"]) <= 300
+        assert result["ai_summary"] == content.split("\n\n")[1].split(" To manage")[0]
+
+    def test_fallback_summary_truncates_long_first_sentence_at_word_boundary(self) -> None:
+        from backend.app.routers.intel_scraper import _summary_from_content
+
+        content = "word " * 79 + "word."
+
+        result = _summary_from_content(content)
+
+        assert result.endswith("…")
+        assert len(result) <= 301
+        assert result[-2] != " "
+
+    def test_fallback_summary_with_only_headings_is_empty(self) -> None:
+        from backend.app.routers.intel_scraper import convert_staging_to_enriched_article
+
+        result = convert_staging_to_enriched_article({"content": "## Facts\n\n### Details"})
+
+        assert result["ai_summary"] == ""
+
     def test_with_timeline_keywords(self) -> None:
         from backend.app.routers.intel_scraper import convert_staging_to_enriched_article
 


### PR DESCRIPTION
## Why

With no `## Summary` section, `convert_staging_to_enriched_article` used `content[:280]` as the article summary. On the KBLI 2025 article published today (PR #5657) that produced a TL;DR that read `**Indonesia is moving forward … Lapangan Usaha Indonesia (**` and a meta description opening with the `## Facts` heading. The site's `description-fields-integrity` test refused the PR; the article had to be cured by hand.

#5659 cleans the RENDERING in the composer; this PR fixes the SOURCE so the summary is prose to begin with.

## What

- `_summary_from_content(content, limit=300)`: first prose paragraph (heading lines skipped, inline markdown stripped), whole sentences accumulated within the limit; if the first sentence alone is too long, a word-boundary cut with `…`. Never ends on `(`, `—`, `,`, `;` or `:`.
- Used only in the no-`## Summary` fallback; the `## Summary` path is unchanged.

## Verification

- `test_intel_scraper_router.py` + `test_article_composer.py` + `test_workspace_marketing_bridge.py`: 100 passed (new: complete sentences from a `## Facts` body; long single sentence cut at a word with `…`; headings-only content yields empty). ruff clean.
- Code by the codex seat (gpt-5.6-terra, `scripts/seat_build.sh`), verified by the session.

Bites: the next News Room publish on Fly (auto-deploy on merge) — observation: the article PR's TL;DR bold line and `excerpt` end on a full sentence and contain no `#`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
