### PR TITLE
fix(ci): the census staleness test broke the trusted-classifier corpus — every PR since #5679 ran all six heavy jobs

### DIFF
--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -619,8 +620,27 @@ class ChangeMapTests(unittest.TestCase):
         # extraction list, and it has no business there (it shells out to
         # `git grep` and writes files). --check re-derives SCRIPTS_COUPLING
         # live and exits 1 on drift (cicatrix #9).
-        repo_root = Path(__file__).resolve().parents[2]
-        census = repo_root / "scripts" / "ci" / "scripts_coupling_census.py"
+        # Locate the census in the CHECKOUT, never relative to __file__:
+        # tests.yml extracts this test FLAT into $RUNNER_TEMP/trusted-classifier/
+        # (no scripts/ci/ above it), where parents[2] resolved to /home/runner/work,
+        # the subprocess 404'd, this assertion failed, and the classify step fell
+        # to run_all=true (enumeration_failed) on EVERY PR from #5679 (2026-09-04)
+        # until this fix — the same disease #5676 cured for security_gate_flags.
+        rel = Path("scripts") / "ci" / "scripts_coupling_census.py"
+        workspace = os.environ.get("GITHUB_WORKSPACE")
+        file_root = Path(__file__).resolve()
+        candidates = [Path.cwd()]
+        if workspace:
+            candidates.append(Path(workspace))
+        if len(file_root.parents) > 2:
+            candidates.append(file_root.parents[2])
+        repo_root = next((c for c in candidates if (c / rel).is_file()), None)
+        if repo_root is None:
+            self.skipTest(
+                "scripts_coupling_census.py not reachable from cwd, GITHUB_WORKSPACE "
+                "or __file__ — staleness is asserted where the checkout is present"
+            )
+        census = repo_root / rel
         completed = subprocess.run(
             [sys.executable, str(census), "--check"],
             cwd=repo_root,


### PR DESCRIPTION
## Why

Since #5679 landed (14:59Z today) every PR's `tests.yml` "Change map" job has reported `run_all=true, reason=enumeration_failed, changed_file_count=0`: #5677, #5678, #5679, #5680, #5681, #5685, #5690 — all paid Playwright, Frontend, three backend shards and Visa Oracle regardless of diff. #5676 (merged 15:32Z) was not the cause and is holding: no `security_gate_flags` error in the logs.

## Cause (mine, from #5679)

`test_scripts_coupling_census_is_not_stale` resolved the census script as `Path(__file__).resolve().parents[2] / scripts/ci/…`. `tests.yml` extracts `test_change_map.py` **flat** into `$RUNNER_TEMP/trusted-classifier/` (no `scripts/ci/` above it), so `parents[2]` was `/home/runner/work`, the subprocess could not open the file, the assertion failed, the corpus step went red, and the classify step's fail-closed fallback wrote the `ENUMERATION_ERROR` sentinel → all jobs. Job log line, PR #5690:

```
stderr: /usr/bin/python3: can't open file '/home/runner/work/scripts/ci/scripts_coupling_census.py': [Errno 2] No such file or directory
```

The same disease #5676 cured one PR earlier for a different file: the corpus that decides trust ran in a layout the test author never executed. Cicatrix #9 (state/layout drift) meets #2 (the job stayed green — `continue-on-error` — while the recommendation silently degraded to run-all).

## Fix (script-only, floor 1)

The test locates the census in the **checkout**: `cwd`, then `GITHUB_WORKSPACE`, then `__file__`-relative as before; it skips with a named reason only when no checkout is reachable. Semantics are the intended ones: the PR head's census is checked against the PR head's embedded block.

Guilt + innocence, both layouts, run locally:
- flat copy of the six extracted files, old test → `FAILED (failures=1)`;
- flat copy, new test → `OK`;
- repo layout, new test → `OK` (47 tests).

## Bites:

Consumer: `tests.yml` "Change map" job — it extracts this file from the **base ref**, so this PR's own run still shows `enumeration_failed` by design. Observation: the first PR opened after this merges must show a Change map annotation with `reason=classified` and, for a scripts-only diff, `run_all:false` with the six jobs in `would_skip`; I append that annotation here as a comment when observed (candidate: a rebase of #5690, scripts-only).

Second, independent defect seen in the same log, not fixed here because it lives in the workflow (hot zone): the "Test-impact map" step's `python3 -c` one-liner uses backslash-escaped quotes inside an f-string expression → `SyntaxError` on Python < 3.12. Flagged for the Gear-3 workflow PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4
