### PR TITLE
fix(auth): a partner JWT is a person, not a colleague — require_team_member refuses it

### DIFF
--- a/apps/backend-rag/backend/app/utils/service_accounts.py
+++ b/apps/backend-rag/backend/app/utils/service_accounts.py
@@ -18,6 +18,15 @@ caller allowed here", and for those a service account genuinely is a
 non-client. See the module-level note in ``services/whatsapp_identity.py`` for
 one such case that is correct as written.
 
+External partners are the third class. A partner is a person — reached through
+the partner portal (``/portal/partner``, see ``routers/auth.py::_redirect_for_role``
+and ``routers/partners.py::_is_partner_role``) — who is not on the team. The
+platform copies ``team_members.role`` verbatim into the JWT, so a ``partner``
+token reaches every gate a colleague's does. :func:`is_human_team_member`
+refuses it; :data:`NON_HUMAN_ROLES` and its SQL renderings deliberately do
+NOT list it, because whether a partner belongs in a roster or a dropdown is a
+product decision, not an authentication one.
+
 This module imports nothing itself, and the package it lives in
 (``backend.app.utils``) is kept free of import-time settings access, so
 importing this module never requires production secrets to be configured.
@@ -36,6 +45,13 @@ SERVICE_ROLES = frozenset({"monitoring"})
 #: Everything that must be excluded from people-shaped artifacts.
 NON_HUMAN_ROLES = CLIENT_ROLES | SERVICE_ROLES
 
+#: Roles held by people who are not on the team: external partners, who log in
+#: through the same door as staff and land on ``/portal/partner``.
+EXTERNAL_ROLES = frozenset({"partner"})
+
+#: Everything an "is this caller a colleague" gate must refuse.
+NON_TEAM_ROLES = NON_HUMAN_ROLES | EXTERNAL_ROLES
+
 
 def normalize_role(role: str | None) -> str:
     """Return a role in the canonical form the comparisons below expect."""
@@ -45,9 +61,9 @@ def normalize_role(role: str | None) -> str:
 def is_human_team_member(role: str | None) -> bool:
     """True when the role belongs to a person on the team.
 
-    Neither clients nor service accounts qualify.
+    Neither clients, service accounts nor external partners qualify.
     """
-    return normalize_role(role) not in NON_HUMAN_ROLES
+    return normalize_role(role) not in NON_TEAM_ROLES
 
 
 def non_human_roles_sql_array() -> list[str]:

--- a/apps/backend-rag/backend/services/garuda_portal/staff_auth.py
+++ b/apps/backend-rag/backend/services/garuda_portal/staff_auth.py
@@ -74,7 +74,7 @@ from fastapi import Request
 from jose import JWTError, jwt
 
 from backend.app.utils.crm_utils import PRACTICES_EXTRA_VIEW_EMAILS
-from backend.app.utils.service_accounts import NON_HUMAN_ROLES, normalize_role
+from backend.app.utils.service_accounts import is_human_team_member, normalize_role
 from backend.services.security.token_revocation import (
     RevocationStoreUnavailable,
     is_session_revoked_sync,
@@ -123,16 +123,17 @@ def _garuda_practice_admin_emails() -> frozenset[str]:
 
 def _is_staff_role(role: str | None) -> bool:
     """True iff `role` names a real person on the team -- never a client,
-    never a service account (`monitoring`), never empty/missing. Reuses
-    `service_accounts.NON_HUMAN_ROLES` (the same exclusion set
-    `deps/auth.py::require_team_member` already gates access with) rather
-    than inventing a second definition of "staff role" that could drift
-    from it.
+    never a service account (`monitoring`), never an external partner,
+    never empty/missing. Delegates to `service_accounts.is_human_team_member`
+    (the predicate `deps/auth.py::require_team_member` gates access with)
+    rather than keeping a second copy of the exclusion set: the copy this
+    replaced still admitted `partner` after the shared predicate stopped.
+    The empty-role refusal is the one thing this adds on top.
     """
     role = normalize_role(role)
     if not role:
         return False
-    return role not in NON_HUMAN_ROLES
+    return is_human_team_member(role)
 
 
 def can_manage_garuda_practices(user: dict[str, Any] | None) -> bool:

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py
@@ -1,0 +1,104 @@
+"""Guilt/innocence for the team gate on ``/api/crm/intelligence/*``.
+
+Ledger row L88 (opened 2026-08-19): ``require_team_member`` was a two-entry
+denylist (``client``, ``monitoring``), so a JWT carrying the role the platform
+itself issues to external partners — ``partner``, which
+``routers/auth.py::_redirect_for_role`` sends to ``/portal/partner`` and
+``routers/partners.py::_is_partner_role`` defines as "not internal team" — was
+granted team-level authority on the six CRM-intelligence routes, none of which
+re-checks the role in its body. These tests pin the gate at the HTTP boundary,
+on the real router, with a database pool that refuses to be touched: a 403
+therefore proves the gate fired BEFORE any client data could be read.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.deps.auth import get_current_user, require_team_member
+from backend.app.deps.database import get_database_pool
+from backend.app.routers import crm_intelligence
+
+_PARTNER: dict[str, Any] = {
+    "email": "partner@example.com",
+    "user_id": "partner@example.com",
+    "role": "partner",
+    "permissions": [],
+}
+_STAFF: dict[str, Any] = {
+    "email": "staff@balizero.com",
+    "user_id": "staff@balizero.com",
+    "role": "Reception",
+    "permissions": [],
+}
+
+_DB_TOUCHED = "the gate must refuse before the database is touched"
+
+
+class _UntouchablePool:
+    """Any attribute access is a test failure: the gate must fire first."""
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        raise AssertionError(f"{_DB_TOUCHED}: pool.{name}")
+
+
+def _app_for(principal: dict[str, Any]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(crm_intelligence.router)
+    app.dependency_overrides[get_current_user] = lambda: principal
+    app.dependency_overrides[get_database_pool] = lambda: _UntouchablePool()
+    return app
+
+
+_ROUTES = [
+    ("GET", "/api/crm/intelligence/evidence-dossiers", None),
+    ("POST", "/api/crm/intelligence/workspace-ai-snapshots", {}),
+    ("GET", "/api/crm/intelligence/workspace-ai-snapshots/review", None),
+    ("POST", "/api/crm/intelligence/workspace-ai-snapshots/auto-approve", {}),
+    ("POST", "/api/crm/intelligence/workspace-ai-snapshots/1/approve", {}),
+    ("POST", "/api/crm/intelligence/1/query", {}),
+]
+
+
+def test_every_intelligence_route_is_behind_the_team_gate() -> None:
+    """Wiring: the six routes exist and each one declares require_team_member."""
+    paths = sorted(route.path for route in crm_intelligence.router.routes)
+    assert paths == [
+        "/api/crm/intelligence/evidence-dossiers",
+        "/api/crm/intelligence/workspace-ai-snapshots",
+        "/api/crm/intelligence/workspace-ai-snapshots/auto-approve",
+        "/api/crm/intelligence/workspace-ai-snapshots/review",
+        "/api/crm/intelligence/workspace-ai-snapshots/{snapshot_id}/approve",
+        "/api/crm/intelligence/{client_id}/query",
+    ], paths
+    unguarded = [
+        route.path
+        for route in crm_intelligence.router.routes
+        if not any(dep.call is require_team_member for dep in route.dependant.dependencies)
+    ]
+    assert unguarded == [], unguarded
+
+
+@pytest.mark.parametrize(("method", "path", "body"), _ROUTES)
+def test_partner_gets_403_before_any_client_data_is_read(
+    method: str, path: str, body: dict[str, Any] | None
+) -> None:
+    """Guilt: at the baseline this returned anything but 403."""
+    client = TestClient(_app_for(_PARTNER))
+    response = client.request(method, path, json=body)
+    assert response.status_code == 403, response.text
+    assert "team members" in response.json()["detail"]
+
+
+def test_staff_passes_the_gate_and_reaches_the_data_layer() -> None:
+    """Innocence: a real free-text staff role is let through — the request
+    dies on the untouchable pool, i.e. AFTER the gate."""
+    client = TestClient(_app_for(_STAFF))
+    with pytest.raises(AssertionError, match=_DB_TOUCHED):
+        client.get("/api/crm/intelligence/evidence-dossiers")

--- a/apps/backend-rag/backend/tests/unit/app/test_dependencies_critical.py
+++ b/apps/backend-rag/backend/tests/unit/app/test_dependencies_critical.py
@@ -209,6 +209,21 @@ class TestAuthDependencies:
             require_team_member(user)
         assert exc_info.value.status_code == 403
 
+    def test_require_team_member_rejects_partner(self):
+        """Guilt (ledger L88, 2026-08-19): ``partner`` is a role the platform
+        itself issues to external partners (routers/auth.py::_redirect_for_role
+        sends it to /portal/partner; partners.py::_is_partner_role defines it
+        as "not internal team"). A person, but not a colleague — team-level
+        authority on e33_cases.py and crm_intelligence.py must be refused."""
+        from fastapi import HTTPException
+
+        from backend.app.dependencies import require_team_member
+
+        user = {"email": "partner@example.com", "role": "partner"}
+        with pytest.raises(HTTPException) as exc_info:
+            require_team_member(user)
+        assert exc_info.value.status_code == 403
+
     def test_require_team_member_allows_a_realistic_free_text_role(self):
         """Innocence: this repo's team roles are free-text job titles, not an
         enum — a realistic one must still pass."""

--- a/apps/backend-rag/backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py
+++ b/apps/backend-rag/backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py
@@ -33,7 +33,19 @@ def test_empty_role_is_still_refused_here(role: str | None) -> None:
     assert _is_staff_role(role) is False
 
 
-def test_partner_never_becomes_a_garuda_staff_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_partner_role_is_refused_on_the_role_path_with_the_admin_allowlist_emptied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scope of this assertion: the ROLE path only.
+
+    ``_staff_principal_from_role`` goes through ``can_manage_garuda_practices``,
+    which consults the admin-email allowlist (``_garuda_practice_admin_emails``)
+    BEFORE the role and grants on an email match whatever the role says. That
+    precedence is untouched by this change and is not asserted here in either
+    direction; the allowlist is emptied so the outcome below is decided by
+    ``_is_staff_role`` alone. With the allowlist empty, a ``partner`` role yields
+    no principal, while a real staff role still does.
+    """
     monkeypatch.setattr(staff_auth, "_garuda_practice_admin_emails", lambda: frozenset())
     assert _staff_principal_from_role("partner@example.com", "partner") is None
     assert _staff_principal_from_role("staff@balizero.com", "Reception") == {

--- a/apps/backend-rag/backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py
+++ b/apps/backend-rag/backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py
@@ -1,0 +1,42 @@
+"""``_is_staff_role`` must agree with ``require_team_member`` about who is staff.
+
+``staff_auth.py`` promises to reuse the team gate's exclusion set rather than
+keep a second definition that could drift. It had drifted once already: when
+``partner`` stopped passing ``is_human_team_member`` the local copy still
+admitted it. It now delegates, and this file pins the agreement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.garuda_portal import staff_auth
+from backend.services.garuda_portal.staff_auth import (
+    _is_staff_role,
+    _staff_principal_from_role,
+)
+
+
+@pytest.mark.parametrize("role", ["partner", "Partner", "  PARTNER  ", "client", "monitoring"])
+def test_non_team_roles_are_not_staff(role: str) -> None:
+    assert _is_staff_role(role) is False
+
+
+@pytest.mark.parametrize("role", ["Accounting", "Tax Lead", "admin", "Specialist Advisor"])
+def test_real_staff_roles_still_qualify(role: str) -> None:
+    assert _is_staff_role(role) is True
+
+
+@pytest.mark.parametrize("role", [None, "", "   "])
+def test_empty_role_is_still_refused_here(role: str | None) -> None:
+    """The one thing this predicate adds on top of the shared one."""
+    assert _is_staff_role(role) is False
+
+
+def test_partner_never_becomes_a_garuda_staff_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(staff_auth, "_garuda_practice_admin_emails", lambda: frozenset())
+    assert _staff_principal_from_role("partner@example.com", "partner") is None
+    assert _staff_principal_from_role("staff@balizero.com", "Reception") == {
+        "email": "staff@balizero.com",
+        "is_admin": False,
+    }

--- a/apps/backend-rag/backend/tests/unit/utils/test_service_accounts.py
+++ b/apps/backend-rag/backend/tests/unit/utils/test_service_accounts.py
@@ -8,6 +8,7 @@ quietly kept its own hand-written `NOT IN ('client')`.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -15,15 +16,19 @@ import pytest
 
 from backend.app.utils.service_accounts import (
     CLIENT_ROLES,
+    EXTERNAL_ROLES,
     NON_HUMAN_ROLES,
     NON_HUMAN_ROLES_SQL,
+    NON_TEAM_ROLES,
     SERVICE_ROLES,
     _sql_literal_list,
     is_human_team_member,
     non_human_roles_sql_array,
+    normalize_role,
 )
 
 ROUTERS = Path(__file__).resolve().parents[3] / "app" / "routers"
+ROSTER = Path(__file__).resolve().parents[3] / "data" / "team_members.json"
 DEPS = Path(__file__).resolve().parents[3] / "app" / "deps"
 
 
@@ -50,6 +55,40 @@ class TestIsHumanTeamMember:
     def test_the_two_sets_are_disjoint(self) -> None:
         assert not (CLIENT_ROLES & SERVICE_ROLES)
         assert NON_HUMAN_ROLES == CLIENT_ROLES | SERVICE_ROLES
+
+
+class TestExternalPartnersAreNotColleagues:
+    """Ledger row L88 (2026-08-19): ``partner`` is a role the platform itself
+    issues — ``routers/auth.py::_redirect_for_role`` sends it to
+    ``/portal/partner`` and ``routers/partners.py::_is_partner_role`` defines
+    it as "not internal team" — yet the gate admitted it, because the
+    exclusion set only ever modelled machines. A partner is a person, so the
+    cure lives in the ACCESS predicate and stays out of the people-shaped SQL
+    exclusions.
+    """
+
+    @pytest.mark.parametrize("role", ["partner", "Partner", "  PARTNER  "])
+    def test_partners_are_people_but_not_team(self, role: str) -> None:
+        """Guilt: this is the assertion that failed before the fix."""
+        assert is_human_team_member(role) is False
+
+    def test_every_role_in_the_repo_roster_still_counts(self) -> None:
+        """Innocence over the real roster, not a hand-picked list: team roles
+        are free-text job titles, and not one of them may be caught."""
+        roster = json.loads(ROSTER.read_text(encoding="utf-8"))
+        roles = sorted({normalize_role(row.get("role")) for row in roster if row.get("role")})
+        assert len(roles) >= 10, f"roster at {ROSTER} looks empty: {roles}"
+        assert [role for role in roles if not is_human_team_member(role)] == []
+
+    def test_partners_stay_out_of_the_people_shaped_exclusions(self) -> None:
+        """Scope pin: only the access predicate changed. Roster, headcount and
+        dropdown queries still exclude exactly clients and machines."""
+        assert EXTERNAL_ROLES == frozenset({"partner"})
+        assert not (EXTERNAL_ROLES & NON_HUMAN_ROLES)
+        assert NON_TEAM_ROLES == NON_HUMAN_ROLES | EXTERNAL_ROLES
+        assert NON_HUMAN_ROLES == frozenset({"client", "monitoring"})
+        assert "partner" not in non_human_roles_sql_array()
+        assert "partner" not in NON_HUMAN_ROLES_SQL
 
 
 class TestSqlRendering:


### PR DESCRIPTION
## Summary

`is_human_team_member` (`backend/app/utils/service_accounts.py`) was a two-entry denylist, `{client, monitoring}`: it modelled "machines are not colleagues" and never the third principal class the platform itself issues. `partner` is a real role — `routers/auth.py::_redirect_for_role` sends it to `/portal/partner`, `routers/partners.py::_is_partner_role` defines it as "not internal team", and login copies `team_members.role` verbatim into the JWT — so a partner token passed `require_team_member` and held team-level authority on the six `/api/crm/intelligence/*` routes (person-first evidence dossiers, per-client NotebookLM query over `clients.full_name`), none of which re-checks the role in its body; plus `e33_cases`, `debug`, the inline `is_human_team_member` gates (`portal_invite`, `crm_portal_integration`, `agentic_rag` A/B control, auto clock-in) and GARUDA staff eligibility, whose `_is_staff_role` kept a second copy of the same set and had already drifted from the shared predicate.

Ledger row L88 (`.claude/skills/modus/PENDING-ARMS.md`, opened 2026-08-19) describes this gap; its proof-of-armed ("a role=partner JWT gets 403 on a team-only endpoint") failed at runtime on the baseline (`is_human_team_member('partner') -> True`). The row stays open until that probe passes against the deployed gate.

## Change (one concern)

- `service_accounts.py`: `EXTERNAL_ROLES = {"partner"}`, `NON_TEAM_ROLES = NON_HUMAN_ROLES | EXTERNAL_ROLES`; the ACCESS predicate `is_human_team_member` refuses `NON_TEAM_ROLES`. `NON_HUMAN_ROLES` and its SQL renderings are deliberately unchanged — a partner is a person, and whether one belongs in a roster or a dropdown is a product decision, not an authentication one (the `apps/mouth` `useTeamMembers.ts` mirror therefore stays in sync; `test_service_accounts_ts_sync.py` passes).
- `garuda_portal/staff_auth.py::_is_staff_role`: delegates to `is_human_team_member` (keeps its own empty-role refusal). Only the ROLE path changes; the admin-email allowlist consulted first by `can_manage_garuda_practices` keeps its precedence and is untouched.
- Tests: guilt (partner / `Partner` / `  PARTNER  ` -> False; `require_team_member` -> 403; TestClient 403 on all six intelligence routes before the DB pool is touched; `_is_staff_role('partner')` False; no GARUDA principal via the role path with the allowlist emptied), innocence over every distinct role in `backend/data/team_members.json` plus the existing free-text titles, scope pins on the set composition, and a wiring pin that every intelligence route declares the gate.

Not an allow-list: team roles are free-text job titles (14 distinct in the repo roster), so an allow-list would over-match and needs the prod census L88 deferred on. Still open and out of scope here: API-key role `user`, X-Internal-Key role `internal`, empty/missing role in the gate, partner rows in people-shaped SQL exclusions.

## Evidence

Baseline: `origin/main` = `af949e6eb5`. Local venv drift note: the M5 venv does not match `requirements.lock.txt` for every pin (134/273 mismatched per an earlier census), so local results are on versions CI does not run; CI is authoritative.

**Targeted checks passed**

| Check | Command | Result |
|---|---|---|
| Runtime probe | `PYTHONPATH=. .venv/bin/python -c "from backend.app.utils.service_accounts import is_human_team_member as f; print(f('partner'))"` | `True` at baseline, `False` with the fix |
| Targeted suites (4 files) | `cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/utils/test_service_accounts.py backend/tests/unit/app/test_dependencies_critical.py backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py -p no:cacheprovider` | `68 passed`, exit 0 (re-run after the test rename in the second commit: `68 passed`) |
| Guilt on baseline sources | same 4 files with `service_accounts.py` + `staff_auth.py` restored to `af949e6eb5` | `11 failed, 31 passed, 1 error` (the error is `test_service_accounts.py` importing the names this PR introduces) |
| Mutant: over-match `{"partner","accounting"}` | `pytest backend/tests/unit/utils/test_service_accounts.py` | `2 failed, 24 passed` (roster innocence catches it) |
| Mutant: typo `{"partners"}` | `pytest test_service_accounts.py test_crm_intelligence_partner_gate.py` | `10 failed, 24 passed` (guilt catches it) |
| Wiring | `test_every_intelligence_route_is_behind_the_team_gate` | passed: 6 routes, each with `dep.call is require_team_member` |
| Lint | `ruff check` on the 7 touched files; `scripts/lint_test_reward_hacking.py` on the new test files (pre-commit) | clean |
| Dependent unit suites that exercise the predicates (`test_agentic_rag_ab_test_auth.py`, `test_crm_portal_integration_require_team_auth.py`, `test_debug.py`, `unit/routers/test_crm_intelligence.py`, `test_portal_invite_p0_capability.py`, `test_portal_invite.py`, `test_service_accounts_ts_sync.py`, `services/garuda_portal/test_staff_transitions_validate.py`) | `96 passed` (run together with the DB-backed file below; the 96 are these files' tests) |

**Failures proven pre-existing by baseline comparison**

| Observation | Baseline comparison |
|---|---|
| `backend/tests/unit/utils backend/tests/unit/app backend/tests/unit/routers` → `3525 passed, 1 skipped, 1 failed` (`unit/app/modules/notifications/test_service.py::TestSMTPProviderAttachments::test_attachment_payload_decoded_once`, `aiosmtplib` is `None` in the local venv) | the same single test fails identically with the two source files restored to `af949e6eb5` (`1 failed`) — environment, not this diff |
| `ruff format --check backend/tests/unit/utils/test_service_accounts.py` → 1 would-reformat (line 208, quote style, not a line this PR touches) | `git show af949e6eb5:<file> \| ruff format --check -` exits 1 too — pre-existing, left as is to keep the diff to one concern |

**Checks not completed (environment)**

- `backend/tests/services/garuda_portal/test_staff_router_transitions.py`: `26 errors` at fixture setup (`asyncpg.exceptions.UndefinedTableError: relation "public.garuda_magic_link_..."` against the local `nuzantara_test` database, which lacks the GARUDA tables). This DB-backed file imports `staff_auth` and is a relevant consumer of `_is_staff_role`; it was NOT run on the baseline sources, so its equivalence with the baseline is not proven here — it is not green, and no result is claimed for it. It runs in CI against the CI schema and should be read there; alternatively on the Pro's isolated test database.
- The pre-push hook's ADVISORY quickcheck ran the scoped backend suite locally at push time (`1 failed, 17061 passed, 175 skipped, 6 xfailed, 154 errors in 499s`, reported as `advisory, rc=1`; the real gate, `Backend Tests (Python)` in `tests.yml`, was skipped locally by default and runs on this PR). Not claimed green. The 1 failure is the deliberate lockfile tripwire (`test_the_installed_sdk_matches_the_version_the_lockfile_pins`: google-genai 2.7.0 installed vs 2.18.1 pinned). The 154 errors are all fixture setup on the local test database: 123 `UndefinedTableError` across the DB-backed `garuda_orders` / `garuda_ops` / `garuda_portal` files (GARUDA tables absent) and 31 `ExclusionViolationError` in `services/visa_engine/test_evaluate_endpoint.py` (a stale `visa_decision_retention_policies` TEST row dated 2026-08-26). None of these files was run on the baseline sources in this environment, so their equivalence with the baseline is not proven here; CI is the authority for them.

## Live verification — still pending

An unauthenticated `GET https://nuzantara-rag.fly.dev/api/crm/intelligence/evidence-dossiers` returns `401` today. That only shows the route is mounted on the public `api` process (`router_registration.py:249`) and auth-gated; `nuzantara-rag` answers 401 before routing, so it proves nothing about this fix. The proof that closes L88 is an AUTHENTICATED request with a `role=partner` JWT returning `403` after deploy (and a staff JWT still passing). Merging a `apps/backend-rag/**` PR deploys by itself; the verifying session runs that probe after the deploy, not the author.

Bites: consumer = the `require_team_member` dependency on `/api/crm/intelligence/*` (public `api` process, `router_registration.py:249`) and every `is_human_team_member` / `_is_staff_role` caller; observed locally = the 4 targeted files pass (`68 passed`) and the 11 guilt tests fail on the baseline sources; pending in production = an authenticated `role=partner` JWT on `GET /api/crm/intelligence/evidence-dossiers` returns `403` (a staff JWT still passes) after the deploy.

## Review handoff (generator ≠ grader)

```
git fetch origin agent/air-m5/backend-rag/partner-not-team-20260904t235718z-ohcesm
git log --oneline af949e6eb5..FETCH_HEAD          # 2 commits
cd apps/backend-rag
PYTHONPATH=. .venv/bin/python -m pytest backend/tests/unit/utils/test_service_accounts.py backend/tests/unit/app/test_dependencies_critical.py backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py backend/tests/unit/services/garuda_portal/test_staff_auth_partner.py -p no:cacheprovider
# guilt: back up the two source files with cp, restore them to af949e6eb5, re-run: expect 11 failed
```

Not armed for auto-merge on purpose: this PR was authored by the session that opened it and must be reviewed, merged and prove-lived by a different session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuBR9yoypkcqbnG21mr1nh
