### PR TITLE
fix(ci): require GARUDA contract consumer typechecking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1845,12 +1845,18 @@ jobs:
       # the merge queue for a reason that isn't a code change here.
       # The staff UI consumes this product contract directly. Run its existing
       # generator's freshness check in the required mouth leg, including when
-      # only products/ changes (the change map conservatively runs all suites).
+      # only the product contract changes (explicit backend + mouth coupling).
       - name: Check GARUDA generated contract
         if: matrix.app == 'mouth' && steps.decide.outputs.run == 'true'
         run: |
           ./node_modules/.bin/openapi-typescript products/garuda-voa/contracts/openapi.yaml \
             --output apps/mouth/src/lib/api/garuda-voa.generated.d.ts --check
+
+      - name: Typecheck mouth contract consumers
+        id: mouth-typecheck
+        if: matrix.app == 'mouth' && steps.decide.outputs.run == 'true'
+        working-directory: apps/mouth
+        run: npx tsc --noEmit
 
       - name: Run tests (with coverage)
         if: matrix.coverage && steps.decide.outputs.run == 'true'

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/brief.yml
@@ -1,0 +1,26 @@
+task_id: b03b-required-contract-checks
+gear: 3
+objective:
+  Make the required mouth CI leg compile generated contract consumers and explicitly route product
+  contract edits to both backend and frontend tests.
+constraints:
+  - Change only the five assigned CI/test/documentation files and lane evidence.
+  - Preserve frontend matrix, needs, cancellation and fail-open behavior. No runtime or frozen contract
+    edits.
+  - Existing OAuth reviewers only; no PII, paid API keys or production actions.
+acceptance:
+  - text:
+      WHEN a contract path changes, CI SHALL select backend and mouth explicitly; unknown siblings SHALL
+      remain fail-open.
+    probe: scripts/ci/test_change_map.py
+  - text:
+      WHEN the required mouth leg runs, it SHALL compile after freshness and before coverage without
+      swallowing errors.
+    probe: scripts/tests/test_required_context_map.py
+  - text: WHEN checked against the current contract, generated types and full mouth TypeScript SHALL pass.
+    probe: .github/workflows/tests.yml
+consumer_map:
+  - "Frontend Tests (Next.js) (mouth, true): mouth-typecheck step."
+  - Required antidotes job runs test_required_context_map.py on the candidate checkout.
+  - Backend shard corpus contains the live GARUDA OpenAPI parity test.
+grader: Independent Anthropic gate by Fable remains pending.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/council-journal.jsonl
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/council-journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "codex-gpt-5.6-sol", "role": "review", "ok": true, "ts": "2026-09-05T11:42:25.011974+00:00", "note": "Actual CLI exit 0; PASS with remote CI proof pending. Same five-file snapshot; final Anthropic gate is separate."}
+{"seat": "kimi-code/k3", "role": "review", "ok": true, "ts": "2026-09-05T11:43:28.165495+00:00", "note": "Actual CLI exit 0; PASS conditional on remote CI execution and timing. Same five-file snapshot; final Anthropic gate is separate."}

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/council-receipts.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/council-receipts.yml
@@ -1,0 +1,35 @@
+artifact_normalization: Trailing blank lines removed; review content unchanged.
+reviews:
+  - seat: codex-gpt-5.6-sol
+    command:
+      - /opt/homebrew/bin/codex
+      - exec
+      - --sandbox
+      - read-only
+      - --skip-git-repo-check
+      - -m
+      - gpt-5.6-sol
+      - -c
+      - model_reasoning_effort=high
+      - <supplied diff prompt>
+    started_at: "2026-09-05T11:41:42.837626+00:00"
+    prompt_sha256: 0c480de3d56ed76d3906f2a5e408ba62af5ea5c4c4c122540f9e2225017f191a # pragma: allowlist secret - verified artifact SHA-256, not credential
+    timeout_seconds: 240
+    exit: 0
+    finished_at: "2026-09-05T11:42:25.011974+00:00"
+    raw_stdout_sha256: 6489fd64619f0cd8c7d1a8479d0503a7bf1473feaaba9f03b28014424a18bdf4 # pragma: allowlist secret - verified artifact SHA-256, not credential
+    review_artifact_sha256: 6489fd64619f0cd8c7d1a8479d0503a7bf1473feaaba9f03b28014424a18bdf4 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - seat: kimi-code/k3
+    command:
+      - /Users/balizero/.kimi-code/bin/kimi
+      - -m
+      - kimi-code/k3
+      - -p
+      - <supplied diff prompt>
+    started_at: "2026-09-05T11:41:42.826986+00:00"
+    prompt_sha256: 0c480de3d56ed76d3906f2a5e408ba62af5ea5c4c4c122540f9e2225017f191a # pragma: allowlist secret - verified artifact SHA-256, not credential
+    timeout_seconds: 240
+    exit: 0
+    finished_at: "2026-09-05T11:43:28.165495+00:00"
+    raw_stdout_sha256: f948346d993acb606e3cd4f5510cbf8cb68153be672bf49936891f381d8c7265 # pragma: allowlist secret - verified artifact SHA-256, not credential
+    review_artifact_sha256: 12b9aeea8f3d076b60e58f95c77246437d6db7faff5ce117f5c6d1d794ad3481 # pragma: allowlist secret - verified artifact SHA-256, not credential

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/kimi-review.txt
@@ -1,0 +1,24 @@
+• **PASS** (conditional) — the supplied diff implements the stated contract with no demonstrable defect, but three conditions remain open below and none are proven by anything in the supplied material.
+
+  ## Findings
+
+  **Medium**
+
+  - **M1 — Timeout headroom unmeasured.** `frontend-tests` carries `timeout-minutes: 16`, justified in the job's own comment as "a cap one minute above the healthy path" (9m13s measured). Adding a full `tsc --noEmit` over `apps/mouth` into that leg consumes part of that margin. If tsc pushes the mouth leg past the cap, the job reports `cancelled` and the required context `Frontend Tests (Next.js) (mouth, true)` goes red on an infrastructure limit, not a code failure — the exact failure family the comment documents. "Full tsc in progress" locally does not measure CI runner time. This must be closed with an observed CI duration before the change can be called safe.
+  - **M2 — Backend-parity claim is prose-only in this diff.** Requirement "backend parity reads that exact OpenAPI file" is asserted in `contracts/README.md` and in the prefix-rule comment, but nothing in the supplied diff pins that `test_garuda_voa_openapi_parity.py` actually references `products/garuda-voa/contracts/openapi.yaml`, nor that the parity test is collected by the `backend-tests` job that `backend_python` selects. If the parity test reads a different path (or lives outside backend-tests' collection), the backend half of the coupling is decorative. The "19 workflow mapping tests pass" result may cover this; it is not shown.
+
+  **Low**
+
+  - **L1 — `npx tsc` resolution is not pinned.** The GARUDA step uses `./node_modules/.bin/openapi-typescript` (deterministic, local). The new step uses `npx tsc`, which falls back to a registry fetch if no local `typescript` binary is reachable from `apps/mouth` — introducing network dependence and version drift into a required leg. Confirm `typescript` is a pinned devDependency resolvable from `apps/mouth` (hoisted root `node_modules` counts), or switch to the `./node_modules/.bin/tsc` form for symmetry.
+  - **L2 — Guard brittleness by name.** `_assert_required_mouth_typecheck` orders via `names.index("Check GARUDA generated contract")` / `names.index("Run tests (with coverage)")`. A rename of either neighbor step raises `ValueError`, not `AssertionError` — it still fails the positive test, so this is acceptable brittleness, but the failure message will be opaque.
+  - **L3 — Guard covers only the new step.** The mutation suite correctly rejects remove/move/reorder/wrong-if/wrong-cwd/continue-on-error/`|| true`/missing-needs/success-only for `mouth-typecheck`, and pins `needs`, `if: !cancelled()`, and matrix-derived context names. It does not pin the pre-existing GARUDA freshness step against its own disarmament (`|| true`, `continue-on-error`). If no other guard covers that step, "generator/check semantics preserved" rests on review discipline, not a test.
+  - **L4 — Prefix is directory-wide, not OpenAPI-only.** `products/garuda-voa/contracts/` routes README and any future nested file to backend+mouth. This matches the stated requirement and the fail-open sibling tests (`contracts-extra`, `other-product`, `products/README.md`) are correct, so it is conservative rather than wrong — noted only because the requirement is phrased as "an OpenAPI contract-only edit."
+
+  ## Unresolved conditions (must close before merge)
+
+  1. **Remote CI proof absent.** 69 change-map + 19 workflow-mapping tests, generator freshness, and actionlint are local. No PR run demonstrates the `mouth-typecheck` step executing green inside the required context, nor that a contract-only diff actually produces `run_frontend_tests=true` end-to-end (the wiring from `suggested_jobs` to `needs.changes.outputs.run_frontend_tests` is not in the supplied diff).
+  2. **M1 timing.** Measured CI duration of the mouth leg with tsc included, vs. the 16-minute cap.
+  3. **M2 verification.** Confirmation that `test_garuda_voa_openapi_parity.py` reads exactly `products/garuda-voa/contracts/openapi.yaml` and runs under `backend-tests`.
+  4. **L1 verification.** Confirmation `npx tsc` resolves locally (no registry fallback) in the `apps/mouth` cwd on a clean runner.
+
+  No scope holes beyond these: the change-map tests cover the fail-open requirement, the guard's mutation matrix matches every disarmament vector enumerated in the required behavior, matrix/`needs`/`!cancelled()` semantics are untouched, and no runtime or contract files are modified.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/mutation-probes.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/mutation-probes.yml
@@ -1,0 +1,17 @@
+command: python .agent/b03b/mutate-workflow.py
+note: Actual temporary workflow mutations; equivalent cases are committed in test_required_context_map.py.
+started_at: "2026-09-05T11:42:22.423486+00:00"
+finished_at: "2026-09-05T11:42:26.511500+00:00"
+exit_by_case:
+  remove: 1
+  move-to-advisory: 1
+  after-tests: 1
+  wrong-matrix: 1
+  wrong-condition: 1
+  wrong-cwd: 1
+  step-advisory: 1
+  job-advisory: 1
+  swallow-error: 1
+  missing-needs: 1
+  success-only-job: 1
+  restored: 0

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/pack.yml
@@ -1,0 +1,66 @@
+gear: 3
+brief_ref: evidence/brief.yml
+council_run: council-journal.jsonl
+lanes:
+  - lane: b03b-build
+    role: build
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - lane: sol-review
+    role: review
+    seat: codex-gpt-5.6-sol
+  - lane: kimi-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+receipts:
+  - claim: 69 change-map tests passed.
+    cmd: python scripts/ci/test_change_map.py
+    exit: 0
+    ts: "2026-09-05T11:45:05.789731+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: 19 required-context tests passed, including 11 disarmament cases.
+    cmd: python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider
+    exit: 0
+    ts: "2026-09-05T11:45:05.789731+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: 11 actual workflow mutations each failed the live guard; restored workflow passed.
+    cmd: python .agent/b03b/mutate-workflow.py
+    exit: 0
+    ts: "2026-09-05T11:42:26.511500+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Current generated product types match OpenAPI.
+    cmd:
+      ./node_modules/.bin/openapi-typescript products/garuda-voa/contracts/openapi.yaml --output apps/mouth/src/lib/api/garuda-voa.generated.d.ts
+      --check
+    exit: 0
+    ts: "2026-09-05T11:45:05.789731+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Full mouth TypeScript passes.
+    cmd: cd apps/mouth && npx tsc --noEmit
+    exit: 0
+    ts: "2026-09-05T11:45:05.789731+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Workflow syntax passes.
+    cmd: actionlint -shellcheck= .github/workflows/tests.yml
+    exit: 0
+    ts: "2026-09-05T11:45:05.789731+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+dissent:
+  - seat: kimi-code/k3
+    objection: Required mouth CI execution and total duration against the 16-minute timeout remain unmeasured.
+    status: PLAUSIBLE
+    disposition: Keep pending until the PR run completes; no timeout change was made.
+  - seat: codex-gpt-5.6-sol
+    objection: Full tsc completion, backend parity source reference and remote CI need empirical confirmation.
+    status: PLAUSIBLE
+    disposition:
+      Full tsc passed; _CONTRACT_PATH and the actual default shard enumeration confirm backend
+      collection. Remote CI remains pending.
+notes:
+  - Initial-check receipt timestamps record evidence capture time; council and mutation timestamps are actual
+    completion times.
+  - Five source hashes are identical before and after mutation probes and match both council inputs.
+  - TypeScript is declared ^5.9.3, locked at 5.9.3, and resolves locally from mouth to the root node_modules/typescript/bin/tsc.
+  - Kimi low-severity notes concern exact guard names, existing generator-step coverage and directory-wide
+    routing; these match the assigned scope.
+  - No Anthropic verdict, remote CI timing or production proof is claimed.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/sol-review.txt
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/sol-review.txt
@@ -1,0 +1,9 @@
+PASS
+
+No severity findings in the supplied diff/context.
+
+Unresolved conditions:
+
+- Full `npx tsc --noEmit` is still in progress; PASS depends on its success.
+- No remote CI proof yet for the required matrix contexts.
+- The exact backend parity-file reference is stated in the supplied context but its test implementation is not shown, so it cannot be independently revalidated here.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/source-hashes.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/source-hashes.yml
@@ -1,0 +1,7 @@
+files:
+  .github/workflows/tests.yml: dd2eb76fe7bc55eb83b4ead6d79a7c5b0c35e14d65e4f7d06c4bf6d85c85fac0 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  scripts/ci/change_map.py: 320bee25c9ead00504b63f4a1224ab589c48803f07f021a94ebb97ebde939dac # pragma: allowlist secret - verified artifact SHA-256, not credential
+  scripts/ci/test_change_map.py: cd6f7422f4d23c088e2a8048fb096ad52d4c382cab0faa198e2d046e46ab29dc # pragma: allowlist secret - verified artifact SHA-256, not credential
+  scripts/tests/test_required_context_map.py: 2de4575544d7a9efc18ce3a6bd6a815e7c4099876e1feb8be9a67dbe393b2030 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  products/garuda-voa/contracts/README.md: 62aae5c7665a32da365cda7a9fdbf94b846e5f71ecb8e1da055c5f8d651c132f # pragma: allowlist secret - verified artifact SHA-256, not credential
+prompt_sha256: 0c480de3d56ed76d3906f2a5e408ba62af5ea5c4c4c122540f9e2225017f191a # pragma: allowlist secret - verified artifact SHA-256, not credential

--- a/products/garuda-voa/contracts/README.md
+++ b/products/garuda-voa/contracts/README.md
@@ -24,8 +24,12 @@ without rewriting the checkout:
   --output apps/mouth/src/lib/api/garuda-voa.generated.d.ts --check
 ```
 
-Changes confined to `products/` currently select all test suites through the
-conservative change-map fallback, so a contract-only edit runs this check too.
+The same required mouth job then runs `npx tsc --noEmit` from `apps/mouth`
+before its coverage tests, so generated contract consumers must also compile.
+
+Changes under `products/garuda-voa/contracts/` explicitly select backend,
+frontend and E2E tests. The backend consumes this OpenAPI in
+`test_garuda_voa_openapi_parity.py`; mouth consumes its generated types.
 The separate `garuda-contract-parity` job continues to enforce the Python
 contract invariants. This product artifact is independent of the global backend
 `schema.d.ts`; generating it does not refresh or alter that unrelated snapshot.

--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -219,6 +219,8 @@ SCRIPTS_COUPLING: frozenset[str] = frozenset(
 # END SCRIPTS_COUPLING
 
 PREFIX_RULES: tuple[tuple[str, frozenset[str]], ...] = (
+    # OpenAPI feeds mouth's generated types and the backend live-router parity test.
+    ("products/garuda-voa/contracts/", frozenset({"backend_python", "mouth"})),
     ("apps/backend-rag/", frozenset({"backend_python"})),
     ("apps/crm-cell/", frozenset({"backend_python"})),
     ("packages/cell-core/", frozenset({"backend_python", "mcp"})),

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -100,6 +100,44 @@ def _staleness_verdict(
 
 
 class ChangeMapTests(unittest.TestCase):
+    def test_garuda_contract_explicitly_selects_both_consumers(self) -> None:
+        for path in (
+            "products/garuda-voa/contracts/openapi.yaml",
+            "products/garuda-voa/contracts/README.md",
+            "products/garuda-voa/contracts/nested/future-schema.yaml",
+        ):
+            for files in ([path], [path, "docs/contract-notes.md"]):
+                with self.subTest(files=files):
+                    result = cm.classify(files)
+                    self.assertFalse(result["run_all"])
+                    self.assertEqual(result["reason"], "classified")
+                    self.assertEqual(result["unknown_paths"], [])
+                    self.assertTrue(result["domains"]["backend_python"])
+                    self.assertTrue(result["domains"]["mouth"])
+                    self.assertEqual(
+                        result["suggested_jobs"],
+                        ["backend-tests", "frontend-tests", "e2e-tests"],
+                    )
+
+    def test_garuda_contract_prefix_keeps_unknown_siblings_fail_open(self) -> None:
+        for path in (
+            "products/garuda-voa/contracts-extra/openapi.yaml",
+            "products/other-product/contracts/openapi.yaml",
+            "products/README.md",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertTrue(result["run_all"])
+                self.assertEqual(result["reason"], "unclassified_paths")
+                self.assertEqual(result["unknown_paths"], [path])
+                self.assertEqual(result["suggested_jobs"], list(cm.TEST_JOBS))
+
+    def test_unrelated_docs_do_not_select_garuda_consumers(self) -> None:
+        result = cm.classify(["docs/contract-notes.md"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["reason"], "classified")
+        self.assertEqual(result["suggested_jobs"], [])
+
     def test_guilt_backend_change_runs_backend_and_e2e(self) -> None:
         result = cm.classify(["apps/backend-rag/backend/app/main.py"])
         self.assertFalse(result["run_all"])

--- a/scripts/tests/test_required_context_map.py
+++ b/scripts/tests/test_required_context_map.py
@@ -14,7 +14,11 @@ Run:  python3 -m pytest scripts/tests/test_required_context_map.py -q
 from __future__ import annotations
 
 import importlib.util
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _MODULE_PATH = REPO_ROOT / "scripts" / "ci" / "required_context_map.py"
@@ -22,6 +26,78 @@ _spec = importlib.util.spec_from_file_location("required_context_map", _MODULE_P
 assert _spec is not None and _spec.loader is not None
 mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+def _assert_required_mouth_typecheck(workflow: dict[str, Any]) -> None:
+    """Pin the compiler in the required leg, not a separately green advisory job."""
+    job = workflow["jobs"]["frontend-tests"]
+    assert "Frontend Tests (Next.js) (mouth, true)" in mod._context_names_for_job(
+        "frontend-tests", job
+    )
+    assert job["needs"] == ["changes"]
+    assert job["if"] == "${{ !cancelled() }}"
+    assert job.get("continue-on-error", False) is False
+    steps = job["steps"]
+    matches = [step for step in steps if step.get("id") == "mouth-typecheck"]
+    assert len(matches) == 1
+    step = matches[0]
+    assert step["if"] == "matrix.app == 'mouth' && steps.decide.outputs.run == 'true'"
+    assert step["working-directory"] == "apps/mouth"
+    assert step["run"].strip() == "npx tsc --noEmit"
+    assert step.get("continue-on-error", False) is False
+    names = [entry.get("name") for entry in steps]
+    assert names.index("Check GARUDA generated contract") < steps.index(step)
+    assert steps.index(step) < names.index("Run tests (with coverage)")
+
+
+def test_required_mouth_job_compiles_contract_consumers() -> None:
+    # immune-enforcement.yml's required antidotes job runs this file from the
+    # candidate checkout. change_map's base-ref self-tests cannot provide that pin.
+    workflow = mod.load_workflow(REPO_ROOT / ".github/workflows/tests.yml")
+    assert workflow is not None
+    _assert_required_mouth_typecheck(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "remove", "move-to-advisory", "after-tests", "wrong-matrix",
+        "wrong-condition", "wrong-cwd", "step-advisory", "job-advisory",
+        "swallow-error", "missing-needs", "success-only-job",
+    ],
+)
+def test_required_mouth_typecheck_rejects_disarmed_mutations(mutation: str) -> None:
+    workflow = deepcopy(mod.load_workflow(REPO_ROOT / ".github/workflows/tests.yml"))
+    assert workflow is not None
+    job = workflow["jobs"]["frontend-tests"]
+    steps = job["steps"]
+    step = next(entry for entry in steps if entry.get("id") == "mouth-typecheck")
+    if mutation in {"remove", "move-to-advisory", "after-tests"}:
+        steps.remove(step)
+        if mutation == "move-to-advisory":
+            workflow["jobs"]["advisory-typecheck"] = {
+                "continue-on-error": True, "steps": [step]
+            }
+        elif mutation == "after-tests":
+            steps.append(step)
+    elif mutation == "wrong-matrix":
+        job["strategy"]["matrix"]["include"][0]["coverage"] = False
+    elif mutation == "wrong-condition":
+        step["if"] = "matrix.app == 'admin-dashboard'"
+    elif mutation == "wrong-cwd":
+        step["working-directory"] = "apps/admin-dashboard"
+    elif mutation == "step-advisory":
+        step["continue-on-error"] = True
+    elif mutation == "job-advisory":
+        job["continue-on-error"] = True
+    elif mutation == "swallow-error":
+        step["run"] += " || true"
+    elif mutation == "missing-needs":
+        job["needs"] = []
+    elif mutation == "success-only-job":
+        job["if"] = "${{ success() }}"
+    with pytest.raises(AssertionError):
+        _assert_required_mouth_typecheck(workflow)
 
 
 def _write(wf_dir: Path, name: str, content: str) -> None:


### PR DESCRIPTION
GARUDA generated-type freshness was required, but compiling its consumers was only covered by a separate non-required context. Contract-only edits also selected frontend tests through the unknown-path fallback. This change runs `npx tsc --noEmit` in the existing required mouth leg and explicitly maps the product contract directory to both backend and mouth consumers.

Bites: `Frontend Tests (Next.js) (mouth, true)` now runs `mouth-typecheck` from `apps/mouth`, after GARUDA freshness and before coverage. The required `antidotes` job runs the candidate workflow guard in `test_required_context_map.py`; removing or disarming the compiler step makes that guard fail.

Validation:

- `python scripts/ci/test_change_map.py` — 69 tests passed. Contract paths, nested paths and README classify with `run_all:false`, `reason:classified`, no unknown paths, and backend/frontend/E2E jobs. Unknown sibling products remain fail-open; unrelated docs select no product jobs.
- `python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider` — 19 passed, including 11 disarmament mutations. The same 11 mutations were applied temporarily to the actual workflow; each produced exit 1 from the live guard, followed by exit 0 on restoration.
- `./node_modules/.bin/openapi-typescript products/garuda-voa/contracts/openapi.yaml --output apps/mouth/src/lib/api/garuda-voa.generated.d.ts --check` — exit 0.
- `cd apps/mouth && npx tsc --noEmit` — exit 0.
- `actionlint -shellcheck= .github/workflows/tests.yml` and Ruff on the three Python files — passed.
- Evidence lint: gear 3, exit 0, actual two-seat council journal. Canary-backed secret preflight covered all 13 changed files: no unaudited findings; the workflow has four unchanged pre-audited baseline findings.

Independent council: Sol PASS; Kimi PASS conditional. Both actual subscription CLI calls exited 0 on the same immutable five-file snapshot. No source changed after review. The backend parity source path and default shard inclusion were verified; TypeScript is declared `^5.9.3`, locked at `5.9.3`, and resolves locally from mouth. Raw review content and receipt hashes are committed.

CI receipt on head `8791eab8ed2869fd0b95bbbe4069c8a9a20271e5`: [required mouth job](https://github.com/Bali-Zero/Teman2/actions/runs/33964324967/job/101301731872) completed SUCCESS from 11:49:55 to 11:56:24 UTC, totaling 6 minutes 29 seconds against the existing 16-minute cap (9 minutes 31 seconds of margin). The new typecheck passed from 11:50:43 to 11:51:17 UTC (34 seconds), after GARUDA freshness and before coverage; the suite and coverage threshold also passed. The admin leg correctly skipped this mouth-only step. Both remote execution and duration conditions from council are now verified for this run.

Pending before merge: [Harness floor recompute](https://github.com/Bali-Zero/Teman2/actions/runs/33964325075/job/101301598911) passed the gear comparison and evidence-pack validation, then failed closed only because no independent `harness/fable-gate` verdict has been posted on this head. Final independent Anthropic grading belongs to Fable. No runtime, frozen contract, dependency or production changes are included.

Evidence: `evidence/2026-09/agent-air-m5-infra-b03b-required-contract-checks/` (`brief.yml`, `pack.yml`, `council-journal.jsonl`, `council-receipts.yml`, `source-hashes.yml`, `mutation-probes.yml`, and both reviewer answers).
