### PR TITLE
feat(infra): the machine-local ~/.claude surface gets a test suite

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -94,6 +94,8 @@ jobs:
               docs/scars/*|\
               .prettierignore|\
               scripts/tests/test_superscar_budget.py|\
+              scripts/home_surface_suite.sh|\
+              scripts/tests/test_home_surface_suite.py|\
               scripts/lint_home_fork.py|\
               scripts/proprioception.py|\
               scripts/agent_start.py|\
@@ -622,6 +624,16 @@ jobs:
         # W-number in the bridge resolves to a real heading in cicatrix-scars.md or its archive)
         # and the `.prettierignore` coverage assertion ride along in the same file.
         run: python -m pytest scripts/tests/test_superscar_budget.py -q
+
+      - name: HOME-surface suite guilt+innocence (the machine-local ~/.claude has a test)
+        if: steps.paths.outputs.relevant == 'true'
+        # Born 2026-09-04. The context diet was applied to Pro and Mini as HOME edits
+        # (settings.json, agents, global CLAUDE.md) with a before/after measure and no
+        # test — family #2, exists != armed. `scripts/home_surface_suite.sh` is the test
+        # the machines now run; this step proves the suite itself still FAILS on a broken
+        # fixture (tool search not deferred, agent without frontmatter, budget over
+        # ceiling) and PASSES on a clean one, so a green run on a machine means something.
+        run: python -m pytest scripts/tests/test_home_surface_suite.py -q
 
       - name: PII gate merge-scope guilt+innocence (.husky/pre-commit)
         if: steps.paths.outputs.relevant == 'true'

--- a/scripts/home_surface_suite.sh
+++ b/scripts/home_surface_suite.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# scripts/home_surface_suite.sh — test suite for the machine-local Claude surface.
+#
+# The repo side of the context diet (CLAUDE.md, rules, hooks) is covered by CI. The
+# HOME side (~/.claude/settings.json, ~/.claude/agents, ~/.claude.json, the four
+# SessionStart hooks as they run on THIS machine) had no suite at all: the 2026-09-04
+# fleet apply on Pro and Mini was measured before/after and never tested. Zero's
+# question ("ma mica deve fare suite test????") is the reason this file exists.
+#
+# Sections (select with --only a,b,c):
+#   settings  ~/.claude/settings.json parses; env.ENABLE_TOOL_SEARCH == "true";
+#             permissions.deny is a list; ~/.claude.json chrome flag is REPORTED.
+#   agents    every ~/.claude/agents/*.md opens with frontmatter carrying name + description.
+#   hooks     the four SessionStart hooks exit 0 and emit <= SESSIONSTART_HOOK_MAX_BYTES (1500).
+#   homefork  scripts/lint_home_fork.py — REPORTED by default (its own failures predate the
+#             diet and are owned by proprioception); --strict-homefork makes it gate.
+#   budget    scripts/context_budget_audit.py --live total <= --max-tokens (default 30000).
+#
+# HOME is honoured, so a test can point the suite at a fixture directory.
+# Exit 0 = PASS, 1 = FAIL, 2 = usage. Never prints a credential: settings.json is
+# parsed for two structural keys and nothing else is echoed.
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ONLY="settings,agents,hooks,homefork,budget"
+MAX_TOKENS="${HOME_SURFACE_MAX_TOKENS:-30000}"
+STRICT_HOMEFORK=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-root) REPO_ROOT="$2"; shift 2 ;;
+    --only) ONLY="$2"; shift 2 ;;
+    --max-tokens) MAX_TOKENS="$2"; shift 2 ;;
+    --strict-homefork) STRICT_HOMEFORK=1; shift ;;
+    -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+    *) echo "usage: $0 [--repo-root DIR] [--only a,b,c] [--max-tokens N] [--strict-homefork]" >&2; exit 2 ;;
+  esac
+done
+
+cd "$REPO_ROOT" || { echo "FAIL repo root not found: $REPO_ROOT"; exit 2; }
+FAIL=0
+want() { case ",$ONLY," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
+ok()   { echo "ok    $*"; }
+bad()  { echo "FAIL  $*"; FAIL=1; }
+info() { echo "info  $*"; }
+
+echo "home_surface_suite host=$(hostname -s 2>/dev/null || hostname) HOME=$HOME repo=$REPO_ROOT"
+
+if want settings; then
+  if out="$(python3 - "$HOME" <<'PY' 2>&1
+import json, sys, pathlib
+home = pathlib.Path(sys.argv[1])
+s = json.loads((home / ".claude" / "settings.json").read_text())
+ts = str(s.get("env", {}).get("ENABLE_TOOL_SEARCH", ""))
+if ts != "true":
+    raise SystemExit(f"env.ENABLE_TOOL_SEARCH is {ts!r}, expected 'true' (MCP + built-ins deferred)")
+deny = s.get("permissions", {}).get("deny")
+if not isinstance(deny, list):
+    raise SystemExit("permissions.deny is not a list")
+chrome = None
+cj = home / ".claude.json"
+if cj.exists():
+    chrome = json.loads(cj.read_text()).get("claudeInChromeDefaultEnabled")
+print(f"tool_search=true deny_entries={len(deny)} claudeInChromeDefaultEnabled={chrome}")
+PY
+)"; then ok "settings: $out"; else bad "settings: $out"; fi
+fi
+
+if want agents; then
+  if out="$(python3 - "$HOME" <<'PY' 2>&1
+import re, sys, pathlib
+adir = pathlib.Path(sys.argv[1]) / ".claude" / "agents"
+files = sorted(adir.glob("*.md")) if adir.is_dir() else []
+broken = []
+for f in files:
+    text = f.read_text(encoding="utf-8", errors="ignore")
+    if not text.startswith("---") or text.count("---") < 2:
+        broken.append(f"{f.name}(no-frontmatter)"); continue
+    fm = text.split("---", 2)[1]
+    for key in ("name", "description"):
+        if not re.search(rf"^{key}:\s*\S", fm, re.M):
+            broken.append(f"{f.name}(no-{key})")
+if broken:
+    raise SystemExit(f"{len(broken)} broken of {len(files)}: " + " ".join(broken[:8]))
+print(f"{len(files)} agents, frontmatter intact")
+PY
+)"; then ok "agents: $out"; else bad "agents: $out"; fi
+fi
+
+if want hooks; then
+  cap="${SESSIONSTART_HOOK_MAX_BYTES:-1500}"
+  for h in escalations_alert_sessionstart proprioception_sessionstart organism_digest_sessionstart memory_recall_sessionstart; do
+    hook="scripts/hooks/$h.sh"
+    [ -f "$hook" ] || { bad "hooks: $hook missing"; continue; }
+    bytes="$(CLAUDE_PROJECT_DIR="$REPO_ROOT" bash "$hook" 2>/dev/null </dev/null | wc -c | tr -d ' ')"
+    rc="${PIPESTATUS[0]}"
+    if [ "$rc" = 0 ] && [ "$bytes" -le "$cap" ]; then ok "hooks: $h bytes=$bytes rc=0"
+    else bad "hooks: $h bytes=$bytes rc=$rc cap=$cap"; fi
+  done
+fi
+
+if want homefork; then
+  if [ -f scripts/lint_home_fork.py ]; then
+    python3 scripts/lint_home_fork.py >/dev/null 2>&1; rc=$?
+    if [ "$rc" = 0 ]; then ok "homefork: lint_home_fork exit 0"
+    elif [ "$STRICT_HOMEFORK" = 1 ]; then bad "homefork: lint_home_fork exit $rc (1=diverged 2=undeclared 4=scan-error 8=.bak)"
+    else info "homefork: lint_home_fork exit $rc — owned by proprioception, not gating here"; fi
+  else info "homefork: scripts/lint_home_fork.py absent"; fi
+fi
+
+if want budget; then
+  if total="$(python3 scripts/context_budget_audit.py --live --json --repo-root "$REPO_ROOT" 2>/dev/null \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["total_est_tokens"])' 2>&1)"; then
+    if [ "$total" -le "$MAX_TOKENS" ] 2>/dev/null; then ok "budget: live surface est. ${total} tokens <= ${MAX_TOKENS}"
+    else bad "budget: live surface est. ${total} tokens > ${MAX_TOKENS}"; fi
+  else bad "budget: context_budget_audit failed: $total"; fi
+fi
+
+if [ "$FAIL" = 0 ]; then echo "SUITE_RESULT=PASS"; exit 0; fi
+echo "SUITE_RESULT=FAIL"; exit 1

--- a/scripts/tests/test_home_surface_suite.py
+++ b/scripts/tests/test_home_surface_suite.py
@@ -1,0 +1,84 @@
+"""Guilt + innocence for scripts/home_surface_suite.sh.
+
+The suite tests the machine-local Claude surface (~/.claude). CI has no such surface,
+so every case here points HOME at a fixture: a clean one must PASS, and each of the
+two structural gates (tool search deferred, agent frontmatter intact) must FAIL when
+its fixture is broken. The hooks/budget sections run against the real repo checkout
+with the fixture HOME, which is the shape a fresh machine presents.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SUITE = REPO_ROOT / "scripts" / "home_surface_suite.sh"
+
+
+def _fixture_home(tmp_path: Path, *, tool_search: str = "true", agent_body: str | None = None) -> Path:
+    home = tmp_path / "home"
+    (home / ".claude" / "agents").mkdir(parents=True)
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"env": {"ENABLE_TOOL_SEARCH": tool_search}, "permissions": {"deny": ["Artifact"]}})
+    )
+    (home / ".claude.json").write_text(json.dumps({"claudeInChromeDefaultEnabled": False}))
+    body = agent_body if agent_body is not None else "---\nname: probe\ndescription: fixture agent\n---\nbody\n"
+    (home / ".claude" / "agents" / "probe.md").write_text(body)
+    return home
+
+
+def _run(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        # never spawn the background arsenal probe from a test
+        "ORGANISM_ARSENAL_REFRESH_ENABLED": "false",
+    }
+    return subprocess.run(
+        ["bash", str(SUITE), "--repo-root", str(REPO_ROOT), *args],
+        capture_output=True, text=True, env=env, timeout=300, check=False,
+    )
+
+
+def test_clean_fixture_passes_structural_sections(tmp_path: Path) -> None:
+    res = _run(_fixture_home(tmp_path), "--only", "settings,agents")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "SUITE_RESULT=PASS" in res.stdout
+    assert "deny_entries=1" in res.stdout
+
+
+def test_tool_search_not_deferred_fails(tmp_path: Path) -> None:
+    res = _run(_fixture_home(tmp_path, tool_search="auto:5"), "--only", "settings")
+    assert res.returncode == 1
+    assert "ENABLE_TOOL_SEARCH" in res.stdout
+    assert "SUITE_RESULT=FAIL" in res.stdout
+
+
+def test_agent_without_frontmatter_name_fails(tmp_path: Path) -> None:
+    res = _run(_fixture_home(tmp_path, agent_body="---\ndescription: nameless\n---\nbody\n"), "--only", "agents")
+    assert res.returncode == 1
+    assert "probe.md(no-name)" in res.stdout
+
+
+def test_budget_ceiling_gates(tmp_path: Path) -> None:
+    res = _run(_fixture_home(tmp_path), "--only", "budget", "--max-tokens", "1")
+    assert res.returncode == 1
+    assert "FAIL  budget:" in res.stdout
+
+
+@pytest.mark.skipif(not (REPO_ROOT / "scripts" / "hooks" / "memory_recall_sessionstart.sh").exists(), reason="hooks absent")
+def test_hooks_and_budget_pass_on_fresh_home(tmp_path: Path) -> None:
+    res = _run(_fixture_home(tmp_path), "--only", "hooks,homefork,budget")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert res.stdout.count("ok    hooks:") == 4
+    assert "ok    budget:" in res.stdout
+
+
+def test_unknown_flag_is_usage_error(tmp_path: Path) -> None:
+    res = _run(_fixture_home(tmp_path), "--bogus")
+    assert res.returncode == 2


### PR DESCRIPTION
## Why

The context diet (2026-09-04) was applied to Pro and Mini as HOME edits: `~/.claude/settings.json`, 38 trimmed agents, the global `CLAUDE.md`, `~/.claude.json`. It was measured before/after with `claude -p` and it was never tested, because that surface had no suite in this repo. Zero asked "ma mica deve fare suite test????". Correct question. This PR is the suite.

## What

- `scripts/home_surface_suite.sh` — five sections, selectable with `--only`: **settings** (JSON parses, `env.ENABLE_TOOL_SEARCH == "true"`, `permissions.deny` is a list, chrome flag reported), **agents** (every `~/.claude/agents/*.md` has frontmatter with `name` + `description`), **hooks** (the four SessionStart hooks exit 0 and emit ≤ `SESSIONSTART_HOOK_MAX_BYTES`), **homefork** (`lint_home_fork.py` reported; `--strict-homefork` gates — its current reds predate the diet and proprioception owns them), **budget** (`context_budget_audit.py --live` ≤ `--max-tokens`, default 30,000). `HOME` is honoured so a test can point it at a fixture. Prints no credential: settings.json is read for two structural keys only.
- `scripts/tests/test_home_surface_suite.py` — guilt + innocence: clean fixture PASSES; tool search left at `auto:5` FAILS naming `ENABLE_TOOL_SEARCH`; an agent without `name` FAILS naming the file; `--max-tokens 1` FAILS on budget; hooks + budget PASS on a fresh HOME against the real checkout; unknown flag exits 2.
- `.github/workflows/immune-enforcement.yml` — the two new paths join the relevance case list and a step runs the pytest, mirroring the superscar step. `test_immune_enforcement_trigger_symmetry.py` still 12/12; actionlint SC222x count unchanged (6 on main, 6 here, all pre-existing).

## Bites:

Consumer: `immune-enforcement.yml` (required, per-PR) runs `test_home_surface_suite.py` whenever the suite, its test, hooks or rules change; `scripts-tests-sweep.yml` collects it nightly. Observation, pre-merge on M5 from this branch: `bash scripts/home_surface_suite.sh` → `SUITE_RESULT=PASS` (33 agents intact, 4 hooks ≤1,500B, live surface est. 19,220 tokens ≤ 30,000). Post-merge the same command is run on Pro (`~/Desktop/nuzantara`) and Mini (`~/nuzantara`), whose pre-merge scratchpad runs were PASS at 23,659 and 26,412 tokens; the fleet numbers are appended here as a comment once observed.

Churn: 3 files, +216, floor 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4
