### PR TITLE
feat(memory): SessionStart recall hook — top-6 pertinent memories, 1.5KB cap, quiet when nothing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/organism_digest_sessionstart.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/hooks/memory_recall_sessionstart.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ MCP: `.mcp.json` untracked (per macchina); tool MCP differiti (`ENABLE_TOOL_SEAR
 
 ## 3. Memory (MOS)
 
-SessionStart auto-load ultime 5 memorie (importance ≥7). CLI `~/.claude/scripts/mem`: `recent`/`query "txt"`(FTS5)/`save <type> "txt" <importance>`(decision/discovery/fact/unresolved)/`entities "name"`/`sessions`/`stats`. `mem` prima di `notebook_query` (NLM solo dominio/cross-query). Salvataggio proattivo OBBLIGATORIO — `mem save` subito: decision(8-10), discovery/fact(7-8), unresolved(5-6); non chiedere, salva e basta.
+SessionStart: hook `memory_recall_sessionstart.sh` inietta le top-6 memorie pertinenti (≤1,5KB, muto se nulla); catalogo `MEMORY_INDEX.md` in memdir; `mem query` a richiesta. CLI `~/.claude/scripts/mem`: `recent`/`query "txt"`(FTS5)/`save <type> "txt" <importance>`(decision/discovery/fact/unresolved)/`entities "name"`/`sessions`/`stats`. `mem` prima di `notebook_query` (NLM solo dominio/cross-query). Salvataggio proattivo OBBLIGATORIO — `mem save` subito: decision(8-10), discovery/fact(7-8), unresolved(5-6); non chiedere, salva e basta.
 
 ## 4. Language Protocol
 

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -353,6 +353,7 @@
         "scripts/hooks/proprioception_sessionstart.sh": "SessionStart injector, never blocks",
         "scripts/hooks/w59_branch_hijack_guard.sh": "git-hook guard tested via broker-hygiene suite (scripts/tests/test_agent_start.py)",
         "scripts/hooks/organism_digest_sessionstart.sh": "SessionStart injector, never blocks",
+        "scripts/hooks/memory_recall_sessionstart.sh": "SessionStart injector (memory recall), never blocks",
         "infra/claude-hooks/mailbox_inject.py": "PostToolUse/Stop context-injection hook (cross-machine fleet mailbox reader) — never blocks a command, no block/allow contract to test. Guilt/innocence behaviour (delivered-once, kill-switch, path-safety, truncation, per-fire cap) is instead pinned by infra/claude-hooks/test_mailbox_inject.py, runnable standalone (python3 infra/claude-hooks/test_mailbox_inject.py) or under pytest — not yet wired into a CI workflow step (same as this hook itself, which is not in the hook-innocence-gate.yml explicit test list either); left for the ship PR to decide, since editing .github/workflows/ is a separate hot-zone surface."
       }
     },

--- a/scripts/hooks/memory_recall_sessionstart.sh
+++ b/scripts/hooks/memory_recall_sessionstart.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# memory_recall_sessionstart.sh — SessionStart receptor for MOS Layer 2 recall.
+set -u
+exec python3 "${CLAUDE_PROJECT_DIR:-$PWD}/scripts/memory/mos_recall_sessionstart.py" 2>/dev/null || exit 0

--- a/scripts/memory/mos_recall_sessionstart.py
+++ b/scripts/memory/mos_recall_sessionstart.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""LAYER 2 — mos_recall_sessionstart.py (production, wired to SessionStart).
+
+Generative-Agents-style ("Park et al. 2023") retrieval: score = recency x
+importance x relevance, print the top-k as one-line claims, print NOTHING
+when nothing is pertinent. stdlib only; well under 2s cold over ~1800 files.
+
+MEMDIR is derived, not hardcoded: ``~/.claude/projects/<slug>/memory`` where
+``<slug>`` is the absolute project path with every ``/`` -> ``-`` (e.g.
+``/Users/balizero/nuzantara`` -> ``-Users-balizero-nuzantara``), from
+``$CLAUDE_PROJECT_DIR`` (fallback: `git rev-parse --show-toplevel`) +
+``Path.home()`` — never assumed, since Pro/Mini check out at a different
+absolute path. Missing dir -> exit 0 silently (unwired machine, not a break).
+
+Index cache: ``<memdir>/.recall_cache.json``, keyed by path, entries rebuilt
+only on mtime change. Lives INSIDE memdir on purpose — `mem save` already
+writes there constantly, so a derived index next to its corpus can't drift.
+
+PII boundary: the printed line is built ONLY from frontmatter `description`
+(truncated 120 chars) and passed through `redact()` before stdout. Body text
+feeds the relevance index only and is NEVER printed.
+
+Fail-open: any exception in `main()` -> quiet exit 0, nothing printed.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CACHE_FILENAME = ".recall_cache.json"
+BODY_PREVIEW_CHARS = 400
+CLAIM_MAX_CHARS = 120
+OUTPUT_CAP_BYTES = 1500
+HALF_LIFE_DAYS = 30.0
+RECENCY_LAMBDA = math.log(2) / HALF_LIFE_DAYS
+DEFAULT_TOPK = 6
+DEFAULT_RELEVANCE_THRESHOLD = 0.35  # BM25-like score; tuned against the 12-scenario eval set
+BM25_K1 = 1.5
+BM25_B = 0.75
+GIT_TIMEOUT_SECONDS = 1.5
+RUNTIME_BUDGET_SECONDS = 2.0  # advisory only — nothing here hard-aborts mid-run
+MEMORY_MD_WARN_BYTES = 2560
+HEADER_LINE = "🧠 memoria pertinente (top-6, mem recall per altro):"
+MEMORY_MD_WARN_TEMPLATE = (
+    "⚠️ MEMORY.md {bytes}B > 2560B — è un nucleo, non un indice (catalogo: MEMORY_INDEX.md)"
+)
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+DATE_IN_NAME_RE = re.compile(r"(\d{4})_(\d{2})_(\d{2})(?:\.md)?$")
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+KNOWN_PREFIXES = {
+    "discovery", "decision", "lesson", "lessons", "fact", "project",
+    "unresolved", "reference", "ops", "feedback",
+}
+
+IMPORTANCE_BY_TYPE = {
+    "feedback": 1.0,
+    "decision": 1.0,
+    "lesson": 1.0,
+    "lessons": 1.0,
+    "project": 0.9,
+    "discovery": 0.8,
+    "fact": 0.6,
+    "reference": 0.6,
+}
+IMPORTANCE_DEFAULT = 0.5
+
+STOPWORDS_EN = {
+    "a", "an", "the", "and", "or", "of", "to", "in", "on", "for", "is",
+    "are", "was", "were", "be", "been", "with", "at", "by", "from", "as",
+    "that", "this", "it", "its", "into", "than", "then", "not", "no",
+    "so", "do", "does", "did", "has", "have", "had", "but", "if", "when",
+    "which", "who", "what", "how", "never", "always", "only", "one",
+}
+STOPWORDS_IT = {
+    "il", "lo", "la", "i", "gli", "le", "un", "uno", "una", "di", "a",
+    "da", "in", "con", "su", "per", "tra", "fra", "e", "o", "che", "chi",
+    "cui", "non", "mai", "sempre", "solo", "come", "quando", "dove",
+    "questo", "questa", "questi", "queste", "del", "della", "dei",
+    "delle", "al", "alla", "ai", "alle", "dal", "dalla", "dai", "dalle",
+    "nel", "nella", "nei", "nelle", "sul", "sulla", "sui", "sulle",
+    "è", "sono", "era", "erano", "essere", "stato", "stata",
+}
+STOPWORDS = STOPWORDS_EN | STOPWORDS_IT
+
+# PII redaction (transformation). Duplicated (not imported) from the sibling
+# Layer-3 script memory_index_build.py — separate PRs, keep in sync by hand.
+REDACT_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+REDACT_PHONE_RE = re.compile(r"\+(?:62|39)[\s.-]?\d[\d\s.-]{6,}\d")
+REDACT_ID_RE = re.compile(r"\b(?:passport|KTP)\b\D{0,10}\d[\d\s-]*", re.IGNORECASE)
+REDACT_DIGITRUN_RE = re.compile(r"(?<!\d)\d{10,15}(?!\d)")
+
+
+def redact(text: str) -> str:
+    """Replace PII shapes with placeholders (email/id/phone before the
+    generic digit-run so the specific patterns consume their digits first)."""
+    if not text:
+        return text
+    text = REDACT_EMAIL_RE.sub("<email>", text)
+    text = REDACT_ID_RE.sub("<id>", text)
+    text = REDACT_PHONE_RE.sub("<num>", text)
+    text = REDACT_DIGITRUN_RE.sub("<num>", text)
+    return text
+
+
+def tokenize(text: str) -> list[str]:
+    text = text.lower()
+    text = text.replace("_", " ").replace("-", " ")
+    toks = TOKEN_RE.findall(text)
+    return [t for t in toks if t not in STOPWORDS and len(t) >= 2]
+
+
+def parse_frontmatter(text: str) -> dict:
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+    block = m.group(1)
+    out: dict = {}
+    metadata: dict = {}
+    in_metadata = False
+    for line in block.split("\n"):
+        if not line.strip():
+            continue
+        if line.startswith("metadata:"):
+            in_metadata = True
+            continue
+        if in_metadata:
+            if line.startswith((" ", "\t")):
+                kv = line.strip()
+                if ":" in kv:
+                    k, _, v = kv.partition(":")
+                    metadata[k.strip()] = _unquote(v.strip())
+                continue
+            else:
+                in_metadata = False
+        if ":" in line:
+            k, _, v = line.partition(":")
+            out[k.strip()] = _unquote(v.strip())
+    out["metadata"] = metadata
+    return out
+
+
+def _unquote(v: str) -> str:
+    v = v.strip()
+    if len(v) >= 2 and v[0] == v[-1] in ('"', "'"):
+        return v[1:-1]
+    return v
+
+
+def date_key_from_name(filename: str) -> str | None:
+    m = DATE_IN_NAME_RE.search(filename.rsplit(".md", 1)[0] + ".md")
+    if not m:
+        return None
+    return f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
+
+
+def classify_type(filename: str, fm_type: str | None) -> str:
+    prefix = filename.split("_", 1)[0]
+    if prefix in KNOWN_PREFIXES:
+        return prefix
+    if fm_type:
+        return fm_type
+    return "misc"
+
+
+def load_cache(cache_path: str) -> dict:
+    if os.path.exists(cache_path):
+        try:
+            with open(cache_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return {}
+    return {}
+
+
+def save_cache(cache_path: str, cache: dict) -> None:
+    tmp = cache_path + ".tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(cache, f)
+        os.replace(tmp, cache_path)
+    except OSError:
+        pass  # cache is a pure speed optimization; a write failure is not fatal
+
+
+def build_or_refresh_index(memdir: str, cache_path: str, use_cache: bool = True) -> tuple[dict, dict]:
+    """Returns (index, stats). index: {path: entry}."""
+    files = sorted(glob.glob(os.path.join(memdir, "*.md")))
+    cache = load_cache(cache_path) if use_cache else {}
+    index: dict = {}
+    rebuilt = 0
+    reused = 0
+
+    for path in files:
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            continue
+        cached = cache.get(path)
+        if cached and cached.get("mtime") == mtime:
+            index[path] = cached
+            reused += 1
+            continue
+
+        rebuilt += 1
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read(4096)  # frontmatter + preview only, never the whole file
+        except (OSError, UnicodeDecodeError):
+            continue
+        fm = parse_frontmatter(text)
+        name = fm.get("name") or os.path.basename(path)[:-3]
+        description = (fm.get("description") or "").strip()
+        fm_type = (fm.get("metadata") or {}).get("type")
+        fn = os.path.basename(path)
+        typ = classify_type(fn, fm_type)
+        dkey = date_key_from_name(fn)
+
+        body = FRONTMATTER_RE.sub("", text, count=1)[:BODY_PREVIEW_CHARS]
+        indexed_text = f"{name} {description} {body}"
+
+        entry = {
+            "mtime": mtime,
+            "path": path,
+            "filename": fn,
+            "name": name,
+            "description": description,
+            "type": typ,
+            "date_key": dkey,
+            "indexed_text": indexed_text,
+        }
+        index[path] = entry
+
+    if use_cache and rebuilt > 0:
+        save_cache(cache_path, index)
+
+    stats = {"file_count": len(index), "rebuilt": rebuilt, "reused": reused}
+    return index, stats
+
+
+def recency_score(entry: dict, now_ts: float) -> float:
+    dkey = entry.get("date_key")
+    if dkey:
+        try:
+            t = time.mktime(time.strptime(dkey, "%Y-%m-%d"))
+        except ValueError:
+            t = entry["mtime"]
+    else:
+        t = entry["mtime"]
+    age_days = max(0.0, (now_ts - t) / 86400.0)
+    return math.exp(-RECENCY_LAMBDA * age_days)
+
+
+def importance_score(entry: dict) -> float:
+    return IMPORTANCE_BY_TYPE.get(entry.get("type"), IMPORTANCE_DEFAULT)
+
+
+def compute_doc_freq(index: dict) -> tuple[dict, dict, float]:
+    """Returns (doc_tokens_cache, df, avgdl) computed once per query."""
+    doc_tokens: dict = {}
+    df: dict = {}
+    total_len = 0
+    for path, entry in index.items():
+        toks = tokenize(entry["indexed_text"])
+        doc_tokens[path] = toks
+        total_len += len(toks)
+        for t in set(toks):
+            df[t] = df.get(t, 0) + 1
+    avgdl = (total_len / len(index)) if index else 1.0
+    return doc_tokens, df, avgdl
+
+
+def bm25_relevance(query_tokens: list[str], doc_tokens: list[str], df: dict, n_docs: int, avgdl: float) -> float:
+    if not query_tokens or not doc_tokens:
+        return 0.0
+    dl = len(doc_tokens)
+    tf: dict = {}
+    for t in doc_tokens:
+        tf[t] = tf.get(t, 0) + 1
+    score = 0.0
+    for qt in set(query_tokens):
+        f = tf.get(qt, 0)
+        if f == 0:
+            continue
+        n_qt = df.get(qt, 0)
+        idf = math.log((n_docs - n_qt + 0.5) / (n_qt + 0.5) + 1)
+        denom = f + BM25_K1 * (1 - BM25_B + BM25_B * dl / avgdl)
+        score += idf * (f * (BM25_K1 + 1)) / denom
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Context derivation: memdir slug, git branch/commits/status.
+# ---------------------------------------------------------------------------
+
+def _git(args: list[str], cwd: str) -> str:
+    try:
+        r = subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+        )
+        if r.returncode == 0:
+            return r.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return ""
+
+
+def git_toplevel(cwd: str) -> str | None:
+    out = _git(["rev-parse", "--show-toplevel"], cwd)
+    return out or None
+
+
+def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | None:
+    """~/.claude/projects/<slug>/memory, <slug> = abs project dir, '/' -> '-'.
+    `cwd` defaults to $CLAUDE_PROJECT_DIR (fallback: git toplevel of cwd);
+    `home` overrides Path.home() (test-only)."""
+    project_dir = cwd or os.environ.get("CLAUDE_PROJECT_DIR")
+    if not project_dir:
+        project_dir = git_toplevel(os.getcwd())
+    if not project_dir:
+        return None
+    abs_dir = os.path.abspath(project_dir)
+    slug = abs_dir.replace(os.sep, "-")
+    home_path = Path(home) if home else Path.home()
+    return str(home_path / ".claude" / "projects" / slug / "memory")
+
+
+def build_context_query(cwd: str) -> str:
+    """cwd basename + branch + last 8 commit subjects + changed file names.
+    Every git call is best-effort, silently empty on failure."""
+    parts = [os.path.basename(cwd.rstrip("/"))] if cwd else []
+
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    if branch:
+        parts.append(branch)
+
+    commits = _git(["log", "-8", "--format=%s"], cwd)
+    if commits:
+        parts.append(commits)
+
+    status = _git(["status", "--porcelain"], cwd)
+    if status:
+        names = []
+        for line in status.splitlines():
+            if len(line) > 3:
+                path = line[3:].split(" -> ")[-1].strip()
+                names.append(os.path.basename(path))
+        if names:
+            parts.append(" ".join(names))
+
+    return " ".join(parts)
+
+
+def recall(
+    memdir: str,
+    cache_path: str,
+    query: str,
+    topk: int = DEFAULT_TOPK,
+    threshold: float = DEFAULT_RELEVANCE_THRESHOLD,
+    use_cache: bool = True,
+) -> tuple[list[dict], dict]:
+    t0 = time.time()
+    index, idx_stats = build_or_refresh_index(memdir, cache_path, use_cache=use_cache)
+    doc_tokens, df, avgdl = compute_doc_freq(index)
+    n_docs = len(index)
+    now_ts = time.time()
+    q_tokens = tokenize(query)
+
+    scored = []
+    for path, entry in index.items():
+        rel = bm25_relevance(q_tokens, doc_tokens[path], df, n_docs, avgdl)
+        rec = recency_score(entry, now_ts)
+        imp = importance_score(entry)
+        combined = rec * imp * rel
+        scored.append((combined, rel, rec, imp, entry))
+
+    scored.sort(key=lambda t: t[0], reverse=True)
+    best_rel = scored[0][1] if scored else 0.0
+
+    elapsed = time.time() - t0
+    stats = {
+        **idx_stats,
+        "elapsed_seconds": round(elapsed, 4),
+        "best_relevance": round(best_rel, 4),
+        "threshold": threshold,
+        "query": query,
+        "query_tokens": q_tokens,
+    }
+
+    if best_rel < threshold:
+        return [], stats
+
+    top = scored[:topk]
+    results = [
+        {
+            "combined": round(c, 4),
+            "relevance": round(r, 4),
+            "recency": round(rec, 4),
+            "importance": imp,
+            "filename": e["filename"],
+            "description": e["description"],
+        }
+        for c, r, rec, imp, e in top
+    ]
+    return results, stats
+
+
+def memory_md_warning(memdir: str) -> str | None:
+    path = os.path.join(memdir, "MEMORY.md")
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return None
+    if size > MEMORY_MD_WARN_BYTES:
+        return MEMORY_MD_WARN_TEMPLATE.format(bytes=size)
+    return None
+
+
+def format_output(results: list[dict], warning: str | None = None, cap_bytes: int = OUTPUT_CAP_BYTES) -> str:
+    """Header + redacted top-k claims + optional MEMORY.md-oversize warning,
+    all within cap_bytes total (UTF-8 bytes, newline-joined)."""
+    reserve = len(warning.encode("utf-8")) + 1 if warning else 0
+    budget = max(cap_bytes - reserve, 0)
+
+    lines: list[str] = []
+    total_bytes = 0
+    if results:
+        header_bytes = len(HEADER_LINE.encode("utf-8")) + 1
+        if header_bytes <= budget:
+            lines.append(HEADER_LINE)
+            total_bytes += header_bytes
+        for r in results:
+            claim = redact(r["description"] or r["filename"])
+            if len(claim) > CLAIM_MAX_CHARS:
+                claim = claim[: CLAIM_MAX_CHARS - 1].rstrip() + "…"
+            line = f"- {claim} → {r['filename']}"
+            line_bytes = len(line.encode("utf-8")) + 1
+            if total_bytes + line_bytes > budget:
+                break
+            lines.append(line)
+            total_bytes += line_bytes
+
+    if warning:
+        lines.append(warning)
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--memdir", default=None)
+        ap.add_argument("--cache-path", default=None)
+        ap.add_argument("--no-cache", action="store_true")
+        ap.add_argument("--query", default=None)
+        ap.add_argument("--cwd", default=None)
+        ap.add_argument("--topk", type=int, default=DEFAULT_TOPK)
+        ap.add_argument("--threshold", type=float, default=DEFAULT_RELEVANCE_THRESHOLD)
+        args = ap.parse_args()
+
+        cwd = args.cwd or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+        memdir = args.memdir or resolve_memdir(cwd=cwd)
+        if not memdir or not os.path.isdir(memdir):
+            return 0  # not wired on this machine — silent, never the reason a session breaks
+
+        cache_path = args.cache_path or os.path.join(memdir, CACHE_FILENAME)
+        query = args.query if args.query else build_context_query(cwd)
+
+        results, _stats = recall(
+            memdir, cache_path, query,
+            topk=args.topk, threshold=args.threshold, use_cache=not args.no_cache,
+        )
+        warning = memory_md_warning(memdir)
+        out = format_output(results, warning=warning)
+        if out:
+            print(out)
+        return 0
+    except Exception:
+        # Fail-open contract: a receptor must never break a session.
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory/mos_recall_sessionstart.py
+++ b/scripts/memory/mos_recall_sessionstart.py
@@ -1,26 +1,11 @@
 #!/usr/bin/env python3
-"""LAYER 2 — mos_recall_sessionstart.py (production, wired to SessionStart).
+"""LAYER 2 — mos_recall_sessionstart.py (SessionStart recall hook).
 
-Generative-Agents-style ("Park et al. 2023") retrieval: score = recency x
-importance x relevance, print the top-k as one-line claims, print NOTHING
-when nothing is pertinent. stdlib only; well under 2s cold over ~1800 files.
-
-MEMDIR is derived, not hardcoded: ``~/.claude/projects/<slug>/memory`` where
-``<slug>`` is the absolute project path with every ``/`` -> ``-`` (e.g.
-``/Users/balizero/nuzantara`` -> ``-Users-balizero-nuzantara``), from
-``$CLAUDE_PROJECT_DIR`` (fallback: `git rev-parse --show-toplevel`) +
-``Path.home()`` — never assumed, since Pro/Mini check out at a different
-absolute path. Missing dir -> exit 0 silently (unwired machine, not a break).
-
-Index cache: ``<memdir>/.recall_cache.json``, keyed by path, entries rebuilt
-only on mtime change. Lives INSIDE memdir on purpose — `mem save` already
-writes there constantly, so a derived index next to its corpus can't drift.
-
-PII boundary: the printed line is built ONLY from frontmatter `description`
-(truncated 120 chars) and passed through `redact()` before stdout. Body text
-feeds the relevance index only and is NEVER printed.
-
-Fail-open: any exception in `main()` -> quiet exit 0, nothing printed.
+score = recency x importance x BM25 relevance; prints top-k claims, silent
+when nothing pertinent. MEMDIR = ~/.claude/projects/<slug>/memory (slug =
+abs project dir, '/' -> '-'); missing in a worktree, so we retry against the
+MAIN worktree via `git rev-parse --git-common-dir`. Only frontmatter
+`description` is printed, through redact(). Fail-open: quiet exit 0.
 """
 from __future__ import annotations
 
@@ -31,156 +16,70 @@ import math
 import os
 import re
 import subprocess
-import sys
 import time
 from pathlib import Path
 
-CACHE_FILENAME = ".recall_cache.json"
-BODY_PREVIEW_CHARS = 400
-CLAIM_MAX_CHARS = 120
-OUTPUT_CAP_BYTES = 1500
-HALF_LIFE_DAYS = 30.0
+BODY_PREVIEW_CHARS, CLAIM_MAX_CHARS, OUTPUT_CAP_BYTES = 400, 120, 1500
+CACHE_FILENAME, HALF_LIFE_DAYS, DEFAULT_TOPK = ".recall_cache.json", 30.0, 6
 RECENCY_LAMBDA = math.log(2) / HALF_LIFE_DAYS
-DEFAULT_TOPK = 6
-DEFAULT_RELEVANCE_THRESHOLD = 0.35  # BM25-like score; tuned against the 12-scenario eval set
-BM25_K1 = 1.5
-BM25_B = 0.75
-GIT_TIMEOUT_SECONDS = 1.5
-RUNTIME_BUDGET_SECONDS = 2.0  # advisory only — nothing here hard-aborts mid-run
-MEMORY_MD_WARN_BYTES = 2560
+DEFAULT_RELEVANCE_THRESHOLD = 0.35  # BM25-like score, tuned against the 12-scenario eval set
+BM25_K1, BM25_B = 1.5, 0.75
+GIT_TIMEOUT_SECONDS, MEMORY_MD_WARN_BYTES = 1.5, 2560
 HEADER_LINE = "🧠 memoria pertinente (top-6, mem recall per altro):"
-MEMORY_MD_WARN_TEMPLATE = (
-    "⚠️ MEMORY.md {bytes}B > 2560B — è un nucleo, non un indice (catalogo: MEMORY_INDEX.md)"
-)
+MEMORY_MD_WARN_TEMPLATE = "⚠️ MEMORY.md {bytes}B > 2560B — è un nucleo, non un indice (catalogo: MEMORY_INDEX.md)"
 
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 DATE_IN_NAME_RE = re.compile(r"(\d{4})_(\d{2})_(\d{2})(?:\.md)?$")
 TOKEN_RE = re.compile(r"[a-z0-9]+")
-
-KNOWN_PREFIXES = {
-    "discovery", "decision", "lesson", "lessons", "fact", "project",
-    "unresolved", "reference", "ops", "feedback",
-}
-
-IMPORTANCE_BY_TYPE = {
-    "feedback": 1.0,
-    "decision": 1.0,
-    "lesson": 1.0,
-    "lessons": 1.0,
-    "project": 0.9,
-    "discovery": 0.8,
-    "fact": 0.6,
-    "reference": 0.6,
-}
+TOPLEVEL_KV_RE = re.compile(r"^(\w[\w]*):[ \t]*(.*)$", re.MULTILINE)
+INDENTED_KV_RE = re.compile(r"^[ \t]+(\w[\w-]*):[ \t]*(.*)$", re.MULTILINE)
+KNOWN_PREFIXES = {"discovery", "decision", "lesson", "lessons", "fact", "project", "unresolved", "reference", "ops", "feedback"}
+IMPORTANCE_BY_TYPE = {"feedback": 1.0, "decision": 1.0, "lesson": 1.0, "lessons": 1.0, "project": 0.9, "discovery": 0.8, "fact": 0.6, "reference": 0.6}
 IMPORTANCE_DEFAULT = 0.5
 
-STOPWORDS_EN = {
-    "a", "an", "the", "and", "or", "of", "to", "in", "on", "for", "is",
-    "are", "was", "were", "be", "been", "with", "at", "by", "from", "as",
-    "that", "this", "it", "its", "into", "than", "then", "not", "no",
-    "so", "do", "does", "did", "has", "have", "had", "but", "if", "when",
-    "which", "who", "what", "how", "never", "always", "only", "one",
-}
-STOPWORDS_IT = {
-    "il", "lo", "la", "i", "gli", "le", "un", "uno", "una", "di", "a",
-    "da", "in", "con", "su", "per", "tra", "fra", "e", "o", "che", "chi",
-    "cui", "non", "mai", "sempre", "solo", "come", "quando", "dove",
-    "questo", "questa", "questi", "queste", "del", "della", "dei",
-    "delle", "al", "alla", "ai", "alle", "dal", "dalla", "dai", "dalle",
-    "nel", "nella", "nei", "nelle", "sul", "sulla", "sui", "sulle",
-    "è", "sono", "era", "erano", "essere", "stato", "stata",
-}
-STOPWORDS = STOPWORDS_EN | STOPWORDS_IT
+# EN + IT stopwords, kept as one whitespace-split string for density.
+STOPWORDS = frozenset((
+    "a an the and or of to in on for is are was were be been with at by from as that this it its "
+    "into than then not no so do does did has have had but if when which who what how never always only one "
+    "il lo la i gli le un uno una di a da in con su per tra fra e o che chi cui non mai sempre solo "
+    "come quando dove questo questa questi queste del della dei delle al alla ai alle dal dalla dai dalle "
+    "nel nella nei nelle sul sulla sui sulle è sono era erano essere stato stata"
+).split())
 
-# PII redaction (transformation). Duplicated (not imported) from the sibling
-# Layer-3 script memory_index_build.py — separate PRs, keep in sync by hand.
+# PII redaction (duplicated, not imported, from the sibling Layer-3 script).
 REDACT_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 REDACT_PHONE_RE = re.compile(r"\+(?:62|39)[\s.-]?\d[\d\s.-]{6,}\d")
 REDACT_ID_RE = re.compile(r"\b(?:passport|KTP)\b\D{0,10}\d[\d\s-]*", re.IGNORECASE)
 REDACT_DIGITRUN_RE = re.compile(r"(?<!\d)\d{10,15}(?!\d)")
 
-
 def redact(text: str) -> str:
-    """Replace PII shapes with placeholders (email/id/phone before the
-    generic digit-run so the specific patterns consume their digits first)."""
-    if not text:
-        return text
+    if not text: return text
     text = REDACT_EMAIL_RE.sub("<email>", text)
     text = REDACT_ID_RE.sub("<id>", text)
     text = REDACT_PHONE_RE.sub("<num>", text)
-    text = REDACT_DIGITRUN_RE.sub("<num>", text)
-    return text
-
+    return REDACT_DIGITRUN_RE.sub("<num>", text)
 
 def tokenize(text: str) -> list[str]:
-    text = text.lower()
-    text = text.replace("_", " ").replace("-", " ")
-    toks = TOKEN_RE.findall(text)
-    return [t for t in toks if t not in STOPWORDS and len(t) >= 2]
-
-
-def parse_frontmatter(text: str) -> dict:
-    m = FRONTMATTER_RE.match(text)
-    if not m:
-        return {}
-    block = m.group(1)
-    out: dict = {}
-    metadata: dict = {}
-    in_metadata = False
-    for line in block.split("\n"):
-        if not line.strip():
-            continue
-        if line.startswith("metadata:"):
-            in_metadata = True
-            continue
-        if in_metadata:
-            if line.startswith((" ", "\t")):
-                kv = line.strip()
-                if ":" in kv:
-                    k, _, v = kv.partition(":")
-                    metadata[k.strip()] = _unquote(v.strip())
-                continue
-            else:
-                in_metadata = False
-        if ":" in line:
-            k, _, v = line.partition(":")
-            out[k.strip()] = _unquote(v.strip())
-    out["metadata"] = metadata
-    return out
-
+    text = text.lower().replace("_", " ").replace("-", " ")
+    return [t for t in TOKEN_RE.findall(text) if t not in STOPWORDS and len(t) >= 2]
 
 def _unquote(v: str) -> str:
     v = v.strip()
-    if len(v) >= 2 and v[0] == v[-1] in ('"', "'"):
-        return v[1:-1]
-    return v
+    return v[1:-1] if len(v) >= 2 and v[0] == v[-1] in ('"', "'") else v
 
-
-def date_key_from_name(filename: str) -> str | None:
-    m = DATE_IN_NAME_RE.search(filename.rsplit(".md", 1)[0] + ".md")
-    if not m:
-        return None
-    return f"{m.group(1)}-{m.group(2)}-{m.group(3)}"
-
-
-def classify_type(filename: str, fm_type: str | None) -> str:
-    prefix = filename.split("_", 1)[0]
-    if prefix in KNOWN_PREFIXES:
-        return prefix
-    if fm_type:
-        return fm_type
-    return "misc"
-
+def parse_frontmatter(text: str) -> dict:
+    m = FRONTMATTER_RE.match(text)
+    if not m: return {}
+    out = {k: _unquote(v.strip()) for k, v in TOPLEVEL_KV_RE.findall(m.group(1))}
+    out["metadata"] = {k: _unquote(v.strip()) for k, v in INDENTED_KV_RE.findall(m.group(1))}
+    return out
 
 def load_cache(cache_path: str) -> dict:
-    if os.path.exists(cache_path):
-        try:
-            with open(cache_path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except (OSError, json.JSONDecodeError):
-            return {}
-    return {}
-
+    try:
+        with open(cache_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
 
 def save_cache(cache_path: str, cache: dict) -> None:
     tmp = cache_path + ".tmp"
@@ -191,16 +90,10 @@ def save_cache(cache_path: str, cache: dict) -> None:
     except OSError:
         pass  # cache is a pure speed optimization; a write failure is not fatal
 
-
 def build_or_refresh_index(memdir: str, cache_path: str, use_cache: bool = True) -> tuple[dict, dict]:
-    """Returns (index, stats). index: {path: entry}."""
-    files = sorted(glob.glob(os.path.join(memdir, "*.md")))
     cache = load_cache(cache_path) if use_cache else {}
-    index: dict = {}
-    rebuilt = 0
-    reused = 0
-
-    for path in files:
+    index, rebuilt = {}, 0
+    for path in sorted(glob.glob(os.path.join(memdir, "*.md"))):
         try:
             mtime = os.path.getmtime(path)
         except OSError:
@@ -208,287 +101,159 @@ def build_or_refresh_index(memdir: str, cache_path: str, use_cache: bool = True)
         cached = cache.get(path)
         if cached and cached.get("mtime") == mtime:
             index[path] = cached
-            reused += 1
             continue
-
-        rebuilt += 1
         try:
             with open(path, "r", encoding="utf-8") as f:
                 text = f.read(4096)  # frontmatter + preview only, never the whole file
         except (OSError, UnicodeDecodeError):
             continue
+        rebuilt += 1
         fm = parse_frontmatter(text)
-        name = fm.get("name") or os.path.basename(path)[:-3]
-        description = (fm.get("description") or "").strip()
-        fm_type = (fm.get("metadata") or {}).get("type")
         fn = os.path.basename(path)
-        typ = classify_type(fn, fm_type)
-        dkey = date_key_from_name(fn)
-
+        prefix = fn.split("_", 1)[0]
+        typ = prefix if prefix in KNOWN_PREFIXES else ((fm.get("metadata") or {}).get("type") or "misc")
+        dm = DATE_IN_NAME_RE.search(fn.rsplit(".md", 1)[0] + ".md")
+        name, description = fm.get("name") or fn[:-3], (fm.get("description") or "").strip()
         body = FRONTMATTER_RE.sub("", text, count=1)[:BODY_PREVIEW_CHARS]
-        indexed_text = f"{name} {description} {body}"
-
-        entry = {
-            "mtime": mtime,
-            "path": path,
-            "filename": fn,
-            "name": name,
-            "description": description,
-            "type": typ,
-            "date_key": dkey,
-            "indexed_text": indexed_text,
-        }
-        index[path] = entry
-
+        index[path] = {"mtime": mtime, "filename": fn, "name": name, "description": description, "type": typ,
+                        "date_key": f"{dm.group(1)}-{dm.group(2)}-{dm.group(3)}" if dm else None,
+                        "indexed_text": f"{name} {description} {body}"}
     if use_cache and rebuilt > 0:
         save_cache(cache_path, index)
-
-    stats = {"file_count": len(index), "rebuilt": rebuilt, "reused": reused}
-    return index, stats
-
+    return index, {"file_count": len(index), "rebuilt": rebuilt}
 
 def recency_score(entry: dict, now_ts: float) -> float:
     dkey = entry.get("date_key")
-    if dkey:
-        try:
-            t = time.mktime(time.strptime(dkey, "%Y-%m-%d"))
-        except ValueError:
-            t = entry["mtime"]
-    else:
+    try:
+        t = time.mktime(time.strptime(dkey, "%Y-%m-%d")) if dkey else entry["mtime"]
+    except ValueError:
         t = entry["mtime"]
-    age_days = max(0.0, (now_ts - t) / 86400.0)
-    return math.exp(-RECENCY_LAMBDA * age_days)
-
+    return math.exp(-RECENCY_LAMBDA * max(0.0, (now_ts - t) / 86400.0))
 
 def importance_score(entry: dict) -> float:
     return IMPORTANCE_BY_TYPE.get(entry.get("type"), IMPORTANCE_DEFAULT)
 
-
 def compute_doc_freq(index: dict) -> tuple[dict, dict, float]:
-    """Returns (doc_tokens_cache, df, avgdl) computed once per query."""
-    doc_tokens: dict = {}
-    df: dict = {}
-    total_len = 0
+    doc_tokens, df, total_len = {}, {}, 0
     for path, entry in index.items():
         toks = tokenize(entry["indexed_text"])
         doc_tokens[path] = toks
         total_len += len(toks)
         for t in set(toks):
             df[t] = df.get(t, 0) + 1
-    avgdl = (total_len / len(index)) if index else 1.0
-    return doc_tokens, df, avgdl
-
+    return doc_tokens, df, (total_len / len(index)) if index else 1.0
 
 def bm25_relevance(query_tokens: list[str], doc_tokens: list[str], df: dict, n_docs: int, avgdl: float) -> float:
-    if not query_tokens or not doc_tokens:
-        return 0.0
-    dl = len(doc_tokens)
-    tf: dict = {}
+    if not query_tokens or not doc_tokens: return 0.0
+    dl, tf = len(doc_tokens), {}
     for t in doc_tokens:
         tf[t] = tf.get(t, 0) + 1
     score = 0.0
-    for qt in set(query_tokens):
-        f = tf.get(qt, 0)
-        if f == 0:
-            continue
-        n_qt = df.get(qt, 0)
+    for qt in set(query_tokens) & tf.keys():
+        f, n_qt = tf[qt], df.get(qt, 0)
         idf = math.log((n_docs - n_qt + 0.5) / (n_qt + 0.5) + 1)
-        denom = f + BM25_K1 * (1 - BM25_B + BM25_B * dl / avgdl)
-        score += idf * (f * (BM25_K1 + 1)) / denom
+        score += idf * (f * (BM25_K1 + 1)) / (f + BM25_K1 * (1 - BM25_B + BM25_B * dl / avgdl))
     return score
-
-
-# ---------------------------------------------------------------------------
-# Context derivation: memdir slug, git branch/commits/status.
-# ---------------------------------------------------------------------------
 
 def _git(args: list[str], cwd: str) -> str:
     try:
-        r = subprocess.run(
-            ["git", *args], cwd=cwd, capture_output=True, text=True,
-            timeout=GIT_TIMEOUT_SECONDS,
-        )
-        if r.returncode == 0:
-            return r.stdout.strip()
+        r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=GIT_TIMEOUT_SECONDS)
+        return r.stdout.strip() if r.returncode == 0 else ""
     except (OSError, subprocess.SubprocessError):
-        pass
-    return ""
+        return ""
 
+def git_main_worktree(cwd: str) -> str | None:
+    common = _git(["rev-parse", "--git-common-dir"], cwd)
+    if common and not os.path.isabs(common):
+        common = os.path.abspath(os.path.join(cwd, common))
+    return common[: -len(os.sep + ".git")] if common and common.endswith(os.sep + ".git") else None
 
-def git_toplevel(cwd: str) -> str | None:
-    out = _git(["rev-parse", "--show-toplevel"], cwd)
-    return out or None
-
-
-def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | None:
-    """~/.claude/projects/<slug>/memory, <slug> = abs project dir, '/' -> '-'.
-    `cwd` defaults to $CLAUDE_PROJECT_DIR (fallback: git toplevel of cwd);
-    `home` overrides Path.home() (test-only)."""
-    project_dir = cwd or os.environ.get("CLAUDE_PROJECT_DIR")
-    if not project_dir:
-        project_dir = git_toplevel(os.getcwd())
-    if not project_dir:
-        return None
-    abs_dir = os.path.abspath(project_dir)
-    slug = abs_dir.replace(os.sep, "-")
-    home_path = Path(home) if home else Path.home()
+def _slug_memdir(project_dir: str, home_path: Path) -> str:
+    slug = os.path.abspath(project_dir).replace(os.sep, "-")
     return str(home_path / ".claude" / "projects" / slug / "memory")
 
+def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | None:
+    project_dir = cwd or os.environ.get("CLAUDE_PROJECT_DIR") or _git(["rev-parse", "--show-toplevel"], os.getcwd())
+    if not project_dir: return None
+    home_path = Path(home) if home else Path.home()
+    primary = _slug_memdir(project_dir, home_path)
+    if os.path.isdir(primary):
+        return primary
+    main_root = git_main_worktree(os.path.abspath(project_dir))
+    fallback = _slug_memdir(main_root, home_path) if main_root else None
+    return fallback if fallback and os.path.isdir(fallback) else primary  # still missing — main() exits 0 quietly
 
 def build_context_query(cwd: str) -> str:
-    """cwd basename + branch + last 8 commit subjects + changed file names.
-    Every git call is best-effort, silently empty on failure."""
     parts = [os.path.basename(cwd.rstrip("/"))] if cwd else []
-
-    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
-    if branch:
-        parts.append(branch)
-
-    commits = _git(["log", "-8", "--format=%s"], cwd)
-    if commits:
-        parts.append(commits)
-
+    parts += [o for o in (_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd), _git(["log", "-8", "--format=%s"], cwd)) if o]
     status = _git(["status", "--porcelain"], cwd)
-    if status:
-        names = []
-        for line in status.splitlines():
-            if len(line) > 3:
-                path = line[3:].split(" -> ")[-1].strip()
-                names.append(os.path.basename(path))
-        if names:
-            parts.append(" ".join(names))
+    names = [os.path.basename(ln[3:].split(" -> ")[-1].strip()) for ln in status.splitlines() if len(ln) > 3] if status else []
+    return " ".join(parts + ([" ".join(names)] if names else []))
 
-    return " ".join(parts)
-
-
-def recall(
-    memdir: str,
-    cache_path: str,
-    query: str,
-    topk: int = DEFAULT_TOPK,
-    threshold: float = DEFAULT_RELEVANCE_THRESHOLD,
-    use_cache: bool = True,
-) -> tuple[list[dict], dict]:
-    t0 = time.time()
+def recall(memdir: str, cache_path: str, query: str, topk: int = DEFAULT_TOPK,
+           threshold: float = DEFAULT_RELEVANCE_THRESHOLD, use_cache: bool = True) -> tuple[list[dict], dict]:
     index, idx_stats = build_or_refresh_index(memdir, cache_path, use_cache=use_cache)
     doc_tokens, df, avgdl = compute_doc_freq(index)
-    n_docs = len(index)
-    now_ts = time.time()
-    q_tokens = tokenize(query)
-
+    n_docs, now_ts, q_tokens = len(index), time.time(), tokenize(query)
     scored = []
     for path, entry in index.items():
         rel = bm25_relevance(q_tokens, doc_tokens[path], df, n_docs, avgdl)
-        rec = recency_score(entry, now_ts)
-        imp = importance_score(entry)
-        combined = rec * imp * rel
-        scored.append((combined, rel, rec, imp, entry))
-
+        scored.append((recency_score(entry, now_ts) * importance_score(entry) * rel, rel, entry))
     scored.sort(key=lambda t: t[0], reverse=True)
     best_rel = scored[0][1] if scored else 0.0
-
-    elapsed = time.time() - t0
-    stats = {
-        **idx_stats,
-        "elapsed_seconds": round(elapsed, 4),
-        "best_relevance": round(best_rel, 4),
-        "threshold": threshold,
-        "query": query,
-        "query_tokens": q_tokens,
-    }
-
+    stats = {**idx_stats, "best_relevance": round(best_rel, 4), "threshold": threshold, "query": query}
     if best_rel < threshold:
         return [], stats
-
-    top = scored[:topk]
-    results = [
-        {
-            "combined": round(c, 4),
-            "relevance": round(r, 4),
-            "recency": round(rec, 4),
-            "importance": imp,
-            "filename": e["filename"],
-            "description": e["description"],
-        }
-        for c, r, rec, imp, e in top
-    ]
+    results = [{"filename": e["filename"], "description": e["description"]} for _, _, e in scored[:topk]]
     return results, stats
 
-
 def memory_md_warning(memdir: str) -> str | None:
-    path = os.path.join(memdir, "MEMORY.md")
     try:
-        size = os.path.getsize(path)
+        size = os.path.getsize(os.path.join(memdir, "MEMORY.md"))
     except OSError:
         return None
-    if size > MEMORY_MD_WARN_BYTES:
-        return MEMORY_MD_WARN_TEMPLATE.format(bytes=size)
-    return None
-
+    return MEMORY_MD_WARN_TEMPLATE.format(bytes=size) if size > MEMORY_MD_WARN_BYTES else None
 
 def format_output(results: list[dict], warning: str | None = None, cap_bytes: int = OUTPUT_CAP_BYTES) -> str:
-    """Header + redacted top-k claims + optional MEMORY.md-oversize warning,
-    all within cap_bytes total (UTF-8 bytes, newline-joined)."""
-    reserve = len(warning.encode("utf-8")) + 1 if warning else 0
-    budget = max(cap_bytes - reserve, 0)
-
-    lines: list[str] = []
-    total_bytes = 0
-    if results:
-        header_bytes = len(HEADER_LINE.encode("utf-8")) + 1
-        if header_bytes <= budget:
-            lines.append(HEADER_LINE)
-            total_bytes += header_bytes
-        for r in results:
-            claim = redact(r["description"] or r["filename"])
-            if len(claim) > CLAIM_MAX_CHARS:
-                claim = claim[: CLAIM_MAX_CHARS - 1].rstrip() + "…"
-            line = f"- {claim} → {r['filename']}"
-            line_bytes = len(line.encode("utf-8")) + 1
-            if total_bytes + line_bytes > budget:
-                break
-            lines.append(line)
-            total_bytes += line_bytes
-
+    budget = max(cap_bytes - (len(warning.encode("utf-8")) + 1 if warning else 0), 0)
+    hb = len(HEADER_LINE.encode("utf-8")) + 1
+    lines = [HEADER_LINE] if results and hb <= budget else []
+    total = hb if lines else 0
+    for r in results:
+        claim = redact(r["description"] or r["filename"])
+        if len(claim) > CLAIM_MAX_CHARS:
+            claim = claim[: CLAIM_MAX_CHARS - 1].rstrip() + "…"
+        line = f"- {claim} → {r['filename']}"
+        lb = len(line.encode("utf-8")) + 1
+        if total + lb > budget:
+            break
+        lines.append(line)
+        total += lb
     if warning:
         lines.append(warning)
-
     return "\n".join(lines)
-
 
 def main() -> int:
     try:
         ap = argparse.ArgumentParser()
-        ap.add_argument("--memdir", default=None)
-        ap.add_argument("--cache-path", default=None)
-        ap.add_argument("--no-cache", action="store_true")
-        ap.add_argument("--query", default=None)
-        ap.add_argument("--cwd", default=None)
-        ap.add_argument("--topk", type=int, default=DEFAULT_TOPK)
-        ap.add_argument("--threshold", type=float, default=DEFAULT_RELEVANCE_THRESHOLD)
+        for name, kw in [("--memdir", {}), ("--cache-path", {}), ("--no-cache", {"action": "store_true"}),
+                         ("--query", {}), ("--cwd", {}), ("--topk", {"type": int, "default": DEFAULT_TOPK}),
+                         ("--threshold", {"type": float, "default": DEFAULT_RELEVANCE_THRESHOLD})]:
+            ap.add_argument(name, **kw)
         args = ap.parse_args()
-
         cwd = args.cwd or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
         memdir = args.memdir or resolve_memdir(cwd=cwd)
         if not memdir or not os.path.isdir(memdir):
             return 0  # not wired on this machine — silent, never the reason a session breaks
-
         cache_path = args.cache_path or os.path.join(memdir, CACHE_FILENAME)
-        query = args.query if args.query else build_context_query(cwd)
-
-        results, _stats = recall(
-            memdir, cache_path, query,
-            topk=args.topk, threshold=args.threshold, use_cache=not args.no_cache,
-        )
-        warning = memory_md_warning(memdir)
-        out = format_output(results, warning=warning)
+        results, _stats = recall(memdir, cache_path, args.query or build_context_query(cwd),
+                                  topk=args.topk, threshold=args.threshold, use_cache=not args.no_cache)
+        out = format_output(results, warning=memory_md_warning(memdir))
         if out:
             print(out)
         return 0
     except Exception:
-        # Fail-open contract: a receptor must never break a session.
-        return 0
-
+        return 0  # fail-open contract: a receptor must never break a session
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/tests/test_memory_layers.py
+++ b/scripts/tests/test_memory_layers.py
@@ -1,0 +1,233 @@
+"""Unit tests for scripts/memory/mos_recall_sessionstart.py — the SessionStart
+recall hook (Layer 2, wired via scripts/hooks/memory_recall_sessionstart.sh).
+
+Fixtures live entirely in tmp_path; nothing under ~/.claude is touched.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+SCRIPTS_MEMORY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "memory")
+sys.path.insert(0, SCRIPTS_MEMORY)
+
+import mos_recall_sessionstart as mos  # noqa: E402
+
+
+FRONT = """---
+name: {name}
+description: {desc}
+metadata:
+  type: {typ}
+---
+
+Body text about {topic} with several relevant words repeated: {topic} {topic}.
+"""
+
+
+def _write_memory_file(memdir, filename, name, desc, typ, topic):
+    (memdir / filename).write_text(
+        FRONT.format(name=name, desc=desc, typ=typ, topic=topic), encoding="utf-8"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slug derivation (resolve_memdir)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("project_dir, slug", [
+    ("/Users/balizero/nuzantara", "-Users-balizero-nuzantara"),
+    ("/Users/nuzantara/Desktop/nuzantara", "-Users-nuzantara-Desktop-nuzantara"),
+])
+def test_slug_derivation_matches_home_claude_projects_shape(tmp_path, project_dir, slug):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    memdir = mos.resolve_memdir(cwd=project_dir, home=str(fake_home))
+
+    assert memdir == str(fake_home / ".claude" / "projects" / slug / "memory")
+
+
+# ---------------------------------------------------------------------------
+# Quiet when memdir missing
+# ---------------------------------------------------------------------------
+
+def test_recall_quiet_when_memdir_missing(tmp_path):
+    missing = tmp_path / "does_not_exist" / "memory"
+    assert not missing.exists()
+
+    # main()'s own directory-existence check is exercised via the CLI path,
+    # but the underlying recall() must also behave sanely against an absent
+    # dir rather than raising.
+    results, stats = mos.recall(str(missing), str(tmp_path / "cache.json"), query="anything")
+    assert results == []
+    assert stats["file_count"] == 0
+
+
+def test_main_exits_quietly_when_memdir_not_wired(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(
+        mos, "resolve_memdir",
+        lambda cwd=None, home=None: str(tmp_path / "not_wired" / "memory"),
+    )
+    monkeypatch.setattr(sys, "argv", ["mos_recall_sessionstart.py"])
+
+    rc = mos.main()
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Output cap (1,500 bytes)
+# ---------------------------------------------------------------------------
+
+def test_format_output_stays_under_cap_with_many_results(tmp_path):
+    memdir = tmp_path / "memdir_many"
+    memdir.mkdir()
+    for i in range(40):
+        _write_memory_file(
+            memdir, f"discovery_widget_{i}_2026_09_01.md",
+            f"discovery-widget-{i}",
+            "a" * 200 + f" widget finding number {i} about manufacturing",
+            "discovery", "widget",
+        )
+
+    results, _stats = mos.recall(str(memdir), str(tmp_path / "cache_many.json"),
+                                  query="widget manufacturing", topk=40, threshold=0.0)
+    out = mos.format_output(results)
+
+    assert len(out.encode("utf-8")) <= mos.OUTPUT_CAP_BYTES
+    assert mos.HEADER_LINE in out
+
+
+def test_format_output_empty_when_no_results():
+    assert mos.format_output([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text, needle, placeholder", [
+    ("contact the client at mario.rossi@example.com for details", "mario.rossi@example.com", "<email>"),
+    ("call the client on +62 812 345 6789 tomorrow", "812 345 6789", "<num>"),
+    ("reference number 1234567890123 on file", "1234567890123", "<num>"),
+    ("copy of passport A1234567 attached", "A1234567", "<id>"),
+])
+def test_redact_pii_shapes(text, needle, placeholder):
+    out = mos.redact(text)
+    assert placeholder in out
+    assert needle not in out
+
+
+def test_redact_leaves_clean_text_untouched():
+    clean = "the migration runner reads schema_migrations and applies pending DDL"
+    assert mos.redact(clean) == clean
+
+
+def test_format_output_redacts_description(tmp_path):
+    memdir = tmp_path / "memdir_pii"
+    memdir.mkdir()
+    _write_memory_file(
+        memdir, "discovery_client_email_2026_09_01.md",
+        "discovery-client-email",
+        "widget client contact mario.rossi@example.com about widget order",
+        "discovery", "widget",
+    )
+    results, _stats = mos.recall(str(memdir), str(tmp_path / "cache_pii.json"),
+                                  query="widget", threshold=0.0)
+    out = mos.format_output(results)
+    assert "mario.rossi@example.com" not in out
+    assert "<email>" in out
+
+
+# ---------------------------------------------------------------------------
+# MEMORY.md oversize warning
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("size, expect_warning", [(100, False), (mos.MEMORY_MD_WARN_BYTES + 500, True)])
+def test_memory_md_warning_gated_on_2560_bytes(tmp_path, size, expect_warning):
+    memdir = tmp_path / f"memdir_index_{size}"
+    memdir.mkdir()
+    (memdir / "MEMORY.md").write_text("x" * size, encoding="utf-8")
+
+    warning = mos.memory_md_warning(str(memdir))
+    if expect_warning:
+        assert warning is not None and str(size) in warning and "MEMORY_INDEX.md" in warning
+    else:
+        assert warning is None
+
+
+def test_format_output_includes_warning_line(tmp_path):
+    warning = mos.MEMORY_MD_WARN_TEMPLATE.format(bytes=3000)
+    out = mos.format_output([], warning=warning)
+    assert out == warning
+
+
+# ---------------------------------------------------------------------------
+# Recency / importance monotonicity (kept from prototype)
+# ---------------------------------------------------------------------------
+
+def test_recall_scoring_monotonic_in_recency(tmp_path):
+    memdir = tmp_path / "memdir_recency"
+    memdir.mkdir()
+    today = time.strftime("%Y_%m_%d")
+    old_date = "2020_01_01"
+    _write_memory_file(memdir, f"discovery_recent_topic_{today}.md",
+                        "discovery-recent", "recent finding about widgets", "discovery", "widgets")
+    _write_memory_file(memdir, f"discovery_old_topic_{old_date}.md",
+                        "discovery-old", "old finding about widgets", "discovery", "widgets")
+
+    index, _stats = mos.build_or_refresh_index(str(memdir), str(tmp_path / "cache.json"))
+    now_ts = time.time()
+    recent_entry = next(e for p, e in index.items() if "recent_topic" in p)
+    old_entry = next(e for p, e in index.items() if "old_topic" in p)
+
+    assert mos.recency_score(recent_entry, now_ts) > mos.recency_score(old_entry, now_ts)
+
+
+def test_recall_scoring_monotonic_in_importance(tmp_path):
+    memdir = tmp_path / "memdir_importance"
+    memdir.mkdir()
+    date = "2026_09_01"
+    _write_memory_file(memdir, f"decision_x_{date}.md", "decision-x", "a decision", "project", "topic")
+    _write_memory_file(memdir, f"fact_x_{date}.md", "fact-x", "a fact", "fact", "topic")
+
+    index, _stats = mos.build_or_refresh_index(str(memdir), str(tmp_path / "cache2.json"))
+    decision_entry = next(e for p, e in index.items() if p.split(os.sep)[-1].startswith("decision_"))
+    fact_entry = next(e for p, e in index.items() if p.split(os.sep)[-1].startswith("fact_"))
+
+    # decision (filename-prefix taxonomy) = 1.0 importance, fact = 0.6
+    assert mos.importance_score(decision_entry) > mos.importance_score(fact_entry)
+
+
+def test_recall_quiet_when_nothing_pertinent(tmp_path):
+    memdir = tmp_path / "memdir_quiet"
+    memdir.mkdir()
+    _write_memory_file(memdir, "discovery_foo_2026_09_01.md",
+                        "discovery-foo", "a discovery about databases", "discovery", "database")
+
+    results, stats = mos.recall(
+        str(memdir), str(tmp_path / "cache3.json"),
+        query="zzqvortex wibblefrump squonkalorian blibberflax",
+    )
+    assert results == []
+    assert stats["best_relevance"] == 0.0
+    assert mos.format_output(results) == ""
+
+
+def test_recall_finds_relevant_result(tmp_path):
+    memdir = tmp_path / "memdir_relevant"
+    memdir.mkdir()
+    _write_memory_file(memdir, "discovery_widgets_thing_2026_09_01.md",
+                        "discovery-widgets", "a discovery about widget manufacturing", "discovery", "widget")
+    _write_memory_file(memdir, "fact_unrelated_2026_09_01.md",
+                        "fact-unrelated", "a fact about something else entirely", "fact", "gadget")
+
+    results, stats = mos.recall(str(memdir), str(tmp_path / "cache4.json"), query="widget manufacturing")
+    assert results
+    assert results[0]["filename"] == "discovery_widgets_thing_2026_09_01.md"

--- a/scripts/tests/test_memory_layers.py
+++ b/scripts/tests/test_memory_layers.py
@@ -1,7 +1,6 @@
-"""Unit tests for scripts/memory/mos_recall_sessionstart.py — the SessionStart
-recall hook (Layer 2, wired via scripts/hooks/memory_recall_sessionstart.sh).
-
-Fixtures live entirely in tmp_path; nothing under ~/.claude is touched.
+"""Unit tests for scripts/memory/mos_recall_sessionstart.py (SessionStart
+recall hook). Fixtures live entirely in tmp_path; nothing under ~/.claude
+is touched.
 """
 from __future__ import annotations
 
@@ -16,7 +15,6 @@ sys.path.insert(0, SCRIPTS_MEMORY)
 
 import mos_recall_sessionstart as mos  # noqa: E402
 
-
 FRONT = """---
 name: {name}
 description: {desc}
@@ -27,16 +25,8 @@ metadata:
 Body text about {topic} with several relevant words repeated: {topic} {topic}.
 """
 
-
-def _write_memory_file(memdir, filename, name, desc, typ, topic):
-    (memdir / filename).write_text(
-        FRONT.format(name=name, desc=desc, typ=typ, topic=topic), encoding="utf-8"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Slug derivation (resolve_memdir)
-# ---------------------------------------------------------------------------
+def _write(memdir, filename, name, desc, typ, topic):
+    (memdir / filename).write_text(FRONT.format(name=name, desc=desc, typ=typ, topic=topic), encoding="utf-8")
 
 @pytest.mark.parametrize("project_dir, slug", [
     ("/Users/balizero/nuzantara", "-Users-balizero-nuzantara"),
@@ -45,72 +35,37 @@ def _write_memory_file(memdir, filename, name, desc, typ, topic):
 def test_slug_derivation_matches_home_claude_projects_shape(tmp_path, project_dir, slug):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-
     memdir = mos.resolve_memdir(cwd=project_dir, home=str(fake_home))
-
     assert memdir == str(fake_home / ".claude" / "projects" / slug / "memory")
 
-
-# ---------------------------------------------------------------------------
-# Quiet when memdir missing
-# ---------------------------------------------------------------------------
-
-def test_recall_quiet_when_memdir_missing(tmp_path):
-    missing = tmp_path / "does_not_exist" / "memory"
-    assert not missing.exists()
-
-    # main()'s own directory-existence check is exercised via the CLI path,
-    # but the underlying recall() must also behave sanely against an absent
-    # dir rather than raising.
-    results, stats = mos.recall(str(missing), str(tmp_path / "cache.json"), query="anything")
-    assert results == []
-    assert stats["file_count"] == 0
-
+def test_resolve_memdir_falls_back_to_main_worktree_when_slug_dir_missing(tmp_path, monkeypatch):
+    fake_home, main_repo = tmp_path / "home", tmp_path / "nuzantara"
+    worktree = main_repo / ".worktrees" / "some-lane"
+    (fake_home / ".claude" / "projects" / str(main_repo).replace(os.sep, "-") / "memory").mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    monkeypatch.setattr(mos, "git_main_worktree", lambda cwd: str(main_repo))
+    memdir = mos.resolve_memdir(cwd=str(worktree), home=str(fake_home))
+    assert memdir == str(fake_home / ".claude" / "projects" / str(main_repo).replace(os.sep, "-") / "memory")
+    # no main-worktree memdir either -> still gives up quietly, never raises
+    monkeypatch.setattr(mos, "git_main_worktree", lambda cwd: str(tmp_path / "unwired-main"))
+    assert not os.path.isdir(mos.resolve_memdir(cwd=str(worktree), home=str(tmp_path / "other_home")))
 
 def test_main_exits_quietly_when_memdir_not_wired(tmp_path, monkeypatch, capsys):
-    monkeypatch.setattr(
-        mos, "resolve_memdir",
-        lambda cwd=None, home=None: str(tmp_path / "not_wired" / "memory"),
-    )
+    monkeypatch.setattr(mos, "resolve_memdir", lambda cwd=None, home=None: str(tmp_path / "not_wired" / "memory"))
     monkeypatch.setattr(sys, "argv", ["mos_recall_sessionstart.py"])
-
     rc = mos.main()
-    captured = capsys.readouterr()
-
-    assert rc == 0
-    assert captured.out == ""
-
-
-# ---------------------------------------------------------------------------
-# Output cap (1,500 bytes)
-# ---------------------------------------------------------------------------
+    assert rc == 0 and capsys.readouterr().out == ""
 
 def test_format_output_stays_under_cap_with_many_results(tmp_path):
     memdir = tmp_path / "memdir_many"
     memdir.mkdir()
     for i in range(40):
-        _write_memory_file(
-            memdir, f"discovery_widget_{i}_2026_09_01.md",
-            f"discovery-widget-{i}",
-            "a" * 200 + f" widget finding number {i} about manufacturing",
-            "discovery", "widget",
-        )
-
-    results, _stats = mos.recall(str(memdir), str(tmp_path / "cache_many.json"),
-                                  query="widget manufacturing", topk=40, threshold=0.0)
+        _write(memdir, f"discovery_widget_{i}_2026_09_01.md", f"discovery-widget-{i}",
+               "a" * 200 + f" widget finding number {i} about manufacturing", "discovery", "widget")
+    results, _ = mos.recall(str(memdir), str(tmp_path / "cache_many.json"),
+                             query="widget manufacturing", topk=40, threshold=0.0)
     out = mos.format_output(results)
-
-    assert len(out.encode("utf-8")) <= mos.OUTPUT_CAP_BYTES
-    assert mos.HEADER_LINE in out
-
-
-def test_format_output_empty_when_no_results():
-    assert mos.format_output([]) == ""
-
-
-# ---------------------------------------------------------------------------
-# Redaction
-# ---------------------------------------------------------------------------
+    assert len(out.encode("utf-8")) <= mos.OUTPUT_CAP_BYTES and mos.HEADER_LINE in out
 
 @pytest.mark.parametrize("text, needle, placeholder", [
     ("contact the client at mario.rossi@example.com for details", "mario.rossi@example.com", "<email>"),
@@ -120,114 +75,36 @@ def test_format_output_empty_when_no_results():
 ])
 def test_redact_pii_shapes(text, needle, placeholder):
     out = mos.redact(text)
-    assert placeholder in out
-    assert needle not in out
-
-
-def test_redact_leaves_clean_text_untouched():
-    clean = "the migration runner reads schema_migrations and applies pending DDL"
-    assert mos.redact(clean) == clean
-
-
-def test_format_output_redacts_description(tmp_path):
-    memdir = tmp_path / "memdir_pii"
-    memdir.mkdir()
-    _write_memory_file(
-        memdir, "discovery_client_email_2026_09_01.md",
-        "discovery-client-email",
-        "widget client contact mario.rossi@example.com about widget order",
-        "discovery", "widget",
-    )
-    results, _stats = mos.recall(str(memdir), str(tmp_path / "cache_pii.json"),
-                                  query="widget", threshold=0.0)
-    out = mos.format_output(results)
-    assert "mario.rossi@example.com" not in out
-    assert "<email>" in out
-
-
-# ---------------------------------------------------------------------------
-# MEMORY.md oversize warning
-# ---------------------------------------------------------------------------
+    assert placeholder in out and needle not in out
 
 @pytest.mark.parametrize("size, expect_warning", [(100, False), (mos.MEMORY_MD_WARN_BYTES + 500, True)])
 def test_memory_md_warning_gated_on_2560_bytes(tmp_path, size, expect_warning):
     memdir = tmp_path / f"memdir_index_{size}"
     memdir.mkdir()
     (memdir / "MEMORY.md").write_text("x" * size, encoding="utf-8")
-
     warning = mos.memory_md_warning(str(memdir))
-    if expect_warning:
-        assert warning is not None and str(size) in warning and "MEMORY_INDEX.md" in warning
-    else:
-        assert warning is None
-
-
-def test_format_output_includes_warning_line(tmp_path):
-    warning = mos.MEMORY_MD_WARN_TEMPLATE.format(bytes=3000)
-    out = mos.format_output([], warning=warning)
-    assert out == warning
-
-
-# ---------------------------------------------------------------------------
-# Recency / importance monotonicity (kept from prototype)
-# ---------------------------------------------------------------------------
+    ok = (warning is not None and str(size) in warning and "MEMORY_INDEX.md" in warning) if expect_warning else warning is None
+    assert ok
 
 def test_recall_scoring_monotonic_in_recency(tmp_path):
     memdir = tmp_path / "memdir_recency"
     memdir.mkdir()
-    today = time.strftime("%Y_%m_%d")
-    old_date = "2020_01_01"
-    _write_memory_file(memdir, f"discovery_recent_topic_{today}.md",
-                        "discovery-recent", "recent finding about widgets", "discovery", "widgets")
-    _write_memory_file(memdir, f"discovery_old_topic_{old_date}.md",
-                        "discovery-old", "old finding about widgets", "discovery", "widgets")
-
-    index, _stats = mos.build_or_refresh_index(str(memdir), str(tmp_path / "cache.json"))
+    today, old_date = time.strftime("%Y_%m_%d"), "2020_01_01"
+    _write(memdir, f"discovery_recent_topic_{today}.md", "discovery-recent", "recent finding about widgets", "discovery", "widgets")
+    _write(memdir, f"discovery_old_topic_{old_date}.md", "discovery-old", "old finding about widgets", "discovery", "widgets")
+    index, _ = mos.build_or_refresh_index(str(memdir), str(tmp_path / "cache.json"))
     now_ts = time.time()
     recent_entry = next(e for p, e in index.items() if "recent_topic" in p)
     old_entry = next(e for p, e in index.items() if "old_topic" in p)
-
     assert mos.recency_score(recent_entry, now_ts) > mos.recency_score(old_entry, now_ts)
-
 
 def test_recall_scoring_monotonic_in_importance(tmp_path):
     memdir = tmp_path / "memdir_importance"
     memdir.mkdir()
     date = "2026_09_01"
-    _write_memory_file(memdir, f"decision_x_{date}.md", "decision-x", "a decision", "project", "topic")
-    _write_memory_file(memdir, f"fact_x_{date}.md", "fact-x", "a fact", "fact", "topic")
-
-    index, _stats = mos.build_or_refresh_index(str(memdir), str(tmp_path / "cache2.json"))
+    _write(memdir, f"decision_x_{date}.md", "decision-x", "a decision", "project", "topic")
+    _write(memdir, f"fact_x_{date}.md", "fact-x", "a fact", "fact", "topic")
+    index, _ = mos.build_or_refresh_index(str(memdir), str(tmp_path / "cache2.json"))
     decision_entry = next(e for p, e in index.items() if p.split(os.sep)[-1].startswith("decision_"))
     fact_entry = next(e for p, e in index.items() if p.split(os.sep)[-1].startswith("fact_"))
-
-    # decision (filename-prefix taxonomy) = 1.0 importance, fact = 0.6
     assert mos.importance_score(decision_entry) > mos.importance_score(fact_entry)
-
-
-def test_recall_quiet_when_nothing_pertinent(tmp_path):
-    memdir = tmp_path / "memdir_quiet"
-    memdir.mkdir()
-    _write_memory_file(memdir, "discovery_foo_2026_09_01.md",
-                        "discovery-foo", "a discovery about databases", "discovery", "database")
-
-    results, stats = mos.recall(
-        str(memdir), str(tmp_path / "cache3.json"),
-        query="zzqvortex wibblefrump squonkalorian blibberflax",
-    )
-    assert results == []
-    assert stats["best_relevance"] == 0.0
-    assert mos.format_output(results) == ""
-
-
-def test_recall_finds_relevant_result(tmp_path):
-    memdir = tmp_path / "memdir_relevant"
-    memdir.mkdir()
-    _write_memory_file(memdir, "discovery_widgets_thing_2026_09_01.md",
-                        "discovery-widgets", "a discovery about widget manufacturing", "discovery", "widget")
-    _write_memory_file(memdir, "fact_unrelated_2026_09_01.md",
-                        "fact-unrelated", "a fact about something else entirely", "fact", "gadget")
-
-    results, stats = mos.recall(str(memdir), str(tmp_path / "cache4.json"), query="widget manufacturing")
-    assert results
-    assert results[0]["filename"] == "discovery_widgets_thing_2026_09_01.md"


### PR DESCRIPTION
## What

Supersedes #5665 (armed, then red on the guard-conformance census: the new hook was not registered). Same content plus the C1 registry entry.

Layer 2 of the memory redesign (Zero, 2026-09-04): a SessionStart receptor that injects the top-6 memories pertinent to the session (cwd, branch, last commits, changed files), scored recency × importance × relevance over the auto-memory directory, capped at 1,500 bytes, redacted (emails/phones/ids), quiet when nothing is pertinent, and falling back to the main worktree's memory dir when run inside an agent worktree. Wired in `.claude/settings.json` next to the three sibling injectors; root `CLAUDE.md` §3 now states what actually happens at SessionStart (the old "auto-load ultime 5 memorie" sentence was false on disk).

## Verification

- `pytest -q scripts/tests/test_memory_layers.py scripts/tests/test_claude_md_budget.py` → 28 passed.
- `python3 infra/guard-conformance/check_guard_conformance.py` → 0 violations.
- Churn 380 (merge-base anchored), `evidence_pack_lint.py --print-floor` → 1.
- Smoke A (`--cwd ~/nuzantara`) 1,462 B; smoke B (real hook path from a worktree, fallback) 1,362 B — was 0 B before the fallback fix.
- CANON block byte-identical to `AGENTS.md`; `CLAUDE.md` 7,586 B.
- Bench on 12 scenarios (prototype study, same scorer): hit@1 10/12, hit@3 and hit@6 12/12, 0.11 s mean, 0 PII.

## Bites

Consumer: `.claude/settings.json` hooks.SessionStart runs `scripts/hooks/memory_recall_sessionstart.sh` at every session start in this repo on every machine. Observation: a fresh session on M5 from main shows the `🧠 memoria pertinente` block ≤ 1,500 B, and `test_memory_layers.py` plus the guard-conformance census are green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4