### PR TITLE
fix(ci): .claude/settings.json and hooks were unclassified — every hook PR paid the six heavy jobs

### DIFF
--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -66,6 +66,14 @@ EXACT_RULES: dict[str, set[str] | frozenset[str]] = {
     | {"infra_workflows", "security_sensitive"},
     "scripts/ci/change_map.py": {"infra_workflows", "security_sensitive"},
     "scripts/ci/test_change_map.py": {"infra_workflows", "security_sensitive"},
+    # Harness config, not app code — the six tests.yml jobs never read
+    # .claude/settings*.json, and it is verified by immune-enforcement.yml
+    # and the hook tests under scripts/tests/, not by tests.yml's jobs.
+    # Before this entry both fell into unknown_paths (run_all=True) — every
+    # hook/settings PR paid the full suite for a file none of the six jobs
+    # touch.
+    ".claude/settings.json": {"fleet_ops"},
+    ".claude/settings.local.json": {"fleet_ops"},
     "package.json": {
         "mouth",
         "admin_dashboard",
@@ -235,6 +243,13 @@ PREFIX_RULES: tuple[tuple[str, frozenset[str]], ...] = (
     (".husky/", frozenset({"infra_workflows", "security_sensitive"})),
     (".security/", frozenset({"infra_workflows", "security_sensitive"})),
     ("scripts/ci/", frozenset({"infra_workflows", "security_sensitive"})),
+    # More specific than the "infra/" catch-all below, so it must stay ahead
+    # of it in this tuple (first match wins). guard-conformance corpora are
+    # verified by guard-conformance.yml's own guilt+innocence run (cicatrix
+    # #3's own ESEGUIBILE), not by tests.yml's six product suites — before
+    # this entry, infra/guard-conformance/registry.json inherited the
+    # broad "infra/" rule and forced every one of the six jobs regardless.
+    ("infra/guard-conformance/", frozenset({"fleet_ops"})),
     ("infra/", frozenset({"infra_workflows", "security_sensitive"})),
     ("config/", frozenset({"infra_workflows", "security_sensitive"})),
     ("data/", frozenset({"backend_python", "docs_content_data"})),
@@ -277,6 +292,10 @@ PREFIX_RULES: tuple[tuple[str, frozenset[str]], ...] = (
     ("scripts/pro/", frozenset({"fleet_ops"})),
     ("scripts/review_routes/", frozenset({"fleet_ops"})),
     ("scripts/ruslana-node/", frozenset({"fleet_ops"})),
+    # Hook scripts, not app code — verified by their own corpus under
+    # scripts/tests/ (e.g. test_precommit_print_gate.sh) and by
+    # immune-enforcement.yml, never by the six tests.yml jobs.
+    (".claude/hooks/", frozenset({"fleet_ops"})),
 )
 
 DOC_PREFIXES = (

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -653,6 +653,72 @@ class ChangeMapTests(unittest.TestCase):
         self.assertFalse(result["run_all"])
         self.assertEqual(result["suggested_jobs"], ["backend-tests", "e2e-tests"])
 
+    def test_innocence_claude_settings_and_hooks_skip_every_test_job(self) -> None:
+        # Before this PR, .claude/settings.json, .claude/settings.local.json
+        # and .claude/hooks/*.py fell into unknown_paths (unmapped) and
+        # forced run_all=True — none of the six tests.yml jobs read the
+        # harness config or hook scripts; they are verified by
+        # immune-enforcement.yml and scripts/tests/ instead. (a) in the PR
+        # body's numbering.
+        for path in (
+            ".claude/settings.json",
+            ".claude/settings.local.json",
+            ".claude/hooks/x.py",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertFalse(result["run_all"])
+                self.assertEqual(result["reason"], "classified")
+                self.assertEqual(result["unknown_paths"], [])
+                self.assertTrue(result["domains"]["fleet_ops"])
+                self.assertEqual(result["suggested_jobs"], [])
+
+    def test_guilt_claude_settings_does_not_suppress_a_real_backend_change(
+        self,
+    ) -> None:
+        # (b) in the PR body's numbering: fleet_ops must not suppress the
+        # job set a co-changed backend_python path already earns.
+        result = cm.classify(
+            [".claude/settings.json", "apps/backend-rag/backend/app/main.py"]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["backend_python"])
+        self.assertIn("backend-tests", result["suggested_jobs"])
+
+    def test_innocence_guard_conformance_registry_skips_every_test_job(self) -> None:
+        # infra/guard-conformance/ is more specific than the "infra/"
+        # catch-all and must win — before this entry the registry inherited
+        # infra_workflows/security_sensitive and forced all six jobs, though
+        # guard-conformance.yml's own guilt+innocence run is what actually
+        # verifies it (cicatrix #3's ESEGUIBILE).
+        result = cm.classify(["infra/guard-conformance/registry.json"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["unknown_paths"], [])
+        self.assertTrue(result["domains"]["fleet_ops"])
+        self.assertFalse(result["domains"]["infra_workflows"])
+        self.assertEqual(result["suggested_jobs"], [])
+
+    def test_innocence_a_hooks_settings_only_pr_shape_skips_every_test_job(
+        self,
+    ) -> None:
+        # (c) in the PR body's numbering: the realistic PR #5681 shape (a
+        # per-prompt recall hook touching scripts/memory, scripts/hooks,
+        # scripts/tests, the guard-conformance registry, and the harness
+        # settings file) must classify cleanly with zero suggested jobs.
+        result = cm.classify(
+            [
+                "scripts/memory/mos_recall_sessionstart.py",
+                "scripts/hooks/organism_alert_sessionstart.sh",
+                "scripts/tests/test_memory_layers.py",
+                "infra/guard-conformance/registry.json",
+                ".claude/settings.json",
+            ]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["unknown_paths"], [])
+        self.assertTrue(result["domains"]["fleet_ops"])
+        self.assertEqual(result["suggested_jobs"], [])
+
     def test_cli_stdout_is_one_compact_json_line(self) -> None:
         script = Path(__file__).with_name("change_map.py")
         completed = subprocess.run(


### PR DESCRIPTION
## Why

Measured on `main` (post-#5679): `.claude/settings.json`, `.claude/settings.local.json` and `.claude/hooks/*.py` all fell into `unknown_paths` and forced `run_all=true` — none of the six `tests.yml` jobs read the harness config or hook scripts. `infra/guard-conformance/registry.json` was already "classified", but via the broad `"infra/"` `PREFIX_RULES` entry (`infra_workflows`+`security_sensitive`), which also forces all six jobs — it is actually verified by `guard-conformance.yml`'s own guilt+innocence run (cicatrix superscar #3's own `→ ESEGUIBILE`), not by `tests.yml`'s product suites. PR #5681 (a per-prompt recall hook touching `scripts/memory`, `scripts/hooks`, `scripts/tests`, `infra/guard-conformance/registry.json`, `.claude/settings.json`) would therefore still pay the full six-job suite for the settings file alone.

## What

- `EXACT_RULES` entries for `.claude/settings.json` and `.claude/settings.local.json` → `fleet_ops`.
- `PREFIX_RULES` entry for `.claude/hooks/` → `fleet_ops`.
- `PREFIX_RULES` entry for `infra/guard-conformance/` → `fleet_ops`, placed **ahead** of the `"infra/"` catch-all (first-match-wins) so the more specific prefix is the one that fires.
- All four routed to the existing zero-job `fleet_ops` domain rather than a new one — same semantics already used for `scripts/`'s uncoupled paths (#5679), and none of the four are documentation, so `docs_content_data` would be a worse fit.
- `test_change_map.py`: guilt+innocence for each path alone (no `unknown_paths`, zero suggested jobs), `.claude/settings.json` combined with a real `backend_python` change (must not suppress `backend-tests`), and the full PR #5681 file shape.

## Verification

```
$ python3 -m pytest -q scripts/ci/test_change_map.py
47 passed, 47 subtests passed in 0.65s

$ python3 scripts/ci/scripts_coupling_census.py --check
scripts_coupling_census: SCRIPTS_COUPLING is up to date.   (exit 0 — this PR does not touch the census block)

$ python3 scripts/evidence_pack_lint.py --print-floor --changed-files-file <this PR's 2 changed paths>
1
```

CLI output on this branch (pasted per the observation below):

```
.claude/settings.json alone                 -> run_all:false reason:classified unknown_paths:[] fleet_ops:true jobs:[]
.claude/settings.local.json alone           -> run_all:false reason:classified unknown_paths:[] fleet_ops:true jobs:[]
.claude/hooks/x.py alone                    -> run_all:false reason:classified unknown_paths:[] fleet_ops:true jobs:[]
infra/guard-conformance/registry.json alone -> run_all:false reason:classified unknown_paths:[] fleet_ops:true infra_workflows:false jobs:[]
.claude/settings.json + backend/app/main.py -> run_all:false backend_python:true jobs:["backend-tests","e2e-tests"]
full PR #5681 file shape (5 files)          -> run_all:false unknown_paths:[] fleet_ops:true jobs:[]
```

Churn: 85 insertions, 0 deletions across 2 files — well under the ~400 target.

## Bites

**Consumer**: `.github/workflows/tests.yml`'s "Change map" job. Dead until #5676 lands (nine-day extraction-list bug, unrelated to this PR — this PR touches no workflow file); bites the moment #5676's fix is in.

**Observation** (the CLI outputs above, captured on this branch — to be re-confirmed live once #5676 merges): the next PR shaped like #5681 gets a Change-map `::notice::` with `would_skip` naming all six jobs and `run_all:false`, instead of paying the full suite for `.claude/settings.json` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4