### PR TITLE
docs(runbook): the merge-queue runbook forbids the setting that is currently LIVE

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -439,7 +439,35 @@ gh api /repos/Bali-Zero/Teman2/rulesets/19779175 \
   --jq '.rules[]|select(.type=="merge_queue")|.parameters'
 ```
 
-### DO NOT flip `ALLGREEN` → `HEADGREEN`
+### `ALLGREEN` → `HEADGREEN`: banned 2026-07-27, OVERRIDDEN by Zero 2026-09-05 — and LIVE
+
+> **Read this box before acting on the section below it.** The ban that follows was a real
+> ruling and its reasoning still holds; it is no longer the standing order. Zero applied
+> `HEADGREEN` on **2026-09-05** as lever L3 of `research/operations/2026-09-05-pr-cycle-time-diet.md`,
+> together with `min_entries_to_merge` 4→1 and `min_entries_to_merge_wait_minutes` 15→2 — the
+> waiting, not the grouping, was the measured cost: a PR arriving with fewer than 3 others sat
+> up to 15 minutes for the batch to fill.
+>
+> **It was applied KNOWING the mechanism is unverified.** GitHub's dedicated page for the
+> setting 404s; only the enum text quoted below is documented. So this is a watched
+> experiment, not a settled ruling, and it carries an explicit exit condition:
+>
+> - **Signal to watch for:** an entry whose REQUIRED checks are RED entering `main` by riding
+>   a green entry in the same group.
+> - **If seen → roll back**, do not debate: `PUT` the pre-change parameters
+>   (`ALLGREEN`, `min_entries_to_merge: 4`, `min_entries_to_merge_wait_minutes: 15`).
+> - **Verify the live value from the RULESET**, never from branch protection — the queue
+>   config lives in ruleset `19779175`, and confirm through the independent GraphQL
+>   `mergeQueue.configuration` view rather than trusting a `PUT` response.
+>
+> Surveillance to date (2026-09-05, this repo's Actions history): **5 queue groups built since
+> the change — PRs #5713–#5717, 2026-09-04 19:57Z–20:02Z — zero non-success conclusions.** No
+> instance of the pathology yet, and a five-entry sample is far too small to close the watch.
+>
+> A session that reads only the heading below will roll back a decision the owner made
+> deliberately, with a rationale, two days later. That is why this box exists.
+
+### The ban, and why it was right in July
 
 It reads like a throughput knob and it is not. In GitHub's own words, `HEADGREEN` is the
 **"Only merge non-failing pull requests" setting DISABLED**: _"pull requests that have failed


### PR DESCRIPTION
## The contradiction

`docs/runbooks/merge-queue-discipline.md:442` heads a section:

> ### DO NOT flip `ALLGREEN` → `HEADGREEN`

Ruleset `19779175`, read live this session:

```
$ gh api /repos/Bali-Zero/Teman2/rulesets/19779175 \
    --jq '.rules[]|select(.type=="merge_queue")|.parameters'
{"check_response_timeout_minutes":90,"grouping_strategy":"HEADGREEN","max_entries_to_build":5,
 "max_entries_to_merge":4,"merge_method":"SQUASH","min_entries_to_merge":1,
 "min_entries_to_merge_wait_minutes":2}
```

Zero applied it on **2026-09-05** as lever L3 of
`research/operations/2026-09-05-pr-cycle-time-diet.md`, with
`min_entries_to_merge` 4→1 and the wait 15→2. The measured cost was the
**waiting**, not the grouping: a PR arriving with fewer than 3 others sat up to
15 minutes for the batch to fill.

The runbook now instructs the next session to roll back a decision the owner
made deliberately, two days later, with a rationale. **A doc that contradicts
the live config does not fail closed — it fails by being obeyed.**

## What this does NOT do

It does not delete the ban. The July 2026-07-27 reasoning is still correct about
what `HEADGREEN` *does* — it is the "Only merge non-failing pull requests"
setting DISABLED — and the override was applied **knowing the mechanism is
unverified**: GitHub's dedicated page for the setting 404s, only the enum text
is documented.

So the section keeps its whole argument and gains a box above it carrying the
three things a doc has to carry when a ban becomes a watched experiment:

- the **override**, dated and attributed;
- the **exit condition** — a RED entry riding a green one into `main`;
- the **rollback recipe** — `PUT` back `ALLGREEN` / `4` / `15`, verified from
  the RULESET and through the independent GraphQL `mergeQueue.configuration`
  view, never from branch protection.

## Surveillance, recorded as what it is

Measured this session across the repo's Actions history, filtering runs on
`gh-readonly-queue/main/*`:

```
queue groups since the change : 5   (PRs #5713–#5717, 2026-09-04 19:57Z–20:02Z)
non-success conclusions       : 0
```

No instance of the pathology yet — and a five-entry sample is far too small to
close the watch. The box says exactly that rather than reporting it as clear.

## Bites

**Consumer:** `runbook section numbers are unique`
(`.github/workflows/runbook-section-numbers.yml`) — a required context, and one
that `main-push-failure-watch.yml:197` also tracks by name. The edit renames a
`###` heading this gate parses, so the gate reads it.

**Observation**, made before reporting the work done:

```
$ python3 -m pytest scripts/tests/test_runbook_section_numbers_are_unique.py -q
5 passed
```

Docs-only, 28 net lines, floor 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQZuToawPdr14poQfAjbq