### PR TITLE
fix(intel-scraper): the poller marks a step done only after its batch reached GitHub

### DIFF
--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -381,6 +381,25 @@ def codex_generate_image(prompt: str, out_path: Path) -> bool:
 # direct commit b19de9bf5a). Writes are staged in-memory during a poller tick
 # and flushed once, per kind, into ONE branch + auto-merged PR.
 _PENDING_COMMITS: list[dict] = []  # {"kind", "gh_path", "content_b64", "message"}
+_PENDING_STEP_MARKS: dict[str, list[tuple[str, str]]] = {}
+
+
+def _defer_step_mark(kind: str, slug: str, step: str) -> None:
+    """Queue a queue-step acknowledgement until its GitHub batch succeeds."""
+    pending = _PENDING_STEP_MARKS.setdefault(kind, [])
+    marker = (slug, step)
+    if marker not in pending:
+        pending.append(marker)
+
+
+def _finalize_deferred_step_marks(kind: str, succeeded: bool) -> None:
+    """Mark a flushed batch's steps done, or leave them queued for retry."""
+    pending = _PENDING_STEP_MARKS.pop(kind, [])
+    if succeeded:
+        for slug, step in pending:
+            mark_step_done(slug, step)
+    elif pending:
+        log(f"  ↩ {len(pending)} {kind} step(s) left unmarked for retry")
 
 
 def _log_gh_failure(op: str, result: "subprocess.CompletedProcess[str]") -> None:
@@ -510,6 +529,7 @@ def _flush_batch(kind: str, branch_prefix: str, title_template: str) -> bool:
     global _PENDING_COMMITS
     batch = [c for c in _PENDING_COMMITS if c["kind"] == kind]
     if not batch:
+        _finalize_deferred_step_marks(kind, succeeded=True)
         return True
     _PENDING_COMMITS = [c for c in _PENDING_COMMITS if c["kind"] != kind]
 
@@ -517,11 +537,10 @@ def _flush_batch(kind: str, branch_prefix: str, title_template: str) -> bool:
     log(f"▶ Flushing {len(batch)} {kind} change(s) → branch {branch}")
 
     if not _create_bot_branch(branch):
-        # The queue items behind this batch were already marked step-done in the
-        # DB (staging succeeds independently of the flush) — a lost batch here
-        # needs a manual re-push, not an automatic retry. The Telegram alert in
-        # main() is what surfaces this instead of it failing silently.
+        # The related queue steps are left unmarked, so the poller retries them
+        # automatically after a lost batch instead of needing a manual re-push.
         log(f"  ❌ Could not create branch {branch} — {len(batch)} staged {kind} change(s) lost, needs manual re-push")
+        _finalize_deferred_step_marks(kind, succeeded=False)
         return False
 
     all_ok = True
@@ -539,7 +558,9 @@ def _flush_batch(kind: str, branch_prefix: str, title_template: str) -> bool:
         "\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"
     )
     if not _open_and_arm_pr(branch, title, body):
+        _finalize_deferred_step_marks(kind, succeeded=False)
         return False
+    _finalize_deferred_step_marks(kind, succeeded=all_ok)
     return all_ok
 
 
@@ -651,7 +672,7 @@ def api_post(path: str, data: dict) -> dict:
         return json.loads(resp.read())
 
 
-def mark_step_done(slug: str, step: str):
+def mark_step_done(slug: str, step: str) -> None:
     """Report a completed step to the backend."""
     try:
         api_post("/api/intel/post-publish-queue/step-done", {"slug": slug, "step": step})
@@ -1266,13 +1287,13 @@ def process_item(item: dict) -> tuple[bool, list[str]]:
         # SEO
         if not done.get("seo"):
             if run_seo(slug, category):
-                mark_step_done(slug, "seo")
+                _defer_step_mark("seo", slug, "seo")
             else:
                 failed_steps.append("seo")
         # Translate
         if not done.get("translate"):
             if run_translate(slug, category):
-                mark_step_done(slug, "translate")
+                _defer_step_mark("translation", slug, "translate")
                 # Auto-rotate hero after successful translate
                 rotate_hero(slug)
             else:
@@ -1284,7 +1305,7 @@ def process_item(item: dict) -> tuple[bool, list[str]]:
         # a cheap no-op (~2 `gh api` calls) when the covers genuinely exist, and
         # regenerates them when the flag lied.
         if run_image(slug, category, title=title):
-            mark_step_done(slug, "image")
+            _defer_step_mark("image", slug, "image")
         else:
             failed_steps.append("image")
 
@@ -1294,7 +1315,7 @@ def process_item(item: dict) -> tuple[bool, list[str]]:
         # Image — same "never skip on completed_steps alone" rule as the intel
         # branch above (see comment there).
         if run_image(slug, category, title=title, article_id=article_id):
-            mark_step_done(slug, "image")
+            _defer_step_mark("image", slug, "image")
         else:
             failed_steps.append("image")
         return (len(failed_steps) == 0, failed_steps)

--- a/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
+++ b/apps/bali-intel-scraper/tests/unit/test_post_publish_poller.py
@@ -31,8 +31,10 @@ def _res(returncode: int = 0, stdout: str = "", stderr: str = "") -> "subprocess
 @pytest.fixture(autouse=True)
 def _reset_pending_commits():
     ppp._PENDING_COMMITS.clear()
+    ppp._PENDING_STEP_MARKS.clear()
     yield
     ppp._PENDING_COMMITS.clear()
+    ppp._PENDING_STEP_MARKS.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -77,6 +79,61 @@ class TestFlushImageBatch:
             ok = ppp.flush_image_batch()
         assert ok is True
         assert calls == []
+
+
+class TestDeferredStepMarks:
+    def test_seo_step_is_marked_done_only_after_the_batch_flushes(self):
+        ppp._stage_commit("seo", "apps/mouth/src/content/articles/business/s.mdx", b"seo", "seo")
+        ppp._defer_step_mark("seo", "S", "seo")
+
+        with (
+            patch.object(ppp, "_create_bot_branch", return_value=True),
+            patch.object(ppp, "_commit_to_branch", return_value=True),
+            patch.object(ppp, "_open_and_arm_pr", return_value=True),
+            patch.object(ppp, "mark_step_done") as mock_mark,
+        ):
+            mock_mark.assert_not_called()
+            assert ppp.flush_seo_batch() is True
+
+        mock_mark.assert_called_once_with("S", "seo")
+
+    def test_seo_step_stays_unmarked_when_the_batch_fails(self, _silence_log):
+        ppp._stage_commit("seo", "apps/mouth/src/content/articles/business/s.mdx", b"seo", "seo")
+        ppp._defer_step_mark("seo", "S", "seo")
+
+        with (
+            patch.object(ppp, "_create_bot_branch", return_value=False),
+            patch.object(ppp, "mark_step_done") as mock_mark,
+        ):
+            assert ppp.flush_seo_batch() is False
+
+        mock_mark.assert_not_called()
+        assert ppp._PENDING_STEP_MARKS == {}
+        assert any("left unmarked for retry" in message for message in _silence_log)
+
+    def test_translation_step_stays_unmarked_when_one_put_fails(self):
+        ppp._stage_commit("translation", "one.fr.mdx", b"one", "translation")
+        ppp._stage_commit("translation", "one.ru.mdx", b"two", "translation")
+        ppp._defer_step_mark("translation", "S", "translate")
+
+        with (
+            patch.object(ppp, "_create_bot_branch", return_value=True),
+            patch.object(ppp, "_commit_to_branch", side_effect=[True, False]),
+            patch.object(ppp, "_open_and_arm_pr", return_value=True) as mock_open_pr,
+            patch.object(ppp, "mark_step_done") as mock_mark,
+        ):
+            assert ppp.flush_translation_batch() is False
+
+        mock_open_pr.assert_called_once()
+        mock_mark.assert_not_called()
+
+    def test_empty_batch_marks_pending_steps(self):
+        ppp._defer_step_mark("seo", "S", "seo")
+
+        with patch.object(ppp, "mark_step_done") as mock_mark:
+            assert ppp.flush_seo_batch() is True
+
+        mock_mark.assert_called_once_with("S", "seo")
 
     def test_creates_branch_puts_with_branch_key_and_arms_automerge(self):
         ppp._stage_commit(
@@ -649,7 +706,8 @@ class TestProcessItemNeverSkipsImageStep:
         assert all_ok is True
         assert failed_steps == []
         mock_image.assert_called_once_with("test-slug", "business", title="Test Title")
-        mock_mark.assert_called_once_with("test-slug", "image")
+        mock_mark.assert_not_called()
+        assert ppp._PENDING_STEP_MARKS == {"image": [("test-slug", "image")]}
         # seo/translate are genuinely done — only the image gate is bypassed
         mock_seo.assert_not_called()
         mock_translate.assert_not_called()
@@ -675,7 +733,8 @@ class TestProcessItemNeverSkipsImageStep:
         mock_image.assert_called_once_with(
             "news-slug", "regulation", title="News Title", article_id="art-1"
         )
-        mock_mark.assert_called_once_with("news-slug", "image")
+        mock_mark.assert_not_called()
+        assert ppp._PENDING_STEP_MARKS == {"image": [("news-slug", "image")]}
 
     def test_regenerates_and_reports_failure_when_flag_lied_and_regen_fails(self):
         """completed_steps.image=true but run_image() itself returns False


### PR DESCRIPTION
## Why

Pro poller log, 2026-09-04 (KBLI 2025 article), first run:

```
📦 SEO/GEO metadata staged for batch commit
✅ translate exit=0
❌ Could not create branch bot/seo-metadata-… — 1 staged seo change(s) lost, needs manual re-push
```

Second run, after the queue row was reset to pending: only the cover step ran — `completed_steps.seo` and `.translate` already said done, because the step was acknowledged right after STAGING, before the batch flush that actually pushes to GitHub. The article needed three manual `UPDATE post_publish_queue SET completed_steps='{}'` re-queues to get its SEO, layout rotation and translations out.

## What

- `_defer_step_mark(kind, slug, step)`: seo → "seo", translate → "translation", image → "image" batches; marks are queued per batch kind.
- `_flush_batch` calls `_finalize_deferred_step_marks(kind, succeeded)`: marks on success (or on an empty batch), leaves them unmarked on branch/PUT/PR failure and logs `↩ n kind step(s) left unmarked for retry`, so the next tick re-runs the step by itself. The "lost, needs manual re-push" alert line is unchanged.

## Verification

- `tests/unit/test_post_publish_poller.py`: 50 passed (new: seo marked only after a successful flush; unmarked when branch creation fails; unmarked when one translation PUT fails even though the PR opens; empty batch marks pending steps). ruff clean.
- Code by the codex seat (gpt-5.6-terra, `scripts/seat_build.sh`), verified by the session.

Bites: the Pro LaunchAgent `com.balizero.post-publish-poller` after `git pull` on `~/nuzantara` — observation: on the next flush failure the log carries `left unmarked for retry` and the following tick re-runs that step for the same slug without any manual `completed_steps` reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
