### PR TITLE
fix(ci): the census staleness diagnostic named ~200 phantom paths for a one-path delta

### DIFF
--- a/scripts/ci/scripts_coupling_census.py
+++ b/scripts/ci/scripts_coupling_census.py
@@ -34,6 +34,7 @@ USAGE
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -179,6 +180,28 @@ def _render_block(paths: set[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
+_QUOTED_TOKEN = re.compile(r'"([^"]+)"')
+
+
+def _block_paths(block: str) -> set[str]:
+    """Every ``scripts/`` path quoted inside a rendered marker block.
+
+    ``_render_block`` PACKS as many paths per line as fit in
+    ``MAX_LINE_WIDTH``, so reading one path per line is wrong: it yields a
+    single bogus token per line with ``", "`` embedded in it, identical on
+    both sides of the comparison. That is what made a one-path delta render
+    as ~100 items churning in both directions, and it is why the whole
+    diagnostic was unreadable at the moment it was needed.
+    """
+
+    return {
+        token
+        for line in block.splitlines()
+        for token in _QUOTED_TOKEN.findall(line)
+        if token.startswith("scripts/")
+    }
+
+
 def _existing_block(text: str) -> str | None:
     try:
         start = text.index(BEGIN_MARKER)
@@ -219,16 +242,8 @@ def _check(embedded: set[str]) -> int:
     if existing.strip() == fresh.strip():
         print("scripts_coupling_census: SCRIPTS_COUPLING is up to date.")
         return 0
-    existing_paths = {
-        line.strip().strip('",')
-        for line in existing.splitlines()
-        if line.strip().startswith('"')
-    }
-    fresh_paths = {
-        line.strip().strip('",')
-        for line in fresh.splitlines()
-        if line.strip().startswith('"')
-    }
+    existing_paths = _block_paths(existing)
+    fresh_paths = _block_paths(fresh)
     added = sorted(fresh_paths - existing_paths)
     removed = sorted(existing_paths - fresh_paths)
     print(
@@ -236,9 +251,23 @@ def _check(embedded: set[str]) -> int:
         "`python3 scripts/ci/scripts_coupling_census.py --write`.",
         file=sys.stderr,
     )
+    if not added and not removed:
+        # The verdict above stays TEXT-based on purpose: the block is a
+        # generated artifact and must be byte-identical to what --write
+        # emits. But "stale with an identical set" is a different fact from
+        # "stale because a path moved", and saying nothing at all here made
+        # the two indistinguishable.
+        print(
+            f"  the coupled SET is identical ({len(fresh_paths)} paths) — only the "
+            "line layout of the generated block differs (rewrap at "
+            f"MAX_LINE_WIDTH={MAX_LINE_WIDTH}). Run --write.",
+            file=sys.stderr,
+        )
     for label, paths in (("+ newly coupled", added), ("- no longer coupled", removed)):
         if paths:
-            print(f"  {label} ({len(paths)}): {paths[:10]}{' …' if len(paths) > 10 else ''}", file=sys.stderr)
+            shown = ", ".join(paths[:10])
+            more = f" … (+{len(paths) - 10} more)" if len(paths) > 10 else ""
+            print(f"  {label} ({len(paths)}): {shown}{more}", file=sys.stderr)
     return 1
 
 

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -3,11 +3,15 @@
 
 from __future__ import annotations
 
+import contextlib
+import importlib.util
+import io
 import json
 import os
 import re
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -973,6 +977,122 @@ class ChangeMapTests(unittest.TestCase):
         parsed = json.loads(completed.stdout)
         self.assertEqual(parsed["mode"], "enforcing")
         self.assertFalse(parsed["run_all"])
+
+
+class CensusCheckDiagnosticTests(unittest.TestCase):
+    """The census's --check diagnostic must name what actually moved.
+
+    It did not. ``_render_block`` packs many paths per line, and ``_check``
+    read one path per LINE, so every line collapsed into a single bogus
+    token with ``", "`` inside it — identical on both sides. On 2026-09-05 a
+    genuine one-path delta printed ~100 items "newly coupled" AND ~100 "no
+    longer coupled", and an earlier session read that as a total reshuffle.
+    A diagnostic that lies is worse than none: this is what the red on
+    `Classifier corpus trust (visibility only)` shows a human.
+    """
+
+    def _census_module(self):
+        rel = Path("scripts") / "ci" / "scripts_coupling_census.py"
+        repo_root = _locate_repo_root(rel)
+        if repo_root is None:
+            self.skipTest(
+                "scripts_coupling_census.py not reachable from cwd, GITHUB_WORKSPACE "
+                "or __file__ — the diagnostic is asserted where the checkout is present"
+            )
+        # Load by path, never by name: tests.yml's trusted extraction copies
+        # a FIXED six-file list flat, and the census is deliberately not in
+        # it (it shells out to `git grep` and writes files). Its own
+        # `import change_map` resolves from sys.modules, already imported
+        # at the top of this file.
+        spec = importlib.util.spec_from_file_location(
+            "scripts_coupling_census_under_test", repo_root / rel
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _run_check(self, census, on_disk_block: str, embedded: set[str]):
+        """Point the census at a synthetic block and return (rc, stderr)."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "change_map.py"
+            target.write_text(
+                "# header\n" + on_disk_block + "\n# trailer\n", encoding="utf-8"
+            )
+            original = census.CHANGE_MAP_PATH
+            census.CHANGE_MAP_PATH = target
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err), contextlib.redirect_stdout(
+                    io.StringIO()
+                ):
+                    rc = census._check(embedded)
+            finally:
+                census.CHANGE_MAP_PATH = original
+        return rc, err.getvalue()
+
+    def test_guilt_one_added_path_is_named_and_nothing_else_is(self) -> None:
+        census = self._census_module()
+        base = {"scripts/a.py", "scripts/b.py", "scripts/c.py"}
+        rc, stderr = self._run_check(
+            census, census._render_block(base), base | {"scripts/zz_new.py"}
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("+ newly coupled (1): scripts/zz_new.py", stderr)
+        self.assertNotIn("- no longer coupled", stderr)
+        # The signature of the old line-per-path reading: a "path" carrying
+        # the separator of the packed line it was cut from.
+        self.assertNotIn('", "', stderr)
+
+    def test_guilt_one_removed_path_is_named_and_nothing_else_is(self) -> None:
+        census = self._census_module()
+        base = {"scripts/a.py", "scripts/b.py", "scripts/c.py"}
+        rc, stderr = self._run_check(
+            census, census._render_block(base | {"scripts/zz_gone.py"}), base
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("- no longer coupled (1): scripts/zz_gone.py", stderr)
+        self.assertNotIn("+ newly coupled", stderr)
+        self.assertNotIn('", "', stderr)
+
+    def test_guilt_a_rewrapped_block_says_the_set_is_identical(self) -> None:
+        # Same paths, one per line instead of packed. The verdict stays
+        # STALE — the block must be byte-identical to what --write emits —
+        # but the old code answered that with an EMPTY diagnostic or with
+        # garbage, which reads like "everything changed".
+        census = self._census_module()
+        paths = {"scripts/a.py", "scripts/b.py", "scripts/c.py"}
+        rewrapped = "\n".join(
+            [
+                census.BEGIN_MARKER,
+                "SCRIPTS_COUPLING: frozenset[str] = frozenset(",
+                "    (",
+                *[f'        "{p}",' for p in sorted(paths)],
+                "    )",
+                ")",
+                census.END_MARKER,
+            ]
+        )
+        rc, stderr = self._run_check(census, rewrapped, paths)
+        self.assertEqual(rc, 1)
+        self.assertIn("the coupled SET is identical (3 paths)", stderr)
+        self.assertNotIn("+ newly coupled", stderr)
+        self.assertNotIn("- no longer coupled", stderr)
+
+    def test_innocence_an_up_to_date_block_exits_zero_and_says_nothing(self) -> None:
+        census = self._census_module()
+        paths = {"scripts/a.py", "scripts/b.py", "scripts/c.py"}
+        rc, stderr = self._run_check(census, census._render_block(paths), paths)
+        self.assertEqual(rc, 0)
+        self.assertEqual(stderr, "")
+
+    def test_innocence_block_paths_reads_a_packed_line_as_many_paths(self) -> None:
+        # The unit fact the three guilt cases rest on: one rendered line
+        # carries several paths, and every one of them must come back.
+        census = self._census_module()
+        paths = {f"scripts/pack_{i}.py" for i in range(12)}
+        block = census._render_block(paths)
+        self.assertEqual(census._block_paths(block), paths)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What it printed, and what was true

`scripts_coupling_census.py --check` is the only thing a human sees when the
`Classifier corpus trust (visibility only)` job goes red. On `origin/main`
right now the true delta is **one path** (`scripts/kb/probe_legal_status_marking.py`,
cured by #5724). This is what the diagnostic said about it:

```
  + newly coupled (11): ['scripts/intake_identity_backfill.py", "scripts/intake_reprocess_backlog.py", …
  - no longer coupled (11): ['scripts/intake_identity_backfill.py", "scripts/intake_reprocess_backlog.py", …
```

~100 items "newly coupled", ~100 "no longer coupled", none of them a real path,
the same names on both sides. On 2026-09-05 an earlier session read that as a
total reshuffle and went hunting for non-determinism in the census that was
never there.

## Two defects in one function

**1. Paths were read one per LINE.** `_render_block` PACKS as many paths per
line as fit in `MAX_LINE_WIDTH=400`; `_check` did

```python
{line.strip().strip('",') for line in block.splitlines() if line.strip().startswith('"')}
```

`.strip('",')` only trims the ends, so a ~10-path line collapsed into ONE token
carrying `", "` inside it. The two sides wrap at different points, so every such
token differed from every other — hence the symmetric garbage.

**2. The set-identical case fell silent.** The verdict is `existing.strip() ==
fresh.strip()` — TEXT, correctly, because the block is a generated artifact that
must be byte-identical to what `--write` emits. But when only the line LAYOUT
differs, both lists are empty and the old code printed the STALE banner and
nothing else. "Stale, no reason given" reads exactly like "everything changed".

## Cure

- `_block_paths()` pulls every quoted `scripts/` token per line, so a packed line
  yields all of its paths;
- the set-identical case now says so, with the count and the reason (rewrap);
- lists print as paths, not as a Python list `repr`.

**The verdict is unchanged** — only the explanation is. A block with the right
set and the wrong layout is still stale, still exit 1.

## Guilt and innocence

New `CensusCheckDiagnosticTests` in `scripts/ci/test_change_map.py` (5 cases).
Mutation run this session — the old line-per-path reading restored in place:

```
FAILED CensusCheckDiagnosticTests::test_guilt_a_rewrapped_block_says_the_set_is_identical
FAILED CensusCheckDiagnosticTests::test_guilt_one_added_path_is_named_and_nothing_else_is
FAILED CensusCheckDiagnosticTests::test_guilt_one_removed_path_is_named_and_nothing_else_is
3 failed, 2 passed
```

Cure restored: `5 passed`. Full file: `59 passed, 47 subtests` (the one remaining
red is `test_scripts_coupling_census_is_not_stale`, which is main's staleness,
cured by #5724 — not by this PR).

The tests load the census with `spec_from_file_location` through the existing
`_locate_repo_root`, never by name: `tests.yml` extracts a FIXED six-file list
FLAT and the census is deliberately not in it. `import change_map` inside the
census resolves from `sys.modules`, already imported at the top of the corpus.

## Bites

**Consumer:** the `changes` job's *"Verify change-map guilt and innocence corpus"*
step. It runs `test_change_map.py` from the BASE ref, but that test locates the
census **in the checkout** (`census = repo_root / rel`, `cwd=repo_root`) — so it
subprocesses **this PR's HEAD copy** of `scripts_coupling_census.py --check`. The
cured diagnostic is therefore what prints in this PR's own job log, with main's
live staleness as the fixture.

Also live on this PR: `Trusted-classifier extraction lists are import-closed`
(`immune-enforcement.yml`, ungated, runs on every PR) — the new imports are all
stdlib, so the extraction list stays closed.

**Observation** — same command, same stale main, this branch:

```
$ python3 scripts/ci/scripts_coupling_census.py --check
scripts_coupling_census: SCRIPTS_COUPLING is STALE — run `... --write`.
  + newly coupled (1): scripts/kb/probe_legal_status_marking.py
```

One line. One path. The one that actually moved.

Floor 1 (`--print-floor` → `1`), 149 net lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQZuToawPdr14poQfAjbq