### PR TITLE
fix(intel-scraper): the poller's sha lookup is an explicit GET, so updates carry a sha

### DIFF
--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -438,8 +438,13 @@ def _commit_to_branch(gh_path: str, content_b64: str, message: str, branch: str)
     """PUT one file to `branch` (create or update — resolves existing sha on that branch)."""
     existing_sha = ""
     try:
+        # `gh api` switches to POST as soon as a `-f` field is given; without
+        # an explicit GET the lookup answers Not Found, the PUT goes out with
+        # no `sha`, and GitHub rejects every update of an existing file with
+        # "Invalid request" (2026-09-04: SEO, layout and 2/4 translations).
         check = subprocess.run(
-            ["gh", "api", f"repos/{GITHUB_OWNER}/{GITHUB_REPO}/contents/{gh_path}",
+            ["gh", "api", "--method", "GET",
+             f"repos/{GITHUB_OWNER}/{GITHUB_REPO}/contents/{gh_path}",
              "-f", f"ref={branch}", "--jq", ".sha"],
             capture_output=True, text=True, timeout=15,
         )

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -990,3 +990,25 @@ def test_poller_targets_the_bali_zero_org_not_the_old_user_path() -> None:
     # create-ref / contents call fails; a whole SEO + layout batch was lost.
     assert ppp.GITHUB_OWNER == "Bali-Zero"
     assert ppp.GITHUB_REPO == "Teman2"
+
+
+def test_commit_to_branch_looks_up_the_existing_sha_with_an_explicit_get() -> None:
+    # 2026-09-04: `gh api … -f ref=<branch>` without --method GET is a POST,
+    # answers Not Found, and the PUT of an existing file then carries no sha
+    # ("gh: Invalid request" on SEO, layout and 2/4 translations).
+    calls: list[list[str]] = []
+    inputs: list[str] = []
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001
+        calls.append(list(cmd))
+        inputs.append(kwargs.get("input") or "")
+        return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+
+    with patch.object(ppp.subprocess, "run", side_effect=fake_run):
+        assert ppp._commit_to_branch("apps/x.mdx", "Zm9v", "msg", "bot/b") is True
+
+    lookup, put = calls[0], calls[1]
+    assert lookup[:4] == ["gh", "api", "--method", "GET"]
+    assert "ref=bot/b" in lookup
+    assert "PUT" in put
+    assert json.loads(inputs[1])["sha"] == "abc123"


### PR DESCRIPTION
## Why

First poller run after #5671 (org fix), Pro log 2026-09-04 22:57 WITA, KBLI 2025 article:

```
❌ gh failure (PUT …/indonesias-kbli-2025-….mdx@bot/seo-metadata-20260904-225735) rc=1: gh: Invalid request.
❌ gh failure (PUT apps/mouth/src/content/homepage-layout.json@bot/homepage-layout-…) rc=1: gh: Invalid request.
✅ staged → ….fr.mdx   ✅ staged → ….ru.mdx
❌ gh failure (PUT ….it.mdx@bot/articles-translations-…)   ❌ gh failure (PUT ….id.mdx@…)
```

Every file that already existed on the branch failed; every new file went through. Reproduced from M5: `gh api repos/…/contents/<path> -f ref=main --jq .sha` answers `Not Found` because `-f` turns the call into a POST; with `--method GET` it returns the sha. `_commit_to_branch` therefore sent the PUT without `sha`, which GitHub rejects for existing files.

## What

- The sha lookup in `_commit_to_branch` passes `--method GET`.
- Test: the lookup is a GET with `ref=<branch>` and the PUT payload carries the sha it returned.

## Verification

- `tests/unit/test_post_publish_poller.py`: 46 passed. ruff clean.

Bites: the Pro LaunchAgent `com.balizero.post-publish-poller` after `git pull` on `~/nuzantara` — observation: re-queuing the KBLI slug with `completed_steps='{}'` yields a run where the SEO, layout and it/id translation PUTs succeed and `bot/seo-metadata-…` + `bot/homepage-layout-…` PRs are opened and armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
