### PR TITLE
fix(blog): reject unknown article categories in metadata

### DIFF
--- a/apps/mouth/src/app/(blog)/[category]/[slug]/page.metadata.test.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/[slug]/page.metadata.test.tsx
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getArticleByLocale, getArticleBySlug } from "@/lib/blog/articles";
+import { CATEGORY_MAP } from "@/lib/blog/categories";
+import { generateArticleMetadata } from "@/lib/blog/metadata";
+import type { Article, ArticleCategory } from "@/lib/blog/types";
+import { generateMetadata } from "./page";
+import { generateMetadata as categoryMetadata } from "../layout";
+
+vi.mock("@/lib/blog/articles", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/blog/articles")>()),
+  getArticleBySlug: vi.fn(),
+  getArticleByLocale: vi.fn(),
+}));
+vi.mock("./ArticleClient", () => ({ ArticleClient: () => null }));
+vi.mock("@/components/blog/MDXContentRSC", () => ({ renderMDXBody: vi.fn() }));
+vi.mock("next/navigation", async (importOriginal) =>
+  importOriginal<typeof import("next/navigation")>(),
+);
+
+const article: Article = {
+  id: "synthetic-article",
+  slug: "bali-digital-nomad-complete-guide",
+  title: "Synthetic article title",
+  excerpt: "Synthetic article description.",
+  content: "Synthetic article body.",
+  coverImage: "/static/og-image.jpg",
+  coverImageAlt: "Synthetic cover",
+  category: "living",
+  tags: [],
+  author: {
+    id: "synthetic-author",
+    name: "Test author",
+    avatar: "",
+    role: "Test",
+    isAI: false,
+  },
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  status: "published",
+  featured: false,
+  trending: false,
+  readingTime: 1,
+  viewCount: 0,
+  shareCount: 0,
+  likeCount: 0,
+  commentCount: 0,
+  aiGenerated: false,
+  relatedArticleIds: [],
+  locale: "en",
+};
+
+const metadata = (category: string, lang?: string, slug = article.slug) =>
+  generateMetadata({
+    params: Promise.resolve({ category, slug }),
+    searchParams: Promise.resolve(lang ? { lang } : {}),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getArticleBySlug).mockResolvedValue(article);
+  vi.mocked(getArticleByLocale).mockResolvedValue(article);
+});
+
+describe("article metadata category validation", () => {
+  // /blog/<real living slug> reproduced the defect: the parent renders its
+  // not-found boundary, while the child's fallback lookup finds a real article
+  // and overrides the parent's noindex metadata with index + googlebot.
+  for (const lang of [undefined, "fr"]) {
+    it.each(["blog", "not-a-category", "constructor", "toString"])(
+      `rejects /%s/<existing slug> before lookup (lang=${lang ?? "en"})`,
+      async (category) => {
+        const result = await metadata(category, lang);
+        const parent = await categoryMetadata({
+          params: Promise.resolve({ category: "not-a-category" }),
+        });
+        expect(result).toEqual({ title: parent.title, robots: parent.robots });
+        expect(getArticleBySlug).not.toHaveBeenCalled();
+        expect(getArticleByLocale).not.toHaveBeenCalled();
+      },
+    );
+  }
+
+  it.each<ArticleCategory>([
+    "visas",
+    "business",
+    "taxes",
+    "property",
+    "living",
+    "trends",
+  ])("preserves canonical /%s article metadata", async (category) => {
+    const current = { ...article, category };
+    vi.mocked(getArticleBySlug).mockResolvedValue(current);
+    expect(await metadata(category)).toEqual(generateArticleMetadata(current));
+    expect(getArticleBySlug).toHaveBeenCalledWith(category, article.slug);
+  });
+
+  it.each(
+    Object.entries(CATEGORY_MAP).filter(([alias, target]) => alias !== target),
+  )("preserves declared alias /%s -> /%s", async (alias, category) => {
+    const current = { ...article, category };
+    vi.mocked(getArticleBySlug).mockResolvedValue(current);
+    expect(await metadata(alias)).toEqual(generateArticleMetadata(current));
+    expect(getArticleBySlug).toHaveBeenCalledWith(alias, article.slug);
+  });
+
+  it.each([undefined, "fr"])(
+    "preserves article.noIndex (lang=%s)",
+    async (lang) => {
+      const archived = { ...article, noIndex: true };
+      vi.mocked(getArticleBySlug).mockResolvedValue(archived);
+      vi.mocked(getArticleByLocale).mockResolvedValue(archived);
+      const result = await metadata("living", lang);
+      expect(result).toEqual(generateArticleMetadata(archived));
+      expect(result.robots).toEqual({ index: false, follow: false });
+      if (lang) {
+        expect(getArticleByLocale).toHaveBeenCalledWith(
+          "living",
+          article.slug,
+          lang,
+        );
+        expect(getArticleBySlug).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("retains notFound for a missing article in a canonical category", async () => {
+    vi.mocked(getArticleBySlug).mockResolvedValue(null);
+    await expect(metadata("living")).rejects.toThrow(
+      "NEXT_HTTP_ERROR_FALLBACK;404",
+    );
+  });
+
+  it("retains the existing static-file rejection before lookup", async () => {
+    expect(await metadata("living", undefined, "cover.jpg")).toEqual({
+      title: "Not Found",
+    });
+    expect(getArticleBySlug).not.toHaveBeenCalled();
+    expect(getArticleByLocale).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx
+++ b/apps/mouth/src/app/(blog)/[category]/[slug]/page.tsx
@@ -90,6 +90,17 @@ export async function generateMetadata({
     return { title: "Not Found" };
   }
 
+  // Unknown categories otherwise fall back to a living article lookup, whose
+  // indexable metadata contradicts the parent layout's not-found boundary.
+  // Validate the resolved value too: Object.prototype names are not aliases.
+  const canonicalCategory = resolveCategoryAlias(category);
+  if (!canonicalCategory || !VALID_CATEGORIES.includes(canonicalCategory)) {
+    return {
+      title: "Page not found",
+      robots: { index: false, follow: false },
+    };
+  }
+
   try {
     const article = lang
       ? await getArticleByLocale(category, slug, lang)

--- a/evidence/2026-09/agent-air-m5-mouth-article-category-metadata-ae08eeb3/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-article-category-metadata-ae08eeb3/brief.yml
@@ -1,0 +1,20 @@
+task_id: article-category-metadata
+gear: 2
+l_level: L2
+gate_class: opus
+objective: Prevent unknown article categories from overriding the not-found boundary with indexable article metadata.
+constraints:
+  - Change only article generateMetadata and focused tests; preserve layouts, category mappings and editorial content.
+  - Preserve valid canonical categories, declared aliases, localized lookups and article.noIndex behavior.
+acceptance:
+  - text: WHEN a category is unknown the article metadata SHALL be nonindexable without looking up an article.
+    probe: page.metadata.test.tsx
+  - text: WHEN the category is canonical or a declared alias the article metadata SHALL retain the existing article behavior.
+    probe: page.metadata.test.tsx
+  - text: WHEN an article has noIndex or is missing the route SHALL retain its existing exclusion or not-found behavior.
+    probe: page.metadata.test.tsx
+consumer_map:
+  - Article-route generateMetadata for /[category]/[slug], including /blog/bali-digital-nomad-complete-guide.
+risks:
+  - Focused metadata tests do not prove a deployed rendered head; independent review and production proof remain pending.
+grader: Independent Anthropic review requested from the Fable consul; no verdict asserted here.

--- a/evidence/2026-09/agent-air-m5-mouth-article-category-metadata-ae08eeb3/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-article-category-metadata-ae08eeb3/pack.yml
@@ -1,0 +1,24 @@
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: article-category-metadata
+    role: build
+    seat: gpt-6-astra
+dissent: []
+pii_scan: clean
+receipts:
+  - claim: Article metadata and parent category regressions preserve canonical, alias, localization and noIndex behavior.
+    cmd: >-
+      cd apps/mouth && npx --no-install vitest run
+      'src/app/(blog)/[category]/[slug]/page.metadata.test.tsx'
+      'src/app/(blog)/[category]/page.metadata.test.tsx'
+      'src/app/(blog)/[category]/layout.test.tsx'
+      --maxWorkers=1 --reporter=json --outputFile=/tmp/b04-category-metadata-fixed.json
+    result: "3 test files passed; 72 tests passed; 0 failed."
+    exit: 0
+    ts: "2026-09-05T06:43:25.863Z"
+    seat: gpt-6-astra
+notes:
+  - Before the source fix the new focused suite failed 8 unknown-category cases and passed 24 controls.
+  - The production probe reproduced conflicting index and noindex tags on the invalid /blog URL; the canonical /living article is separately indexable and present in the sitemap.
+  - This change handles invalid-route metadata only; it does not change article content or its indexing policy.
+  - The Fable consul owns independent review and the controlled shipping path; CI, real-browser QA and production proof remain pending.


### PR DESCRIPTION
## Behavior

`/blog/bali-digital-nomad-complete-guide` reaches an unknown category. Its parent layout renders the not-found boundary, but the article lookup falls back to `living` and the child previously emitted the real article's indexable metadata. The served HTML consequently contained both `index, follow` and `noindex`.

Article `generateMetadata` now rejects unknown categories before article lookup and returns the same not-found title and robots policy as the category layout. Canonical categories, declared aliases, localized lookups, `article.noIndex`, and existing static-file and missing-article behavior are preserved.

Bites: The `/[category]/[slug]` article route consumes this validation during metadata generation. Focused regressions observe nonindexable metadata without article lookup. Local full-app production builds at exact commit `32c9734f8ac0323ca782e50d39d542fcde221895` confirm that the invalid route no longer emits conflicting positive `index` metadata; canonical and excluded article controls retain their correct policies. This is local production-build evidence, not a deployed-production observation.

## Remaining requirement: exactly one robots tag is NOT passed

The exact app was built and exercised with both CLI and application resolving Next 16.3.3, React 19.2.8 and Node 26.5.0 on Pro. Chrome 152.0.7977.82 inspected the loaded DOM. Both `next start` and `next dev --webpack` produce the same counts:

| Source | Invalid HTTP HTML | Googlebot-UA HTTP HTML | Loaded Chrome DOM |
| --- | ---: | ---: | ---: |
| Committed semantic fix | 2 | 2 | 3 |
| One private `robots: null` candidate | 1 | 1 | 2 |

The committed fix removes conflicting positive `index` instructions but does not meet the one-tag requirement. The same previously documented null candidate also fails that requirement in a production build; it was not committed or pushed. Canonical and already excluded controls each retain one correct robots tag in every mode and surface. Existing streamed not-found status behavior is unchanged.

Pinned framework source and browser mutations support two contributions from the server error insertion and client HTTP fallback boundary. Removing child metadata does not remove both. No additional variant or framework/layout workaround was implemented. The literal browser criterion remains unmet and must not be inferred from green CI.

Earlier receipts labelled Next 16.3.1 used a root CLI 16.3.1 with app-resolved dependencies 16.3.3. Those historical observations are retained with this limitation. The first full-app build with that mixed launcher failed during unrelated prerendering; changing only to the application-resolved CLI allowed both full builds to succeed. The aligned receipts supersede the earlier version interpretation.

## Validation

- Original-source focused regressions: 8 failed, 24 passed.
- Committed article metadata and existing category metadata/layout suites: 72 passed across three files.
- Full committed and private-candidate production builds: exit 0, TypeScript and all 1,766 static pages completed.
- ESLint, Prettier, staged checks, normal commit/push hooks, and branch-specific evidence validation passed.
- Exact app source and environment, build logs, HTTP/DOM receipts, framework evidence and failure specification: `.worktrees/ops-visa-consuls/output/reviews/b04-robots-production/`.
- Synthetic inputs and public tracked article controls; no deployed-production requests. Private source restored, candidate build quarantined from the restored source, owned browser/server closed.

## Independent review

The Fable consul is asked to review the semantic fix with the unresolved one-tag limitation above. Independent review remains pending; this draft asserts no independent verdict and does not arm merge or deployment.

The source change is 11 lines in `generateMetadata`, with one adjacent test file and task evidence. Editorial content, category mappings and layouts are unchanged.

Evidence: [brief](evidence/2026-09/agent-air-m5-mouth-article-category-metadata-ae08eeb3/brief.yml) and [pack](evidence/2026-09/agent-air-m5-mouth-article-category-metadata-ae08eeb3/pack.yml).
