### PR TITLE
chore(ci): re-snapshot required contexts — the Merah Putih guard is now required

### DIFF
--- a/infra/required.d/contexts.json
+++ b/infra/required.d/contexts.json
@@ -1,6 +1,6 @@
 {
   "_doc": "Advisory snapshot of main's required-status-check contexts (Merge-OS v2 Wave 0, research/operations/2026-08-10-merge-os-v2-submission-system.md §4). Read by scripts/ci/check_required_workflow_conformance.py. Drift vs live branch protection is expected and cured by REGEN, never hand-edit — see regen_command below.",
-  "generated_at": "2026-08-27",
+  "generated_at": "2026-09-05",
   "source": "api",
   "derived_from_pr": null,
   "repo": "Bali-Zero/Teman2",
@@ -56,10 +56,22 @@
       "job_id": "harness-floor"
     },
     {
+      "name": "Merah Putih DAY palette holds its contrast law",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/merah-putih-day-contrast.yml",
+      "job_id": "contrast-guard"
+    },
+    {
       "name": "R1 gate — adversarial review present",
       "app_id": null,
       "workflow_file": ".github/workflows/adversarial-review-gate.yml",
       "job_id": "gate"
+    },
+    {
+      "name": "Visa Oracle fullstack smoke",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/tests.yml",
+      "job_id": "visa-oracle-fullstack-smoke"
     },
     {
       "name": "actionlint — workflow schema + expression gate",


### PR DESCRIPTION
The promotion #5614's header spelled out in three ordered steps is complete.
(1) The required shape landed on `main` with #5666 (e91a7df061): `pull_request:`
with no top-level `paths:`, `merge_group:`, and a sentinel that reads the guarded
list out of the workflow's own `push.paths`. (2) A real `merge_group` run was
observed before touching protection — run 33893659676 on
`gh-readonly-queue/main/pr-5691-…`, job "Merah Putih DAY palette holds its
contrast law", success in 50s, with its own annotation `non-PR event
(merge_group) — running the full guard`. (3) Only then was the context added to
branch protection, which now requires 13 contexts.

This commit is step (3)'s MIRROR, not the lever: `infra/required.d/contexts.json`
is a GENERATED snapshot (`scripts/ci/snapshot_required_contexts.py`), so it is
regenerated, never hand-edited. It had been stale since 2026-08-27 at 11 entries
while live protection carried 12 — "Visa Oracle fullstack smoke" (app_id 15368)
had been added to protection and never re-snapshotted, which is why this diff
carries two contexts and not one.

Not done here, and stated rather than discovered later: adding a required
context makes every open PR whose last run predates the trigger BLOCKED until it
is pushed. Measured with `scripts/ci/check_promotion_readiness.py --context
"Merah Putih DAY palette holds its contrast law"`: of 30 open PRs examined, 8
already report the context (PASS) and 22 do not (ABSENT). The 22 are PRs whose
head predates #5614's `pull_request:` trigger; a push or a reopen starts the
check and clears them. That instrument is advisory — its workflow executes its
corpus, not the instrument — so this is a reported cost, not an overridden gate.

Bites: consumer is the REQUIRED `antidotes` job in
`.github/workflows/immune-enforcement.yml`, which runs
`scripts/tests/test_check_required_workflow_conformance.py` against this file.
Observation: `python3 scripts/ci/check_required_workflow_conformance.py` reports
"13 required context(s) checked, 0 violation(s)" here where it reported 11
before, and the 37-test corpus passes. Second observation on this very PR: its
own check rollup must list "Merah Putih DAY palette holds its contrast law" as a
required context — the first PR opened after the promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BtRLGhgeDNBmP3XQs7Z1y