### PR TITLE
test(ci): reproduce tests.yml's trusted-classifier extraction layout locally

### DIFF
--- a/scripts/ci/test_trusted_extraction_layout.py
+++ b/scripts/ci/test_trusted_extraction_layout.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Prove the trusted-classifier corpus actually RUNS in the layout that judges it.
+
+WHY THIS EXISTS. tests.yml's "Extract trusted classifier (base ref)" step copies a
+hand-kept list of ``scripts/ci/*`` files FLAT into ``$RUNNER_TEMP/trusted-classifier/``
+(no ``scripts/ci/`` directory above them) and then runs ``test_change_map.py`` /
+``test_impact_map.py`` from THAT directory, with the job's cwd left at the checkout
+root. scripts/tests/test_classifier_extraction_closure.py already proves the
+extraction list is import-closed by static AST inspection — but that catches only
+one failure shape (a missing sibling module). It was NOT what broke on 2026-09-04
+(#5679): ``test_change_map.py``'s own ``test_scripts_coupling_census_is_not_stale``
+called ``Path(__file__).resolve().parents[2]`` to relocate the repo root, which
+resolves to a nonsense directory once the file has no ``scripts/ci/`` above it in a
+flat temp dir — an import-closure check cannot see that, because the import graph
+was fine; the corpus imported cleanly and then failed AT RUNTIME. #5692 fixed it by
+trying ``Path.cwd()`` and ``$GITHUB_WORKSPACE`` first. This file is the regression
+guard for that class of bug: it actually EXECUTES the corpus in the exact flat
+layout, from the exact repo-root cwd CI uses, so a future ``Path(__file__)``/cwd
+assumption that only breaks once extracted is caught locally, without a GitHub
+Actions runner.
+
+Guilt case: delete one file from the flat copy before running the corpus — the
+missing-sibling ModuleNotFoundError this file's design would also have caught,
+proving this is a real test and not one that can only ever pass.
+Innocence case: the current, unmodified extraction list runs clean today.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+TESTS_YML = REPO / ".github" / "workflows" / "tests.yml"
+CI_DIR = REPO / "scripts" / "ci"
+
+# Same anchor as scripts/tests/test_classifier_extraction_closure.py's EXTRACT_RE
+# (single quantifier, linear — a `\S+`-only version was CodeQL-flagged HIGH for
+# catastrophic backtracking): match the shell `for f in <paths>; do` loop, not
+# YAML structure, so a renamed step still gets found.
+EXTRACT_RE = re.compile(r"for f in ([^;\n]+);\s*do")
+CI_PREFIX = "scripts/ci/"
+
+# The two corpus files this probe actually executes in the flat layout. Both are
+# always present in tests.yml's list today; asserted below rather than assumed.
+CORPUS_FILES = ("test_change_map.py", "test_impact_map.py")
+
+
+def _tests_yml_extraction_list() -> tuple[str, ...]:
+    """Parse tests.yml's own `for f in scripts/ci/...` extraction loop.
+
+    Deliberately scoped to tests.yml only (not every workflow, unlike the
+    closure test's discovery pass) — this probe reproduces ONE specific job's
+    layout, and a change to security.yml's separate list is that guard's own
+    business, not this one's.
+    """
+
+    text = TESTS_YML.read_text(encoding="utf-8")
+    matches = [m for m in EXTRACT_RE.finditer(text) if CI_PREFIX in m.group(1)]
+    if not matches:
+        raise AssertionError(
+            "tests.yml no longer has a discoverable `for f in scripts/ci/...; do` "
+            "extraction loop — either the shell shape changed or the trust "
+            "boundary itself was removed. Fix this probe (or its regex) before "
+            "trusting anything below."
+        )
+    if len(matches) > 1:
+        raise AssertionError(
+            f"tests.yml has {len(matches)} extraction loops matching scripts/ci/ — "
+            "this probe assumes exactly one; disambiguate before trusting it."
+        )
+    tokens = matches[0].group(1).split()
+    files = tuple(tok for tok in tokens if tok.startswith(CI_PREFIX))
+    if tuple(tokens) != files:
+        raise AssertionError(
+            f"tests.yml's extraction list mixes scripts/ci/ paths with tokens this "
+            f"probe cannot check: {[t for t in tokens if not t.startswith(CI_PREFIX)]}"
+        )
+    return files
+
+
+def _extract_flat(files: tuple[str, ...], dest: Path, *, omit: str | None = None) -> None:
+    """Reproduce the "Extract trusted classifier (base ref)" step's shape:
+    every file copied FLAT (basename only) into one directory, executable bit
+    kept for the one shell script in the list. ``omit`` drops one basename —
+    the guilt fixture for "a sibling went missing from the flat copy"."""
+
+    for rel in files:
+        name = Path(rel).name
+        if name == omit:
+            continue
+        src = REPO / rel
+        if not src.is_file():
+            raise AssertionError(f"tests.yml extracts {rel}, which does not exist on disk")
+        dst = dest / name
+        shutil.copyfile(src, dst)
+        if name.endswith(".sh"):
+            dst.chmod(dst.stat().st_mode | 0o111)
+
+
+def _run(script: Path) -> subprocess.CompletedProcess[str]:
+    # CI's step runs `python3 "$CLASSIFIER_DIR/test_change_map.py"` as a plain
+    # `run:` step, whose default working directory is the checkout root — NOT
+    # the extraction directory. Reproduced exactly: script path inside the temp
+    # dir, cwd at the repo root.
+    return subprocess.run(
+        [sys.executable, str(script)],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+class TrustedExtractionLayoutTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.files = _tests_yml_extraction_list()
+        self.tmp = tempfile.TemporaryDirectory(prefix="trusted-extraction-layout-")
+        self.addCleanup(self.tmp.cleanup)
+        self.dest = Path(self.tmp.name)
+
+    def test_the_extraction_shape_is_discoverable(self) -> None:
+        # Innocence for the probe itself (mirrors the closure test's own
+        # self-check): if this ever finds nothing, every test below would pass
+        # vacuously — assert the list is non-trivial and carries both corpus
+        # files this probe depends on.
+        self.assertGreaterEqual(len(self.files), 2)
+        basenames = {Path(f).name for f in self.files}
+        for corpus_file in CORPUS_FILES:
+            self.assertIn(
+                corpus_file,
+                basenames,
+                f"tests.yml's extraction list no longer carries {corpus_file} — "
+                "update CORPUS_FILES or the list itself.",
+            )
+
+    def test_innocence_current_extraction_runs_both_corpora_clean(self) -> None:
+        _extract_flat(self.files, self.dest)
+        for corpus_file in CORPUS_FILES:
+            with self.subTest(corpus_file=corpus_file):
+                result = _run(self.dest / corpus_file)
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    f"{corpus_file} failed when run from the flat trusted-extraction "
+                    f"layout (cwd={REPO}):\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+                )
+
+    def test_guilt_a_missing_sibling_breaks_the_flat_corpus(self) -> None:
+        # security_gate_flags.py is imported by test_change_map.py
+        # (`import security_gate_flags as sgf`) but is not itself one of
+        # CORPUS_FILES — omitting it from the flat copy reproduces exactly the
+        # #5070 shape (a corpus file whose sibling import silently vanished)
+        # and must fail loudly, proving this probe can actually detect
+        # breakage rather than only ever reporting green.
+        omitted = "security_gate_flags.py"
+        self.assertIn(
+            omitted,
+            {Path(f).name for f in self.files},
+            f"{omitted} is no longer in tests.yml's extraction list — pick a "
+            "different guilt fixture.",
+        )
+        _extract_flat(self.files, self.dest, omit=omitted)
+        result = _run(self.dest / "test_change_map.py")
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "test_change_map.py passed even with security_gate_flags.py missing "
+            "from the flat extraction — this probe would not have caught #5070.",
+        )
+        self.assertIn("security_gate_flags", result.stderr + result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_trusted_extraction_layout.py
+++ b/scripts/tests/test_trusted_extraction_layout.py
@@ -1,0 +1,35 @@
+"""Thin wire-up for scripts/ci/test_trusted_extraction_layout.py.
+
+scripts/ci/*.py is never globbed by any pytest run in this repo (verified:
+scripts-tests-sweep.yml collects only `scripts/tests/`, and every workflow that
+runs a scripts/ci/*.py test names that exact file, never a directory pattern) —
+so the corpus-in-the-flat-layout probe next to the files it protects would
+otherwise never execute anywhere except by hand. Re-exporting its
+unittest.TestCase here puts it on the nightly `scripts/tests/` sweep
+(scripts-tests-sweep.yml, report-only) and the local pre-push habit of running
+`pytest scripts/tests/`.
+
+CONSUMER, HONESTLY STATED: this is NOT a per-PR gate. scripts-tests-sweep.yml is
+`schedule:`-only and `continue-on-error: true` by design (cicatrix superscar #2
+staging plan — see that workflow's own header). Wiring THIS specific probe into
+a required per-PR check (mirroring how test_classifier_extraction_closure.py was
+armed in immune-enforcement.yml) is the follow-up PR's job, not this one's.
+
+Same basename as its scripts/ci/ counterpart is deliberate, not an oversight —
+pytest never collects both in one run (scripts/ci/ is not swept, see above), so
+the "import file mismatch" collision that basename would otherwise risk does not
+arise in any wiring this repo actually runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CI_DIR = REPO / "scripts" / "ci"
+sys.path.insert(0, str(CI_DIR))
+
+from test_trusted_extraction_layout import (  # noqa: E402
+    TrustedExtractionLayoutTests as TrustedExtractionLayoutTests,
+)


### PR DESCRIPTION
## Why

`tests.yml`'s "Extract trusted classifier (base ref)" step copies `scripts/ci/*`
FLAT into `$RUNNER_TEMP/trusted-classifier/` and runs `test_change_map.py` /
`test_impact_map.py` from there, with cwd left at the checkout root.
`scripts/tests/test_classifier_extraction_closure.py` already proves the
extraction list is import-closed by static AST inspection — that catches a
missing-sibling import (#5070's shape), but it did NOT and could NOT have
caught #5679 (2026-09-04): `test_change_map.py`'s own
`test_scripts_coupling_census_is_not_stale` called
`Path(__file__).resolve().parents[2]` to relocate the repo root, which
resolves to a nonsense directory once the file has no `scripts/ci/` above it
in a flat temp dir. The import graph was fine; the corpus failed AT RUNTIME.
`#5692` fixed it by trying `Path.cwd()` / `$GITHUB_WORKSPACE` first. Nothing
proved that fix would stay fixed except a GitHub Actions runner noticing —
this closes that gap locally.

## What

- `scripts/ci/test_trusted_extraction_layout.py` — parses `tests.yml`'s own
  `for f in scripts/ci/...` loop (fails loudly if that shape ever changes),
  copies exactly those files flat into a tmp dir, and:
  - **innocence**: runs `test_change_map.py` and `test_impact_map.py` from
    that flat dir, cwd at the repo root (CI's exact shape) — both must exit 0
    on current `main`.
  - **guilt**: omits `security_gate_flags.py` from the flat copy (a sibling
    `test_change_map.py` imports) and asserts the corpus fails loudly —
    proving this probe would have caught #5070's shape too, not just #5679's.
- `scripts/tests/test_trusted_extraction_layout.py` — thin re-export of the
  same `unittest.TestCase` (same pattern as
  `scripts/tests/test_harness_gate_read.py` importing
  `scripts/ci/harness_gate_read.py`), so the probe rides the nightly
  `scripts/tests/` sweep (`scripts-tests-sweep.yml`) and the local
  `pytest scripts/tests/` habit.

`scripts/ci/*.py` is never globbed by any pytest run in this repo today
(verified: `scripts-tests-sweep.yml` collects only `scripts/tests/`, every
other workflow names an exact `scripts/ci/*.py` file) — so without the thin
wrapper this new probe would run only by hand. It is **not yet a per-PR
gate**: `scripts-tests-sweep.yml` is `schedule:`-only and
`continue-on-error: true` by design. Wiring it into a required per-PR check
(mirroring how `test_classifier_extraction_closure.py` was armed in
`immune-enforcement.yml`) is a follow-up, tracked separately — this PR is
script-only (floor 1), no workflow file touched.

## Bites

**Consumer**: the nightly `scripts/tests/ sweep` job
(`scripts-tests-sweep.yml`, already armed, runs on schedule) — ships in this
PR, no future job needed. Secondary consumer: any dev running
`pytest scripts/tests/` before pushing a `scripts/ci/` change.

**Observation**: `python3 -m pytest -q scripts/tests/test_trusted_extraction_layout.py`
→ `3 passed, 2 subtests passed` today (see verification below). The guilt
subtest inside `test_guilt_a_missing_sibling_breaks_the_flat_corpus` fails
loudly (non-zero exit, `security_gate_flags` in stderr) when
`security_gate_flags.py` is dropped from the flat copy — verified locally
before opening this PR.

## Verification (all run 2026-09-05, this branch)

```
$ python3 scripts/ci/test_trusted_extraction_layout.py
test_guilt_a_missing_sibling_breaks_the_flat_corpus ... ok
test_innocence_current_extraction_runs_both_corpora_clean ... ok
test_the_extraction_shape_is_discoverable ... ok
Ran 3 tests in 0.446s
OK

$ python3 -m pytest -q scripts/ci/test_change_map.py scripts/ci/test_trusted_extraction_layout.py scripts/tests/test_trusted_extraction_layout.py
53 passed, 51 subtests passed in 1.40s
(no "import file mismatch" despite the shared basename — scripts/ci/ is
never swept alongside scripts/tests/ in any real CI wiring, verified by
grep; this run proves it isn't fragile even when forced together)

$ python3 scripts/ci/scripts_coupling_census.py --check
scripts_coupling_census: SCRIPTS_COUPLING is up to date.

$ printf 'scripts/ci/test_trusted_extraction_layout.py\nscripts/tests/test_trusted_extraction_layout.py\n' | python3 scripts/ci/change_map.py
{"run_all":false, "suggested_jobs":[all six], "would_skip":[], "domains": {"infra_workflows":true,"security_sensitive":true,"fleet_ops":true, ...}}
```

Last item confirms the brief's own hedge precisely: the top-level `run_all`
field is literally `false` (paths classify cleanly, no `unknown_paths`), but
because both new files live under `scripts/ci/`, `security_sensitive`/
`infra_workflows` domains fire and `_suggested_jobs()` returns all six jobs
unconditionally — `would_skip` is empty, so in *effect* this PR pays for the
full suite, same as any other `scripts/ci/` change. That is intended
behavior of the existing classifier, not a defect of this PR.

## Floor

1 (script-only, no workflow file changed, 215 net lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScrkeSvMGqYfnJXJjUcLq4