### PR TITLE
fix(mcp-auth): load roles.yaml strictly — five appended lines granted a role the wildcard

### DIFF
--- a/apps/nuzantara-mcp/nuzantara_mcp/auth.py
+++ b/apps/nuzantara-mcp/nuzantara_mcp/auth.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import wraps
+import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable, TypeVar
 
@@ -97,17 +98,47 @@ def _load_role_taxonomy() -> dict[str, list[str]]:
         logger.warning("roles.yaml not found at %s — taxonomy empty, per-tool auth fails closed", path)
         return {}
 
+    # roles.yaml decides which tools a role may call, so it is loaded STRICTLY.
+    # PyYAML's safe_load lets a duplicate top-level key win in silence, and `roles:`
+    # is a mapping keyed by role name: measured 2026-09-05 on a scratch copy of the
+    # shipped file, appending five lines that repeat an existing role with
+    # `tools: ["*"]` replaced that role's 11 named tools with a wildcard, and the
+    # diff read as an appended block. Loaded by PATH because scripts/lib is not an
+    # importable package — the same assumption about repo layout that
+    # _DEFAULT_ROLES_YAML above already makes by reaching into a sibling app tree.
+    # There is deliberately no fallback to yaml.safe_load: silently downgrading to
+    # the permissive loader when the strict one is absent would restore the defect.
     try:
-        import yaml  # deferred — keeps fastmcp import-safe on minimal deps
-    except ImportError:
-        logger.warning("PyYAML not installed — per-tool auth disabled (fails closed)")
+        import importlib.util
+
+        # ONE canonical module name, shared with the sibling reader in
+        # apps/team-agent/mcp-wrapper/permissions.py: loading the same file twice under
+        # two names produces two distinct StrictYAMLError CLASSES, so an `except` in one
+        # caller would not catch the error raised through the other.
+        strict_path = Path(__file__).resolve().parents[3] / "scripts" / "lib" / "yaml_strict.py"
+        yaml_strict = sys.modules.get("nuzantara_yaml_strict")
+        if yaml_strict is None:
+            spec = importlib.util.spec_from_file_location("nuzantara_yaml_strict", strict_path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"not loadable: {strict_path}")
+            yaml_strict = importlib.util.module_from_spec(spec)
+            sys.modules["nuzantara_yaml_strict"] = yaml_strict
+            spec.loader.exec_module(yaml_strict)
+    except Exception as exc:  # noqa: BLE001 — missing loader must not boot a permissive server
+        logger.warning(
+            "strict policy loader unavailable (%s) — taxonomy empty, per-tool auth fails closed",
+            exc,
+        )
         return {}
 
     try:
-        with path.open() as fh:
-            data: Any = yaml.safe_load(fh)
+        data: Any = yaml_strict.load_policy(path)
     except Exception as exc:  # noqa: BLE001 — we deliberately catch all parser errors
-        logger.warning("Failed to parse roles.yaml (%s) — taxonomy empty", exc)
+        # This branch now also fires on an AMBIGUOUS document, not only an unparseable
+        # one. Logged at WARNING with the loader's own message, which names the
+        # duplicate key and its line: an escalation attempt that fails closed and
+        # leaves no legible trace is only half a control.
+        logger.warning("Refused to load roles.yaml (%s) — taxonomy empty", exc)
         return {}
 
     roles = (data or {}).get("roles", {}) if isinstance(data, dict) else {}

--- a/apps/nuzantara-mcp/tests/test_roles_yaml_is_loaded_strictly.py
+++ b/apps/nuzantara-mcp/tests/test_roles_yaml_is_loaded_strictly.py
@@ -218,3 +218,84 @@ def test_this_battery_is_collected_by_the_MCP_test_job():
         encoding="utf-8"
     )
     assert script.rstrip().endswith("tests"), "the job must still collect tests/ wholesale"
+
+
+# ------------------------------------------- the wrapper is deployed by COPY, not pip
+
+
+def _onboarded_tree(tmp_path: Path, *, stage_loader: bool) -> Path:
+    """Reproduce what apps/team-agent/onboarding/mac-bootstrap.sh puts on a Mac.
+
+    `cp -r .../mcp-wrapper/* $HOME/.nuzantara/mcp-wrapper/` — this subtree and NOT the
+    repo's top-level scripts/. The `stage_loader` switch is the one line the bootstrap
+    adds.
+    """
+    import shutil
+
+    root = tmp_path / "home" / ".nuzantara"
+    dest = root / "mcp-wrapper"
+    shutil.copytree(WRAPPER, dest, ignore=shutil.ignore_patterns("__pycache__"))
+    if stage_loader:
+        (dest / "lib").mkdir(exist_ok=True)
+        shutil.copy(REPO_ROOT / "scripts" / "lib" / "yaml_strict.py", dest / "lib" / "yaml_strict.py")
+    return dest
+
+
+def _checker_cls_from(tree: Path, name: str):
+    """Import the COPIED permissions.py, not the repo one, under its own module name."""
+    spec = importlib.util.spec_from_file_location(name, tree / "permissions.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module.PermissionChecker
+
+
+def test_guilt_the_onboarded_wrapper_refuses_LOUDLY_when_the_loader_was_not_staged(
+    tmp_path, monkeypatch
+):
+    """Measured 2026-09-05: a repo-relative-only lookup made this tree unstartable.
+
+    server.py:45 builds the PermissionChecker at MODULE IMPORT, so a missing loader is
+    not a degraded wrapper — it is no wrapper. That is still the correct posture (the
+    alternative, falling back to yaml.safe_load, restores the escalation), but it must
+    say so instead of raising a bare FileNotFoundError about a path in a repo the
+    machine does not have.
+    """
+    # The loader is cached under a canonical name; a repo-side import earlier in this
+    # session would otherwise satisfy the lookup and hide the very case under test.
+    monkeypatch.delitem(sys.modules, "nuzantara_yaml_strict", raising=False)
+    tree = _onboarded_tree(tmp_path, stage_loader=False)
+    checker_cls = _checker_cls_from(tree, "permissions_onboarded_bare")
+    with pytest.raises(RuntimeError, match="strict policy loader not found"):
+        checker_cls(str(tree / "config" / "roles.yaml"))
+
+
+def test_innocence_the_onboarded_wrapper_works_when_the_loader_IS_staged(tmp_path, monkeypatch):
+    monkeypatch.delitem(sys.modules, "nuzantara_yaml_strict", raising=False)
+    tree = _onboarded_tree(tmp_path, stage_loader=True)
+    checker = _checker_cls_from(tree, "permissions_onboarded_staged")(
+        str(tree / "config" / "roles.yaml")
+    )
+    assert checker.is_allowed("visa_specialist", "get_visa_details") is True
+    assert checker.is_allowed("tax_consultant", "anything_at_all") is False
+
+
+def test_guilt_the_onboarded_wrapper_still_refuses_the_poison(tmp_path, monkeypatch):
+    """The cure must survive the deployment, not only the checkout."""
+    monkeypatch.delitem(sys.modules, "nuzantara_yaml_strict", raising=False)
+    tree = _onboarded_tree(tmp_path, stage_loader=True)
+    poisoned = tree / "config" / "poisoned.yaml"
+    poisoned.write_text(ROLES.read_text(encoding="utf-8") + POISON, encoding="utf-8")
+    checker_cls = _checker_cls_from(tree, "permissions_onboarded_poison")
+    with pytest.raises(Exception, match="duplicate key"):
+        checker_cls(str(poisoned))
+
+
+def test_the_onboarding_script_actually_stages_the_loader():
+    """Superscar #2 in its deployment form: the code needs a file the copy must ship."""
+    script = (
+        REPO_ROOT / "apps" / "team-agent" / "onboarding" / "mac-bootstrap.sh"
+    ).read_text(encoding="utf-8")
+    assert "scripts/lib/yaml_strict.py" in script
+    assert '"$WRAPPER_DIR/lib/yaml_strict.py"' in script

--- a/apps/nuzantara-mcp/tests/test_roles_yaml_is_loaded_strictly.py
+++ b/apps/nuzantara-mcp/tests/test_roles_yaml_is_loaded_strictly.py
@@ -1,0 +1,220 @@
+"""roles.yaml is a POLICY document, and both of its readers now load it strictly.
+
+THE DEFECT. `yaml.safe_load` lets a duplicate top-level key win, in silence — last
+one wins, no warning. `roles:` in
+`apps/team-agent/mcp-wrapper/config/roles.yaml` is a mapping keyed by role name, so
+appending five lines that repeat an existing role replaces it. Measured 2026-09-05 on
+a scratch copy of the shipped file:
+
+    get_allowed_tools("tax_consultant")            11 named tools  ->  ["*"]
+    is_allowed("tax_consultant", "publish_article")   False        ->  True
+    is_allowed("tax_consultant", "anything_at_all")   False        ->  True
+
+That is privilege escalation whose diff reads as an appended block. It is not a claim
+that the repo is breached — anyone who can append to the file can edit it outright.
+What the silence defeats is REVIEW, and review is the control this actually relies on.
+
+WHY THIS FILE LIVES UNDER apps/nuzantara-mcp/tests/ AND NOT BESIDE THE WRAPPER.
+`apps/team-agent/mcp-wrapper` is named by NO workflow in `.github/workflows/` — its
+existing `tests/test_permissions.py` and `tests/test_server.py` are run by no CI job
+(superscar #2, filed separately; arming that tree is a workflow edit and a different
+concern). `apps/nuzantara-mcp/tests` IS collected wholesale by tests.yml's "MCP Server
+Tests" job, so putting BOTH readers' cases here arms them today. The file under attack
+is the same one for both readers, which is what makes one battery the honest shape.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ROLES = REPO_ROOT / "apps" / "team-agent" / "mcp-wrapper" / "config" / "roles.yaml"
+WRAPPER = REPO_ROOT / "apps" / "team-agent" / "mcp-wrapper"
+
+
+def _yaml_strict():
+    """The shared loader, by path — so the guilt cases can name its exact type.
+
+    Registered under the SAME canonical module name the two readers use. Loading the
+    file twice under two names produces two distinct StrictYAMLError classes, and
+    `pytest.raises` on the wrong one fails while the cure works perfectly — measured
+    while writing this battery, which is why the readers cache it too.
+    """
+    cached = sys.modules.get("nuzantara_yaml_strict")
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(
+        "nuzantara_yaml_strict", REPO_ROOT / "scripts" / "lib" / "yaml_strict.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["nuzantara_yaml_strict"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+STRICT_ERROR = _yaml_strict().StrictYAMLError
+
+#: Five appended lines. Written as the attack, not as a paraphrase of it.
+POISON = '\n  tax_consultant:\n    description: "appended"\n    tools:\n      - "*"\n'
+
+
+def _permission_checker_cls():
+    """Load the wrapper's checker by path — it is not an installed package."""
+    if str(WRAPPER) not in sys.path:
+        sys.path.insert(0, str(WRAPPER))
+    module = importlib.import_module("permissions")
+    return importlib.reload(module).PermissionChecker
+
+
+def _poisoned(tmp_path: Path, extra: str = POISON) -> Path:
+    target = tmp_path / "roles.yaml"
+    target.write_text(ROLES.read_text(encoding="utf-8") + extra, encoding="utf-8")
+    return target
+
+
+def _taxonomy_for(path: Path, monkeypatch) -> dict[str, list[str]]:
+    """`ROLE_TAXONOMY` is built at IMPORT time, so the module is reloaded per case."""
+    monkeypatch.setenv("NUZANTARA_MCP_ROLES_YAML", str(path))
+    import nuzantara_mcp.auth as auth
+
+    return importlib.reload(auth).ROLE_TAXONOMY
+
+
+# ------------------------------------------------------------------ the attack itself
+
+
+def test_the_escalation_is_real_under_plain_safe_load(tmp_path):
+    """Pins WHAT IS BEING PREVENTED, not just that the cure fires.
+
+    Without this, the guilt cases below would still pass if the poison stopped being
+    a poison — a guard proved only against a payload nobody checked is still standing
+    guard over nothing.
+    """
+    document = yaml.safe_load(_poisoned(tmp_path).read_text(encoding="utf-8"))
+    assert document["roles"]["tax_consultant"]["tools"] == ["*"]
+    shipped = yaml.safe_load(ROLES.read_text(encoding="utf-8"))
+    assert shipped["roles"]["tax_consultant"]["tools"] != ["*"]
+    assert len(shipped["roles"]["tax_consultant"]["tools"]) == 11
+
+
+# --------------------------------------------------------- guilt: the wrapper's reader
+
+
+def test_guilt_the_permission_checker_refuses_a_duplicated_role(tmp_path):
+    checker_cls = _permission_checker_cls()
+    with pytest.raises(STRICT_ERROR) as exc:
+        checker_cls(str(_poisoned(tmp_path)))
+    assert "duplicate key" in str(exc.value)
+    assert "tax_consultant" in str(exc.value)
+
+
+def test_guilt_no_checker_can_be_built_on_a_poisoned_file(tmp_path):
+    """Refusing at load is only useful if no caller can route around it."""
+    checker_cls = _permission_checker_cls()
+    poisoned = _poisoned(tmp_path)
+    for _ in range(2):
+        with pytest.raises(STRICT_ERROR):
+            checker_cls(str(poisoned))
+
+
+def test_guilt_an_empty_roles_mapping_is_refused(tmp_path):
+    """Not an escalation — a disarmed control that denies uniformly and looks correct."""
+    target = tmp_path / "roles.yaml"
+    target.write_text("roles: {}\n", encoding="utf-8")
+    checker_cls = _permission_checker_cls()
+    with pytest.raises(STRICT_ERROR, match="roles") as exc:
+        checker_cls(str(target))
+    assert "denies everything" in str(exc.value)
+
+
+def test_guilt_an_alias_is_refused(tmp_path):
+    """An anchor defined far from its use puts the governing value out of the reader's eye."""
+    target = tmp_path / "roles.yaml"
+    target.write_text(
+        'wildcard: &w ["*"]\nroles:\n  intern:\n    tools: *w\n', encoding="utf-8"
+    )
+    checker_cls = _permission_checker_cls()
+    with pytest.raises(STRICT_ERROR, match="alias"):
+        checker_cls(str(target))
+
+
+# ------------------------------------------------------------ guilt: the MCP's reader
+
+
+def test_guilt_the_mcp_taxonomy_is_EMPTY_on_a_poisoned_file(tmp_path, monkeypatch):
+    """auth.py must never raise — its contract is degrade-to-empty, which fails closed.
+
+    The two readers therefore fail DIFFERENTLY on the same poisoned file, on purpose:
+    the wrapper raises at construction, the MCP server boots with no taxonomy and
+    denies every decorated tool. Both refuse; neither escalates.
+    """
+    assert _taxonomy_for(_poisoned(tmp_path), monkeypatch) == {}
+
+
+def test_guilt_the_poisoned_file_never_yields_a_wildcard_role(tmp_path, monkeypatch):
+    taxonomy = _taxonomy_for(_poisoned(tmp_path), monkeypatch)
+    assert all("*" not in tools for tools in taxonomy.values())
+
+
+def test_guilt_the_refusal_is_logged_with_the_offending_key(tmp_path, monkeypatch, caplog):
+    """A control that fails closed and leaves no legible trace is only half a control."""
+    with caplog.at_level("WARNING"):
+        _taxonomy_for(_poisoned(tmp_path), monkeypatch)
+    assert any("duplicate key" in r.getMessage() for r in caplog.records)
+    assert any("tax_consultant" in r.getMessage() for r in caplog.records)
+
+
+# ------------------------------------------------------------------------- innocence
+
+
+def test_innocence_the_shipped_file_still_builds_a_working_checker():
+    """A loader strict enough to refuse the file actually shipped would be useless."""
+    checker = _permission_checker_cls()(str(ROLES))
+    assert checker.is_allowed("visa_specialist", "get_visa_details") is True
+    assert checker.is_allowed("visa_specialist", "regenerate_invoice") is False
+    assert checker.is_allowed("admin", "anything_at_all") is True
+    assert checker.is_allowed("tax_consultant", "get_compliance_alerts") is True
+    assert checker.is_allowed("tax_consultant", "compose_article") is False
+    assert checker.is_allowed("hacker", "get_visa_details") is False
+
+
+def test_innocence_the_shipped_file_still_builds_a_populated_taxonomy(monkeypatch):
+    taxonomy = _taxonomy_for(ROLES, monkeypatch)
+    assert len(taxonomy) >= 4
+    assert "get_visa_details" in taxonomy["visa_specialist"]
+
+
+def test_innocence_both_readers_agree_on_the_shipped_file(monkeypatch):
+    """One writer, two readers: they may fail differently, they must not READ differently."""
+    taxonomy = _taxonomy_for(ROLES, monkeypatch)
+    checker = _permission_checker_cls()(str(ROLES))
+    for role, tools in taxonomy.items():
+        assert checker.get_allowed_tools(role) == tools
+
+
+def test_innocence_a_role_repeated_in_DIFFERENT_mappings_is_not_a_duplicate(tmp_path):
+    """The over-match direction: `tools:` appears once per role and that is legal."""
+    target = tmp_path / "roles.yaml"
+    target.write_text(
+        "roles:\n  a:\n    tools: [\"x\"]\n  b:\n    tools: [\"y\"]\n", encoding="utf-8"
+    )
+    checker = _permission_checker_cls()(str(target))
+    assert checker.get_allowed_tools("a") == ["x"]
+    assert checker.get_allowed_tools("b") == ["y"]
+
+
+def test_this_battery_is_collected_by_the_MCP_test_job():
+    """A guard nobody runs is superscar #2. Asserts the wiring, not the intent."""
+    workflow = (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")
+    assert "cd apps/nuzantara-mcp" in workflow
+    assert "test-coverage.sh" in workflow
+    script = (REPO_ROOT / "apps" / "nuzantara-mcp" / "scripts" / "test-coverage.sh").read_text(
+        encoding="utf-8"
+    )
+    assert script.rstrip().endswith("tests"), "the job must still collect tests/ wholesale"

--- a/apps/team-agent/mcp-wrapper/permissions.py
+++ b/apps/team-agent/mcp-wrapper/permissions.py
@@ -16,12 +16,25 @@ from typing import Any
 # is in REVIEW rather than in the file's permissions.
 #
 # The loader is loaded by PATH rather than imported: scripts/lib is not an importable
-# package, and this file already assumes the repo layout (see the sibling reader in
-# apps/nuzantara-mcp/nuzantara_mcp/auth.py, which reaches across app trees for the very
-# roles.yaml this class reads). There is deliberately NO fallback to yaml.safe_load: a
-# permission checker that quietly downgrades to the permissive loader when the strict
-# one is missing would be the whole defect with an extra step.
-_YAML_STRICT = Path(__file__).resolve().parents[3] / "scripts" / "lib" / "yaml_strict.py"
+# package. There is deliberately NO fallback to yaml.safe_load — a permission checker
+# that quietly downgrades to the permissive loader when the strict one is missing would
+# be the whole defect with an extra step.
+#
+# TWO CANDIDATE LOCATIONS, because this file is deployed by COPY and not by package.
+# apps/team-agent/onboarding/mac-bootstrap.sh:90-93 does
+# `cp -r .../mcp-wrapper/* $HOME/.nuzantara/mcp-wrapper/`, which ships this subtree and
+# NOT the repo's top-level scripts/. Measured 2026-09-05 by reproducing that layout: a
+# repo-relative-only lookup raised FileNotFoundError, and because server.py:45 builds
+# the checker at MODULE IMPORT, the wrapper would not start at all on a team member's
+# Mac. "Fail closed" is the right posture for an ambiguous policy file; it is the wrong
+# posture for a loader that is merely somewhere else, because it converts a possible
+# review-defeating edit into a certain outage. So: the repo path when running from the
+# checkout, and a copy staged beside this file when running from the onboarded tree —
+# one source of truth in the repo, deliberately shipped, never a second edited copy.
+_YAML_STRICT_CANDIDATES = (
+    Path(__file__).resolve().parents[3] / "scripts" / "lib" / "yaml_strict.py",
+    Path(__file__).resolve().parent / "lib" / "yaml_strict.py",
+)
 
 
 _YAML_STRICT_MODULE = "nuzantara_yaml_strict"
@@ -39,9 +52,19 @@ def _load_yaml_strict():
     cached = sys.modules.get(_YAML_STRICT_MODULE)
     if cached is not None:
         return cached
-    spec = importlib.util.spec_from_file_location(_YAML_STRICT_MODULE, _YAML_STRICT)
+    for candidate in _YAML_STRICT_CANDIDATES:
+        if candidate.is_file():
+            break
+    else:
+        raise RuntimeError(
+            "strict policy loader not found — looked in "
+            + ", ".join(str(c) for c in _YAML_STRICT_CANDIDATES)
+            + ". This wrapper will not start without it, by design: falling back to "
+            "yaml.safe_load would silently restore the duplicate-key escalation."
+        )
+    spec = importlib.util.spec_from_file_location(_YAML_STRICT_MODULE, candidate)
     if spec is None or spec.loader is None:  # pragma: no cover - unreachable if the file exists
-        raise RuntimeError(f"strict policy loader not importable at {_YAML_STRICT}")
+        raise RuntimeError(f"strict policy loader not importable at {candidate}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[_YAML_STRICT_MODULE] = module
     spec.loader.exec_module(module)

--- a/apps/team-agent/mcp-wrapper/permissions.py
+++ b/apps/team-agent/mcp-wrapper/permissions.py
@@ -1,18 +1,71 @@
 """Role-based permission checker for MCP tool access."""
 
 import fnmatch
+import importlib.util
+import sys
+from pathlib import Path
 from typing import Any
 
-import yaml
+# roles.yaml decides which tools a role may call, so it is a POLICY document and is
+# loaded strictly: PyYAML's safe_load lets a duplicate top-level key win in silence,
+# and `roles:` is a mapping keyed by role name. Measured 2026-09-05 on a scratch copy
+# of the shipped file: appending five lines that repeat `tax_consultant:` with
+# `tools: ["*"]` took get_allowed_tools("tax_consultant") from 11 named tools to
+# ["*"], and is_allowed("tax_consultant", <anything>) from False to True. That is
+# privilege escalation whose diff reads as an appended block, which is why the defect
+# is in REVIEW rather than in the file's permissions.
+#
+# The loader is loaded by PATH rather than imported: scripts/lib is not an importable
+# package, and this file already assumes the repo layout (see the sibling reader in
+# apps/nuzantara-mcp/nuzantara_mcp/auth.py, which reaches across app trees for the very
+# roles.yaml this class reads). There is deliberately NO fallback to yaml.safe_load: a
+# permission checker that quietly downgrades to the permissive loader when the strict
+# one is missing would be the whole defect with an extra step.
+_YAML_STRICT = Path(__file__).resolve().parents[3] / "scripts" / "lib" / "yaml_strict.py"
+
+
+_YAML_STRICT_MODULE = "nuzantara_yaml_strict"
+
+
+def _load_yaml_strict():
+    """Load the shared strict loader by path, once, under a canonical module name.
+
+    The module is registered under ONE canonical name shared by every path-loader of it
+    (apps/team-agent/mcp-wrapper/permissions.py, apps/nuzantara-mcp/nuzantara_mcp/auth.py,
+    and the test battery). Loading the same file twice under two names produces two
+    distinct StrictYAMLError CLASSES, so `except StrictYAMLError` in one caller does not
+    catch the error raised through the other — measured while writing this battery.
+    """
+    cached = sys.modules.get(_YAML_STRICT_MODULE)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(_YAML_STRICT_MODULE, _YAML_STRICT)
+    if spec is None or spec.loader is None:  # pragma: no cover - unreachable if the file exists
+        raise RuntimeError(f"strict policy loader not importable at {_YAML_STRICT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_YAML_STRICT_MODULE] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 class PermissionChecker:
     def __init__(self, config_path: str = "config/roles.yaml"):
-        with open(config_path) as f:
-            data: dict[str, Any] = yaml.safe_load(f)
+        yaml_strict = _load_yaml_strict()
+        data: dict[str, Any] = yaml_strict.load_policy(config_path)
+        roles = data.get("roles")
+        if not isinstance(roles, dict) or not roles:
+            # An empty `roles:` grants nothing, so it is not an escalation — but it is
+            # a disarmed control that looks like a working one, and every caller then
+            # gets a uniform False that is indistinguishable from a correct denial.
+            raise yaml_strict.StrictYAMLError(
+                f"{config_path}: `roles:` is missing or empty — a permission checker "
+                f"with no roles denies everything and cannot be told apart from one "
+                f"that is working."
+            )
         self.roles: dict[str, list[str]] = {
             role: info.get("tools", [])
-            for role, info in data.get("roles", {}).items()
+            for role, info in roles.items()
+            if isinstance(info, dict)
         }
 
     def is_allowed(self, role: str, tool_name: str) -> bool:

--- a/apps/team-agent/onboarding/mac-bootstrap.sh
+++ b/apps/team-agent/onboarding/mac-bootstrap.sh
@@ -90,6 +90,13 @@ fi
 if [[ -d "$MONOREPO_ROOT/apps/team-agent/mcp-wrapper" ]]; then
   echo "📋 Copying MCP wrapper from monorepo..."
   cp -r "$MONOREPO_ROOT/apps/team-agent/mcp-wrapper/"* "$WRAPPER_DIR/"
+  # permissions.py loads the shared strict YAML loader from scripts/lib, which this
+  # copy does not otherwise ship. Without it the wrapper raises at import (server.py
+  # builds the PermissionChecker at module scope) and never starts. Staged as a COPY
+  # of the repo's single source, never edited here — if this file drifts from
+  # scripts/lib/yaml_strict.py, re-run this bootstrap rather than patching it.
+  mkdir -p "$WRAPPER_DIR/lib"
+  cp "$MONOREPO_ROOT/scripts/lib/yaml_strict.py" "$WRAPPER_DIR/lib/yaml_strict.py"
   echo "✅ MCP wrapper installed"
 else
   echo "⚠️  MCP wrapper not found"

--- a/evidence/2026-09/agent-nuzantara-ops-roles-strict-0905-6ee7a450/brief.yml
+++ b/evidence/2026-09/agent-nuzantara-ops-roles-strict-0905-6ee7a450/brief.yml
@@ -1,0 +1,70 @@
+task_id: roles-strict-0905
+gear: 2
+l_level: L1
+gate_class: opus
+objective: >-
+  roles.yaml decides which MCP tools a role may call. Both of its readers loaded it with
+  yaml.safe_load, which lets a DUPLICATE top-level key win in silence, and `roles:` is a
+  mapping keyed by role name. Move both readers onto scripts/lib/yaml_strict.py, and ship
+  the loader to the one reader that is deployed by copy rather than by package.
+
+  Measured on a scratch copy of the shipped file before any change: appending five lines
+  that repeat `tax_consultant:` with `tools: ["*"]` took get_allowed_tools from 11 named
+  tools to ["*"], and is_allowed("tax_consultant", <anything>) from False to True. The
+  diff reads as an appended block. This is not a claim the repo is breached -- anyone who
+  can append can edit outright. What the silence defeats is REVIEW.
+
+  Gear 2 by SIZE, deterministically: --print-floor returns 2 and --print-floor-source
+  returns "size" on this changed-file list with the numstat supplied. Recorded because I
+  first computed the floor WITHOUT the numstat, got 1, and opened the PR on that number --
+  the SIZE term cannot see a size it was not given. Same shape as the #5682 mistake earlier
+  in this lane: I measured the floor with an input that could not produce the answer I was
+  checking for.
+constraints:
+  - >-
+    The two readers keep their OWN failure contracts and therefore fail differently on the
+    same poisoned file. permissions.py raises at construction (server.py:45 builds the
+    checker at module import, so it already crashed on a bad config). auth.py never raises:
+    it degrades to an empty taxonomy and every decorated tool denies, which is its
+    documented Legge 4 contract. Both refuse; neither escalates.
+  - >-
+    No fallback to yaml.safe_load in either reader, under any condition. Silently
+    downgrading to the permissive loader when the strict one is absent restores the whole
+    defect with an extra step.
+  - >-
+    One canonical sys.modules name for the path-loaded module. scripts/lib is not an
+    importable package, and loading one file twice under two names produces two distinct
+    StrictYAMLError CLASSES, so `except StrictYAMLError` in one caller does not catch the
+    error raised through the other. Measured: four guilt cases failed against a working
+    cure before this was fixed.
+  - >-
+    "Fail closed" is right for an ambiguous policy file and WRONG for a loader that is
+    merely somewhere else. apps/team-agent/mcp-wrapper is installed by
+    `cp -r .../mcp-wrapper/*` (mac-bootstrap.sh:90-93), which does not ship the repo's
+    scripts/. A repo-relative-only lookup made the wrapper unstartable on every onboarded
+    Mac -- reproduced as FileNotFoundError. One source of truth in the repo, staged into
+    $WRAPPER_DIR/lib/ by the bootstrap, never a second editable copy (superscar #1).
+  - >-
+    apps/team-agent/mcp-wrapper is named by NO workflow: its 16 tests are run by no CI job.
+    Arming that tree is a workflow edit and a separate concern, and is NOT smuggled in
+    here. The battery therefore lives under apps/nuzantara-mcp/tests, which tests.yml
+    collects wholesale, and asserts its own collection wiring.
+  - >-
+    Guilt AND innocence, both directions (superscar #3). The battery also pins the ATTACK
+    under plain safe_load, so it cannot pass by the poison quietly ceasing to be a poison.
+acceptance:
+  - >-
+    WHEN the poisoned roles.yaml is loaded, THEN PermissionChecker raises StrictYAMLError
+    naming the duplicated key and its line, AND auth.py's ROLE_TAXONOMY is {} with a WARNING
+    carrying the same message. probe: pytest apps/nuzantara-mcp/tests/test_roles_yaml_is_loaded_strictly.py
+  - >-
+    WHEN the shipped roles.yaml is loaded, THEN both readers still agree on all four roles
+    and every pre-existing assertion holds. probe: pytest apps/nuzantara-mcp/tests -k "innocence or per_tool_auth or tripwire"
+  - >-
+    WHEN the wrapper runs from the onboarded copy with the loader staged, THEN it starts and
+    still refuses the poison; without it staged, it raises a message naming both candidate
+    paths rather than a bare FileNotFoundError. probe: pytest -k onboarded
+  - >-
+    WHEN mac-bootstrap.sh runs, THEN it stages scripts/lib/yaml_strict.py into
+    $WRAPPER_DIR/lib/. probe: test_the_onboarding_script_actually_stages_the_loader
+pii_scan: clean


### PR DESCRIPTION
roles.yaml decides which MCP tools a role may call, so it is a POLICY document, but
both readers used `yaml.safe_load`, which lets a duplicate top-level key win in
silence. `roles:` is a mapping keyed by role name. Measured on a scratch copy of the
shipped file:

  get_allowed_tools("tax_consultant")               11 named tools  ->  ["*"]
  is_allowed("tax_consultant", "publish_article")      False        ->  True
  is_allowed("tax_consultant", "anything_at_all")      False        ->  True

Five appended lines, and the diff reads as an added block. This is not a claim that
the repo is breached — anyone who can append to the file can edit it outright. What
the silence defeats is REVIEW, which is the control this actually relies on.

Both readers now go through scripts/lib/yaml_strict.py, and they fail DIFFERENTLY on
purpose, each keeping its own contract:

  permissions.py   raises at construction (it already crashed on a bad config; the
                   error is now legible and names the key and its line). Also refuses
                   an empty `roles:` — not an escalation, but a control that denies
                   uniformly while looking like one that works.
  auth.py          never raises, per its documented contract: it degrades to an empty
                   taxonomy and every decorated tool fails closed. The WARNING now
                   carries the loader's message, so a refused escalation leaves a
                   legible trace instead of looking like a missing file.

No fallback to yaml.safe_load in either. Silently downgrading to the permissive
loader when the strict one is absent would restore the defect with an extra step, so
an unreachable loader is itself a refusal — observed live while building this: a
missing `import sys` made the loader unavailable and the taxonomy went empty with a
warning, which is exactly the designed behaviour.

ONE CANONICAL MODULE NAME. scripts/lib is not an importable package, so all three
call sites load it by path — under the SAME name, `nuzantara_yaml_strict`, cached in
sys.modules. Loading one file twice under two names produces two distinct
StrictYAMLError CLASSES, so `except StrictYAMLError` in one caller does not catch the
error raised through the other. Measured while writing the battery: four guilt cases
failed against a working cure. The path crossing itself is not new here — auth.py's
_DEFAULT_ROLES_YAML already reaches out of its own app tree for this very file.

WHERE THE BATTERY LIVES, and why it is not beside the wrapper.
apps/team-agent/mcp-wrapper is named by NO workflow — its tests/test_permissions.py
and tests/test_server.py are run by no CI job at all (16 tests, green locally, armed
by nothing). Arming that tree is a workflow edit and a separate concern; it is not
smuggled in here. apps/nuzantara-mcp/tests IS collected wholesale by tests.yml, so
both readers' cases live there and are armed today. The battery also pins the ATTACK
under plain safe_load, so it cannot pass by the poison quietly ceasing to be one, and
asserts its own collection wiring.

Bites: the "MCP Server Tests" job (.github/workflows/tests.yml:1505, `cd apps/nuzantara-mcp
&& ./scripts/test-coverage.sh`, whose last argument is `tests`). Observation: pytest over
tests/test_roles_yaml_is_loaded_strictly.py plus the pre-existing tests/test_per_tool_auth.py
and tests/test_rbac_decorator_yaml_taxonomy_tripwire.py -> 35 passed; the wrapper's own
tests/ -> 16 passed unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

CORRECTION, commit 2 — the wrapper is deployed by `cp`, so the loader has to ship
with it. mac-bootstrap.sh:90-93 copies `.../mcp-wrapper/*` and NOT the repo's
top-level scripts/. Reproduced: the repo-relative-only lookup raised FileNotFoundError
in that layout, and since server.py:45 builds the checker at module import, every
team member onboarded after this merged would have had a wrapper that could not start.

The line above that read "an unreachable loader is itself a refusal" was true for
auth.py (degrade-to-empty is its documented contract) and wrong for permissions.py: it
turned a POSSIBLE review-defeating edit into a CERTAIN outage. permissions.py now
looks in the repo path and then beside itself, mac-bootstrap.sh stages the loader into
$WRAPPER_DIR/lib/ as a copy of the single repo source, and four new cases run against a
real reproduction of the onboarded tree — including the assertion that the bootstrap
script actually stages it, which is superscar #2 in its deployment form.

Still no fallback to yaml.safe_load anywhere. Found before merge by an independent
packaging read, not after.
