### PR TITLE
fix(ci): the coupling census never read a tree that runs in a REQUIRED CI leg

### DIFF
--- a/scripts/ci/scripts_coupling_census.py
+++ b/scripts/ci/scripts_coupling_census.py
@@ -56,6 +56,12 @@ TREES = [
     "apps/evaluator",
     "apps/mouth",
     "apps/admin-dashboard",
+    # NOT covered by "apps/admin-dashboard" above — a different tree whose
+    # name merely starts with it. Its vitest suite runs inside the REQUIRED
+    # `(mouth, true)` leg of frontend-tests (tests.yml, "Run
+    # admin-dashboard-local tests"), so code it executes belongs in the
+    # census corpus. Held by test_census_trees_cover_every_app_tests_yml_runs.
+    "apps/admin-dashboard-local",
     "apps/wa-mirror",
     "packages/core",
     ".github/workflows/tests.yml",

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import importlib.util
 import io
@@ -734,6 +735,108 @@ class ChangeMapTests(unittest.TestCase):
         if message.startswith("WARNING"):
             print(message)
         self.assertTrue(should_pass, message)
+
+    def test_census_trees_cover_every_app_tests_yml_runs(self) -> None:
+        """``TREES`` is the census's INPUT corpus, and it was hand-written.
+
+        ``apps/admin-dashboard-local`` runs ``npx vitest run`` inside the
+        REQUIRED ``(mouth, true)`` leg of frontend-tests, yet was absent
+        from ``TREES`` for as long as the census existed — so any repo-root
+        ``scripts/`` file that tree imports or invokes was invisible to the
+        coupling census. That is the UNDER-match direction (superscar #3):
+        it SKIPS a suite that should have run, which is the expensive
+        mistake, not the cheap one.
+
+        Note the trap the fix had to avoid: ``apps/admin-dashboard`` is a
+        PREFIX of ``apps/admin-dashboard-local`` and covers none of it.
+        Coverage is asserted by tree ENTITY, never by substring.
+
+        This re-derives the requirement from ``tests.yml`` on every run
+        rather than trusting the one-off audit that found the gap — the
+        next app added to a job leg has to be declared, or this goes red.
+        """
+
+        rel = Path("scripts") / "ci" / "scripts_coupling_census.py"
+        repo_root = _locate_repo_root(rel)
+        if repo_root is None:
+            self.skipTest(
+                "scripts_coupling_census.py not reachable from cwd, GITHUB_WORKSPACE "
+                "or __file__ — TREES coverage is asserted where the checkout is present"
+            )
+        workflow = repo_root / ".github" / "workflows" / "tests.yml"
+        if not workflow.is_file():
+            self.skipTest("tests.yml absent from this checkout")
+        text = workflow.read_text(encoding="utf-8")
+
+        # TREES is read as a LITERAL from the source: importing the census
+        # would pull it into tests.yml's trusted-extraction closure, and it
+        # has no business there (it shells out to `git grep` and writes).
+        tree_node = next(
+            (
+                node.value
+                for node in ast.parse(
+                    (repo_root / rel).read_text(encoding="utf-8")
+                ).body
+                if isinstance(node, ast.Assign)
+                and any(
+                    isinstance(t, ast.Name) and t.id == "TREES" for t in node.targets
+                )
+            ),
+            None,
+        )
+        self.assertIsNotNone(tree_node, "TREES assignment not found in the census")
+        trees = ast.literal_eval(tree_node)
+
+        entered = set(
+            re.findall(r"(?:cd|working-directory:)\s+apps/([A-Za-z0-9._-]+)", text)
+        )
+        # `cd apps/${{ matrix.app }}` — resolve it, never skip it. A form
+        # this guard cannot resolve must FAIL, not pass quietly: a guard
+        # that fail-opens on the case it does not understand is the whole
+        # family #2 pattern in miniature.
+        expressions = []
+        for match in re.finditer(r"apps/\$\{\{([^}]*)\}\}", text):
+            expr = match.group(1).strip()
+            expressions.append(expr)
+            # Name the LINE, not just the expression: the next person to hit
+            # this is reading a red CI log, not this file, and "an expression
+            # I cannot resolve" without a location is a hunt.
+            line_no = text.count("\n", 0, match.start()) + 1
+            self.assertEqual(
+                expr,
+                "matrix.app",
+                f".github/workflows/tests.yml:{line_no} enters apps/ through an "
+                f"expression this guard cannot resolve: {match.group(0)!r}\n"
+                f"    {text.splitlines()[line_no - 1].strip()}\n"
+                "Teach this test the form (see the `- app:` matrix handling just "
+                "below) — do not let it through, or the tree it names goes "
+                "unchecked against the census TREES list.",
+            )
+        if expressions:
+            matrix_apps = set(
+                re.findall(r"^\s*-\s*app:\s*([A-Za-z0-9._-]+)\s*$", text, re.MULTILINE)
+            )
+            self.assertTrue(
+                matrix_apps,
+                "tests.yml uses `apps/${{ matrix.app }}` but declares no `- app:` "
+                "matrix values this guard can read",
+            )
+            entered |= matrix_apps
+
+        uncovered = sorted(
+            tree
+            for tree in (f"apps/{name}" for name in entered)
+            if not any(tree == t or tree.startswith(f"{t}/") for t in trees)
+        )
+        self.assertEqual(
+            uncovered,
+            [],
+            "tests.yml executes code from these trees, but the coupling census "
+            f"does not read them: {uncovered}. Any repo-root scripts/ file they "
+            "import or invoke is invisible to SCRIPTS_COUPLING — the UNDER-match "
+            "direction. Add each to TREES in scripts_coupling_census.py and re-run "
+            "--write.",
+        )
 
     def test_guilt_fleet_ops_combined_with_backend_change_still_runs_backend(
         self,


### PR DESCRIPTION
## The blind spot

`TREES` in `scripts/ci/scripts_coupling_census.py` is the census's INPUT corpus,
and it was hand-written. `apps/admin-dashboard-local` was never in it — yet
`tests.yml` runs:

```yaml
- name: Run admin-dashboard-local tests (except real Python process integration)
  if: matrix.app == 'mouth' && steps.decide.outputs.run == 'true'
  run: |
    cd apps/admin-dashboard-local
    npx vitest run --exclude='**/garuda-preview-process-integration.test.ts'
```

inside the **required** `(mouth, true)` leg of frontend-tests. Any repo-root
`scripts/` file that tree imports or invokes was therefore invisible to
`SCRIPTS_COUPLING` — the **UNDER-match** direction (superscar #3), the one that
SKIPS a suite that should have run. The census exists to cure exactly that
direction; it had a hole in its own input.

## The near-miss worth naming

`apps/admin-dashboard` **is** in `TREES` and is a **PREFIX** of
`apps/admin-dashboard-local`, covering none of it. Entity, never substring — on
both sides: the coverage check uses `tree == t or tree.startswith(f"{t}/")`, not
containment.

## Zero churn, which is why now

Measured in-process, `_census()` with and without the new tree:

```
TREES with the tree   : 136
TREES without it      : 136
paths it contributes  : []
```

Both `scripts/` refs inside that tree (`setup-cockpit-pin.sh`,
`start-cockpit.sh`) name files under `apps/admin-dashboard-local/scripts/`, not
repo-root ones, so the census's own resolution rule already discards them. The
blindness is closed before it costs anything, rather than after it bites.

## The guard re-derives, it does not trust this audit

`test_census_trees_cover_every_app_tests_yml_runs` reads the requirement out of
`tests.yml` on every run — literal `cd` / `working-directory:` entries plus the
`- app:` matrix values — and compares by entity against `TREES` parsed as a
literal via `ast` (importing the census would pull it into the trusted-extraction
closure, and it has no business there: it shells out to `git grep` and writes
files).

An `apps/${{ ... }}` form it cannot resolve **FAILS** rather than passing
quietly. A guard that fail-opens on the case it does not understand is family #2
in miniature. The failure names the exact line, at a reviewer's request:

```
AssertionError: 'env.SOME_OTHER_THING' != 'matrix.app'
 : .github/workflows/tests.yml:1849 enters apps/ through an expression this guard
   cannot resolve: 'apps/${{ env.SOME_OTHER_THING }}'
    cd apps/${{ env.SOME_OTHER_THING }}
Teach this test the form (see the `- app:` matrix handling just below) — do not
let it through, or the tree it names goes unchecked against the census TREES list.
```

## Bites

**Consumer:** the `changes` job's *"Verify change-map guilt and innocence corpus"*
step, which runs `test_change_map.py` — the same corpus this PR extends — and
`Trusted-classifier extraction lists are import-closed`
(`immune-enforcement.yml`, ungated on every PR); the one new import is `ast`,
stdlib, so the closure holds.

**Observations**, both made before reporting the work done, on this branch
rebased onto `origin/main` (`bcea489468`, which carries #5727):

```
$ python3 -m pytest scripts/ci/test_change_map.py -q
66 passed, 49 subtests            # main is 65 — measured on the same checkout

# guilt, by mutation:
#   remove "apps/admin-dashboard-local" from TREES
#     -> AssertionError: Lists differ: ['apps/admin-dashboard-local'] != []
#   turn one `cd apps/${{ matrix.app }}` into `cd apps/${{ env.SOME_OTHER_THING }}`
#     -> the unresolvable-expression failure quoted above
```

## Adversarial review

Cross-session, with `nuzantara-b2`, who owned this lane while #5727 was landing.
This branch was held unpushed and a rebase aborted mid-conflict rather than
raced (superscar #5). That seat reviewed the parked commit, asked for the
line-naming failure message above — now implemented and mutation-proved — and
released the lane. Generator was not grader.

Independently re-verified here rather than taken on report: `--check` still
exits 1 on a stale block and `--warn-only` exits 0, proved by dropping one path
from the generated block and running both.

Floor 1, 99 net lines, `scripts/ci/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQZuToawPdr14poQfAjbq