### PR TITLE
docs(rules): superscar becomes a 2.5KB core — scars recalled by pertinence

### DIFF
--- a/.claude/rules/cicatrix-superscar.md
+++ b/.claude/rules/cicatrix-superscar.md
@@ -1,190 +1,33 @@
-# cicatrix-superscar.md — le 10 famiglie (PONTE)
+# cicatrix-superscar.md — le 10 famiglie (NUCLEO)
 
-> **PONTE, non enciclopedia.** ~99 cicatrici in 10 famiglie + orfane. Per famiglia: **malattia**,
-> **segnale-precoce**, **antidoto**, **membri** (1-3 parole — corpo in `cicatrix-scars.md`/
-> `-archive.md`, mai qui). Dettaglio → grep il W-number, o `scar query "<tema>"`/`--list`/
-> `--family N`. ⚠️ **Può arrivarti STALE** (M5, checkout indietro apposta) — riferimento: `git show
-> origin/main:<path>`.
->
-> **Budget ≤8KB**, armato da `scripts/tests/test_superscar_budget.py` (byte + completezza: ogni
-> W-number qui ha un corpo reale). Iniettato a OGNI sessione e subagent. Tre nomi disambiguano
-> collisioni: `W81-armamento-sospeso`, `W81b-dlq-blind-heal-loop`, `W84-tcc-dead`. Storia:
-> `research/operations/2026-08-21-token-ceremony-ci-system-audit.md`.
->
-> **Dominanza:** #1 HOME-fork, #2 Esiste≠Armato, #5 Sibling-race, #4 Secret-clear = 65-75%.
+> **NUCLEO ≤2.560B**, corpo in `cicatrix-scars.md`/`-archive.md` richiamato per pertinenza
+> dall'hook SessionStart (non più iniettato in blocco). Dettaglio → grep il W-number, o `scar
+> query "<tema>"`/`--list`/`--family N`. Tre nomi disambiguano collisioni: `W81-armamento-sospeso`, `W81b-dlq-blind-heal-loop`, `W84-tcc-dead`.
+
+**Dominanza:** #1 HOME-fork, #2 Esiste≠Armato, #5 Sibling-race, #4 Secret-clear = 65-75%.
 
 ---
 
-## #1 — HOME-fork drift (deploy-path desync)
+## #1 — HOME-fork drift · $HOME diverge dal repo, il fix non arriva · lint `cmp -s` live vs git, contro origin/main mai locale · → `scripts/lint_home_fork.py`
 
-**MALATTIA:** il runtime esegue una copia in `$HOME` divergente dal repo; il fix nel repo non la
-raggiunge.
+## #2 — Esiste≠Armato · cron "verdi" mascherano worker morti, output vuoto · monitora esito/heartbeat non PID/exit-code, green≠working · → `scripts/pending_arms_report.py`
 
-**SEGNALE-PRECOCE:** plist/cron che invoca `~/scripts/`; path con username; "due copie
-byte-identical".
+## #3 — Guard-over-match / UNDER-match · guardia giudica substring non entità, OVER/UNDER simmetrici · mai guardia senza guilt+innocence, su entità mai substring · → `infra/guard-conformance/`
 
-**ANTIDOTO:** lint CI `cmp -s` live vs git, contro `origin/main` mai il checkout locale.
-**→ ESEGUIBILE:** `scripts/lint_home_fork.py` — sha256 sulle coppie, `--discover`.
+## #4 — Secret in the clear · segreti prod esposti nel filesystem, `.bak` eredita l'esposizione · chmod 0600 live+.bak, mai cat secret, ruota se esposto · → `scripts/secrets_permissions_audit.py`
 
-**MEMBRI:** W50/W51/W52 (wrapper/plist) · W68/W72/W73 (bridge openclaw) · W70 (path-drift) · W76
-(repomap stale) · M5-dev-env (venv) · TAC wa-mirror (fork orfana) · W81-armamento-sospeso
-(worktree sparito).
+## #5 — Sibling-race / shared-worktree · agenti/cron paralleli sullo stesso checkout, collisioni stash · ogni agent in worktree dedicato, reap solo a 2-AND · → `scripts/agent_start.py`
 
----
+## #6 — Anti-hallucination blindness · LLM immagina file/righe plausibili, a valle le crede vere · mai costruire su path citato senza find/ls/cat in QUESTO turno
 
-## #2 — Esiste ≠ Armato (cron theater / blind autopilot)
+## #7 — Daemon KeepAlive misconfig · KeepAlive=true su one-shot, ogni exit letto come morte · loop bloccante reale o StartInterval senza KeepAlive · → `scripts/lint_plist_keepalive.py`
 
-**MALATTIA:** demoni/cron "verdi" mascherano worker morti, eccezioni ingoiate, output vuoti.
+## #8 — Network flap / proxy fragility · componenti long-running crashano sui flap di rete · socket keep-alive persistenti, retry con backoff, cattura InterfaceError
 
-**SEGNALE-PRECOCE:** `/health` guarda il web non i worker; cron verde a output vuoto.
+## #9 — State-schema mutation drift · step cambia formato payload, lettori a valle rompono · deploy unificato sui contratti, già-su-main è CONTENUTO mai SHA-ancestor · → `scripts/branch_graveyard_cleanup.sh::content_on_main()`
 
-**ANTIDOTO:** monitora l'esito/heartbeat, non PID né exit-code (green≠working). W81: lo STATO DI
-ATTIVAZIONE conta.
-**→ ESEGUIBILE:** `scripts/pending_arms_report.py` — allarma `PENDING-ARMS.md` aperte >48h.
-
-**MEMBRI:** W74 (cron-theater) · W69 (checks disarmati) · W64/W34 (asyncpg death) · W71
-(mcp_integrity mente) · W32 (pg-bridge muto) · 503-RAG (worker giù) · W70 (log_tail cieco) ·
-W81-armamento-sospeso (cron exit 127/78) · W81b-dlq-blind-heal-loop (DLQ mai puliti) ·
-W84-tcc-dead (launchd perde TCC) · W84-tccutil-recidiva (`reset All`) · W87 (identity su PROD) ·
-W97 (display-cap) · W101 (fail-closed decapitato) · W101-recidiva-fly-backup (Fase 2) · W104
-(`redis-cli` NOAUTH) · W108 (19/20 cron muti) · W110 (heartbeat errato) · W116 (cura morta) · W118
-(11h fermo) · W120 (sentinella disarmata) · W122 (SIGINT→130) · W123 (`success`≠armato) · W126
-(draft in coda).
+## #10 — Active-active split-brain · singleton su host diversi, ognuno credendosi unico · SSOT nel DB, graceful-exit se node≠hostname
 
 ---
 
-## #3 — Guard-over-match (substring trapping) — gemello UNDER-match (W82)
-
-**MALATTIA:** la guardia decide su substring, non entità/intento. OVER clobbera; UNDER lascia
-passare il fatto riformulato.
-
-**SEGNALE-PRECOCE:** `if "keyword" in testo`; escape-clause su UNA frase.
-
-**ANTIDOTO:** nessuna guardia senza test di innocenza E colpevolezza, su entità mai su substring.
-**→ ESEGUIBILE:** `infra/guard-conformance/` — senza guilt+innocence = FAIL CI.
-
-**MEMBRI:** W68 (villa zoning) · W72 (B211/KITAS) · W73 (5 insieme) · W77 (asse linguistico) ·
-W68b (variante) · W82 (traduzioni) · W83 (3 falsi BLOCK) · W84 (char-class) · W85 (`stash`/`list`)
-· W92 (path vs cwd) · W94 (whole-command) · W95 (`async def`) · W99 (self-closing) · W109
-(collocazione) · W112 (Prettier) · W115 (post-selezione) · W119 (`\s` newline) · W127
-(`levelname`/`levelno`).
-
----
-
-## #4 — Secret in the clear (world-readable credentials)
-
-**MALATTIA:** segreti prod esposti sul filesystem, bypassando Fly secrets. `.bak` eredita
-l'esposizione.
-
-**SEGNALE-PRECOCE:** `cat`/`echo` di file-chiave su ssh; `.bak` senza chmod.
-
-**ANTIDOTO:** `chmod 0600` (live + `.bak*`); mai `cat` di un secret; ruota se world-readable.
-**→ ESEGUIBILE:** `scripts/secrets_permissions_audit.py` — `--fix` chmod 0600.
-
-**MEMBRI:** P0 2026-06-03 (`.env` readable) · W65 (`.bak` key) · W75 (fly-ssh leak) · P0 2026-05-21
-(pw in 32 file) · 2026-04-29 (plist world-readable).
-
----
-
-## #5 — Sibling-race / shared-worktree chaos
-
-**MALATTIA:** agenti/cron paralleli sullo stesso checkout → collisioni stash, distruzione
-silente.
-
-**SEGNALE-PRECOCE:** `git checkout` nella cartella globale; worktree scaduto reapabile mentre è
-vivo.
-
-**ANTIDOTO:** ogni agent in worktree dedicato (`agent_start.py`); reap solo a 2-AND.
-
-**MEMBRI:** W62 (TTL violato) · W63 (nested worktree) · W80 (reap non-mergiati) ·
-agent-library-evolver (REPO_ROOT) · W59 (madre) · 2026-04-29 (untracked persi).
-
----
-
-## #6 — Anti-hallucination blindness (phantom citations)
-
-**MALATTIA:** un LLM immagina file/righe/conclusioni plausibili; chi sta a valle le prende per
-vere.
-
-**SEGNALE-PRECOCE:** piano su report LLM senza audit fisico; `file:line` mai ri-eseguito.
-
-**ANTIDOTO:** mai costruire su un path citato senza `find`/`ls`/`cat` in QUESTO turno. Anche il
-refuter allucina (W65).
-
-**MEMBRI:** META 2026-06-05 (3 falsi) · W74 (phantom scorer.py) · W65 (refuter falso-refuta) · W78
-(cicatrice sbagliata) · W100 (7/8 false-clean) · W90 (ground-truth stantio) · W113 (correzione
-mente). Linea: W65→W90→W100→W113.
-
----
-
-## #7 — Daemon-vs-cron KeepAlive misconfig
-
-**MALATTIA:** `KeepAlive=true` su script one-shot → ogni exit letto come morte → restart storm.
-
-**SEGNALE-PRECOCE:** `KeepAlive=true` + `nohup … &`; contatore `runs` cresce.
-
-**ANTIDOTO:** loop bloccante reale o `StartInterval` senza KeepAlive.
-**→ ESEGUIBILE:** `scripts/lint_plist_keepalive.py` — `nohup &`=FAIL.
-
-**MEMBRI:** W67/W67b (wa-mirror storm) · W60 (Fly api flapping) · 2026-04-29 (53 plist, 13%
-corretti).
-
----
-
-## #8 — Network flap / proxy fragility
-
-**MALATTIA:** componenti long-running crashano sui flap di rete (proxy/WG/pg-proxy).
-
-**SEGNALE-PRECOCE:** chiamata singola senza retry; log pieni di `TimeoutError`.
-
-**ANTIDOTO:** socket persistenti keep-alive; retry con backoff; cattura `InterfaceError`.
-
-**MEMBRI:** W49 (98 timeout) · W55 (Telegram one-shot) · W32 (InterfaceError) · W47 (solo
-numero).
-
----
-
-## #9 — State-schema mutation drift
-
-**MALATTIA:** uno step cambia il formato di un payload/file-stato; i lettori a valle si rompono.
-
-**SEGNALE-PRECOCE:** modifica ai dati intermedi (DLQ, redis) senza scope end-to-end.
-
-**ANTIDOTO:** deploy unificato sui contratti condivisi. W88: "già su main" per CONTENUTO, mai per
-SHA-ancestor o timestamp.
-**→ ESEGUIBILE:** `scripts/branch_graveyard_cleanup.sh::content_on_main()`.
-
-**MEMBRI:** W54 (timestamp) · W53 (DLQ TERMINAL) · W61 (attempts) · W86 (DOCSYNC stale) · W88
-(cherry post-squash) · W102 (two-dot) · W106 (proxy congelato) · W106b (checkout proxy) ·
-W109b (2 PR bloccate) · W111 (`rerun` stantio) · W114 (fake e codice) · W118 (3 proxy
-mentono) · W125 (resa a mano) · W131 (un nome, due ruoli).
-
----
-
-## #10 — Active-active split-brain
-
-**MALATTIA:** un singleton gira su host diversi, ognuno credendosi unico → carico duplicato.
-
-**SEGNALE-PRECOCE:** `localhost` come hostname fleet-wide; nessuna master-election.
-
-**ANTIDOTO:** SSOT nel DB (`expected_status`/`assigned_node`); graceful-exit se `node≠hostname`.
-
-**MEMBRI:** W67c (spam dal Mini) · 2026-05-07 (mata_garuda) · NLM feeder split-brain.
-
----
-
-## Orfane (uniche per natura, non forzate in un cluster)
-
-- **W38** NOSUPERUSER (hardening) · **P3 FLAKY**+**W129** «adesso» non condiviso
-- **W33** kill-switch auto-remediation · **W39** Dependabot bump (routine)
-- **W40**/**W128** collisione numerazione/numero cicatrice (`lint_scar_number_collision.py`)
-- Atlas migrate-lint paywall · Deploy crash cell-core (ordering CI)
-- **W96** test scrivono STATO PRODUZIONE (`Path.home()`)
-
-**→ dettaglio:** grep il W-number in `cicatrix-scars.md`/`-archive.md`.
-
----
-
-> **Manutenzione:** scar nuova → 1 riga in MEMBRI, corpo in `cicatrix-scars.md`. Più di 1-2 frasi
-> qui È un corpo: sta nel file sbagliato. Non rientra in nessuna delle 10 → orfana, o serve
-> un'11ª famiglia. Metodo: skill `modus` Gear 3.
+> **Manutenzione:** scar nuova → corpo in `cicatrix-scars.md`; MEMBRI/Orfane → `scar --list`/`--family N`.

--- a/scripts/memory/mos_recall_sessionstart.py
+++ b/scripts/memory/mos_recall_sessionstart.py
@@ -6,6 +6,17 @@ when nothing pertinent. MEMDIR = ~/.claude/projects/<slug>/memory (slug =
 abs project dir, '/' -> '-'); missing in a worktree, so we retry against the
 MAIN worktree via `git rev-parse --git-common-dir`. Only frontmatter
 `description` is printed, through redact(). Fail-open: quiet exit 0.
+
+Also indexes `docs/scars/cicatrix-scars.md` + `cicatrix-scars-archive.md`
+(2026-09-04): each numbered scar heading becomes a `type="scar"` candidate
+in the SAME recency x importance x BM25 pool as the memory files, so a
+matching scar is recalled by pertinence instead of the whole
+`cicatrix-superscar.md` roster being injected wholesale every turn (that
+bridge is now a 2.5KB index of families only — see
+`.claude/rules/cicatrix-superscar.md`). Resolved from `docs/scars/` under
+the SAME project root as MEMDIR, which is repo-relative and therefore
+identical on every machine (unlike MEMDIR's `~/.claude/projects/<slug>`
+mapping, which can differ across hosts).
 """
 from __future__ import annotations
 
@@ -34,8 +45,16 @@ TOKEN_RE = re.compile(r"[a-z0-9]+")
 TOPLEVEL_KV_RE = re.compile(r"^(\w[\w]*):[ \t]*(.*)$", re.MULTILINE)
 INDENTED_KV_RE = re.compile(r"^[ \t]+(\w[\w-]*):[ \t]*(.*)$", re.MULTILINE)
 KNOWN_PREFIXES = {"discovery", "decision", "lesson", "lessons", "fact", "project", "unresolved", "reference", "ops", "feedback"}
-IMPORTANCE_BY_TYPE = {"feedback": 1.0, "decision": 1.0, "lesson": 1.0, "lessons": 1.0, "project": 0.9, "discovery": 0.8, "fact": 0.6, "reference": 0.6}
+IMPORTANCE_BY_TYPE = {"feedback": 1.0, "decision": 1.0, "lesson": 1.0, "lessons": 1.0, "scar": 1.0, "project": 0.9, "discovery": 0.8, "fact": 0.6, "reference": 0.6}
 IMPORTANCE_DEFAULT = 0.5
+
+# Scar-section indexing (Layer 2 also recalls docs/scars/*.md by pertinence).
+SCAR_FILES = ("cicatrix-scars.md", "cicatrix-scars-archive.md")
+SCAR_BODY_PREVIEW_CHARS = 160  # claim length, distinct from the 400-char memory-body preview above
+SCAR_HEADING_RE = re.compile(r"^#{2,4} (.+)$", re.MULTILINE)
+SCAR_WNUM_RE = re.compile(r"\bW\d+[a-z]?\b")
+SCAR_DATE_RE = re.compile(r"2026-\d\d-\d\d")
+SCAR_SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 # EN + IT stopwords, kept as one whitespace-split string for density.
 STOPWORDS = frozenset((
@@ -123,6 +142,16 @@ def build_or_refresh_index(memdir: str, cache_path: str, use_cache: bool = True)
     return index, {"file_count": len(index), "rebuilt": rebuilt}
 
 def recency_score(entry: dict, now_ts: float) -> float:
+    if entry.get("type") == "scar":
+        # A cicatrix scar is a disease pattern, not a status note: one filed in April is
+        # exactly as valid a warning today as one filed last week. The 30-day half-life
+        # below is right for "what did I decide/discover recently" but wrong for scars —
+        # applying it here buried every scar older than ~6 weeks under fresher, less
+        # relevant memory notes (measured 2026-09-04: W67/W67b had the HIGHEST raw BM25
+        # relevance of all 1,941 candidates for a KeepAlive-storm query, 13.3/12.6, yet
+        # ranked #21/#23 after a ~90-day-old recency multiplier of ~0.13 crushed them).
+        # Scars compete on relevance x importance alone.
+        return 1.0
     dkey = entry.get("date_key")
     try:
         t = time.mktime(time.strptime(dkey, "%Y-%m-%d")) if dkey else entry["mtime"]
@@ -183,6 +212,59 @@ def resolve_memdir(cwd: str | None = None, home: str | None = None) -> str | Non
     fallback = _slug_memdir(main_root, home_path) if main_root else None
     return fallback if fallback and os.path.isdir(fallback) else primary  # still missing — main() exits 0 quietly
 
+def resolve_scars_dir(cwd: str | None = None) -> str | None:
+    project_dir = cwd or os.environ.get("CLAUDE_PROJECT_DIR") or _git(["rev-parse", "--show-toplevel"], os.getcwd())
+    if not project_dir:
+        return None
+    d = os.path.join(project_dir, "docs", "scars")
+    return d if os.path.isdir(d) else None
+
+def _slugify(heading: str) -> str:
+    return SCAR_SLUG_RE.sub("-", heading.lower()).strip("-")[:60]
+
+def split_scar_sections(text: str) -> list[tuple[str, str]]:
+    """(heading_text, body_text) for every `##`/`###`/`####` heading — a
+    fallback-free single pass, since both scar files use that heading form
+    consistently for every entry that carries a W-number."""
+    matches = list(SCAR_HEADING_RE.finditer(text))
+    sections = []
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections.append((m.group(1).strip(), text[m.end():end].strip()))
+    return sections
+
+def build_scar_index(scars_dir: str) -> dict:
+    """One `type="scar"` entry per W-numbered heading in either scar file.
+    Headings with no W-number (older `RESOLVED`-only entries) are skipped —
+    the output format cites a W-number, so there is nothing to cite for them."""
+    index: dict = {}
+    for fn in SCAR_FILES:
+        path = os.path.join(scars_dir, fn)
+        try:
+            mtime = os.path.getmtime(path)
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for heading, body in split_scar_sections(text):
+            wm = SCAR_WNUM_RE.search(heading)
+            if not wm:
+                continue
+            wnum = wm.group(0)
+            dm = SCAR_DATE_RE.search(heading) or SCAR_DATE_RE.search(body[:200])
+            key = f"{fn}#{_slugify(heading)}"
+            index[key] = {
+                "mtime": mtime,
+                "filename": f"{fn}#{_slugify(heading)}",
+                "name": wnum,
+                "description": body[:SCAR_BODY_PREVIEW_CHARS].strip(),
+                "type": "scar",
+                "date_key": dm.group(0) if dm else None,
+                "indexed_text": f"{heading} {body[:BODY_PREVIEW_CHARS]}",
+                "wnum": wnum,
+            }
+    return index
+
 def build_context_query(cwd: str) -> str:
     parts = [os.path.basename(cwd.rstrip("/"))] if cwd else []
     parts += [o for o in (_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd), _git(["log", "-8", "--format=%s"], cwd)) if o]
@@ -191,8 +273,14 @@ def build_context_query(cwd: str) -> str:
     return " ".join(parts + ([" ".join(names)] if names else []))
 
 def recall(memdir: str, cache_path: str, query: str, topk: int = DEFAULT_TOPK,
-           threshold: float = DEFAULT_RELEVANCE_THRESHOLD, use_cache: bool = True) -> tuple[list[dict], dict]:
+           threshold: float = DEFAULT_RELEVANCE_THRESHOLD, use_cache: bool = True,
+           scars_dir: str | None = None) -> tuple[list[dict], dict]:
     index, idx_stats = build_or_refresh_index(memdir, cache_path, use_cache=use_cache)
+    scar_count = 0
+    if scars_dir:
+        scar_index = build_scar_index(scars_dir)
+        scar_count = len(scar_index)
+        index = {**index, **scar_index}
     doc_tokens, df, avgdl = compute_doc_freq(index)
     n_docs, now_ts, q_tokens = len(index), time.time(), tokenize(query)
     scored = []
@@ -201,10 +289,16 @@ def recall(memdir: str, cache_path: str, query: str, topk: int = DEFAULT_TOPK,
         scored.append((recency_score(entry, now_ts) * importance_score(entry) * rel, rel, entry))
     scored.sort(key=lambda t: t[0], reverse=True)
     best_rel = scored[0][1] if scored else 0.0
-    stats = {**idx_stats, "best_relevance": round(best_rel, 4), "threshold": threshold, "query": query}
+    stats = {**idx_stats, "scar_count": scar_count, "best_relevance": round(best_rel, 4),
+              "threshold": threshold, "query": query}
     if best_rel < threshold:
         return [], stats
-    results = [{"filename": e["filename"], "description": e["description"]} for _, _, e in scored[:topk]]
+    results = []
+    for _, _, e in scored[:topk]:
+        r = {"filename": e["filename"], "description": e["description"]}
+        if e.get("wnum"):
+            r["wnum"] = e["wnum"]
+        results.append(r)
     return results, stats
 
 def memory_md_warning(memdir: str) -> str | None:
@@ -223,7 +317,8 @@ def format_output(results: list[dict], warning: str | None = None, cap_bytes: in
         claim = redact(r["description"] or r["filename"])
         if len(claim) > CLAIM_MAX_CHARS:
             claim = claim[: CLAIM_MAX_CHARS - 1].rstrip() + "…"
-        line = f"- {claim} → {r['filename']}"
+        prefix = f"[{r['wnum']}] " if r.get("wnum") else ""
+        line = f"- {prefix}{claim} → {r['filename']}"
         lb = len(line.encode("utf-8")) + 1
         if total + lb > budget:
             break
@@ -238,7 +333,8 @@ def main() -> int:
         ap = argparse.ArgumentParser()
         for name, kw in [("--memdir", {}), ("--cache-path", {}), ("--no-cache", {"action": "store_true"}),
                          ("--query", {}), ("--cwd", {}), ("--topk", {"type": int, "default": DEFAULT_TOPK}),
-                         ("--threshold", {"type": float, "default": DEFAULT_RELEVANCE_THRESHOLD})]:
+                         ("--threshold", {"type": float, "default": DEFAULT_RELEVANCE_THRESHOLD}),
+                         ("--scars-dir", {})]:
             ap.add_argument(name, **kw)
         args = ap.parse_args()
         cwd = args.cwd or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
@@ -246,8 +342,10 @@ def main() -> int:
         if not memdir or not os.path.isdir(memdir):
             return 0  # not wired on this machine — silent, never the reason a session breaks
         cache_path = args.cache_path or os.path.join(memdir, CACHE_FILENAME)
+        scars_dir = args.scars_dir or resolve_scars_dir(cwd)
         results, _stats = recall(memdir, cache_path, args.query or build_context_query(cwd),
-                                  topk=args.topk, threshold=args.threshold, use_cache=not args.no_cache)
+                                  topk=args.topk, threshold=args.threshold, use_cache=not args.no_cache,
+                                  scars_dir=scars_dir)
         out = format_output(results, warning=memory_md_warning(memdir))
         if out:
             print(out)

--- a/scripts/tests/test_memory_layers.py
+++ b/scripts/tests/test_memory_layers.py
@@ -108,3 +108,86 @@ def test_recall_scoring_monotonic_in_importance(tmp_path):
     decision_entry = next(e for p, e in index.items() if p.split(os.sep)[-1].startswith("decision_"))
     fact_entry = next(e for p, e in index.items() if p.split(os.sep)[-1].startswith("fact_"))
     assert mos.importance_score(decision_entry) > mos.importance_score(fact_entry)
+
+
+# --- scar-section indexing (2026-09-04): cicatrix-scars.md is now recalled by pertinence,
+# not injected wholesale via cicatrix-superscar.md — see mos_recall_sessionstart.py's
+# build_scar_index()/resolve_scars_dir().
+
+FIXTURE_SCARS_MD = """### 🐛 W501 (P1 STRUCTURAL): a plist KeepAlive=true wrapped a one-shot nohup script and every exit was read as death, causing a restart storm (2026-06-01)
+
+The launchd daemon relaunched the wrapper every few seconds because KeepAlive=true
+treats a clean exit from a one-shot nohup child as a crash. Antidote: a real blocking
+loop or StartInterval without KeepAlive.
+
+### 🐛 W502 (P2 STRUCTURAL): a substring guard trapped innocent commands because it decided on `if "keyword" in text` instead of entity/intent (2026-06-02)
+
+The worktree-isolation hook matched on a bare substring and produced false BLOCK
+verdicts on unrelated commands that merely contained the trigger word.
+
+### ✅ RESOLVED: an unrelated cleanup with no W-number attached (2026-06-03)
+
+This entry has no W-number in its heading and must not be indexed by build_scar_index.
+"""
+
+
+def _write_scars_fixture(scars_dir):
+    scars_dir.mkdir(parents=True, exist_ok=True)
+    (scars_dir / "cicatrix-scars.md").write_text(FIXTURE_SCARS_MD, encoding="utf-8")
+
+
+def test_scar_entries_are_immune_to_recency_decay():
+    """A months-old scar must not be outranked purely on age — see
+    recency_score()'s scar branch: a disease pattern from April is exactly
+    as valid a warning today as one filed last week."""
+    now_ts = time.mktime(time.strptime("2026-09-04", "%Y-%m-%d"))
+    old_scar = {"type": "scar", "date_key": "2026-04-01", "mtime": 0}
+    recent_discovery = {"type": "discovery", "date_key": "2026-09-01", "mtime": 0}
+    assert mos.recency_score(old_scar, now_ts) == 1.0
+    assert mos.recency_score(recent_discovery, now_ts) < 1.0
+
+
+def test_build_scar_index_only_indexes_w_numbered_headings(tmp_path):
+    scars_dir = tmp_path / "scars_index_only"
+    _write_scars_fixture(scars_dir)
+    index = mos.build_scar_index(str(scars_dir))
+    wnums = {e["wnum"] for e in index.values()}
+    assert wnums == {"W501", "W502"}
+    assert all(e["type"] == "scar" for e in index.values())
+
+
+def test_a_scar_query_naming_the_family_signal_ranks_that_section_first(tmp_path):
+    memdir = tmp_path / "memdir_scar_query"
+    memdir.mkdir()
+    scars_dir = tmp_path / "scars_query"
+    _write_scars_fixture(scars_dir)
+
+    results, _stats = mos.recall(
+        str(memdir), str(tmp_path / "cache_scars.json"),
+        query="plist KeepAlive nohup restart storm",
+        topk=5, threshold=0.0, scars_dir=str(scars_dir),
+    )
+    assert results, "expected at least one scar candidate"
+    assert results[0]["wnum"] == "W501"
+    assert results[0]["filename"].startswith("cicatrix-scars.md#")
+
+    out = mos.format_output(results)
+    assert "[W501]" in out
+    assert "W502" not in out or "[W502]" not in out.split("[W501]")[0]
+
+
+def test_a_different_family_signal_ranks_the_other_section_first(tmp_path):
+    memdir = tmp_path / "memdir_scar_query2"
+    memdir.mkdir()
+    scars_dir = tmp_path / "scars_query2"
+    _write_scars_fixture(scars_dir)
+
+    results, _stats = mos.recall(
+        str(memdir), str(tmp_path / "cache_scars2.json"),
+        query='guard substring keyword in text false BLOCK entity intent',
+        topk=5, threshold=0.0, scars_dir=str(scars_dir),
+    )
+    assert results
+    assert results[0]["wnum"] == "W502"
+    out = mos.format_output(results)
+    assert "[W502]" in out

--- a/scripts/tests/test_superscar_budget.py
+++ b/scripts/tests/test_superscar_budget.py
@@ -10,11 +10,20 @@ a artefact that claims to be a thin bridge but is secretly carrying full
 TRAUMA/ANTIBODY/GOTCHA paragraphs in its MEMBRI bullet lists instead of
 `cicatrix-scars.md`, where the full corpus lives).
 
+Second diet (2026-09-04, `scripts/memory/mos_recall_sessionstart.py`): the
+bridge went from an 8,192-byte MEMBRI-list edition down to a 2,560-byte
+NUCLEO — one line per family (name, disease, antidote, executable) — because
+the SessionStart recall hook now ALSO indexes `cicatrix-scars.md` and
+`cicatrix-scars-archive.md` by section, so individual scars are recalled by
+pertinence instead of the whole roster being injected wholesale every turn.
+The MEMBRI lists and the Orfane section were dropped from the bridge; their
+bodies still live in the two scar files, unmoved.
+
 This guard is two things, deliberately kept together because they trade off
 against each other — shrinking the file is only safe if nothing fell off
 the truck on the way down:
 
-1. A byte-budget assertion: `cicatrix-superscar.md` stays <=8192 bytes.
+1. A byte-budget assertion: `cicatrix-superscar.md` stays <=2560 bytes.
 2. A completeness assertion: every `W\\d+[a-z]?` token that appears anywhere
    in `cicatrix-superscar.md` resolves to a real body heading in either
    `cicatrix-scars.md` or `cicatrix-scars-archive.md`.
@@ -50,7 +59,7 @@ SUPERSCAR = RULES_DIR / "cicatrix-superscar.md"
 SCARS = SCARS_DIR / "cicatrix-scars.md"
 ARCHIVE = SCARS_DIR / "cicatrix-scars-archive.md"
 
-BYTE_BUDGET = 8_192
+BYTE_BUDGET = 2_560
 
 _WNUM_TOKEN_RE = re.compile(r"\bW\d+[a-z]?\b")
 _HEADING_RE = re.compile(r"^#{2,4} ")


### PR DESCRIPTION
## What
`cicatrix-superscar.md` was capped at 8,192B and always-injected wholesale into every
session and subagent. It shrinks to a 2,462B NUCLEO: one line per family (name, disease
≤12 words, antidote ≤15 words, executable). The 10 MEMBRI lists and the Orfane section are
dropped from the bridge — their bodies still live, unmoved, in `docs/scars/cicatrix-scars.md`
and `cicatrix-scars-archive.md`.

`scripts/memory/mos_recall_sessionstart.py` (the SessionStart recall hook from #5670) now
also indexes those two scar files: every `##`/`###`/`####` heading carrying a W-number
becomes a `type="scar"` candidate (111 found) in the same recency x importance x BM25 pool
as the memory files, output as `- [W-number] <claim> → cicatrix-scars.md#<slug>` lines.

**Fix found while benching (not asked for, but load-bearing):** the existing 30-day recency
half-life crushed scars that were months old even when they were the single most relevant
match by raw BM25 — measured: W67/W67b had the HIGHEST relevance of all 1,941 candidates for
a KeepAlive-storm query (13.3 / 12.6) but ranked #21/#23 after a ~90-day-old recency
multiplier of ~0.13 buried them under fresher, less relevant memory notes. A cicatrix scar is
a disease pattern, not a status note — one filed in April is exactly as valid a warning today
as one filed last week. `recency_score()` now returns `1.0` for `type="scar"`; scars compete
on relevance x importance alone.

Note: the mandate described the scar bodies as living under `.claude/rules/` — that moved to
`docs/scars/` in an earlier PR (L02-PR1); `resolve_scars_dir()` and `build_scar_index()` use
the actual current location, verified against `test_superscar_budget.py`'s own `SCARS_DIR`.

## Verification
- `wc -c .claude/rules/cicatrix-superscar.md` → 2,462B (budget 2,560B)
- `python3 -m pytest -q scripts/tests/test_superscar_budget.py scripts/tests/test_memory_layers.py scripts/tests/test_claude_md_budget.py scripts/tests/test_context_budget_audit.py` → 47 passed
- `python3 -m pytest -q scripts/tests/test_cicatrix_scar_pointer_integrity.py` (sibling guard) → 8 passed
- `python3 scripts/lint_scar_number_collision.py` → 0 collisions
- `python3 infra/guard-conformance/check_guard_conformance.py` → 0 violations
- Churn since merge-base: 397 lines (< 400) · `evidence_pack_lint.py --print-floor` → 1
- Live smoke: `bash scripts/hooks/memory_recall_sessionstart.sh | wc -c` → 969B (≤ 1500); with
  `--query "plist KeepAlive nohup restart storm"` → 1,394B with `[W67]`/`[W67b]` lines present

**8-scenario bench** (family signal query → live hook → top-3 W-numbers → expected family?):

| Query | Top hits | Expected family | Hit? |
|---|---|---|---|
| plist KeepAlive nohup restart storm | W67, W67b | #7 Daemon KeepAlive | yes (top-1) |
| cat di un .env su ssh | W75 | #4 Secret-clear | yes (top-1) |
| if keyword in testo guardia | W99 | #3 Guard-over-match | yes (top-1) |
| cron verde con output vuoto | W81, W84 | #2 Esiste≠Armato | yes (top-1) |
| git checkout nella cartella globale | W83 | #5 Sibling-race | no — lost to #3 |
| localhost come hostname fleet-wide | W94, W87 | #10 Active-active | no — lost to #3 |
| timestamp rompe staleness | W54, W53 | #9 State-schema | yes (top-1) |
| file:line mai ri-eseguito | (none in top-3) | #6 Anti-hallucination | no |

5/8 hit top-1/2 in the expected family. The 3 misses all lose to family #3
(guard-over-match, 18 members — the largest, most lexically broad family) on short generic
queries; confirmed NOT an indexing bug — every target W-number (W59/W62/W63/W80 for #5,
W67c for #10, W74/W65/W78/W100/W90/W113 for #6) is present and correctly typed in the built
scar index, they just score lower on raw BM25 relevance than family #3's entries for that
exact phrasing. A real limit of lexical (non-semantic) matching, not something this PR's
scope covers fixing.

## Bites
Consumer: every session/subagent loads `.claude/rules/cicatrix-superscar.md` at boot, and the
SessionStart recall hook now indexes `.claude/rules/cicatrix-scars*.md`'s actual current home
(`docs/scars/cicatrix-scars*.md`). Observation: `wc -c` is 2,462B on this branch (was 8,189B on
main), `test_superscar_budget.py` is green at `BYTE_BUDGET = 2_560`, and a live run of
`memory_recall_sessionstart.sh` with a family-signal query shows `[W…]` lines sourced from
`cicatrix-scars.md#<slug>` in its output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4