### PR TITLE
feat(memory): land the 12-scenario recall bench a live threshold has been citing all along

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-memory-recall-eval-bench-4a8d44a0/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-memory-recall-eval-bench-4a8d44a0/brief.yml
@@ -1,0 +1,51 @@
+task_id: memory-recall-eval-bench-0905
+gear: 2
+l_level: L2
+gate_class: opus
+grader: codex-gpt-5.6-xhigh-readonly
+pii: none
+objective: |
+  `scripts/memory/mos_recall_sessionstart.py:43` justifies a constant that runs at every session
+  start — `DEFAULT_RELEVANCE_THRESHOLD = 0.35  # BM25-like score, tuned against the 12-scenario
+  eval set` — and that eval set was never in the repo. It lived in
+  `agent/air-m5/infra/memory-layers-testbench` (one commit, no PR, ever), so the threshold's
+  stated tuning basis could not be inspected, re-run or falsified by anyone reading the line.
+
+  It also ROTTED while it sat outside, which is the argument for landing it rather than leaving
+  it: the module replaced `MEMDIR_DEFAULT` with a `resolve_memdir()` resolver (necessary — the
+  hook must fall back to the MAIN worktree's memdir when it fires inside an agent worktree) and
+  the bench kept referencing the constant, dying at argparse-construction time. Nothing went red,
+  because nothing ran it.
+
+  Gear 2 by SIZE alone: two NEW files, 577 net lines, no hot-zone path, no workflow edit. The
+  floor recompute reaches 2 through the size term only; this brief declares it.
+
+  Same worktree, deliberately NOT landed: `memory_core_build.py`. It selects top-level sections
+  by English heading text ("Machines + lingua", "Sensitive", "Projects") while the live MEMORY.md
+  has "Macchine + lingua", "Segreti e dati", "Mandati attivi" — it would drop nearly everything it
+  was written to keep. Archiving a prototype that cannot run is a different call from landing a
+  bench that does.
+constraints:
+  - "OPERATOR INSTRUMENT, declared as such (Zero, 2026-09-05): `scripts-tests-sweep.yml:29` is
+    `schedule:` + `workflow_dispatch:` by its own stated design, with pytest `continue-on-error`,
+    so nothing under `scripts/tests/` has a PR-triggered gate. Wiring one means editing a
+    workflow — hot zone, floor 3 — and is a separate PR. The PR body must say this, not imply
+    the opposite; its first version implied the opposite and was corrected."
+  - "READ-ONLY on MEMDIR, enforced not merely claimed: `mos.recall(..., use_cache=True)` writes an
+    UNREDACTED cache (memory name, description, body preview), so `--out` and `--cache-path` are
+    refused when they resolve inside `--memdir`."
+  - "No memory CONTENT, no PII, no operator home path in any committed file. PII findings fail the
+    run (exit 2) rather than being reported and ignored."
+  - "Generator != grader: implementer subagent wrote the diff under a fixed spec; codex GPT-5.6
+    xhigh red-teamed it read-only; the conducting Opus 5 session re-ran every claim on disk and
+    performed the mutations itself."
+acceptance:
+  - "`pytest scripts/tests/test_recall_eval_bench.py` passes, and a DEAD bench fails it: stubbing
+    `run_prototype()` to return empty must turn the end-to-end test RED."
+  - "The path-separation guard fires: `--cache-path` inside `--memdir` exits non-zero and writes
+    nothing there; removing the guard must turn its test RED."
+  - "The bench runs against the live memory dir using main's module and reports
+    `missing_expected_files: []`, hit@3 100%, `pii_findings: []`."
+  - "Bites: the observation is the live run above, made before reporting the work done — not a
+    future job. The absence of a PR-triggered gate is stated in the PR body as a known limit,
+    not papered over."

--- a/scripts/memory/recall_eval.py
+++ b/scripts/memory/recall_eval.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import mos_recall_sessionstart as mos  # noqa: E402
@@ -127,6 +128,37 @@ def main() -> int:
     ap.add_argument("--skip-baseline", action="store_true")
     args = ap.parse_args()
 
+    # DEFECT 2 fix: the docstring above claims this bench is "read-only on MEMDIR", but
+    # nothing enforced it -- mos.recall(..., use_cache=True) calls build_or_refresh_index
+    # -> save_cache(cache_path, index), and that cache serialises each memory's `name`,
+    # `description` and a body preview UNREDACTED. If --cache-path (or --out) points inside
+    # --memdir, this bench itself becomes the leak: an unredacted copy of the operator's
+    # real memory content written back into the memory dir it is supposed to only measure.
+    # This is not a theoretical concern -- it is the concrete failure mode of the very cache
+    # this bench forces on (use_cache=True in run_prototype). Resolve real paths and refuse
+    # to run rather than silently write there.
+    memdir_real = Path(args.memdir).resolve() if args.memdir else None
+    out_real = Path(args.out).resolve()
+    cache_real = Path(args.cache_path).resolve()
+
+    def _is_inside(path: Path, base: Path) -> bool:
+        try:
+            path.relative_to(base)
+            return True
+        except ValueError:
+            return False
+
+    if memdir_real is not None:
+        offenders = [flag for flag, p in (("--out", out_real), ("--cache-path", cache_real)) if _is_inside(p, memdir_real)]
+        if offenders:
+            raise SystemExit(
+                f"recall_eval.py: {', '.join(offenders)} resolve(s) inside --memdir ({memdir_real}) -- "
+                "this bench is read-only on MEMDIR by contract. mos.recall(..., use_cache=True) writes "
+                "an UNREDACTED cache (memory name/description/body preview) to --cache-path, so a "
+                "--cache-path (or --out) under MEMDIR is a concrete PII/content leak into the memory "
+                "dir, not a theoretical one. Point --out and --cache-path outside --memdir."
+            )
+
     os.makedirs(args.out, exist_ok=True)
 
     missing = verify_expected_files_exist(args.memdir)
@@ -180,7 +212,13 @@ def main() -> int:
                 "baseline_rank": b_rank,
                 "baseline_returncode": b_rc,
                 "baseline_elapsed_s": round(b_elapsed, 4),
-                "baseline_stderr_snippet": (b_err or "")[:200],
+                # DEFECT 4 fix: the raw baseline stderr used to be copied verbatim into the
+                # report ("baseline_stderr_snippet": b_err[:200]) -- `mem recall` is free to
+                # echo back fragments of the query or matched memory content on error, and
+                # this report is a shared artifact (CLAUDE.md Part A rule 4: no client PII/
+                # OSINT in cleartext in any shared artifact). Record only the fact that stderr
+                # was non-empty, never its content.
+                "baseline_stderr_nonempty": bool((b_err or "").strip()),
             })
 
         rows.append(row)
@@ -214,6 +252,16 @@ def main() -> int:
 
     print(json.dumps({k: v for k, v in report.items() if k != "rows"}, indent=2))
     print(f"\n[recall_eval] wrote {report_path}", file=sys.stderr)
+
+    # DEFECT 4 fix: a PII hit used to sit quietly in the report's pii_findings list with
+    # exit code 0 -- a green CI/cron run and a positive PII finding looked identical from
+    # the outside (exactly the "green != working" shape this repo's scar family #2 names).
+    # Surface it on stderr and fail the process so a caller (human or cron) cannot miss it.
+    if pii_findings:
+        print(f"[recall_eval] PII findings: {len(pii_findings)}", file=sys.stderr)
+        for finding in pii_findings:
+            print(f"  scenario={finding['scenario']!r} layer={finding['layer']} hits={finding['hits']}", file=sys.stderr)
+        return 2
     return 0
 
 

--- a/scripts/memory/recall_eval.py
+++ b/scripts/memory/recall_eval.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Evaluation harness for LAYER 2 (mos_recall_sessionstart.py) against a
+fixed 12-scenario query -> expected-file set, plus a baseline comparison
+against the existing `mem recall` CLI (~/.claude/scripts/mem).
+
+Read-only on MEMDIR. Writes only inside the scratchpad dir given via --out.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import mos_recall_sessionstart as mos  # noqa: E402
+
+SCENARIOS = [
+    ("merge PR apps/backend-rag migration release_command",
+     "discovery_merging_a_backend_rag_pr_deploys_by_itself_2026_09_01.md"),
+    ("flyctl ssh console postgres superuser psql stdin",
+     "discovery_flyctl_ssh_console_without_dash_C_swallows_piped_stdin_2026_08_30.md"),
+    ("merge queue phantom conflict armed PR autoMergeRequest",
+     "discovery_curing_a_phantom_conflict_on_an_armed_pr_is_merging_it_2026_09_01.md"),
+    ("rollback script dry-run flag parsing",
+     "lesson_a_rollback_script_that_executes_on_any_unknown_flag_2026_09_02.md"),
+    ("git checkout -- after mutation test uncommitted cure",
+     "lesson_a_guilt_mutation_restored_with_git_checkout_wipes_the_uncommitted_cure_2026_09_04.md"),
+    ("github secret scanning alerts list api",
+     "discovery_github_secret_scanning_api_returns_the_secret_itself_2026_08_20.md"),
+    ("WR2 carousel launchd cron rearm",
+     "decision_wr2_runs_only_on_command_2026_09_01.md"),
+    ("launchctl kickstart plist environment reload",
+     "discovery_launchctl_kickstart_does_not_reload_environment_variables_2026_09_02.md"),
+    ("jsonb double encoded json.dumps asyncpg",
+     "discovery_jsonb_codec_double_encodes_and_test_pools_hide_it_2026_08_27.md"),
+    ("worktree reaper prune squash merged branch",
+     "discovery_the_worktree_reaper_is_a_guard_that_can_only_ever_say_no_2026_09_01.md"),
+    ("ssh mini LAN tailscale office",
+     "fact_mini_is_in_the_office_on_a_separate_isp_line_2026_08_12.md"),
+    ("context diet /context tokens CLAUDE.md MEMORY.md",
+     "project_context_diet_index_architecture_2026_09_04.md"),
+]
+
+PII_PATTERNS = [
+    ("email", re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")),
+    ("phone_id_it", re.compile(r"\+(?:62|39)[\s.-]?\d[\d\s.-]{6,}\d")),
+    ("digit_run_8plus", re.compile(r"\d{8,}")),
+    ("passport_ktp", re.compile(r"\b(?:passport|KTP)\b\D{0,10}\d", re.IGNORECASE)),
+]
+
+
+def pii_scan(text: str) -> list[str]:
+    hits = []
+    for name, pat in PII_PATTERNS:
+        if pat.search(text):
+            hits.append(name)
+    return hits
+
+
+def verify_expected_files_exist(memdir: str) -> list[str]:
+    missing = []
+    for _q, expected in SCENARIOS:
+        if not os.path.exists(os.path.join(memdir, expected)):
+            missing.append(expected)
+    return missing
+
+
+def rank_of(expected_filename: str, ranked_filenames: list[str]) -> int | None:
+    try:
+        return ranked_filenames.index(expected_filename) + 1
+    except ValueError:
+        return None
+
+
+def run_prototype(memdir: str, cache_path: str, query: str, k: int = 6):
+    t0 = time.time()
+    results, stats = mos.recall(memdir, cache_path, query, topk=k, use_cache=True)
+    elapsed = time.time() - t0
+    ranked = [r["filename"] for r in results]
+    out_text = mos.format_output(results)
+    return ranked, elapsed, out_text, stats
+
+
+def run_baseline(mem_bin: str, query: str, k: int = 6):
+    """Baseline: ~/.claude/scripts/mem recall "<q>" -k 6"""
+    t0 = time.time()
+    try:
+        proc = subprocess.run(
+            [mem_bin, "recall", query, "-k", str(k)],
+            capture_output=True, text=True, timeout=30,
+        )
+        out = proc.stdout
+        err = proc.stderr
+        rc = proc.returncode
+    except Exception as e:  # noqa: BLE001
+        out, err, rc = "", str(e), -1
+    elapsed = time.time() - t0
+    # extract .md filenames mentioned in the baseline's output, in order of appearance
+    filenames = re.findall(r"([A-Za-z0-9_.\-]+\.md)", out)
+    # de-dup preserving order
+    seen = set()
+    ranked = []
+    for fn in filenames:
+        if fn not in seen:
+            seen.add(fn)
+            ranked.append(fn)
+    return ranked, elapsed, out, err, rc
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    # mos_recall_sessionstart.py renamed its MEMDIR_DEFAULT constant to resolve_memdir(), a
+    # function: called from an agent worktree, a bare constant can only ever point at the
+    # worktree's own (nonexistent) memdir, whereas resolve_memdir() falls back to the MAIN
+    # worktree's memdir via `git rev-parse --git-common-dir`. Nothing caught this rename
+    # while this bench lived only in an unmerged worktree — which is exactly why it is being
+    # landed now. The companion test (scripts/tests/test_recall_eval_bench.py) pins this API
+    # surface with inspect.signature so the next rename fails loudly instead of rotting quietly.
+    ap.add_argument("--memdir", default=mos.resolve_memdir())
+    ap.add_argument("--cache-path", required=True)
+    ap.add_argument("--mem-bin", default=os.path.expanduser("~/.claude/scripts/mem"))
+    ap.add_argument("--out", required=True, help="scratchpad dir to write JSON report + session-mode output")
+    ap.add_argument("--skip-baseline", action="store_true")
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+
+    missing = verify_expected_files_exist(args.memdir)
+    if missing:
+        print(f"WARNING: {len(missing)} expected file(s) not found in MEMDIR: {missing}", file=sys.stderr)
+
+    rows = []
+    proto_hit1 = proto_hit3 = proto_hit6 = 0
+    base_hit1 = base_hit3 = base_hit6 = 0
+    proto_latencies = []
+    base_latencies = []
+    pii_findings = []
+
+    for query, expected in SCENARIOS:
+        p_ranked, p_elapsed, p_out, p_stats = run_prototype(args.memdir, args.cache_path, query)
+        p_rank = rank_of(expected, p_ranked)
+        proto_latencies.append(p_elapsed)
+        if p_rank == 1:
+            proto_hit1 += 1
+        if p_rank and p_rank <= 3:
+            proto_hit3 += 1
+        if p_rank and p_rank <= 6:
+            proto_hit6 += 1
+
+        p_hits = pii_scan(p_out)
+        if p_hits:
+            pii_findings.append({"scenario": query, "layer": "prototype", "hits": p_hits})
+
+        row = {
+            "query": query,
+            "expected": expected,
+            "prototype_rank": p_rank,
+            "prototype_output_bytes": len(p_out.encode("utf-8")),
+            "prototype_elapsed_s": round(p_elapsed, 4),
+        }
+
+        if not args.skip_baseline:
+            b_ranked, b_elapsed, b_out, b_err, b_rc = run_baseline(args.mem_bin, query)
+            b_rank = rank_of(expected, b_ranked)
+            base_latencies.append(b_elapsed)
+            if b_rank == 1:
+                base_hit1 += 1
+            if b_rank and b_rank <= 3:
+                base_hit3 += 1
+            if b_rank and b_rank <= 6:
+                base_hit6 += 1
+            b_hits = pii_scan(b_out)
+            if b_hits:
+                pii_findings.append({"scenario": query, "layer": "baseline", "hits": b_hits})
+            row.update({
+                "baseline_rank": b_rank,
+                "baseline_returncode": b_rc,
+                "baseline_elapsed_s": round(b_elapsed, 4),
+                "baseline_stderr_snippet": (b_err or "")[:200],
+            })
+
+        rows.append(row)
+
+    n = len(SCENARIOS)
+    report = {
+        "n_scenarios": n,
+        "missing_expected_files": missing,
+        "prototype": {
+            "hit_at_1": proto_hit1, "hit_at_3": proto_hit3, "hit_at_6": proto_hit6,
+            "hit_at_1_pct": round(100 * proto_hit1 / n, 1),
+            "hit_at_3_pct": round(100 * proto_hit3 / n, 1),
+            "hit_at_6_pct": round(100 * proto_hit6 / n, 1),
+            "mean_latency_s": round(sum(proto_latencies) / n, 4),
+        },
+        "baseline": None if args.skip_baseline else {
+            "hit_at_1": base_hit1, "hit_at_3": base_hit3, "hit_at_6": base_hit6,
+            "hit_at_1_pct": round(100 * base_hit1 / n, 1),
+            "hit_at_3_pct": round(100 * base_hit3 / n, 1),
+            "hit_at_6_pct": round(100 * base_hit6 / n, 1),
+            "mean_latency_s": round(sum(base_latencies) / n, 4) if base_latencies else None,
+        },
+        "pii_findings": pii_findings,
+        "pii_finding_count": len(pii_findings),
+        "rows": rows,
+    }
+
+    report_path = os.path.join(args.out, "recall_eval_report.json")
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    print(json.dumps({k: v for k, v in report.items() if k != "rows"}, indent=2))
+    print(f"\n[recall_eval] wrote {report_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_recall_eval_bench.py
+++ b/scripts/tests/test_recall_eval_bench.py
@@ -8,13 +8,12 @@ under ~/.claude or the operator's real memdir is touched.
 """
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import os
 import subprocess
 import sys
-
-import pytest
 
 SCRIPTS_MEMORY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "memory")
 sys.path.insert(0, SCRIPTS_MEMORY)
@@ -33,6 +32,18 @@ def test_the_bench_api_surface_it_depends_on_still_exists():
     caught the rename until the bench was actually run again. Pin the exact
     callables and parameter names the bench calls so the next rename over there
     breaks a test HERE, loudly, instead of silently rotting an eval bench again.
+
+    DEFECT 5: name-only pinning (checking a param name is present *somewhere* in the
+    signature) is both too strict and too loose against the REAL call shape.
+    run_prototype() calls `mos.recall(memdir, cache_path, query, topk=k,
+    use_cache=True)` -- the first three arguments POSITIONALLY, in that order, and
+    `topk`/`use_cache` as keywords. `mos.format_output(results)` passes `results`
+    positionally. `resolve_memdir()` is called with zero arguments as a CLI default
+    (`ap.add_argument("--memdir", default=mos.resolve_memdir())`). A signature change
+    that keeps every name but makes `memdir` keyword-only, or reorders the first
+    three params, would still satisfy the old name-only assertions while breaking the
+    bench at runtime with a TypeError. `inspect.signature(...).bind(...)` reproduces
+    the actual call shape and raises TypeError itself if it no longer fits.
     """
     for name in ("recall", "format_output", "resolve_memdir"):
         assert callable(getattr(mos, name, None)), (
@@ -40,18 +51,43 @@ def test_the_bench_api_surface_it_depends_on_still_exists():
             "on mos_recall_sessionstart -- a rename here silently rots the bench."
         )
 
-    recall_params = set(inspect.signature(mos.recall).parameters)
-    for p in ("memdir", "cache_path", "query", "topk", "use_cache"):
-        assert p in recall_params, (
-            f"recall_eval.py calls mos.recall(...) with a '{p}' argument; it is no "
-            "longer in mos.recall's signature -- a rename here silently rots the bench."
-        )
-
-    format_output_params = set(inspect.signature(mos.format_output).parameters)
-    assert "results" in format_output_params, (
-        "recall_eval.py calls mos.format_output(results); 'results' is no longer in "
-        "mos.format_output's signature -- a rename here silently rots the bench."
+    recall_sig = inspect.signature(mos.recall)
+    recall_param_names = list(recall_sig.parameters)
+    assert recall_param_names[:3] == ["memdir", "cache_path", "query"], (
+        "run_prototype() calls mos.recall(memdir, cache_path, query, ...) "
+        "POSITIONALLY in that exact order; mos.recall's first three parameters "
+        "are no longer (memdir, cache_path, query) in that order -- a reorder here "
+        "silently rots the bench (wrong values bound to the wrong names)."
     )
+    try:
+        recall_sig.bind("dummy_memdir", "dummy_cache_path", "dummy_query", topk=6, use_cache=True)
+    except TypeError as e:
+        raise AssertionError(
+            "recall_eval.py's run_prototype() calls "
+            "mos.recall(memdir, cache_path, query, topk=k, use_cache=True) -- that "
+            "exact call shape no longer binds against mos.recall's signature "
+            f"({e}); a rename/reorder/keyword-only change here silently rots the "
+            "bench."
+        ) from e
+
+    format_output_sig = inspect.signature(mos.format_output)
+    try:
+        format_output_sig.bind("dummy_results")
+    except TypeError as e:
+        raise AssertionError(
+            "recall_eval.py calls mos.format_output(results) positionally; "
+            f"mos.format_output's first parameter no longer accepts a positional "
+            f"argument ({e}) -- a rename here silently rots the bench."
+        ) from e
+
+    try:
+        inspect.signature(mos.resolve_memdir).bind()
+    except TypeError as e:
+        raise AssertionError(
+            "recall_eval.py calls mos.resolve_memdir() with zero arguments as a "
+            f"CLI default; that no longer binds ({e}) -- a new required parameter "
+            "here silently rots the bench."
+        ) from e
 
 
 def test_the_twelve_scenario_set_matches_what_the_live_threshold_cites():
@@ -96,12 +132,20 @@ SYNTHETIC_MEMORIES = [
 
 def test_the_bench_runs_end_to_end_on_a_synthetic_memdir(tmp_path):
     """Full subprocess smoke test: the bench must run clean against a throwaway
-    memdir that has real memory-file shape but none of the SCENARIOS' expected
-    filenames. This does NOT assert a hit rate -- a synthetic corpus legitimately
-    can't hit real expected files, so every scenario should legitimately miss. What
-    it proves instead is that the bench correctly REPORTS a memdir that lacks its
-    corpus (missing_expected_files has all 12 entries) rather than silently scoring
-    an empty or broken run as if it were a real result.
+    memdir that has real memory-file shape but (deliberately, for 11 of the 12
+    scenarios) none of the SCENARIOS' expected filenames.
+
+    DEFECT 1: the previous version of this test only asserted shape (exit code,
+    report-file existence, its keys, "12 missing") -- never that mos.recall()
+    actually ran and returned anything. Replacing run_prototype()'s body with
+    `return [], 0, "", {}` still passed all of that. Plant ONE scenario's real
+    expected file -- read live_query/live_expected from recall_eval.SCENARIOS at
+    RUNTIME rather than hardcoding a filename here, so this stays honest if
+    SCENARIOS ever changes -- with body text built from that scenario's own query
+    string, so there is a genuine, high-overlap BM25 match to find. A stubbed
+    run_prototype returns zero results for every scenario, which flips both
+    assertions below: missing_expected_files would stay at 12 (the planted file
+    would never be "found" by a dead recall) and hit_at_6 would stay at 0.
     """
     memdir = tmp_path / "memdir"
     memdir.mkdir()
@@ -109,6 +153,19 @@ def test_the_bench_runs_end_to_end_on_a_synthetic_memdir(tmp_path):
         (memdir / filename).write_text(
             SYNTHETIC_FRONT.format(name=name, desc=desc, typ=typ, topic=topic), encoding="utf-8"
         )
+
+    live_query, live_expected = recall_eval.SCENARIOS[0]
+    (memdir / live_expected).write_text(
+        "---\n"
+        "name: live-scenario\n"
+        f"description: {live_query}\n"
+        "metadata:\n"
+        "  type: discovery\n"
+        "---\n\n"
+        f"Body text about {live_query}, distinct vocabulary: "
+        f"{live_query} {live_query} {live_query}.\n",
+        encoding="utf-8",
+    )
 
     out_dir = tmp_path / "out"
     cache_path = tmp_path / "cache.json"
@@ -132,31 +189,120 @@ def test_the_bench_runs_end_to_end_on_a_synthetic_memdir(tmp_path):
     for key in ("n_scenarios", "prototype", "missing_expected_files", "pii_findings"):
         assert key in report
 
-    assert len(report["missing_expected_files"]) == 12, (
-        "synthetic memdir carries none of SCENARIOS' expected filenames; the bench "
-        "must report all 12 as missing rather than silently scoring the run as if "
-        "the real corpus were present."
+    assert len(report["missing_expected_files"]) == 11, (
+        "11 of SCENARIOS' 12 expected filenames are genuinely absent from this "
+        "synthetic memdir; only the one planted above (SCENARIOS[0]'s expected "
+        "file) is present. The bench must report exactly 11 missing -- 12 would "
+        "mean the planted file was never found, which is what a dead/stubbed "
+        "run_prototype() would also produce."
+    )
+    assert report["prototype"]["hit_at_6"] >= 1, (
+        "the planted file carries genuine query-matching vocabulary for "
+        "SCENARIOS[0] and should land inside the prototype's top 6; a stubbed "
+        "run_prototype() (`return [], 0, \"\", {}`) returns zero results for every "
+        "scenario and would leave hit_at_6 at 0 -- this is the assertion DEFECT 1 "
+        "found missing."
+    )
+    assert report["pii_findings"] == [], (
+        "DEFECT 4: the synthetic corpus carries no PII, so pii_findings must "
+        "genuinely be empty, not merely present as a report key."
     )
 
 
-def test_the_bench_never_writes_into_the_memory_dir():
+def _write_synthetic_memdir(memdir):
+    for filename, name, desc, typ, topic in SYNTHETIC_MEMORIES:
+        (memdir / filename).write_text(
+            SYNTHETIC_FRONT.format(name=name, desc=desc, typ=typ, topic=topic), encoding="utf-8"
+        )
+
+
+def _snapshot_dir(d):
+    """(size, mtime_ns, sha256) per file -- strict enough to catch a content OR a
+    timestamp-only mutation (e.g. an in-place re-save with identical bytes)."""
+    snap = {}
+    for p in sorted(d.iterdir()):
+        st = p.stat()
+        snap[p.name] = (st.st_size, st.st_mtime_ns, hashlib.sha256(p.read_bytes()).hexdigest())
+    return snap
+
+
+def test_the_bench_never_writes_into_the_memory_dir(tmp_path):
     """recall_eval.py measures the operator's REAL memories (or, in tests, a
     synthetic stand-in) and is read-only on --memdir by contract -- it may only
-    write inside the scratchpad dir given via --out. A bench that ever opens a
-    path derived from args.memdir in a write mode could corrupt or fabricate
-    entries in the operator's actual memory corpus, which is exactly the kind of
-    irreversible action this repo treats as off-limits without explicit care.
-    Static-scan the source rather than the running process: cheap, and it catches
-    the mistake even in a code path this test's own runs never exercise.
+    write inside the scratchpad dir given via --out / --cache-path.
+
+    DEFECT 3: the previous version of this test statically grepped source lines for
+    `args.memdir` sitting next to `open(`/`"w"` -- that catches nothing real, because
+    the actual write path is indirect: mos.recall(..., use_cache=True) calls
+    build_or_refresh_index() -> save_cache(cache_path, index), and cache_path is a
+    CLI flag value, never a literal expression containing the string "args.memdir"
+    anywhere in this file's source. Replace the static scan with a BEHAVIOURAL one:
+    snapshot every file under a synthetic memdir, run the bench for real with
+    --out/--cache-path OUTSIDE it (as the contract requires), and assert the memdir
+    is byte-identical afterwards with no new file added.
     """
-    src_path = os.path.join(SCRIPTS_MEMORY, "recall_eval.py")
-    with open(src_path, "r", encoding="utf-8") as f:
-        lines = f.readlines()
-    for i, line in enumerate(lines, start=1):
-        if "args.memdir" in line:
-            assert '"w"' not in line and "open(" not in line, (
-                f"recall_eval.py:{i} appears to open a path derived from args.memdir "
-                "in a write mode -- the bench is READ-ONLY on MEMDIR by contract "
-                "(it measures the operator's real memories) and may only write "
-                "inside --out."
-            )
+    memdir = tmp_path / "memdir"
+    memdir.mkdir()
+    _write_synthetic_memdir(memdir)
+
+    before = _snapshot_dir(memdir)
+
+    out_dir = tmp_path / "out"
+    cache_path = tmp_path / "cache.json"  # deliberately OUTSIDE memdir
+    proc = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(SCRIPTS_MEMORY, "recall_eval.py"),
+            "--memdir", str(memdir),
+            "--cache-path", str(cache_path),
+            "--out", str(out_dir),
+            "--skip-baseline",
+        ],
+        capture_output=True, text=True, timeout=60, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, f"bench exited nonzero: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+
+    after = _snapshot_dir(memdir)
+    assert after == before, (
+        "memdir contents (size/mtime/sha256) changed after a bench run that "
+        "declares itself read-only on --memdir -- a genuine mutation, not just a "
+        "static-scan miss."
+    )
+    assert set(after) == set(before), "a new file appeared inside memdir during a bench run."
+
+
+def test_the_bench_refuses_a_cache_path_inside_memdir(tmp_path):
+    """DEFECT 2's companion: asserts the guard added to recall_eval.py's main()
+    actually fires. mos.recall(..., use_cache=True) writes an UNREDACTED cache
+    (memory name/description/body preview) to --cache-path via save_cache() -- a
+    --cache-path resolving inside --memdir is a concrete content leak back into the
+    memory dir this bench is supposed to only measure. Without a test that exercises
+    the guard end-to-end (not just reads its source), a later refactor could move the
+    check after the write, or drop it, and nothing would catch it -- the same way the
+    read-only contract itself rotted silently before DEFECT 3's fix.
+    """
+    memdir = tmp_path / "memdir"
+    memdir.mkdir()
+    _write_synthetic_memdir(memdir)
+
+    out_dir = tmp_path / "out"
+    bad_cache_path = memdir / ".recall_cache.json"  # INSIDE memdir -- the leak DEFECT 2 fixes
+    proc = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(SCRIPTS_MEMORY, "recall_eval.py"),
+            "--memdir", str(memdir),
+            "--cache-path", str(bad_cache_path),
+            "--out", str(out_dir),
+            "--skip-baseline",
+        ],
+        capture_output=True, text=True, timeout=60, cwd=REPO_ROOT,
+    )
+    assert proc.returncode != 0, (
+        "recall_eval.py must refuse to run (non-zero exit) when --cache-path "
+        f"resolves inside --memdir (stdout={proc.stdout!r} stderr={proc.stderr!r})"
+    )
+    assert not bad_cache_path.exists(), (
+        "the read-only-on-memdir guard fired too late -- a cache file was still "
+        "written inside memdir before the process exited."
+    )

--- a/scripts/tests/test_recall_eval_bench.py
+++ b/scripts/tests/test_recall_eval_bench.py
@@ -1,0 +1,162 @@
+"""Guardrails for scripts/memory/recall_eval.py (the LAYER 2 recall-quality
+eval bench). This bench was written months ago, lived only in an abandoned,
+unmerged worktree, and rotted silently while mos_recall_sessionstart.py's API
+moved on under it (MEMDIR_DEFAULT -> resolve_memdir()) with nothing to catch
+the drift. These tests exist so the next API move fails loudly here instead
+of rotting a bench nobody runs. Fixtures live entirely in tmp_path; nothing
+under ~/.claude or the operator's real memdir is touched.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+SCRIPTS_MEMORY = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "memory")
+sys.path.insert(0, SCRIPTS_MEMORY)
+
+import mos_recall_sessionstart as mos  # noqa: E402
+import recall_eval  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(SCRIPTS_MEMORY))
+
+
+def test_the_bench_api_surface_it_depends_on_still_exists():
+    """recall_eval.py imports mos_recall_sessionstart and calls a handful of its
+    names directly (mos.recall, mos.format_output, mos.resolve_memdir). This bench
+    lived only in an unmerged worktree for months while that module's API moved on
+    underneath it (MEMDIR_DEFAULT was renamed to resolve_memdir()) and nothing
+    caught the rename until the bench was actually run again. Pin the exact
+    callables and parameter names the bench calls so the next rename over there
+    breaks a test HERE, loudly, instead of silently rotting an eval bench again.
+    """
+    for name in ("recall", "format_output", "resolve_memdir"):
+        assert callable(getattr(mos, name, None)), (
+            f"recall_eval.py calls mos.{name}(...); it is missing or not callable "
+            "on mos_recall_sessionstart -- a rename here silently rots the bench."
+        )
+
+    recall_params = set(inspect.signature(mos.recall).parameters)
+    for p in ("memdir", "cache_path", "query", "topk", "use_cache"):
+        assert p in recall_params, (
+            f"recall_eval.py calls mos.recall(...) with a '{p}' argument; it is no "
+            "longer in mos.recall's signature -- a rename here silently rots the bench."
+        )
+
+    format_output_params = set(inspect.signature(mos.format_output).parameters)
+    assert "results" in format_output_params, (
+        "recall_eval.py calls mos.format_output(results); 'results' is no longer in "
+        "mos.format_output's signature -- a rename here silently rots the bench."
+    )
+
+
+def test_the_twelve_scenario_set_matches_what_the_live_threshold_cites():
+    """mos_recall_sessionstart.py:43 defines DEFAULT_RELEVANCE_THRESHOLD = 0.35 with
+    the comment 'tuned against the 12-scenario eval set' -- citing THIS module's
+    SCENARIOS list as the justification for a live production constant. If the count
+    drifts from 12 (a scenario added/removed without re-tuning), that comment's
+    stated tuning basis is silently invalidated while still reading as authoritative.
+    Also guards the shape every row must have: a non-empty query string paired with
+    a non-empty expected memory filename.
+    """
+    assert len(recall_eval.SCENARIOS) == 12, (
+        "mos_recall_sessionstart.py's DEFAULT_RELEVANCE_THRESHOLD comment cites a "
+        "'12-scenario eval set' as its tuning justification; SCENARIOS no longer has "
+        "12 entries, so that constant's stated basis is now silently wrong."
+    )
+    for query, expected in recall_eval.SCENARIOS:
+        assert isinstance(query, str) and query.strip()
+        assert isinstance(expected, str) and expected.strip()
+        assert expected.endswith(".md")
+
+
+SYNTHETIC_FRONT = """---
+name: {name}
+description: {desc}
+metadata:
+  type: {typ}
+---
+
+Body text about {topic}, distinct vocabulary: {topic} {topic} {topic}.
+"""
+
+SYNTHETIC_MEMORIES = [
+    ("discovery_zephyr_octagon_2026_01_01.md", "discovery-zephyr", "zephyr octagon finding", "discovery", "zephyr octagon"),
+    ("decision_quokka_ledger_2026_01_02.md", "decision-quokka", "quokka ledger decision", "decision", "quokka ledger"),
+    ("fact_marmalade_turbine_2026_01_03.md", "fact-marmalade", "marmalade turbine fact", "fact", "marmalade turbine"),
+    ("project_ultraviolet_kayak_2026_01_04.md", "project-ultraviolet", "ultraviolet kayak project", "project", "ultraviolet kayak"),
+    ("discovery_flamingo_abacus_2026_01_05.md", "discovery-flamingo", "flamingo abacus finding", "discovery", "flamingo abacus"),
+    ("fact_penguin_xylophone_2026_01_06.md", "fact-penguin", "penguin xylophone fact", "fact", "penguin xylophone"),
+]
+
+
+def test_the_bench_runs_end_to_end_on_a_synthetic_memdir(tmp_path):
+    """Full subprocess smoke test: the bench must run clean against a throwaway
+    memdir that has real memory-file shape but none of the SCENARIOS' expected
+    filenames. This does NOT assert a hit rate -- a synthetic corpus legitimately
+    can't hit real expected files, so every scenario should legitimately miss. What
+    it proves instead is that the bench correctly REPORTS a memdir that lacks its
+    corpus (missing_expected_files has all 12 entries) rather than silently scoring
+    an empty or broken run as if it were a real result.
+    """
+    memdir = tmp_path / "memdir"
+    memdir.mkdir()
+    for filename, name, desc, typ, topic in SYNTHETIC_MEMORIES:
+        (memdir / filename).write_text(
+            SYNTHETIC_FRONT.format(name=name, desc=desc, typ=typ, topic=topic), encoding="utf-8"
+        )
+
+    out_dir = tmp_path / "out"
+    cache_path = tmp_path / "cache.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(SCRIPTS_MEMORY, "recall_eval.py"),
+            "--memdir", str(memdir),
+            "--cache-path", str(cache_path),
+            "--out", str(out_dir),
+            "--skip-baseline",
+        ],
+        capture_output=True, text=True, timeout=60, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, f"bench exited nonzero: stdout={proc.stdout!r} stderr={proc.stderr!r}"
+
+    report_path = out_dir / "recall_eval_report.json"
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    for key in ("n_scenarios", "prototype", "missing_expected_files", "pii_findings"):
+        assert key in report
+
+    assert len(report["missing_expected_files"]) == 12, (
+        "synthetic memdir carries none of SCENARIOS' expected filenames; the bench "
+        "must report all 12 as missing rather than silently scoring the run as if "
+        "the real corpus were present."
+    )
+
+
+def test_the_bench_never_writes_into_the_memory_dir():
+    """recall_eval.py measures the operator's REAL memories (or, in tests, a
+    synthetic stand-in) and is read-only on --memdir by contract -- it may only
+    write inside the scratchpad dir given via --out. A bench that ever opens a
+    path derived from args.memdir in a write mode could corrupt or fabricate
+    entries in the operator's actual memory corpus, which is exactly the kind of
+    irreversible action this repo treats as off-limits without explicit care.
+    Static-scan the source rather than the running process: cheap, and it catches
+    the mistake even in a code path this test's own runs never exercise.
+    """
+    src_path = os.path.join(SCRIPTS_MEMORY, "recall_eval.py")
+    with open(src_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines, start=1):
+        if "args.memdir" in line:
+            assert '"w"' not in line and "open(" not in line, (
+                f"recall_eval.py:{i} appears to open a path derived from args.memdir "
+                "in a write mode -- the bench is READ-ONLY on MEMDIR by contract "
+                "(it measures the operator's real memories) and may only write "
+                "inside --out."
+            )


### PR DESCRIPTION
## The dangling citation

`scripts/memory/mos_recall_sessionstart.py:43` justifies a constant that runs at every session start:

```python
DEFAULT_RELEVANCE_THRESHOLD = 0.35  # BM25-like score, tuned against the 12-scenario eval set
```

**That eval set was never in the repo.** It lived in `agent/air-m5/infra/memory-layers-testbench` —
one commit, no PR, ever — so the threshold's stated tuning basis could not be inspected, re-run or
falsified by anyone reading the line. This PR lands it.

## It rotted while it sat outside, which is the argument for landing it

`mos_recall_sessionstart.py` replaced `MEMDIR_DEFAULT` with a `resolve_memdir()` resolver — a
necessary change, since the hook must fall back to the MAIN worktree's memdir when it fires inside
an agent worktree. The bench kept referencing the constant and died at argparse-construction time
with `AttributeError`. Nothing went red, because nothing ran it.

One line is fixed. The rot is what `scripts/tests/test_recall_eval_bench.py` exists to stop
recurring — not this instance of it, the next one.

## The four tests

| test | what it stops |
|---|---|
| `test_the_bench_api_surface_it_depends_on_still_exists` | the exact failure above: pins `recall` / `format_output` / `resolve_memdir` by name **and** by `inspect.signature` parameter names |
| `test_the_twelve_scenario_set_matches_what_the_live_threshold_cites` | silently invalidating `DEFAULT_RELEVANCE_THRESHOLD`'s stated basis by changing the set the comment cites |
| `test_the_bench_runs_end_to_end_on_a_synthetic_memdir` | the bench scoring a memdir that lacks its corpus. Driven as a subprocess over a synthetic `tmp_path` memdir, asserting it **reports** all 12 expected files missing rather than quietly producing a number |
| `test_the_bench_never_writes_into_the_memory_dir` | the read-only-on-MEMDIR contract — this tool reads the operator's real memories and may write only inside `--out` |

## Bites — and a correction to what this section first claimed

**The first version of this PR body said the tests "ship in this PR and run on it." That was
false, and the adversarial review caught it.** `.github/workflows/scripts-tests-sweep.yml:29`
states in its own comment that its triggers are `schedule:` + `workflow_dispatch:`, **deliberately
NOT `pull_request:`**, and its pytest step is `continue-on-error: true`. Nothing under
`scripts/tests/` has a PR-triggered gate — not this file, and not `test_memory_layers.py`, which
has been on main for weeks.

**So this ships as an OPERATOR INSTRUMENT, declared as such** (Zero, 2026-09-05). Wiring it into a
PR-triggered job means editing a workflow — a hot zone, floor Gear 3 — and that is its own PR, not
a rider on this one.

**Observation, made before reporting the work done** — the bench driven against the LIVE memory
dir using main's module:

```
n_scenarios: 12    missing_expected_files: []
hit@1  10/12  83.3%     hit@3  12/12  100.0%     hit@6  12/12  100.0%
mean_latency 0.107s     pii_findings: 0
```

And the new refusal path, run live:

```
$ recall_eval.py --memdir <MEMDIR> --cache-path <MEMDIR>/x.json --out ...
recall_eval.py: --cache-path resolve(s) inside --memdir -- this bench is read-only on MEMDIR by
contract. mos.recall(..., use_cache=True) writes an UNREDACTED cache ...
```

## Adversarial review

**Seat:** `codex exec` GPT-5.6, `model_reasoning_effort=xhigh`, `--sandbox read-only`, dispatched
on the diff and told to default to defective. Generator ≠ grader.

**Five P1 findings. Every one reproduced before being accepted; all fixed in the second commit.**

| finding | status |
|---|---|
| all four tests pass with `run_prototype()` stubbed to return nothing — the bench could be a corpse and the suite would not know | FIXED: the E2E now plants one scenario's real expected file and requires `hit_at_6 >= 1`; stubbing goes RED |
| "read-only on MEMDIR" was a claim, not a check — `mos.recall(use_cache=True)` writes an UNREDACTED cache (name, description, body preview) to `--cache-path`, which could point into the memory dir | FIXED: `main()` refuses when `--out` or `--cache-path` resolves inside `--memdir` |
| the anti-mutation test grepped source lines for `open(` near `args.memdir` and saw nothing — the real write goes through `save_cache` | FIXED: replaced by a behavioural snapshot (size/mtime/sha256 before and after a real subprocess run) plus a test that the refusal actually fires |
| baseline stderr was copied raw into the report, and PII findings did not fail the run | FIXED: stderr reduced to a boolean; PII findings exit 2; the test asserts the list is EMPTY, not merely present |
| API pinning matched parameter names while the bench calls positionally | FIXED: binds the real call shapes with `inspect.signature(...).bind()` |

Guilt re-proved by mutation on the corrected code: stubbing `run_prototype` → RED; removing the
path-separation guard → RED.

## Deliberately NOT landed from the same worktree

`memory_core_build.py`, the Layer-1 prototype that auto-built a capped `MEMORY.core.md`. It selects
top-level sections by English heading text — `"Machines + lingua"`, `"Sensitive"`, `"Projects"` —
and the live `MEMORY.md` has `## Macchine + lingua`, `## Segreti e dati`, `## Mandati attivi`. It
would drop nearly everything it was written to keep. The nucleus it would generate is hand-curated
by design now, capped at 2560B. Archiving a prototype that cannot run against today's file is a
different call from archiving this bench, which runs and measures a shipped feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfHGbs6ruua4JpZ5EdeB7S
