### PR TITLE
fix(news-room): internal publishes reach news_items and the post-publish queue

### DIFF
--- a/apps/backend-rag/backend/app/routers/intel.py
+++ b/apps/backend-rag/backend/app/routers/intel.py
@@ -675,6 +675,7 @@ def _workspace_publish_blockers(item: dict[str, Any]) -> list[str]:
 async def workspace_marketing_publish_news(
     item_id: str,
     body: WorkspaceNewsPublishRequest,
+    request: Request = None,  # type: ignore
 ) -> dict[str, Any]:
     """Publish one ready News Room item after Damar explicitly confirms."""
 
@@ -765,12 +766,14 @@ async def workspace_marketing_publish_news(
     from backend.app.routers.intel_scraper import publish_staging_item_internal
 
     try:
+        # Internal publishing has no request context, so preserve the route pool explicitly.
         result = await publish_staging_item_internal(
             "news",
             item_id,
             actor="workspace-agent:damar",
             allow_generated_cover=False,
             position=body.position,
+            pool=getattr(request.app.state, "db_pool", None) if request else None,
         )
     except Exception:
         staging_service.compare_and_set_status(

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -715,6 +715,8 @@ async def publish_staging_item_internal(
     actor: str,
     allow_generated_cover: bool = True,
     position: str = "latest",
+    *,
+    pool: Any | None = None,
 ) -> dict[str, Any]:
     """Publish path for internal callers that carry their own authorization.
 
@@ -730,7 +732,15 @@ async def publish_staging_item_internal(
         request=None,
         actor=actor,
         allow_generated_cover=allow_generated_cover,
+        pool=pool,
     )
+
+
+def _resolve_publish_pool(pool: Any | None, request: Request | None) -> Any | None:
+    """Prefer an explicitly supplied pool for internal publish callers."""
+    if pool is not None:
+        return pool
+    return getattr(request.app.state, "db_pool", None) if request else None
 
 
 async def _publish_staging_item(
@@ -740,6 +750,8 @@ async def _publish_staging_item(
     request: Request | None,
     actor: str,
     allow_generated_cover: bool = True,
+    *,
+    pool: Any | None = None,
 ) -> dict[str, Any]:
     """Publish implementation. Callers are responsible for authorization."""
     # Single funnel-in for both callers (the admin HTTP endpoint and the Telegram
@@ -1115,9 +1127,9 @@ async def _publish_staging_item(
 
         # Step 4: Write to news_items table (serves /api/news for balizero.com frontend)
         try:
-            pool = getattr(request.app.state, "db_pool", None) if request else None
-            if pool:
-                slug = item_id  # item_id is already a slug-friendly identifier
+            publish_pool = _resolve_publish_pool(pool, request)
+            if publish_pool:
+                slug = article_slug or item_id
                 summary = (data.get("content") or "")[:500]
                 content_full = data.get("content") or ""
                 ai_summary = (
@@ -1126,7 +1138,17 @@ async def _publish_staging_item(
                     else ""
                 )
                 ai_tags = data.get("tags") or []
-                image_url = data.get("image_url") or data.get("cover_image")
+                if (
+                    (
+                        publish_result is not None
+                        and publish_result.success
+                        and publish_result.image_path
+                    )
+                    or data.get("published_cover_path")
+                ):
+                    image_url = f"/static/news/{slug}.jpg"
+                else:
+                    image_url = data.get("image_url") or data.get("cover_image")
                 priority_val = data.get("priority", "medium")
                 if priority_val not in ("high", "medium", "low"):
                     priority_val = "medium"
@@ -1143,7 +1165,9 @@ async def _publish_staging_item(
                 }
                 news_category = category if category in valid_categories else "business"
 
-                async with pool.acquire() as conn:
+                # news_items.slug has no unique constraint on prod (only a plain
+                # index), so ON CONFLICT (slug) raises; guard by existence instead.
+                async with publish_pool.acquire() as conn:
                     await conn.execute(
                         """
                         INSERT INTO news_items (
@@ -1151,8 +1175,8 @@ async def _publish_staging_item(
                             category, priority, status, image_url, published_at,
                             ai_summary, ai_tags, external_id
                         )
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'approved', $9, NOW(), $10, $11, $12)
-                        ON CONFLICT (slug) DO NOTHING
+                        SELECT $1, $2, $3, $4, $5, $6, $7, $8, 'approved', $9, NOW(), $10, $11, $12
+                        WHERE NOT EXISTS (SELECT 1 FROM news_items WHERE slug = $2)
                         """,
                         title,
                         slug,
@@ -1181,11 +1205,10 @@ async def _publish_staging_item(
 
         # Step 4b: Enqueue for post-processing (translate + image + SEO) — DB-backed
         try:
-            if not pool:
-                pool = getattr(request.app.state, "db_pool", None) if request else None
-            if not pool:
+            publish_pool = _resolve_publish_pool(pool, request)
+            if not publish_pool:
                 raise RuntimeError("No DB pool available")
-            async with pool.acquire() as conn:
+            async with publish_pool.acquire() as conn:
                 await conn.execute(
                     """
                     INSERT INTO post_publish_queue (slug, category, source)

--- a/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_intel_scraper_router.py
@@ -736,6 +736,17 @@ class TestSubmitFromScraper:
 
 
 class TestPublishStagingItem:
+    @staticmethod
+    def _fake_pool() -> tuple[MagicMock, MagicMock]:
+        connection = MagicMock()
+        connection.execute = AsyncMock()
+        acquired = MagicMock()
+        acquired.__aenter__ = AsyncMock(return_value=connection)
+        acquired.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock()
+        pool.acquire.return_value = acquired
+        return pool, connection
+
     @pytest.mark.asyncio
     async def test_workspace_cover_is_slug_named_jpeg_before_publish(self, tmp_path) -> None:
         """A workspace PNG reaches the composer as the canonical slug-named JPEG."""
@@ -767,6 +778,7 @@ class TestPublishStagingItem:
             auto_merge_enabled=True,
             image_path=f"/static/news/{generate_slug(title)}.jpg",
         )
+        pool, connection = self._fake_pool()
 
         with (
             patch("backend.app.routers.intel_scraper.staging_service") as mock_staging,
@@ -786,13 +798,84 @@ class TestPublishStagingItem:
             mock_metric.labels.return_value.inc = MagicMock()
 
             result = await publish_staging_item_internal(
-                "news", item_id, actor="test", allow_generated_cover=False
+                "news", item_id, actor="test", allow_generated_cover=False, pool=pool
             )
 
         assert result["success"] is True
         request = mock_publish.await_args.args[0]
         assert request.cover_image_filename == f"{generate_slug(title)}.jpg"
         assert base64.b64decode(request.cover_image_base64).startswith(b"\xff\xd8")
+        calls_by_statement = {
+            call.args[0]: call.args for call in connection.execute.await_args_list
+        }
+        news_args = next(
+            args for statement, args in calls_by_statement.items() if "INSERT INTO news_items" in statement
+        )
+        queue_args = next(
+            args
+            for statement, args in calls_by_statement.items()
+            if "INSERT INTO post_publish_queue" in statement
+        )
+        assert news_args[2] == "example"
+        assert news_args[9] == "/static/news/example.jpg"
+        assert queue_args[1] == "example"
+        # news_items.slug carries no unique constraint on prod: ON CONFLICT (slug)
+        # raises InvalidColumnReferenceError there, so the insert must be guarded
+        # by existence instead (measured 2026-09-04).
+        assert "ON CONFLICT" not in news_args[0]
+        assert "WHERE NOT EXISTS (SELECT 1 FROM news_items WHERE slug = $2)" in news_args[0]
+
+    @pytest.mark.asyncio
+    async def test_internal_publish_without_pool_keeps_returning_successfully(self, tmp_path) -> None:
+        from backend.app.routers.intel_scraper import publish_staging_item_internal
+
+        _unused_pool, connection = self._fake_pool()
+        item_id = "news-without-pool"
+        cover_dir = tmp_path / "covers"
+        cover_dir.mkdir()
+        image_output = BytesIO()
+        Image.new("RGB", (1200, 630), color="navy").save(image_output, format="PNG")
+        (cover_dir / f"{item_id}.png").write_bytes(image_output.getvalue())
+        staging_data = {
+            "title": "Article without a database pool",
+            "content": "Content for the published article.",
+            "category": "business",
+            "relevance_score": 80,
+            "cover_image": f"covers/{item_id}.png",
+        }
+        publish_response = SimpleNamespace(
+            success=True,
+            article_url="https://balizero.com/business/no-pool",
+            commit_sha="abc123",
+            mdx_path="apps/mouth/src/content/articles/business/no-pool.mdx",
+            pull_request_number=1,
+            auto_merge_enabled=True,
+            image_path=None,
+        )
+
+        with (
+            patch("backend.app.routers.intel_scraper.staging_service") as mock_staging,
+            patch("backend.app.routers.intel_scraper.intel_user_actions_total") as mock_metric,
+            patch(
+                "backend.app.routers.intel_scraper.ingest_intel_to_qdrant",
+                new=AsyncMock(return_value=True),
+            ),
+            patch("backend.app.routers.intel_scraper.invalidate_cache", new=AsyncMock()),
+            patch(
+                "backend.app.routers.article_composer.publish_article_internal",
+                new=AsyncMock(return_value=publish_response),
+            ),
+        ):
+            mock_staging.load_staging_item.return_value = staging_data
+            mock_staging.get_staging_dir.return_value = tmp_path
+            mock_metric.labels.return_value.inc = MagicMock()
+
+            result = await publish_staging_item_internal(
+                "news", item_id, actor="test", allow_generated_cover=False, pool=None
+            )
+
+        assert result["success"] is True
+        connection.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_not_found(self) -> None:

--- a/apps/backend-rag/backend/tests/unit/routers/test_workspace_marketing_bridge.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_workspace_marketing_bridge.py
@@ -278,9 +278,15 @@ async def test_workspace_publish_uses_named_actor_and_existing_cover_only(
     )
     monkeypatch.setattr(intel_scraper, "publish_staging_item_internal", publish)
 
+    app = FastAPI()
+    pool = object()
+    app.state.db_pool = pool
+    request = _request()
+    request.scope["app"] = app
     result = await intel.workspace_marketing_publish_news(
         "news_1",
         intel.WorkspaceNewsPublishRequest(confirmation="DAMAR_CONFIRMED"),
+        request=request,
     )
 
     assert result["success"] is True
@@ -291,6 +297,7 @@ async def test_workspace_publish_uses_named_actor_and_existing_cover_only(
         actor="workspace-agent:damar",
         allow_generated_cover=False,
         position="latest",
+        pool=pool,
     )
 
 


### PR DESCRIPTION
## Why

Measured on prod 2026-09-04 after the KBLI 2025 article went live (PR #5657): no `news_items` row (the `/api/news` list the homepage and listings read) and no `post_publish_queue` row (the Pro poller: SEO, translations, images). The newest queue row was from 2026-07-18 — every publish through the ChatGPT News Room bridge since then created its GitHub PR and nothing else.

Cause: `publish_staging_item_internal` calls the publisher with `request=None`; Step 4 resolves the pool from `request.app.state.db_pool` and silently skips, Step 4b raises "No DB pool available" into a swallowed warning. Two more latent faults in the same block: the news_items row was keyed by the staging item id instead of the article slug, and `ON CONFLICT (slug)` on `news_items` raises on prod because that column has no unique constraint (only a plain index — `post_publish_queue` does have `uq_ppq_slug`).

## What

- `_publish_staging_item(…, *, pool=None)`; `_resolve_publish_pool(pool, request)` used by Step 4 and 4b; `publish_staging_item_internal` forwards `pool`; the bridge route passes `request.app.state.db_pool` explicitly.
- news_items: `slug = article_slug`, `image_url = /static/news/<slug>.jpg` when a cover was committed; insert guarded by `WHERE NOT EXISTS`, no ON CONFLICT.

## Verification

- `test_intel_scraper_router.py` + `test_workspace_marketing_bridge.py` + `test_article_composer.py`: 106 passed (new: pool path writes news_items with the article slug and site image_url plus the queue row; `pool=None` + `request=None` executes nothing and still returns; the bridge route forwards the app pool; the news_items statement carries no ON CONFLICT and the NOT EXISTS guard).
- ruff clean. Code by the codex seat (gpt-5.6-terra, `scripts/seat_build.sh`); reviewed by a spalla-review seat (BLOCK on the ON CONFLICT clause), cured and re-tested by the session.
- The KBLI 2025 article's two rows were backfilled by hand on 2026-09-04 (11:48Z); the Pro poller picked the queue row at its next tick and logged "Preserved authored SEO fields: seoTitle, seoDescription".

Bites: Damar's next `newsroom_publish` on Fly (auto-deploy on merge) — observation: `SELECT slug FROM post_publish_queue ORDER BY created_at DESC LIMIT 1` returns the new article's slug within a minute of the publish, and `/api/news?status=approved` lists it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
