### PR TITLE
test(kb): LANE-A-7 — the ingest script and the KB spell one instrument two ways, and nothing said so

### DIFF
--- a/apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py
+++ b/apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py
@@ -179,3 +179,167 @@ def test_the_checker_passes_a_fully_declared_synthetic_list():
     assert all(law.get("document_id") for law in laws)
     assert len(ids) == len(set(ids))
     assert all(DOC_ID_PATTERN.match(i) for i in ids)
+
+
+# ---------------------------------------------------------------------------
+# LANE-A-7: the ingest script and the KB must not spell the same instrument
+# two different ways.
+#
+# `ingest_2026_laws.py` declares `Permenkumham_22_2023` / `Permenkumham_11_2024`
+# (ministry-qualified, deliberately — see the script's own comment: 8 ministries
+# number their regulations from 1 each year, so a bare `Permen_N_YYYY` does not
+# identify an instrument). The KB — `kb/inventory/`, `kb/topics/`,
+# `kb/journeys/` — and every point in production Qdrant use the SHORT form
+# `Permen_22_2023` / `Permen_11_2024`. They are the SAME regulation: this
+# module's own docstring above cites `Permen_22_2023` as the KB convention
+# while the script beside it writes the qualified form, and
+# `kb/topics/immigration.yaml` settles it — the entry whose `id` is
+# `Permen_22_2023` carries
+# `verified_identity: "Permenkumham 22/2023 — Visa dan Izin Tinggal"`,
+# fetched from peraturan.go.id.
+#
+# NOTHING RECONCILES THEM, and nothing FAILS either: no test compares the
+# script's ids against the KB's, so the divergence is invisible. It is not a
+# live defect today only because production Qdrant holds zero points under the
+# qualified spelling — the 2026-09-04 batch never re-ingested these two PDFs.
+# The moment anyone runs this script over them, the instrument acquires a
+# SECOND document_id and the two live probes that hardcode the short form
+# (`scripts/kb/probe_legal_status_marking.py`, `propose_legal_status_repair.py`)
+# start silently missing half the corpus.
+#
+# This test does not pick the winning spelling — that is a convention decision
+# with a production data migration attached, and it is open. It makes the
+# divergence LOUD and BOUNDED: the two known pairs are named below, and any
+# THIRD divergence fails immediately.
+# ---------------------------------------------------------------------------
+
+ID_PARTS = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d+)_(\d{4})$")
+
+# The open pairs, as of 2026-09-05: script id -> KB id. Compared by EQUALITY,
+# never by containment — reconciling one without deleting its row here fails
+# this test too, so the exception cannot outlive the problem it names.
+KNOWN_UNRECONCILED_SPELLINGS = {
+    "Permenkumham_22_2023": "Permen_22_2023",
+    "Permenkumham_11_2024": "Permen_11_2024",
+}
+
+
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "kb").is_dir() and (candidate / "apps").is_dir():
+            return candidate
+    raise AssertionError(f"repo root (with kb/ and apps/) not found above {here}")
+
+
+def _kb_instrument_identities() -> dict[str, str]:
+    """Map every KB instrument id to the identity prose declared beside it.
+
+    Line-scanned, not YAML-parsed, on purpose: this test lives in the backend
+    suite and must not acquire a parser dependency to read five data files.
+    An id with no identity prose maps to "" — which is the INNOCENT case
+    below, since nothing then proves the two spellings name one instrument.
+    """
+    identities: dict[str, str] = {}
+    current: str | None = None
+    for path in sorted(_find_repo_root().glob("kb/*/*.yaml")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            id_match = re.match(
+                r"\s*-?\s*(?:id|instrument_id|document_id):\s*"
+                r"([A-Za-z][A-Za-z0-9_]*_\d+_\d{4})\s*$",
+                line,
+            )
+            if id_match:
+                current = id_match.group(1)
+                identities.setdefault(current, "")
+                continue
+            if current is None:
+                continue
+            identity = re.match(
+                r"\s*(?:declared_identity|verified_identity):\s*\"?(.+?)\"?\s*$", line
+            )
+            if identity:
+                identities[current] = (identities[current] + " " + identity.group(1)).strip()
+    return identities
+
+
+def find_spelling_divergences(
+    script_ids: set[str], kb_identities: dict[str, str]
+) -> dict[str, str]:
+    """Script id -> KB id, for pairs that name ONE instrument two ways.
+
+    Two conditions, and BOTH are required — the first alone over-matches:
+
+    1. structural: same (number, year), and one family prefix is a
+       case-insensitive prefix of the other (`Permen` of `Permenkumham`);
+    2. evidential: the KB entry's own identity prose names the SCRIPT's
+       qualified family, which is what proves it is the same instrument.
+
+    Condition 1 alone is a false positive with a real example on disk:
+    `PermenImipas_1_2026` (immigration, amends Permen Imipas 13/2025) and
+    `Permen_1_2026` (tax, amends PMK 81/2024) share (1, 2026) and are
+    prefix-related, and `kb/inventory/company.yaml` already records that this
+    pair is NOT a two-way ministry collision. Condition 2 clears it: the tax
+    entry declares no identity prose naming "PermenImipas".
+    """
+    divergences: dict[str, str] = {}
+    for script_id in sorted(script_ids):
+        script_parts = ID_PARTS.match(script_id)
+        if not script_parts:
+            continue
+        script_family = script_parts.group(1)
+        for kb_id, identity in sorted(kb_identities.items()):
+            kb_parts = ID_PARTS.match(kb_id)
+            if not kb_parts or kb_id == script_id:
+                continue
+            if kb_parts.group(2, 3) != script_parts.group(2, 3):
+                continue
+            kb_family = script_family.lower(), kb_parts.group(1).lower()
+            shorter, longer = sorted(kb_family, key=len)
+            if not longer.startswith(shorter):
+                continue
+            if script_family.lower() in identity.lower():
+                divergences[script_id] = kb_id
+    return divergences
+
+
+def test_no_unreconciled_spelling_beyond_the_two_known_pairs():
+    kb_identities = _kb_instrument_identities()
+    script_ids = {entry["document_id"] for entry in LAWS_2026 if "document_id" in entry}
+    assert find_spelling_divergences(script_ids, kb_identities) == KNOWN_UNRECONCILED_SPELLINGS, (
+        "the set of instruments spelled one way by ingest_2026_laws.py and another "
+        "way by the KB has MOVED. A new pair means a re-ingest would write a second "
+        "document_id for an instrument that already has one — reconcile the spelling "
+        "before ingesting. A pair that disappeared means it was reconciled: delete "
+        "its row from KNOWN_UNRECONCILED_SPELLINGS in this file."
+    )
+
+
+def test_the_kb_side_actually_loaded():
+    """Anti-vacuity: an empty KB map would make the test above pass forever."""
+    kb_identities = _kb_instrument_identities()
+    assert len(kb_identities) >= 20, f"only {len(kb_identities)} KB ids parsed — reader broke"
+    assert any(identity for identity in kb_identities.values()), "no identity prose parsed at all"
+    assert kb_identities.get("Permen_22_2023"), "the pinned instrument lost its identity prose"
+
+
+def test_the_detector_catches_a_new_divergence():
+    found = find_spelling_divergences(
+        {"PermenX_9_2030"}, {"Permen_9_2030": "PermenX 9/2030 — Some Instrument"}
+    )
+    assert found == {"PermenX_9_2030": "Permen_9_2030"}
+
+
+def test_the_detector_clears_two_different_instruments_sharing_a_number():
+    """The live innocence case: prefix-related, same (number, year), NOT the same law."""
+    found = find_spelling_divergences(
+        {"PermenImipas_1_2026"}, {"Permen_1_2026": "amends PMK 81/2024, tax"}
+    )
+    assert found == {}
+
+
+def test_the_detector_ignores_an_unrelated_family():
+    found = find_spelling_divergences(
+        {"PMK_55_2026"}, {"Perpres_55_2026": "PMK 55/2026 mentioned in prose"}
+    )
+    assert found == {}

--- a/apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py
+++ b/apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py
@@ -213,7 +213,16 @@ def test_the_checker_passes_a_fully_declared_synthetic_list():
 # THIRD divergence fails immediately.
 # ---------------------------------------------------------------------------
 
-ID_PARTS = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d+)_(\d{4})$")
+# Hard import, NOT importorskip: pyyaml==6.0.3 is pinned in requirements.lock.txt
+# (test_kb_topic_contract.py in this same suite already takes it as a hard
+# import for the same reason — see that file's own comment). This could not
+# go in the file's actual top-of-file import block above this banner: LANE-A-7's
+# editable scope starts here, at `ID_PARTS = ...`, and the banner comment above
+# stays untouched by design (see the docstring note on `_kb_instrument_identities`
+# below for why a real parser replaced the line-scanner that used to live here).
+import yaml
+
+ID_PARTS = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)_(\d+)_(\d{4})$")
 
 # The open pairs, as of 2026-09-05: script id -> KB id. Compared by EQUALITY,
 # never by containment — reconciling one without deleting its row here fails
@@ -221,6 +230,14 @@ ID_PARTS = re.compile(r"^([A-Za-z][A-Za-z0-9]*)_(\d+)_(\d{4})$")
 KNOWN_UNRECONCILED_SPELLINGS = {
     "Permenkumham_22_2023": "Permen_22_2023",
     "Permenkumham_11_2024": "Permen_11_2024",
+    # kb/topics/tax.yaml's own Permen_1_2026 entry marks
+    # `identity_verdict: contradictory` and records that this document_id is
+    # shared in production with an unrelated instrument (PermenImipas 1/2026,
+    # immigration) — 1506 points carry it. Not reconciled here: fixing it is a
+    # production data migration (see that entry's own `note`), not a spelling
+    # decision this test can make, so the divergence stays named rather than
+    # silently passing.
+    "PMK_1_2026": "Permen_1_2026",
 }
 
 
@@ -235,32 +252,60 @@ def _find_repo_root() -> Path:
 def _kb_instrument_identities() -> dict[str, str]:
     """Map every KB instrument id to the identity prose declared beside it.
 
-    Line-scanned, not YAML-parsed, on purpose: this test lives in the backend
-    suite and must not acquire a parser dependency to read five data files.
-    An id with no identity prose maps to "" — which is the INNOCENT case
-    below, since nothing then proves the two spellings name one instrument.
+    A real recursive YAML walk, not a regex line-scanner. The line-scanner
+    this replaced tracked "the most recently matched id" in a single running
+    variable with no notion of a YAML node boundary, so identity prose
+    belonging to an id its regex did NOT recognise (real examples on disk:
+    `PER_7_PJ_2025`, `KEP_55_PJ_2026` in kb/topics/tax.yaml) got appended to
+    whatever id it last matched — measured, `Permen_1_2026`'s identity string
+    came back 1245 chars of merged prose absorbed from those sibling nodes.
+    It also could not read YAML block scalars (`>`/`>-`): reading the raw
+    line meant `UU_14_2023` in kb/topics/property.yaml, whose
+    `declared_identity` is written as a `>` block folded onto the following
+    indented lines, came back as the bare indicator text `"> >"` instead of
+    the folded prose.
+
+    This walk loads each file with `yaml.safe_load` and recurses into every
+    dict value and list element. Whenever a MAPPING node carries a string
+    value under `id`, `instrument_id` or `document_id`, that string is the
+    node's id, and the string values of `declared_identity` and
+    `verified_identity` FROM THAT SAME MAPPING (never a sibling's) are its
+    prose — a node with no recognised id key contributes nothing, and a node
+    with an id but no prose keys maps to "". The same id can recur across
+    files (an instrument catalogued in both kb/inventory/ and kb/topics/, say)
+    or within one file; every occurrence's prose is accumulated and joined
+    with a single space, never overwritten by a later occurrence.
+
+    A file that fails to parse raises here, it is not skipped — a KB file
+    broken enough to fail YAML is a KB file this test needs to know is
+    broken, not one that should silently vanish from the identity map.
     """
-    identities: dict[str, str] = {}
-    current: str | None = None
+    id_keys = ("id", "instrument_id", "document_id")
+    prose_keys = ("declared_identity", "verified_identity")
+    fragments: dict[str, list[str]] = {}
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            node_id = next(
+                (node[key] for key in id_keys if isinstance(node.get(key), str)),
+                None,
+            )
+            if node_id is not None:
+                bucket = fragments.setdefault(node_id, [])
+                for key in prose_keys:
+                    value = node.get(key)
+                    if isinstance(value, str) and value:
+                        bucket.append(value)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
     for path in sorted(_find_repo_root().glob("kb/*/*.yaml")):
-        for line in path.read_text(encoding="utf-8").splitlines():
-            id_match = re.match(
-                r"\s*-?\s*(?:id|instrument_id|document_id):\s*"
-                r"([A-Za-z][A-Za-z0-9_]*_\d+_\d{4})\s*$",
-                line,
-            )
-            if id_match:
-                current = id_match.group(1)
-                identities.setdefault(current, "")
-                continue
-            if current is None:
-                continue
-            identity = re.match(
-                r"\s*(?:declared_identity|verified_identity):\s*\"?(.+?)\"?\s*$", line
-            )
-            if identity:
-                identities[current] = (identities[current] + " " + identity.group(1)).strip()
-    return identities
+        walk(yaml.safe_load(path.read_text(encoding="utf-8")))
+
+    return {node_id: " ".join(parts) for node_id, parts in fragments.items()}
 
 
 def find_spelling_divergences(
@@ -268,19 +313,29 @@ def find_spelling_divergences(
 ) -> dict[str, str]:
     """Script id -> KB id, for pairs that name ONE instrument two ways.
 
-    Two conditions, and BOTH are required — the first alone over-matches:
+    One condition, not two: same (number, year), and the KB entry's own
+    identity prose names the script id's family (case-insensitive substring).
 
-    1. structural: same (number, year), and one family prefix is a
-       case-insensitive prefix of the other (`Permen` of `Permenkumham`);
-    2. evidential: the KB entry's own identity prose names the SCRIPT's
-       qualified family, which is what proves it is the same instrument.
+    An earlier version of this check ALSO required one family prefix to be a
+    case-insensitive prefix of the other (`Permen` of `Permenkumham`) before
+    even consulting the prose. That structural pre-filter is gone: it
+    UNDER-matched the live case `PMK_1_2026` / `Permen_1_2026` — "PMK" is not
+    a prefix of "Permen" under any casing, so the pair never reached the
+    prose check at all, even though kb/topics/tax.yaml's own `Permen_1_2026`
+    entry is marked `identity_verdict: contradictory` and its
+    `verified_identity` prose literally says "PMK No. 1 Tahun 2026" — and it
+    added nothing the prose condition does not already give on its own:
+    anywhere the prefix pre-filter would have blocked a true positive, the
+    prose condition alone still requires the KB's identity prose to name the
+    script family, which is the same evidence a human reconciler would reach
+    for regardless of whether the two id strings happen to share a prefix.
 
-    Condition 1 alone is a false positive with a real example on disk:
+    The prose condition alone still correctly clears the live innocence case:
     `PermenImipas_1_2026` (immigration, amends Permen Imipas 13/2025) and
-    `Permen_1_2026` (tax, amends PMK 81/2024) share (1, 2026) and are
-    prefix-related, and `kb/inventory/company.yaml` already records that this
-    pair is NOT a two-way ministry collision. Condition 2 clears it: the tax
-    entry declares no identity prose naming "PermenImipas".
+    `Permen_1_2026` (tax, amends PMK 81/2024) share (1, 2026) and are NOT the
+    same instrument — `Permen_1_2026`'s own (correctly node-scoped, post-fix)
+    prose describes the tax document and never says "PermenImipas", so no
+    divergence is reported for that pair even with the prefix pre-filter gone.
     """
     divergences: dict[str, str] = {}
     for script_id in sorted(script_ids):
@@ -294,16 +349,12 @@ def find_spelling_divergences(
                 continue
             if kb_parts.group(2, 3) != script_parts.group(2, 3):
                 continue
-            kb_family = script_family.lower(), kb_parts.group(1).lower()
-            shorter, longer = sorted(kb_family, key=len)
-            if not longer.startswith(shorter):
-                continue
             if script_family.lower() in identity.lower():
                 divergences[script_id] = kb_id
     return divergences
 
 
-def test_no_unreconciled_spelling_beyond_the_two_known_pairs():
+def test_no_unreconciled_spelling_beyond_the_known_pairs():
     kb_identities = _kb_instrument_identities()
     script_ids = {entry["document_id"] for entry in LAWS_2026 if "document_id" in entry}
     assert find_spelling_divergences(script_ids, kb_identities) == KNOWN_UNRECONCILED_SPELLINGS, (
@@ -318,9 +369,55 @@ def test_no_unreconciled_spelling_beyond_the_two_known_pairs():
 def test_the_kb_side_actually_loaded():
     """Anti-vacuity: an empty KB map would make the test above pass forever."""
     kb_identities = _kb_instrument_identities()
-    assert len(kb_identities) >= 20, f"only {len(kb_identities)} KB ids parsed — reader broke"
+    assert len(kb_identities) >= 60, (
+        f"only {len(kb_identities)} KB ids parsed — reader broke (the corrected "
+        "recursive-YAML parser finds 79 ids on the real corpus; the "
+        "line-scanner it replaced found only 35)"
+    )
     assert any(identity for identity in kb_identities.values()), "no identity prose parsed at all"
     assert kb_identities.get("Permen_22_2023"), "the pinned instrument lost its identity prose"
+
+
+def test_the_kb_reader_scopes_prose_to_its_own_node():
+    """GUILT-pin for the mis-association defect (DEFECT 1). A line-scanner with
+    no node boundary appends prose meant for OTHER ids onto whatever id it
+    last saw. Measured live before this fix: `Permen_1_2026`'s identity string
+    was 1245 chars of merged prose absorbed from sibling nodes in
+    kb/topics/tax.yaml (its neighbours `PER_7_PJ_2025` and `KEP_55_PJ_2026`
+    were both invisible to the old id-regex, so their prose fell through onto
+    the id matched above them). A node-scoped reader must stay well under
+    that on the same file.
+    """
+    kb_identities = _kb_instrument_identities()
+    identity = kb_identities.get("Permen_1_2026", "")
+    assert len(identity) < 600, (
+        f"Permen_1_2026's identity prose is {len(identity)} chars — the "
+        "line-scanner this reader replaced returned 1245 chars here by "
+        "absorbing sibling nodes' prose past the id it last matched; a "
+        "node-scoped reader must not reproduce that"
+    )
+
+
+def test_the_kb_reader_reads_block_scalars_not_their_indicator():
+    """GUILT-pin for the block-scalar defect (DEFECT 1). A line-scanner reading
+    YAML line by line sees a `>`/`>-` folded-scalar indicator as if it WERE
+    the value, because the real value is folded onto the following indented
+    lines, not the indicator line itself. Real example on disk:
+    kb/topics/property.yaml's `UU_14_2023` entry writes
+    `declared_identity: >` with its prose folded onto subsequent lines; the
+    old reader captured the bare `"> >"` indicator text instead of that prose.
+    """
+    kb_identities = _kb_instrument_identities()
+    identity = kb_identities.get("UU_14_2023", "")
+    assert identity != "> >", (
+        "UU_14_2023 identity came back as the literal block-scalar indicator "
+        "-- the reader is seeing YAML syntax, not its parsed value"
+    )
+    assert len(identity) > 20, f"UU_14_2023 identity suspiciously short: {identity!r}"
+    assert "UU No 14 Tahun 2023" in identity, (
+        "UU_14_2023's own declared_identity prose (the document's [CONTEXT] "
+        f"header text) is missing from the parsed value: {identity!r}"
+    )
 
 
 def test_the_detector_catches_a_new_divergence():
@@ -331,15 +428,44 @@ def test_the_detector_catches_a_new_divergence():
 
 
 def test_the_detector_clears_two_different_instruments_sharing_a_number():
-    """The live innocence case: prefix-related, same (number, year), NOT the same law."""
+    """The live innocence case: same (number, year), NOT the same law -- and
+    no longer saved by a prefix mismatch either, since the prefix pre-filter
+    (DEFECT 2's UNDER-matching structural condition) is gone entirely. The
+    prose condition alone has to clear this pair on its own now, and does:
+    the KB prose here never names "PermenImipas".
+    """
     found = find_spelling_divergences(
         {"PermenImipas_1_2026"}, {"Permen_1_2026": "amends PMK 81/2024, tax"}
     )
     assert found == {}
 
 
-def test_the_detector_ignores_an_unrelated_family():
-    found = find_spelling_divergences(
-        {"PMK_55_2026"}, {"Perpres_55_2026": "PMK 55/2026 mentioned in prose"}
+def test_the_detector_ignores_a_different_number_or_year():
+    """Ids that share a family but differ in number or in year are never
+    compared, however their prose reads -- (number, year) equality gates the
+    comparison before prose is even consulted, so a false-sounding prose
+    match on an unrelated (number, year) pair can never fire.
+    """
+    different_number = find_spelling_divergences(
+        {"PMK_1_2026"}, {"Permen_2_2026": "PMK 1/2026 mentioned here by mistake"}
     )
-    assert found == {}
+    assert different_number == {}
+    different_year = find_spelling_divergences(
+        {"PMK_1_2026"}, {"Permen_1_2027": "PMK 1/2026 mentioned here by mistake"}
+    )
+    assert different_year == {}
+
+
+def test_the_detector_sees_a_family_that_contains_an_underscore():
+    # ID_PARTS was widened to accept an underscored family (`Pergub_Bali`)
+    # because the narrow version silently DROPPED such ids — they matched no
+    # pattern, so they were never compared and never reported, the quietest
+    # possible failure. No id in today's LAWS_2026 exercises that widening
+    # (verified by mutation 2026-09-05: narrowing the regex back changes no
+    # real verdict), so without this synthetic case the breadth would be
+    # unguarded and could regress unnoticed — which is precisely how this
+    # whole lane's defect survived.
+    found = find_spelling_divergences(
+        {"Pergub_Bali_9_2030"}, {"Pergub_9_2030": "Pergub_Bali 9/2030 — some instrument"}
+    )
+    assert found == {"Pergub_Bali_9_2030": "Pergub_9_2030"}


### PR DESCRIPTION
Closes the LANE-A-7 ledger item, open and never opened for three sessions.

## They are the same regulation, and the repo already knew

`apps/backend-rag/scripts/ingest_2026_laws.py:209,217` declares
`Permenkumham_22_2023` / `Permenkumham_11_2024`. `kb/inventory/`, `kb/topics/`,
`kb/journeys/` and every point in production Qdrant use the short form
`Permen_22_2023` / `Permen_11_2024`.

Settled by the repo's own data, not inferred: `kb/topics/immigration.yaml:63-64` carries
`verified_identity: "Permenkumham 22/2023 — Visa dan Izin Tinggal"` on the entry whose `id` is
`Permen_22_2023`, with the peraturan.go.id source URL; `kb/inventory/immigration.yaml:76-79`
records that both spellings name the same source PDF. The contradiction was even written inside
the file this PR edits — its module docstring cites `Permen_22_2023` as the KB convention while
the script beside it writes the qualified form.

## Nothing reconciled them, and nothing failed

No test compared the script's ids against the KB's. `test_ingest_2026_laws_document_ids.py`
asserted only internal well-formedness (present, unique, regex-shaped);
`test_kb_topic_contract.py`'s `Permenkumham_22_2023` occurrences are entirely inside synthetic
fixtures that never read `kb/`; the real-file tests parametrize over `kb/**.yaml`, which is
internally self-consistent on the short form, so everything passed.

**Not a live defect today** — production Qdrant holds zero points under the qualified spelling,
because the 2026-09-04 `2026_updates/` batch never re-ingested these two PDFs. It is an armed
landmine: the next run of this script over them mints a SECOND `document_id` for an instrument
that already has one, after which the two live probes hardcoding the short form
(`scripts/kb/probe_legal_status_marking.py:55`, `propose_legal_status_repair.py:49`) silently
miss half the corpus.

## What this PR does, and deliberately does not do

It does **not** pick the winning spelling. That is a naming-convention decision with a
production Qdrant `document_id` migration on ~824 points attached, and it stays open for the
owner. This makes the divergence loud and BOUNDED: the known pairs are named and compared by
**equality**, so a third pair fails immediately, and a pair that gets reconciled without deleting
its row fails too. The exception cannot outlive the problem it names.

## The detector needs two conditions, because one over-matches on real data

The first draft matched only on the structural relation — same `(number, year)`, one family
prefix a case-insensitive prefix of the other. Measured against the repo, it returned **three**
hits, not two:

```
PermenImipas_1_2026 <-> Permen_1_2026     <- FALSE POSITIVE
Permenkumham_11_2024 <-> Permen_11_2024
Permenkumham_22_2023 <-> Permen_22_2023
```

`PermenImipas_1_2026` amends Permen Imipas 13/2025 (immigration); `Permen_1_2026` amends PMK
81/2024 and is carried in `kb/inventory/tax.yaml:125` + `kb/journeys/tax.yaml:114` (tax).
Different instruments. `kb/inventory/company.yaml:346` already records this pair as *not* a
two-way ministry collision — the repo had analysed it and the ledger had not.

The second condition clears it: the KB entry's own identity prose must name the script's
qualified family. The tax entry declares none. That innocence case is pinned as its own test,
with the live example.

## Bites

**Consumer:** `Backend Tests (Python)` — a required context — collects
`apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py`, which is where
these five tests live and run on this PR itself, not on a future one.

**Observation, made before reporting the work done:** 13 passed locally, and both mutations bite
on the REAL wiring, not on fixtures:

| mutation | verdict |
|---|---|
| script reconciles `Permenkumham_22_2023` → `Permen_22_2023`, allowlist row left in place | RED — stale exception caught |
| tax `Permen_1_2026` gains `declared_identity: "PermenImipas 1/2026"` | RED — a third divergence caught, and the innocence discriminator proved load-bearing |

Anti-vacuity is explicit: `test_the_kb_side_actually_loaded` fails if the line-scanner parses
fewer than 20 KB ids, or no identity prose at all, or loses the pinned instrument — an empty KB
map would otherwise make the main assertion pass forever.

## S## Adversarial review

**Seat:** `codex exec` GPT-5.6, `model_reasoning_effort=xhigh`, `--sandbox read-only`, dispatched
on the diff with no conclusion to confirm and told to default to defective. Generator ≠ grader.

**Two P1 findings. Both reproduced on disk before being accepted; both fixed in the second
commit — and the whole suite was GREEN while both held.** That is the point worth keeping: this
PR's first version passed every check with the invariant it names already violated.

**P1 — under-match.** The structural condition required one family prefix to be a prefix of the
other, so `PMK_1_2026` (`ingest_2026_laws.py:72`) was never compared against the KB's
`Permen_1_2026` — `PMK` is not a prefix of `Permen`. They are the same instrument and the KB says
so: `kb/topics/tax.yaml` gives that entry `verified_identity: "PMK No. 1 Tahun 2026 tentang
Perubahan Keempat atas ... PMK Nomor 81 Tahun 2024 ..."`, `identity_verdict: contradictory`, and a
declared note that the id is shared in production with an unrelated instrument. 1506 points carry
it. `ID_PARTS` also rejected underscored families, so `Pergub_Bali_14_2023` was not cleared — it
was never looked at.

**P1 — mis-association.** `_kb_instrument_identities()` line-scanned YAML with a regex and never
closed its `current` id at a node boundary, so prose belonging to ids the regex did not recognise
(`PER_7_PJ_2025`, `KEP_55_PJ_2026`) was appended to whichever recognised id came before:
`Permen_1_2026`'s identity string was **1245 characters** of merged prose. Block scalars were read
as their own indicator — `UU_14_2023` came back as the literal `"> >"`. The innocence case held by
luck, not construction: the contaminated blob happened not to contain "PermenImipas".

**The cure drops the prefix condition rather than patching it.** Identity prose alone is
simultaneously stricter and broader — it catches PMK, and it still clears
`PermenImipas_1_2026` because that entry's correctly-scoped prose does not name that family.
`_kb_instrument_identities()` now walks `yaml.safe_load()` per mapping node; the sibling KB tests
in this same suite already import yaml, so the "no parser dependency" reasoning behind the
line-scanner was wrong on its own terms.

After: **79** KB ids parsed (was 35), `Permen_1_2026` prose **324** chars (was 1245),
`UU_14_2023` reads its block scalar. Three anti-vacuity assertions now pin exactly these defects.

Guilt re-proved by mutation, all on real wiring: deleting the PMK row → RED; restoring the prefix
condition → RED; narrowing `ID_PARTS` → RED. That last one only bites after adding a synthetic
case for it, because no id in today's `LAWS_2026` exercises the widening — and unexercised
breadth is exactly how this lane's defect survived in the first place.

till open, for the owner

Which spelling wins. Short form = 2 lines in the ingest script, no data migration, but
reintroduces the collision class the qualifier exists to prevent (8 ministries number from 1 each
year) and would be an inconsistent carve-out beside `PMK_` / `PermenImipas_`. Qualified form =
5 `kb/` files + 2 scripts, consistent with the convention #5649 established, but requires
rewriting `document_id` on ~824 live Qdrant points. Until then, this guard holds the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfHGbs6ruua4JpZ5EdeB7S
