### PR TITLE
test(mouth): enforce same-origin browser API clients

### DIFF
--- a/apps/mouth/DOCUMENTATION.md
+++ b/apps/mouth/DOCUMENTATION.md
@@ -294,8 +294,7 @@ apps/mouth/
 ```bash
 # .env.local
 
-# Backend API
-NEXT_PUBLIC_API_URL=https://nuzantara-rag.fly.dev
+# Backend API (server only; browser clients use the same-origin /api proxy)
 NUZANTARA_API_URL=https://nuzantara-rag.fly.dev
 
 # WebSocket
@@ -345,7 +344,8 @@ Or use Vercel dashboard/GitHub integration for automatic deployments.
 
 **Environment Variables (Vercel Dashboard):**
 
-- `NEXT_PUBLIC_API_URL` - Backend API URL (https://nuzantara-rag.fly.dev)
+- `NUZANTARA_API_URL` - Server-side backend URL (https://nuzantara-rag.fly.dev). Browser clients use `/api`, forwarded by `src/app/api/[...path]/route.ts`, to preserve same-origin authentication and CSRF handling.
+- `NEXT_PUBLIC_API_URL` - Legacy fallback in server routes, after `NUZANTARA_API_URL`. Do not use it as a browser API base URL.
 - `NEXT_PUBLIC_FRONTEND_URL` - Frontend URL (https://www.balizero.com)
 - `SENTRY_DSN` - Error tracking
 
@@ -574,7 +574,7 @@ class ApiClientBase {
   protected token: string | null;
 
   constructor(baseUrl?: string) {
-    this.baseUrl = baseUrl || process.env.NEXT_PUBLIC_API_URL;
+    this.baseUrl = baseUrl || "/api";
     this.token = localStorage.getItem("auth_token");
   }
 

--- a/apps/mouth/DOCUMENTATION.md
+++ b/apps/mouth/DOCUMENTATION.md
@@ -294,7 +294,7 @@ apps/mouth/
 ```bash
 # .env.local
 
-# Backend API (server only; browser clients use the same-origin /api proxy)
+# Backend API (server only; src/app browser clients use the same-origin /api proxy)
 NUZANTARA_API_URL=https://nuzantara-rag.fly.dev
 
 # WebSocket
@@ -344,7 +344,7 @@ Or use Vercel dashboard/GitHub integration for automatic deployments.
 
 **Environment Variables (Vercel Dashboard):**
 
-- `NUZANTARA_API_URL` - Server-side backend URL (https://nuzantara-rag.fly.dev). Browser clients use `/api`, forwarded by `src/app/api/[...path]/route.ts`, to preserve same-origin authentication and CSRF handling.
+- `NUZANTARA_API_URL` - Server-side backend URL (https://nuzantara-rag.fly.dev). Browser clients under `src/app` use `/api`, forwarded by `src/app/api/[...path]/route.ts`, to preserve same-origin authentication and CSRF handling. The guard scans `src/app` only; it does not cover browser references in `src/lib`, hooks, or transitive imports.
 - `NEXT_PUBLIC_API_URL` - Legacy fallback in server routes, after `NUZANTARA_API_URL`. Do not use it as a browser API base URL.
 - `NEXT_PUBLIC_FRONTEND_URL` - Frontend URL (https://www.balizero.com)
 - `SENTRY_DSN` - Error tracking
@@ -566,15 +566,17 @@ import { Toast } from "@/components/ui/toast";
 
 ### API Client Base
 
+`ApiClientBase` requires an explicit `baseUrl`; the constructor does not supply a default.
+
 ```typescript
-// /lib/api/client.ts
+// src/lib/api/client.ts (abridged)
 
 class ApiClientBase {
   protected baseUrl: string;
   protected token: string | null;
 
-  constructor(baseUrl?: string) {
-    this.baseUrl = baseUrl || "/api";
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
     this.token = localStorage.getItem("auth_token");
   }
 

--- a/apps/mouth/src/app/api-client-same-origin.test.ts
+++ b/apps/mouth/src/app/api-client-same-origin.test.ts
@@ -1,0 +1,130 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const APP_DIR = dirname(fileURLToPath(import.meta.url));
+const FORBIDDEN = "NEXT_PUBLIC_API_URL";
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const file = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(file);
+    return /\.[jt]sx?$/.test(file) && !/\.(test|spec|d)\.[jt]sx?$/.test(file)
+      ? [file]
+      : [];
+  });
+}
+
+function inspect(
+  file: string,
+  source: string,
+): { browser: boolean; hits: string[] } {
+  const tree = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+  // Next's client boundary is a module directive, not a directory property:
+  // route.ts and Server Components in the same segment still run on the server.
+  const directives: string[] = [];
+  for (const statement of tree.statements) {
+    if (
+      !ts.isExpressionStatement(statement) ||
+      !ts.isStringLiteral(statement.expression)
+    )
+      break;
+    directives.push(statement.expression.text);
+  }
+  const browser =
+    basename(file) === "api-client.ts" || directives.includes("use client");
+  const hits: string[] = [];
+  if (browser) {
+    const visit = (node: ts.Node): void => {
+      // Match the exact name regardless of receiver, excluding comments.
+      // StringLiteralLike also covers env[`NAME`].
+      if (
+        (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) &&
+        node.text === FORBIDDEN
+      ) {
+        const { line } = tree.getLineAndCharacterOfPosition(
+          node.getStart(tree),
+        );
+        hits.push(
+          `${file}:${line + 1}: browser API calls must use the same-origin /api proxy`,
+        );
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(tree);
+  }
+  return { browser, hits };
+}
+
+describe("browser API clients stay on the same-origin proxy", () => {
+  it("checks the real app, including all three GARUDA API clients", () => {
+    const inspected = sourceFiles(APP_DIR).map((file) => ({
+      file: relative(APP_DIR, file),
+      ...inspect(relative(APP_DIR, file), readFileSync(file, "utf8")),
+    }));
+    const browserFiles = inspected
+      .filter((entry) => entry.browser)
+      .map((entry) => entry.file);
+    expect(browserFiles.length).toBeGreaterThan(100);
+    expect(browserFiles).toEqual(
+      expect.arrayContaining([
+        "(workspace)/garuda-voa/api-client.ts",
+        "visa/voa/orders/api-client.ts",
+        "visa/voa/upload/api-client.ts",
+      ]),
+    );
+    expect(inspected.flatMap((entry) => entry.hits)).toEqual([]);
+  });
+
+  it.each([
+    [
+      "visa/example/api-client.ts",
+      "export const base = process.env.NEXT_PUBLIC_API_URL;",
+    ],
+    [
+      "visa/example/page.tsx",
+      '"use client"; const base = process.env.NEXT_PUBLIC_API_URL;',
+    ],
+    [
+      "visa/example/page.tsx",
+      '"use client"; const base = process.env["NEXT_PUBLIC_API_URL"];',
+    ],
+    [
+      "visa/example/page.tsx",
+      '"use client"; const base = process.env[`NEXT_PUBLIC_API_URL`];',
+    ],
+  ])("rejects executable browser references in %s", (file, source) => {
+    expect(inspect(file, source).hits).toEqual([
+      expect.stringContaining(`${file}:1:`),
+    ]);
+  });
+
+  it("does not turn explanatory comments into violations or client directives", () => {
+    expect(
+      inspect(
+        "visa/example/api-client.ts",
+        `// ${FORBIDDEN} caused the incident\n/* ${FORBIDDEN} */\nexport const base = "/api";`,
+      ).hits,
+    ).toEqual([]);
+    expect(
+      inspect(
+        "visa/example/page.tsx",
+        `// "use client"\nconst base = process.env.${FORBIDDEN};`,
+      ).browser,
+    ).toBe(false);
+  });
+
+  it.each([
+    "api/auth/login/route.ts",
+    "api/portal/deadlines/ical/route.ts",
+    "visa/voa/auth/continue/page.tsx",
+  ])("preserves legitimate server-side configuration in %s", (file) => {
+    // Login and calendar proxy upstream requests; continue renders a server-only
+    // magic-link preview. None is browser code, so none needs a blanket exemption.
+    const source = readFileSync(join(APP_DIR, file), "utf8");
+    expect(source).toContain(`process.env.${FORBIDDEN}`);
+    expect(inspect(file, source)).toEqual({ browser: false, hits: [] });
+  });
+});

--- a/apps/mouth/src/app/api-client-same-origin.test.ts
+++ b/apps/mouth/src/app/api-client-same-origin.test.ts
@@ -58,7 +58,7 @@ function inspect(
   return { browser, hits };
 }
 
-describe("browser API clients stay on the same-origin proxy", () => {
+describe("src/app browser API clients stay on the same-origin proxy", () => {
   it("checks the real app, including all three GARUDA API clients", () => {
     const inspected = sourceFiles(APP_DIR).map((file) => ({
       file: relative(APP_DIR, file),
@@ -124,7 +124,6 @@ describe("browser API clients stay on the same-origin proxy", () => {
     // Login and calendar proxy upstream requests; continue renders a server-only
     // magic-link preview. None is browser code, so none needs a blanket exemption.
     const source = readFileSync(join(APP_DIR, file), "utf8");
-    expect(source).toContain(`process.env.${FORBIDDEN}`);
     expect(inspect(file, source)).toEqual({ browser: false, hits: [] });
   });
 });

--- a/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/brief.yml
@@ -1,5 +1,5 @@
 gear: 1
-objective: Prevent direct backend origins in browser-facing app API clients.
+objective: Prevent direct backend origins in src/app browser API clients without blocking server cleanup.
 scope:
   - apps/mouth/src/app/api-client-same-origin.test.ts
   - apps/mouth/DOCUMENTATION.md
@@ -7,10 +7,11 @@ constraints:
   - No runtime changes, no server-side URL restriction, no import-graph policy.
   - No client data, credentials, production writes, merge or deploy.
 acceptance:
-  - Current app scan and browser/server/comment controls pass.
-  - A temporary app api-client.ts reading NEXT_PUBLIC_API_URL fails naming its path;
-    restoring the tree passes.
-  - Required frontend CI executes this new test.
+  - WHEN the current src/app tree is scanned, the browser/server/comment controls SHALL pass.
+  - WHEN a temporary app api-client.ts reads NEXT_PUBLIC_API_URL, the guard SHALL fail naming its path.
+  - WHEN legacy server env references are removed, innocence controls SHALL still pass.
+  - WHEN reading the documented constructor, baseUrl SHALL be required without a default.
+  - WHEN required frontend CI runs, it SHALL execute this test.
 consumer_map:
   - Vitest includes src/**/*.test.{ts,tsx} through apps/mouth/vitest.config.ts; existing
     frontend CI consumes this test.

--- a/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/brief.yml
@@ -1,0 +1,16 @@
+gear: 1
+objective: Prevent direct backend origins in browser-facing app API clients.
+scope:
+  - apps/mouth/src/app/api-client-same-origin.test.ts
+  - apps/mouth/DOCUMENTATION.md
+constraints:
+  - No runtime changes, no server-side URL restriction, no import-graph policy.
+  - No client data, credentials, production writes, merge or deploy.
+acceptance:
+  - Current app scan and browser/server/comment controls pass.
+  - A temporary app api-client.ts reading NEXT_PUBLIC_API_URL fails naming its path;
+    restoring the tree passes.
+  - Required frontend CI executes this new test.
+consumer_map:
+  - Vitest includes src/**/*.test.{ts,tsx} through apps/mouth/vitest.config.ts; existing
+    frontend CI consumes this test.

--- a/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/depth1-kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/depth1-kimi-review.txt
@@ -1,0 +1,13 @@
+• **PASS**
+
+  Checked the candidate diff against Fable's three rulings, using only the supplied source:
+
+  **Ruling 1 — required `baseUrl`, documented.** `apps/mouth/DOCUMENTATION.md` now states "`ApiClientBase` requires an explicit `baseUrl`; the constructor does not supply a default" and the snippet shows `constructor(baseUrl: string)` with no `|| "/api"` fallback. This matches the grounded actual constructor at `client.ts:43-74` (`constructor(baseUrl: string) { this.baseUrl = baseUrl; ...`). The remaining `localStorage.getItem` line in the snippet is pre-existing abridged material (real code guards on `typeof window` and uses `safeStorage`), explicitly out of scope per the brief.
+
+  **Ruling 2 — reverse-lock removed.** The diff deletes `expect(source).toContain(\`process.env.${FORBIDDEN}\`)` from the server-innocence test in `api-client-same-origin.test.ts`. The final guard source confirms it is gone, while the meaningful assertion (`inspect(file, source)).toEqual({ browser: false, hits: [] })`) is retained, so the three server files are still verified as non-browser with zero hits. `FORBIDDEN` remains used elsewhere in the file, so no dead-constant fallout. Later env cleanup is no longer blocked by the test.
+
+  **Ruling 3 — scope narrowed to `src/app`, scanner unchanged.** The `describe` is renamed to "src/app browser API clients stay on the same-origin proxy", and both doc hunks now say "src/app browser clients". The added doc sentence — "The guard scans `src/app` only; it does not cover browser references in `src/lib`, hooks, or transitive imports" — is demonstrably accurate: `APP_DIR` is `dirname(fileURLToPath(import.meta.url))` of a test located in `src/app/`, and the final scanner source is byte-identical in logic to the pre-correction version (no expansion to lib/hooks/transitives).
+
+  **Scope discipline.** The diff touches only `apps/mouth/DOCUMENTATION.md` and the test file — docs/test, as owned. No runtime files changed; the 9-test suite structure (real-app scan, 4 rejection cases, comment/directive non-flagging, 3 server-innocence cases) is intact.
+
+  No demonstrable correctness or scope defects found. (Per instructions, no tests were executed by me; this is source review only.)

--- a/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/depth1-receipts.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/depth1-receipts.yml
@@ -1,0 +1,59 @@
+rework_base: ac8b2ce25acf
+depth: 1
+builder: OpenAI GPT-6 (exact backend variant not exposed)
+source_sha256:
+  apps/mouth/DOCUMENTATION.md: 847ba2339be408381d4191c18fdc513396e20d5a71e5962a8c9a456e3625a9d7 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  apps/mouth/src/app/api-client-same-origin.test.ts: 09b7b94cb276ac8a61efe39dd3ed10b5ba4d5893f53a79b50607ceb12c2dabc1 # pragma: allowlist secret - verified artifact SHA-256, not credential
+review:
+  seat: kimi-code/k3
+  started_at: "2026-09-05T13:25:12.316120+00:00"
+  prompt_sha256: f7e76ffcc610ea684a05db6aee1d3ece41eb860605fe094247d0d354234d3e09 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  timeout_seconds: 240
+  environment_keys:
+    - HOME
+    - PATH
+    - LANG
+    - LC_ALL
+    - TERM
+    - TMPDIR
+    - USER
+    - SHELL
+  command: /Users/balizero/.kimi-code/bin/kimi -m kimi-code/k3 -p <supplied prompt>
+  exit: 0
+  finished_at: "2026-09-05T13:26:25.469971+00:00"
+  stdout_sha256: a7d296f14d9a0c0ed15bf40cbb59d124df571cb6b0a12f900f2ed4889c3b5933 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  committed_answer_sha256: 4f32749f74a7745ca14b6fe52013f0e784935e630d1d1f50c436bd6d339f4aac # pragma: allowlist secret - verified artifact SHA-256, not credential
+probes:
+  - name: browser-guilt
+    command: npx --offline vitest run src/app/api-client-same-origin.test.ts
+    cwd: apps/mouth
+    started_at: "2026-09-05T13:25:36.593232+00:00"
+    finished_at: "2026-09-05T13:25:40.847551+00:00"
+    exit: 1
+    log_sha256: 0ec597cbb0f250a761c7db0905d9b5e69b7f49c8c465e5bae38c3fbc4a6eb23f # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - name: server-cleanup-innocence
+    command: npx --offline vitest run src/app/api-client-same-origin.test.ts
+    cwd: apps/mouth
+    started_at: "2026-09-05T13:25:40.848767+00:00"
+    finished_at: "2026-09-05T13:25:45.825100+00:00"
+    exit: 0
+    log_sha256: 99e4226fd6d460e30b8672bb01ec2681c7bed3c24a84da8d465e4c396d7f8b0a # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - name: reverse-lock-guilt
+    command: npx --offline vitest run src/app/api-client-same-origin.test.ts
+    cwd: apps/mouth
+    started_at: "2026-09-05T13:25:45.825576+00:00"
+    finished_at: "2026-09-05T13:25:50.368165+00:00"
+    exit: 1
+    log_sha256: ac2f5fa0d4b355b780a63e5d2aaf609a0aaa5bcb0d9853ff496d5b307d3a2eed # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - name: restored-candidate
+    command: npx --offline vitest run src/app/api-client-same-origin.test.ts
+    cwd: apps/mouth
+    started_at: "2026-09-05T13:25:50.369323+00:00"
+    finished_at: "2026-09-05T13:25:55.015048+00:00"
+    exit: 0
+    log_sha256: da1d70ea710110e8a52582aa849d99cda63d4d73b72aa4f6ff3bde45a287d94b # pragma: allowlist secret - verified artifact SHA-256, not credential
+probe_driver_sha256: d0d72c4fd6aa0b5e9125249453a38a8656fa6a1d874e943d2b39f033f8a7045f # pragma: allowlist secret - verified artifact SHA-256, not credential
+notes:
+  - Server cleanup was simulated in memory by removing env access from read source; no handler file changed.
+  - Probe driver is local .agent/x01-depth1/probes.py; actual output hashes bind its four runs.
+  - Committed reviewer answer trims trailing blank lines only; stdout_sha256 binds the unmodified local stdout.

--- a/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/pack.yml
@@ -1,50 +1,50 @@
 gear: 1
 brief_ref: evidence/brief.yml
 lanes:
-  - lane: x01
+  - lane: x01-depth1
     role: build
-    seat: OpenAI GPT-6 (this Codex session; exact backend variant not exposed)
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
   - lane: x01-review
     role: review
     seat: kimi-code/k3
 pii_scan: clean
 receipts:
-  - claim: Focused guard and controls pass on this worktree.
-    cmd: cd apps/mouth && npx vitest run src/app/api-client-same-origin.test.ts
-    result: 9 passed; final run after guilty fixture removal.
+  - claim: Final guard and controls pass on the corrected source.
+    cmd: cd apps/mouth && npx --offline vitest run src/app/api-client-same-origin.test.ts
+    result: 9 passed after restoring all temporary probes.
     exit: 0
-    ts: "2026-09-05T11:05:15+00:00"
-    seat: Codex parent
-  - claim: A forbidden access in a real scanned temporary client is rejected.
-    cmd:
-      Create src/app/__x01_guilt/api-client.ts with process.env[`NEXT_PUBLIC_API_URL`];
-      run the same vitest command; remove fixture in finally.
+    ts: "2026-09-05T13:25:55.015048+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim:
+      Browser guilt fails; cleanup innocence passes; the old reverse-lock fails cleanup; restored candidate
+      passes.
+    cmd: python .agent/x01-depth1/probes.py
     result:
-      1 failed / 8 passed, diagnostic names __x01_guilt/api-client.ts:1; original
-      tree restored.
-    exit: 1
-    ts: "2026-09-05T11:05:13+00:00"
-    seat: Codex parent
-  - claim: Independent Kimi reviewed the supplied final source and documentation diff.
-    cmd: kimi -m kimi-code/k3 -p <final supplied source and documentation diff>
-    result:
-      PASS; source inspection only, no tests claimed by reviewer. Prompt SHA-256
-      3ae80e825b9788e299b5a8bcf9d0736195a3631a2c0864c3f52dbb57aa8d6024
+      "Browser: 1 failed/8 passed. Cleanup: 9 passed. Reverse-lock: 3 failed/6 passed. Restored: 9
+      passed."
     exit: 0
-    ts: "2026-09-05T11:07:33.988861+00:00"
+    ts: "2026-09-05T13:25:55.015048+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Full mouth TypeScript passes.
+    cmd: cd apps/mouth && npx --offline tsc --noEmit
+    exit: 0
+    ts: "2026-09-05T13:27:07.258573+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Independent Kimi reviewed the final two-file source snapshot against all three Fable rulings.
+    cmd: /Users/balizero/.kimi-code/bin/kimi -m kimi-code/k3 -p <supplied prompt>
+    result: PASS; source review only. Actual answer and hashes are in depth1-kimi-review.txt and depth1-receipts.yml.
+    exit: 0
+    ts: "2026-09-05T13:26:25.469971+00:00"
     seat: kimi-code/k3
-dissent:
-  - seat: kimi-code/k3
-    objection:
-      Initial template access blind spot fixed with StringLiteralLike; final
-      review PASS.
-    status: CONFIRMED
-  - seat: kimi-code/k3
-    objection:
-      Initial server setup concern refuted by verified NUZANTARA_API_URL precedence;
-      documentation now explicitly names the legacy fallback.
-    status: RETRACTED
+dissent: []
+provenance:
+  - Depth-1 correction of PR5775 at ac8b2ce25acf, following the current Fable BOARD ruling.
+  - Current builder identity is Codex/OpenAI GPT-6; no Anthropic builder or final-gate identity is claimed.
+  - The TypeScript receipt timestamp records evidence capture; probe and review timestamps are actual completion
+    times.
+  - Source hashes match the reviewed snapshot after all temporary probes.
 residual_risks:
-  - Explicit client boundaries and named api-client.ts files only; transitive imports
-    and arbitrary data-flow are not traversed.
-  - Required CI execution and independent Anthropic gate remain pending.
+  - Guard covers explicit client boundaries and named api-client.ts files under src/app only; src/lib, hooks
+    and transitive imports are outside its scan.
+  - Prior required CI success on ac8b2ce25acf is historical; corrected-head CI and independent Anthropic
+    gate remain pending.

--- a/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-api-origin/pack.yml
@@ -1,0 +1,50 @@
+gear: 1
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: x01
+    role: build
+    seat: OpenAI GPT-6 (this Codex session; exact backend variant not exposed)
+  - lane: x01-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+receipts:
+  - claim: Focused guard and controls pass on this worktree.
+    cmd: cd apps/mouth && npx vitest run src/app/api-client-same-origin.test.ts
+    result: 9 passed; final run after guilty fixture removal.
+    exit: 0
+    ts: "2026-09-05T11:05:15+00:00"
+    seat: Codex parent
+  - claim: A forbidden access in a real scanned temporary client is rejected.
+    cmd:
+      Create src/app/__x01_guilt/api-client.ts with process.env[`NEXT_PUBLIC_API_URL`];
+      run the same vitest command; remove fixture in finally.
+    result:
+      1 failed / 8 passed, diagnostic names __x01_guilt/api-client.ts:1; original
+      tree restored.
+    exit: 1
+    ts: "2026-09-05T11:05:13+00:00"
+    seat: Codex parent
+  - claim: Independent Kimi reviewed the supplied final source and documentation diff.
+    cmd: kimi -m kimi-code/k3 -p <final supplied source and documentation diff>
+    result:
+      PASS; source inspection only, no tests claimed by reviewer. Prompt SHA-256
+      3ae80e825b9788e299b5a8bcf9d0736195a3631a2c0864c3f52dbb57aa8d6024
+    exit: 0
+    ts: "2026-09-05T11:07:33.988861+00:00"
+    seat: kimi-code/k3
+dissent:
+  - seat: kimi-code/k3
+    objection:
+      Initial template access blind spot fixed with StringLiteralLike; final
+      review PASS.
+    status: CONFIRMED
+  - seat: kimi-code/k3
+    objection:
+      Initial server setup concern refuted by verified NUZANTARA_API_URL precedence;
+      documentation now explicitly names the legacy fallback.
+    status: RETRACTED
+residual_risks:
+  - Explicit client boundaries and named api-client.ts files only; transitive imports
+    and arbitrary data-flow are not traversed.
+  - Required CI execution and independent Anthropic gate remain pending.


### PR DESCRIPTION
Adds an AST-based Vitest guard for named `api-client.ts` files and explicit `use client` modules under `apps/mouth/src/app`. It rejects executable `NEXT_PUBLIC_API_URL` references while ignoring explanatory comments and preserving server-side configuration. The scan does not cover `src/lib`, hooks, transitive imports, or arbitrary dynamic environment keys.

Documentation describes the same-origin `/api` proxy for the guarded browser clients and accurately shows that `ApiClientBase` requires an explicit `baseUrl` without a default. The server innocence checks permit future removal of legacy env references; they require only that those files remain server-side with no browser findings.

Bites: the required mouth Vitest suite discovers `src/app/api-client-same-origin.test.ts`. The real app passes all 9 controls. A temporary browser client with the forbidden access fails naming its path; simulated legacy cleanup passes, whereas restoring the former reverse-lock makes the cleanup fail.

Validation on the corrected source:

- `cd apps/mouth && npx --offline vitest run src/app/api-client-same-origin.test.ts` — 9 passed after restoring all temporary probes.
- `python .agent/x01-depth1/probes.py` — real browser fixture: 1 failed / 8 passed; server cleanup simulated in memory: 9 passed; reverse-lock reintroduced against the same cleanup: 3 failed / 6 passed; restored candidate: 9 passed. Actual probe receipt timestamps and log hashes are committed. No runtime handler file changed.
- `cd apps/mouth && npx --offline tsc --noEmit` — exit 0.
- Prettier, `git diff --check`, and evidence lint with canonical staging plus real per-task source paths — passed; evidence lint exit 0, no violations.
- Canary-backed `scripts/detect_secrets_check_file.py` covered both source files and all four evidence files — zero findings.
- Kimi K3 subscription review of the final supplied source and two-file diff — PASS, exit 0. Source hashes match before and after probes. Review output, prompt/output hashes, and truthful Codex builder provenance are in the evidence directory.

This is the single depth-1 correction requested by Fable: required constructor argument, removal of the reverse-lock, and explicit `src/app` scope. The scanner implementation is unchanged. No runtime or dependency changes.

Evidence: `evidence/2026-09/agent-air-m5-mouth-x01-api-origin/` (`brief.yml`, `pack.yml`, `depth1-receipts.yml`, `depth1-kimi-review.txt`).

## Adversarial review

Kimi K3 reviewed the final source supplied by the Codex builder and returned PASS, with no demonstrable findings. The review ended at 2026-09-05T13:26:25Z; actual CLI exit was 0. The committed source matches that reviewed snapshot. Fable's independent Anthropic gate is separate.

Historical CI only: the [required mouth job on the previous head](https://github.com/Bali-Zero/Teman2/actions/runs/33962613489/job/101297134527) passed on `ac8b2ce25acfa98cd5f5731132e13c5de34fefc8`. Corrected-head CI and the independent Anthropic gate remain pending. This PR stays draft and unarmed.
