### PR TITLE
fix(ci): route kb/ in the change map, and to the backend suite that guards it

### DIFF
--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -217,6 +217,14 @@ PREFIX_RULES: tuple[tuple[str, frozenset[str]], ...] = (
     ("infra/", frozenset({"infra_workflows", "security_sensitive"})),
     ("config/", frozenset({"infra_workflows", "security_sensitive"})),
     ("data/", frozenset({"backend_python", "docs_content_data"})),
+    # kb/ is the knowledge-base corpus (inventories, topics, journeys, ops
+    # probes), added 2026-08-25 and never routed — every kb/-only PR fell into
+    # unknown_paths and tripped run_all. It takes data/'s pairing, and the
+    # backend_python half is load-bearing, not symmetry: nine suites under
+    # apps/backend-rag/backend/tests/unit/kb/ read kb/inventory/*.yaml
+    # directly, and _suggested_jobs() grants docs_content_data none of the six
+    # jobs — so routing kb/ to docs alone would silence the corpus's own guard.
+    ("kb/", frozenset({"backend_python", "docs_content_data"})),
     ("public/", frozenset({"mouth", "docs_content_data"})),
     # fleet_ops (2026-08-20): top-level scripts/ (outside scripts/ci/, already
     # mapped above) is NOT mapped as a whole — a per-file coupling census this

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -126,6 +126,57 @@ class ChangeMapTests(unittest.TestCase):
                 self.assertFalse(result["domains"]["mouth"])
                 self.assertNotIn("frontend-tests", result["suggested_jobs"])
 
+    def test_guilt_kb_corpus_files_run_the_backend_suite_that_guards_them(
+        self,
+    ) -> None:
+        # kb/ landed 2026-08-25 (#4907/#4974) and was never wired into the
+        # routing tables, so every kb/-only PR fell into `unknown_paths` ->
+        # run_all=true. Measured on PR #5662 (one file, kb/inventory/
+        # immigration.yaml): CodeQL-python 14m01s, plus ~9m of Snyk/Bandit/
+        # Safety, against a YAML data file.
+        #
+        # The obvious cure is wrong. Routing kb/ to docs_content_data ALONE
+        # would switch off the tests that protect these very files:
+        # apps/backend-rag/backend/tests/unit/kb/ holds nine suites that read
+        # kb/inventory/*.yaml directly (test_kb_inventory_contract,
+        # test_kb_topic_contract, test_kb_inventory_probe_topic, ...), and
+        # _suggested_jobs() never grants docs_content_data any of the six
+        # jobs. The precedent is data/ -- both backend_python and
+        # docs_content_data -- so the corpus keeps its own guard.
+        for path in (
+            "kb/inventory/immigration.yaml",
+            "kb/topics/immigration.yaml",
+            "kb/ops/probe_retrieval.py",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertFalse(result["run_all"])
+                self.assertEqual(result["unknown_paths"], [])
+                self.assertTrue(result["domains"]["backend_python"])
+                self.assertIn("backend-tests", result["suggested_jobs"])
+
+    def test_innocence_kb_does_not_drag_in_the_frontend_or_e2e_suites(
+        self,
+    ) -> None:
+        # The other half: kb/ is backend data, so widening it to the FRONTEND
+        # would trade one kind of waste for another. data/ reaches mouth only
+        # through an explicit filename rule (the KBLI canonical pins); nothing
+        # under kb/ is read by a frontend suite.
+        #
+        # e2e-tests is deliberately NOT asserted absent. It is granted by
+        # `backend_python` at _suggested_jobs()'s own last rule
+        # (`domains.intersection({"backend_python", "mouth", "packages_core"})`),
+        # so demanding the backend suite that guards this corpus necessarily
+        # brings e2e with it. This test's first draft asserted otherwise and
+        # was wrong about the code, not the other way round — recorded here so
+        # nobody "fixes" the rule to satisfy a mistaken expectation.
+        result = cm.classify(["kb/inventory/immigration.yaml"])
+        self.assertFalse(result["domains"]["mouth"])
+        self.assertFalse(result["domains"]["packages_core"])
+        self.assertNotIn("frontend-tests", result["suggested_jobs"])
+        self.assertNotIn("packages-core-tests", result["suggested_jobs"])
+        self.assertNotIn("mcp-tests", result["suggested_jobs"])
+
     def test_guilt_kbli_canonical_pin_inputs_also_run_frontend(self) -> None:
         # Red-team HIGH-9, 2026-08-14: apps/mouth/src/lib/
         # kbli-canonical-pins.test.ts is a REQUIRED frontend-tests suite (no


### PR DESCRIPTION
Second half of the CI-waste investigation ([#5676](https://github.com/Bali-Zero/Teman2/pull/5676) is the first). Different classifier, different bug, same symptom.

`kb/` landed 2026-08-25 (#4907/#4974) and was never added to `change_map.py`'s routing tables. Every file under it lands in `unknown_paths`, which trips the classifier's fail-open to `run_all=true`. Unlike #5676's crash, **this fail-open is working as designed** — an unrouted path *should* run everything. The defect is the coverage gap behind it.

Measured on PR #5662, whose entire diff is `kb/inventory/immigration.yaml`:

| check | duration |
|---|---|
| CodeQL Analysis (python) | 14m01s |
| CodeQL Analysis (javascript) | 3m40s |
| Snyk Node.js | 4m05s |
| Snyk Docker | 2m21s |
| Snyk Python | 53s |
| Bandit | 49s |
| Safety | 40s |

A full security sweep of a YAML data file.

## The obvious cure is wrong

Routing `kb/` to `docs_content_data` alone reads right — it *is* data, not code. But `_suggested_jobs()` grants that domain **none** of the six jobs, and nine suites under `apps/backend-rag/backend/tests/unit/kb/` read `kb/inventory/*.yaml` directly:

```
test_kb_inventory_contract.py      test_kb_topic_contract.py
test_kb_inventory_probe_topic.py   test_kb_probe_history_contract.py
test_legal_status_field_integrity_contract.py  ... and four more
```

The tidy fix would have switched off the corpus's own guard: a `kb/`-only PR could then break the inventory contract with nothing running to notice it. That is a worse defect than the one being cured — it trades visible waste for invisible risk.

So `kb/` takes **`data/`'s pairing**, `{backend_python, docs_content_data}`, where the `backend_python` half is load-bearing rather than symmetry.

## Bites

**Consumer: `scripts/ci/change_map.py`'s own guilt/innocence corpus** (`scripts/ci/test_change_map.py`), which `tests.yml` and `security.yml` both execute from a base-ref copy on every PR.

Before, classifying `kb/inventory/immigration.yaml`:

```
run_all: True   unknown_paths: ['kb/inventory/immigration.yaml']
jobs: [backend-tests, mcp-tests, evaluator-critical-tests,
       frontend-tests, packages-core-tests, e2e-tests]     # all six
```

After:

```
run_all: False  unknown_paths: []
jobs:       ['backend-tests', 'e2e-tests']
would_skip: ['mcp-tests', 'evaluator-critical-tests',
             'frontend-tests', 'packages-core-tests']
```

Corpus: **38 passed, 43 subtests** with the fix; **4 failed** with `change_map.py` stashed back to `main` — so both new tests genuinely bite.

## One note for the reader

The innocence test deliberately does **not** assert that `e2e-tests` is absent. `e2e` is granted by `backend_python` at `_suggested_jobs()`'s last rule (`domains.intersection({"backend_python", "mouth", "packages_core"})`), so demanding the suite that guards this corpus necessarily brings e2e with it. That test's first draft asserted otherwise and was wrong about the code, not the other way round. The comment records it so a later reader does not "fix" the rule to satisfy a mistaken expectation.

Frontend, packages-core and mcp **are** asserted absent — that is where the real innocence lies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ERaKVZvVgHRsPQJF7u5JB