### PR TITLE
fix(prepush): the census pre-push section gave the one remedy that cannot work

### DIFF
--- a/scripts/quickcheck.sh
+++ b/scripts/quickcheck.sh
@@ -10,7 +10,8 @@
 # it NEVER blocks — see the bottom of this file and the call site in
 # `.husky/pre-push`).
 #
-# SCOPE (four checks, each scoped to what actually changed vs origin/main):
+# SCOPE (six checks; 1-3 are scoped to what changed vs origin/main, 3b/3c are
+# deliberately unconditional — each says why at its own definition):
 #   1. impact-scoped pytest, via `scripts/ci/impact_map.py` (the SAME engine
 #      the PR lane's test-selection uses) — only the backend test modules
 #      the diff can actually reach, never the full 17k-test suite.
@@ -18,6 +19,12 @@
 #      package.json's own `format`/`format:check` scripts).
 #   3. `actionlint` — only when `.github/workflows/` is touched, run with no
 #      file args (same auto-discovery scope as `.github/workflows/actionlint.yml`).
+#   3b. skills-canon: untracked drift between `.claude/skills` and
+#      `.agents/skills` — unconditional, because the drift it catches is by
+#      definition untracked and never appears in a diff.
+#   3c. scripts-coupling: `scripts/ci/scripts_coupling_census.py --check`,
+#      unconditional — a stale SCRIPTS_COUPLING block landing on main makes
+#      every later PR re-buy all six heavy suites.
 #   4. R1 heading presence: if the current branch has an open PR, check its
 #      body for the LITERAL line `## Adversarial review` — exact string,
 #      anchored, case-sensitive. NOT a substring match on "adversarial":
@@ -396,7 +403,20 @@ run_scripts_coupling_census_check() {
     fi
 
     printf '%s\n' "$out" | sed 's/^/            /'
-    echo "   [scripts-coupling] STALE (rc=$rc) — fix: python3 scripts/ci/scripts_coupling_census.py --write"
+    if [ "$rc" -ne 1 ]; then
+        # rc=2 is the census tool failing on itself, not a stale block: it
+        # exits 2 when `git grep -P` breaks (an old git without PCRE, most
+        # likely). Telling the user to run --write there would be WRONG advice
+        # — `main()` calls `_census()` before it dispatches to either mode, so
+        # --write walks the identical `_run_git_grep()` path and dies the same
+        # way. One remedy printed for two different faults is how an advisory
+        # becomes noise.
+        echo "   [scripts-coupling] the census TOOL failed (rc=$rc) — this is NOT a staleness"
+        echo "                      result and --write will not fix it: it runs the same"
+        echo "                      \`git grep -P\` first. See the output above."
+        return 0
+    fi
+    echo "   [scripts-coupling] STALE (rc=1) — fix: python3 scripts/ci/scripts_coupling_census.py --write"
     echo "                      then commit scripts/ci/change_map.py in THIS PR."
     echo "                      A mention of a repo-root scripts/ path anywhere under apps/,"
     echo "                      packages/core or tests.yml counts — a COMMENT counts too."


### PR DESCRIPTION
## The defect

`scripts_coupling_census.py` has two nonzero exits:

- **1** — the block is stale. Remedy: `--write`.
- **2** — `git grep -P` itself failed (an old git without PCRE support; the
  script's own comment names that case).

The section #5732 added treated **any** nonzero `rc` as staleness and printed
`fix: ... --write`.

On `rc=2` that advice is **wrong**, not merely unhelpful. `main()` calls
`_census()` *before* it dispatches to either mode:

```python
coupled, unresolved, embedded = _census()   # <- runs _run_git_grep()
if args.write:
    _write(embedded)
```

So `--write` walks the identical `_run_git_grep()` path and dies exactly the
same way. One remedy printed for two different faults is how an advisory turns
into noise — which is the failure mode this section was added to cure.

## Also, while here

The file's `SCOPE` header still said **"four checks"** while `main()` runs six.
`3b` (skills-canon) went unlisted when it was added, and `3c` (the census
section) inherited the drift. Both are now listed, each with the one-line reason
it is unconditional.

## Bites

**Consumer:** `.husky/pre-push:58` → `scripts/quickcheck.sh`, on every push from
a fleet machine.

**Observation** — all three branches driven, not reasoned about:

| rc | how it was produced | what prints |
|---|---|---|
| 0 | clean main | `SCRIPTS_COUPLING is up to date.` |
| 1 | one path dropped from the generated block | `STALE (rc=1) — fix: ... --write` |
| 2 | `REF_PATTERN` replaced with `"(?<INVALID"` so `git grep -P` errors | `the census TOOL failed (rc=2) ... --write will not fix it: it runs the same \`git grep -P\` first.` |

Both mutations were reverted from a `cp` backup, never with `git checkout --`.

## Adversarial review

`spalla-review` seat, dispatched on #5732's diff with an assume-defective
framing, read-only — it simulated the python3-missing, missing-script and
broken-`git grep` branches rather than reading them, and raised this one.
Generator was not grader.

I re-verified its claim before accepting it: read `main()` in the census to
confirm `_census()` really does precede the mode dispatch, so the "`--write`
fails identically" reasoning holds rather than merely sounding right.

Its other #5732 note — that the PR's Bites observation sourced the function
directly instead of going through the real `.husky/pre-push` entrypoint — is a
fair criticism of the *evidence*, not of the code (it separately confirmed the
call path is reached). Nothing to change here; recorded so the next Bites in
this file exercises the hook.

Shell-and-comments only, advisory path unchanged, still always `return 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQZuToawPdr14poQfAjbq