### PR TITLE
fix(prepush): catch SCRIPTS_COUPLING staleness in the PR that causes it, not hours later on main

### DIFF
--- a/scripts/quickcheck.sh
+++ b/scripts/quickcheck.sh
@@ -342,6 +342,70 @@ PYEOF
 }
 
 # ---------------------------------------------------------------------------
+# 3c. scripts-coupling — SCRIPTS_COUPLING staleness, caught while it is free
+#
+# Added 2026-09-05 after the SAME breakage landed on main three times inside
+# 24h (#5707 -> cured by #5711 -> re-broken by #5709 -> cured by #5724).
+# `scripts/ci/scripts_coupling_census.py --check` exiting 1 fails
+# `scripts/ci/test_change_map.py::test_scripts_coupling_census_is_not_stale`
+# inside the trusted FLAT extraction; the `changes` job then treats the
+# classifier as untrustworthy and degrades to `run_all=true`, so EVERY
+# subsequent PR re-buys all six heavy suites until someone runs `--write`.
+#
+# WHY HERE and not as a required CI check. The signal is not missing — it
+# already exists at every layer: `Classifier corpus trust (visibility only)`
+# goes red on the PR that causes it, and a scheduled tests.yml run on main
+# plus main-push-failure-watch.yml alerts afterwards. What failed three
+# times was READING it, not detecting it. Arming the existing job as a
+# REQUIRED context was considered and REJECTED: that job also fires when
+# the trusted extraction itself breaks, which is exactly what #5679 did on
+# every PR until #5692 — requiring it converts a cost degradation into a
+# repo-wide outage. So the fix belongs at the only moment the cure is free:
+# the push that introduces the coupling, in the PR that owns it.
+#
+# WHY the census is NOT narrowed to ignore comments. A mention inside a
+# COMMENT couples exactly like an import here (#5709's case). Narrowing it
+# moves toward the UNDER-match direction — superscar #3, the one that SKIPS
+# a suite that should have run — and it would not have prevented #5707,
+# whose coupling was a genuine runtime `exec_module`. Over-match costs CI
+# minutes on edits to one script; under-match costs a missed regression.
+#
+# UNCONDITIONAL, like skills-canon above: the census reads the whole TREES
+# corpus, so a diff that touches nothing under apps/ can still be the one
+# that goes stale via a lockfile-ish indirect path, and the run is ~2s.
+# ---------------------------------------------------------------------------
+run_scripts_coupling_census_check() {
+    if [ ! -f scripts/ci/scripts_coupling_census.py ]; then
+        echo "   [scripts-coupling] scripts/ci/scripts_coupling_census.py not on this branch yet — skipping."
+        return 0
+    fi
+    local py=""
+    if command -v python3 >/dev/null 2>&1; then
+        py="$(command -v python3)"
+    else
+        echo "   [scripts-coupling] python3 not found — skipping."
+        return 0
+    fi
+
+    local out rc
+    out="$("$py" scripts/ci/scripts_coupling_census.py --check 2>&1)"
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "   [scripts-coupling] SCRIPTS_COUPLING is up to date."
+        return 0
+    fi
+
+    printf '%s\n' "$out" | sed 's/^/            /'
+    echo "   [scripts-coupling] STALE (rc=$rc) — fix: python3 scripts/ci/scripts_coupling_census.py --write"
+    echo "                      then commit scripts/ci/change_map.py in THIS PR."
+    echo "                      A mention of a repo-root scripts/ path anywhere under apps/,"
+    echo "                      packages/core or tests.yml counts — a COMMENT counts too."
+    echo "                      Landed unfixed, every later PR re-buys all six heavy suites."
+    echo "                      (advisory — the real gate is the changes job's corpus step)"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # 4. R1 — literal '## Adversarial review' heading on the branch's open PR
 # ---------------------------------------------------------------------------
 run_r1_check() {
@@ -404,6 +468,7 @@ main() {
     run_prettier_changed "$changed_existing"
     run_actionlint_if_touched "$changed_all"
     run_skills_canonical_check
+    run_scripts_coupling_census_check
     run_r1_check
 
     echo "🩺 quickcheck done (advisory — see .husky/pre-push for the real gates)."


### PR DESCRIPTION
## Three times in 24 hours

| # | event |
|---|---|
| #5707 | introduced a genuine coupling (`nuzantara_mcp/auth.py:118` `exec_module`s `scripts/lib/yaml_strict.py`), corpus went stale |
| #5711 | cured it — `--write`, 134 → 135 |
| #5709 | re-introduced it **two commits later**, via a COMMENT naming `scripts/kb/probe_legal_status_marking.py` |
| #5724 | cures it again — 135 → 136 |

Each time, `scripts_coupling_census.py --check` exits 1, which fails
`test_change_map.py::test_scripts_coupling_census_is_not_stale` inside the
trusted FLAT extraction; the `changes` job declares the classifier
untrustworthy and degrades to `run_all=true`. Every PR opened meanwhile
re-buys all six heavy suites.

## The signal was never missing

It already exists at every layer: `Classifier corpus trust (visibility only)`
goes red **on the PR that causes it**, and a scheduled `tests.yml` run on main
plus `main-push-failure-watch.yml` alert afterwards. What failed three times
was **reading** it.

So this adds no new detector. It moves the existing one to the only moment the
cure is free — the push that introduces the coupling, in the PR that owns it.
`scripts/quickcheck.sh` is the pre-push advisory surface (`.husky/pre-push:58`),
unconditional like the `skills-canon` check beside it, ~2s.

## Two alternatives considered and REJECTED

Both are recorded in the code comment so they are not re-litigated:

**Arm the existing visibility job as a REQUIRED context.** It also fires when
the trusted extraction itself breaks — which is exactly what #5679 did on
EVERY PR until #5692. Requiring it converts a cost degradation into a repo-wide
outage. The cost here is CI minutes; the cost of that is the repo.

**Narrow the census so a mention inside a COMMENT stops coupling.** That moves
toward UNDER-match — superscar #3, the direction that SKIPS a suite that should
have run — and it would not have prevented #5707, whose coupling was a genuine
runtime `exec_module`. Over-match costs CI minutes on edits to one script;
under-match costs a missed regression.

## Bites

**Consumer:** `.husky/pre-push:58` → `scripts/quickcheck.sh`, on every push from
a fleet machine.

**Observation**, run live on this branch against today's stale main:

```
$ bash -c 'source scripts/quickcheck.sh; run_scripts_coupling_census_check'
   [scripts-coupling] STALE (rc=1) — fix: python3 scripts/ci/scripts_coupling_census.py --write
                      then commit scripts/ci/change_map.py in THIS PR.
                      ...
```

It fires, and it names the fix.

## Ordering note, stated rather than hidden

On today's main the census's own `--check` diagnostic is unreadable — it prints
~100 phantom paths on both sides for a one-path delta. **#5725 cures that**, and
it is ahead of this PR in the queue. With #5725's census the same section
prints (measured this session, cured `_check` driven against this checkout):

```
scripts_coupling_census: SCRIPTS_COUPLING is STALE — run `... --write`.
  + newly coupled (1): scripts/kb/probe_legal_status_marking.py
```

One line, one path. This PR is worth little without #5725 and is sequenced
behind it deliberately.

## Adversarial review

Not dispatched to an external seat: this is a ~40-line advisory shell function
in a file whose every path already ends in `return 0`, with no CI-blocking
authority by construction. The two design choices that DO carry weight — not
making the check required, and not narrowing the census — are argued above with
the counter-evidence (#5679→#5692, and #5707's genuine coupling) that would
falsify them.

Docs-and-shell only, no gate semantics changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQZuToawPdr14poQfAjbq