### PR TITLE
fix(news-room): the published URL uses the served category, not the content folder

### DIFF
--- a/apps/backend-rag/backend/app/routers/article_composer.py
+++ b/apps/backend-rag/backend/app/routers/article_composer.py
@@ -1016,8 +1016,13 @@ async def publish_article_internal(request: PublishRequest) -> PublishResponse:
             json_object_updates=layout_updates,
         )
 
-        # Build article URL
-        article_url = f"https://balizero.com/{category_folder}/{slug}"
+        # Build article URL. The MDX lives under the CONTENT FOLDER
+        # (`category_folder`, e.g. "business_regulations"), but the site
+        # only routes the SERVED category (e.g. "business") — see
+        # backend/services/article_routes.py.
+        from backend.services.article_routes import served_category
+
+        article_url = f"https://balizero.com/{served_category(category_folder)}/{slug}"
 
         pr_number = result.get("pull_request_number")
         if pr_number:

--- a/apps/backend-rag/backend/app/routers/intel_scraper.py
+++ b/apps/backend-rag/backend/app/routers/intel_scraper.py
@@ -40,6 +40,7 @@ from backend.app.utils.internal_api_auth import verify_internal_api_key
 from backend.app.utils.logging_utils import get_logger
 from backend.core.cache import invalidate_cache
 from backend.core.qdrant_db import QdrantClient
+from backend.services.article_routes import served_category
 from backend.services.cover_images import _cover_as_jpeg
 from backend.services.intel.intel_staging_service import assert_valid_item_id
 
@@ -818,7 +819,7 @@ async def _publish_staging_item(
         try:
             from claude_validator import ClaudeValidator
 
-            published_url = f"{settings.balizero_website_url}/{category}/{item_id}"
+            published_url = f"{settings.balizero_website_url}/{served_category(category)}/{item_id}"
 
             ClaudeValidator.add_published_article(
                 title=title,
@@ -846,7 +847,7 @@ async def _publish_staging_item(
             )
 
         # Step 3: Publish to GitHub/Vercel → balizero.com
-        published_url = f"{settings.balizero_website_url}/{category}/{item_id}"
+        published_url = f"{settings.balizero_website_url}/{served_category(category)}/{item_id}"
         github_commit_sha = None
         mdx_path = None
         article_slug = item_id  # fallback: use item_id if GitHub publish fails

--- a/apps/backend-rag/backend/services/article_routes.py
+++ b/apps/backend-rag/backend/services/article_routes.py
@@ -1,0 +1,59 @@
+"""Content-folder → served-category mapping for public article URLs.
+
+Bali Zero's site collapses 13 content folders (where MDX files live, and
+where the CMS/Article Composer writes them) onto 7 categories the Next.js
+frontend actually routes (`apps/mouth/src/lib/blog/categories.ts::CATEGORY_MAP`,
+consumed there by `normalizeCategory`/`articleUrl`). Any backend code that
+hands out a public `article_url`/`published_url` MUST run the folder through
+this table first, or the link 404s with "Article not found" — measured live
+2026-09-05: `https://balizero.com/business_regulations/<slug>` (folder name)
+404s while `https://balizero.com/business/<slug>` (served category) renders.
+
+This table is a hand-kept COPY of `CATEGORY_MAP` in `categories.ts` — there is
+no cross-language import path between the FastAPI backend and the Next.js
+frontend. `tests/unit/services/test_article_routes.py` parses the TypeScript
+source and asserts every key here maps identically, so a drift in either file
+fails CI instead of shipping another dead link.
+"""
+
+from __future__ import annotations
+
+# Keep this literally in sync with `CATEGORY_MAP` in
+# apps/mouth/src/lib/blog/categories.ts. See test_article_routes.py.
+_FOLDER_TO_SERVED_CATEGORY: dict[str, str] = {
+    # Canonical categories
+    "visas": "visas",
+    "business": "business",
+    "taxes": "taxes",
+    "property": "property",
+    "living": "living",
+    "trends": "trends",
+    # Backward compat (old category names)
+    "immigration": "visas",
+    "lifestyle": "living",
+    "tech": "trends",
+    "bali_news": "living",
+    # Folder mappings (14 folders → 7 categories)
+    "tax": "taxes",
+    "tax-legal": "taxes",
+    "digital-nomad": "living",
+    "bali-news": "living",
+    "business_regulations": "business",
+    "emerging_trends": "trends",
+    "social_media": "trends",
+    "news": "business",
+    # Backend compatibility
+    "general": "business",
+    "legal": "taxes",
+}
+
+
+def served_category(folder: str) -> str:
+    """Map a content-folder name to the category the site actually serves.
+
+    An unknown folder is returned unchanged (never raises, never silently
+    defaults to some other category) so a new content folder cannot break
+    the publish flow — it will just 404 as itself until someone extends this
+    table and its TypeScript twin.
+    """
+    return _FOLDER_TO_SERVED_CATEGORY.get(folder, folder)

--- a/apps/backend-rag/backend/tests/unit/routers/test_article_composer.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_article_composer.py
@@ -507,6 +507,55 @@ async def test_publish_article_without_cover_image(
     assert call_args[1]["pull_request"] is True
     assert call_args[1]["must_not_exist_paths"] == [call_args[1]["files"][0]["path"]]
 
+    # The returned article_url uses the SERVED category ("visas"), not the
+    # content folder the MDX was written to ("immigration" — see
+    # category_map above). Regression guard for the folder-vs-served-category
+    # bug: see backend/services/article_routes.py.
+    assert call_args[1]["files"][0]["path"].startswith(
+        "apps/mouth/src/content/articles/immigration/"
+    )
+    assert data["article_url"].startswith("https://balizero.com/visas/")
+
+
+@pytest.mark.asyncio
+@patch("backend.services.integrations.github_publisher.github_publisher")
+async def test_publish_article_url_uses_served_category_not_content_folder(
+    mock_publisher,
+    test_client,
+    sample_enriched_article,
+):
+    """A ``business_regulations`` article is written to the
+    ``business_regulations`` content folder (unmapped in ``category_map`` so
+    it passes through as its own folder name) but MUST be served at
+    ``/business/`` — the site only routes served categories, not folder
+    names. Measured live 2026-09-05: the folder-named URL 404s.
+    """
+    mock_publisher.is_configured = True
+    mock_publisher.check_file_exists = AsyncMock(return_value=False)
+    mock_publisher.create_commit_with_files = AsyncMock(
+        return_value={
+            "success": True,
+            "commit_sha": "regcat1",
+            "files_count": 1,
+            "branch": "auto-publish/regcat1",
+            "pull_request_number": 91,
+            "auto_merge_enabled": True,
+        },
+    )
+
+    article = sample_enriched_article.model_copy(update={"category": "business_regulations"})
+    request = PublishRequest(article=article, position="normal", slug="new-kbli-rules")
+    response = test_client.post("/api/articles/publish", json=request.model_dump())
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+
+    call_args = mock_publisher.create_commit_with_files.call_args
+    mdx_path = call_args[1]["files"][0]["path"]
+    assert mdx_path == "apps/mouth/src/content/articles/business_regulations/new-kbli-rules.mdx"
+    assert data["article_url"] == "https://balizero.com/business/new-kbli-rules"
+
 
 @pytest.mark.asyncio
 @patch("backend.services.integrations.github_publisher.github_publisher")

--- a/apps/backend-rag/backend/tests/unit/services/test_article_routes.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_article_routes.py
@@ -1,0 +1,128 @@
+"""Cross-language drift tripwire for the folder → served-category table.
+
+`apps/mouth/src/lib/blog/categories.ts::CATEGORY_MAP` is the SSOT for which
+public category (`/business/`, `/visas/`, `/taxes/`, ...) each content
+folder is served at. `backend/services/article_routes.py::served_category`
+is a hand-kept Python COPY of that table — the FastAPI backend and the
+Next.js frontend cannot share a constant across languages. A folder present
+on only one side means the backend builds an `article_url`/`published_url`
+that the site does not route (measured live 2026-09-05: the folder-named
+URL 404s with "Article not found" while the served-category URL renders).
+
+This test is the mechanism, not the comment promising sync. It reads the TS
+source as plain text (no bundler, no AST parser — a tripwire), extracts the
+`CATEGORY_MAP` object literal, and compares it against the Python table as
+dicts, not as text, so formatting/ordering/quoting style can never flip it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.services.article_routes import _FOLDER_TO_SERVED_CATEGORY, served_category
+
+# Five levels up from this file (services -> unit -> tests -> backend ->
+# backend-rag) reaches apps/ itself, same convention as
+# test_service_accounts_ts_sync.py's _TS_HOOK_PATH (six levels up from one
+# directory deeper, also landing on apps/).
+_TS_CATEGORIES_PATH = (
+    Path(__file__).resolve().parents[5] / "mouth" / "src" / "lib" / "blog" / "categories.ts"
+)
+
+_CATEGORY_MAP_BLOCK_RE = re.compile(
+    r"export\s+const\s+CATEGORY_MAP\s*:\s*Record<string,\s*ArticleCategory>\s*=\s*\{"
+    r"(?P<body>.*?)\n\};",
+    re.DOTALL,
+)
+
+_ENTRY_RE = re.compile(
+    r"""^\s*(?:"(?P<qkey>[^"]+)"|(?P<bkey>[A-Za-z_][A-Za-z0-9_]*))\s*:\s*"(?P<value>[^"]+)"\s*,?\s*$"""
+)
+
+
+def _extract_ts_category_map(source: str) -> dict[str, str]:
+    """Parse the `CATEGORY_MAP` object literal out of TS source as text.
+
+    Raises if the declaration cannot be found at all, so a rename or a
+    reformat past what this regex tolerates breaks this test LOUDLY instead
+    of silently comparing against an empty extracted map and passing for the
+    wrong reason.
+    """
+    match = _CATEGORY_MAP_BLOCK_RE.search(source)
+    if match is None:
+        raise AssertionError(
+            "Could not find `export const CATEGORY_MAP: Record<string, "
+            f"ArticleCategory> = {{...}}` in {_TS_CATEGORIES_PATH} — the "
+            "declaration was renamed, reformatted past what this regex "
+            "tolerates, or removed. Update this test's extraction pattern "
+            "to match the new shape; do not delete this test or weaken it "
+            "to skip on a miss."
+        )
+    entries: dict[str, str] = {}
+    for line in match.group("body").splitlines():
+        line = line.strip()
+        if not line or line.startswith("//"):
+            continue
+        entry_match = _ENTRY_RE.match(line)
+        if entry_match is None:
+            continue
+        key = entry_match.group("qkey") or entry_match.group("bkey")
+        entries[key] = entry_match.group("value")
+    return entries
+
+
+class TestServedCategoryStaysInSyncWithCategoriesTs:
+    """Guilt + innocence for the cross-language sync itself."""
+
+    def test_python_table_matches_the_ts_category_map_exactly(self) -> None:
+        """Guilt: a folder present on only one side, or mapped to a
+        different served category on each side, must fail this test.
+        """
+        assert _TS_CATEGORIES_PATH.is_file(), f"expected TS file at {_TS_CATEGORIES_PATH}"
+
+        ts_map = _extract_ts_category_map(_TS_CATEGORIES_PATH.read_text())
+
+        # Non-vacuity: an empty extracted map would trivially equal an
+        # empty Python dict and pass for the wrong reason.
+        assert ts_map, (
+            "Extracted an EMPTY CATEGORY_MAP from "
+            f"{_TS_CATEGORIES_PATH} — that is almost certainly a bug in "
+            "this test's extraction regex, not a real empty table."
+        )
+
+        assert ts_map == _FOLDER_TO_SERVED_CATEGORY, (
+            f"backend/services/article_routes.py's served-category table has "
+            f"drifted from CATEGORY_MAP in {_TS_CATEGORIES_PATH}. A folder "
+            "present on only one side (or mapped to a different served "
+            "category on each side) means the backend hands out a public "
+            "URL the site does not route the same way the frontend does."
+        )
+
+    def test_extraction_raises_when_the_declaration_is_absent(self) -> None:
+        """Innocence of the tripwire itself: prove the fail-loud path fires."""
+        with pytest.raises(AssertionError, match="Could not find"):
+            _extract_ts_category_map("// CATEGORY_MAP was removed here\n")
+
+    def test_extraction_ignores_an_unrelated_object_literal(self) -> None:
+        """Innocence: a same-shaped object for something else must not match."""
+        source = 'export const SOME_OTHER_MAP: Record<string, string> = {\n  foo: "bar",\n};\n'
+        with pytest.raises(AssertionError, match="Could not find"):
+            _extract_ts_category_map(source)
+
+
+class TestServedCategory:
+    """Direct unit coverage of `served_category` itself."""
+
+    def test_business_regulations_folder_serves_business(self) -> None:
+        assert served_category("business_regulations") == "business"
+
+    def test_immigration_folder_serves_visas(self) -> None:
+        assert served_category("immigration") == "visas"
+
+    def test_unknown_folder_is_returned_unchanged(self) -> None:
+        assert served_category("some-new-folder-nobody-mapped-yet") == (
+            "some-new-folder-nobody-mapped-yet"
+        )


### PR DESCRIPTION
## Why

Measured in Chrome on 2026-09-05: the News Room publish returned `https://balizero.com/business_regulations/<slug>` for the KBLI 2025 article, and that page renders "Article not found" — so does an older article under the same path. `https://balizero.com/business/<slug>` renders it. The URL was built from the content FOLDER; the site routes 7 served categories that 13 folders collapse onto (`apps/mouth/src/lib/blog/categories.ts`: `business_regulations/` → `/business/`, `immigration/` → `/visas/`, `tax-legal/` → `/taxes/`, …). The link handed to Damar, and stored as `published_url`, was dead.

## What

- `backend/services/article_routes.py::served_category(folder)`: the folder→category table; unknown folders pass through.
- Composer `article_url` and both `published_url` fallbacks in the staging publisher go through it. The MDX still lands in its content folder.
- Tests: the Python table is parsed against `categories.ts` and must be identical (fails loud if the TS declaration moves); `business_regulations` → `business`, `immigration` → `visas`; a `business_regulations` publish writes the MDX in that folder and returns `/business/<slug>`.

## Verification

- `test_article_routes.py` + `test_article_composer.py` + `test_intel_scraper_router.py` + `test_workspace_marketing_bridge.py`: 115 passed. ruff clean. Code by a Sonnet builder, verified by the session.

Bites: Damar's next `newsroom_publish` on Fly (auto-deploy on merge) — observation: the `published_url` in the bridge response opens the article (HTTP 200 with the article `<h1>`), not the not-found page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeDJCspmXHEjirHmfpf4Z
