### PR TITLE
docs(research): measure PR cycle-time on Bali-Zero/Teman2 and rank levers to cut it

### DIFF
--- a/evidence/2026-09/agent-air-m5-docs-pr-cycle-time-8ffcafa5/brief.yml
+++ b/evidence/2026-09/agent-air-m5-docs-pr-cycle-time-8ffcafa5/brief.yml
@@ -1,0 +1,56 @@
+task_id: pr-cycle-time-diet-0905
+gear: 2
+l_level: L2
+gate_class: opus
+objective: |
+  Deep-research capture ordered by Zero, 2026-09-04/05: "studia come diminuire drasticamente il
+  tempo delle PR". Not a re-summary of the 2026-09-04 evening numbers (110-114 CPU-min,
+  15-17 min wall, 12 required contexts on a single 3-file PR) — a fresh, independent
+  `gh api`/GraphQL measurement of the last 30 merged PRs on Bali-Zero/Teman2 (both `pull_request`
+  and `merge_group` runs, per-job timing, live merge-queue config introspection), cross-checked
+  against the evening numbers, plus SOTA sourcing (GitHub merge-queue/status-check docs,
+  Nx/Turborepo affected-testing, CodeQL cadence/caching, flaky-test quarantine) and a ranked
+  levers plan with three empirically-grounded targets for a trivial PR (certain/base/stretch).
+
+  Central finding: the entire 30-PR sample fell inside a now-closed window (2026-09-04
+  14:59-16:25Z) where tests.yml's change-map classifier was broken (#5679 introduced a second
+  corpus-staleness bug on top of the first, both since fixed by #5692) — so every measured number
+  in this report, including three PRs that touched only `.md` files, reflects the CI system's
+  worst case (`run_all=True` fail-open), not its designed steady state. This PR itself
+  (research-only) is the first PR created against a base carrying the #5692 fix, and its own CI
+  run is offered as the live falsification test for the report's central claim (§2 of the main
+  file) — the observation goes in the PR's Bites section, not the file, since the file predates
+  the run.
+
+  STUDY-ONLY: no CI/workflow file is touched. Every lever (L1-L9) is a recommendation, ranked and
+  scoped (Gear, decider: session vs Zero), not executed.
+
+  Gear 2 by SIZE: 2 new markdown files, +473 net lines, no code, no `.github/workflows/` touch
+  (so no hot-zone floor 3 — the report is ABOUT workflow files, it does not edit any), no
+  consumer surface.
+constraints:
+  - "Docs-only diff: research/operations/2026-09-05-pr-cycle-time-diet.md and its
+    -lane-measurements.md sibling, plus this evidence dir. No `.github/workflows/*` edit — every
+    number about CI behavior comes from `gh api`/GraphQL read calls executed live in this
+    session, and every code-reading claim (change_map.py, security.yml, tests.yml) cites the
+    exact lines read this turn."
+  - "Anti-hallucination: every PR-title quote (#5676, #5679, #5692) and every merge-queue config
+    value (checkResponseTimeout, mergingStrategy, etc.) was fetched live via `gh api`/`gh api
+    graphql` in this session, not recalled from the team lead's earlier brief. The two GitHub
+    Docs page fetches that 404'd (managing-a-merge-queue) are flagged as unreached, not
+    silently treated as confirming the inference built on the GraphQL enum text alone."
+  - "Generator != grader: the synthesis author is the conducting Claude session; the adversarial
+    review seat is codex (GPT-5, `codex exec --sandbox read-only`), dispatched on the full draft
+    with a red-team prompt. First pass returned BLOCK with 10 findings (1 blocker on the
+    per-PR/per-batch merge_group attribution, 9 major on arithmetic/enumeration/overclaim); every
+    finding was checked against the raw JSON in the scratchpad (not just reworded) — one was
+    rebutted with a new direct check (zero shared head_sha across PR-tagged merge_group runs)
+    and logged as such, the other nine produced real data/text corrections, all dispositioned in
+    the main file's Adversarial review section with the exact fix."
+acceptance:
+  - "Report exists at research/operations/2026-09-05-pr-cycle-time-diet.md with frontmatter
+    (date/domain/client_case/sources/adversarial_review) per research/CLAUDE.md §15."
+  - "The raw-measurement sibling sits beside it with the -lane-measurements suffix, and every
+    number the main file cites traces to a table in the sibling."
+  - "R1 gate satisfied: adversarial_review seat declared (codex), ## Adversarial review section
+    present with all 10 findings dispositioned against verifiable data, not reworded prose."

--- a/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
+++ b/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
@@ -2,7 +2,7 @@
 date: 2026-09-05
 domain: operations
 client_case: none — internal PR-cycle-time study, raw measurement lane (sibling of 2026-09-05-pr-cycle-time-diet.md)
-adversarial_review: none (raw data lane; the review sits on the main file)
+adversarial_review: codex  # same seat as the main file — its 10 findings were dispositioned against these tables
 sources: gh api (repos/Bali-Zero/Teman2), GraphQL mergeQueue introspection — all fetched live in this session, 2026-09-04/05
 ---
 

--- a/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
+++ b/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
@@ -244,3 +244,7 @@ rate — but it confirms the gate mechanism itself works exactly as designed whe
   read off the number, not confirmed from billing/runner-group config).
 - The single-digit-percent share of PRs that used an admin merge override (excluded from the
   sample by construction — merge-queue behavior only applies to queue-routed merges).
+
+## Adversarial review
+
+Seat: codex (GPT-5, `codex exec --sandbox read-only`), one round on the main report. Nine of its ten findings were arithmetic or attribution errors that were checked and corrected against the tables in THIS file (off-by-ones in job counts, a 5-vs-6 heavy-job enumeration, totals that did not reconcile, a wrong "same commit" claim); the tenth (HEADGREEN causality) was rebutted by a direct check on `merge_group` head SHAs, also recorded here. Dispositions, one per finding, live in the main report's `## Adversarial review`; this lane holds the raw rows they were verified against and carries no independent narrative to review.

--- a/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
+++ b/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
@@ -2,7 +2,7 @@
 date: 2026-09-05
 domain: operations
 client_case: none — internal PR-cycle-time study, raw measurement lane (sibling of 2026-09-05-pr-cycle-time-diet.md)
-adversarial_review: codex  # same seat as the main file — its 10 findings were dispositioned against these tables
+adversarial_review: codex
 sources: gh api (repos/Bali-Zero/Teman2), GraphQL mergeQueue introspection — all fetched live in this session, 2026-09-04/05
 ---
 

--- a/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
+++ b/research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md
@@ -1,0 +1,246 @@
+---
+date: 2026-09-05
+domain: operations
+client_case: none — internal PR-cycle-time study, raw measurement lane (sibling of 2026-09-05-pr-cycle-time-diet.md)
+adversarial_review: none (raw data lane; the review sits on the main file)
+sources: gh api (repos/Bali-Zero/Teman2), GraphQL mergeQueue introspection — all fetched live in this session, 2026-09-04/05
+---
+
+# PR cycle-time — raw measurement lane
+
+> Companion to `2026-09-05-pr-cycle-time-diet.md`. This file is the evidence: every number in the
+> main report's §1 traces back to a table here. Method in one line: 30 most-recently-merged PRs on
+> `Bali-Zero/Teman2` (all merged 2026-09-04, 08:21–15:35 UTC, a 7h14m window — this was a
+> high-velocity day, not a representative week; treat medians as this-session, not annual, truth),
+> `gh api repos/Bali-Zero/Teman2/actions/runs?head_sha=<PR head SHA>` per PR for `pull_request`
+> runs (bypasses the Actions-runs-list 1000-item cap that a plain `event=pull_request&created=...`
+> query hits — verified live: total_count 3054 for the window, only the newest ~700 fit in 1000
+> paginated rows, and worse, the `pull_requests[]` field GitHub attaches to a run is *cleared once
+> the PR merges or closes* — so matching old runs to old PRs by that field silently loses most of
+> the sample. `head_sha` filtering sidesteps both). `merge_group` runs matched by parsing the PR
+> number out of `head_branch` (`gh-readonly-queue/main/pr-<n>-<sha>`) — GitHub does not expose a
+> `pull_requests[]` link for merge-group runs. Job-level timing (`actions/runs/{id}/jobs`) fetched
+> only for the two multi-job workflows that contain the required checks (`Tests & Coverage`,
+> `Security Scanning`); every other workflow's job IS the run, so run-level `created_at` /
+> `run_started_at` / `updated_at` stand in for queue-wait / duration without an extra call per run.
+> Total API calls: ~30 (PR metadata) + ~30 (head SHA) + ~30 (PR-event runs) + 30+39 (TC jobs) +
+> 30+39 (Security jobs) ≈ 228, well inside the 5000/hr authenticated budget (0 used before this
+> session per `gh api rate_limit`).
+>
+> **Per-PR vs per-batch attribution, checked not assumed.** `merge_group` batches up to 5 queue
+> entries (`maximumEntriesToBuild: 5`, §5) into one merge attempt, raising the question of whether
+> the `pr-<n>-<sha>` in a run's `head_branch` names the WHOLE batch (in which case matching by
+> that number would misattribute a shared batch's runs to one PR) or one temporary ref per queue
+> entry. Checked directly: across all 487 matched `merge_group` runs, zero `head_sha` values are
+> shared across two different `pr_number` values — every entry has its own unique temporary
+> commit. Consistent with GitHub's documented cumulative-batch build (entry N's temp branch
+> contains entries 1..N but is still built and reported under entry N's own PR number) — per-PR
+> attribution below is exact, not inferred.
+
+## 1. Sample
+
+30 PRs, numbers 5648–5685 (not contiguous — 5661, 5664–5666, 5669, 5673, 5675, 5682 are excluded:
+either not merged or fell outside the most-recent-30 window). Every PR in the sample went through
+the required-checks gate and the merge queue; none was an admin override.
+
+## 2. Open → merge wall time, per PR (minutes)
+
+| PR | wall (min) | PR | wall (min) | PR | wall (min) |
+|---|---|---|---|---|---|
+| 5680 | 28.3 | 5670 | 35.1 | 5654 | 48.6 |
+| 5658 | 29.5 | 5662 | 35.3 | 5649 | 50.5 |
+| 5677 | 31.1 | 5667 | 37.1 | 5652 | 54.9 |
+| 5663 | 31.2 | 5679 | 37.2 | 5657 | 61.0 |
+| 5683 | 31.4 | 5681 | 39.2 | 5674 | 67.8 |
+| 5685 | 31.5 | 5659 | 44.2 | 5651 | 83.0 |
+| 5671 | 31.8 | 5648 | 44.5 | 5676 | 116.4 |
+| 5668 | 31.9 | | | 5650 | 123.5 |
+| 5656 | 33.0 | | | 5653 | 173.1 |
+| 5684 | 33.2 | | | | |
+| 5672 | 33.7 | | | | |
+| 5678 | 33.7 | | | | |
+| 5655 | 34.2 | | | | |
+| 5660 | 34.4 | | | | |
+
+**median 35.2 min · mean 50.0 min · min 28.3 (#5680) · max 173.1 (#5653).** Six PRs exceed 60
+min (#5657, #5674, #5651, #5676, #5650, #5653); §5 shows only 4 of those 6 are explained by a
+merge-queue requeue (#5674, #5651, #5650, #5653) — #5657 and #5676 are not.
+
+## 3. Top-15 jobs by total minutes, `pull_request` event (30 PRs)
+
+| job | total min | median dur (min) | median queue (s) | n |
+|---|---|---|---|---|
+| CodeQL Analysis (python) | 363.3 | 13.69 | 70 | 30 |
+| Frontend Tests (Next.js) (mouth, true) | 281.3 | 7.81 | 68 | 30 |
+| E2E Tests (Playwright) | 257.4 | 7.57 | 70 | 30 |
+| Backend Shard 2 | 185.2 | 5.60 | 68 | 30 |
+| Visa Oracle fullstack smoke | 173.1 | 6.03 | 71 | 30 |
+| Backend Shard 3 | 167.0 | 5.09 | 68 | 30 |
+| Backend Shard 1 | 162.9 | 5.36 | 68 | 30 |
+| npm audit (advisory) | 149.0 | 2.40 | 69 | 30 |
+| Backend Static (Python) | 104.1 | 3.28 | 70 | 30 |
+| Immune enforcement (superscar antidotes) | 91.5 | 2.02 | 0 | 30 |
+| SAST — Bandit + ESLint Security | 89.6 | 1.77 | 0 | 22 |
+| Snyk Node.js Security | 74.8 | 1.87 | 70 | 30 |
+| CodeQL Analysis (javascript) | 70.2 | 3.17 | 71 | 30 |
+| Snyk Docker Security | 68.2 | 2.31 | 70 | 30 |
+| Frontend Tests (Next.js) (admin-dashboard, false) | 65.9 | 1.57 | 70 | 30 |
+
+"queue" = job `started_at` − run `created_at`; for `needs:`-gated jobs (e.g. a fan-in summary
+after three shards) this also absorbs upstream wait, so it over-states pure runner-allocation
+delay for those specific jobs — noted, not corrected, because the jobs it affects (Test Summary,
+Backend Tests (Python) as a context) are not in this top-15 by duration.
+
+Total `pull_request`-event runner-minutes across all jobs, 30 PRs: **3320.7**, mean **110.7
+min/PR** — matches the 110–114 CPU-minutes the team lead measured on 2026-09-04 evening on a
+different (3-file scripts-only) PR to within rounding. Cross-validates the method.
+
+## 4. Same, `merge_group` event (matched to the 30 PRs by branch-name PR number)
+
+39 matched runs per workflow (not 30 — see §5: nine PRs re-entered the queue).
+
+| job | total min | median dur (min) | n |
+|---|---|---|---|
+| CodeQL Analysis (python) | 515.9 | 14.78 | 39 |
+| Frontend Tests (Next.js) (mouth, true) | 394.6 | 8.60 | 39 |
+| E2E Tests (Playwright) | 344.6 | 7.32 | 39 |
+| Backend Shard 2 | 307.8 | 7.12 | 39 |
+| Backend Shard 1 | 298.4 | 7.38 | 39 |
+| Backend Shard 3 | 276.6 | 6.72 | 39 |
+| Immune enforcement (superscar antidotes) | 248.1 | 6.50 | 39 |
+| npm audit (advisory) | 200.1 | 5.63 | 39 |
+| Visa Oracle fullstack smoke | 195.3 | 3.90 | 39 |
+| Backend Static (Python) | 145.1 | 3.25 | 39 |
+| Detect Secrets | 118.3 | 2.88 | 39 |
+| Frontend Tests (Next.js) (admin-dashboard, false) | 117.2 | 1.78 | 39 |
+| CodeQL Analysis (javascript) | 106.6 | 4.02 | 39 |
+| Snyk Docker Security | 92.6 | 2.32 | 39 |
+| Snyk Node.js Security | 91.8 | 1.83 | 39 |
+
+Total `merge_group`-event runner-minutes: **4090.1**, mean **136.3 min/PR** — the re-run in the
+merge queue costs *more* CPU than the original PR check run (110.7). Combined CI cost per merged
+PR in this sample: **≈247 runner-minutes**, and roughly half of it (136.3/247 = 55%) is the
+re-run that happens *after* the PR already went green once.
+
+## 5. Merge-queue requeue (`mergingStrategy: ALLGREEN`)
+
+Live GraphQL introspection of `repository.mergeQueue.configuration`
+(`Bali-Zero/Teman2`, fetched this session):
+
+| field | value |
+|---|---|
+| `checkResponseTimeout` | 5400 s (90 min) |
+| `maximumEntriesToBuild` | 5 |
+| `maximumEntriesToMerge` | 4 |
+| `minimumEntriesToMerge` | 4 |
+| `minimumEntriesToMergeWaitTime` | 900 s (15 min) |
+| `mergingStrategy` | `ALLGREEN` |
+| `mergeMethod` | `SQUASH` |
+
+`ALLGREEN` enum description (fetched live): *"Entries only allowed to merge if they are
+passing."* The alternative, `HEADGREEN`: *"Failing Entries are allowed to merge if they are with
+a passing entry."* GitHub's own text is the only documentation of the mechanism reached in this
+session (the dedicated `managing-a-merge-queue` doc page 404'd on fetch, twice, from two
+different URL guesses) — read the two enum strings as read, not expanded into "avoids cancelling
+N others", which this session cannot verify without the doc page or a controlled reproduction.
+
+9 of 30 PRs (30%) have **two** `Tests & Coverage` `merge_group` runs instead of one. Full
+sequence, not a sample:
+
+| PR | 1st MG run | 2nd MG run | PR's own wall time (min) |
+|---|---|---|---|
+| 5648 | cancelled (08:46) | success (08:49) | 44.5 |
+| 5650 | cancelled (09:05) | cancelled (10:21) | 123.5 |
+| 5651 | cancelled (09:32) | success (09:40) | 83.0 |
+| 5652 | success (09:05) | cancelled (09:23) | 54.9 |
+| 5653 | cancelled (10:49) | success (11:41) | 173.1 |
+| 5654 | success (09:25) | cancelled (09:40) | 48.6 |
+| 5657 | success (10:56) | cancelled (11:06) | 61.0 |
+| 5659 | success (10:53) | cancelled (11:06) | 44.2 |
+| 5674 | cancelled (13:52) | success (14:15) | 67.8 |
+
+The pattern is NOT uniform, and the report's main file does not claim it is: 5 of the 9
+(5648, 5650, 5651, 5653, 5674) show `cancelled` before `success` or `cancelled`, consistent with
+a batch that failed and blocked this PR's own merge until a later attempt — these five include
+4 of the 6 PRs whose open→merge time exceeds 60 minutes (5650, 5651, 5653, 5674). The other 4
+(5652, 5654, 5657, 5659) show `success` FIRST and `cancelled` SECOND — the PR already merged via
+the successful entry, and the later `cancelled` run is a leftover duplicate from a batch the PR
+was still nominally part of; it did not add wall time. PR 5650's two entries are both
+`cancelled` — its 123.5 min implies at least one more attempt this query did not capture (either
+a third `merge_group` run outside the matched set, or a manual re-queue); not resolved in this
+session. The two outliers NOT explained by this table at all are 5657 (61.0 min, but its own
+requeue happened AFTER its success, so cannot be the cause) and 5676 (116.4 min, only one
+`Tests & Coverage` `merge_group` entry — its delay has a different, unidentified source).
+
+`minimumEntriesToMerge: 4` with `minimumEntriesToMergeWaitTime: 900s`: the queue waits for a
+total of 4 entries (the arriving PR counts as one of the 4) before batching. A PR that arrives
+when fewer than 3 OTHERS are already queued (so the running total is below 4) can wait up to
+**15 minutes** for company before GitHub gives up and starts the batch anyway — a fixed tax with
+no relationship to the PR's own diff size, paid disproportionately by whoever is *not* shipping
+in a burst.
+
+## 6. Jobs finishing under 90 s (runner-spin-up dominated), `pull_request` event
+
+53 of 72 distinct job names had a median duration under 90 seconds — the majority of the 12
+required contexts included. Fastest cluster (4–7 s): `Security Summary`, `Test Summary`,
+`SonarQube Analysis` (these are fan-in/summary steps, not real work). Most sentinel/lint/guard
+jobs (`Root Guard`, `actionlint`, `Docs Guardian`, `Harness floor recompute`, `token-lint`, ~40
+more) land in the 29–45 s band — almost entirely checkout + runner cold-start, since the guard
+logic itself is a few hundred milliseconds of Python/bash.
+
+## 7. Cancelled / failed, `pull_request` event vs `merge_group` event
+
+| | success | skipped | cancelled | failure |
+|---|---|---|---|---|
+| `pull_request` (1862 records) | 1802 | 50 | 7 | 3 |
+| `merge_group` (1384 records) | 1299 | 59 | 12 | 14 |
+
+`merge_group` has a visibly higher failure rate (14 vs 3) and cancellation rate (12 vs 7) than
+the `pull_request` run of the same PR. The two runs are not the same commit: `pull_request`
+builds the PR's own head SHA, `merge_group` builds a temporary merge of that PR against the
+current queue state (§1 methodology note) — so a `merge_group` failure can be a genuine
+integration break the PR-run could never have seen, not necessarily a repeat of the same check.
+This session did not read individual job logs to classify cause (§10 limit), so neither "flaky"
+nor "genuine regression" is asserted here — only the raw rate difference and, from §5, that at
+least some of the `cancelled` entries are the whole-batch-cancel side effect of ANOTHER queue
+member's failure, not this PR's own.
+
+## 8. Checks per PR and which one is slowest
+
+Median 62 required+advisory checks per PR (range 57–67) by this session's run-level counting
+(each non-multi-job workflow = 1; `Tests & Coverage` and `Security Scanning` sub-jobs counted
+individually). The team lead's 2026-09-04 evening measurement on a different PR read 72–75 via
+`gh pr checks`, which also counts re-run/duplicate entries from `merge_group` — same phenomenon,
+different counting rule; not a contradiction.
+
+Single slowest `pull_request`-event job, per PR — **CodeQL Analysis (python) is the slowest
+check on 19 of 30 PRs (63%)**, Frontend Tests (mouth) on 7/30, E2E Tests on 3/30, one Backend
+Shard on 1/30. Median share of total PR wall time held by that one slowest job: **34%** (min 8%
+on the PR that also hit a 15 s CodeQL fast-path plus a long human-review gap, max 46%).
+
+## 9. CodeQL path-gating: measured effectiveness
+
+`security.yml`'s `codeql` job runs unconditionally (job-level `if: ${{ !cancelled() }}`, no path
+filter — deliberately, per the in-file comment: a job-level path skip would collapse the matrix
+and leave `CodeQL Analysis (python)`/`(javascript)` as required contexts that never report,
+which is worse than running them). The *expensive* steps (Initialize/Autobuild/Analyze) are
+gated per-language by a step-level `if: env.RUN_THIS_LANGUAGE == 'true'`, fed by the same
+change-map classifier as the test-impact system.
+
+Measured on this sample: 3 of 30 PRs (10%) finished `CodeQL Analysis (python)` in under 45
+seconds (gate held, no Python touched); the other 27 (90%) ran the full 11–15 min analysis. This
+session's PR mix is unusually Python-heavy (agent/fix PRs, not docs), so 90% is not a general
+rate — but it confirms the gate mechanism itself works exactly as designed when a PR is clean.
+
+## 10. What this lane deliberately did not measure
+
+- Per-step timing inside a job (only job-level `started_at`/`completed_at`; a step-level
+  breakdown of the CodeQL Analyze step vs Initialize/checkout would need
+  `actions/runs/{id}/timing` or job logs, not attempted here — CPU cost/time tradeoff, flagged
+  as a limit not a gap silently dropped).
+- Runner-pool contention as a variable (`ubuntu-latest` hosted runners; whether Bali-Zero/Teman2
+  is on standard or larger runners was not checked — the 60–70s median queue-before-start on
+  most jobs is consistent with standard hosted-runner cold start, not a starved pool, but this is
+  read off the number, not confirmed from billing/runner-group config).
+- The single-digit-percent share of PRs that used an admin merge override (excluded from the
+  sample by construction — merge-queue behavior only applies to queue-routed merges).

--- a/research/operations/2026-09-05-pr-cycle-time-diet.md
+++ b/research/operations/2026-09-05-pr-cycle-time-diet.md
@@ -1,0 +1,227 @@
+---
+date: 2026-09-05
+domain: operations
+client_case: none — internal CI/PR-cycle-time study (session M5, mandato Zero: "studia come diminuire drasticamente il tempo delle PR")
+adversarial_review: codex
+sources: gh api / GraphQL live measurement of Bali-Zero/Teman2 (this session, 30 merged PRs + live merge-queue config introspection) + code reading of .github/workflows/security.yml, tests.yml, scripts/ci/change_map.py (this session) + GitHub Docs (merge queue, branch protection status checks, CodeQL workflow config, codeql-action dependency-caching) + community sources on Nx/Turborepo affected-testing and flaky-test quarantine (marked search-only) + Codex GPT-5 red-team on the draft (§ Adversarial review)
+---
+
+# Diminuire il tempo delle PR — dove va il tempo e cosa si può togliere
+
+> Mandato Zero, 2026-09-04/05: «studia come diminuire drasticamente il tempo delle PR».
+> Metodo: non ripartire dalle cifre della sera del 4/9 (110-114 CPU-min, 15-17 min wall, 12
+> contesti richiesti) — rimisurarle sul repo vivo con `gh api`, poi confrontarle con ciò che
+> fanno i migliori (merge queue, monorepo affected-testing, CodeQL, cache) e proporre un piano
+> classificato per leva. Tabelle grezze: `2026-09-05-pr-cycle-time-diet-lane-measurements.md`.
+
+## 0. Executive summary
+
+- **Il campione misurato è caduto per intero nella finestra "classificatore CI morto".** 30 PR
+  merged il 4/9 (08:21-15:35 UTC); il fix che lo rianima (#5692) è arrivato solo alle 16:25:30Z.
+  Risultato: anche tre PR puramente-documentarie (solo `.md`) in questo campione hanno pagato
+  Backend Shard×3, Frontend Tests, E2E Tests e Visa Oracle per intero (5-12 min ciascuno) — SOLO
+  CodeQL (classificato in un workflow diverso, indipendente) si è fermato correttamente. Questo
+  non è il regime "a riposo" del repo: è il caso peggiore, ed è quello che il numero mediano sotto
+  descrive.
+- **Anche così, mediana open→merge 35,2 min, media 50,0 min** (30 PR, min 28,3 · max 173,1).
+  110,7 CPU-minuti/PR sul run della PR (conferma quasi esatta dei 110-114 osservati la sera
+  prima su un'altra PR) più **136,3 CPU-minuti/PR nella coda di merge** — il re-run in coda
+  costa PIÙ del check originale. CodeQL Analysis (python) è il check più lento su 19/30 PR (63%)
+  e vale da solo una mediana del 34% del wall time totale della PR.
+- **Un moltiplicatore reale, ma solo parzialmente spiegato, è la coda di merge.**
+  `mergeQueue.configuration` (letta live via GraphQL): `mergingStrategy: ALLGREEN`, batch fino a
+  5 PR, `minimumEntriesToMerge: 4` con fino a 15 minuti di attesa per raggiungerlo. 9 PR su 30
+  (30%) hanno avuto un secondo tentativo di `merge_group`; di questi, 5 mostrano un `cancelled`
+  PRIMA del tentativo che ha permesso il merge — un pattern coerente con un batch fallito che ha
+  bloccato il PR — e questi cinque includono 4 dei 6 outlier oltre i 60 minuti. Gli altri 2
+  outlier (incluso il peggiore, 173 min più uno da 116 min senza alcun secondo tentativo
+  registrato) NON sono spiegati da questo pattern (dettaglio in §5 del file-lane). `HEADGREEN`
+  è l'alternativa che GitHub stesso descrive (testo dell'enum letto live, non la pagina doc
+  dedicata che ha risposto 404 in questa sessione) — il meccanismo esatto va verificato dalla UI
+  prima di usarla.
+- **Tre bersagli per un PR banale** (§5): da un caso peggiore osservato di 28,3-33,7 min, a
+  ~9-26 / ~2-8 / ~2-6 minuti (certo / base / stretch, range non punti — n=3 misurazioni),
+  aritmetica tracciata riga per riga in §5. Il pavimento condiviso da tutti e tre è un contesto
+  RICHIESTO (`Immune enforcement`, "antidotes") che nessuna leva qui tocca. Le leve più grandi
+  (batching della coda, dedup del merge_group, gating di VOA) sono decisioni di Zero; le più
+  sicure (classificatore robusto, path-gating advisory, cache) sono spedibili dalla sessione via
+  Gear 3.
+
+## 1. Cosa dice la misura (30 PR, dettaglio in `-lane-measurements.md`)
+
+| Metrica | Valore |
+|---|---|
+| Open→merge, mediana / media | 35,2 / 50,0 min |
+| CPU-min/PR, run della PR | 110,7 (media) |
+| CPU-min/PR, coda di merge | 136,3 (media) — **più** del run della PR |
+| Check più lento più frequente | CodeQL Analysis (python), 19/30 PR (63%) |
+| Quota mediana del wall time dal check più lento | 34% |
+| PR ricacciati in coda ≥1 volta (batch ALLGREEN fallito) | 9/30 (30%) |
+| Job che finiscono sotto i 90s | 53/72 nomi distinti — costo dominato dal cold-start del runner, non dal lavoro |
+| Check per PR (conteggio a livello di run) | mediana 62 (range 57-67) |
+
+Le tre PR di solo-`.md` nel campione (#5680, #5658, #5672 — nessun file Python/JS/backend/
+frontend) hanno comunque pagato 28,3-33,7 minuti di wall time (28,3 · 29,5 · 33,7 — media 30,5)
+perché tests.yml stava fallendo aperto (`run_all=True`, il default fail-safe quando l'estrazione
+del classificatore fallisce — vedi §2). Solo il gate di CodeQL, che vive in un workflow
+indipendente (`security.yml`, `RUN_THIS_LANGUAGE` per-step, non collegato allo stesso corpus
+rotto), ha funzionato: CodeQL Analysis (python) ha finito in 18-27s su queste tre invece dei
+consueti 11-15 min. Tutti gli altri job pesanti — Backend Shard×3, Frontend Tests (mouth), E2E
+Tests, PIÙ Visa Oracle fullstack smoke, che NON fa parte del classificatore di `change_map.py`
+(§4, L5/L7) — hanno girato per intero anche su queste tre PR puramente documentarie.
+
+## 2. Diagnosi: il classificatore era morto per l'intero campione
+
+`scripts/ci/change_map.py` classifica ogni path in uno di 11 domini; `docs_content_data` (che
+include `docs/`, `research/`, `.claude/skills|rules|commands|agents/`, `evidence/`) non guadagna
+NESSUNO dei sei `TEST_JOBS` del modulo (letti dal sorgente in questo turno, nome esatto della
+costante): `backend-tests`, `mcp-tests`, `evaluator-critical-tests`, `frontend-tests`,
+`packages-core-tests`, `e2e-tests` (`_suggested_jobs()`). **Visa Oracle fullstack smoke non è in
+questo elenco** — non è gestito da `change_map.py` e ha girato per intero su tutte e 30 le PR del
+campione, incluse le tre di sola documentazione (§1); lo stesso vale per gli scanner advisory
+(Snyk×3, npm audit, SAST, Detect Secrets — §4 L5). Il meccanismo dei sei `TEST_JOBS` è corretto —
+la sua ESECUZIONE non lo era:
+
+- **#5676** (merged 15:32:20Z) ha corretto un corpus morto da 9 giorni: "ogni PR ha girato ogni
+  job" (titolo della PR, letto in questo turno).
+- **#5679** (merged 14:59:02Z, PRIMA di #5676 nonostante il numero più alto — l'ordine di merge
+  non segue l'ordine dei numeri PR) ha esteso la classificazione di `scripts/**`.
+- **#5692** (merged 16:25:30Z) ha corretto un secondo guasto introdotto dalla combinazione delle
+  due: "every PR since #5679 ran all six heavy jobs" (titolo della PR, letto in questo turno).
+
+Il campione di 30 PR di questo report (08:21-15:35Z) è quindi interamente compreso nella
+finestra rotta. Cicatrice #2 (Esiste≠Armato): il meccanismo di path-gating esiste nel codice da
+prima di oggi, ma non era ARMATO per nessuna delle 30 PR misurate. Alle 09:05 di oggi (2026-09-05,
+quando questo report viene scritto) nessuna PR è stata ancora creata e fusa contro una base che
+porta #5692 — il repo non ha ancora prodotto un esempio dal vivo di "PR di documentazione con
+zero job pesanti". **Questa stessa PR (research-only, tocca solo `research/**` ed
+`evidence/**`) è il primo caso reale**: l'osservazione dal vivo del suo proprio run è nella
+sezione Bites del corpo della PR, non in questo file (il file è scritto prima che il run esista).
+
+## 3. Cosa fanno i migliori (fonti fetchate; le non-fetchate sono marcate search-only)
+
+**3.1 GitHub, status check "skipped" = passing.** Un check richiesto che viene skippato via
+path-filter riporta `success`/`skipped`/`neutral` e NON blocca il merge — la doc lo conferma
+(troubleshooting required status checks); una discussione della community lo chiama esplicitamente
+un problema quando il path-filter è a livello di WORKFLOW (il job non parte affatto e il contesto
+non riporta mai, restando "in attesa" per sempre). Il pattern corretto — quello che
+`security.yml` già usa per CodeQL — è: il JOB parte sempre (soddisfa il contesto richiesto), solo
+gli STEP costosi sono condizionati. `tests.yml` usa lo stesso pattern per i sei job pesanti.
+
+**3.2 GitHub, merge queue.** Introspezione GraphQL live (non dalla doc, dal repo stesso, §1
+lane-file): `checkResponseTimeout` 5400s (soffitto raramente toccato), `mergingStrategy` con due
+soli valori enum (letti live): `ALLGREEN` ("Entries only allowed to merge if they are passing")
+e `HEADGREEN` ("Failing Entries are allowed to merge if they are with a passing entry").
+`minimumEntriesToMerge`/`minimumEntriesToMergeWaitTime` sono documentati altrove (ricerca
+web, non verificati sulla pagina ufficiale — quella specifica pagina ha risposto 404 in questa
+sessione) come il meccanismo che aspetta fino a N minuti un quorum di PR prima di aprire un
+batch; la guida generica trovata suggerisce "1 e 0 a meno di 20+ PR/giorno" — soglia che questo
+repo supera nel campione misurato (30 PR in 7 ore).
+
+**3.3 Monorepo affected-only testing** [search-only, cifre di terzi]. Nx/Turborepo calcolano
+l'insieme "affected" dal grafo delle dipendenze, non da un file di regole scritto a mano come
+`change_map.py`; un caso citato riporta una CI da 45 a 4 minuti saltando l'80% dei task. Il
+nostro `change_map.py` è lo stesso principio (path→dominio→job) ma manuale e quindi fragile al
+tipo di rottura di §2 — un grafo derivato da import reali non avrebbe un "corpus" da tenere
+sincronizzato a mano.
+
+**3.4 CodeQL, cadenza e caching.** La doc ufficiale raccomanda `pull_request` come trigger
+primario ("we recommend that you configure code scanning to analyse all pull requests"), NON
+solo schedule — quindi spostare CodeQL fuori dal path della PR (come inizialmente ipotizzato nel
+mandato) andrebbe contro la pratica raccomandata; il repo ha già la soluzione raccomandata
+(path-gating per-step, non per-job). La leva restante è interna al job: `codeql-action/init@v4`
+supporta `dependency-caching: true` (verificato sulla issue/changelog del repo `codeql-action`,
+non sulla pagina docs ufficiale che non è stata fetchata) — introdotto per Java/dipendenze
+pesanti; l'impatto su un linguaggio interpretato come Python (nessun passo di build) NON è
+verificato in questa sessione e va misurato prima di contarlo come certo. C'è anche una cache
+overlay-base per l'incremental analysis, citata dal changelog ma non approfondita qui.
+
+**3.5 Flaky-test quarantine** [search-only]. Pratica convergente (Google, Meta): rilevamento
+automatico via flip-rate su commit invariato, quarantena in una suite non-bloccante con
+owner+SLA+ri-qualificazione. Non misurato se questo repo ha test flaky nel senso proprio (i 3
+`failure` e 7 `cancelled` su 1862 record del run-PR in §1 lane-file non sono stati classificati
+causa per causa in questa sessione — richiederebbe leggere i log di ciascuno).
+
+## 4. Piano — leve ordinate per minuti-risparmiati-per-PR ÷ (rischio+cerimonia)
+
+| # | Leva | Meccanismo | Risparmio atteso | Rischio se rotto | Gear | Decide |
+|---|---|---|---|---|---|---|
+| L1 | Blindare il classificatore | test unitario sul corpus estratto simulando l'estrazione flat (così non può morire in silenzio una terza volta); rimuovere la maschera `continue-on-error: true` sullo step di estrazione (deve essere un segnale rosso visibile, non silenzioso); correggere l'f-string con virgolette escapate in `tests.yml` righe 400-407 (verificato leggendo il file in questo turno: sintassi illegale su Python <3.12 dentro `{}` di un f-string) | protegge, non sottrae: impedisce la ricaduta a run_all=True su OGNI PR, cioè protegge tutto il risparmio delle leve sotto | ALTO se assente — è già successo due volte oggi | 3 (edita `.github/workflows/tests.yml`) | sessione |
+| L2 | Verificare dal vivo che `docs_content_data` salti i sei `TEST_JOBS` | nessuna modifica: osservare il run di QUESTA PR (§2) — se conferma, chiudere l'incertezza; se no, è un bug nuovo da aprire subito. Non copre Visa Oracle né gli scanner advisory, che non sono nel classificatore (§2) | conferma (o smentisce) i sei `TEST_JOBS` su ogni PR di sola documentazione — non tocca VOA/advisory (L5) | — | 0 (osservazione) | sessione |
+| L3 | Coda di merge: `ALLGREEN`→`HEADGREEN` | il testo dell'enum letto via GraphQL ("failing entries allowed to merge if with a passing entry") suggerisce che un fallimento non cancelli l'intero batch, ma il meccanismo esatto non è verificato oltre quel testo (§ lane-file §5) | 4 dei 6 outlier oltre i 60 min (5650, 5651, 5653, 5674) mostrano un `cancelled` prima del tentativo riuscito — plausibile bersaglio, non certo | cambia la semantica di "cosa può finire in coda con un vicino rosso" — la pagina doc dedicata ha risposto 404 in questa sessione, verificare dalla UI prima di girare l'interruttore | 0 (impostazione repo, non workflow) | **Zero** |
+| L4 | Coda di merge: `minimumEntriesToMerge` 4→1, `minimumEntriesToMergeWaitTime` 900s→60-120s | riduce l'attesa fissa di un PR che arriva con meno di 3 altri già in coda, da fino 15 min a 1-2 min | nessuno strutturale — solo più batch piccoli, più runner-minuti totali se il traffico è denso | 0 (impostazione repo) | **Zero** |
+| L5 | Path-gating esteso: security/lint advisory (Snyk×3, npm audit, SAST, Detect Secrets) + Visa Oracle seguono lo stesso classificatore dei sei `TEST_JOBS` | oggi girano SEMPRE indipendentemente dal diff (misurato: girano anche su #5680/#5658/#5672) — 6 job advisory: 414,1 CPU-min/30PR nel run-PR (npm audit 149,0 + Snyk Node 74,8 + Snyk Docker 68,2 + Snyk Python 15,2 + SAST 89,6 + Detect Secrets 17,2); VOA da sola 173,1 CPU-min/30PR | ~2-6 min/PR di wall time per un PR di sola-doc (il job advisory più lento residuo, non la somma — girano in parallelo) | i job sono advisory (non nei 12 contesti richiesti) tranne VOA che LO è — gating VOA su un PR non-app è una scelta di prodotto, non solo tecnica | 3 (edita `security.yml` + il workflow VOA) | sessione per gli advisory; **Zero** per VOA (è required) |
+| L6 | `merge_group`: non ri-eseguire i job non sensibili all'integrazione (CodeQL×2, Immune enforcement, npm audit, Detect Secrets, Snyk×3 — leggono il diff, non lo stato del backend/frontend) | dei 4090,1 CPU-min/30PR nella coda, 1394,4 min (34,1%) sono questi otto job, che il PR-run ha già eseguito sullo stesso diff poco prima | 46,5 CPU-min/PR in coda; wall time solo se uno di questi era il collo di bottiglia del batch | decisione di sicurezza (accettare di non ri-scansionare contro un base branch aggiornato) — la scansione schedulata copre comunque le derive del base | 3 (edita più workflow) | **Zero** (trade-off di sicurezza) |
+| L7 | Consolidare le ~40 sentinelle/guardie sotto i 90s in UN workflow "fast-gates" con job multipli | oggi ogni sentinella è un run/workflow separato = cold-start del runner ripetuto ~40 volte; un solo workflow con più job condivide meno overhead di checkout/setup ripetuto se raggruppati per stack (python vs node) | qualche decina di secondi/PR — piccolo per singola PR, ma ~40 avvii di runner in meno per PR moltiplicato su tutta la coda | ceremonia alta (tocca ~40 file .yml), va fatto a piccoli lotti | 3 × N PR | sessione, spezzato in più PR |
+| L8 | `cancel-in-progress` sui workflow che non ce l'hanno ancora | oggi 46/118 workflow ce l'hanno; estendere agli altri | 0 min sul primo push di un PR banale; utile su iterazioni con push rapidi | nessuno — pattern già in uso altrove nel repo | 3 | sessione |
+| L9 | Un solo "gate" aggregato al posto di 12 contesti richiesti | un job fan-in che dipende (`needs:`) da tutti i job path-gated e riporta un solo stato; riduce le occasioni di finire "Expected — Waiting for status" per sempre (bug GitHub documentato dalla community quando un contesto non riporta mai) | pochi minuti di latenza di propagazione GitHub + elimina gli incidenti rari-ma-costosi di contesto bloccato (quando capitano, 10-60+ min di intervento manuale) | riduce la granularità dei fallimenti visibili in `gh pr checks` — serve un buon riepilogo nel job fan-in | 3, grande refactor | sessione, ma da pianificare come PR dedicata |
+
+## 5. Tre bersagli per una PR banale (solo `research/**`, `docs/**`, `.claude/skills|rules/**`)
+
+Baseline: 28,3-33,7 min (§1, tre PR misurate) — il caso PEGGIORE già misurato (classificatore
+morto). Sotto, l'aritmetica riga per riga di cosa resta dopo ogni leva, usando le durate REALI
+osservate su quelle tre PR per i job che NON sono nei sei `TEST_JOBS` (n=3, quindi un range, non
+un punto — Codex ha giustamente bocciato una prima versione di questa tabella che dava un solo
+numero "certo" senza mostrare la somma).
+
+Cosa resta dopo aver tolto i sei `TEST_JOBS` (L1), dalle tre PR misurate: Immune enforcement
+(superscar antidotes) 1,7-6,7 min · Visa Oracle fullstack smoke 3,8-10,6 min · npm audit
+0,9-5,6 min · Detect Secrets 0,5-0,7 min · Change map (i due step di decisione stessi, non
+eliminabili, ~1-1,6 min cad.) · Snyk×3 già vicino a zero (gating proprio, indipendente,
+funzionante anche nella finestra rotta) · ~40 sentinelle sotto i 90s (mai il collo di bottiglia).
+Questi girano in PARALLELO: il pavimento è il più lento fra loro, non la somma.
+
+| Bersaglio | Wall time (range) | Come | Certezza |
+|---|---|---|---|
+| **Certo** | ~9-26 min | L1 toglie i sei `TEST_JOBS`; resta il job non-gated più lento fra Immune enforcement (1,7-6,7 min, è uno dei 12 contesti richiesti — "antidotes" — non gate-abile senza una decisione di prodotto) e Visa Oracle (3,8-10,6 min, anch'esso richiesto); l'attesa di coda resta INVARIATA (1-15 min, dipende da quanti altri PR sono in coda) | meccanismo confermato leggendo `change_map.py`; magnitudine da confermare dal vivo (L2, questa stessa PR — vedi §2) |
+| **Base** (+L4+L5) | ~2-8 min | L4 abbassa il tetto dell'attesa di coda da 15 a ~1,5 min; L5 estende il gating a VOA/npm-audit/Detect-Secrets/SAST (tutti advisory tranne VOA), lasciando Immune enforcement (1,7-6,7 min, required) come unico job non comprimibile senza una decisione di prodotto | L4 è un'impostazione (Zero); L5 è una PR Gear 3 (sessione) per la parte advisory, decisione di Zero per VOA |
+| **Stretch** (+L3+L9) | ~2-6 min | stessa aritmetica di Base — L3 e L9 non toccano il pavimento di Immune enforcement, riducono la CODA della distribuzione (meno batch-cancellation da assorbire, meno propagazione multi-contesto): il range si stringe, non si sposta molto verso il basso | L3 è una decisione di sicurezza/processo di Zero; L9 è un refactor Gear 3 non banale |
+
+Il pavimento pratico condiviso da tutti e tre i bersagli è `Immune enforcement (superscar
+antidotes)`, un contesto RICHIESTO che non è nel classificatore di `change_map.py` — nessuna
+delle leve L1-L9 lo tocca; comprimerlo sotto i 1,7-6,7 min osservati è fuori dallo scope di
+questo report (richiederebbe guardare dentro `immune-enforcement.yml`, non fatto qui).
+
+L'aritmetica di L6 (deduplicare `merge_group`) non tocca il wall-time di UNA PR isolata — riduce
+il CPU totale della flotta (46,5 CPU-min/PR), rilevante quando la coda è densa (il caso di questo
+campione: 30 PR in 7 ore), non nel caso "una PR alla volta" usato per i tre bersagli sopra.
+
+## 6. Limiti
+
+Il campione è un singolo giorno ad alta velocità (30 PR in 7h14m) — mediane qui non sono medie
+annuali. I tre bersagli di §5 poggiano su n=3 PR di sola-documentazione: sono un range osservato,
+non una distribuzione. Il meccanismo di `HEADGREEN` è descritto solo dal testo enum letto via
+GraphQL in questa sessione; la pagina doc dedicata (`managing-a-merge-queue`) ha risposto HTTP 404
+al fetch, due volte, da due URL diversi — Zero dovrebbe verificarla dalla UI prima di girare
+l'interruttore. `dependency-caching` su CodeQL non è stato misurato per Python; il changelog lo
+descrive esplicitamente per Java. La causa dei 3 `failure` e 7 `cancelled` PR-event non è stata
+letta log-per-log (nessuna prova che siano flaky-in-senso-proprio vs fallimenti reali). Il
+conteggio "62 check/PR" di questo report e il "72-75" della sera prima usano regole di conteggio
+diverse (§8 lane-file) — non è una contraddizione ma non ho riconciliato le due fonti a livello di
+singolo check. Il pattern di re-code in coda (§5 lane-file) spiega 4 dei 6 outlier oltre i 60
+minuti: PR #5650 (123,5 min) ha bisogno di un terzo tentativo non catturato da questa query, e
+#5657 (61,0) / #5676 (116,4) NON sono spiegati dal pattern di batch-cancellation — la causa dei
+loro tempi resta non identificata in questa sessione.
+
+## Adversarial review
+
+Seat: Codex GPT-5 (`codex exec --sandbox read-only`, contesto fresco, prompt red-team "trova il
+difetto, default a difettoso"), sulla bozza precedente a questa versione. Verdetto: **BLOCK**,
+10 finding (tutti major/blocker, nessun minor). Disposizione:
+
+| # | Sev | Finding (sintesi) | Esito |
+|---|---|---|---|
+| 1 | blocker | matching `merge_group`→PR solo dal numero nel `head_branch`, senza verificare che un batch da 5 non condivida quel numero fra più PR | **respinto con prova**: nessun `head_sha` è condiviso fra due `pr_number` diversi sui 487 run (§ lane-file, metodologia) — il matching è per-entry, non per-batch |
+| 2 | major | tabella dei 9 re-code incompleta/sbagliata (una riga con placeholder, un caso con la sequenza invertita) | **fixed**: tabella completa con tutte e 9 le righe reali, e il pattern misto (5 cancelled→success, 4 success→cancelled) descritto senza generalizzare (§ lane-file §5) |
+| 3 | major | "HEADGREEN evita che un guasto ne cancelli altri quattro" presentato come certo | **fixed**: declassato a "testo dell'enum letto, meccanismo non verificato oltre quello"; il nesso causale con gli outlier ridotto a "4 di 6, non tutti e sei" |
+| 4 | major | "stessi commit" fra run PR e run merge_group, più un claim di flakiness non provato | **fixed**: rimossa l'affermazione "stessi commit" (sono commit diversi per costruzione), rimosso il claim di flakiness non supportato (§10 lo dichiarava già non misurato — contraddizione interna corretta) |
+| 5 | major | off-by-one su "meno di 4 altri" per `minimumEntriesToMerge: 4` | **fixed**: corretto in "meno di 3 altri già in coda" (il PR stesso conta come una delle 4 entry) |
+| 6 | major | range "28-37 min" non corrisponde ai tre valori reali (28,3/29,5/33,7) | **fixed**: sostituito con i tre valori esatti ovunque compaia |
+| 7 | major | "5 job pesanti" enumerati come 6 voci, con Visa Oracle scambiato per uno dei sei `TEST_JOBS` | **fixed**: elencati i sei `TEST_JOBS` esatti dal sorgente (`backend-tests, mcp-tests, evaluator-critical-tests, frontend-tests, packages-core-tests, e2e-tests`), VOA esplicitamente segnalato come NON incluso; verificato anche che `backend-static` condivide il gating (era erroneamente nella lista "residua") |
+| 8 | major | bersaglio "Certo" = 22 min presentato come certo mentre la riga stessa ammette che serve conferma dal vivo | **fixed**: tabella di §5 riscritta come range (9-26 / 2-8 / 2-6), con l'aritmetica dei job residui mostrata riga per riga dai dati reali delle tre PR, non un numero singolo |
+| 9 | major | passo "Base" (22→12, cioè -10) non riconciliabile con "-13 min" dichiarato per L4 | **fixed**: stessa riscrittura del punto 8 — ogni passo ora mostra la somma dei componenti, non una sottrazione isolata |
+| 10 | major | somma "149+75+68+90=~380" per 5-6 job nominati ma solo 4 numeri usati | **fixed**: ricalcolato con tutti e 6 i job nominati (npm audit, Snyk Node/Docker/Python, SAST, Detect Secrets) = 414,1 CPU-min/30PR nel run-PR, numero verificato via script (non a mano) |
+
+Nessun finding scartato senza fix: tutti e 10 hanno prodotto una modifica al testo o ai dati. Non
+richiesto un secondo giro — le correzioni sono verificabili contro i dati grezzi in
+`-lane-measurements.md`, non contro un nuovo giudizio soggettivo.

--- a/research/operations/2026-09-05-pr-cycle-time-diet.md
+++ b/research/operations/2026-09-05-pr-cycle-time-diet.md
@@ -91,12 +91,23 @@ la sua ESECUZIONE non lo era:
 
 Il campione di 30 PR di questo report (08:21-15:35Z) è quindi interamente compreso nella
 finestra rotta. Cicatrice #2 (Esiste≠Armato): il meccanismo di path-gating esiste nel codice da
-prima di oggi, ma non era ARMATO per nessuna delle 30 PR misurate. Alle 09:05 di oggi (2026-09-05,
-quando questo report viene scritto) nessuna PR è stata ancora creata e fusa contro una base che
-porta #5692 — il repo non ha ancora prodotto un esempio dal vivo di "PR di documentazione con
-zero job pesanti". **Questa stessa PR (research-only, tocca solo `research/**` ed
-`evidence/**`) è il primo caso reale**: l'osservazione dal vivo del suo proprio run è nella
-sezione Bites del corpo della PR, non in questo file (il file è scritto prima che il run esista).
+prima di oggi, ma non era ARMATO per nessuna delle 30 PR misurate.
+
+**Aggiornamento a PR aperta (2026-09-04T16:40-16:42Z, PR #5696, questo stesso report).** Primo
+caso dal vivo contro una base che porta #5692. Risultato misurato sul run reale, non stimato:
+`Backend Tests (Python)`, `Backend Shard ${{ matrix.shard }}` (tutti e tre), `Backend Static
+(Python)`, `E2E Tests (Playwright)`, `MCP Server Tests`, `Shared Core Package Tests`, `Evaluator
+Critical Tests`, `Visa Oracle fullstack smoke` e `npm audit (advisory)` sono tutti
+`completed/skipped`; `CodeQL Analysis (python)`/`(javascript)` hanno girato in 24s (gate
+per-step, come atteso, §9 lane-file); `Snyk` ×3 skipped. **Ma `Frontend Tests (Next.js) (mouth,
+true)` e `(admin-dashboard, false)` sono girati per intero (`success`, non `skipped`)**, e
+`Detect Secrets` pure (`success`, 31s — non gated, mai lo è stato). Il classificatore quindi
+FUNZIONA per 8 dei 9 job/famiglie non-VOA/non-CodeQL previsti, ma NON per Frontend Tests: la
+leva L2 di §4 è confermata solo parzialmente, non del tutto come sperato — resta un secondo bug
+o una scelta deliberata da chiarire (`frontend-tests` potrebbe avere una propria condizione
+indipendente dal `run_all` di `change_map.py`, non letta in questo turno). Non corretto in
+questa PR (fuori scope, resta un `TEST_JOBS` nominale nel codice anche se il suo comportamento
+osservato lo contraddice).
 
 ## 3. Cosa fanno i migliori (fonti fetchate; le non-fetchate sono marcate search-only)
 
@@ -147,7 +158,7 @@ causa per causa in questa sessione — richiederebbe leggere i log di ciascuno).
 | # | Leva | Meccanismo | Risparmio atteso | Rischio se rotto | Gear | Decide |
 |---|---|---|---|---|---|---|
 | L1 | Blindare il classificatore | test unitario sul corpus estratto simulando l'estrazione flat (così non può morire in silenzio una terza volta); rimuovere la maschera `continue-on-error: true` sullo step di estrazione (deve essere un segnale rosso visibile, non silenzioso); correggere l'f-string con virgolette escapate in `tests.yml` righe 400-407 (verificato leggendo il file in questo turno: sintassi illegale su Python <3.12 dentro `{}` di un f-string) | protegge, non sottrae: impedisce la ricaduta a run_all=True su OGNI PR, cioè protegge tutto il risparmio delle leve sotto | ALTO se assente — è già successo due volte oggi | 3 (edita `.github/workflows/tests.yml`) | sessione |
-| L2 | Verificare dal vivo che `docs_content_data` salti i sei `TEST_JOBS` | nessuna modifica: osservare il run di QUESTA PR (§2) — se conferma, chiudere l'incertezza; se no, è un bug nuovo da aprire subito. Non copre Visa Oracle né gli scanner advisory, che non sono nel classificatore (§2) | conferma (o smentisce) i sei `TEST_JOBS` su ogni PR di sola documentazione — non tocca VOA/advisory (L5) | — | 0 (osservazione) | sessione |
+| L2 | Verificare dal vivo che `docs_content_data` salti i sei `TEST_JOBS` | **FATTO in questa PR** (§2, run 2026-09-04T16:40-16:42Z): 5 delle 6 famiglie skippate correttamente (backend×3+static, E2E, MCP, packages-core, evaluator, VOA, npm-audit) — `frontend-tests` NO, ha girato per intero nonostante sia nel diff solo-doc | conferma PARZIALE: 8/9 job/famiglie osservate si comportano come atteso, `frontend-tests` no — nuovo bug da aprire, non fatto in questa PR (fuori scope) | — | 0 (osservazione) | sessione |
 | L3 | Coda di merge: `ALLGREEN`→`HEADGREEN` | il testo dell'enum letto via GraphQL ("failing entries allowed to merge if with a passing entry") suggerisce che un fallimento non cancelli l'intero batch, ma il meccanismo esatto non è verificato oltre quel testo (§ lane-file §5) | 4 dei 6 outlier oltre i 60 min (5650, 5651, 5653, 5674) mostrano un `cancelled` prima del tentativo riuscito — plausibile bersaglio, non certo | cambia la semantica di "cosa può finire in coda con un vicino rosso" — la pagina doc dedicata ha risposto 404 in questa sessione, verificare dalla UI prima di girare l'interruttore | 0 (impostazione repo, non workflow) | **Zero** |
 | L4 | Coda di merge: `minimumEntriesToMerge` 4→1, `minimumEntriesToMergeWaitTime` 900s→60-120s | riduce l'attesa fissa di un PR che arriva con meno di 3 altri già in coda, da fino 15 min a 1-2 min | nessuno strutturale — solo più batch piccoli, più runner-minuti totali se il traffico è denso | 0 (impostazione repo) | **Zero** |
 | L5 | Path-gating esteso: security/lint advisory (Snyk×3, npm audit, SAST, Detect Secrets) + Visa Oracle seguono lo stesso classificatore dei sei `TEST_JOBS` | oggi girano SEMPRE indipendentemente dal diff (misurato: girano anche su #5680/#5658/#5672) — 6 job advisory: 414,1 CPU-min/30PR nel run-PR (npm audit 149,0 + Snyk Node 74,8 + Snyk Docker 68,2 + Snyk Python 15,2 + SAST 89,6 + Detect Secrets 17,2); VOA da sola 173,1 CPU-min/30PR | ~2-6 min/PR di wall time per un PR di sola-doc (il job advisory più lento residuo, non la somma — girano in parallelo) | i job sono advisory (non nei 12 contesti richiesti) tranne VOA che LO è — gating VOA su un PR non-app è una scelta di prodotto, non solo tecnica | 3 (edita `security.yml` + il workflow VOA) | sessione per gli advisory; **Zero** per VOA (è required) |


### PR DESCRIPTION
## Why

Zero: "studia come diminuire drasticamente il tempo delle PR". This is the study — a fresh
`gh api`/GraphQL measurement of the last 30 merged PRs (not a re-summary of the 2026-09-04
evening numbers), plus GitHub-docs/community sourcing on merge queues, monorepo affected-testing,
CodeQL cadence/caching, and flaky-test quarantine.

## What

- `research/operations/2026-09-05-pr-cycle-time-diet.md` — findings, diagnosis, SOTA notes, nine
  ranked levers (L1-L9, each with mechanism/expected saving/risk/Gear/decider), three targets.
- `research/operations/2026-09-05-pr-cycle-time-diet-lane-measurements.md` — the raw measurement
  tables every number in the main file traces back to.
- `evidence/2026-09/agent-air-m5-docs-pr-cycle-time-8ffcafa5/brief.yml` — Harness floor 2 (by
  SIZE: 473 net lines, no `.github/workflows/*` touched).

**Central finding**: the whole 30-PR sample fell inside a now-closed window
(2026-09-04 14:59-16:25Z) where tests.yml's change-map classifier was broken — #5679 introduced a
second corpus bug on top of the first (#5676), both fixed by #5692. Every measured number,
including three PRs that touched only `.md` files, reflects the CI system's worst case
(`run_all=True` fail-open), not its designed steady state.

**Three targets for a trivial PR** (baseline: 28.3-33.7 min measured worst-case):
certain ~9-26 min · base ~2-8 min · stretch ~2-6 min (ranges, not points — n=3 measured
documentation-only PRs; arithmetic traced row-by-row in §5).

**Adversarial review**: Codex GPT-5 red-teamed the first draft, verdict BLOCK, 10 findings (1
blocker on merge_group/PR attribution methodology, 9 major on arithmetic/enumeration/overclaim).
All ten dispositioned against raw data in the main file's `## Adversarial review` section — one
rebutted with a new direct check (zero shared `head_sha` across PR-tagged `merge_group` runs),
nine produced real corrections.

## Bites

**Consumer**: Zero's decision on the Zero-owned levers — merge-queue `ALLGREEN`→`HEADGREEN`,
`minimumEntriesToMerge`/wait tuning, `merge_group` dedup for non-integration-sensitive jobs
(CodeQL/Snyk/npm-audit/Detect-Secrets), and gating Visa Oracle fullstack smoke on app-path diffs
— plus the session-shippable levers (classifier hardening/L1, advisory-scanner path-gating/L5,
`cancel-in-progress` coverage/L8) queued as follow-up PRs in the order given in §4.

**Observation**: the raw measurement tables in `-lane-measurements.md` — every figure (110.7
CPU-min/PR, 136.3 CPU-min/PR in the merge queue, 34.1% of merge-queue CPU spent on
non-integration-sensitive re-runs, 9/30 PRs requeued) is a direct `gh api`/GraphQL read executed
in this session, not carried over from an earlier report. This PR itself is also the first PR
created against a base carrying the #5692 classifier fix — its own CI run is the live
falsification test for the report's central claim (§2), noted for whoever reviews the checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4