### PR TITLE
fix(kb): the bare-`Permen` freeze guard could silently skip the file that broke it

### DIFF
--- a/apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py
+++ b/apps/backend-rag/backend/tests/unit/core/test_ingest_2026_laws_document_ids.py
@@ -510,7 +510,18 @@ def test_the_detector_sees_a_family_that_contains_an_underscore():
 # here fails too, and the exception cannot outlive the problem it names.
 # ---------------------------------------------------------------------------
 
-BARE_PERMEN_ID = re.compile(r"\bPermen_(\d+)_(\d{4})\b")
+# No LEADING \b on purpose. `\b` requires a non-word char before `P`, so
+# `aPermen_1_2026` -- an id glued to a preceding word character -- was invisible
+# to the scan. Dropping it is a strict widening with no false-positive risk:
+# `Permen_` needs an underscore immediately after `Permen`, which no
+# ministry-qualified id has (`Permenkumham_`, `PermenImipas_` continue with a
+# letter), so the qualified forms still cannot match. The TRAILING \b stays --
+# it is what stops `Permen_1_20260` from reading as `Permen_1_2026`.
+#
+# Two assumptions left standing DELIBERATELY, because no id in kb/ violates
+# them and widening further would start matching prose: ids are exact-case
+# (`permen_1_2026` is not matched) and never split across a line break.
+BARE_PERMEN_ID = re.compile(r"Permen_(\d+)_(\d{4})\b")
 
 # Frozen 2026-09-05. Every entry is an instrument whose KB id drops the
 # ministry qualifier and is therefore ambiguous across the eight ministries.
@@ -548,8 +559,23 @@ def _bare_permen_ids_in_kb() -> set[str]:
             continue
         try:
             text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
+        except (OSError, UnicodeDecodeError) as exc:
+            # NOT skipped. `_kb_instrument_identities` above states the rule for
+            # its own walk -- "a KB file broken enough to fail YAML is a KB file
+            # this test needs to know is broken, not one that should silently
+            # vanish" -- and the first version of this function contradicted it
+            # 270 lines later with a bare `continue`. That is precisely the
+            # under-match this frozen set exists to prevent: an undecodable KB
+            # file introducing a seventeenth bare id would have disappeared from
+            # the invariant instead of failing it. Caught by adversarial review
+            # before it could matter, 2026-09-05.
+            raise AssertionError(
+                f"{path} is under kb/ and matches this scan's suffix allowlist, "
+                f"but could not be read as UTF-8 ({exc!r}). It is not skipped. "
+                "If a binary file legitimately belongs under kb/, drop its suffix "
+                "from _KB_TEXT_SUFFIXES -- do not swallow the error here, or the "
+                "frozen set silently stops covering that file."
+            ) from exc
         found.update(match.group(0) for match in BARE_PERMEN_ID.finditer(text))
     return found
 
@@ -580,4 +606,15 @@ def test_innocence_a_ministry_qualified_id_is_not_counted_as_bare():
         assert BARE_PERMEN_ID.search(qualified) is None, (
             f"{qualified} is ministry-qualified and must not count as a bare id"
         )
-    assert BARE_PERMEN_ID.search("Permen_1_2026") is not None
+    # Guilt, in the shapes a YAML file actually writes them, plus the
+    # glued-prefix case the leading \b used to miss.
+    for bare in (
+        "Permen_1_2026",
+        "id: Permen_1_2026",
+        '"Permen_1_2026"',
+        "Permen_1_2026:",
+        "aPermen_1_2026",
+    ):
+        assert BARE_PERMEN_ID.search(bare) is not None, f"{bare} must count as bare"
+    # The trailing \b still bites: a longer year is a different token.
+    assert BARE_PERMEN_ID.search("Permen_1_20260") is None


### PR DESCRIPTION
## Two defects in #5733, found after it merged

Both are the guard failing in **the direction it exists to prevent**. Found by
an adversarial review dispatched on #5733 before merge; the review returned
after the merge landed, so this is the follow-up rather than a fixup.

### 1. A decode failure was swallowed — the under-match, inside the under-match guard

`_bare_permen_ids_in_kb()` walked `kb/` and did:

```python
except (OSError, UnicodeDecodeError):
    continue
```

`_kb_instrument_identities` states the opposite rule **270 lines above, in the
same file**:

> A file that fails to parse raises here, it is not skipped — a KB file broken
> enough to fail YAML is a KB file this test needs to know is broken, not one
> that should silently vanish from the identity map.

So an undecodable KB file introducing a seventeenth bare id would have
**vanished from the frozen set instead of failing it**. The whole point of the
frozen set is that the population cannot grow unnoticed.

It now raises, naming the file and the correct remedy — drop the suffix from
`_KB_TEXT_SUFFIXES` if a binary legitimately belongs under `kb/`; do not swallow.

### 2. The regex had a leading `\b`, so a glued id was invisible

`\b` requires a non-word character before `P`, so `aPermen_44_2044` did not
match. Dropping it is a **strict widening with no false-positive risk**:
`Permen_` needs an underscore immediately after `Permen`, and every
ministry-qualified id continues with a letter (`Permenkumham_`,
`PermenImipas_`), so the qualified forms still cannot match. Verified, not
assumed.

The **trailing** `\b` stays — it is what stops `Permen_1_20260` reading as
`Permen_1_2026`.

Two assumptions are left standing deliberately, and are now written down rather
than implied: ids are exact-case, and never split across a line break. Widening
past either would start matching prose.

## Guilt, by mutation against the CURED file

| mutation | result |
|---|---|
| undecodable `.yaml` planted under `kb/` | **RED**, naming the file and the remedy |
| `aPermen_44_2044` planted under `kb/` | **RED** — invisible before this change |

The second one's "before" is measured, not asserted:

```python
>>> re.compile(r"\bPermen_(\d+)_(\d{4})\b").search("aPermen_1_2026")
None
```

Innocence widened with the shapes YAML actually writes (`id: X`, `"X"`, `X:`),
kept for all six ministry-qualified forms, and extended with `Permen_1_20260`,
which must NOT match.

```
$ python3 -m pytest .../test_ingest_2026_laws_document_ids.py
18 passed
```

## Adversarial review

`spalla-review` seat, dispatched on the diff of #5733 (and #5732) with an
assume-defective framing, read-only. It independently recomputed the 16-element
frozen set from its own walk and confirmed it matches, verified the entity-safety
of the regex against all six qualified forms, and raised both defects above.
Generator was not grader.

Its two findings were re-verified here before being accepted — the sibling
docstring quoted above was read in this session, and the `\b` gap reproduced in
a live interpreter. One of its notes is NOT actioned and is called out below.

## Not actioned, deliberately

The review also observed that `kb/` today holds only `.yaml`, `.py` and
`.gitkeep` files, so `_KB_TEXT_SUFFIXES`' inclusion of `.yml`/`.md`/`.json` is
forward-compatible rather than load-bearing. Confirmed independently
(`14 .yaml, 3 .py, 2 .gitkeep`). Left as is: a wider read allowlist is the
over-match direction, which costs nothing here, and narrowing it is what defect
#1 above punishes.

A separate finding of the same review, on `scripts/quickcheck.sh` from #5732
(the `rc=2` census-tool-failure path is reported as staleness with a `--write`
remedy that would fail identically), is a different file with a different
consumer and ships separately.

Floor 1, test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQZuToawPdr14poQfAjbq