### PR TITLE
docs(evidence): make category table provenance reproducible

### DIFF
--- a/evidence/2026-09/agent-air-m5-mouth-b04b-category-boundary/probes.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-b04b-category-boundary/probes.yml
@@ -18,6 +18,6 @@ mutation_sha256: 740b6199576b593a1ee7bd02cce85170ae8f1c10ee7ad28b4be93d655f43d0a
 table_source_sha256: 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - verified artifact digest or public Git commit, not a credential
 source_base: 58e8b0b027a25f8e213414577f154f16599d7ce6 # pragma: allowlist secret - verified artifact digest or public Git commit, not a credential
 table_source_path: apps/mouth/src/lib/blog/category-seo.ts
-table_source_git_ref: 4c1247aa45f1181a03db4a1514b53f772bacabb7 # pragma: allowlist secret - public Git commit
+table_source_git_ref: cd407c561304c6b0ea9b1318aa1103ba12d7c49a # pragma: allowlist secret - public Git commit
 sha256_representation: UTF-8 bytes of CATEGORY_SEO initializer getText(sourceFile), excluding the trailing semicolon and newline.
 correction_ref: evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/pack.yml

--- a/evidence/2026-09/agent-air-m5-mouth-b04b-category-boundary/probes.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-b04b-category-boundary/probes.yml
@@ -15,5 +15,9 @@ guilt_summary:
   - Duration  2.54s (transform 466ms, setup 828ms, import 2.14s, tests 101ms, environment 2.64s)
   - "\u23AF\u23AF\u23AF\u23AF\u23AF\u23AF Failed Tests 28 \u23AF\u23AF\u23AF\u23AF\u23AF\u23AF\u23AF"
 mutation_sha256: 740b6199576b593a1ee7bd02cce85170ae8f1c10ee7ad28b4be93d655f43d0a1 # pragma: allowlist secret - verified artifact digest or public Git commit, not a credential
-table_source_sha256: 821228d56ed1ebd7e2b35f634de87121f779372d2e954d3f219eb11cc4e15e14 # pragma: allowlist secret - verified artifact digest or public Git commit, not a credential
+table_source_sha256: 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - verified artifact digest or public Git commit, not a credential
 source_base: 58e8b0b027a25f8e213414577f154f16599d7ce6 # pragma: allowlist secret - verified artifact digest or public Git commit, not a credential
+table_source_path: apps/mouth/src/lib/blog/category-seo.ts
+table_source_git_ref: 4c1247aa45f1181a03db4a1514b53f772bacabb7 # pragma: allowlist secret - public Git commit
+sha256_representation: UTF-8 bytes of CATEGORY_SEO initializer getText(sourceFile), excluding the trailing semicolon and newline.
+correction_ref: evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/pack.yml

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/brief.yml
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/brief.yml
@@ -1,0 +1,14 @@
+task_id: b04b-evidence-provenance
+gear: 1
+objective: Make the merged B04b category-table receipt reproducible and correct the historical builder attribution.
+constraints:
+  - Evidence only; no application, test or article changes.
+  - Fresh branch after PR5778 merged; never rewrite existing commits.
+acceptance:
+  - text: A reviewer can reproduce the CATEGORY_SEO initializer digest at the pinned commit and compare it byte for byte to the parent initializer.
+    probe: evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
+consumer_map:
+  - Independent reviewers reproduce the B04b category-table move from pinned Git objects.
+risks:
+  - This corrects evidence metadata only; it makes no new runtime, CI or production claim.
+pii: none

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/kimi-depth1-review.txt
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/kimi-depth1-review.txt
@@ -1,0 +1,16 @@
+• **PASS**
+
+  Scoped static review of the supplied bytes only; nothing executed here.
+
+  Prescribed corrections verified:
+
+  - **Receipt scope:** `receipts[0].scope` explicitly marks the 13:42Z execution as historical, pre-correction, and defers current-recipe execution to `depth_1_correction.isolated_replay`. Satisfies the prior request.
+  - **Recipe-hash link:** `depth_1_correction.isolated_replay.recipe_sha256` (`becb8baf…`) is present, linking the replay to the exact recipe bytes. Satisfied.
+  - **Reference swap:** `child` in `reproduce.cjs` and `table_source_git_ref` in `probes.yml` both use `cd407c56…`; no unreachable feature ref remains. `depth_1_correction.changed_reference` matches.
+  - **Attribution:** `lanes[0].seat` and `correction.historical_builder` are byte-identical to the mandated string `builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed)`. The historical receipt's `seat` field names no runtime model variant, consistent with the depth-1 reason.
+  - **Historical framing:** `review.scope` explicitly limits the prior PASS to the pre-correction recipe, and `review.verdict` states Kimi did not execute the recipe. No self-execution implied.
+  - **Digest coherence:** `899ab453…` is consistent across recipe assertion, receipt result, `corrected_digest`, `isolated_replay.sha256`, and `table_source_sha256`; `initializer_utf8_bytes: 1481` recorded; `prior_digest` retained as historical, not rewritten.
+
+  Minor observation (non-blocking): the stated PR5778 merge-commit claim and isolated replay results are accepted as builder-reported metadata, as scoped.
+
+  No defects in the correction surface.

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/kimi-review.txt
@@ -1,0 +1,22 @@
+• **PASS**
+
+  Findings from static review of the supplied source:
+
+  **Reproduction recipe — correct and self-consistent**
+  - `reproduce.cjs` pins both refs (`58e8b0b…` parent, `4c1247aa…` child) and reads content exclusively via `git show <ref>:<path>`, so the input is a pinned Git object, not working-tree state. Provenance claim holds.
+  - Byte representation is well-defined: `node.initializer.getText(sourceFile)` returns exact source text of the initializer node, which by AST construction excludes the trailing semicolon and newline — matching `sha256_representation` in `probes.yml:14`. The UTF-8 hash spec in `probes.yml` matches the `createHash("sha256").update(after, "utf8")` call exactly.
+  - Guard rails are sound: `assert(node.initializer, …)` and `values.length === 1` prevent silently hashing an empty or ambiguous extraction.
+  - Receipt in `pack.yml` (`initializer_byte_equal true; SHA-256 899ab453…`, exit 0) matches the supplied recipe stdout verbatim, and `table_source_sha256` in `probes.yml:13` is the same digest. The correction chain 821…→ 899… is internally coherent: prior digest had no reproducible representation, new one is pinned to Git objects plus a deterministic extractor.
+
+  **Provenance / attribution**
+  - The correction block is scoped correctly: it annotates attribution metadata (B04b builder = OpenAI GPT-6, legacy "Codex Opus 4.8" trailers incorrect) without rewriting history, consistent with the `never rewrite existing commits` constraint. Note this attribution claim is asserted, not machine-verifiable from the pack itself — acceptable for a metadata correction, but a reviewer can only confirm the digest claim, not the trailer history.
+  - Lane seat declaration ("exact runtime variant not exposed") is honest rather than over-claimed.
+
+  **Scope discipline — no hidden runtime changes**
+  - All artifacts live under `evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/`; `probes.yml` timestamps (11:25) precede the correction receipt (13:42), consistent with an evidence-only followup after PR5778. `pii: none` / `pii_scan: clean` plausible — only commit hashes and digests present, and the `# pragma: allowlist secret` annotations are appropriate (these are digests/commits, not credentials).
+
+  **Minor gaps (non-blocking)**
+  - The byte-equality claim covers the `CATEGORY_SEO` initializer only; it does not prove the rest of the move (imports, re-export wiring in `layout.tsx`) was behavior-preserving. The earlier guilt/candidate probe results (28 failed → restored) support that, but the candidate-side log has no digest recorded — only `guilt_log_sha256` is pinned.
+  - Recipe depends on the `typescript` package and repo access; reproducibility is contingent on those, which is standard but worth noting for an independent reviewer.
+
+  No new test suite is warranted — this is a static evidence correction and the acceptance criterion (reproduce the initializer digest at the pinned commit) is fully covered by the shipped recipe.

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/pack.yml
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/pack.yml
@@ -1,0 +1,31 @@
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: b04b-evidence-provenance
+    role: build
+    seat: OpenAI Codex GPT-6; exact runtime variant not exposed.
+  - lane: b04b-evidence-review
+    role: review
+    seat: kimi-code/k3 via existing OAuth CLI
+dissent: []
+pii_scan: clean
+receipts:
+  - claim: The pinned CATEGORY_SEO initializer is byte-identical to the parent and reproduces the corrected digest.
+    cmd: node evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
+    result: initializer_byte_equal true; SHA-256 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - reproduced artifact digest
+    exit: 0
+    ts: "2026-09-05T13:42:29.725140+00:00"
+    seat: OpenAI Codex via TypeScript Compiler API
+correction:
+  prior_digest: 821228d56ed1ebd7e2b35f634de87121f779372d2e954d3f219eb11cc4e15e14 # pragma: allowlist secret - historical artifact digest
+  reason: The previous table_source_sha256 had no reproducible byte representation and did not match the initializer. It is superseded by a pinned Git-object extraction recipe.
+  corrected_digest: 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - reproduced artifact digest
+  historical_builder: The B04b pack correctly identifies OpenAI GPT-6. Legacy commit trailers naming Codex Opus 4.8 are incorrect; no Anthropic builder execution is claimed. Existing commit history is preserved.
+  verifier: Kimi source review and Fable independent gate are distinct from builder attribution.
+review:
+  verdict: PASS, static source review only; Kimi did not execute the recipe.
+  output_format: CLI review text with trailing blank lines removed.
+  finished_at: "2026-09-05T13:43:34.169017+00:00"
+  prompt_sha256: 912146e4afed22680118c433ce5e401554235dad005d4d586afca954a4bf416f # pragma: allowlist secret - review prompt digest
+  review_sha256: ed5247a8ad3deb11eac5c573dcbd5b835398c223bbab4ca02b19964a90449782 # pragma: allowlist secret - review artifact digest
+  limits: The replay proves initializer byte equality and its digest, not application wiring or production behavior. Existing TypeScript dependency and pinned Git objects are required.
+post_review_change: Moved the existing artifact-digest allowlist comment onto the hash literal line after formatting; executable recipe unchanged.

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/pack.yml
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/pack.yml
@@ -2,7 +2,7 @@ brief_ref: evidence/brief.yml
 lanes:
   - lane: b04b-evidence-provenance
     role: build
-    seat: OpenAI Codex GPT-6; exact runtime variant not exposed.
+    seat: "builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed)"
   - lane: b04b-evidence-review
     role: review
     seat: kimi-code/k3 via existing OAuth CLI
@@ -10,6 +10,7 @@ dissent: []
 pii_scan: clean
 receipts:
   - claim: The pinned CATEGORY_SEO initializer is byte-identical to the parent and reproduces the corrected digest.
+    scope: Historical execution before the child-reference correction; current recipe execution is recorded under depth_1_correction.isolated_replay.
     cmd: node evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
     result: initializer_byte_equal true; SHA-256 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - reproduced artifact digest
     exit: 0
@@ -19,9 +20,10 @@ correction:
   prior_digest: 821228d56ed1ebd7e2b35f634de87121f779372d2e954d3f219eb11cc4e15e14 # pragma: allowlist secret - historical artifact digest
   reason: The previous table_source_sha256 had no reproducible byte representation and did not match the initializer. It is superseded by a pinned Git-object extraction recipe.
   corrected_digest: 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - reproduced artifact digest
-  historical_builder: The B04b pack correctly identifies OpenAI GPT-6. Legacy commit trailers naming Codex Opus 4.8 are incorrect; no Anthropic builder execution is claimed. Existing commit history is preserved.
+  historical_builder: "builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed)"
   verifier: Kimi source review and Fable independent gate are distinct from builder attribution.
 review:
+  scope: Historical review of the pre-correction recipe and metadata; not a review of the depth-1 changes below.
   verdict: PASS, static source review only; Kimi did not execute the recipe.
   output_format: CLI review text with trailing blank lines removed.
   finished_at: "2026-09-05T13:43:34.169017+00:00"
@@ -29,3 +31,28 @@ review:
   review_sha256: ed5247a8ad3deb11eac5c573dcbd5b835398c223bbab4ca02b19964a90449782 # pragma: allowlist secret - review artifact digest
   limits: The replay proves initializer byte equality and its digest, not application wiring or production behavior. Existing TypeScript dependency and pinned Git objects are required.
 post_review_change: Moved the existing artifact-digest allowlist comment onto the hash literal line after formatting; executable recipe unchanged.
+depth_1_correction:
+  reason: Replace the unmerged feature reference with the reachable PR5778 merge commit and remove unsupported runtime model attribution.
+  changed_reference: cd407c561304c6b0ea9b1318aa1103ba12d7c49a # pragma: allowlist secret - public Git commit
+  checked_at: "2026-09-05T19:50:35.054728+00:00"
+  isolated_replay:
+    fetch: git fetch --no-tags --filter=blob:none --depth=128 origin main
+    main_ref: 2a97d99f610c3c43bae65925ee2978008bc41ec5 # pragma: allowlist secret - public Git commit
+    only_ref: refs/remotes/origin/main
+    shared_object_alternates: false
+    parent_and_merge_reachable: true
+    previous_feature_commit_absent_without_lazy_fetch: true
+    recipe_sha256: becb8baf01793cf9accffb5bf40ff9c20cefd471188509c2dd6b4daf59bd4a01 # pragma: allowlist secret - verified recipe digest
+    initializer_utf8_bytes: 1481
+    sha256: 899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4 # pragma: allowlist secret - reproduced artifact digest
+    result: The recipe exits 0 in a new independent main-only object store using the existing TypeScript dependency; both initializers are byte-identical.
+  legacy_trailer: Existing commit trailers remain historical and are not rewritten.
+depth_1_review:
+  verdict: PASS, independent static source review only; no reviewer execution.
+  seat: kimi-code/k3 via existing OAuth CLI
+  finished_at: "2026-09-05T19:52:50.095804+00:00"
+  artifact: evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/kimi-depth1-review.txt
+  prompt_sha256: 78eb35c456bbbfd7b2d04b92203d64c507ca994d775d22b579f99831f3199f7b # pragma: allowlist secret - review prompt digest
+  output_format: CLI review text with trailing blank lines removed.
+  review_sha256: 5090903792f42533757507541d28b331de3d3144d2d500ce804e0fbef9667176 # pragma: allowlist secret - review artifact digest
+  limits: Reviewed the final recipe, corrected probes and pack before this review receipt was appended. Historical review remains unchanged; Fable independently gates the eventual commit.

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
@@ -4,7 +4,7 @@ const { execFileSync } = require("node:child_process");
 const { createHash } = require("node:crypto");
 const ts = require("typescript");
 const parent = "58e8b0b027a25f8e213414577f154f16599d7ce6"; // pragma: allowlist secret - public Git commit
-const child = "4c1247aa45f1181a03db4a1514b53f772bacabb7"; // pragma: allowlist secret - public Git commit
+const child = "cd407c561304c6b0ea9b1318aa1103ba12d7c49a"; // pragma: allowlist secret - public Git commit
 function initializer(ref, path) {
   const text = execFileSync("git", ["show", `${ref}:${path}`], {
     encoding: "utf8",

--- a/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
+++ b/evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs
@@ -1,0 +1,39 @@
+// Run from the repository root: node <this-file>.
+const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
+const { createHash } = require("node:crypto");
+const ts = require("typescript");
+const parent = "58e8b0b027a25f8e213414577f154f16599d7ce6"; // pragma: allowlist secret - public Git commit
+const child = "4c1247aa45f1181a03db4a1514b53f772bacabb7"; // pragma: allowlist secret - public Git commit
+function initializer(ref, path) {
+  const text = execFileSync("git", ["show", `${ref}:${path}`], {
+    encoding: "utf8",
+  });
+  const source = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true);
+  const values = [];
+  function walk(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.name.getText(source) === "CATEGORY_SEO"
+    ) {
+      assert(node.initializer, "CATEGORY_SEO must have an initializer");
+      values.push(node.initializer.getText(source));
+    }
+    ts.forEachChild(node, walk);
+  }
+  walk(source);
+  assert.equal(values.length, 1, "exactly one CATEGORY_SEO declaration");
+  return values[0];
+}
+const before = initializer(
+  parent,
+  "apps/mouth/src/app/(blog)/[category]/layout.tsx",
+);
+const after = initializer(child, "apps/mouth/src/lib/blog/category-seo.ts");
+assert.equal(after, before, "initializer bytes must match the parent");
+const sha256 = createHash("sha256").update(after, "utf8").digest("hex");
+assert.equal(
+  sha256,
+  "899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4", // pragma: allowlist secret - public artifact digest
+);
+console.log(JSON.stringify({ initializer_byte_equal: true, sha256 }));


### PR DESCRIPTION
The merged B04b receipt recorded a category-table digest without a reproducible byte representation. This evidence-only correction uses the SHA-256 of the exact TypeScript initializer and ships the extraction command. Both initializers contain 1,481 UTF-8 bytes and produce `899ab45308ca82e278995d395bf07919cb8bfa5537066d106b52511577ed74e4`.

The depth-1 correction pins the extracted module to the reachable PR #5778 merge commit, `cd407c561304c6b0ea9b1318aa1103ba12d7c49a`, in both the recipe and the original probes receipt. Its previous feature-branch reference was unavailable in a main-only clone. The parent stays `58e8b0b027a25f8e213414577f154f16599d7ce6`.

Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed). Existing commit history and the historical independent review remain unchanged and explicitly historical. This PR changes evidence only.

Bites: independent reviewers can run `node evidence/2026-09/agent-air-m5-ops-b04b-evidence-provenance/reproduce.cjs` from a repository checkout with its existing TypeScript dependency. The command reads the pinned Git objects, asserts one initializer in each, verifies byte equality, and checks the digest. Actual execution also succeeded in a new independent object store fetched only from `main` with `--no-tags --filter=blob:none --depth=128`, with no shared-object alternates. Both pinned commits were ancestors of fetched main `2a97d99f610c3c43bae65925ee2978008bc41ec5`. The old feature commit was absent locally with lazy fetching disabled. GitHub independently reports #5778 merged at the new reference.

Validation: actual recipe replay and independent byte-count/digest extraction PASS; final evidence Gear-1 lint PASS; Prettier and whitespace checks PASS; four-file canary-verified secret scan PASS; pre-commit and pre-push hooks ran normally. No application or test-suite code changed.

## Adversarial review

Kimi K3 via the existing OAuth CLI returned PASS at 2026-09-05T19:52:50Z on the final recipe, probes, and corrected pack. This was a static source review; Kimi did not execute the reproduction. The review receipt and review artifact were appended afterward. The earlier 13:43Z review and 13:42Z execution are explicitly historical. Full scope, timestamps, prompt/output hashes, and recipe hash are in the evidence pack.

Final corrective head: `7951b717f55874b9f4e018e18e03648cf98ca5e3`; exactly one commit after `dcbc20988d8bd8ec9b7b5c30c62de5710c408dd4`, changing four evidence files (+47/-4).

Draft and unarmed. Fable independently re-gates this exact head and owns shipping. This replay proves initializer bytes and digest, not application wiring or production behavior.
