### PR TITLE
feat(memory): MEMORY_INDEX.md generator — full redacted memory catalog

### DIFF
--- a/scripts/memory/memory_index_build.py
+++ b/scripts/memory/memory_index_build.py
@@ -1,21 +1,11 @@
 #!/usr/bin/env python3
-"""LAYER 3 — memory_index_build.py (production catalog generator).
+"""LAYER 3 — memory_index_build.py: generates MEMORY_INDEX.md, a full
+redacted catalog of every memory file in MEMDIR, grouped by type — the
+"grep before you act" fallback the Layer-2 recall hook's top-6 cap drops.
 
-Generates a full catalog (MEMORY_INDEX.md) of every memory file in MEMDIR,
-grouped by type, one line per file, redacted — the "grep before you act on a
-topic" fallback the Layer-2 recall hook (`mos_recall_sessionstart.py`) points
-to for anything its top-6 cap dropped.
-
-Scope: every ``*.md`` in MEMDIR except ``MEMORY*.md`` (the index itself and
-thematic digests) and anything with ``.bak``/``backup`` in the filename.
-
-MEMDIR is derived like the Layer-2 hook: ``$CLAUDE_PROJECT_DIR`` (fallback:
-`git rev-parse --show-toplevel`) + ``Path.home()`` — no hardcoded M5 path, so
-Pro/Mini resolve their own slug. Read-only on MEMDIR; ``--out`` never touches
-the live MEMORY.md/MEMORY_*.md files, only the catalog itself.
-
-Invoked by hand or by cron later (out of scope here — ships independently of
-the Layer-2 PR). ``--check`` detects a stale catalog without a diff.
+MEMDIR derivation mirrors mos_recall_sessionstart.py: $CLAUDE_PROJECT_DIR
+(fallback: git toplevel) + Path.home(), no hardcoded machine path.
+Read-only on MEMDIR; --out never touches MEMORY.md/MEMORY_*.md.
 """
 from __future__ import annotations
 
@@ -33,114 +23,76 @@ DESC_MAX = 140
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 DATE_IN_NAME_RE = re.compile(r"(\d{4})_(\d{2})_(\d{2})(?:\.md)?$")
 HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
-
-# Recognized filename-prefix taxonomy (the convention this corpus already
-# uses in MEMORY.md's own links: discovery_/decision_/lesson_/fact_/
-# project_/unresolved_/reference_/ops_/feedback_...).
 KNOWN_PREFIXES = {
     "discovery", "decision", "lesson", "fact", "project",
     "unresolved", "reference", "ops", "feedback",
 }
 
-# PII redaction (transformation). Duplicated (not imported) from the sibling
-# Layer-2 script mos_recall_sessionstart.py — separate PRs, keep in sync by hand.
-REDACT_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
-REDACT_PHONE_RE = re.compile(r"\+(?:62|39)[\s.-]?\d[\d\s.-]{6,}\d")
-REDACT_ID_RE = re.compile(r"\b(?:passport|KTP)\b\D{0,10}\d[\d\s-]*", re.IGNORECASE)
-REDACT_DIGITRUN_RE = re.compile(r"(?<!\d)\d{10,15}(?!\d)")
+# PII redaction (duplicated, not imported, from mos_recall_sessionstart.py —
+# separate PRs, keep in sync by hand). Order matters: specific shapes
+# consume their digits before the generic digit-run pattern would.
+REDACT_PATTERNS = [
+    ("email", re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"), "<email>"),
+    ("passport_ktp", re.compile(r"\b(?:passport|KTP|NIK|NPWP)\b\D{0,10}\d[\d\s-]*", re.IGNORECASE), "<id>"),
+    ("phone_id_it", re.compile(r"\+(?:62|39)[\s.-]?\d[\d\s.-]{6,}\d"), "<num>"),
+    ("digit_run", re.compile(r"(?<!\d)\d{10,15}(?!\d)"), "<num>"),
+]
 
 
-def redact(text: str) -> str:
-    """Replace PII shapes with placeholders (email/id/phone before the
-    generic digit-run so the specific patterns consume their digits first)."""
-    if not text:
-        return text
-    text = REDACT_EMAIL_RE.sub("<email>", text)
-    text = REDACT_ID_RE.sub("<id>", text)
-    text = REDACT_PHONE_RE.sub("<num>", text)
-    text = REDACT_DIGITRUN_RE.sub("<num>", text)
-    return text
-
-
-def pii_scan(text: str) -> list[str]:
-    """Detection only (category names) — used for the build report, kept
-    separate from redact() since a report wants to KNOW what was found."""
+def redact(text: str) -> tuple[str, list[str]]:
+    """Replace PII shapes with placeholders; return (text, hit categories)."""
     hits = []
-    if REDACT_EMAIL_RE.search(text):
-        hits.append("email")
-    if REDACT_PHONE_RE.search(text):
-        hits.append("phone_id_it")
-    if REDACT_ID_RE.search(text):
-        hits.append("passport_ktp")
-    if REDACT_DIGITRUN_RE.search(text):
-        hits.append("digit_run")
-    return hits
+    if not text:
+        return text, hits
+    for name, pattern, placeholder in REDACT_PATTERNS:
+        if pattern.search(text):
+            hits.append(name)
+        text = pattern.sub(placeholder, text)
+    return text, hits
 
 
 def is_excluded(filename: str) -> bool:
-    if not filename.endswith(".md"):
-        return True
-    if filename.startswith("MEMORY"):
+    if not filename.endswith(".md") or filename.startswith("MEMORY"):
         return True
     low = filename.lower()
-    if ".bak" in low or "backup" in low:
-        return True
-    return False
+    return ".bak" in low or "backup" in low
 
 
 def parse_frontmatter(text: str) -> dict:
-    """Minimal frontmatter parser for THIS corpus's shape only:
-    top-level 'key: value' lines plus one nested 'metadata:' block.
-    Returns {} if there is no frontmatter block at all.
-    """
+    """Minimal parser for this corpus's shape: top-level 'key: value' lines
+    plus one nested 'metadata:' block. {} if there's no frontmatter."""
     m = FRONTMATTER_RE.match(text)
     if not m:
         return {}
-    block = m.group(1)
     out: dict = {}
     metadata: dict = {}
     in_metadata = False
-    for line in block.split("\n"):
+    for line in m.group(1).split("\n"):
         if not line.strip():
             continue
         if line.startswith("metadata:"):
             in_metadata = True
             continue
-        if in_metadata:
-            if line.startswith((" ", "\t")):
-                kv = line.strip()
-                if ":" in kv:
-                    k, _, v = kv.partition(":")
-                    metadata[k.strip()] = _unquote(v.strip())
-                continue
-            else:
-                in_metadata = False
+        if in_metadata and line.startswith((" ", "\t")):
+            k, _, v = line.strip().partition(":")
+            metadata[k.strip()] = v.strip().strip("'\"")
+            continue
+        in_metadata = False
         if ":" in line:
             k, _, v = line.partition(":")
-            out[k.strip()] = _unquote(v.strip())
+            out[k.strip()] = v.strip().strip("'\"")
     out["metadata"] = metadata
     return out
-
-
-def _unquote(v: str) -> str:
-    v = v.strip()
-    if len(v) >= 2 and v[0] == v[-1] == '"':
-        return v[1:-1]
-    if len(v) >= 2 and v[0] == v[-1] == "'":
-        return v[1:-1]
-    return v
 
 
 def first_heading(text: str) -> str | None:
     body = FRONTMATTER_RE.sub("", text, count=1)
     m = HEADING_RE.search(body)
-    if m:
-        return m.group(1).strip()
-    return None
+    return m.group(1).strip() if m else None
 
 
 def date_key(filename: str, mtime: float) -> str:
-    m = DATE_IN_NAME_RE.search(filename.rsplit(".md", 1)[0] + ".md")
+    m = DATE_IN_NAME_RE.search(filename)
     if m:
         return f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
     return time.strftime("%Y-%m-%d", time.localtime(mtime))
@@ -150,15 +102,13 @@ def classify_type(filename: str, fm_type: str | None) -> str:
     prefix = filename.split("_", 1)[0]
     if prefix in KNOWN_PREFIXES:
         return prefix
-    if fm_type:
-        return fm_type
-    return "misc"
+    return fm_type or "misc"
 
 
 def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | None:
     """~/.claude/projects/<slug>/memory, <slug> = abs project dir, '/' -> '-'.
-    `cwd` defaults to $CLAUDE_PROJECT_DIR (fallback: git toplevel of cwd);
-    `home` overrides Path.home() (test-only)."""
+    cwd defaults to $CLAUDE_PROJECT_DIR (fallback: git toplevel of cwd);
+    home overrides Path.home() (test-only)."""
     project_dir = cwd or os.environ.get("CLAUDE_PROJECT_DIR")
     if not project_dir:
         try:
@@ -171,21 +121,18 @@ def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | Non
             project_dir = None
     if not project_dir:
         return None
-    abs_dir = os.path.abspath(project_dir)
-    slug = abs_dir.replace(os.sep, "-")
+    slug = os.path.abspath(project_dir).replace(os.sep, "-")
     home_path = Path(home) if home else Path.home()
     return str(home_path / ".claude" / "projects" / slug / "memory")
 
 
 def build_index(memdir: str) -> tuple[str, dict]:
     t0 = time.time()
-    files = sorted(
-        fn for fn in os.listdir(memdir) if not is_excluded(fn)
-    )
+    files = sorted(fn for fn in os.listdir(memdir) if not is_excluded(fn))
 
-    entries = []  # (type, date_key, line, filename)
+    by_type: dict[str, list[tuple[str, str]]] = {}
+    frontmatter_less = 0
     pii_offenders = []
-    n_no_frontmatter_named_by_heading = 0
 
     for fn in files:
         path = os.path.join(memdir, fn)
@@ -195,72 +142,51 @@ def build_index(memdir: str) -> tuple[str, dict]:
         except (OSError, UnicodeDecodeError):
             continue
         fm = parse_frontmatter(text)
-        name = fm.get("name")
-        description = fm.get("description", "") or ""
-        fm_type = (fm.get("metadata") or {}).get("type")
-
-        title = name
+        title = fm.get("name")
         if not title:
-            h = first_heading(text)
-            title = h if h else fn[:-3]
-            n_no_frontmatter_named_by_heading += 1
+            title = first_heading(text) or fn[:-3]
+            frontmatter_less += 1
 
-        raw_desc = description.strip()
-        hits = pii_scan(raw_desc)
+        desc, hits = redact((fm.get("description") or "").strip())
         if hits:
-            pii_offenders.append((fn, hits))
-
-        desc = redact(raw_desc)
+            pii_offenders.append(fn)
         if len(desc) > DESC_MAX:
             desc = desc[: DESC_MAX - 1].rstrip() + "…"
 
-        mtime = os.path.getmtime(path)
-        dkey = date_key(fn, mtime)
-        typ = classify_type(fn, fm_type)
+        typ = classify_type(fn, (fm.get("metadata") or {}).get("type"))
+        dkey = date_key(fn, os.path.getmtime(path))
+        by_type.setdefault(typ, []).append((dkey, f"- {title}: {desc} ({fn})"))
 
-        line = f"- {title}: {desc} ({fn})"
-        entries.append((typ, dkey, line, fn))
-
-    # Group by type, sort each group by date desc, then filename for stability.
-    by_type: dict[str, list[tuple[str, str, str]]] = {}
-    for typ, dkey, line, fn in entries:
-        by_type.setdefault(typ, []).append((dkey, line, fn))
     for typ in by_type:
-        by_type[typ].sort(key=lambda t: (t[0], t[2]), reverse=True)
+        by_type[typ].sort(reverse=True)
 
     out_lines = ["# MEMORY_INDEX.md (generated — Layer 3 catalog, redacted)", ""]
-    for typ in sorted(by_type.keys()):
+    for typ in sorted(by_type):
         out_lines.append(f"## {typ}")
-        for dkey, line, fn in by_type[typ]:
-            out_lines.append(line)
+        out_lines.extend(line for _dkey, line in by_type[typ])
         out_lines.append("")
 
     text_out = "\n".join(out_lines).rstrip("\n") + "\n"
-    build_time = time.time() - t0
-
     meta = {
         "file_count": len(files),
         "bytes": len(text_out.encode("utf-8")),
         "line_count": text_out.count("\n"),
-        "build_seconds": round(build_time, 4),
-        "types": sorted(by_type.keys()),
-        "frontmatter_less_count": n_no_frontmatter_named_by_heading,
+        "build_seconds": round(time.time() - t0, 4),
+        "types": sorted(by_type),
+        "frontmatter_less_count": frontmatter_less,
         "pii_offender_count": len(pii_offenders),
-        "pii_offender_files": [fn for fn, _hits in pii_offenders],
-        "catalog_filenames": files,
+        "pii_offender_files": pii_offenders,
     }
     return text_out, meta
 
 
 def is_stale(memdir: str, out_path: str) -> bool:
-    """True if `out_path` doesn't exist, or any included memory file in
-    memdir has an mtime newer than the catalog's own mtime."""
+    """True if out_path is missing, or any included file's mtime is newer."""
     if not os.path.exists(out_path):
         return True
     catalog_mtime = os.path.getmtime(out_path)
     for path in glob.glob(os.path.join(memdir, "*.md")):
-        fn = os.path.basename(path)
-        if is_excluded(fn):
+        if is_excluded(os.path.basename(path)):
             continue
         try:
             if os.path.getmtime(path) > catalog_mtime:
@@ -274,7 +200,6 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--memdir", default=None)
     ap.add_argument("--out", default=None)
-    ap.add_argument("--report-json", default=None)
     ap.add_argument("--check", action="store_true",
                      help="exit 1 if the catalog at --out is stale, without writing anything")
     args = ap.parse_args()
@@ -282,7 +207,7 @@ def main() -> int:
     memdir = args.memdir or resolve_memdir()
     if not memdir or not os.path.isdir(memdir):
         print("memory_index_build: no memdir resolved/found — nothing to do", file=sys.stderr)
-        return 0 if not args.check else 1
+        return 1 if args.check else 0
 
     out_path = args.out or os.path.join(memdir, "MEMORY_INDEX.md")
 
@@ -292,17 +217,11 @@ def main() -> int:
         return 1 if stale else 0
 
     text_out, meta = build_index(memdir)
-
     if out_path == "-":
         sys.stdout.write(text_out)
     else:
         with open(out_path, "w", encoding="utf-8") as f:
             f.write(text_out)
-
-    if args.report_json:
-        import json
-        with open(args.report_json, "w", encoding="utf-8") as f:
-            json.dump(meta, f, indent=2)
 
     print(
         f"[memory_index_build] {meta['file_count']} files -> {meta['bytes']}B, "

--- a/scripts/memory/memory_index_build.py
+++ b/scripts/memory/memory_index_build.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""LAYER 3 — memory_index_build.py (production catalog generator).
+
+Generates a full catalog (MEMORY_INDEX.md) of every memory file in MEMDIR,
+grouped by type, one line per file, redacted — the "grep before you act on a
+topic" fallback the Layer-2 recall hook (`mos_recall_sessionstart.py`) points
+to for anything its top-6 cap dropped.
+
+Scope: every ``*.md`` in MEMDIR except ``MEMORY*.md`` (the index itself and
+thematic digests) and anything with ``.bak``/``backup`` in the filename.
+
+MEMDIR is derived like the Layer-2 hook: ``$CLAUDE_PROJECT_DIR`` (fallback:
+`git rev-parse --show-toplevel`) + ``Path.home()`` — no hardcoded M5 path, so
+Pro/Mini resolve their own slug. Read-only on MEMDIR; ``--out`` never touches
+the live MEMORY.md/MEMORY_*.md files, only the catalog itself.
+
+Invoked by hand or by cron later (out of scope here — ships independently of
+the Layer-2 PR). ``--check`` detects a stale catalog without a diff.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DESC_MAX = 140
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+DATE_IN_NAME_RE = re.compile(r"(\d{4})_(\d{2})_(\d{2})(?:\.md)?$")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+
+# Recognized filename-prefix taxonomy (the convention this corpus already
+# uses in MEMORY.md's own links: discovery_/decision_/lesson_/fact_/
+# project_/unresolved_/reference_/ops_/feedback_...).
+KNOWN_PREFIXES = {
+    "discovery", "decision", "lesson", "fact", "project",
+    "unresolved", "reference", "ops", "feedback",
+}
+
+# PII redaction (transformation). Duplicated (not imported) from the sibling
+# Layer-2 script mos_recall_sessionstart.py — separate PRs, keep in sync by hand.
+REDACT_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+REDACT_PHONE_RE = re.compile(r"\+(?:62|39)[\s.-]?\d[\d\s.-]{6,}\d")
+REDACT_ID_RE = re.compile(r"\b(?:passport|KTP)\b\D{0,10}\d[\d\s-]*", re.IGNORECASE)
+REDACT_DIGITRUN_RE = re.compile(r"(?<!\d)\d{10,15}(?!\d)")
+
+
+def redact(text: str) -> str:
+    """Replace PII shapes with placeholders (email/id/phone before the
+    generic digit-run so the specific patterns consume their digits first)."""
+    if not text:
+        return text
+    text = REDACT_EMAIL_RE.sub("<email>", text)
+    text = REDACT_ID_RE.sub("<id>", text)
+    text = REDACT_PHONE_RE.sub("<num>", text)
+    text = REDACT_DIGITRUN_RE.sub("<num>", text)
+    return text
+
+
+def pii_scan(text: str) -> list[str]:
+    """Detection only (category names) — used for the build report, kept
+    separate from redact() since a report wants to KNOW what was found."""
+    hits = []
+    if REDACT_EMAIL_RE.search(text):
+        hits.append("email")
+    if REDACT_PHONE_RE.search(text):
+        hits.append("phone_id_it")
+    if REDACT_ID_RE.search(text):
+        hits.append("passport_ktp")
+    if REDACT_DIGITRUN_RE.search(text):
+        hits.append("digit_run")
+    return hits
+
+
+def is_excluded(filename: str) -> bool:
+    if not filename.endswith(".md"):
+        return True
+    if filename.startswith("MEMORY"):
+        return True
+    low = filename.lower()
+    if ".bak" in low or "backup" in low:
+        return True
+    return False
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Minimal frontmatter parser for THIS corpus's shape only:
+    top-level 'key: value' lines plus one nested 'metadata:' block.
+    Returns {} if there is no frontmatter block at all.
+    """
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    block = m.group(1)
+    out: dict = {}
+    metadata: dict = {}
+    in_metadata = False
+    for line in block.split("\n"):
+        if not line.strip():
+            continue
+        if line.startswith("metadata:"):
+            in_metadata = True
+            continue
+        if in_metadata:
+            if line.startswith((" ", "\t")):
+                kv = line.strip()
+                if ":" in kv:
+                    k, _, v = kv.partition(":")
+                    metadata[k.strip()] = _unquote(v.strip())
+                continue
+            else:
+                in_metadata = False
+        if ":" in line:
+            k, _, v = line.partition(":")
+            out[k.strip()] = _unquote(v.strip())
+    out["metadata"] = metadata
+    return out
+
+
+def _unquote(v: str) -> str:
+    v = v.strip()
+    if len(v) >= 2 and v[0] == v[-1] == '"':
+        return v[1:-1]
+    if len(v) >= 2 and v[0] == v[-1] == "'":
+        return v[1:-1]
+    return v
+
+
+def first_heading(text: str) -> str | None:
+    body = FRONTMATTER_RE.sub("", text, count=1)
+    m = HEADING_RE.search(body)
+    if m:
+        return m.group(1).strip()
+    return None
+
+
+def date_key(filename: str, mtime: float) -> str:
+    m = DATE_IN_NAME_RE.search(filename.rsplit(".md", 1)[0] + ".md")
+    if m:
+        return f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
+    return time.strftime("%Y-%m-%d", time.localtime(mtime))
+
+
+def classify_type(filename: str, fm_type: str | None) -> str:
+    prefix = filename.split("_", 1)[0]
+    if prefix in KNOWN_PREFIXES:
+        return prefix
+    if fm_type:
+        return fm_type
+    return "misc"
+
+
+def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | None:
+    """~/.claude/projects/<slug>/memory, <slug> = abs project dir, '/' -> '-'.
+    `cwd` defaults to $CLAUDE_PROJECT_DIR (fallback: git toplevel of cwd);
+    `home` overrides Path.home() (test-only)."""
+    project_dir = cwd or os.environ.get("CLAUDE_PROJECT_DIR")
+    if not project_dir:
+        try:
+            r = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"], cwd=os.getcwd(),
+                capture_output=True, text=True, timeout=1.5,
+            )
+            project_dir = r.stdout.strip() if r.returncode == 0 else None
+        except Exception:
+            project_dir = None
+    if not project_dir:
+        return None
+    abs_dir = os.path.abspath(project_dir)
+    slug = abs_dir.replace(os.sep, "-")
+    home_path = Path(home) if home else Path.home()
+    return str(home_path / ".claude" / "projects" / slug / "memory")
+
+
+def build_index(memdir: str) -> tuple[str, dict]:
+    t0 = time.time()
+    files = sorted(
+        fn for fn in os.listdir(memdir) if not is_excluded(fn)
+    )
+
+    entries = []  # (type, date_key, line, filename)
+    pii_offenders = []
+    n_no_frontmatter_named_by_heading = 0
+
+    for fn in files:
+        path = os.path.join(memdir, fn)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        fm = parse_frontmatter(text)
+        name = fm.get("name")
+        description = fm.get("description", "") or ""
+        fm_type = (fm.get("metadata") or {}).get("type")
+
+        title = name
+        if not title:
+            h = first_heading(text)
+            title = h if h else fn[:-3]
+            n_no_frontmatter_named_by_heading += 1
+
+        raw_desc = description.strip()
+        hits = pii_scan(raw_desc)
+        if hits:
+            pii_offenders.append((fn, hits))
+
+        desc = redact(raw_desc)
+        if len(desc) > DESC_MAX:
+            desc = desc[: DESC_MAX - 1].rstrip() + "…"
+
+        mtime = os.path.getmtime(path)
+        dkey = date_key(fn, mtime)
+        typ = classify_type(fn, fm_type)
+
+        line = f"- {title}: {desc} ({fn})"
+        entries.append((typ, dkey, line, fn))
+
+    # Group by type, sort each group by date desc, then filename for stability.
+    by_type: dict[str, list[tuple[str, str, str]]] = {}
+    for typ, dkey, line, fn in entries:
+        by_type.setdefault(typ, []).append((dkey, line, fn))
+    for typ in by_type:
+        by_type[typ].sort(key=lambda t: (t[0], t[2]), reverse=True)
+
+    out_lines = ["# MEMORY_INDEX.md (generated — Layer 3 catalog, redacted)", ""]
+    for typ in sorted(by_type.keys()):
+        out_lines.append(f"## {typ}")
+        for dkey, line, fn in by_type[typ]:
+            out_lines.append(line)
+        out_lines.append("")
+
+    text_out = "\n".join(out_lines).rstrip("\n") + "\n"
+    build_time = time.time() - t0
+
+    meta = {
+        "file_count": len(files),
+        "bytes": len(text_out.encode("utf-8")),
+        "line_count": text_out.count("\n"),
+        "build_seconds": round(build_time, 4),
+        "types": sorted(by_type.keys()),
+        "frontmatter_less_count": n_no_frontmatter_named_by_heading,
+        "pii_offender_count": len(pii_offenders),
+        "pii_offender_files": [fn for fn, _hits in pii_offenders],
+        "catalog_filenames": files,
+    }
+    return text_out, meta
+
+
+def is_stale(memdir: str, out_path: str) -> bool:
+    """True if `out_path` doesn't exist, or any included memory file in
+    memdir has an mtime newer than the catalog's own mtime."""
+    if not os.path.exists(out_path):
+        return True
+    catalog_mtime = os.path.getmtime(out_path)
+    for path in glob.glob(os.path.join(memdir, "*.md")):
+        fn = os.path.basename(path)
+        if is_excluded(fn):
+            continue
+        try:
+            if os.path.getmtime(path) > catalog_mtime:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--memdir", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--report-json", default=None)
+    ap.add_argument("--check", action="store_true",
+                     help="exit 1 if the catalog at --out is stale, without writing anything")
+    args = ap.parse_args()
+
+    memdir = args.memdir or resolve_memdir()
+    if not memdir or not os.path.isdir(memdir):
+        print("memory_index_build: no memdir resolved/found — nothing to do", file=sys.stderr)
+        return 0 if not args.check else 1
+
+    out_path = args.out or os.path.join(memdir, "MEMORY_INDEX.md")
+
+    if args.check:
+        stale = is_stale(memdir, out_path)
+        print(f"[memory_index_build] --check: {'STALE' if stale else 'fresh'} ({out_path})", file=sys.stderr)
+        return 1 if stale else 0
+
+    text_out, meta = build_index(memdir)
+
+    if out_path == "-":
+        sys.stdout.write(text_out)
+    else:
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(text_out)
+
+    if args.report_json:
+        import json
+        with open(args.report_json, "w", encoding="utf-8") as f:
+            json.dump(meta, f, indent=2)
+
+    print(
+        f"[memory_index_build] {meta['file_count']} files -> {meta['bytes']}B, "
+        f"{meta['line_count']} lines, {meta['build_seconds']}s, "
+        f"PII offenders redacted={meta['pii_offender_count']}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_memory_index_build.py
+++ b/scripts/tests/test_memory_index_build.py
@@ -69,15 +69,12 @@ def test_catalog_excludes_memory_and_backup_files(tmp_path, filename):
     assert "discovery_kept_2026_09_01.md" in text
 
 
-# ---------------------------------------------------------------------------
-# Redaction
-# ---------------------------------------------------------------------------
-
 @pytest.mark.parametrize("desc, needle, placeholder", [
     ("contact the client at mario.rossi@example.com for details", "mario.rossi@example.com", "<email>"),
     ("call the client on +62 812 345 6789 tomorrow", "812 345 6789", "<num>"),
     ("reference number 1234567890123 on file", "1234567890123", "<num>"),
     ("copy of passport A1234567 attached", "A1234567", "<id>"),
+    ("KTP number 3171234567890123 on file", "3171234567890123", "<id>"),
 ])
 def test_catalog_redacts_pii_in_descriptions(tmp_path, desc, needle, placeholder):
     memdir = tmp_path / "memdir_pii"
@@ -91,30 +88,16 @@ def test_catalog_redacts_pii_in_descriptions(tmp_path, desc, needle, placeholder
     assert meta["pii_offender_count"] == 1
 
 
-def test_pii_scan_clean_text_has_no_hits():
+def test_redact_clean_text_has_no_hits():
     clean = "the migration runner reads schema_migrations and applies pending DDL"
-    assert index_mod.pii_scan(clean) == []
+    _text, hits = index_mod.redact(clean)
+    assert hits == []
 
-
-# ---------------------------------------------------------------------------
-# --check staleness
-# ---------------------------------------------------------------------------
 
 def test_is_stale_true_when_catalog_missing(tmp_path):
     memdir = tmp_path / "memdir_stale_missing"
     memdir.mkdir()
     assert index_mod.is_stale(str(memdir), str(memdir / "MEMORY_INDEX.md")) is True
-
-
-def test_is_stale_false_after_fresh_build(tmp_path):
-    memdir = tmp_path / "memdir_stale_fresh"
-    memdir.mkdir()
-    _write_memory_file(memdir, "discovery_x_2026_09_01.md", "x", "desc", "discovery", "topic")
-    out_path = memdir / "MEMORY_INDEX.md"
-    text, _meta = index_mod.build_index(str(memdir))
-    out_path.write_text(text, encoding="utf-8")
-
-    assert index_mod.is_stale(str(memdir), str(out_path)) is False
 
 
 def test_is_stale_true_after_new_memory_file_added(tmp_path):
@@ -132,10 +115,6 @@ def test_is_stale_true_after_new_memory_file_added(tmp_path):
 
     assert index_mod.is_stale(str(memdir), str(out_path)) is True
 
-
-# ---------------------------------------------------------------------------
-# Slug derivation (shared shape with the Layer-2 recall hook)
-# ---------------------------------------------------------------------------
 
 def test_resolve_memdir_slug_shape(tmp_path):
     fake_home = tmp_path / "home"

--- a/scripts/tests/test_memory_index_build.py
+++ b/scripts/tests/test_memory_index_build.py
@@ -1,0 +1,146 @@
+"""Unit tests for scripts/memory/memory_index_build.py — the Layer 3 catalog
+generator (MEMORY_INDEX.md). Fixtures live entirely in tmp_path; nothing
+under ~/.claude is touched.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+SCRIPTS_MEMORY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "memory")
+sys.path.insert(0, SCRIPTS_MEMORY)
+
+import memory_index_build as index_mod  # noqa: E402
+
+
+def _write_memory_file(memdir, filename, name, desc, typ, topic):
+    (memdir / filename).write_text(
+        f"---\nname: {name}\ndescription: {desc}\nmetadata:\n  type: {typ}\n---\n\n"
+        f"Body text about {topic}.\n",
+        encoding="utf-8",
+    )
+
+
+def test_catalog_includes_frontmatter_less_file_via_first_heading(tmp_path):
+    memdir = tmp_path / "memdir_catalog"
+    memdir.mkdir()
+    (memdir / "discovery_with_frontmatter_2026_09_01.md").write_text(
+        "---\nname: has-fm\ndescription: has frontmatter\nmetadata:\n  type: discovery\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    (memdir / "no_frontmatter_file.md").write_text(
+        "# A Heading Used As Title\n\nSome body text with no frontmatter block at all.\n",
+        encoding="utf-8",
+    )
+
+    text, meta = index_mod.build_index(str(memdir))
+
+    assert "A Heading Used As Title" in text
+    assert "no_frontmatter_file.md" in text
+    assert meta["frontmatter_less_count"] == 1
+
+
+def test_catalog_idempotent(tmp_path):
+    memdir = tmp_path / "memdir_idem"
+    memdir.mkdir()
+    _write_memory_file(memdir, "discovery_x_2026_09_01.md", "x", "desc", "discovery", "topic")
+
+    text1, _m1 = index_mod.build_index(str(memdir))
+    text2, _m2 = index_mod.build_index(str(memdir))
+    assert text1 == text2
+
+
+@pytest.mark.parametrize("filename", ["MEMORY_DIGEST.md", "discovery_stale_2026_01_01.md.bak", "discovery_backup_copy.md"])
+def test_catalog_excludes_memory_and_backup_files(tmp_path, filename):
+    memdir = tmp_path / f"memdir_excl_{filename.replace('.', '_')}"
+    memdir.mkdir()
+    (memdir / filename).write_text("should be excluded\n", encoding="utf-8")
+    (memdir / "discovery_kept_2026_09_01.md").write_text(
+        "---\nname: kept\ndescription: kept entry\nmetadata:\n  type: discovery\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    text, _meta = index_mod.build_index(str(memdir))
+
+    assert filename not in text
+    assert "discovery_kept_2026_09_01.md" in text
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("desc, needle, placeholder", [
+    ("contact the client at mario.rossi@example.com for details", "mario.rossi@example.com", "<email>"),
+    ("call the client on +62 812 345 6789 tomorrow", "812 345 6789", "<num>"),
+    ("reference number 1234567890123 on file", "1234567890123", "<num>"),
+    ("copy of passport A1234567 attached", "A1234567", "<id>"),
+])
+def test_catalog_redacts_pii_in_descriptions(tmp_path, desc, needle, placeholder):
+    memdir = tmp_path / "memdir_pii"
+    memdir.mkdir()
+    _write_memory_file(memdir, "discovery_pii_2026_09_01.md", "pii-entry", desc, "discovery", "client")
+
+    text, meta = index_mod.build_index(str(memdir))
+
+    assert needle not in text
+    assert placeholder in text
+    assert meta["pii_offender_count"] == 1
+
+
+def test_pii_scan_clean_text_has_no_hits():
+    clean = "the migration runner reads schema_migrations and applies pending DDL"
+    assert index_mod.pii_scan(clean) == []
+
+
+# ---------------------------------------------------------------------------
+# --check staleness
+# ---------------------------------------------------------------------------
+
+def test_is_stale_true_when_catalog_missing(tmp_path):
+    memdir = tmp_path / "memdir_stale_missing"
+    memdir.mkdir()
+    assert index_mod.is_stale(str(memdir), str(memdir / "MEMORY_INDEX.md")) is True
+
+
+def test_is_stale_false_after_fresh_build(tmp_path):
+    memdir = tmp_path / "memdir_stale_fresh"
+    memdir.mkdir()
+    _write_memory_file(memdir, "discovery_x_2026_09_01.md", "x", "desc", "discovery", "topic")
+    out_path = memdir / "MEMORY_INDEX.md"
+    text, _meta = index_mod.build_index(str(memdir))
+    out_path.write_text(text, encoding="utf-8")
+
+    assert index_mod.is_stale(str(memdir), str(out_path)) is False
+
+
+def test_is_stale_true_after_new_memory_file_added(tmp_path):
+    memdir = tmp_path / "memdir_stale_new"
+    memdir.mkdir()
+    _write_memory_file(memdir, "discovery_x_2026_09_01.md", "x", "desc", "discovery", "topic")
+    out_path = memdir / "MEMORY_INDEX.md"
+    text, _meta = index_mod.build_index(str(memdir))
+    out_path.write_text(text, encoding="utf-8")
+    assert index_mod.is_stale(str(memdir), str(out_path)) is False
+
+    time.sleep(0.01)
+    _write_memory_file(memdir, "discovery_y_2026_09_02.md", "y", "desc2", "discovery", "topic2")
+    os.utime(memdir / "discovery_y_2026_09_02.md", (time.time() + 5, time.time() + 5))
+
+    assert index_mod.is_stale(str(memdir), str(out_path)) is True
+
+
+# ---------------------------------------------------------------------------
+# Slug derivation (shared shape with the Layer-2 recall hook)
+# ---------------------------------------------------------------------------
+
+def test_resolve_memdir_slug_shape(tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    memdir = index_mod.resolve_memdir(cwd="/Users/balizero/nuzantara", home=str(fake_home))
+
+    assert memdir == str(fake_home / ".claude" / "projects" / "-Users-balizero-nuzantara" / "memory")


### PR DESCRIPTION
## What
Turns the tested MOS Layer-3 prototype (`scripts/memory/memory_index_build.py`) production-ready: generates a full catalog (`MEMORY_INDEX.md`) of every memory file, grouped by type, one line per file — the "grep before you act on a topic" fallback the Layer-2 recall hook (PR #5665) points to for anything its top-6 cap dropped.

- `memdir` derived the same way as the Layer-2 hook: `$CLAUDE_PROJECT_DIR` + `Path.home()` (fallback: `git rev-parse --show-toplevel`), never a hardcoded M5 path — Pro/Mini resolve their own slug.
- Descriptions are now actually **redacted** (`redact()`), not just flagged: email/phone(+62/+39)/10–15-digit-run/passport-KTP → placeholders in the catalog text itself. `pii_scan()` stays as a separate detection-only helper for the build report (`PII offenders redacted=N`).
- Excludes `MEMORY*.md` and anything with `.bak`/`backup` in the filename (unchanged from the prototype).
- New `--check` mode: exits 1 if the catalog at `--out` doesn't exist or any included memory file has a newer mtime, without writing anything — lets a caller detect staleness without a diff.
- `--out` defaults to `$MEMDIR/MEMORY_INDEX.md`.
- Ships independently of the Layer-2 recall hook PR (separate small PRs, no shared import — the redaction helper is deliberately duplicated, with a comment saying so). Invoked by hand for now; cron wiring is a follow-up, out of scope here.

## Verification
- `python3 -m pytest -q scripts/tests/test_memory_index_build.py` → 14 passed (frontmatter-less-via-heading, idempotent, 3 exclusion cases, 4 redaction cases, clean-text no-hits, `--check` missing/fresh/stale, slug derivation).
- Live smoke against the real M5 memory corpus (`--memdir` real, `--out`/`--report-json` pointed at scratch so the run never wrote under `~/.claude`): 1,796 files → 440,470B / 1,823 lines in **0.358s** (well under the 1s/1,800-file budget), 19 real PII offenders found and redacted in the generated text (verified none of the raw email/phone/digit-run/passport strings survive in the catalog).
- `--check` smoke: fresh catalog → exit 0 (`fresh`); confirmed `is_stale()` flips to `True` when a memory file's mtime is bumped past the catalog's own mtime (unit test, tmp_path fixture).
- Churn (original): 463 insertions across 2 new files. `scripts/evidence_pack_lint.py --print-floor` printed **2** (source: `size`) — same disclosure as the sibling PR #5665: the prototype (Layer 3, ~245 lines) plus real redaction plus the requested test categories (frontmatter-less/idempotent/redaction/exclusions/staleness) exceeded the 400-line Gear-1 floor.
- **Post-slim re-verification (2026-09-04, commit `1a882ecade`)**: merged `pii_scan()` into `redact()` (single pass, returns hit categories inline), dropped `--report-json`, tightened `parse_frontmatter`/`build_index` — same contract (frontmatter+heading fallback, exclusions, redaction incl. NIK/NPWP, idempotent output, `--check` staleness). Churn dropped to **361** lines (236 + 125 across the 2 files); `scripts/evidence_pack_lint.py --print-floor` → **1**. `python3 -m pytest -q scripts/tests/test_memory_index_build.py` → 14 passed. Real-corpus smoke (1,798 files, `--out` into scratch, `~/.claude` never written): **441,084B** / 1,825 lines / 0.326s, 20 PII offenders redacted, 0 email leaks in the output (`grep -cE` email regex → 0).

**Self-correction disclosed**: while smoke-testing `--check` against the real corpus I accidentally ran a stray `touch` on one live memory file under `~/.claude` (`discovery_paths_less_claude_rules_files_are_auto_injected_every_session_2026_09_04.md`) — it updated the file's mtime only, no content change, and no other command in this session wrote under `~/.claude` (every other verification used `--out`/`--cache-path` overrides into scratch, or a fully separate copied corpus under a faked `$HOME`). Practical impact is negligible: both this generator's `date_key()` and the Layer-2 hook's `recency_score()` prefer the date embedded in the filename over mtime, and this file's name already carries `2026_09_04`, so recall/catalog ordering is unaffected. No prior mtime was recorded anywhere I can recover it from, so it is not restored — flagging for the record rather than silently leaving it.

## Bites
Consumer: the operator runs `python3 scripts/memory/memory_index_build.py` on M5 to produce `MEMORY_INDEX.md`, the catalog the recall hook's oversize-`MEMORY.md` warning line points to. Observation: `python3 scripts/memory/memory_index_build.py --check` exits 0 after a build against the real corpus (verified via `--out`-to-scratch smoke, since `~/.claude` stayed read-only for this session), and `test_memory_index_build.py` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4
