### PR TITLE
test(second-home): guard consent reservation and print rule

### DIFF
--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -74,6 +74,53 @@ describe("StudioApp", () => {
     window.location.hash = "";
   });
 
+  it.each(["question", "verdict"])(
+    "keeps the real consent banner inside its measured reservation at the %s stage",
+    async (stage) => {
+      if (stage === "verdict") {
+        window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      }
+      const { container } = render(<StudioApp />);
+      const dismiss = await screen.findByRole("button", { name: "Got it" });
+      const reservation = container.querySelector(".bz-shs-consent-space");
+      const banner = dismiss.closest(".fixed");
+
+      // StudioApp measures the first child of this host. Assert the actual
+      // banner occupies that position, not merely that the class exists.
+      expect(reservation).not.toBeNull();
+      expect(banner).not.toBeNull();
+      expect(reservation?.firstElementChild).toBe(banner);
+      expect(reservation).toContainElement(dismiss);
+    },
+  );
+
+  it("hides the consent reservation with an important display:none rule in the mounted print stylesheet", async () => {
+    const { container } = render(<StudioApp />);
+    await screen.findByRole("button", { name: "Got it" });
+
+    // Inspect parsed CSS attached to this render. jsdom cannot prove printed
+    // geometry, but it can prove the shipped rule targets the reservation.
+    const printRules = Array.from(container.querySelectorAll("style"))
+      .flatMap((style) => Array.from(style.sheet?.cssRules ?? []))
+      .filter(
+        (rule): rule is CSSMediaRule =>
+          rule.type === CSSRule.MEDIA_RULE &&
+          (rule as CSSMediaRule).media.mediaText === "print",
+      )
+      .flatMap((rule) => Array.from(rule.cssRules))
+      .filter(
+        (rule): rule is CSSStyleRule =>
+          rule.type === CSSRule.STYLE_RULE &&
+          (rule as CSSStyleRule).selectorText === ".bz-shs-consent-space",
+      );
+
+    expect(printRules).toHaveLength(1);
+    expect(printRules[0].style.getPropertyValue("display")).toBe("none");
+    expect(printRules[0].style.getPropertyPriority("display")).toBe(
+      "important",
+    );
+  });
+
   it("full happy path (under_55 + deposit + ready_130k) renders a strong-fit verdict with the Imigrasi sentence", async () => {
     render(<StudioApp />);
 

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/banner-outside.patch
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/banner-outside.patch
@@ -1,0 +1,6 @@
+--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
++++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+@@ -835 +834,0 @@
+-          <ConsentBanner />
+@@ -836,0 +836 @@
++        <ConsentBanner />

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/brief.yml
@@ -1,0 +1,20 @@
+task_id: s01b-consent-reservation
+gear: 1
+objective:
+  Keep the real consent banner inside its measured space and retain the mounted print rule that
+  hides that space.
+constraints:
+  - Only StudioApp.test.tsx and lane evidence change. No runtime edits.
+  - Mount the real ConsentBanner; do not claim jsdom geometry or a new browser run.
+  - Record and reverify historical browser receipt hashes instead of copying large files.
+acceptance:
+  - text:
+      Removing the wrapper or moving the banner outside it fails the question and verdict containment
+      tests.
+    probe: wrapper-removed.patch and banner-outside.patch
+  - text: Removing the print rule fails the mounted CSSOM assertion for display:none!important.
+    probe: print-rule-removed.patch
+  - text: Restoring unchanged runtime source passes both StudioApp and SavePlanBar suites.
+    probe: cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+consumer_map:
+  - StudioApp.test.tsx in the frontend Vitest suite.

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/historical-browser-manifest.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/historical-browser-manifest.yml
@@ -1,0 +1,24 @@
+status: historical-browser-receipts-not-rerun
+verified_at: "2026-09-05T11:31:59.344751+00:00"
+historical_directory: /Users/balizero/nuzantara/.worktrees/ops-visa-consuls/output/playwright/s01-banner-clearance
+source_path: apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+recorded_source_sha256: 9b904e19f3da96203b532998aaa885163da78a62c208ae9d42d103a510951a8a # pragma: allowlist secret - verified artifact SHA-256, not credential
+source_match_verified_before_mutations: true
+records:
+  - width: 320
+    base_commit: cce13f6e3174e65b08c7c420584b6e54fbf5eea5 # pragma: allowlist secret - verified Git commit SHA, not credential
+    recorded_source_sha256: 9b904e19f3da96203b532998aaa885163da78a62c208ae9d42d103a510951a8a # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - width: 390
+    base_commit: cce13f6e3174e65b08c7c420584b6e54fbf5eea5 # pragma: allowlist secret - verified Git commit SHA, not credential
+    recorded_source_sha256: 9b904e19f3da96203b532998aaa885163da78a62c208ae9d42d103a510951a8a # pragma: allowlist secret - verified artifact SHA-256, not credential
+artifacts:
+  - file: exercise-320.js
+    sha256: 29bf383727de01963c30bc9ea3d1c2d749d231a6eb03814779307b4f1516c20f # pragma: allowlist secret - verified artifact SHA-256, not credential
+    bytes: 7698
+  - file: exercise-390.js
+    sha256: 82336e94f1c917796f64a22bed3f922163625a2d0a3bce88a21389aa2aff9dce # pragma: allowlist secret - verified artifact SHA-256, not credential
+    bytes: 7698
+  - file: measurements.json
+    sha256: 92a8ec6bdc2d0fb6b9142b374f6d559c7db18c066c632c3c10d31f9aad39ee13 # pragma: allowlist secret - verified artifact SHA-256, not credential
+    bytes: 7000
+limits: Files remain in the original local receipt directory. This committed manifest identifies them by hash; it does not embed them or claim a current browser rerun.

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/kimi-receipt.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/kimi-receipt.yml
@@ -1,0 +1,10 @@
+model_requested: kimi-code/k3
+started_at: "2026-09-05T11:32:22.743948+00:00"
+prompt_sha256: c977a1491b06e1a59089a4b16d8a0b351c02e63355a980a9ea48c52c4c446186 # pragma: allowlist secret - verified artifact SHA-256, not credential
+command: kimi -m kimi-code/k3 -p <supplied test diff and runtime context>
+timeout_seconds: 240
+exit: 0
+finished_at: "2026-09-05T11:33:55.502117+00:00"
+raw_stdout_sha256: c9b7ce7d2ba2204a9cc2373c149c0cbda883446f5fbd61758598ac006c4e0869 # pragma: allowlist secret - verified artifact SHA-256, not credential
+answer_sha256: 21dfe91cdd5aa9ec2a48ed2006ac1321d6d0011c47cd8852637309763d504ffb # pragma: allowlist secret - verified artifact SHA-256, not credential
+artifact_normalization: Trailing blank lines removed from stdout; review content unchanged.

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/kimi-review.txt
@@ -1,0 +1,21 @@
+• PASS
+
+  The tests satisfy every stated requirement, and the four mutation runs line up exactly with what the assertions should catch. Findings below are low-severity notes, not blockers.
+
+  **Why the requirement set is met**
+
+  - Real mounts: `render(<StudioApp />)` mounts the actual `StudioApp` and its real `ConsentBanner` child — no mocks, no stand-ins. `window.location.hash` drives the verdict stage through the app's own hydration path, and `await screen.findByRole("button", { name: "Got it" })` correctly waits for the post-effect mount (banner sets `visible` in `useEffect`), with the existing `beforeEach` localStorage clear guaranteeing visibility.
+  - Wrapper removed → fail: `expect(reservation).not.toBeNull()` dies immediately. Matches the observed 2 fail (both stages).
+  - Banner outside wrapper → fail: `expect(reservation?.firstElementChild).toBe(banner)` is an identity check against `dismiss.closest(".fixed")`, not a class-existence check — an empty or differently-filled wrapper fails it. Matches 2 fail.
+  - Print rule removed → fail: the CSSOM walk (`style.sheet.cssRules` → MEDIA_RULE with `mediaText === "print"` → STYLE_RULE with exact selector `.bz-shs-consent-space`) yields zero rules, and `toHaveLength(1)` fails. Matches 1 fail. The positive assertions on `display: none` + `important` priority pin the rule's substance, not just its presence.
+  - No jsdom geometry claims: the comment explicitly disclaims printed geometry, and no test touches `getBoundingClientRect` or layout. The print test only proves the shipped rule exists and targets the reservation — exactly what jsdom can honestly prove.
+  - Containment in both stages: `it.each(["question", "verdict"])` runs the identity/containment assertions against the same mounted tree at both stages; `expect(reservation).toContainElement(dismiss)` is the child-containment check proper.
+  - Run counts are internally consistent: 2 + 2 + 1 failures on the three mutations, 54 pass restored — no unexplained collateral failures in either suite, which says the tests are coupled to the regression and not to incidental structure.
+
+  **Low-severity findings (brittleness / false-red risk, accepted for a regression pin)**
+
+  1. **Low — exact-selector and single-rule pinning.** `selectorText === ".bz-shs-consent-space"` and `toHaveLength(1)` will go red on legitimate, non-regression CSS edits: a selector list (`.a, .bz-shs-consent-space`), a second harmless print rule, or a reformatted media query. This is a false-red-on-refactor risk, not a false-green risk — acceptable for a pin, but the next editor should know the test guards the rule verbatim, not its effect.
+  2. **Low — `closest(".fixed")` couples to a Tailwind utility class.** If the banner is restyled (class renamed) while staying correctly inside the wrapper, `banner` becomes null and the test goes red despite no regression. Mitigated in practice because the banner's fixed positioning is itself part of the bug class being pinned (a non-fixed banner wouldn't need measured reservation), so this coupling is arguably intentional.
+  3. **Low — implicit assumption that the `<style>` tag stays inside `container`.** Verified empirically by the passing runs (React only hoists `<style>` with a `precedence` prop, which this inline tag lacks). If a future React/version change hoists it to `<head>`, the print test false-reds. Not actionable today.
+
+  **No false-green path found within scope:** moving the banner outside the wrapper can't pass the identity check; duplicating the banner (inside + outside) would make `findByRole` throw on multiple "Got it" buttons; weakening `display:none` to non-important or a wrong selector fails the priority/selector assertions. Runtime source is untouched. Historical browser receipts being recorded separately without rerun is consistent with the tests' own honesty about jsdom's limits.

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/pack.yml
@@ -1,0 +1,51 @@
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: s01b-consent-reservation
+    role: build
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - lane: kimi-cross-family-review
+    role: review
+    seat: kimi-code/k3
+dissent: []
+pii_scan: clean
+receipts:
+  - claim: "wrapper-removed: Test Files  1 failed | 1 passed (2); Tests  2 failed | 52 passed (54)"
+    cmd:
+      git apply --unidiff-zero evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/wrapper-removed.patch
+      && (cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx)
+    exit: 1
+    ts: "2026-09-05T11:34:13.072144+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: "banner-outside: Test Files  1 failed | 1 passed (2); Tests  2 failed | 52 passed (54)"
+    cmd:
+      git apply --unidiff-zero evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/banner-outside.patch
+      && (cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx)
+    exit: 1
+    ts: "2026-09-05T11:34:18.835216+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: "print-rule-removed: Test Files  1 failed | 1 passed (2); Tests  1 failed | 53 passed (54)"
+    cmd:
+      git apply --unidiff-zero evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/print-rule-removed.patch
+      && (cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx)
+    exit: 1
+    ts: "2026-09-05T11:34:24.582806+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: "candidate-restored: Test Files  2 passed (2); Tests  54 passed (54)"
+    cmd: cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+    exit: 0
+    ts: "2026-09-05T11:34:30.122636+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim:
+      Kimi K3 returned PASS with only nonblocking brittleness notes. Review content and receipt are
+      committed.
+    cmd: kimi -m kimi-code/k3 -p <supplied test diff and runtime context>
+    exit: 0
+    ts: "2026-09-05T11:33:55.502117+00:00"
+    seat: kimi-code/k3
+notes:
+  - Gear floor is 1 for the single changed test path.
+  - The historical browser manifest identifies existing 320/390 receipts; this PR does not claim a current
+    browser rerun.
+  - Restored StudioApp source matches the recorded historical source; see historical-browser-manifest.yml.
+  - Kimi notes exact selector, fixed class and inline stylesheet pinning may require intentional test updates
+    after refactors. No source changed after review. Independent Anthropic gate and CI pending.

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/print-rule-removed.patch
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/print-rule-removed.patch
@@ -1,0 +1,9 @@
+--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
++++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+@@ -866,5 +866 @@
+-        @media print {
+-          .bz-shs-consent-space {
+-            display: none !important;
+-          }
+-        }
++

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/probes.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/probes.yml
@@ -1,0 +1,39 @@
+source_base: 58e8b0b027a25f8e213414577f154f16599d7ce6 # pragma: allowlist secret - verified Git commit SHA, not credential
+command: cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+tests:
+  - case: wrapper-removed
+    cmd: git apply --unidiff-zero evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/wrapper-removed.patch && (cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx)
+    exit: 1
+    ts: "2026-09-05T11:34:13.072144+00:00"
+    summary:
+      - Test Files  1 failed | 1 passed (2)
+      - Tests  2 failed | 52 passed (54)
+    log_sha256: 43c7b7a4424c2a92d48665bf0c8fa3749bbca92d133fad5e5be029b45bb9bd42 # pragma: allowlist secret - verified artifact SHA-256, not credential
+    patch_sha256: 128300d9ba5649d5160209f1b8cdab7ba9bf686577522cb76e108b759960a74c # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - case: banner-outside
+    cmd: git apply --unidiff-zero evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/banner-outside.patch && (cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx)
+    exit: 1
+    ts: "2026-09-05T11:34:18.835216+00:00"
+    summary:
+      - Test Files  1 failed | 1 passed (2)
+      - Tests  2 failed | 52 passed (54)
+    log_sha256: e1e2da0f3ff6deac38510cbf1e5c1592eb4972c435d9e946906f7e5c5f89612d # pragma: allowlist secret - verified artifact SHA-256, not credential
+    patch_sha256: 32a2b32fce5285d6e4284122a38cd738e6ee3574af2ae3d9070f16e8e3b53eec # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - case: print-rule-removed
+    cmd: git apply --unidiff-zero evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/print-rule-removed.patch && (cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx)
+    exit: 1
+    ts: "2026-09-05T11:34:24.582806+00:00"
+    summary:
+      - Test Files  1 failed | 1 passed (2)
+      - Tests  1 failed | 53 passed (54)
+    log_sha256: 1874ccb2918f56552d1f8021003899ec6e2830614bd873be2fe34f7e5149491c # pragma: allowlist secret - verified artifact SHA-256, not credential
+    patch_sha256: 1feb4d4390d6658e100cfe5af3fe04e1b10cdfb852e734cccac9c206b138ee36 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - case: candidate-restored
+    cmd: cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx
+    exit: 0
+    ts: "2026-09-05T11:34:30.122636+00:00"
+    summary:
+      - Test Files  2 passed (2)
+      - Tests  54 passed (54)
+    log_sha256: f103679c54d88316f3c96a2518568dfda3a87678b293520352eb8e7d5f0267f4 # pragma: allowlist secret - verified artifact SHA-256, not credential
+restored_runtime_sha256: 9b904e19f3da96203b532998aaa885163da78a62c208ae9d42d103a510951a8a # pragma: allowlist secret - verified artifact SHA-256, not credential

--- a/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/wrapper-removed.patch
+++ b/evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/wrapper-removed.patch
@@ -1,0 +1,14 @@
+--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
++++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+@@ -827,10 +827 @@
+-        <div
+-          ref={consentSpaceRef}
+-          className="bz-shs-consent-space"
+-          style={{
+-            height: consentHeight,
+-            display: consentHeight > 0 ? "block" : "contents",
+-          }}
+-        >
+-          <ConsentBanner />
+-        </div>
++        <ConsentBanner />


### PR DESCRIPTION
Removing StudioApp's consent reservation previously left its regression suite green. This change adds real mounted-banner checks at both question and verdict stages and reads the mounted CSSOM to verify the reservation's `@media print` rule retains `display: none !important`. Runtime source is unchanged.

Bites: the frontend Vitest suite now fails if `.bz-shs-consent-space` is removed, if the real `ConsentBanner` moves outside the measured first-child position, or if the print rule disappears.

Validation:

- `cd apps/mouth && npx vitest run src/app/visa/second-home/studio/StudioApp.test.tsx src/app/visa/second-home/studio/components/SavePlanBar.test.tsx` — 54 tests passed across two suites.
- Three separately executed committed patch recipes: wrapper removal gives 2 failures / 52 passes; moving the banner outside gives 2 failures / 52 passes; removing the print rule gives 1 failure / 53 passes. Each patch was reversed before the next, and the restored source returned 54 passing tests. Exact commands, timestamps and hashes are in `probes.yml`.
- Normal pre-commit hooks passed, including full `npm run typecheck -w apps/mouth` (`tsc --noEmit`), formatting and secret/off-limits checks.
- `scripts/evidence_pack_lint.py` on the staged changed paths and numstat with canonical evidence staging — exit 0, no violations, gear floor 1.
- `scripts/detect_secrets_check_file.py` scanned all ten changed files with its positive-control canary — exit 0, zero findings. Only individually verified artifact/commit hash lines carry allowlist comments; scanner and baseline are untouched.
- Kimi K3 cross-family review: PASS, CLI exit 0. Nonblocking notes identify expected refactor sensitivity around the exact selector, fixed utility class and inline stylesheet location. No test source changed after review.

Historical browser receipts:

The compact `historical-browser-manifest.yml` re-verifies `exercise-320.js`, `exercise-390.js` and `measurements.json` in the original receipt directory. Their recorded StudioApp SHA-256 matches the unchanged current source. These are historical browser measurements; this PR neither reruns the browser exercise nor claims jsdom proves geometry.

Evidence: `evidence/2026-09/agent-air-m5-mouth-s01b-consent-reservation/` contains the brief, pack, three reproducible mutation patches, probe receipts, browser hash manifest and Kimi review/receipt. Prepared for independent Anthropic review by the Fable consul.


## Required mouth CI receipt

Current head `4b66e4a8e9dc993e791f219a6fdf9902797a96ce`: required `Frontend Tests (Next.js) (mouth, true)` completed SUCCESS. Actual job logs include 35 StudioApp +19 SavePlanBar cases. [Required job receipt](https://github.com/Bali-Zero/Teman2/actions/runs/33963822453/job/101300411512). Independent Fable gate and shipping remain separate.
