### PR TITLE
fix(intel-scraper): the post-publish poller targets the Bali-Zero org

### DIFF
--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -70,8 +70,11 @@ API_KEY = os.environ.get("SCRAPER_API_KEY", "internal-scraper-key")
 TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_CHAT_ID = os.environ.get("TELEGRAM_OWNER_CHAT_ID", "8847435604")
 
-GITHUB_OWNER = "Balizero1987"
-GITHUB_REPO = "Teman2"
+# The repository lives under the Bali-Zero org; on the old user path GitHub
+# answers 307 and every `gh api` create-ref/contents call fails (2026-09-04:
+# SEO and layout batches lost after a successful run). Env overrides for tests.
+GITHUB_OWNER = os.environ.get("POST_PUBLISH_GITHUB_OWNER", "Bali-Zero")
+GITHUB_REPO = os.environ.get("POST_PUBLISH_GITHUB_REPO", "Teman2")
 IMAGE_GH_DIR = "apps/mouth/public/static/news"
 
 # ── Codex $imagegen cover engine ─────────────────────────────────────────────

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -983,3 +983,10 @@ class TestAgyGenerateText:
         assert "--print" in cmd and "some prompt" in cmd
         # PATH must include agy's install dir even if the cron PATH lacks it
         assert ppp.AGY_BIN_DIR in captured["env"]["PATH"].split(":")
+
+
+def test_poller_targets_the_bali_zero_org_not_the_old_user_path() -> None:
+    # 2026-09-04: on Balizero1987/Teman2 GitHub answers 307 and every gh api
+    # create-ref / contents call fails; a whole SEO + layout batch was lost.
+    assert ppp.GITHUB_OWNER == "Bali-Zero"
+    assert ppp.GITHUB_REPO == "Teman2"


### PR DESCRIPTION
## Why

First full post-publish run since the queue was repaired (2026-09-04, KBLI 2025 article), from `post_publish_poller_20260904.log` on Pro:

```
✅ translate exit=0
✅ Hero rotation staged (hero_main=indonesias-kbli-2025-shake-up-…)
⏭ Both covers already on GitHub
❌ gh failure (create-ref bot/seo-metadata-20260904-195556) rc=1: gh: HTTP 307
❌ Could not create branch … — 1 staged seo change(s) lost, needs manual re-push
❌ gh failure (create-ref bot/homepage-layout-20260904-195558) rc=1: gh: HTTP 307
```

The poller still targets `Balizero1987/Teman2`; the repository lives under the `Bali-Zero` org and GitHub answers 307 on the old user path. Same family as #5653 (backend publisher) — the third copy of the old owner in the ship path.

## What

- `GITHUB_OWNER`/`GITHUB_REPO` default to `Bali-Zero`/`Teman2`, env-overridable (`POST_PUBLISH_GITHUB_OWNER/REPO`).
- Test pinning the org.

## Verification

- `tests/unit/test_post_publish_poller.py`: 45 passed. ruff clean.

Bites: the Pro LaunchAgent `com.balizero.post-publish-poller` after `git pull` on `~/nuzantara` — observation: re-queuing the KBLI slug (`status='pending', attempts=0`) yields a run whose log ends with `bot/seo-metadata-…` and `bot/homepage-layout-…` branches created and PRs opened, no `HTTP 307`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
