### PR TITLE
fix(api): enforce timeout through JSON response consumption

### DIFF
--- a/apps/mouth/scripts/check-api-response-timeout.ts
+++ b/apps/mouth/scripts/check-api-response-timeout.ts
@@ -1,0 +1,183 @@
+/** Loopback-only proof: real fetch, HTTP server, API facade and CRM consumer. */
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
+import { ApiClient } from "../src/lib/api/api-client";
+import { ApiClientBase } from "../src/lib/api/client";
+import { ApiError } from "../src/lib/api/error-handler";
+
+/** Independent review attack, preserved as a reproducible command. */
+async function adversarial(): Promise<void> {
+  const closed = new Set<string>();
+  const server = createServer((request, response) => {
+    const path = request.url!;
+    response.on("close", () => closed.add(path));
+    response.setHeader("Content-Type", "application/json");
+    if (path === "/fast") {
+      response.write("[");
+      setTimeout(() => response.end("]"), 20);
+    } else if (path === "/truncated") {
+      response.write("[");
+      setTimeout(() => response.destroy(), 30);
+    } else if (path === "/malformed-error") {
+      response.writeHead(503).end("invalid-json");
+    } else {
+      response.writeHead(path === "/stalled-error" ? 503 : 200);
+      response.flushHeaders();
+      response.write("[");
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const api = new ApiClientBase(`http://127.0.0.1:${address.port}`);
+  const watchdog = new AbortController();
+  try {
+    const results = await Promise.race([
+      Promise.allSettled([
+        api.request("/fast", {}, 1_000),
+        api.request("/stall", {}, 200),
+        api.request("/truncated", {}, 1_000),
+        api.request("/malformed-error", {}, 1_000),
+        api.request("/stalled-error", {}, 250),
+      ]),
+      delay(2_000, undefined, { signal: watchdog.signal }).then(() => {
+        throw new Error("Concurrent requests did not settle");
+      }),
+    ]);
+    assert.equal(results[0].status, "fulfilled");
+    assert.deepEqual(results[0].value, []);
+    assert.equal(results[1].status, "rejected");
+    assert.equal(results[1].reason.message, "Request timeout");
+    assert.equal(results[2].status, "rejected");
+    assert.equal(results[2].reason.name, "TypeError");
+    assert.notEqual(results[2].reason.message, "Request timeout");
+    for (const result of results.slice(3)) {
+      assert.equal(result.status, "rejected");
+      assert(result.reason instanceof ApiError);
+      assert.equal(result.reason.statusCode, 503);
+    }
+    for (
+      let attempt = 0;
+      attempt < 50 && !closed.has("/stalled-error");
+      attempt++
+    ) {
+      await delay(10);
+    }
+    assert(closed.has("/stall") && closed.has("/stalled-error"));
+    process.stdout.write(
+      "Adversarial PASS: concurrency, truncated socket, HTTP errors, socket cleanup\n",
+    );
+  } finally {
+    watchdog.abort();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+async function main(): Promise<void> {
+  const consumerMode = process.argv.includes("--consumer-default");
+  const requests: string[] = [];
+  let bodyStarted = false;
+  let connectionClosed = false;
+  const server = createServer((request, response) => {
+    requests.push(`${request.method} ${request.url}`);
+    if (request.url === "/empty") {
+      response.writeHead(204).end();
+      return;
+    }
+    response.setHeader("Content-Type", "application/json");
+    if (request.url === "/malformed") {
+      response.end("not-json");
+    } else if (request.url === "/error") {
+      response.writeHead(503).end('{"detail":"Synthetic unavailable"}');
+    } else if (request.url === "/complete") {
+      response.write("[");
+      setTimeout(() => response.end("]"), 20);
+    } else {
+      response.writeHead(200);
+      response.flushHeaders();
+      response.write("[");
+      bodyStarted = true;
+      response.on("close", () => {
+        connectionClosed = true;
+      });
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert(address && typeof address === "object");
+  const api = new ApiClient(`http://127.0.0.1:${address.port}`);
+  const deadline = consumerMode ? 30_000 : 200;
+  const watchdog = new AbortController();
+  const started = performance.now();
+  try {
+    // Consumer mode exercises the facade's real composition with its unchanged
+    // 30-second default, without replacing request(), fetch(), or timers.
+    const pending = consumerMode
+      ? api.crm.getPractices()
+      : api.request("/api/crm/practices", {}, deadline);
+    const outcome = await Promise.race([
+      pending.then(
+        () => "unexpected success",
+        (error: Error) => error.message,
+      ),
+      delay(deadline + 1_000, "watchdog: still pending", {
+        signal: watchdog.signal,
+      }),
+    ]);
+    const elapsedMs = Math.round(performance.now() - started);
+    assert(bodyStarted, "The server must have sent headers and a partial body");
+    assert.equal(outcome, "Request timeout");
+    assert(elapsedMs >= deadline - 10 && elapsedMs < deadline + 1_000);
+    for (let attempt = 0; attempt < 50 && !connectionClosed; attempt++) {
+      await delay(10);
+    }
+    assert(
+      connectionClosed,
+      "Aborting the body must close the HTTP connection",
+    );
+    assert.deepEqual(await api.request("/complete", {}, 1_000), []);
+    assert.deepEqual(await api.request("/empty"), {});
+    await assert.rejects(api.request("/malformed"), SyntaxError);
+    await assert.rejects(
+      api.request("/error"),
+      (error: unknown) => error instanceof ApiError && error.statusCode === 503,
+    );
+    assert.deepEqual(requests, [
+      "GET /api/crm/practices",
+      "GET /complete",
+      "GET /empty",
+      "GET /malformed",
+      "GET /error",
+    ]);
+    process.stdout.write(
+      `${JSON.stringify({
+        consumer: consumerMode ? "api.crm.getPractices" : "api.request",
+        deadline_ms: deadline,
+        elapsed_ms: elapsedMs,
+        body_started: bodyStarted,
+        outcome,
+        connection_closed: connectionClosed,
+        compatibility_cases: 4,
+        requests: requests.length,
+      })}\n`,
+    );
+  } finally {
+    watchdog.abort();
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+(process.argv.includes("--adversarial") ? adversarial() : main()).catch(
+  (error: unknown) => {
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  },
+);

--- a/apps/mouth/src/lib/api/client-response-timeout.test.ts
+++ b/apps/mouth/src/lib/api/client-response-timeout.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientBase } from "./client";
+import { CrmApi } from "./crm/crm.api";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe("request deadline includes the JSON body", () => {
+  let client: ApiClientBase;
+  let body: ReadableStreamDefaultController<Uint8Array>;
+  let signal: AbortSignal;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    client = new ApiClientBase("http://localhost");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, options: RequestInit) => {
+        signal = options.signal!;
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller): void {
+            body = controller;
+            signal.addEventListener("abort", () => {
+              const error = new Error("Body read aborted");
+              error.name = "AbortError";
+              controller.error(error);
+            });
+          },
+        });
+        return new Response(stream, {
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("terminates a CRM request whose headers arrived but body stalled", async () => {
+    const pending = new CrmApi(client).getPractices();
+    const rejected = expect(pending).rejects.toThrow("Request timeout");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost/api/crm/practices",
+      expect.any(Object),
+    );
+    body.enqueue(new TextEncoder().encode("["));
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(signal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(signal.aborted).toBe(true);
+    await rejected;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves a complete body and clears the timer after consumption", async () => {
+    const pending = new CrmApi(client).getPractices();
+    await vi.advanceTimersByTimeAsync(0);
+    body.enqueue(new TextEncoder().encode("["));
+    await vi.advanceTimersByTimeAsync(20_000);
+    body.enqueue(new TextEncoder().encode("]"));
+    body.close();
+    await expect(pending).resolves.toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("honors the custom POST deadline during body consumption", async () => {
+    const rejected = expect(client.post("/synthetic", {}, 40)).rejects.toThrow(
+      "Request timeout",
+    );
+    await vi.advanceTimersByTimeAsync(40);
+    expect(signal.aborted).toBe(true);
+    await rejected;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps malformed JSON distinguishable from a timeout", async () => {
+    const pending = client.request("/synthetic");
+    const rejected = expect(pending).rejects.toBeInstanceOf(SyntaxError);
+    await vi.advanceTimersByTimeAsync(0);
+    body.enqueue(new TextEncoder().encode("not-json"));
+    body.close();
+    await rejected;
+    expect(signal.aborted).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/mouth/src/lib/api/client.ts
+++ b/apps/mouth/src/lib/api/client.ts
@@ -553,7 +553,9 @@ export class ApiClientBase implements IApiClient {
         return {} as T;
       }
 
-      return response.json();
+      // Keep the deadline and AbortError handling active while the body is read.
+      // Headers can arrive promptly even when the JSON body stalls.
+      return await response.json();
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {
         throw new Error("Request timeout");

--- a/research/operations/frontier-20260904t235706z-82e423.md
+++ b/research/operations/frontier-20260904t235706z-82e423.md
@@ -112,47 +112,7 @@ No production repair cycles were needed after the one-line correction.
 
 ## Adversarial review
 
-Seat: Codex CLI 0.153.2 (`codex exec --sandbox read-only -c model_reasoning_effort=xhigh`),
-a different model family from the author. Dispatched on 2026-09-05 by the review-lead
-session (a Claude session distinct from the authoring session, run
-`20260904t235718z-ohcesm`) from an isolated review worktree at commit `31dd173c04`, with
-the full `origin/main...HEAD` diff and six claims to refute. The repository helper
-`.claude/scripts/codex-spalla.sh` could not be used as shipped: codex-cli 0.153.2 no
-longer accepts `--full-auto` (`error: unexpected argument '--full-auto' found`), so the
-same prompt shape was sent to `codex exec` directly. Transcript:
-`~/logs/codex-spalla/20260905T0410Z-review-PR-5754-direct-codex-exec.md` on Air-M5.
+Seat: Codex CLI 0.153.2 (`codex exec --sandbox read-only`, xhigh), a different model family from the author, dispatched 2026-09-05 by the review-lead session (run `20260904t235718z-ohcesm`, a Claude session distinct from the authoring one) from an isolated worktree at `31dd173c04` with the full diff and six claims to refute. Verdict **LGTM**, none refuted; the loopback proof did not run inside the seat's sandbox (`listen EPERM`). Transcript: `~/logs/codex-spalla/20260905T0410Z-review-PR-5754-direct-codex-exec.md` (Air-M5). The repo helper `.claude/scripts/codex-spalla.sh` is stale against codex-cli 0.153.2 (`--full-auto` removed) and was not used as shipped; noted, not fixed here.
 
-Verdict: **LGTM**. All six refutation attempts returned NOT REFUTED:
-
-- Claim 1 (deadline covers body consumption): reproduced in memory by the seat —
-  baseline still pending after 60 ms with a 20 ms deadline, HEAD rejects with
-  `Request timeout` (`client.ts:558`).
-- Claim 2 (no change on 204 / non-JSON / error branches, retry, interfaces): 157
-  client/CRM tests pass; the caller signal was already overridden by the internal
-  controller before this change (pre-existing limit, unchanged).
-- Claim 3 (the stubbed stream models real fetch): the abort-errored stream matches the
-  Fetch Standard abort mechanism; the seat notes a passing unit test is not an
-  empirical browser verification.
-- Claim 4 (loopback script): assertions present; NOT executed by the seat (`listen
-  EPERM` inside its sandbox) — covered by the review lead's own runs below.
-- Claim 5 (ESLint): run by the seat with `--no-ignore` on the three TypeScript files,
-  exit 0; neither `return-await` rule is configured.
-- Claim 6 (ledger claims): no contradiction with the diff; browser and production
-  evidence are declared absent by the ledger itself.
-
-Review-lead executions at `31dd173c04` (new runs, not reused):
-
-- vitest, five files (`client-response-timeout`, `client`, `api-client-base`,
-  `api-error-status`, `crm.api`): 5 files, 157 tests passed.
-- `scripts/check-api-response-timeout.ts --adversarial`: PASS (concurrency, truncated
-  socket, HTTP errors, socket cleanup).
-- `scripts/check-api-response-timeout.ts` (200 ms deadline): `Request timeout` at
-  209 ms, body started, connection closed, four compatibility cases passed.
-- Guilt: with `return await response.json()` reverted to `return response.json()`, the
-  new test file fails 2 of 4 (the two stalled-body deadlines) and passes the two
-  innocence cases; restored afterwards, tree clean.
-
-Reused, not re-executed: the author's default-deadline consumer run (`api.crm.getPractices`,
-rejected at 30,030 ms) and the owner-reported external review (157 tests; 30,013 ms).
-
-Not verified by this review: browser end-to-end behaviour and production.
+Review-lead executions at `31dd173c04` (new, not reused): vitest 5 files / 157 passed; `check-api-response-timeout.ts --adversarial` PASS; default mode `Request timeout` at 209 ms with the connection closed; guilt: reverting `return await` makes the new test file fail 2 of 4 and pass the 2 innocence cases.
+Reused, not re-executed: the author's 30,030 ms consumer run and the owner-reported external review (157 tests; 30,013 ms). Not verified here: browser end-to-end and production.

--- a/research/operations/frontier-20260904t235706z-82e423.md
+++ b/research/operations/frontier-20260904t235706z-82e423.md
@@ -1,0 +1,107 @@
+# Request-body deadline evidence
+
+- Run: `20260904t235706z-82e423`
+- Start: `2026-09-04T23:57:06Z`
+- Machine: `Air-M5`
+- Base: `af949e6eb5d1767454dd788cd7a8e5be4b89967d`
+
+## Frozen implementation contract
+
+- TARGET: Keep the existing request deadline active until JSON consumption settles.
+- CURRENT FAILURE OR GAP: Successful headers clear the timer while the body is pending.
+- ROOT-CAUSE HYPOTHESIS: Returning the body promise without awaiting it runs `finally` prematurely.
+- REAL CONSUMER: `useCrmPractices -> api.crm.getPractices -> ApiClientBase.request`.
+- Bites: The real CRM client, against a loopback HTTP server sending headers and an unfinished JSON body, rejects with `Request timeout` and releases its connection.
+- IN SCOPE: Successful JSON body lifetime; regression and consumer tests.
+- OUT OF SCOPE: Retry policy, caller cancellation, streaming chat, authentication, backend middleware.
+- EXPECTED SURFACES: Shared client; regression tests; local HTTP proof; this ledger.
+- SUCCESS METRIC: Stalled body rejects at the configured deadline; complete JSON and existing HTTP errors retain their behavior.
+- FAILURE CONDITIONS: Indefinite pending request, missing abort, changed valid payload, leaked timer, unrelated diff.
+- REVERSIBILITY: Revert the single local commit.
+- MAXIMUM BLAST RADIUS: Await placement in the JSON success branch; no interface or dependency change.
+
+## Baseline and scope
+
+`git ls-remote origin refs/heads/main` matched the local `origin/main` above.
+The broker-created worktree started at that exact SHA with clean status.
+The main checkout remained untouched. Worktree census was count-only; other
+session paths, branches, files and reports were not inspected.
+Two native investigators examined backend middleware/wiring and frontend
+request/streaming transport respectively; neither authored production changes.
+Only synthetic payloads and loopback HTTP are used. No deployment or remote writes.
+
+## Candidate ranking
+
+Scores are impact/evidence/verifiability/boundedness/risk, each 0-5.
+Priority = 2I + 2E + 2V + B - 2R.
+
+| Candidate | Scores | Priority | Evidence and disposition |
+| --- | --- | --- | --- |
+| JSON body deadline | 4/5/5/5/1 | 31 | Selected: body remained pending after a 10 ms deadline; actual signal was not aborted at 60 ms. |
+| CORS on rate-limit responses | 4/5/5/5/2 | 29 | CORS registered inside limiter; 429 short-circuit has no CORS headers; preflight also reaches limiter. Separate backend change. |
+| npm advisory waiver path union | 3/5/5/5/1 | 29 | Two disjoint advisory waivers return no findings for their union of nodes. Advisory-only CI consumer reduces impact. |
+| Safety report shape | 4/4/5/5/2 | 27 | `_extract_findings` drops legacy list rows and unsupported shapes. Requires scanner schema/leniency compatibility work. |
+| Truncated chat stream completion | 4/5/4/3/2 | 25 | EOF/trailing error produces `onDone` on partial text. Multiple backend terminal shapes require broader protocol work. |
+| Readiness accepts closed DB pool | 4/4/4/3/2 | 23 | `/health/ready` checks pool presence, not usability; Fly actually consumes it. Probe load/failure policy needs evaluation. |
+| Scanner/compression ordering alone | 5/4/1/2/3 | 16 | Rejected: scanner prefix `/api/agentic/` does not match mounted `/api/agentic-rag`; isolated scanner proof would not establish a real consumer. |
+
+## Current-state evidence
+
+- `client.ts` creates an AbortController timeout, then returns `response.json()`
+  directly inside `try/finally`; the finally clears the timer.
+- `api-client.ts` extends `ApiClientBase`, constructs `CrmApi(this)` and does not
+  override `request`; `crm.api.ts` forwards `getPractices` to that request.
+- `useCrmPractices.ts` awaits `api.crm.getPractices` in its React Query function.
+- Existing timeout tests delay `fetch` itself; they do not deliver headers before
+  delaying the body. This misses the failing phase of the request.
+- `error-handler.ts::safeFetch` already uses `return await response.json()`;
+  the correction reuses the existing language-level mechanism.
+
+Production incident frequency is unknown. A reproducible transport failure and
+the source wiring establish susceptibility, not a measured production outage.
+
+## Reproduction commands
+
+Run from `apps/mouth` in this worktree. Tests and temporary artifacts must stay
+in the isolated worktree. No production credentials or services are required.
+
+| Check | Command | Observed result |
+| --- | --- | --- |
+| Baseline HTTP failure | `node --import tsx scripts/check-api-response-timeout.ts` before production edit | Exit 1: `watchdog: still pending`, not `Request timeout`. |
+| Baseline regression | Targeted command below, before production edit, with `--testTimeout 1500` | Exit 1: 2 failed / 2 passed; both failing signals remained un-aborted. |
+| Corrected regression | `node --import tsx ../../node_modules/vitest/vitest.mjs run src/lib/api/client-response-timeout.test.ts --configLoader native --no-cache --maxWorkers 1` | Exit 0: 4 passed. |
+| Client/CRM compatibility | Same command, adding `src/lib/api/client.test.ts src/lib/api/__tests__/api-client-base.test.ts src/lib/api/__tests__/api-error-status.test.ts src/lib/api/crm/crm.api.test.ts` | Exit 0: 5 files / 157 tests passed. |
+| Real HTTP / short deadline | `node --import tsx scripts/check-api-response-timeout.ts` | Exit 0: 200 ms deadline; 249 ms observed; body started; connection closed; four compatibility cases. |
+| Actual CRM default deadline | `node --import tsx scripts/check-api-response-timeout.ts --consumer-default` | Exit 0: `api.crm.getPractices`; 30,000 ms deadline; 30,030 ms observed; connection closed; five HTTP requests. |
+| Adversarial HTTP | `node --import tsx scripts/check-api-response-timeout.ts --adversarial` | Exit 0: concurrency, truncated socket, HTTP errors, socket cleanup. |
+| Lint, including normally ignored tests/scripts | `node ../../node_modules/eslint/bin/eslint.js --no-ignore src/lib/api/client.ts src/lib/api/client-response-timeout.test.ts scripts/check-api-response-timeout.ts` | Exit 0, no diagnostics. |
+| Package types | `npm run typecheck -- --incremental false` | Exit 0, no diagnostics. |
+| Whitespace | `git diff --check` | Exit 0. |
+
+Formatting from the worktree root uses the lockfile's version, installed only in
+the run-local npm cache (the existing shared dependencies lacked Prettier):
+
+```sh
+npm exec --cache .frontier/npm-cache --yes --package prettier@3.9.6 -- prettier --check apps/mouth/src/lib/api/client.ts apps/mouth/src/lib/api/client-response-timeout.test.ts apps/mouth/scripts/check-api-response-timeout.ts research/operations/frontier-20260904t235706z-82e423.md
+```
+
+Exit 0 after formatting the newly authored proof script. No existing client
+formatting was changed. The first `--configLoader runner` test launch failed
+because the existing config needs `__dirname`; using the native loader plus
+the already-installed `tsx` preserved that config and avoided shared cache writes.
+The existing `poolOptions` deprecation warning remains outside this change.
+
+## Falsification and limitations
+
+The independent reviewer, who authored no implementation, ran five concurrent
+loopback requests: fast JSON succeeded; stalled 200 timed out; truncated 200
+retained its network `TypeError`; malformed and stalled 503 retained `ApiError(503)`;
+both stalled sockets closed. The `--adversarial` mode preserves those attacks.
+The default-deadline mode defeats the alternative explanation that only the
+mocked stream cooperates with abort: no fetch, timer or client method is replaced.
+The same HTTP proof failed before the production edit and passed afterward.
+
+No deployment, browser end-to-end run or production incident measurement occurred.
+Synchronous parsing that blocks the event loop cannot be interrupted by this timer.
+Caller-provided cancellation and error-body classification remain outside scope.
+No production repair cycles were needed after the one-line correction.

--- a/research/operations/frontier-20260904t235706z-82e423.md
+++ b/research/operations/frontier-20260904t235706z-82e423.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: codex
+---
+
 # Request-body deadline evidence
 
 - Run: `20260904t235706z-82e423`
@@ -105,3 +109,50 @@ No deployment, browser end-to-end run or production incident measurement occurre
 Synchronous parsing that blocks the event loop cannot be interrupted by this timer.
 Caller-provided cancellation and error-body classification remain outside scope.
 No production repair cycles were needed after the one-line correction.
+
+## Adversarial review
+
+Seat: Codex CLI 0.153.2 (`codex exec --sandbox read-only -c model_reasoning_effort=xhigh`),
+a different model family from the author. Dispatched on 2026-09-05 by the review-lead
+session (a Claude session distinct from the authoring session, run
+`20260904t235718z-ohcesm`) from an isolated review worktree at commit `31dd173c04`, with
+the full `origin/main...HEAD` diff and six claims to refute. The repository helper
+`.claude/scripts/codex-spalla.sh` could not be used as shipped: codex-cli 0.153.2 no
+longer accepts `--full-auto` (`error: unexpected argument '--full-auto' found`), so the
+same prompt shape was sent to `codex exec` directly. Transcript:
+`~/logs/codex-spalla/20260905T0410Z-review-PR-5754-direct-codex-exec.md` on Air-M5.
+
+Verdict: **LGTM**. All six refutation attempts returned NOT REFUTED:
+
+- Claim 1 (deadline covers body consumption): reproduced in memory by the seat —
+  baseline still pending after 60 ms with a 20 ms deadline, HEAD rejects with
+  `Request timeout` (`client.ts:558`).
+- Claim 2 (no change on 204 / non-JSON / error branches, retry, interfaces): 157
+  client/CRM tests pass; the caller signal was already overridden by the internal
+  controller before this change (pre-existing limit, unchanged).
+- Claim 3 (the stubbed stream models real fetch): the abort-errored stream matches the
+  Fetch Standard abort mechanism; the seat notes a passing unit test is not an
+  empirical browser verification.
+- Claim 4 (loopback script): assertions present; NOT executed by the seat (`listen
+  EPERM` inside its sandbox) — covered by the review lead's own runs below.
+- Claim 5 (ESLint): run by the seat with `--no-ignore` on the three TypeScript files,
+  exit 0; neither `return-await` rule is configured.
+- Claim 6 (ledger claims): no contradiction with the diff; browser and production
+  evidence are declared absent by the ledger itself.
+
+Review-lead executions at `31dd173c04` (new runs, not reused):
+
+- vitest, five files (`client-response-timeout`, `client`, `api-client-base`,
+  `api-error-status`, `crm.api`): 5 files, 157 tests passed.
+- `scripts/check-api-response-timeout.ts --adversarial`: PASS (concurrency, truncated
+  socket, HTTP errors, socket cleanup).
+- `scripts/check-api-response-timeout.ts` (200 ms deadline): `Request timeout` at
+  209 ms, body started, connection closed, four compatibility cases passed.
+- Guilt: with `return await response.json()` reverted to `return response.json()`, the
+  new test file fails 2 of 4 (the two stalled-body deadlines) and passes the two
+  innocence cases; restored afterwards, tree clean.
+
+Reused, not re-executed: the author's default-deadline consumer run (`api.crm.getPractices`,
+rejected at 30,030 ms) and the owner-reported external review (157 tests; 30,013 ms).
+
+Not verified by this review: browser end-to-end behaviour and production.


### PR DESCRIPTION
## Summary

Keep the existing request timeout active until a successful JSON response body has been fully consumed.

Previously, `fetch` could receive response headers while the body remained incomplete. `return response.json()` returned the still-pending body promise, but the surrounding `finally` immediately cleared the request timer. A stalled JSON body could therefore leave a request pending indefinitely after its headers had arrived. The surrounding `catch` also no longer handled a later rejection from that body promise.

`return await response.json()` keeps execution inside the existing `try` until body consumption settles. The existing timeout can abort a stalled body read, the existing `catch` translates `AbortError` into `Request timeout`, and `finally` clears the timer afterward. No timeout values, retry policy, caller cancellation, HTTP error classification, interfaces, or dependencies change.

Bites: `useCrmPractices → api.crm.getPractices → ApiClientBase.request` reaches the corrected success branch. The recorded loopback HTTP proof invokes the real `api.crm.getPractices` client with native fetch and its unchanged 30,000 ms timeout: an unfinished JSON body rejected with `Request timeout` at 30,030 ms and its connection closed. The owner-reported external review repeated this at 30,013 ms with the connection closed. The React hook wiring is source-verified; the browser hook itself was not exercised end to end.

## Scope and provenance

- Run: `20260904t235706z-82e423`.
- Implementation commit: `31dd173c04b8836a71f310ff3a0dc597af4b6af9`.
- Base: `af949e6eb5d1767454dd788cd7a8e5be4b89967d`; it matched both local `origin/main` and GitHub `main` during publication preparation.
- The application change remains only `return await response.json()` plus two explanatory comment lines.
- Exactly four committed files; 387 insertions and 1 deletion:
  - `apps/mouth/src/lib/api/client.ts`
  - `apps/mouth/src/lib/api/client-response-timeout.test.ts`
  - `apps/mouth/scripts/check-api-response-timeout.ts`
  - `research/operations/frontier-20260904t235706z-82e423.md`
- `.frontier/` is untracked local working material and is not part of this PR.
- No next-candidate work or unrelated session changes are included.

## Verification already available for this code

These are existing results, not new executions performed while publishing this PR. The committed [evidence ledger](https://github.com/Bali-Zero/Teman2/blob/31dd173c04b8836a71f310ff3a0dc597af4b6af9/research/operations/frontier-20260904t235706z-82e423.md) records the original run and commands.

| Source | Check | Recorded result |
| --- | --- | --- |
| Original run, before the application correction | Loopback stalled JSON body | Failed: watchdog still pending instead of `Request timeout`. |
| Original run, before the application correction | Four targeted regression cases | 2 failed / 2 passed; the failing request signals remained un-aborted. |
| Original run, corrected code | Client/CRM compatibility and regression suites | 5 files / 157 tests passed. |
| Original run, corrected code | Loopback HTTP, 200 ms timeout | Rejected at 249 ms; body started; connection closed; four compatibility cases passed. |
| Original run, corrected code | Real `api.crm.getPractices`, default 30,000 ms timeout | Rejected at 30,030 ms; connection closed. |
| Original run, corrected code | Concurrent adversarial HTTP cases | Fast JSON, stalled body, truncated socket, and malformed/stalled HTTP 503 behavior checked successfully. |
| Original run, corrected code | Explicit ESLint including tests/script, package typecheck, pinned Prettier, whitespace and ordinary commit hooks | Passed. |
| External review reported by the owner for this commit | Client/CRM tests and concurrent HTTP proof | 157 tests and the concurrent proof repeated successfully; no introduced blocking defects reported. |
| External review reported by the owner for this commit | Real CRM consumer, default 30,000 ms timeout | Rejected at 30,013 ms; connection closed. |

Elapsed times are observations, not hard real-time guarantees.

## Publication checks performed now

- Confirmed the existing worktree, unchanged commit and clean tracked index/worktree; only `.frontier/` is untracked.
- Confirmed the exact four-file commit and PR diff, and no tracked `.frontier/` paths.
- Confirmed the parent is the current `origin/main` and remote `main` SHA; no base adaptation was necessary.
- `git diff --check origin/main...HEAD`: passed.
- `scripts/evidence_pack_lint.py --print-floor` using the changed paths and numstat: floor `1`.
- A read-only native investigator independently audited the four-file scope and evidence qualifications; no tests were repeated by that investigator.
- The ordinary `git push` hooks passed without bypasses: changed-file Prettier, skills canonicity, scripts coupling, consumer-map and branch tip-drift checks. The backend suite was not run locally (the hook's normal default); this is not a claim of a fresh backend test pass.
- The pushed branch SHA was checked against the local implementation commit. Push and PR creation were separate operations.
- `python scripts/check_adversarial_review.py --diff origin/main`: **failed**, because the committed research ledger lacks YAML frontmatter with an `adversarial_review:` key. This is an explicit open review-metadata gate, not a passing check. The original commit is preserved; no reviewer identity or exemption has been fabricated to make it pass.

## Adversarial review

The original run exercised materially different failure modes: real rather than mocked fetch/HTTP transport, the unmodified default CRM deadline, concurrent fast and stalled requests, truncated successful responses, malformed and stalled error bodies, and connection cleanup. Complete JSON remained valid; truncation retained its network `TypeError`; HTTP 503 retained `ApiError(503)`.

The owner reports a subsequent external review found no introduced blocking defects and repeated the tests and real-consumer proofs listed above. This report is attributed to that review, not claimed as a fresh publication-session execution.

**Independent repository review is still required.** The reviewing session must assess the unchanged implementation and resolve the research ledger's R1 metadata requirement with truthful reviewer provenance. This PR neither claims that final approval nor requests a gate bypass.

## Limits and handoff

- No browser end-to-end or production verification, production deployment, or production incident-frequency measurement has been performed. No deployment command was invoked; the repository's Vercel integration started an automatic preview check after the authorized push, which is not runtime verification by this session.
- The timer cannot interrupt synchronous JSON parsing that blocks the event loop.
- Caller-provided cancellation, retry behavior and error-body classification remain outside scope.
- The original evidence ledger's statement that there were no remote writes applies to the original local run. This subsequent branch push and PR opening are explicitly owner-authorized publication steps.
- Prepared for an independent Claude session to review. Do not merge, enable auto-merge, or deploy from this authoring session.

Optional reproduction from `apps/mouth` in a checkout of this commit (already completed for the results above):

```sh
node --import tsx ../../node_modules/vitest/vitest.mjs run src/lib/api/client-response-timeout.test.ts src/lib/api/client.test.ts src/lib/api/__tests__/api-client-base.test.ts src/lib/api/__tests__/api-error-status.test.ts src/lib/api/crm/crm.api.test.ts --configLoader native --no-cache --maxWorkers 1
node --import tsx scripts/check-api-response-timeout.ts --adversarial
node --import tsx scripts/check-api-response-timeout.ts --consumer-default
```
