### PR TITLE
fix(memory): skip harness-envelope prompts and long pasted logs in per-prompt recall

### DIFF
--- a/scripts/memory/mos_recall_sessionstart.py
+++ b/scripts/memory/mos_recall_sessionstart.py
@@ -281,7 +281,7 @@ def build_context_query(cwd: str) -> str:
 
 def recall(memdir: str, cache_path: str, query: str, topk: int = DEFAULT_TOPK,
            threshold: float = DEFAULT_RELEVANCE_THRESHOLD, use_cache: bool = True,
-           scars_dir: str | None = None) -> tuple[list[dict], dict]:
+           scars_dir: str | None = None, min_overlap: int = 0) -> tuple[list[dict], dict]:
     index, idx_stats = build_or_refresh_index(memdir, cache_path, use_cache=use_cache)
     scar_count = 0
     if scars_dir:
@@ -293,15 +293,21 @@ def recall(memdir: str, cache_path: str, query: str, topk: int = DEFAULT_TOPK,
     scored = []
     for path, entry in index.items():
         rel = bm25_relevance(q_tokens, doc_tokens[path], df, n_docs, avgdl)
-        scored.append((recency_score(entry, now_ts) * importance_score(entry) * rel, rel, entry))
+        scored.append((recency_score(entry, now_ts) * importance_score(entry) * rel, rel, path, entry))
     scored.sort(key=lambda t: t[0], reverse=True)
     best_rel = scored[0][1] if scored else 0.0
+    # min_overlap (2026-09-04, per-prompt caller only — default 0 leaves every other
+    # caller unaffected): a long pasted-log query can clear the relevance floor on a
+    # single rare token's IDF alone, so also require the WINNING candidate to share at
+    # least this many distinct query terms with the caller's own text.
+    best_overlap = len(set(q_tokens) & set(doc_tokens[scored[0][2]])) if scored else 0
     stats = {**idx_stats, "scar_count": scar_count, "best_relevance": round(best_rel, 4),
-              "threshold": threshold, "query": query}
-    if best_rel < threshold:
+              "threshold": threshold, "query": query, "best_overlap": best_overlap,
+              "min_overlap": min_overlap}
+    if best_rel < threshold or best_overlap < min_overlap:
         return [], stats
     results = []
-    for _, _, e in scored[:topk]:
+    for _, _, _, e in scored[:topk]:
         r = {"filename": e["filename"], "description": e["description"]}
         if e.get("wnum"):
             r["wnum"] = e["wnum"]

--- a/scripts/memory/mos_recall_userprompt.py
+++ b/scripts/memory/mos_recall_userprompt.py
@@ -13,7 +13,19 @@ would be a quoting hazard as a CLI argv) with a STRICTER budget: top-3,
 analogue.
 
 Kill switch: CLAUDE_RECALL_PROMPT_DISABLED=1. Tunables (env):
-RECALL_PROMPT_MAX_BYTES, RECALL_PROMPT_MIN_RELEVANCE, RECALL_PROMPT_TOPK.
+RECALL_PROMPT_MAX_BYTES, RECALL_PROMPT_MIN_RELEVANCE, RECALL_PROMPT_TOPK,
+RECALL_PROMPT_MIN_OVERLAP.
+
+2026-09-04 follow-up (live observation, minutes after the first merge): the
+hook fired on a harness-generated turn, not a human one — a `"prompt"` that
+was itself a `[SYSTEM NOTIFICATION - NOT USER INPUT] …` envelope — and a
+long machine-generated block can clear the relevance floor on a single rare
+token's IDF alone. Three cures, all quiet-by-default: (1) an envelope-shape
+gate (`is_harness_envelope()`) recognizes the harness's own wrapper tags and
+never scores them; (2) the query text is capped at MAX_QUERY_CHARS before
+scoring, so a pasted log does not become a 400-term query; (3) `recall()`
+(in the sibling module) now also requires the WINNING candidate to share at
+least `min_overlap` distinct query terms, not just clear the score floor.
 
 Fail-open, same as the sibling: any error/malformed stdin -> silent exit 0;
 nothing on stderr ever (would surface as hook noise).
@@ -31,14 +43,29 @@ DEFAULT_MAX_BYTES = 600
 DEFAULT_MIN_RELEVANCE = 0.45  # higher than SessionStart's 0.35 — a per-turn hit must be more certain
 DEFAULT_TOPK = 3
 DEFAULT_CLAIM_MAX_CHARS = 110
+DEFAULT_MIN_OVERLAP = 2  # >=2 distinct query terms must land in the winning candidate
 MIN_PROMPT_CHARS = 12
 MIN_INFORMATIVE_TERMS = 2
 MIN_TERM_CHARS = 4
+# 1,200 chars is ~2 paragraphs / a long paste's opening — long enough that a genuine
+# question always fits inside it, short enough that a multi-KB pasted log or stack
+# trace does not turn into a 400-term query that can match anything by sheer volume.
+MAX_QUERY_CHARS = 1200
+NOT_USER_INPUT_MARKER = "NOT USER INPUT"
+NOT_USER_INPUT_SCAN_CHARS = 200  # harness envelopes carry this marker near the very top
+HARNESS_ENVELOPE_PREFIXES = (
+    "[SYSTEM NOTIFICATION",
+    "<task-notification",
+    "<teammate-message",
+    "<cross-session-message",
+    "<system-reminder",
+)
 HEADER = "🧠 recall:"
 KILL_SWITCH_ENV = "CLAUDE_RECALL_PROMPT_DISABLED"
 MAX_BYTES_ENV = "RECALL_PROMPT_MAX_BYTES"
 MIN_RELEVANCE_ENV = "RECALL_PROMPT_MIN_RELEVANCE"
 TOPK_ENV = "RECALL_PROMPT_TOPK"
+MIN_OVERLAP_ENV = "RECALL_PROMPT_MIN_OVERLAP"
 
 
 def _env_int(name: str, default: int) -> int:
@@ -62,6 +89,18 @@ def is_slash_or_bang(prompt: str) -> bool:
     return stripped.startswith("/") or stripped.startswith("!")
 
 
+def is_harness_envelope(prompt: str) -> bool:
+    """A harness-generated turn (background-task notification, teammate
+    relay, cross-session message, an injected system-reminder) is never a
+    human question — and its own machinery text ("staff activity log",
+    "keychain", scar numbers quoted verbatim in status text) makes it
+    lexically dense enough to clear the relevance floor by accident."""
+    stripped = prompt.lstrip()
+    if stripped.startswith(HARNESS_ENVELOPE_PREFIXES):
+        return True
+    return NOT_USER_INPUT_MARKER in prompt[:NOT_USER_INPUT_SCAN_CHARS]
+
+
 def has_enough_informative_terms(prompt: str, min_terms: int = MIN_INFORMATIVE_TERMS,
                                   min_chars: int = MIN_TERM_CHARS) -> bool:
     """Reuses mos.tokenize() (EN+IT stopwords, len>=2 already stripped) and
@@ -76,6 +115,8 @@ def should_run(prompt: str) -> bool:
         return False
     if is_slash_or_bang(prompt):
         return False
+    if is_harness_envelope(prompt):
+        return False
     if not has_enough_informative_terms(prompt):
         return False
     return True
@@ -83,14 +124,16 @@ def should_run(prompt: str) -> bool:
 
 def build_recall_output(prompt: str, cwd: str, max_bytes: int = DEFAULT_MAX_BYTES,
                          min_relevance: float = DEFAULT_MIN_RELEVANCE, topk: int = DEFAULT_TOPK,
-                         claim_max_chars: int = DEFAULT_CLAIM_MAX_CHARS) -> str:
+                         claim_max_chars: int = DEFAULT_CLAIM_MAX_CHARS,
+                         min_overlap: int = DEFAULT_MIN_OVERLAP) -> str:
     memdir = mos.resolve_memdir(cwd=cwd)
     if not memdir or not os.path.isdir(memdir):
         return ""  # not wired on this machine — same silent contract as the sibling
     cache_path = os.path.join(memdir, mos.CACHE_FILENAME)
     scars_dir = mos.resolve_scars_dir(cwd)
-    results, _stats = mos.recall(memdir, cache_path, prompt, topk=topk, threshold=min_relevance,
-                                  scars_dir=scars_dir)
+    query = prompt[:MAX_QUERY_CHARS]
+    results, _stats = mos.recall(memdir, cache_path, query, topk=topk, threshold=min_relevance,
+                                  scars_dir=scars_dir, min_overlap=min_overlap)
     if not results:
         return ""
     return mos.format_output(results, cap_bytes=max_bytes, header=HEADER, claim_max_chars=claim_max_chars)
@@ -116,6 +159,7 @@ def main() -> int:
             max_bytes=_env_int(MAX_BYTES_ENV, DEFAULT_MAX_BYTES),
             min_relevance=_env_float(MIN_RELEVANCE_ENV, DEFAULT_MIN_RELEVANCE),
             topk=_env_int(TOPK_ENV, DEFAULT_TOPK),
+            min_overlap=_env_int(MIN_OVERLAP_ENV, DEFAULT_MIN_OVERLAP),
         )
         if out:
             print(out)

--- a/scripts/tests/test_memory_recall_userprompt.py
+++ b/scripts/tests/test_memory_recall_userprompt.py
@@ -206,3 +206,95 @@ def test_is_slash_or_bang(prompt, expected):
 ])
 def test_has_enough_informative_terms(prompt, expected):
     assert mup.has_enough_informative_terms(prompt) == expected
+
+
+# --- 2026-09-04 follow-up: harness-envelope prompts and long pasted logs -----
+# Live observation, minutes after the first merge: the hook fired on a
+# background-task notification (not a human prompt) and emitted 3 weak hits
+# for ~350B — a staff activity log, an unrelated keychain note, W102. Cures:
+# an envelope-shape gate, a query-length cap, and a min_overlap floor.
+
+NOTIFICATION_SHAPED_PROMPT = (
+    "[SYSTEM NOTIFICATION - NOT USER INPUT] a background task has completed.\n"
+    "<task-notification>\n"
+    "  <task-id>keepalive-restart-storm-triage</task-id>\n"
+    "  <status>completed</status>\n"
+    "  <summary>plist KeepAlive nohup restart storm review finished, W501 W502"
+    " staff activity log keychain note reviewed, no action needed</summary>\n"
+    "</task-notification>"
+)
+
+
+@pytest.mark.parametrize("prefix", [
+    "[SYSTEM NOTIFICATION - NOT USER INPUT] task finished",
+    "<task-notification><status>done</status></task-notification>",
+    '<teammate-message teammate_id="team-lead" summary="status update">hello</teammate-message>',
+    '<cross-session-message from="worker">build finished</cross-session-message>',
+    "<system-reminder>background context injected here</system-reminder>",
+])
+def test_is_harness_envelope_true_for_every_wrapper_shape(prefix):
+    assert mup.is_harness_envelope(prefix)
+
+
+@pytest.mark.parametrize("prompt", [
+    "normal question about the merge queue and the cancelled check",
+    "il plist ha KeepAlive true e il servizio riparte in loop",
+])
+def test_is_harness_envelope_false_for_ordinary_prompts(prompt):
+    assert not mup.is_harness_envelope(prompt)
+
+
+def test_notification_shaped_prompt_is_silent_even_with_a_strong_lexical_match(tmp_path, monkeypatch, capsys):
+    """The notification text itself contains "plist KeepAlive nohup restart
+    storm" and the W501/W502 scar numbers verbatim — a relevance-only gate
+    would fire hard. The envelope gate must block it BEFORE scoring."""
+    memdir = tmp_path / "memdir_notif"
+    memdir.mkdir()
+    scars_dir = tmp_path / "scars_notif"
+    _write_scars_fixture(scars_dir)
+    rc, out = _run_main(monkeypatch, capsys, json.dumps({"prompt": NOTIFICATION_SHAPED_PROMPT}),
+                         memdir=memdir, scars_dir=scars_dir)
+    assert rc == 0 and out == ""
+
+
+def test_long_pasted_log_with_one_incidental_keepalive_is_silent(tmp_path, monkeypatch, capsys):
+    memdir = tmp_path / "memdir_log"
+    memdir.mkdir()
+    scars_dir = tmp_path / "scars_log"
+    _write_scars_fixture(scars_dir)
+    noise = " ".join(f"line{i} token{i} value{i}" for i in range(1, 400))  # ~5000 chars, no overlap
+    prompt = noise + " one incidental KeepAlive mention buried in the middle of this log " + noise
+    rc, out = _run_main(monkeypatch, capsys, json.dumps({"prompt": prompt}), memdir=memdir, scars_dir=scars_dir)
+    assert rc == 0 and out == ""
+
+
+def test_query_is_truncated_to_max_query_chars(monkeypatch, tmp_path):
+    memdir = tmp_path / "memdir_trunc"
+    memdir.mkdir()
+    captured = {}
+
+    def _spy_recall(memdir_, cache_path, query, **kwargs):
+        captured["query"] = query
+        return [], {}
+
+    monkeypatch.setattr(mup.mos, "resolve_memdir", lambda cwd=None, home=None: str(memdir))
+    monkeypatch.setattr(mup.mos, "resolve_scars_dir", lambda cwd=None: None)
+    monkeypatch.setattr(mup.mos, "recall", _spy_recall)
+    long_prompt = "x" * 5000
+    mup.build_recall_output(long_prompt, str(tmp_path))
+    assert len(captured["query"]) == mup.MAX_QUERY_CHARS
+
+
+def test_keepalive_scar_prompt_still_fires_after_the_follow_up_gates(tmp_path, monkeypatch, capsys):
+    """Regression pin: the original scar-shaped-prompt case (test 1 above)
+    must still clear every new gate (envelope shape, truncation, overlap)."""
+    memdir = tmp_path / "memdir_regress"
+    memdir.mkdir()
+    scars_dir = tmp_path / "scars_regress"
+    _write_scars_fixture(scars_dir)
+    prompt = "il plist ha KeepAlive true e il servizio riparte in loop"
+    rc, out = _run_main(monkeypatch, capsys, json.dumps({"prompt": prompt}), memdir=memdir, scars_dir=scars_dir)
+    assert rc == 0
+    assert out != ""
+    assert len(out.encode("utf-8")) <= mup.DEFAULT_MAX_BYTES
+    assert "W501" in out


### PR DESCRIPTION
## Why

Follow-up to #5681 (merged as part of `main` at 505358859b). Live observation in the team lead's session, minutes after the merge: the `UserPromptSubmit` recall hook fired on a harness-generated turn, not a human prompt — the `"prompt"` field was itself a `[SYSTEM NOTIFICATION - NOT USER INPUT] … <task-notification>` block — and emitted 3 weak hits (a staff activity log, an unrelated keychain note, W102) for ~350B. Two problems: noise cost on every background-task notification / teammate message, and a long machine-generated block clearing the 0.45 relevance floor on a single rare token's IDF alone.

## What

- **`is_harness_envelope()`** (new, `mos_recall_userprompt.py`) — quiet when the whitespace-stripped prompt starts with `[SYSTEM NOTIFICATION`, `<task-notification`, `<teammate-message`, `<cross-session-message`, or `<system-reminder`, or carries `NOT USER INPUT` in its first 200 chars. Wired into `should_run()` alongside the existing length/slash/informative-terms gates.
- **`MAX_QUERY_CHARS = 1200`** — prompts longer than that are scored on their first 1,200 chars only. Chosen because it's long enough that a genuine question always fits inside it (the repo's own prompts rarely exceed a few hundred chars), while short enough that a multi-KB pasted log or stack trace can't turn into a 400-term query that matches anything by sheer volume.
- **`min_overlap`** — `recall()` in `mos_recall_sessionstart.py` gains an opt-in parameter (default `0`, so SessionStart's own call path is byte-for-byte unaffected — verified via `test_memory_layers.py`'s 17 pre-existing tests, unchanged). When set, the WINNING candidate must share at least that many distinct query terms with its own indexed text, not just clear the relevance-score floor. The per-prompt hook passes it as `RECALL_PROMPT_MIN_OVERLAP` (env, default **2**).

Implemented in the shared engine (not duplicated in the per-prompt module) because computing "does the winning candidate actually share terms with the query" requires the same `doc_tokens`/BM25 internals `recall()` already builds — re-deriving them in `mos_recall_userprompt.py` would have meant rebuilding the index twice.

## Tests

11 new cases in `scripts/tests/test_memory_recall_userprompt.py` (43 total, up from 32):
- the exact `[SYSTEM NOTIFICATION - NOT USER INPUT] <task-notification>…` shape, WITH the W501/W502 scar numbers and "plist KeepAlive nohup restart storm" quoted verbatim inside it (to prove the envelope gate blocks it before scoring, not that it merely fails to match) → 0B.
- a 5,000-char pasted-log shape with one incidental "KeepAlive" mention → 0B (caught by `min_overlap`, since only 1 distinct term overlaps).
- a direct spy-based unit test asserting the query handed to `recall()` is truncated to exactly `MAX_QUERY_CHARS`.
- `is_harness_envelope()` parametrized true/false over all 5 wrapper shapes plus 2 ordinary prompts.
- a regression pin: the original KeepAlive scar-shaped prompt still fires and stays ≤600B after all three new gates.

## Verification run

- `python3 -m pytest -q scripts/tests/test_memory_recall_userprompt.py scripts/tests/test_memory_layers.py` → **43 passed** (11 new + 32 pre-existing, unchanged).
- `python3 infra/guard-conformance/check_guard_conformance.py` → `10 bridge guards, 19 hook entries, 7 wr2-pregate checks, 17 evidence-pack-lint checks, 6 required-workflow-conformance checks, 0 violation(s)`.
- `python3 scripts/context_budget_audit.py` → unchanged.
- Churn: `git diff --shortstat origin/main...HEAD` → 3 files changed, 151 insertions(+), 9 deletions(-) = 160 net lines.
- Live smoke against the real memory dir (CLAUDE_PROJECT_DIR = this worktree, falls back to the main worktree's memdir):

| prompt | bytes | wall time | result |
|---|---|---|---|
| `perché la PR è caduta dalla merge queue dopo il check cancellato` | 424 | ~0.088s | `[W126]` + `decision_merge_queue_batches_4_prs_...` |
| `plist KeepAlive nohup restart storm` | 438 | ~0.080s | `[W67]` + `[W67b]` |
| `ok` | 0 | ~0.018s | silent (length gate) |
| `[SYSTEM NOTIFICATION - NOT USER INPUT] <task-notification>…` (with W102/plist/KeepAlive/merge-queue text embedded) | **0** | ~0.018s | silent (envelope gate — fast, exits before scoring) |
| 5,000-char pasted log, one incidental "KeepAlive" | **0** | ~0.084s | silent (min_overlap gate — scores, then rejects) |

## Bites

**CONSUMER:** every Claude Code session in this repo on M5/Pro/Mini, via the `UserPromptSubmit` hook shipped in #5681 — this PR only changes the two Python modules it already calls, so no `.claude/settings.json`/registry change is needed.

**OBSERVATION:** the five live-smoke rows above — the two new negatives (notification envelope, pasted log) now correctly emit 0 bytes where the pre-fix hook (per the team lead's live report) emitted ~350B of weak hits.

This is also the first scripts-only PR after #5679/#5685 landed (touches only `scripts/memory/*` and `scripts/tests/*`, no `.claude/settings.json`/hooks/workflow files) — the `tests.yml` Change-map job's `::notice::` on this PR should show `run_all:false` with the six heavy jobs in `would_skip`, as the observation that #5679 bites on a real PR:

`<PASTE THE ::notice:: LINE HERE ONCE THE tests.yml CHANGE-MAP JOB RUNS ON THIS PR>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4