### PR TITLE
fix(visa-oracle): dedupe fallback display and reset absent edits

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
@@ -215,6 +215,80 @@ describe("OutcomeSheet — honest five-state rendering", () => {
     expect(onEditMissingInput).toHaveBeenCalledWith("stay_days");
   });
 
+  it.each<Language>(["en", "id"])(
+    "shows repeated unroutable details only once in %s without an Edit action",
+    (language) => {
+      const message = text("Additional detail needed", "Perlu detail tambahan");
+      const outcome: OutcomeViewModel = {
+        ...common(),
+        state: "NEEDS_INPUT",
+        candidates: [],
+        missingInputs: [
+          { code: "missing.a", message, sourceIds: [] },
+          { code: "missing.b", message, sourceIds: [] },
+        ],
+      };
+      const { container } = renderSheet("NEEDS_INPUT", language, {
+        outcome,
+        onEditMissingInput: vi.fn(),
+      });
+      expect(screen.getAllByText(message[language])).toHaveLength(1);
+      expect(
+        container.querySelectorAll(".oracle-action-list > li"),
+      ).toHaveLength(1);
+      expect(
+        screen.queryByRole("button", { name: /edit|ubah/i }),
+      ).not.toBeInTheDocument();
+      expect(outcome.missingInputs.map((input) => input.code)).toEqual([
+        "missing.a",
+        "missing.b",
+      ]);
+    },
+  );
+
+  it("keeps editable details distinct from identical fallback copy and each other", () => {
+    const message = text("Detail needed");
+    const onEditMissingInput = vi.fn();
+    const outcome: OutcomeViewModel = {
+      ...common(),
+      state: "NEEDS_INPUT",
+      candidates: [],
+      missingInputs: [
+        { code: "missing.a", message, sourceIds: [] },
+        {
+          code: "missing.stay",
+          message,
+          sourceIds: [],
+          questionId: "stay_days",
+        },
+        { code: "missing.b", message, sourceIds: [] },
+        {
+          code: "missing.entry",
+          message,
+          sourceIds: [],
+          questionId: "entry_pattern",
+        },
+        { code: "missing.c", message: text("Different detail"), sourceIds: [] },
+      ],
+    };
+    const { container } = renderSheet("NEEDS_INPUT", "en", {
+      outcome,
+      onEditMissingInput,
+    });
+    expect(screen.getAllByText("Detail needed")).toHaveLength(3);
+    expect(screen.getByText("Different detail")).toBeInTheDocument();
+    expect(container.querySelectorAll(".oracle-action-list > li")).toHaveLength(
+      4,
+    );
+    const buttons = screen.getAllByRole("button", { name: "Edit" });
+    expect(buttons).toHaveLength(2);
+    buttons.forEach((button) => fireEvent.click(button));
+    expect(onEditMissingInput.mock.calls).toEqual([
+      ["stay_days"],
+      ["entry_pattern"],
+    ]);
+  });
+
   it("has no always-on WhatsApp/QR handoff and renders only an explicit slot", () => {
     const first = renderSheet("NEEDS_INPUT");
     expect(first.container.querySelector("[href*='wa.me']")).toBeNull();

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
@@ -402,6 +402,19 @@ export function OutcomeSheet({
     [outcome.sources],
   );
   const rows = answerRows(language, facts);
+  // Collapse repeated fallback copy only in this view. The adapter retains
+  // every missing fact code for SHADOW parity; each editable row stays distinct.
+  const fallbackMessages = new Set<string>();
+  const visibleMissingInputs =
+    outcome.state === "NEEDS_INPUT"
+      ? outcome.missingInputs.filter((input) => {
+          if (input.questionId) return true;
+          const message = localized(input.message, language);
+          if (fallbackMessages.has(message)) return false;
+          fallbackMessages.add(message);
+          return true;
+        })
+      : [];
   const [checkedDocs, setCheckedDocs] = useState<Set<string>>(new Set());
   const [shareState, setShareState] = useState<
     "idle" | "copied" | "shared" | "failed"
@@ -496,7 +509,7 @@ export function OutcomeSheet({
         <section>
           <p>{translate(language, "outcome.needs_input_body" as I18nKey)}</p>
           <ul className="oracle-action-list">
-            {outcome.missingInputs.map((input) => (
+            {visibleMissingInputs.map((input) => (
               <li key={input.code}>
                 <span>{localized(input.message, language)}</span>
                 {input.questionId && onEditMissingInput && (

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -319,6 +319,28 @@ describe("Visa Oracle authoritative outcome adapter", () => {
     },
   );
 
+  it("retains both missing fact codes when neither has a visited question", () => {
+    const response = makeVisaOracleResponse("NEEDS_INPUT");
+    response.decision.missing_facts = [
+      "work.indonesia_source_compensation",
+      "investment.pt_pma_committed",
+    ];
+    const outcome = buildEngineOutcome(response, {
+      editableQuestionIds: ["stay_days"],
+    });
+    if (outcome.state !== "NEEDS_INPUT") throw new Error("unexpected state");
+    expect(outcome.missingInputs.map((input) => input.code)).toEqual(
+      response.decision.missing_facts,
+    );
+    expect(outcome.missingInputs.map((input) => input.questionId)).toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(outcome.missingInputs[0].message).toEqual(
+      outcome.missingInputs[1].message,
+    );
+  });
+
   it.each([
     { editableQuestionIds: undefined },
     { editableQuestionIds: [] },

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -754,6 +754,45 @@ describe("2026-08-23 owner ruling: stepchild evidence questions fire only for fa
 });
 
 describe("editing, pruning and branch projection", () => {
+  it.each(["work_role", "unknown-question"])(
+    "EDIT resets an absent target %s without retaining the previous interview",
+    (questionId) => {
+      const state: FlowState = {
+        ...startOffshore("tourism"),
+        language: "id",
+        attempt: 7,
+        blockedAnswer: {
+          questionId: "application_channel",
+          conflictsWithQuestionId: "wants_onshore_conversion",
+        },
+      };
+      expect(state.history).not.toContainEqual({
+        kind: "question",
+        questionId,
+      });
+      const next = reduce(state, { type: "EDIT", questionId });
+      expect(next).toEqual({
+        language: "id",
+        attempt: 8,
+        history: [{ kind: "framing" }],
+        facts: {},
+        blockedAnswer: null,
+      });
+    },
+  );
+
+  it("EDIT keeps the current visited question in the same attempt", () => {
+    const state: FlowState = {
+      ...startOffshore("tourism"),
+      language: "id",
+      attempt: 7,
+    };
+    expectQuestion(state, "trip_scope");
+    expect(reduce(state, { type: "EDIT", questionId: "trip_scope" })).toEqual(
+      state,
+    );
+  });
+
   it("editing category removes stale descendants from the abandoned branch", () => {
     let state = startOffshore("work");
     state = answer(state, "trip_scope", "single");

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -335,8 +335,8 @@ export function restoreInterviewSnapshot(
  * evaluation-lease cache key, which now covers every engine mode — SHADOW,
  * internal preview and the rendered REAL verdict — not just SHADOW) can
  * key off `state.attempt` instead of enumerating which actions perform a
- * reset. Called from RESTART and from SELECT_CATEGORY's defensive
- * fallback below — both discard the ENTIRE interview (facts + history),
+ * reset. Called from RESTART and the EDIT / SELECT_CATEGORY defensive
+ * fallbacks below — all discard the ENTIRE interview (facts + history),
  * which is exactly what makes them resets rather than ordinary
  * forward/backward navigation.
  */
@@ -825,6 +825,10 @@ export function flowReducer(state: FlowState, action: FlowAction): FlowState {
         kind: "question",
         questionId: action.questionId,
       };
+      if (!state.history.some((node) => sameNode(node, target))) {
+        // An absent target cannot safely reopen this interview's branch.
+        return resetFlow(state);
+      }
       const history = truncateToNode(state.history, target);
       return {
         ...state,

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts
@@ -56,6 +56,21 @@ describe("shadow public-contract parity", () => {
     expect(shadowParityMatches(response, outcome)).toBe(false);
   });
 
+  it("distinguishes missing fact sets even when their fallback messages are identical", () => {
+    const response = makeVisaOracleResponse("NEEDS_INPUT");
+    response.decision.missing_facts = [
+      "work.indonesia_source_compensation",
+      "investment.pt_pma_committed",
+    ];
+    const baseline = buildEngineOutcome(response);
+    expect(shadowParityMatches(response, baseline)).toBe(true);
+    response.decision.missing_facts = [
+      "work.indonesia_source_compensation",
+      "person.birth_date",
+    ];
+    expect(shadowParityMatches(response, baseline)).toBe(false);
+  });
+
   it("does not call the zero-candidate preview harness parity", () => {
     const response = makeVisaOracleResponse("TEMPORARILY_UNAVAILABLE");
     const preview = buildPreviewOutcome({}, new Date("2026-08-03T04:00:00Z"));

--- a/evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/brief.yml
@@ -1,0 +1,38 @@
+task_id: v01b-fallback-edit
+gear: 1
+objective:
+  Collapse repeated fallback copy in the outcome view while preserving decision semantics and
+  safe edit navigation.
+scope:
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+  - apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts
+constraints:
+  - No adapter/parity runtime changes and no loss of missing-fact codes.
+  - No legal claims, eligibility, pricing, backend, credentials or production changes.
+  - Independent Anthropic review and shipping remain with Fable.
+acceptance:
+  - text:
+      WHEN unroutable details have identical localized copy the outcome SHALL show one fallback line
+      without an Edit action.
+    probe: "OutcomeSheet.test.tsx: shows repeated unroutable details only once in en/id"
+  - text:
+      WHEN editable rows share text the outcome SHALL preserve each edit action and the adapter SHALL
+      retain all missing-fact codes for semantic parity.
+    probe:
+      "OutcomeSheet.test.tsx: keeps editable details distinct; engine-adapter.test.ts: retains both
+      missing fact codes; shadow-parity.test.ts: distinguishes missing fact sets"
+  - text:
+      WHEN EDIT targets a question absent from history the reducer SHALL reset facts/history and advance
+      attempt while preserving language.
+    probe:
+      "flow.test.ts: EDIT resets an absent target; EDIT keeps the current visited question; existing
+      editing/pruning tests"
+consumer_map:
+  - OutcomeSheet renders NEEDS_INPUT responses while the unchanged adapter/parity chain retains complete
+    semantics.
+  - flowReducer handles Edit actions from the current interview history.
+  - Existing frontend Vitest job consumes all four regression suites.

--- a/evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/pack.yml
@@ -1,0 +1,72 @@
+gear: 1
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: v01b
+    role: build
+    seat: OpenAI GPT-6 (exact variant not exposed)
+  - lane: v01b-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+seat_override:
+  "R8 applicability only: existing visa-route UI message rendering and interview navigation;
+  no immigration rule, claim, eligibility or price is authored. Tests use synthetic outcomes and existing
+  fixtures."
+receipts:
+  - claim: Removing display deduplication is rejected.
+    cmd:
+      Temporarily render outcome.missingInputs rather than visibleMissingInputs; cd apps/mouth && npx
+      vitest run 'src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx' -t 'shows repeated
+      unroutable' (restore original source in finally)
+    result: 2 failed, 24 skipped; duplicate fallback rendered twice instead of once in EN and ID.
+    exit: 1
+    ts: "2026-09-05T11:34:39.192492+00:00"
+    seat: Codex V-01b builder
+  - claim: Deduplicating editable rows is rejected by the mixed fallback/editable regression.
+    cmd:
+      Temporarily remove the questionId early return from display filtering; cd apps/mouth && npx vitest
+      run 'src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx' -t 'keeps editable details'
+      (restore original source in finally)
+    result: 1 failed, 25 skipped; editable rows were hidden, leaving one repeated label instead of three.
+    exit: 1
+    ts: "2026-09-05T11:34:41.667869+00:00"
+    seat: Codex V-01b builder
+  - claim: Removing the EDIT history guard is rejected.
+    cmd:
+      Temporarily remove the EDIT history guard/reset; cd apps/mouth && npx vitest run 'src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts'
+      -t 'EDIT resets an absent target' (restore original source in finally)
+    result:
+      2 failed, 79 skipped; both known-unvisited and unknown targets retained attempt 7/history/facts
+      instead of reset attempt 8.
+    exit: 1
+    ts: "2026-09-05T11:34:43.758399+00:00"
+    seat: Codex V-01b builder
+  - claim: Final focused renderer, adapter, parity and flow suites pass.
+    cmd:
+      cd apps/mouth && npx vitest run 'src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx'
+      'src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts' 'src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts'
+      'src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts'
+    result: 150 passed across 4 files after all temporary mutations were restored.
+    exit: 0
+    ts: "2026-09-05T11:34:46.219997+00:00"
+    seat: Codex V-01b builder
+  - claim: Full frontend TypeScript project passes.
+    cmd: cd apps/mouth && npx tsc --noEmit
+    result: Exited 0.
+    exit: 0
+    ts: "2026-09-05T11:36:43.584910+00:00"
+    seat: Codex V-01b builder
+  - claim:
+      Independent Kimi inspected the final diff, actual files and unchanged semantic invariants; verdict
+      PASS.
+    cmd: kimi -m kimi-code/k3 -p <read-only review prompt with final diff and unchanged context>
+    result:
+      PASS; no blocking findings. Active-language fallback deduplication and retention of editable
+      rows match scope. Prompt SHA-256 a2916b5cd902203c828249ff7f5310825439b15fb2e61ea88531d9d18834b7f0
+    exit: 0
+    ts: "2026-09-05T11:37:08.543611+00:00"
+    seat: kimi-code/k3
+dissent: []
+residual_risks:
+  - Display deduplication intentionally leaves all missing-fact codes in the semantic outcome.
+  - Required CI, independent Anthropic review and production observation remain pending.

--- a/evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/source-sha256.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/source-sha256.yml
@@ -1,0 +1,6 @@
+apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.test.tsx: 0842045a3f9300b4883f2260814a33c44495190b22b488403128fb0e8d67547c # pragma: allowlist secret - verified source SHA-256, not credential
+apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx: 1c2ed5d31b9240037c43da14d45e220f9b021c9eac00dead7ab99997dd9a89ad # pragma: allowlist secret - verified source SHA-256, not credential
+apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts: 13782ee97a73847b44b0b1d6459a30c63021f0c9f763679772a95de8ed075e35 # pragma: allowlist secret - verified source SHA-256, not credential
+apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts: 030c0e03f284d3971e0ff0f737ab9069062775a23e86bc6b41ef160f577dfd32 # pragma: allowlist secret - verified source SHA-256, not credential
+apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts: 3e696747ead08a9df23f65e25c42a27d803318fb4841c76e4ea278c8444fc160 # pragma: allowlist secret - verified source SHA-256, not credential
+apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts: 6e51532b268e5caf34e9d67ce3db6a930809ba71bfecd52ff28b1081e68a4203 # pragma: allowlist secret - verified source SHA-256, not credential


### PR DESCRIPTION
When multiple missing facts cannot map to a visited interview question, Visa Oracle repeats identical fallback copy. Collapse those repeated lines only in `OutcomeSheet`; retain every semantic missing-fact code in the unchanged adapter/parity chain and keep each editable row even when labels match. If an `EDIT` target is absent from history, restart using the existing reset primitive, preserving language and advancing the attempt counter. Current/visited edits retain their existing pruning behavior.

Bites: `OutcomeSheet` now renders one fallback line for two unroutable facts in both EN and ID, while the mixed case keeps two distinct Edit actions. `flowReducer` resets known-unvisited and unknown targets. Existing frontend suites exercise both behaviors; adapter/parity tests still distinguish `[A,B]` from `[A,C]` despite identical fallback text. Production observation remains with Fable after the independent gate.

## Validation

- Four focused suites — `OutcomeSheet.test.tsx`, `engine-adapter.test.ts`, `shadow-parity.test.ts`, `flow.test.ts`: **150 passed** after all mutations were restored.
- Guilt: reverting the display to the raw input list yields **2 failures** (EN/ID); wrongly deduplicating editable rows yields **1 failure**; removing the EDIT reset yields **2 failures** (known-unvisited/unknown targets).
- Innocence: distinct fallback text and both editable actions remain visible; the source outcome keeps both codes; identical parity input matches and different missing-fact sets mismatch; current/visited edits and branch pruning remain green.
- `cd apps/mouth && npx tsc --noEmit`: passed.
- Per-task evidence: `evidence/2026-09/agent-air-m5-mouth-v01b-fallback-edit/`. Source SHA-256 manifest records verified non-credential digests. Existing detect-secrets local preflight scanned all evidence with its positive control: clean.

## Adversarial review

Kimi `kimi-code/k3` inspected the final diff, actual files and unchanged semantic chain: **PASS**, no blocking findings. Completed 2026-09-05T11:37:08.543611+00:00; prompt SHA-256 `a2916b5cd902203c828249ff7f5310825439b15fb2e61ea88531d9d18834b7f0`. Fable owns independent Anthropic review and all merge/arm/deploy actions.


## Required mouth CI receipt

Current head `82207e62c1a85553c009cd5aeeab5e00751d03ce`: required `Frontend Tests (Next.js) (mouth, true)` completed SUCCESS. Actual job logs include 26 OutcomeSheet +35 adapter +81 flow +8 shadow-parity cases. [Required job receipt](https://github.com/Bali-Zero/Teman2/actions/runs/33963882729/job/101300538412). Independent Fable gate and shipping remain separate.
