### PR TITLE
fix(ci): `security_sensitive` named two questions, and answered both by running all six suites

### DIFF
--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -250,7 +250,32 @@ PREFIX_RULES: tuple[tuple[str, frozenset[str]], ...] = (
     # this entry, infra/guard-conformance/registry.json inherited the
     # broad "infra/" rule and forced every one of the six jobs regardless.
     ("infra/guard-conformance/", frozenset({"fleet_ops"})),
-    ("infra/", frozenset({"infra_workflows", "security_sensitive"})),
+    # Also more specific than the catch-all, and the ONE sub-tree of infra/
+    # that a tests.yml suite genuinely reads (census 2026-09-05, all 38
+    # sub-trees against all six suites):
+    # apps/backend-rag/backend/tests/unit/core/test_ingest_target_registry.py
+    # opens infra/eventbus/regulatory_ingest_runner.py by that literal path
+    # and asserts on its contents, and scripts/ci/ingest_target_lint.py
+    # hardcodes the same path in DECLARED_ENTRYPOINTS. Every other sub-tree
+    # (ghostty, launchagents, required.d, conductor, vcr, healer, home-fork,
+    # …) either has zero hits in the six suites' trees, or hits confined to
+    # scripts/ (covered by SCRIPTS_COUPLING below), or — claude-hooks,
+    # launchagents — hits that are PROSE inside docstrings naming the
+    # directory, not code that opens or imports anything there.
+    ("infra/eventbus/", frozenset({"backend_python", "security_sensitive"})),
+    # The catch-all. `infra_workflows` (2026-09-05) was the second half of
+    # the same over-match `infra/guard-conformance/` was carved out of above,
+    # applied to the other 37 sub-trees: infra/ is fleet payload — plists,
+    # wrappers, terminal profiles, required-context mirrors — not CI workflow
+    # definitions. Those live in .github/, which keeps infra_workflows and
+    # keeps forcing all six suites. `security_sensitive` STAYS: CodeQL's
+    # config (.github/codeql-config.yml) declares no paths-ignore, so it
+    # analyses infra/'s Python and shell like any other tree, and dropping
+    # the domain here would silence that scan — the UNDER-match twin of the
+    # defect being cured. The security posture of an infra/-only PR is
+    # therefore byte-identical to before this change; only the six product
+    # suites stop being bought.
+    ("infra/", frozenset({"fleet_ops", "security_sensitive"})),
     ("config/", frozenset({"infra_workflows", "security_sensitive"})),
     ("data/", frozenset({"backend_python", "docs_content_data"})),
     # kb/ is the knowledge-base corpus (inventories, topics, journeys, ops
@@ -423,10 +448,36 @@ def _domains_for_path(path: str) -> set[str]:
 
 
 def _suggested_jobs(domains: set[str], run_all: bool) -> list[str]:
-    # CI infrastructure and security-sensitive surfaces can affect any suite
-    # indirectly. They are known paths, but never candidates for selective
-    # execution.
-    if run_all or domains.intersection({"infra_workflows", "security_sensitive"}):
+    # CI infrastructure can affect any suite indirectly: the workflow files,
+    # the classifier itself and the hooks that run around them are known
+    # paths, but never candidates for selective execution.
+    #
+    # `security_sensitive` was in this set until 2026-09-05 and is NOT, because
+    # it names TWO unrelated questions under one word (cicatrix #3, over-match
+    # on the domain instead of the entity):
+    #   1. "which SECURITY SCANNERS must run" — read by
+    #      scripts/ci/security_gate_flags.py, which is the only thing this
+    #      domain was ever designed to answer, and still answers unchanged;
+    #   2. "which of the six PRODUCT TEST SUITES must run" — answered here.
+    # Conflating them made every security-sensitive path buy all six suites,
+    # whatever its real coupling. Measured on PR #5697: a one-file diff
+    # (infra/ghostty/machines/m5.ghostty) classified correctly — run_all
+    # false, reason `classified`, only infra_workflows + security_sensitive
+    # lit, no frontend domain at all — and still ran Frontend Tests for 16 of
+    # its 18 steps, because this line looked at the union.
+    #
+    # Dropping it here is not an UNDER-match (the twin defect), because no
+    # rule reaches `security_sensitive` alone: every entry that carries it —
+    # EXACT_RULES' package.json / pyproject.toml, PYTHON_MANIFEST_NAMES,
+    # PREFIX_RULES' .github/ .husky/ .security/ scripts/ci/ config/ infra/,
+    # and the two additive rules below (`auth|security|migrations|deploy`
+    # path parts, Dockerfile/fly.toml basenames) — also carries the domains
+    # of the code it actually touches. So a lockfile change still fans out to
+    # its own runtimes, a workflow edit still runs everything through
+    # infra_workflows, and what stops is only the fan-out to suites that
+    # cannot read the changed file: pyproject.toml no longer runs the
+    # frontend, package-lock.json no longer runs the Python suites.
+    if run_all or domains.intersection({"infra_workflows"}):
         return list(TEST_JOBS)
 
     jobs: list[str] = []

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -14,6 +14,30 @@ import change_map as cm
 import security_gate_flags as sgf
 
 
+def _locate_repo_root(rel: Path) -> Path | None:
+    """Find the checkout that contains ``rel``, or None.
+
+    Never resolve the checkout relative to ``__file__`` alone: tests.yml
+    extracts this file FLAT into $RUNNER_TEMP/trusted-classifier/ (no
+    scripts/ci/ above it), where parents[2] is /home/runner/work and every
+    path built from it 404s. That mis-resolution turned the census staleness
+    assertion red on EVERY PR from #5679 (2026-09-04) until #5692, and the
+    classify step fell to run_all=true meanwhile. Any test here that touches
+    the checkout goes through this function and SKIPS when it is absent —
+    the assertion is made where the checkout exists, never faked where it
+    does not.
+    """
+
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    file_root = Path(__file__).resolve()
+    candidates = [Path.cwd()]
+    if workspace:
+        candidates.append(Path(workspace))
+    if len(file_root.parents) > 2:
+        candidates.append(file_root.parents[2])
+    return next((c for c in candidates if (c / rel).is_file()), None)
+
+
 class ChangeMapTests(unittest.TestCase):
     def test_guilt_backend_change_runs_backend_and_e2e(self) -> None:
         result = cm.classify(["apps/backend-rag/backend/app/main.py"])
@@ -620,21 +644,11 @@ class ChangeMapTests(unittest.TestCase):
         # extraction list, and it has no business there (it shells out to
         # `git grep` and writes files). --check re-derives SCRIPTS_COUPLING
         # live and exits 1 on drift (cicatrix #9).
-        # Locate the census in the CHECKOUT, never relative to __file__:
-        # tests.yml extracts this test FLAT into $RUNNER_TEMP/trusted-classifier/
-        # (no scripts/ci/ above it), where parents[2] resolved to /home/runner/work,
-        # the subprocess 404'd, this assertion failed, and the classify step fell
-        # to run_all=true (enumeration_failed) on EVERY PR from #5679 (2026-09-04)
-        # until this fix — the same disease #5676 cured for security_gate_flags.
+        # Locate the census in the CHECKOUT, never relative to __file__ —
+        # see _locate_repo_root's docstring for the flat-extraction trap and
+        # the #5679→#5692 outage it caused.
         rel = Path("scripts") / "ci" / "scripts_coupling_census.py"
-        workspace = os.environ.get("GITHUB_WORKSPACE")
-        file_root = Path(__file__).resolve()
-        candidates = [Path.cwd()]
-        if workspace:
-            candidates.append(Path(workspace))
-        if len(file_root.parents) > 2:
-            candidates.append(file_root.parents[2])
-        repo_root = next((c for c in candidates if (c / rel).is_file()), None)
+        repo_root = _locate_repo_root(rel)
         if repo_root is None:
             self.skipTest(
                 "scripts_coupling_census.py not reachable from cwd, GITHUB_WORKSPACE "
@@ -738,6 +752,123 @@ class ChangeMapTests(unittest.TestCase):
         self.assertEqual(result["unknown_paths"], [])
         self.assertTrue(result["domains"]["fleet_ops"])
         self.assertEqual(result["suggested_jobs"], [])
+
+    def test_innocence_infra_fleet_payload_skips_every_test_job(self) -> None:
+        # The measurement that opened this cure (PR #5697, 2026-09-05): a diff
+        # of ONE file under infra/ classified perfectly — run_all false,
+        # reason `classified`, no frontend domain lit — and still ran all six
+        # heavy jobs, Frontend Tests included (16 of its 18 steps executed),
+        # because both domains the "infra/" catch-all handed out were in
+        # _suggested_jobs()'s multiplier set. Third recidive of cicatrix #3's
+        # over-match half in two days (scripts/ #5679, .claude/ #5685, this),
+        # and the cure's own precedent was already in this file: the
+        # infra/guard-conformance/ carve-out above.
+        result = cm.classify(["infra/ghostty/machines/m5.ghostty"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["reason"], "classified")
+        self.assertEqual(result["unknown_paths"], [])
+        self.assertTrue(result["domains"]["fleet_ops"])
+        self.assertFalse(result["domains"]["infra_workflows"])
+        self.assertEqual(result["suggested_jobs"], [])
+        self.assertEqual(result["would_skip"], list(cm.TEST_JOBS))
+
+    def test_guilt_infra_still_buys_the_security_scanners(self) -> None:
+        # The UNDER-match twin, pinned so a later "simplification" cannot
+        # take it: .github/codeql-config.yml declares NO paths-ignore, so
+        # CodeQL analyses infra/'s Python and shell like any other tree.
+        # infra/ therefore keeps `security_sensitive` — the domain
+        # security_gate_flags.py reads — even though it no longer buys a
+        # single product test suite. `CodeQL Analysis (python)` and
+        # `(javascript)` are both required contexts on main.
+        #
+        # The path is deliberately a real .py file reached by the CATCH-ALL
+        # rule, not by the infra/eventbus/ carve-out — the carve-out carries
+        # security_sensitive of its own, so an eventbus path would stay green
+        # while the catch-all silently lost the domain.
+        result = cm.classify(["infra/claude-hooks/host_boundary.py"])
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["security_sensitive"])
+        self.assertEqual(result["suggested_jobs"], [])
+        flags = sgf.compute_flags(result, js_manifest=False)
+        self.assertTrue(flags["run_codeql_python"])
+        self.assertTrue(flags["run_codeql_js"])
+
+    def test_guilt_infra_eventbus_runs_the_backend_suite_that_reads_it(
+        self,
+    ) -> None:
+        # The one real coupling the 2026-09-05 census found across all 38
+        # infra/ sub-trees, and it is a literal-path read, not an import:
+        # test_ingest_target_registry.py opens this exact file and asserts on
+        # its contents, and scripts/ci/ingest_target_lint.py names it in
+        # DECLARED_ENTRYPOINTS. Both are checked here so a rename of either
+        # side fails this test instead of silently un-coupling the rule.
+        runner = "infra/eventbus/regulatory_ingest_runner.py"
+        result = cm.classify([runner])
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["backend_python"])
+        self.assertIn("backend-tests", result["suggested_jobs"])
+        self.assertNotIn("frontend-tests", result["suggested_jobs"])
+
+        rel = Path("apps/backend-rag/backend/tests/unit/core/test_ingest_target_registry.py")
+        repo_root = _locate_repo_root(rel)
+        if repo_root is None:
+            self.skipTest(
+                "the coupled backend test is not reachable from cwd, GITHUB_WORKSPACE "
+                "or __file__ — the coupling is asserted where the checkout is present"
+            )
+        self.assertIn(runner, (repo_root / rel).read_text(encoding="utf-8"))
+
+    def test_guilt_infra_does_not_suppress_a_real_backend_change(self) -> None:
+        # fleet_ops maps to zero jobs, so a co-changed product path must keep
+        # every job it earns on its own — the union, never the minimum.
+        result = cm.classify(
+            ["infra/launchagents/com.example.plist", "apps/backend-rag/backend/app/main.py"]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertIn("backend-tests", result["suggested_jobs"])
+
+    def test_guilt_workflow_definitions_still_force_every_suite(self) -> None:
+        # infra_workflows stays in _suggested_jobs()'s multiplier set and
+        # .github/ keeps it: editing what RUNS the suites still buys them all.
+        result = cm.classify([".github/workflows/some-workflow.yml"])
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["infra_workflows"])
+        self.assertEqual(result["suggested_jobs"], list(cm.TEST_JOBS))
+
+    def test_innocence_manifests_reach_their_own_runtimes_and_no_others(
+        self,
+    ) -> None:
+        # The other half of dropping `security_sensitive` from the multiplier:
+        # it must not become an UNDER-match. Every manifest still fans out to
+        # the runtimes it can actually break — via its OWN domains, which is
+        # why the drop is safe — and stops paying for the ones it cannot.
+        python = cm.classify(["pyproject.toml"])
+        self.assertTrue(python["domains"]["security_sensitive"])
+        for job in ("backend-tests", "mcp-tests", "evaluator-critical-tests", "e2e-tests"):
+            self.assertIn(job, python["suggested_jobs"])
+        self.assertNotIn("frontend-tests", python["suggested_jobs"])
+        self.assertNotIn("packages-core-tests", python["suggested_jobs"])
+
+        node = cm.classify(["package-lock.json"])
+        self.assertTrue(node["domains"]["security_sensitive"])
+        for job in ("frontend-tests", "packages-core-tests"):
+            self.assertIn(job, node["suggested_jobs"])
+        self.assertNotIn("backend-tests", node["suggested_jobs"])
+        self.assertNotIn("mcp-tests", node["suggested_jobs"])
+
+    def test_innocence_a_security_sensitive_path_part_no_longer_buys_all_six(
+        self,
+    ) -> None:
+        # The additive `auth|security|migrations|deploy` rule tags a path
+        # security_sensitive ON TOP of its prefix domains. Before the split
+        # that tag alone forced all six suites onto a frontend-only file.
+        result = cm.classify(["apps/mouth/src/app/auth/page.tsx"])
+        self.assertFalse(result["run_all"])
+        self.assertTrue(result["domains"]["security_sensitive"])
+        self.assertTrue(result["domains"]["mouth"])
+        self.assertIn("frontend-tests", result["suggested_jobs"])
+        self.assertNotIn("backend-tests", result["suggested_jobs"])
+        self.assertNotIn("mcp-tests", result["suggested_jobs"])
 
     def test_cli_stdout_is_one_compact_json_line(self) -> None:
         script = Path(__file__).with_name("change_map.py")

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import unittest
@@ -869,6 +870,95 @@ class ChangeMapTests(unittest.TestCase):
         self.assertIn("frontend-tests", result["suggested_jobs"])
         self.assertNotIn("backend-tests", result["suggested_jobs"])
         self.assertNotIn("mcp-tests", result["suggested_jobs"])
+
+    def test_infra_coupling_census_is_not_stale(self) -> None:
+        # The RATCHET, and the reason it exists: before the `infra/` catch-all
+        # stopped buying all six suites, a new coupling from a suite into
+        # infra/ was harmless — the over-match ran the suite anyway. Removing
+        # the over-match removes that accidental safety net, so the census
+        # that justified the carve-out has to be re-derived on every run
+        # instead of trusted as a one-off (the same reasoning that turned the
+        # scripts/ audit into scripts_coupling_census.py --check, cicatrix #9:
+        # a rule whose evidence was measured once and never again).
+        #
+        # This pins the FULL reference profile — file -> segment -> count —
+        # not just the set of segments, so adding a reference to an
+        # already-listed sub-tree trips it too. Every entry below was read by
+        # hand on 2026-09-05. The `infra/eventbus` ones are the carved-out
+        # coupling (PREFIX_RULES, pinned by its own test above) — and only ONE
+        # of them is a real read: test_ingest_target_registry.py opens the
+        # runner; ingest_paths.py and outbox_handlers.py merely name it in a
+        # docstring. Every NON-eventbus entry is PROSE: a docstring naming the
+        # plist that invokes the module, a README paragraph, a comment, a
+        # branch-name string in a fixture, a data-note inside a corpus JSON.
+        # None of them opens, imports or subprocesses anything under infra/.
+        #
+        # When this goes red: read the new reference. Prose -> update the pin.
+        # A real read/import -> add a PREFIX_RULES carve-out mapping that
+        # sub-tree to the domain of the suite that reads it, THEN update the
+        # pin. Do not update the pin to make the test quiet.
+        expected: dict[str, dict[str, int]] = {
+            "apps/backend-rag/backend/app/utils/ingest_paths.py": {"infra/eventbus": 1},
+            "apps/backend-rag/backend/scripts/federation_alert_daemon.py": {"infra/launchagents": 1},
+            "apps/backend-rag/backend/scripts/kg_fix_68112_node.py": {"infra/kg-68112-licenses": 1},
+            "apps/backend-rag/backend/services/federation_alerts/__init__.py": {"infra/launchd": 1},
+            "apps/backend-rag/backend/services/garuda_orders/outbox_handlers.py": {"infra/eventbus": 1},
+            "apps/backend-rag/backend/services/sota_loop/__init__.py": {"infra/launchagents": 1},
+            "apps/backend-rag/backend/services/sota_loop/_promote.py": {"infra/launchagents": 1},
+            "apps/backend-rag/backend/services/sota_loop/m13_weekly.py": {"infra/claude-hooks": 1},
+            "apps/backend-rag/backend/tests/unit/core/test_ingest_target_registry.py": {"infra/eventbus": 1},
+            "apps/backend-rag/backend/tests/unit/response/test_w119c_outbound_marker_newline_bleed.py": {"infra/claude-hooks": 1},
+            "apps/backend-rag/backend/tests/unit/routers/test_ingest_path_confinement.py": {"infra/eventbus": 1},
+            "apps/backend-rag/backend/tests/unit/scripts/test_codex_tri_llm_review_script.py": {"infra/y": 1},
+            "apps/backend-rag/backend/tests/unit/services/ingestion/test_ingest_success_is_reported_honestly.py": {"infra/eventbus": 1},
+            "apps/backend-rag/backend/tests/unit/services/sota_loop/test_m13_weekly_repo_root.py": {"infra/claude-hooks": 1},
+            "apps/evaluator/nlm_deep_research/scripts/run_nb5_t4_monitor.sh": {"infra/launchagents": 1},
+            "apps/mouth/data/KBLI_2025_FINAL_CLEAN.json": {"infra/workflows": 1},
+            "apps/wa-mirror/README.md": {"infra/home-fork": 2},
+        }
+        # The trees the six heavy jobs actually execute. scripts/ci/ is
+        # DELIBERATELY absent: it is mapped to infra_workflows (all six jobs)
+        # and it contains this very file, so including it would make the pin
+        # count its own prose and change on every edit to it.
+        trees = (
+            "apps/backend-rag",
+            "apps/nuzantara-mcp",
+            "apps/evaluator",
+            "apps/mouth",
+            "apps/admin-dashboard",
+            "apps/admin-dashboard-local",
+            "apps/wa-mirror",
+            "packages/core",
+        )
+        repo_root = _locate_repo_root(Path("scripts") / "ci" / "change_map.py")
+        if repo_root is None:
+            self.skipTest(
+                "no checkout reachable from cwd, GITHUB_WORKSPACE or __file__ — the "
+                "infra/ census is re-derived where the checkout is present"
+            )
+        present = [t for t in trees if (repo_root / t).is_dir()]
+        completed = subprocess.run(
+            ["git", "grep", "-nIE", r"infra/[a-z0-9_-]+", "--", *present],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        # git grep exits 1 on "no matches", which is a legitimate (if
+        # surprising) outcome; anything else is a broken invocation.
+        self.assertIn(completed.returncode, (0, 1), completed.stderr)
+        found: dict[str, dict[str, int]] = {}
+        for line in completed.stdout.splitlines():
+            path, _, rest = line.partition(":")
+            for token in re.findall(r"infra/[a-z0-9_-]+", rest):
+                found.setdefault(path, {}).setdefault(token, 0)
+                found[path][token] += 1
+        self.assertEqual(
+            found,
+            expected,
+            "the infra/ reference profile moved — a suite's tree gained or lost a "
+            "reference into infra/. Read it before touching this pin: prose -> update "
+            "the pin; a real read/import -> carve the sub-tree out in PREFIX_RULES first.",
+        )
 
     def test_cli_stdout_is_one_compact_json_line(self) -> None:
         script = Path(__file__).with_name("change_map.py")


### PR DESCRIPTION
## The defect

`change_map.py`'s `security_sensitive` domain was read by **two unrelated consumers**:
`scripts/ci/security_gate_flags.py` picks the security SCANNERS from it, and
`_suggested_jobs()` used it to multiply out all six product TEST suites. Any path tagged
security-sensitive therefore bought every suite, whatever its real coupling — cicatrix #3's
over-match half, judging the domain instead of the entity, and the third recidive of that
family in two days (`scripts/` #5679, `.claude/` #5685, now `infra/`).

Measured on PR #5697, whose diff was **one** file, `infra/ghostty/machines/m5.ghostty`: the
classifier was RIGHT — `run_all: false`, `reason: classified`, only `infra_workflows` +
`security_sensitive` lit, no frontend domain at all — and Frontend Tests still ran 16 of its 18
steps, because `_suggested_jobs()` read the union of the two domains.

## What the handoff said was impossible, and was not

The inherited note declared this a Gear-3 domain-model rewrite because "removing
`security_sensitive` from the `infra/` catch-all means a required context no longer starts →
merge queue jammed". **Measured, false.** `security.yml:574-616` carries an explicit,
load-bearing comment: the CodeQL job deliberately has NO job-level `if:`, precisely so the two
required matrix contexts always report; the saving lives entirely in the per-leg step gate. The
same shape holds in `tests.yml` for `frontend-tests` (`if: !cancelled()` + a "Decide whether to
run" step). Nothing jams. The cure is three rules, not a rewrite.

The real constraint is the opposite one, and it is honoured: `.github/codeql-config.yml`
declares no `paths-ignore`, so CodeQL analyses `infra/` like any other tree — dropping
`security_sensitive` there would be the UNDER-match twin. It stays.

## The change

- `_suggested_jobs()` multiplies on `infra_workflows` alone. Not an under-match: **no rule
  reaches `security_sensitive` by itself** — every entry carrying it also carries the domains of
  the code it touches. `pyproject.toml` still runs backend/mcp/evaluator/e2e through its own
  domains and merely stops running the frontend; `package-lock.json` is the mirror image.
- The `infra/` catch-all maps to `fleet_ops` (zero jobs) instead of `infra_workflows`. `infra/`
  is fleet payload — plists, wrappers, terminal profiles, required-context mirrors — not
  workflow definitions. Those live in `.github/`, which keeps `infra_workflows` and keeps
  forcing all six. `security_sensitive` stays, so an infra-only PR's security posture is
  byte-identical to before.
- `infra/eventbus/` is carved out to `backend_python`, ahead of the catch-all. A census of all
  38 `infra/` sub-trees against the six suites found exactly one real coupling:
  `apps/backend-rag/backend/tests/unit/core/test_ingest_target_registry.py:78` opens
  `infra/eventbus/regulatory_ingest_runner.py` by literal path and asserts on its contents, and
  `scripts/ci/ingest_target_lint.py` names it in `DECLARED_ENTRYPOINTS`. Every other sub-tree
  has zero hits in the six suites' trees, or hits confined to `scripts/` (already covered by
  `SCRIPTS_COUPLING`), or hits that are **prose inside a docstring** naming the directory.

Seven guilt+innocence cases added. `_locate_repo_root()` is extracted from the census-staleness
test so any test touching the checkout survives `tests.yml`'s **flat** trusted-classifier
extraction — the mis-resolution that turned that assertion red on every PR from #5679 until
#5692.

## Guilt proof — four mutations, four reds

Each half of the defect restored in `change_map.py`, corpus re-run:

| mutation | verdict | first test to bite |
|---|---|---|
| `security_sensitive` back in the multiplier | RED | `test_guilt_infra_eventbus_runs_the_backend_suite_that_reads_it` |
| `infra/` back to `infra_workflows` | RED | `test_guilt_infra_still_buys_the_security_scanners` |
| `infra/eventbus/` carve-out deleted | RED | `test_guilt_infra_eventbus_runs_the_backend_suite_that_reads_it` |
| `infra/` loses `security_sensitive` (under-match twin) | RED | `test_guilt_infra_still_buys_the_security_scanners` |

A first draft of the under-match case pointed at an `infra/eventbus/` path and did **not** bite —
the carve-out supplies `security_sensitive` of its own. It now names
`infra/claude-hooks/host_boundary.py`, a real `.py` reached by the catch-all.

## Bites

**Consumer:** `tests.yml`'s `changes` job, step *Verify change-map guilt and innocence corpus*,
which runs the classifier and its corpus extracted from `base_sha` — so this corpus starts
judging from the first PR opened after this merges, and this PR is itself judged by main's
copy (which maps `scripts/ci/` to all six, correctly).

**Observation, made before reporting the work:** the CLI on PR #5697's exact diff, from this
branch —

```
$ printf 'infra/ghostty/machines/m5.ghostty\n' | python3 scripts/ci/change_map.py
{"reason":"classified","run_all":false,
 "domains":{...,"fleet_ops":true,"infra_workflows":false,"security_sensitive":true,...},
 "suggested_jobs":[],
 "would_skip":["backend-tests","mcp-tests","evaluator-critical-tests",
               "frontend-tests","packages-core-tests","e2e-tests"]}
```

All six skipped, `security_sensitive` still lit. Mixed with a backend file the union still
holds (`['backend-tests','e2e-tests']`), and `infra/eventbus/` alone earns the same pair.
`test_change_map.py` + `test_security_gate_flags.py`: 75 passed, 56 subtests.

**Post-merge:** the `Change-map` `::notice::` on the first `infra/`-touching PR after this
lands is where the live consumer speaks; it will be read there.

## Not in this PR

The 2026-09-05 handoff's §7.3 — `frontend-tests` on a **doc-only** diff — is **not
reproducible** and needs no cure: every doc-only shape classifies to zero jobs today
(`docs/**.md`, `README.md`, `docs/` + `evidence/`, `docs/` + `research/`). That observation
dates from the nine-day window in which the classifier itself was dead on a missing import and
its correct fail-open ran all six jobs on *every* PR — cured by #5692/#5704, not a separate
defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfHGbs6ruua4JpZ5EdeB7S

## Adversarial review

**Seat:** `codex exec` GPT-5.6, `model_reasoning_effort=xhigh`, `--sandbox read-only`,
dispatched on the working-tree diff with no conclusion to confirm and an explicit instruction
to default to defective. Generator ≠ grader: it did not write this diff.

**Returned one finding, MEDIUM — accepted and cured in the second commit:**

> the `infra/` catch-all classifies any future `infra/**` as known, so it can never reach
> `unknown_paths`/`run_all`, and `fleet_ops + security_sensitive` then selects zero suites.
> There is no census/ratchet for `infra/` equivalent to `SCRIPTS_COUPLING`; the test blesses
> only `ghostty`. Any new `infra/` file later consumed by backend/frontend stays classified
> `run_all=false` with no suite.

Correct, and caused by this diff specifically: while the catch-all bought all six suites, a new
coupling into `infra/` was harmless because the suite ran anyway. `test_infra_coupling_census_is_not_stale`
re-derives the profile every run (file → `infra/<segment>` → count, so a new reference inside an
already-referenced file trips it too) and is proved by mutation.

Re-deriving the census found four references the by-hand one had missed — all `infra/eventbus`,
two in production code — which strengthens the carve-out rather than weakening it.

The two other hunts it was pointed at came back empty, consistent with what was measured here
independently: no required context stops reporting (CodeQL's job-level `if:` is deliberately
absent, `security.yml:574-616`), and the `run_all` fail-open contract is untouched.
