### PR TITLE
fix(secondhome): make plan save and copy failures recoverable

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -537,6 +537,40 @@ export function StudioApp() {
   const [plan, setPlan] = useState<PlanState>(emptyPlan);
   const [stepIndex, setStepIndex] = useState(0);
   const hydratedOnce = useRef(false);
+  const consentSpaceRef = useRef<HTMLDivElement>(null);
+  const [consentHeight, setConsentHeight] = useState(0);
+
+  useEffect(() => {
+    const host = consentSpaceRef.current;
+    if (!host) return;
+
+    // The fixed banner contributes no document height. Reserve its measured
+    // size here so recovery controls can scroll fully above it at any width.
+    const measure = () =>
+      setConsentHeight(
+        host.firstElementChild?.getBoundingClientRect().height ?? 0,
+      );
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(measure);
+    const observeBanner = () => {
+      resizeObserver?.disconnect();
+      if (host.firstElementChild)
+        resizeObserver?.observe(host.firstElementChild);
+      measure();
+    };
+    const mutationObserver = new MutationObserver(observeBanner);
+    mutationObserver.observe(host, { childList: true });
+    observeBanner();
+    window.addEventListener("resize", measure);
+
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, []);
 
   const sequence = computeSequence(plan);
   const isVerdictStage = stepIndex >= sequence.length;
@@ -790,7 +824,16 @@ export function StudioApp() {
           </div>
         ) : null}
 
-        <ConsentBanner />
+        <div
+          ref={consentSpaceRef}
+          className="bz-shs-consent-space"
+          style={{
+            height: consentHeight,
+            display: consentHeight > 0 ? "block" : "contents",
+          }}
+        >
+          <ConsentBanner />
+        </div>
 
         <style>{`
         .bz-shs-layout {
@@ -818,6 +861,11 @@ export function StudioApp() {
           .bz-shs-layout * {
             transition: none !important;
             animation: none !important;
+          }
+        }
+        @media print {
+          .bz-shs-consent-space {
+            display: none !important;
           }
         }
       `}</style>

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
@@ -1,13 +1,157 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { emptyPlan } from "@/lib/secondhome-studio/plan-codec";
+import {
+  decodePlanFragment,
+  emptyPlan,
+  loadPlan,
+} from "@/lib/secondhome-studio/plan-codec";
 import { SavePlanBar } from "./SavePlanBar";
 
 const originalPrintDescriptor = Object.getOwnPropertyDescriptor(
   window,
   "print",
 );
+
+describe("SavePlanBar persistence feedback", () => {
+  const originalClipboard = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard",
+  );
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  });
+
+  it("confirms a save only after the plan is persisted", () => {
+    const plan = emptyPlan();
+    render(<SavePlanBar plan={plan} onClear={vi.fn()} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save on this device" }),
+    );
+    expect(loadPlan()).toEqual(plan);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Plan saved on this device",
+    );
+  });
+
+  it.each(["SecurityError", "QuotaExceededError"])(
+    "replaces an earlier save confirmation with recovery instructions when %s prevents saving",
+    (name) => {
+      const plan = emptyPlan();
+      render(<SavePlanBar plan={plan} onClear={vi.fn()} />);
+      const saveButton = screen.getByRole("button", {
+        name: "Save on this device",
+      });
+      fireEvent.click(saveButton);
+      vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+        throw new DOMException("Cannot store plan", name);
+      });
+      fireEvent.click(saveButton);
+      expect(screen.getByRole("status")).not.toHaveTextContent(
+        "Plan saved on this device",
+      );
+      expect(screen.getByRole("status")).toHaveTextContent(/couldn't save/i);
+      expect(
+        screen.getByRole("textbox", { name: "Plan link" }),
+      ).toHaveAttribute("readonly");
+    },
+  );
+
+  it.each(["denied", "absent"])(
+    "offers a selectable, branch-sanitized link when the clipboard is %s, without a network call",
+    async (clipboardState) => {
+      const fetch = vi.fn();
+      vi.stubGlobal("fetch", fetch);
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value:
+          clipboardState === "absent"
+            ? undefined
+            : {
+                writeText: vi
+                  .fn()
+                  .mockRejectedValue(
+                    new DOMException("Denied", "NotAllowedError"),
+                  ),
+              },
+      });
+      const plan = {
+        ...emptyPlan(),
+        age: "under_55" as const,
+        route: "property" as const,
+        property: "owns_qualifying_strata" as const,
+        capital: "ready_130k" as const,
+      };
+      const { rerender } = render(
+        <SavePlanBar plan={plan} onClear={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Copy plan link" }));
+      const input = (await screen.findByRole("textbox", {
+        name: "Plan link",
+      })) as HTMLInputElement;
+      const url = new URL(input.value);
+      expect(url.pathname).toBe("/visa/second-home/studio");
+      expect(url.search).toBe("");
+      expect(decodePlanFragment(url.hash.slice(3))).toEqual({
+        ...plan,
+        capital: null,
+      });
+      input.focus();
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(input.value.length);
+      expect(screen.getByRole("status")).not.toHaveTextContent(
+        "Plan link copied",
+      );
+      expect(screen.getByRole("status")).toHaveTextContent(/select and copy/i);
+      expect(fetch).not.toHaveBeenCalled();
+      rerender(
+        <SavePlanBar
+          plan={{ ...plan, checklist: { passport_bio_page: true } }}
+          onClear={vi.fn()}
+        />,
+      );
+      expect(
+        decodePlanFragment(new URL(input.value).hash.slice(3))?.checklist,
+      ).toEqual({ passport_bio_page: true });
+    },
+  );
+
+  it("confirms a successful copy and removes the manual fallback on retry", async () => {
+    const writeText = vi
+      .fn()
+      .mockRejectedValueOnce(new DOMException("Denied", "NotAllowedError"))
+      .mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    render(<SavePlanBar plan={emptyPlan()} onClear={vi.fn()} />);
+    const copyButton = screen.getByRole("button", { name: "Copy plan link" });
+    fireEvent.click(copyButton);
+    await screen.findByRole("textbox", { name: "Plan link" });
+    fireEvent.click(copyButton);
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Plan link copied"),
+    );
+    expect(
+      screen.queryByRole("textbox", { name: "Plan link" }),
+    ).not.toBeInTheDocument();
+  });
+});
 
 describe("SavePlanBar resting-state boundary (WCAG 2.2 SC 1.4.11)", () => {
   // Regression guard (2026-09-01): Save/Copy-Link/Print share `buttonStyle`,

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -335,25 +335,43 @@ const clearButtonLayoutStyle: React.CSSProperties = {
  *  abandoned-branch answer (e.g. a leftover `capital` value after
  *  switching to the property route) never leaks into a shared link. */
 export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
-  const [savedFeedback, setSavedFeedback] = useState(false);
-  const [copiedFeedback, setCopiedFeedback] = useState(false);
+  const [feedback, setFeedback] = useState<
+    | "savedConfirmation"
+    | "saveFailed"
+    | "copiedConfirmation"
+    | "copyFailed"
+    | null
+  >(null);
+  const [showManualLink, setShowManualLink] = useState(false);
+
+  useEffect(() => {
+    if (feedback !== "savedConfirmation" && feedback !== "copiedConfirmation")
+      return;
+    const timeout = window.setTimeout(() => setFeedback(null), 2500);
+    return () => window.clearTimeout(timeout);
+  }, [feedback]);
+
+  function planLink(): string {
+    if (typeof window === "undefined") return "";
+    return `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(relevantPlan(plan))}`;
+  }
 
   function handleSave() {
-    savePlan(plan);
-    setSavedFeedback(true);
-    window.setTimeout(() => setSavedFeedback(false), 2500);
+    const saved = savePlan(plan);
+    setFeedback(saved ? "savedConfirmation" : "saveFailed");
+    setShowManualLink(!saved);
   }
 
   async function handleCopyLink() {
     if (typeof window === "undefined") return;
-    const url = `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(relevantPlan(plan))}`;
+    setFeedback(null);
     try {
-      await navigator.clipboard.writeText(url);
-      setCopiedFeedback(true);
-      window.setTimeout(() => setCopiedFeedback(false), 2500);
+      await navigator.clipboard.writeText(planLink());
+      setFeedback("copiedConfirmation");
+      setShowManualLink(false);
     } catch {
-      // Clipboard blocked (permissions/private mode) — silent no-op; the
-      // user can still select the link text manually if we ever render it.
+      setFeedback("copyFailed");
+      setShowManualLink(true);
     }
   }
 
@@ -477,7 +495,7 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
         </button>
       </div>
       <div role="status" aria-live="polite" style={{ minHeight: "1.2em" }}>
-        {savedFeedback ? (
+        {feedback ? (
           <p
             style={{
               margin: 0,
@@ -485,18 +503,7 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
               color: "var(--text-primary)",
             }}
           >
-            {getCopy("savePlanBar.savedConfirmation")}
-          </p>
-        ) : null}
-        {copiedFeedback ? (
-          <p
-            style={{
-              margin: 0,
-              fontSize: "var(--text-sm, 0.85rem)",
-              color: "var(--text-primary)",
-            }}
-          >
-            {getCopy("savePlanBar.copiedConfirmation")}
+            {getCopy(`savePlanBar.${feedback}`)}
           </p>
         ) : null}
         {clearArmed ? (
@@ -511,6 +518,31 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
           </p>
         ) : null}
       </div>
+      {showManualLink ? (
+        <label
+          style={{
+            display: "grid",
+            gap: "var(--space-2, 0.5rem)",
+            minWidth: 0,
+          }}
+        >
+          {getCopy("savePlanBar.manualLinkLabel")}
+          <input
+            type="text"
+            readOnly
+            value={planLink()}
+            onFocus={(event) => event.currentTarget.select()}
+            style={{
+              ...buttonStyle,
+              cursor: "text",
+              width: "100%",
+              minWidth: 0,
+              boxSizing: "border-box",
+              background: "var(--surface-base)",
+            }}
+          />
+        </label>
+      ) : null}
       <p
         style={{
           margin: 0,

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
@@ -146,7 +146,7 @@ describe("savePlan / loadPlan — localStorage roundtrip", () => {
       route: "deposit",
       capital: "ready_130k",
     };
-    savePlan(plan);
+    expect(savePlan(plan)).toBe(true);
     expect(loadPlan()).toEqual(plan);
   });
 
@@ -171,6 +171,23 @@ describe("savePlan / loadPlan — localStorage roundtrip", () => {
     );
     expect(loadPlan()).toBeNull();
   });
+
+  it.each(["SecurityError", "QuotaExceededError"])(
+    "returns false when storage rejects the write with %s",
+    (name) => {
+      const setItem = vi
+        .spyOn(window.localStorage, "setItem")
+        .mockImplementation(() => {
+          throw new DOMException("Cannot store plan", name);
+        });
+      try {
+        expect(savePlan(emptyPlan())).toBe(false);
+        expect(loadPlan()).toBeNull();
+      } finally {
+        setItem.mockRestore();
+      }
+    },
+  );
 });
 
 describe("clearPlan — SavePlanBar 'Clear saved plan' action", () => {
@@ -337,6 +354,7 @@ describe("P2-C12 — a throwing localStorage GETTER never crashes the codec", ()
 
   it("savePlan is a safe no-op and never throws", () => {
     expect(() => savePlan(emptyPlan())).not.toThrow();
+    expect(savePlan(emptyPlan())).toBe(false);
   });
 
   it("clearPlan is a safe no-op and never throws", () => {
@@ -352,6 +370,7 @@ describe("SSR-safety — functions never throw when window is undefined", () => 
   it("savePlan is a no-op and loadPlan returns null without window", () => {
     vi.stubGlobal("window", undefined);
     expect(() => savePlan(emptyPlan())).not.toThrow();
+    expect(savePlan(emptyPlan())).toBe(false);
     expect(loadPlan()).toBeNull();
   });
 

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -470,8 +470,13 @@ export const COPY = {
     body: "Your saved plan stays on this device unless you copy and share its link.",
     saveButton: "Save on this device",
     savedConfirmation: "Plan saved on this device",
+    saveFailed:
+      "This browser couldn't save your plan. Copy the link below or save a PDF to keep it.",
     copyLinkButton: "Copy plan link",
     copiedConfirmation: "Plan link copied",
+    copyFailed:
+      "Copying is unavailable in this browser. Select and copy the plan link below.",
+    manualLinkLabel: "Plan link",
     printButton: "Print / Save as PDF",
     linkWarning:
       "Anyone who receives the link may be able to view the answers it contains.",

--- a/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
+++ b/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
@@ -143,12 +143,15 @@ function isValidPlanShape(value: unknown): value is PlanState {
   return true;
 }
 
-export function savePlan(p: PlanState): void {
-  if (!hasLocalStorage()) return;
+/** True only after storage accepts the write, so callers can give honest feedback. */
+export function savePlan(p: PlanState): boolean {
+  if (!hasLocalStorage()) return false;
   try {
     window.localStorage.setItem(PLAN_STORAGE_KEY, JSON.stringify(p));
+    return true;
   } catch {
-    // Storage full, blocked (private mode), or unavailable — no-op.
+    // Storage full, blocked (private mode), or unavailable — keep the plan in memory.
+    return false;
   }
 }
 

--- a/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/brief.yml
@@ -13,8 +13,12 @@ acceptance:
     probe: SavePlanBar.test.tsx
   - text: WHEN the manual link is used it SHALL contain the current relevant plan only in the URL fragment and make no network call.
     probe: SavePlanBar.test.tsx
+  - text: WHEN the consent banner is open the manual link SHALL remain fully visible and keyboard/pointer usable at maximum scroll at 320 and 390 pixels.
+    probe: exercise-320.js
+  - text: The local banner reservation SHALL follow its rendered height and disappear on dismissal, subsequent absent-banner loads and print.
+    probe: exercise-390.js
 consumer_map:
   - Second Home Studio plan save and copy controls at /visa/second-home/studio.
 risks:
-  - Synthetic browser API failures do not prove real-browser behavior or production rollout.
+  - Local Chrome fault injection verifies browser behavior but does not establish production rollout or real client persistence.
 grader: Independent Anthropic review requested from the Fable consul; no verdict asserted here.

--- a/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/brief.yml
@@ -1,0 +1,20 @@
+task_id: studio-save-feedback
+gear: 2
+l_level: L2
+gate_class: opus
+objective: Make Second Home Studio plan saving and copying truthful and recoverable when browser APIs fail.
+constraints:
+  - Plan persistence and recovery remain browser-local; sharing uses the existing sanitized URL fragment.
+  - No backend, pricing, regulatory, credential or production data changes.
+acceptance:
+  - text: WHEN storage rejects a write the Studio SHALL not report that the plan was saved.
+    probe: SavePlanBar.test.tsx
+  - text: WHEN clipboard access is denied or absent the Studio SHALL offer a selectable plan link.
+    probe: SavePlanBar.test.tsx
+  - text: WHEN the manual link is used it SHALL contain the current relevant plan only in the URL fragment and make no network call.
+    probe: SavePlanBar.test.tsx
+consumer_map:
+  - Second Home Studio plan save and copy controls at /visa/second-home/studio.
+risks:
+  - Synthetic browser API failures do not prove real-browser behavior or production rollout.
+grader: Independent Anthropic review requested from the Fable consul; no verdict asserted here.

--- a/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/pack.yml
@@ -1,0 +1,28 @@
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: studio-plan-persistence
+    role: build
+    seat: gpt-6-astra
+dissent: []
+pii_scan: clean
+seat_override: >-
+  R8 applicability only: this visa-route UI change authors no immigration or pricing claim.
+  It handles browser storage and clipboard failures using the existing plan codec and relevance filter.
+receipts:
+  - claim: Plan persistence, manual recovery, Studio integration and copy-claim regressions pass.
+    cmd: >-
+      cd apps/mouth && npx vitest run
+      src/lib/secondhome-studio/__tests__/plan-codec.test.ts
+      src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+      src/app/visa/second-home/studio/StudioApp.test.tsx
+      src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
+      --maxWorkers=1 --reporter=json --outputFile=/tmp/s01-save-feedback-fixed.json
+    result: "4 test files passed; 180 tests passed; 0 failed."
+    exit: 0
+    ts: "2026-09-05T06:32:13.814Z"
+    seat: gpt-6-astra
+notes:
+  - The same final codec and component regressions on original HEAD sources failed 10 tests and passed 56; corrected sources were restored byte-for-byte afterward.
+  - Failure injection targets window.localStorage because the test setup uses LocalStorageMock, not the browser Storage prototype.
+  - Independent review, CI, real-browser QA and production proof remain pending.
+  - The Fable consul owns independent review and the controlled shipping path.

--- a/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/pack.yml
@@ -7,22 +7,52 @@ dissent: []
 pii_scan: clean
 seat_override: >-
   R8 applicability only: this visa-route UI change authors no immigration or pricing claim.
-  It handles browser storage and clipboard failures using the existing plan codec and relevance filter.
+  It handles browser storage and clipboard failures using the existing plan codec and relevance filter,
+  and reserves the actual local consent-banner height so recovery controls remain reachable.
 receipts:
   - claim: Plan persistence, manual recovery, Studio integration and copy-claim regressions pass.
     cmd: >-
-      cd apps/mouth && npx vitest run
+      cd apps/mouth && npx --no-install vitest run
       src/lib/secondhome-studio/__tests__/plan-codec.test.ts
       src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
       src/app/visa/second-home/studio/StudioApp.test.tsx
       src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
-      --maxWorkers=1 --reporter=json --outputFile=/tmp/s01-save-feedback-fixed.json
+      --maxWorkers=1 --reporter=json --outputFile=/tmp/s01-clearance-fixed.json
     result: "4 test files passed; 180 tests passed; 0 failed."
     exit: 0
-    ts: "2026-09-05T06:32:13.814Z"
+    ts: "2026-09-05T07:24:55.903Z"
+    seat: gpt-6-astra
+  - claim: Real Chrome preserves all three recovery paths and keeps the full manual input above the open banner at 320 pixels.
+    cmd: >-
+      ssh pro 'cd /Users/nuzantara/nuzantara/.worktrees/mouth-studio-s01-clearance-qa &&
+      /opt/homebrew/bin/node /Users/nuzantara/.npm/_npx/31e32ef8478fbf80/node_modules/@playwright/cli/playwright-cli.js
+      --session s01-clearance-320 run-code --filename output/playwright/s01-clearance/exercise-320.js'
+    result: >-
+      PASS: input bottom 510.828125 < banner top 699 at maximum scroll;
+      reservation 145 equals banner height 145; all three pointer hit targets reach the input;
+      keyboard and pointer selection 380/380. Resize and enlarged text update the reservation;
+      dismissed and absent banner reserve zero; print display none and zero height.
+    exit: 0
+    ts: "2026-09-05T07:28:20.650Z"
+    seat: gpt-6-astra
+  - claim: Real Chrome confirms the same recovery and banner lifecycle at 390 pixels.
+    cmd: >-
+      ssh pro 'cd /Users/nuzantara/nuzantara/.worktrees/mouth-studio-s01-clearance-qa &&
+      /opt/homebrew/bin/node /Users/nuzantara/.npm/_npx/31e32ef8478fbf80/node_modules/@playwright/cli/playwright-cli.js
+      --session s01-clearance-390 run-code --filename output/playwright/s01-clearance/exercise-390.js'
+    result: >-
+      PASS: input bottom 531.90625 < banner top 699; document/body widths equal 390;
+      reservation equals actual banner height and tracks enlarged text to 199.25 pixels.
+      All storage/clipboard, selection, resize, dismiss, reload and print checks passed.
+    exit: 0
+    ts: "2026-09-05T07:28:45.138Z"
     seat: gpt-6-astra
 notes:
   - The same final codec and component regressions on original HEAD sources failed 10 tests and passed 56; corrected sources were restored byte-for-byte afterward.
   - Failure injection targets window.localStorage because the test setup uses LocalStorageMock, not the browser Storage prototype.
-  - Independent review, CI, real-browser QA and production proof remain pending.
+  - The parent independently reran all four suites including StudioApp at 2026-09-05 15:27:39 WITA and reported 180/180 passing; existing React act and styled-jsx warnings remain.
+  - The exact cce13f6e baseline browser receipt records 9.90625 pixels of input occlusion with the banner open. The single local StudioApp correction adds no guessed spacing or global banner change.
+  - Browser source identity is cce13f6e plus StudioApp SHA-256 9b904e19f3da96203b532998aaa885163da78a62c208ae9d42d103a510951a8a; app-resolved Next CLI and runtime are both 16.3.3.
+  - The earlier root-CLI 16.3.1/app-runtime 16.3.3 receipt is retained as historical; current browser evidence uses aligned versions. Local telemetry HTTP 500 responses are expected with the backend intentionally unavailable.
+  - Independent Anthropic review, updated CI and production proof remain pending; no independent verdict is asserted.
   - The Fable consul owns independent review and the controlled shipping path.


### PR DESCRIPTION
Second Home Studio now confirms a save only after browser storage accepts the write. Storage failures and denied or absent clipboard access provide truthful feedback and a selectable, read-only plan link. The link uses the existing `relevantPlan` filter and URL fragment; recovery does not send a request.

The Studio also reserves the actual height of its existing fixed consent banner so the recovery field remains fully reachable on narrow screens. The local reservation follows resize and text reflow, becomes zero when the banner is dismissed or absent, and is removed from print. Global banner behavior and plan-processing logic are unchanged by the layout correction.

Bites: Second Home Studio at `/visa/second-home/studio` consumes the persistence/clipboard outcomes and measured banner height. Real Chrome at 320 and 390 px showed the full manual link above the open banner at maximum scroll, all three pointer hit targets reachable, and 380/380 characters selectable after both keyboard and pointer interaction. All three failure paths preserved truthful feedback.

Validation:

- Four existing Vitest files, including StudioApp integration: **180 passed, 0 failed**. The parent independently reran the same suites with the same result; existing React act/styled-jsx warnings remain.
- Corrected-environment Chrome used the app-resolved Next **16.3.3** launcher and runtime. Storage rejection, denied/missing clipboard, message lifetime, 320↔390 resize, enlarged banner text, dismissal/reload, and print checks passed.
- At maximum scroll, input bottom was **510.83 / 531.91 px**, above banner top **699 px** at 320 / 390 px. Reserved height equaled the actual banner height, including after text enlargement. Document/body widths equaled the viewport widths.
- Original failure evidence is retained: save/copy regressions failed against the original sources; the exact previous PR head also exposed **9.91 px** of banner occlusion before this single layout correction.
- Pre-commit hooks passed, including `tsc --noEmit`; ESLint, formatting, whitespace checks and staged branch-specific evidence validation passed. No hooks were bypassed.

Browser evidence uses synthetic data and injected local browser failures; production rollout and backend persistence are not established. Expected local telemetry HTTP 500 responses came from the deliberately unavailable backend. The earlier mixed Next-version receipt is retained separately and is superseded by the aligned-runtime checks. Source/runtime hashes, scripts, geometry and screenshots are available to the consul in `.worktrees/ops-visa-consuls/output/playwright/s01-banner-clearance/`.

## Adversarial review

Independent Anthropic review and updated CI remain pending. This draft does not assert an independent verdict or arm merge/deployment. No new immigration or pricing claim is introduced; the evidence retains the narrow R8 applicability override for browser recovery under an existing visa route.

Evidence: [brief](evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/brief.yml) and [pack](evidence/2026-09/agent-air-m5-mouth-studio-save-feedback-92de9ea4/pack.yml).
