### PR TITLE
docs(visa-oracle): describe absent EDIT target reset

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -1130,8 +1130,8 @@ export function getTreeSteps(
     // "category" entirely — yet "category" still sits earlier in `order`
     // than "review_gate", so the old `idx < currentIdx → "done"` rule
     // marked it "done" even though it was never asked, exposing a
-    // tap-to-edit button whose EDIT dispatch was a silent no-op
-    // (`truncateToNode` finds no matching history entry). Ground truth
+    // tap-to-edit button for a question absent from history. EDIT now
+    // resets the flow when its target is absent. Ground truth
     // for any REAL question step is the fact itself — `pruneFacts`
     // already guarantees `facts` only ever holds keys for questions
     // actually answered on the current path, so a question step is
@@ -1176,9 +1176,8 @@ export function getTreeSteps(
  * actual question node. "framing"/"confirmation"/"verdict" can reach
  * "done" status too (they're plain forward moves through the trunk, not
  * questions) and must never render as editable — `flowReducer`'s EDIT
- * action only knows how to truncate history to a `{ kind: "question" }`
- * node, so dispatching EDIT with one of those ids would silently no-op
- * (`truncateToNode` finds no match and returns the history unchanged).
+ * action requires a matching `{ kind: "question" }` history entry and
+ * resets the flow when its target is absent.
  * Current/pending/pruned steps are never editable either — you can't jump
  * forward to an answer that doesn't exist yet. Pure, so `LivingTree` never
  * has to re-derive this rule itself.

--- a/evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/brief.yml
@@ -1,0 +1,9 @@
+gear: 1
+objective: Correct two flow.ts comments describing EDIT with an absent history target.
+constraints:
+  - Comments only; no runtime or test changes.
+acceptance:
+  - WHEN EDIT has no matching question history entry, both comments SHALL describe the existing reset.
+  - WHEN comments are omitted, the TypeScript and emitted JavaScript SHALL match the parent.
+consumer_map:
+  - Developers and reviewers reading flow.ts beside getTreeSteps and isEditableTreeStep.

--- a/evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/kimi-review.txt
@@ -1,0 +1,8 @@
+• **PASS.**
+
+  Both comments accurately describe the supplied EDIT implementation:
+
+  - Comment 1 ("EDIT now resets the flow when its target is absent"): matches the guard — if no history node matches the `{ kind: "question", questionId }` target, `resetFlow(state)` is returned.
+  - Comment 2 ("EDIT requires a matching `{ kind: "question" }` history entry and resets the flow when its target is absent"): also correct — `sameNode` requires `kind === "question"` plus equal `questionId`, and the absent-target path resets rather than no-ops (the old `truncateToNode`-silence claim was rightly removed).
+
+  Minor note: "requires a matching entry" slightly glosses that EDIT still truncates when the entry exists, but no falsehood. No runtime changes made.

--- a/evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/pack.yml
@@ -1,0 +1,45 @@
+gear: 1
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: v01b-edit-comments
+    role: build
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - lane: comment-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+seat_override: >-
+  R8 applicability only, following the merged PR5782 precedent: this Fable-assigned follow-up changes
+  two code comments, with identical comment-free TypeScript and emitted JavaScript. No immigration
+  rule, claim, eligibility or price is authored; no NotebookLM query is claimed.
+receipts:
+  - claim: Candidate syntax is valid; comment-free TypeScript and emitted JavaScript are byte-identical to the parent.
+    cmd: node -
+    result: Node stdin used TypeScript createSourceFile/createPrinter(removeComments)/transpileModule; no parse diagnostics.
+    exit: 0
+    ts: "2026-09-05T13:41:32.420255+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Comment diff passes whitespace validation.
+    cmd: git diff --check
+    exit: 0
+    ts: "2026-09-05T13:41:32.420456+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Independent comment-truth review PASS.
+    cmd: /Users/balizero/.kimi-code/bin/kimi -m kimi-code/k3 -p <supplied comment diff and implementation>
+    exit: 0
+    ts: "2026-09-05T13:40:52.627588+00:00"
+    seat: kimi-code/k3
+dissent: []
+review_artifacts:
+  started_at: "2026-09-05T13:40:34.840402+00:00"
+  finished_at: "2026-09-05T13:40:52.627588+00:00"
+  timeout_seconds: 240
+  source_sha256: 9fb82f0dde9d46011a35f65150e461b91cd4b4cce3ebb39d82f5a6af872b524e # pragma: allowlist secret - verified artifact SHA-256, not credential
+  prompt_sha256: e310f52177dd7f239bb5f2b122774f351ff44a0d92f8dc07ef387ef6a2a7c347 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  raw_stdout_sha256: 5b58695b828c69978aba583c6d7b646c0aaf6b16f02dfeeeab6d879ef35d9fbb # pragma: allowlist secret - verified artifact SHA-256, not credential
+  committed_answer_sha256: 874b48b1e6c3a36185f355ddf9fe0ebfcb0b2a73c02bed46f13c7c7ca3cbcdd6 # pragma: allowlist secret - verified artifact SHA-256, not credential
+notes:
+  - Fresh parent 12e3871175e2 includes merged PR5782. Current builder is Codex, not Anthropic.
+  - Syntax/diff timestamps record capture; review timestamps are actual. Committed review trims trailing blank lines
+    only.
+  - No new tests or mutation assertions were added for comments. Final Anthropic grading remains separate.


### PR DESCRIPTION
Two comments in `flow.ts` still described EDIT with an absent history target as a silent no-op after #5782 changed that path to `resetFlow(state)`. Both comments now describe the existing reset behavior. The diff changes only those comments and lane evidence.

Bites: developers and reviewers reading `getTreeSteps` and `isEditableTreeStep` now see the same absent-target behavior implemented by the EDIT guard at `flow.ts:823-831`.

Validation:

- `git diff --unified=0` confirms two comment hunks; `git diff --check` passes.
- A Node stdin probe using the TypeScript compiler API found no parse diagnostics and byte-identical comment-free TypeScript and emitted JavaScript versus parent `12e3871175e2`.
- Prettier passes. No new unit tests or mutation assertions were added for this comments-only correction.
- Evidence lint: Gear 1, exit 0. R8 applicability is explicitly recorded using the merged #5782 precedent: no immigration rule, eligibility, price or regulatory claim is authored; no NotebookLM query is claimed.
- Canary-backed secret scan covers the source and all three evidence files.
- Normal pre-commit and pre-push hooks passed, including full `npm run typecheck -w apps/mouth` / `tsc --noEmit`.

## Adversarial review

Kimi K3 independently reviewed the two comments against the actual EDIT and resetFlow implementations: PASS, CLI exit 0, completed 2026-09-05T13:40:52Z. Actual review and verified source/prompt/output hashes are in `evidence/2026-09/agent-air-m5-mouth-v01b-edit-comments/`. Builder provenance is Codex/OpenAI GPT-6, with the exact backend variant not exposed. Final Anthropic grading remains separate.

Draft only; no runtime or test files changed, no ready/arm/merge/deploy.
