### PR TITLE
fix(e33): require access to both clients for principal links

### DIFF
--- a/apps/backend-rag/backend/app/routers/e33_cases.py
+++ b/apps/backend-rag/backend/app/routers/e33_cases.py
@@ -317,8 +317,11 @@ async def create_case(
     """Mint a new E33 case starting at ``fit_memo``.
 
     Property basis is out of V1 scope (pending addendum 007 —
-    ``property_validation_standard``). Client existence, archival state and
-    RBAC and the optional practice's client association are checked BEFORE any insert.
+    ``property_validation_standard``). Before any insert, validate the requested
+    client's existence, archival state and caller access, the optional practice's
+    client association, and the optional principal client's existence, archival
+    state and caller access. Principal and dependent may have different client IDs;
+    this access check does not establish their family relationship.
 
     On a case_id collision (``asyncpg.UniqueViolationError``) re-mint once;
     a second collision is a 500 (astronomically unlikely — 6 hex chars).
@@ -353,6 +356,24 @@ async def create_case(
             )
 
     repo = E33CaseRepository(db_pool)
+    if body.principal_case_id is not None:
+        unavailable = HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="principal case is not available",
+        )
+        principal = await repo.load(body.principal_case_id)
+        if principal is None:
+            raise unavailable
+        principal_client = await _fetch_client_for_create(db_pool, principal.client_id)
+        if principal_client is None or principal_client["deleted_at"] is not None:
+            raise unavailable
+        try:
+            _assert_client_access(current_user, principal_client["assigned_to"])
+        except HTTPException as exc:
+            if exc.status_code != status.HTTP_403_FORBIDDEN:
+                raise
+            raise unavailable from None
+
     today = date.today()
     case: E33Case | None = None
     last_error: asyncpg.UniqueViolationError | None = None

--- a/apps/backend-rag/backend/tests/routers/test_e33_cases.py
+++ b/apps/backend-rag/backend/tests/routers/test_e33_cases.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 import backend.app.routers.e33_cases as e33_cases_module
@@ -95,6 +95,7 @@ class TestCreateCase:
         )
         fake_repo = MagicMock()
         fake_repo.insert = AsyncMock(side_effect=lambda case: case)
+        fake_repo.load = AsyncMock()
 
         with patch.object(e33_cases_module, "E33CaseRepository", return_value=fake_repo):
             response = client.post(
@@ -110,7 +111,154 @@ class TestCreateCase:
         assert body["stage_history"] == []
         fake_repo.insert.assert_awaited_once()
         assert fake_repo.insert.await_args.args[0].practice_id is None
+        fake_repo.load.assert_not_awaited()
         conn.fetchval.assert_not_awaited()
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "scenario, role, principal_client_id, assigned_to, expected_status",
+        [
+            ("different-clients", "team_member", 2, "TEAM@balizero.com", 201),
+            ("admin", "admin", 2, "other@example.com", 201),
+            ("same-client", "team_member", 1, "team@balizero.com", 201),
+            ("missing-principal", "team_member", 2, "team@balizero.com", 422),
+            ("missing-client", "team_member", 2, "team@balizero.com", 422),
+            ("archived-client", "team_member", 2, "team@balizero.com", 422),
+            ("other-staff", "team_member", 2, "other@example.com", 422),
+            ("unassigned", "team_member", 2, None, 422),
+        ],
+        ids=lambda value: str(value),
+    )
+    def test_principal_link_requires_access_to_both_clients(
+        self,
+        mock_db_pool,
+        scenario: str,
+        role: str,
+        principal_client_id: int,
+        assigned_to: str | None,
+        expected_status: int,
+    ) -> None:
+        pool, conn = mock_db_pool
+        user = {"id": "2", "email": "team@balizero.com", "role": role}
+        requested_client = {
+            "full_name": "Synthetic dependent",
+            "assigned_to": user["email"],
+            "deleted_at": None,
+        }
+        principal_client = {
+            "full_name": "Synthetic principal",
+            "assigned_to": assigned_to,
+            "deleted_at": "2026-01-01" if scenario == "archived-client" else None,
+        }
+        rows = [requested_client]
+        if scenario != "missing-principal":
+            rows.append(None if scenario == "missing-client" else principal_client)
+        conn.fetchrow = AsyncMock(side_effect=rows)
+        fake_repo = MagicMock()
+        fake_repo.insert = AsyncMock(side_effect=lambda case: case)
+        principal = (
+            None
+            if scenario == "missing-principal"
+            else _existing_case(client_id=principal_client_id)
+        )
+        fake_repo.load = AsyncMock(return_value=principal)
+        client = TestClient(_make_app(pool, user), raise_server_exceptions=False)
+
+        with patch.object(e33_cases_module, "E33CaseRepository", return_value=fake_repo):
+            response = client.post(
+                "/api/e33/cases",
+                json={
+                    "client_id": 1,
+                    "basis": "deposit",
+                    "dependent_code": "E31B",
+                    "principal_case_id": "E33-2026-abc123",
+                },
+            )
+
+        assert response.status_code == expected_status
+        fake_repo.load.assert_awaited_once_with("E33-2026-abc123")
+        assert conn.fetchrow.await_count == len(rows)
+        if principal is not None:
+            assert conn.fetchrow.await_args.args[1:] == (principal_client_id,)
+        if expected_status == 201:
+            fake_repo.insert.assert_awaited_once()
+            created = fake_repo.insert.await_args.args[0]
+            assert (created.client_id, created.dependent_code, created.principal_case_id) == (
+                1,
+                "E31B",
+                "E33-2026-abc123",
+            )
+        else:
+            assert response.json() == {"detail": "principal case is not available"}
+            fake_repo.insert.assert_not_awaited()
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "access_error",
+        [HTTPException(409, "synthetic conflict"), RuntimeError("synthetic failure")],
+    )
+    def test_unexpected_principal_access_error_is_not_masked(
+        self, mock_db_pool, team_user, access_error: Exception
+    ) -> None:
+        pool, conn = mock_db_pool
+        conn.fetchrow = AsyncMock(
+            return_value={
+                "full_name": "Synthetic client",
+                "assigned_to": team_user["email"],
+                "deleted_at": None,
+            }
+        )
+        fake_repo = MagicMock()
+        fake_repo.load = AsyncMock(return_value=_existing_case(client_id=2))
+        fake_repo.insert = AsyncMock()
+        client = TestClient(_make_app(pool, team_user), raise_server_exceptions=False)
+        with (
+            patch.object(e33_cases_module, "E33CaseRepository", return_value=fake_repo),
+            patch.object(
+                e33_cases_module, "_assert_client_access", side_effect=[None, access_error]
+            ),
+        ):
+            response = client.post(
+                "/api/e33/cases",
+                json={
+                    "client_id": 1,
+                    "basis": "deposit",
+                    "dependent_code": "E31B",
+                    "principal_case_id": "E33-2026-abc123",
+                },
+            )
+        assert response.status_code == (409 if isinstance(access_error, HTTPException) else 500)
+        fake_repo.insert.assert_not_awaited()
+
+    @pytest.mark.integration
+    def test_configured_crm_admin_can_link_different_clients(self, mock_db_pool, team_user) -> None:
+        pool, conn = mock_db_pool
+        conn.fetchrow = AsyncMock(
+            return_value={"full_name": "Synthetic client", "assigned_to": None, "deleted_at": None}
+        )
+        fake_repo = MagicMock()
+        fake_repo.load = AsyncMock(return_value=_existing_case(client_id=2))
+        fake_repo.insert = AsyncMock(side_effect=lambda case: case)
+        client = TestClient(_make_app(pool, team_user), raise_server_exceptions=False)
+        with (
+            patch.object(e33_cases_module, "E33CaseRepository", return_value=fake_repo),
+            patch(
+                "backend.app.utils.crm_utils._crm_admin_emails",
+                return_value=frozenset({team_user["email"]}),
+            ),
+        ):
+            response = client.post(
+                "/api/e33/cases",
+                json={
+                    "client_id": 1,
+                    "basis": "deposit",
+                    "dependent_code": "E31B",
+                    "principal_case_id": "E33-2026-abc123",
+                },
+            )
+        assert response.status_code == 201
+        fake_repo.load.assert_awaited_once_with("E33-2026-abc123")
+        fake_repo.insert.assert_awaited_once()
 
     @pytest.mark.integration
     @pytest.mark.parametrize("role", ["admin", "team_member"])
@@ -293,7 +441,13 @@ class TestCreateCase:
 
         response = client.post(
             "/api/e33/cases",
-            json={"client_id": 1, "basis": "deposit", "practice_id": 42},
+            json={
+                "client_id": 1,
+                "basis": "deposit",
+                "practice_id": 42,
+                "dependent_code": "E31B",
+                "principal_case_id": "E33-2026-abc123",
+            },
         )
 
         assert response.status_code == 403

--- a/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/brief.yml
@@ -1,0 +1,22 @@
+task_id: s02b-principal-access
+gear: 2
+l_level: L2
+gate_class: opus
+objective: Require caller access to the principal client before linking an E33 dependent case.
+constraints:
+  - Reuse existing CRM access and configured admin allowlists; different client IDs remain valid.
+  - No family relationship proof, schema changes, client data access or deployment in this patch.
+  - Only router, its synthetic tests and lane evidence change.
+acceptance:
+  - text:
+      WHEN a principal is supplied the route SHALL allow callers with access to both clients and reject unavailable
+      principals with the same 422 before insert.
+    probe: backend/tests/routers/test_e33_cases.py
+  - text:
+      WHEN the principal is omitted no repository load SHALL occur; configured CRM administrators and unexpected
+      errors SHALL preserve existing access semantics.
+    probe: backend/tests/routers/test_e33_cases.py
+  - text: WHEN the principal guard is removed the suite SHALL fail, then pass after exact source restoration.
+    probe: verify_principal_access.py
+consumer_map:
+  - POST /api/e33/cases uses the principal-client access guard before minting and inserting.

--- a/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/pack.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/pack.yml
@@ -1,0 +1,70 @@
+brief_ref: evidence/brief.yml
+plan_ref: "Fable consul ruling 2026-09-05T12:1xZ: access to both clients is the approved minimum."
+lanes:
+  - lane: s02b-principal-access
+    role: build
+    seat: OpenAI GPT-6 Codex session; exact backend variant not exposed
+  - lane: s02b-principal-access-review
+    role: review
+    seat: kimi-code/k3 via existing OAuth CLI
+dissent:
+  - seat: kimi-code/k3
+    status: RETRACTED
+    objection:
+      Requested-client denial lacked a supplied principal in its regression test. Added both dependent
+      fields; final delta reviewed PASS.
+pii_scan: clean
+review_status:
+  Kimi K3 PASS on implementation and final test delta; independent Anthropic gate remains with
+  Fable.
+baseline: caa8e9708cad5b18c4c033ab0398982d8d4b8fcc # pragma: allowlist secret - verified source or prompt digest
+verification_scope:
+  host: Pro
+  snapshot: /tmp/s02b-principal-access.GGRCZu
+  venv: /Users/nuzantara/nuzantara/apps/backend-rag/.venv
+  environment: env -i, synthetic database URLs on loopback port 1, mocked repository/client rows only.
+  reproduction:
+    From an isolated apps/backend-rag snapshot, run python <evidence-dir>/verify_principal_access.py
+    <receipt-output-dir> using the existing Pro venv and inert environment.
+  source_identity: M5 source hashes match the restored Pro snapshot byte for byte.
+  file_sha256:
+    backend/app/routers/e33_cases.py: 9714791ebcda1066d33a2633130967c9b51c8c790c8e1c784dc97d62e1e41857 # pragma: allowlist secret - verified source or prompt digest
+    backend/tests/routers/test_e33_cases.py: 55dffa2ae6432e2d357638c00b91842adee28346e5326731e46e401ba4a0e0bc # pragma: allowlist secret - verified source or prompt digest
+receipts:
+  - claim: guilt-no-principal-guard
+    cmd: "python verify_principal_access.py <receipt-output-dir> (guilt phase: python -m pytest backend/tests/routers/test_e33_cases.py)"
+    result: 11 failed, 41 passed, 1 warning in 0.94s
+    exit: 1
+    ts: "2026-09-05T13:29:05.661498+00:00"
+    seat: OpenAI Codex orchestration; Python executed on Pro
+  - claim: innocence-restored
+    cmd: python -m pytest backend/tests/routers/test_e33_cases.py
+    result: 52 passed, 1 warning in 0.64s
+    exit: 0
+    ts: "2026-09-05T13:29:06.821797+00:00"
+    seat: OpenAI Codex orchestration; Python executed on Pro
+  - claim: ruff
+    cmd: python -m ruff check backend/app/routers/e33_cases.py backend/tests/routers/test_e33_cases.py
+    result: All checks passed!
+    exit: 0
+    ts: "2026-09-05T13:29:06.887243+00:00"
+    seat: OpenAI Codex orchestration; Python executed on Pro
+  - claim: Kimi K3 initial review
+    cmd: kimi -m kimi-code/k3 -p <scoped read-only prompt>
+    result: PASS; raw response in review-kimi-initial.txt
+    exit: 0
+    ts: "2026-09-05T13:28:40.124661+00:00"
+    seat: kimi-code/k3 (requested model; existing OAuth CLI)
+    prompt_sha256: b97cd7c95db52a4d325646007b8507fb1f8bacf668c3e72f388d97ad3f6da8bd # pragma: allowlist secret - verified source or prompt digest
+  - claim: Kimi K3 final-delta review
+    cmd: kimi -m kimi-code/k3 -p <scoped read-only prompt>
+    result: PASS; raw response in review-kimi-final-delta.txt
+    exit: 0
+    ts: "2026-09-05T13:29:47.416154+00:00"
+    seat: kimi-code/k3 (requested model; existing OAuth CLI)
+    prompt_sha256: 24f0051204da1b6dd2d8f6fcf9d552458b02c229f29356c8337c9b6a21140ec3 # pragma: allowlist secret - verified source or prompt digest
+residuals:
+  - Access to both client records does not prove kinship; any relationship-evidence requirement is a separate
+    owner business decision.
+  - The insert foreign-key fallback remains for deletion races after lookup. No production behavior or final
+    Anthropic approval is claimed.

--- a/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/review-kimi-final-delta.txt
+++ b/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/review-kimi-final-delta.txt
@@ -1,0 +1,5 @@
+• **PASS.**
+
+  The added `dependent_code: "E31B"` and `principal_case_id: "E33-2026-abc123"` close the prior gap — the payload now matches the dependent-request shape, so the 403 provably comes from requested-client access denial, not from a schema 422 or a generic-422 principal failure.
+
+  Ordering holds: access assertion runs before practice lookup, so `conn.fetchval.assert_not_awaited()` remains a valid discriminator — principal-case validation and the principal repository are never reached, and the 403-conversion wrapper is irrelevant to this path. The supplied principal IDs are valid-format and cannot short-circuit earlier than the client check per the stated policy and implementation order. No defect introduced; testcase is self-consistent with both mock (`fetchrow` = client row lookup) and assertion.

--- a/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/review-kimi-initial.txt
+++ b/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/review-kimi-initial.txt
@@ -1,0 +1,26 @@
+• # Verdict: PASS
+
+  The implementation satisfies every stated requirement, and the test matrix is decisive for each of them.
+
+  ## Requirement trace (all CONFIRMED, code-supported)
+
+  - **Missing principal → 422**: `principal is None: raise unavailable` (e33_cases.py, new block ~line 363). Covered by `missing-principal` scenario; asserts `insert.assert_not_awaited()` and exact detail string.
+  - **Missing/archived principal client → 422**: `principal_client is None or principal_client["deleted_at"] is not None` (~line 366). Covered by `missing-client` / `archived-client` scenarios, both asserting identical `{"detail": "principal case is not available"}` and no insert.
+  - **Helper 403 → same 422**: try/except converts only `status_code == 403` to `unavailable` (~lines 368–373). Covered by `other-staff` and `unassigned` (None assigned_to → 403 path). Exact-detail assertion makes the "identical" clause verifiable, not implied.
+  - **Unexpected errors not disguised**: non-403 HTTPException re-raised (`if exc.status_code != 403: raise`); non-HTTP exceptions never enter the except clause. `test_unexpected_principal_access_error_is_not_masked` proves both (409 passthrough, RuntimeError → 500), with `side_effect=[None, access_error]` proving the requested-client call succeeded first and the error originates from the principal call specifically.
+  - **Requested-client 403 unchanged**: that code path is untouched by the diff, and the conversion `try` wraps only the principal `_assert_client_access` call — a requested-client 403 raises before the principal block is reached.
+  - **Omitted principal → no load**: guarded by `if body.principal_case_id is not None`; the pre-existing happy-path test now asserts `fake_repo.load.assert_not_awaited()`.
+  - **Different client IDs allowed, dual access enforced**: `different-clients` scenario (client 1 vs principal client 2, case-mismatched email `TEAM@…` also exercising the helper's lowercasing) and `admin` role scenario return 201; `test_configured_crm_admin_can_link_different_clients` covers the email-allowlist admin path with `assigned_to=None` on both clients.
+  - **Before insert**: every 422/4xx/5xx scenario asserts `insert.assert_not_awaited()`.
+
+  ## Test-quality checks (CONFIRMED)
+
+  - `conn.fetchrow` ordering assumption (requested client first, principal second) matches `side_effect=rows` sequencing, and `await_count == len(rows)` pins the short-circuit points precisely (e.g., `missing-principal` consumes exactly 1 row).
+  - `await_args.args[1:] == (principal_client_id,)` verifies the second fetch targets the principal's client, not the requested one — including `same-client` where both are 1.
+  - The `_crm_admin_emails` patch in the admin test is self-validating: team_member role + `assigned_to=None` means the test returns 422 if the patch no-ops, so it cannot pass for the wrong reason.
+
+  ## Findings
+
+  **PLAUSIBLE (non-blocking) — no explicit regression test that a requested-client 403 still returns 403 (not 422) when `principal_case_id` is also supplied.** The code structure makes masking impossible (the requested-client check raises before, and outside, the conversion `try`), and the pre-existing suite presumably covers the plain requested-client 403. If you want belt-and-suspenders, one parametrized row with requested-client denied + valid principal asserting `403` would close it. This is hardening, not a defect.
+
+  No CONFIRMED defects. Scope discipline held: no kinship proof, no new schema, no new helpers — the ruling as stated is implemented exactly.

--- a/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/verify_principal_access.py
+++ b/evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/verify_principal_access.py
@@ -1,0 +1,68 @@
+"""Run only in an isolated backend snapshot with synthetic database configuration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def main() -> int:
+    output = Path(sys.argv[1])
+    output.mkdir(parents=True, exist_ok=True)
+    router = Path("backend/app/routers/e33_cases.py")
+    tests = Path("backend/tests/routers/test_e33_cases.py")
+    original = router.read_bytes()
+    source = original.decode()
+    start = source.index("    if body.principal_case_id is not None:\n")
+    end = source.index("    today = date.today()", start)
+    receipts = []
+
+    def run(name: str, args: list[str]) -> int:
+        started = datetime.now(timezone.utc).isoformat()
+        result = subprocess.run([sys.executable, *args], capture_output=True, text=True)
+        log = re.sub(r"\x1b\[[0-9;]*m", "", result.stdout + result.stderr)
+        (output / f"{name}.log").write_text(log)
+        summary = next(
+            (line for line in reversed(log.splitlines()) if line.strip()), ""
+        )
+        receipts.append(
+            {
+                "name": name,
+                "command": args,
+                "started_at": started,
+                "finished_at": datetime.now(timezone.utc).isoformat(),
+                "exit_code": result.returncode,
+                "summary": summary,
+            }
+        )
+        print(f"{name}: exit={result.returncode}; {summary}")
+        return result.returncode
+
+    pytest_args = ["-m", "pytest", str(tests)]
+    try:
+        router.write_text(source[:start] + source[end:])
+        guilt = run("guilt-no-principal-guard", pytest_args)
+    finally:
+        router.write_bytes(original)
+    assert router.read_bytes() == original, "Failed to restore exact router source"
+    innocence = run("innocence-restored", pytest_args)
+    lint = run("ruff", ["-m", "ruff", "check", str(router), str(tests)])
+    record = {
+        "receipts": receipts,
+        "router_restored_exactly": True,
+        "file_sha256": {
+            str(path): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in [router, tests]
+        },
+    }
+    (output / "results.json").write_text(json.dumps(record, indent=2) + "\n")
+    return 0 if guilt == 1 and innocence == 0 and lint == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The E33 create route accepted a principal case reference without checking the caller's access to that principal's client. It now loads the principal and reuses the existing client/archive/access checks before minting or inserting. Missing, archived and inaccessible principals all return `422 {"detail":"principal case is not available"}`.

Different principal and dependent client IDs remain valid when the caller can access both. Configured CRM administrator allowlists remain effective. The requested-client 403 and unexpected non-403 errors preserve their existing behavior; an omitted principal performs no additional repository load. This implements Fable's 2026-09-05 access-to-both ruling. It does not establish kinship; any relationship-evidence requirement remains a separate business decision.

Bites: `POST /api/e33/cases` consumes the principal-client check before `E33CaseRepository.insert`. In the isolated Pro snapshot, `python verify_principal_access.py <receipt-dir>` removed the guard and produced **11 failed / 41 passed**, restored the exact router bytes and produced **52 passed**, then ran Ruff successfully. Rejected synthetic cases assert `insert.assert_not_awaited()`; authorized different-client cases assert the preserved principal link. The committed source hashes match the tested Pro files.

Validation:

- Pro existing venv, isolated `/tmp/s02b-principal-access.GGRCZu`, `env -i`, inert loopback-port-1 database configuration and synthetic `mock_db_pool` fixtures. Final suite: `python -m pytest backend/tests/routers/test_e33_cases.py` -> **52 passed**, one existing LangChain warning.
- `python -m ruff check backend/app/routers/e33_cases.py backend/tests/routers/test_e33_cases.py` -> passed. Normal pre-commit hooks, including FastAPI import smoke, passed.
- `scripts/evidence_pack_lint.py` against the canonical staged pack/brief with this diff's changed paths and numstat -> exit 0, no violations or notices. `scripts/detect_secrets_check_file.py` scanned all seven changed files -> clean, runtime canary detected.
- Independent OAuth `kimi -m kimi-code/k3 -p <scoped prompt>` -> **PASS**, zero confirmed defects. Its optional missing-payload test finding was addressed, and the final test delta received a second **PASS**. Actual response artifacts and dated prompt-hash receipts are committed.

Evidence: `evidence/2026-09/agent-air-m5-backend-rag-s02b-principal-access/{brief.yml,pack.yml,verify_principal_access.py,review-kimi-*.txt}`. Seven files; 370 additions, 4 deletions.

Draft prepared for Fable's independent Anthropic gate. CI and production behavior are not claimed by the local receipts.


Current CI on `2ccd79dbb54da27deba09931662aa4ccafbb7de0`: [Tests & Coverage run33969149185](https://github.com/Bali-Zero/Teman2/actions/runs/33969149185) succeeded. Final rollup observed2026-09-05T13:48:03Z:75 checks passed,3 skipped,0 failures/pending. The original `backend-shard-2` artifact9970461855 is bound to this run/head; its JUnit records52 E33 router tests,0 failure/error/skip. Root independently parsed the downloaded original XML and verified its hash. No source change or CI rerun after review.
