### PR TITLE
chore(ghostty): the m5 reading-comfort keys were live-only — the repo copy was the stale side

### DIFF
--- a/infra/ghostty/machines/m5.ghostty
+++ b/infra/ghostty/machines/m5.ghostty
@@ -75,6 +75,25 @@ palette = 15=#2A2520
 window-width = 124
 window-height = 36
 
+# ─── Reading comfort (2026-08-29) ──────────────────────────────────────────
+# Ghostty has no line-height key; `adjust-cell-height` IS the line-height knob
+# (it takes px or %). 10% on JetBrains Mono at 15pt lands around the 1.4-1.6x
+# range that reading research treats as comfortable for sustained text — and
+# this window is read as prose all day (Claude Code transcripts), not scanned
+# as code. Raise it before reaching for a different font: it is the cheaper
+# and more reversible of the two levers.
+adjust-cell-height = 10%
+
+# The fleet default is `background` — the padding is painted with the
+# `background` colour, which on this machine is already the ivory, so there is
+# no black frame to fix. `extend` matters for a different case: a full-screen
+# TUI (btop, lazygit, yazi) paints its own darker background, and with
+# `background` that colour stops 12px short of the window edge, leaving an
+# ivory band around the app. `extend` carries the nearest grid cell's colour
+# out to the edge instead. It self-disables on prompt rows and on powerline
+# glyphs, so it cannot smear the starship prompt.
+window-padding-color = extend
+
 # ─── Fleet reach (palette, per-machine) ────────────────────────────────────
 # command-palette-entry ACCUMULATES across included files, so per-machine
 # entries live here. Same convention as keys.ghostty: TYPED, never executed —


### PR DESCRIPTION
`scripts/lint_home_fork.py` reports this pair as DIVERGED and says, as it always
does, that "the checkout matches origin/main, so the LIVE copy is the stale
side". Here that sentence is wrong, and the direction matters: the live file
carries two keys the repo copy has never had, set on 2026-08-29, a day AFTER the
repo copy's last commit (8d9fb4e8e8, 2026-08-28). Overwriting the live copy from
the repo — the lint's own suggested gesture — would have deleted them.

So the cure runs the other way: the 19 live-only lines are brought INTO the repo,
comments included, and nothing else in the file changes (`git diff --stat`: 19
insertions, 0 deletions). The two keys are `adjust-cell-height = 10%` and
`window-padding-color = extend`; their reasoning is in the comments that come
with them and is not restated here.

Superscar #1 is HOME-fork drift in both directions, and its lint can only ever
guess which side is stale — it compares bytes, not history. Reading the diff
before reaching for `cp` is the part that is not automatable.

Bites: consumer is `scripts/lint_home_fork.py`, run on every M5 session by the
proprioception probe `home_fork_scripts`, which flagged this pair. Observation:
`cmp -s ~/.config/ghostty/machine.ghostty infra/ghostty/machines/m5.ghostty` is
byte-identical on this branch (it was a 19-line diff against origin/main), so the
pair drops out of the lint's DIVERGED list the moment this lands — 3 diverged
pairs become 2, the remaining two being the `~/.claude/hooks` pair that
`host_boundary.py` reserves for the operator. Second observation: this exact byte
sequence has been the live Ghostty config on this machine since 2026-08-29 and
`scripts/tests/test_ghostty_guards.sh` passes 17/17 against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BtRLGhgeDNBmP3XQs7Z1y