### PR TITLE
fix(visa-oracle): reopen the current interview question for missing facts

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
@@ -46,9 +46,11 @@ const ANSWERS = [
 ] as const;
 type FixtureState = NonNullable<Parameters<typeof makeVisaOracleResponse>[0]>;
 
-function verdictSnapshot(): ReturnType<typeof createInterviewSnapshot> {
+function verdictSnapshot(
+  answers: readonly (readonly [string, string])[] = ANSWERS,
+): ReturnType<typeof createInterviewSnapshot> {
   let state: FlowState = flowReducer(initialFlowState(), { type: "ADVANCE" });
-  for (const [questionId, value] of ANSWERS) {
+  for (const [questionId, value] of answers) {
     state = flowReducer(state, { type: "ANSWER", questionId, value });
   }
   state = flowReducer(state, { type: "ADVANCE" });
@@ -56,10 +58,12 @@ function verdictSnapshot(): ReturnType<typeof createInterviewSnapshot> {
   return createInterviewSnapshot(state, new Date());
 }
 
-function installVerdictResume(): void {
-  expect(saveInterviewResume(verdictSnapshot(), { now: new Date() })).toBe(
-    true,
-  );
+function installVerdictResume(
+  answers: readonly (readonly [string, string])[] = ANSWERS,
+): void {
+  expect(
+    saveInterviewResume(verdictSnapshot(answers), { now: new Date() }),
+  ).toBe(true);
 }
 
 function engineFetch(
@@ -206,6 +210,90 @@ describe("OracleShell authoritative evaluate integration", () => {
       }),
     ).toBeInTheDocument();
     expect(screen.queryByText("Visit Visa C1")).toBeNull();
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      category: "remote",
+      questionId: "remote_compensation",
+      factPath: "work.indonesia_source_compensation",
+      internalMode: false,
+      details: [
+        ["sponsor_category", "NONE"],
+        ["remote_clients", "foreign"],
+        ["remote_compensation", "no"],
+        ["remote_employer_country", "US"],
+        ["remote_pt_pma", "no"],
+      ],
+    },
+    {
+      category: "invest",
+      questionId: "investment_pt_pma",
+      factPath: "investment.pt_pma_committed",
+      internalMode: true,
+      details: [
+        ["sponsor_category", "NONE"],
+        ["investment_vehicle", "pt_pma"],
+        ["investment_pt_pma", "yes"],
+        ["investment_capital_idr", "10000000000"],
+        ["investment_paid_up_capital_idr", "10000000000"],
+        ["investment_role", "SHAREHOLDER_DIRECTOR"],
+      ],
+    },
+  ] as const)(
+    "missing-input Edit reopens the $category interview question",
+    async ({ category, questionId, factPath, internalMode, details }) => {
+      installVerdictResume([
+        ...ANSWERS.slice(0, 5),
+        ["category", category],
+        ["trip_scope", "single"],
+        ...details,
+        ["stay_days", "30"],
+        ["review_gate", "none"],
+      ]);
+      const response = makeVisaOracleResponse("NEEDS_INPUT");
+      response.mode = internalMode ? "CURATED" : "ENGINE";
+      response.decision.missing_facts = [factPath];
+      global.fetch = vi.fn<typeof fetch>(
+        async () =>
+          new Response(JSON.stringify(response), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      render(<OracleShell internalMode={internalMode} />);
+
+      await expectStateHeading("NEEDS_INPUT");
+      fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+      expect(
+        await screen.findByRole("heading", {
+          name: translate("en", `q.${questionId}`),
+        }),
+      ).toBeInTheDocument();
+      expect(global.fetch).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps an unavailable missing question actionable through the existing handoff, without a dead Edit", async () => {
+    const response = makeVisaOracleResponse("NEEDS_INPUT");
+    response.decision.missing_facts = ["work.indonesia_source_compensation"];
+    global.fetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    render(<OracleShell />);
+
+    await expectStateHeading("NEEDS_INPUT");
+    expect(screen.queryByRole("button", { name: /^edit$/i })).toBeNull();
+    expect(screen.getByText(/Bali Zero can help clarify/)).toBeInTheDocument();
+    expect(screen.getByText("Continue with Bali Zero")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/work\.indonesia_source_compensation/),
+    ).toBeNull();
     expect(global.fetch).toHaveBeenCalledOnce();
   });
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
@@ -599,6 +599,9 @@ function OracleShellRuntime({
                   assumptions,
                   facts: state.facts,
                   interviewBranchesRemaining,
+                  editableQuestionIds: state.history.flatMap((node) =>
+                    node.kind === "question" ? [node.questionId] : [],
+                  ),
                 });
                 emitVisaOracleTelemetry({
                   event: "visa_oracle_v2_engine_result",
@@ -629,6 +632,9 @@ function OracleShellRuntime({
                 assumptions,
                 facts: state.facts,
                 interviewBranchesRemaining,
+                editableQuestionIds: state.history.flatMap((node) =>
+                  node.kind === "question" ? [node.questionId] : [],
+                ),
               });
               emitVisaOracleTelemetry({
                 event: "visa_oracle_v2_engine_result",
@@ -715,6 +721,7 @@ function OracleShellRuntime({
     retryNonce,
     state.attempt,
     state.facts,
+    state.history,
   ]);
 
   useEffect(() => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -8,6 +8,8 @@ import {
   buildEngineOutcome,
 } from "./engine-adapter";
 import { TEST_NOW, makeVisaOracleResponse } from "./visa-oracle-test-fixture";
+import { translate, type I18nKey } from "./i18n";
+import { QUESTIONS } from "./tree";
 
 describe("Visa Oracle authoritative outcome adapter", () => {
   it("shows each source's own dates, not the decision's evaluation clock", () => {
@@ -280,7 +282,9 @@ describe("Visa Oracle authoritative outcome adapter", () => {
   });
 
   it("maps missing engine facts back to editable interview questions", () => {
-    const outcome = buildEngineOutcome(makeVisaOracleResponse("NEEDS_INPUT"));
+    const outcome = buildEngineOutcome(makeVisaOracleResponse("NEEDS_INPUT"), {
+      editableQuestionIds: ["stay_days"],
+    });
     expect(outcome.state).toBe("NEEDS_INPUT");
     if (outcome.state !== "NEEDS_INPUT") throw new Error("unexpected state");
     expect(outcome.missingInputs[0]).toMatchObject({
@@ -288,6 +292,58 @@ describe("Visa Oracle authoritative outcome adapter", () => {
       questionId: "stay_days",
     });
   });
+
+  it.each([
+    ["work.indonesia_source_compensation", "remote_compensation"],
+    ["work.indonesia_source_compensation", "work_indonesia_compensation"],
+    ["investment.pt_pma_committed", "investment_pt_pma"],
+    ["investment.pt_pma_committed", "remote_pt_pma"],
+    ["immigration.current_status_code", "stay_permit_code"],
+  ] as const)(
+    "routes missing %s to the visited %s question",
+    (factPath, questionId) => {
+      const response = makeVisaOracleResponse("NEEDS_INPUT");
+      response.decision.missing_facts = [factPath];
+      const outcome = buildEngineOutcome(response, {
+        editableQuestionIds: ["category", questionId, "stay_days"],
+      });
+      if (outcome.state !== "NEEDS_INPUT") throw new Error("unexpected state");
+      expect(outcome.missingInputs[0]).toMatchObject({
+        code: factPath,
+        questionId,
+        message: {
+          en: translate("en", QUESTIONS[questionId].i18nKey as I18nKey),
+          id: translate("id", QUESTIONS[questionId].i18nKey as I18nKey),
+        },
+      });
+    },
+  );
+
+  it.each([
+    { editableQuestionIds: undefined },
+    { editableQuestionIds: [] },
+    { editableQuestionIds: ["stay_days"] },
+    {
+      editableQuestionIds: [
+        "remote_compensation",
+        "work_indonesia_compensation",
+      ],
+    },
+  ])(
+    "offers no arbitrary edit when the target is absent or ambiguous: %j",
+    ({ editableQuestionIds }) => {
+      const response = makeVisaOracleResponse("NEEDS_INPUT");
+      response.decision.missing_facts = ["work.indonesia_source_compensation"];
+      const outcome = buildEngineOutcome(response, { editableQuestionIds });
+      if (outcome.state !== "NEEDS_INPUT") throw new Error("unexpected state");
+      expect(outcome.missingInputs[0].questionId).toBeUndefined();
+      expect(outcome.missingInputs[0].message.en).toContain("Bali Zero");
+      expect(outcome.missingInputs[0].message.id).toContain("Bali Zero");
+      expect(JSON.stringify(outcome.missingInputs[0].message)).not.toContain(
+        "work.indonesia_source_compensation",
+      );
+    },
+  );
 });
 
 describe("support reasons are sentences, not machine codes", () => {

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -3,6 +3,7 @@ import {
   VisaOracleResponseError,
 } from "./engine-response";
 import { QUESTIONS, type OracleFacts } from "./tree";
+import { translate, type I18nKey } from "./i18n";
 import { trustedPrimarySourceUrl } from "./trusted-source-url";
 import type {
   InterviewAssumption,
@@ -638,16 +639,19 @@ function price(
   };
 }
 
-function questionForFact(path: string): string | undefined {
-  for (const question of Object.values(QUESTIONS)) {
-    if (
+function questionForFact(
+  path: string,
+  editableQuestionIds: readonly string[] = [],
+): string | undefined {
+  const matches = Object.values(QUESTIONS).filter(
+    (question) =>
+      editableQuestionIds.includes(question.id) &&
       question.decisionMapping.kind !== "HUMAN_CONTEXT" &&
-      question.decisionMapping.factPaths.includes(path)
-    ) {
-      return question.id;
-    }
-  }
-  return undefined;
+      question.decisionMapping.factPaths.includes(path),
+  );
+  // Several branches can collect the same fact. Only offer an Edit that
+  // identifies one question in this interview's current history.
+  return matches.length === 1 ? matches[0].id : undefined;
 }
 
 function nonEmpty<T>(values: T[]): [T, ...T[]] {
@@ -661,6 +665,8 @@ export interface BuildEngineOutcomeOptions {
   assumptions?: readonly InterviewAssumption[];
   facts?: OracleFacts;
   interviewBranchesRemaining?: number;
+  /** Question nodes in the current, pruning-aware interview history. */
+  editableQuestionIds?: readonly string[];
 }
 
 /**
@@ -792,17 +798,27 @@ function buildValidatedOutcome(
         candidates: [],
         pathsRemaining: Math.max(1, options.interviewBranchesRemaining ?? 1),
         missingInputs: nonEmpty(
-          response.decision.missing_facts.map((path) => ({
-            code: path,
-            message: text(
-              `Verified evaluation needs: ${path}`,
-              `Evaluasi terverifikasi memerlukan: ${path}`,
-            ),
-            sourceIds: [],
-            ...(questionForFact(path)
-              ? { questionId: questionForFact(path) }
-              : {}),
-          })),
+          response.decision.missing_facts.map((path) => {
+            const questionId = questionForFact(
+              path,
+              options.editableQuestionIds,
+            );
+            const question = questionId ? QUESTIONS[questionId] : undefined;
+            return {
+              code: path,
+              message: question
+                ? text(
+                    translate("en", question.i18nKey as I18nKey),
+                    translate("id", question.i18nKey as I18nKey),
+                  )
+                : text(
+                    "Bali Zero can help clarify an additional detail needed for this assessment.",
+                    "Bali Zero dapat membantu memperjelas detail tambahan yang diperlukan untuk penilaian ini.",
+                  ),
+              sourceIds: [],
+              ...(questionId ? { questionId } : {}),
+            };
+          }),
         ),
       };
     case "HUMAN_REVIEW_REQUIRED":

--- a/evidence/2026-09/agent-air-m5-mouth-oracle-edit-routing-77d9ea82/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-oracle-edit-routing-77d9ea82/brief.yml
@@ -1,0 +1,38 @@
+task_id: oracle-edit-routing
+gear: 2
+l_level: L2
+gate_class: opus
+objective: >-
+  Make Visa Oracle NEEDS_INPUT Edit controls reopen the question visited in
+  the current interview, instead of the first registry question sharing
+  the same fact. Show existing EN/ID question text and a readable contact
+  fallback when the interview has no unambiguous editable question.
+constraints:
+  - No rule, price, dataset, signing, activation, or evaluation-mode changes.
+  - Reuse the existing interview history and question translations.
+  - Draft PR only; independent Fable review is pending. No merge, arm, or deploy.
+acceptance:
+  - text: WHEN compensation is missing in REMOTE, Edit SHALL reopen remote_compensation.
+    status: verified
+    probe: OracleShell.test.tsx
+  - text: WHEN PT PMA is missing in INVEST, Edit SHALL reopen investment_pt_pma, including internal CURATED preview.
+    status: verified
+    probe: OracleShell.test.tsx
+  - text: WHEN the question is absent or ambiguous, the adapter SHALL omit an Edit target and raw fact paths from the display message.
+    status: verified
+    probe: engine-adapter.test.ts
+  - text: WHILE public SHADOW gating applies, existing authority and request-deduplication tests SHALL remain green.
+    status: verified
+    probe: OracleShell.shadow-dedupe-adversarial.test.tsx
+assumptions:
+  - text: The pruning-aware interview history identifies questions that the existing Edit reducer can reopen.
+    status: verified
+    probe: OracleShell.test.tsx
+consumer_map:
+  - OracleShell passes current question IDs to authoritative and internal-preview outcome adapters.
+  - OutcomeSheet renders Edit only when the adapter supplies an unambiguous questionId.
+risks:
+  - Questions not visited in this interview remain available through the existing contact flow; no new interview branch is invented.
+  - Verification uses synthetic component tests, not a live backend or browser deployment.
+grader: Independent Fable review requested through the coordinating session; no verdict recorded yet.
+pii: none

--- a/evidence/2026-09/agent-air-m5-mouth-oracle-edit-routing-77d9ea82/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-oracle-edit-routing-77d9ea82/pack.yml
@@ -1,0 +1,59 @@
+brief_ref: evidence/brief.yml
+plan_ref: V-01 from the two-consul GARUDA VOA, Second Home, and Visa Oracle completion mandate.
+lanes:
+  - lane: oracle-edit-routing
+    role: build
+    seat: gpt-6-astra
+seat_override: >-
+  R8 applicability only: these Visa Oracle paths change navigation among
+  existing questions and reuse their existing translations. No regulatory
+  claim, eligibility rule, visa fact, or price is authored or changed, so
+  there is no new legal assertion to verify with NotebookLM. Independent
+  cross-family Fable review remains pending and is not waived by this note.
+pii_scan: clean
+receipts:
+  - claim: Before the fix, regression tests exposed wrong shared-fact targets and dead Edit offers.
+    cmd: >-
+      ../../node_modules/.bin/vitest run
+      'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts'
+      --maxWorkers=1 -t 'routes missing|offers no arbitrary edit'
+    result: >-
+      9 failed before the production-code change. REMOTE compensation
+      selected work_indonesia_compensation; INVEST PT PMA selected
+      remote_pt_pma; stay_permit_code selected current_status_code.
+    exit: 1
+    ts: "2026-09-05T06:29:37Z"
+    seat: gpt-6-astra
+  - claim: Scoped regression, preview, SHADOW parity, and deduplication verification.
+    cmd: >-
+      ../../node_modules/.bin/vitest run
+      'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts'
+      'src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx'
+      'src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts'
+      'src/app/(visa-oracle)/visa-oracle/_lib/preview-adapter.test.ts'
+      'src/app/(visa-oracle)/visa-oracle/_lib/gold-oracle-baseline.test.ts'
+      'src/app/(visa-oracle)/visa-oracle/_components/OracleShell.shadow-dedupe-adversarial.test.tsx'
+      --maxWorkers=1
+    result: 6 files passed, 80 tests passed; one worker, no backend or real client data.
+    exit: 0
+    ts: "2026-09-05T06:30:47Z"
+    seat: gpt-6-astra
+  - claim: ESLint reports no errors on the changed production files.
+    cmd: >-
+      ../../node_modules/.bin/eslint
+      'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts'
+      'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts'
+      'src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx'
+      'src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx'
+    result: >-
+      Exit 0. Existing privacy-link warnings remain; test files are ignored
+      by the repository ESLint configuration and are checked by Vitest.
+    exit: 0
+    ts: "2026-09-05T06:33:01Z"
+    seat: gpt-6-astra
+dissent: []
+review_status: pending-independent-fable-review
+notes:
+  - Receipt commands run from apps/mouth in the isolated mouth-oracle-edit-routing worktree.
+  - Existing SHADOW/NO-GO posture is unchanged. Passing tests are not an independent review verdict.
+  - No full Next.js build or production-browser proof has been performed by this lane.


### PR DESCRIPTION
Visa Oracle's NEEDS_INPUT Edit control selected the first registry question sharing a fact, even when that question belonged to another interview branch. REMOTE compensation could point to WORK, and INVEST PT PMA to REMOTE. The adapter now resolves a unique question from the current interview history, displays its existing EN/ID wording, and omits Edit when no valid destination exists. Both authoritative and internal CURATED previews receive the history context.

Bites: OracleShell and OutcomeSheet consume the corrected projection; component tests click Edit and reopen the REMOTE and INVEST questions, while an unavailable target keeps the existing contact flow without a dead control.

Validation: 80 tests passed across six scoped suites, including SHADOW parity and request deduplication. The pre-commit hook passed the full apps/mouth TypeScript check, formatting, and other mandatory checks. Evidence-pack validation passed using this branch's own staged brief and pack. Existing privacy-link ESLint warnings remain; test files are excluded from ESLint and exercised by Vitest.

Scope: four frontend files plus branch-specific evidence. No rule, price, dataset, signing, activation, or evaluation-mode change. No production-browser proof or Next.js build is claimed.

Browser validation on exact head `511bf901c64e10a6eb57bcff6a0c7361f8736a44`: real Chrome on Pro localhost, with CLI and app both resolving Next 16.3.3. Seeded synthetic interviews use the existing flow and response fixtures. An intercepted NEEDS_INPUT response reopens `remote_compensation` and `investment_pt_pma` through the visible Edit button; the question receives focus, and the request counter stays at one after editing without a new answer. The missing-target control has no Edit and retains human-readable consultant contact. No horizontal overflow at 390 px; INVEST also checked at 1280 px; no page errors. Four source hashes remained unchanged, and the owned server/browser sessions were closed. This validates the browser interaction against a synthetic engine response, not a backend or deployed-production journey. Receipts: `.worktrees/ops-visa-consuls/output/playwright/v01-511bf901/`.

## Adversarial review

Independent Fable 5.1 review requested through the coordinating console and pending. This PR is a draft for that review; no review PASS, merge authorization, auto-merge, or deployment is claimed.
