### PR TITLE
chore(ci): invoke the installed mouth compiler directly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1856,7 +1856,7 @@ jobs:
         id: mouth-typecheck
         if: matrix.app == 'mouth' && steps.decide.outputs.run == 'true'
         working-directory: apps/mouth
-        run: npx tsc --noEmit
+        run: ../../node_modules/.bin/tsc --noEmit
 
       - name: Run tests (with coverage)
         if: matrix.coverage && steps.decide.outputs.run == 'true'

--- a/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/brief.yml
@@ -1,0 +1,15 @@
+gear: 3
+objective: Invoke the installed mouth compiler directly and accurately describe its required CI guard.
+constraints:
+  - Only the workflow invocation, its existing assertion, the module docstring and lane evidence change.
+  - Preserve routing, required context, matrix, conditions, order and failure behavior.
+acceptance:
+  - text: WHEN the required mouth leg runs, it SHALL use the repository-local tsc from apps/mouth.
+    probe: cd apps/mouth && ../../node_modules/.bin/tsc --noEmit
+  - text: WHEN a compiler step is removed or disarmed, the existing guard cases SHALL still fail.
+    probe: python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider
+  - text: WHEN the PR describes parent routing, it SHALL state contracts-only run_all narrowed from six to three suggested jobs.
+    probe: python scripts/ci/test_change_map.py
+consumer_map:
+  - Required Frontend Tests (Next.js) (mouth, true) executes the local compiler.
+  - Required antidotes runs test_required_context_map.py from the candidate checkout.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/council-journal.jsonl
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/council-journal.jsonl
@@ -1,0 +1,2 @@
+{"seat": "codex-gpt-5.6-sol", "ok": true, "ts": "2026-09-05T13:53:49.451160+00:00", "role": "review"}
+{"seat": "kimi-code/k3", "ok": true, "ts": "2026-09-05T13:54:25.094012+00:00", "role": "review"}

--- a/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/council-receipts.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/council-receipts.yml
@@ -1,0 +1,43 @@
+parent_pr: 5785
+source_sha256:
+  .github/workflows/tests.yml: ac5a3f3caf89e61ac61930b4da7e2a77aac71e98fba0937303e1d7103831d8fc # pragma: allowlist secret - verified artifact SHA-256, not credential
+  scripts/tests/test_required_context_map.py: 193ab0b14a215c727366133ddd63af157d72c0d171c58cf073abcac658cf0549 # pragma: allowlist secret - verified artifact SHA-256, not credential
+reviews:
+  - seat: codex-gpt-5.6-sol
+    command:
+      - /opt/homebrew/bin/codex
+      - exec
+      - --sandbox
+      - read-only
+      - --skip-git-repo-check
+      - -m
+      - gpt-5.6-sol
+      - -c
+      - model_reasoning_effort=high
+      - <supplied prompt>
+    started_at: "2026-09-05T13:53:30.009373+00:00"
+    prompt_sha256: 4bfee88bca86811bc17460f620e981309d386576bab04e864a740978cb938e94 # pragma: allowlist secret - verified artifact SHA-256, not credential
+    timeout_seconds: 240
+    exit: 0
+    finished_at: "2026-09-05T13:53:49.451160+00:00"
+    stdout_sha256: 63558092bc83e93ebc96e4889fc818cff7ded1a8a682f0ee9f767659a9cfbd2b # pragma: allowlist secret - verified artifact SHA-256, not credential
+    committed_answer_sha256: 63558092bc83e93ebc96e4889fc818cff7ded1a8a682f0ee9f767659a9cfbd2b # pragma: allowlist secret - verified artifact SHA-256, not credential
+  - seat: kimi-code/k3
+    command:
+      - /Users/balizero/.kimi-code/bin/kimi
+      - -m
+      - kimi-code/k3
+      - -p
+      - <supplied prompt>
+    started_at: "2026-09-05T13:53:30.019981+00:00"
+    prompt_sha256: 4bfee88bca86811bc17460f620e981309d386576bab04e864a740978cb938e94 # pragma: allowlist secret - verified artifact SHA-256, not credential
+    timeout_seconds: 240
+    exit: 0
+    finished_at: "2026-09-05T13:54:25.094012+00:00"
+    stdout_sha256: 592eca4c6663640f8e9b818b9106de476af612e5179d5a454e3b637a6c3d544e # pragma: allowlist secret - verified artifact SHA-256, not credential
+    committed_answer_sha256: dbdb7e9c39f8a4078ff3f91939e13d48d79413a47521f8172e3b4d24263c6221 # pragma: allowlist secret - verified artifact SHA-256, not credential
+notes:
+  - Final re-review after the first Kimi wording nit; both final seats PASS.
+  - Committed answers trim trailing blank lines only; raw stdout hashes bind the local originals.
+  - Both calls used only HOME PATH LANG LC_ALL TERM TMPDIR USER SHELL environment keys, with existing subscription
+    OAuth.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/kimi-review.txt
@@ -1,0 +1,18 @@
+• **Verdict: PASS**
+
+  Findings (against supplied source only):
+
+  - **Path correctness holds.** The install step runs `npm install --no-fund` with no `working-directory`, i.e. at repo root, so `node_modules/.bin/tsc` lives at root. The typecheck step declares `working-directory: apps/mouth`, making `../../node_modules/.bin/tsc` resolve to exactly that root binary. This is also consistent with the sibling GARUDA step already invoking `./node_modules/.bin/openapi-typescript` from root. Per the supplied disclosure, root `.bin/tsc` → `../typescript/bin/tsc`; accepted as stated.
+  - **Config discovery unchanged.** `tsc --noEmit` resolves `tsconfig.json` from the cwd (`apps/mouth`) regardless of how the binary is invoked, so dropping `npx` does not alter which project is typechecked. Behavior preserved; only the resolution path (and npx's implicit lookup/download surface) is removed.
+  - **Assertion pin is exact, not shape-only.** `step["run"].strip() == "../../node_modules/.bin/tsc --noEmit"` fails on a revert to `npx tsc`, on `|| true` appends (`swallow-error`), and on any future command drift — the pin strength is unchanged from the first PASS snapshot, now pointing at the new command.
+  - **Mutation matrix intact and still discriminating.** All 11 cases are preserved verbatim; each still trips a distinct assertion (`wrong-cwd` → `working-directory`, `wrong-condition` → `if`, `after-tests` → ordering, etc.). The GARUDA-before-typecheck-before-tests order assertions are untouched and consistent with the supplied workflow context.
+  - **Docstring correction is accurate.** The new text matches what the file actually does: the boolean-stringify regression note is retained (the real bug), the false "not a guard / not registered" claim is gone, and the "guards the required mouth compiler step… required antidotes job runs these checks from the candidate checkout" statement matches both `_assert_required_mouth_typecheck` and the comment in `test_required_mouth_job_compiles_contract_consumers`.
+  - **Context/conditions/order preserved.** `if:`, `working-directory`, `continue-on-error` default, matrix gating, `!cancelled()`, needs, and timeout are all unchanged per the diff — nothing outside the two stated hunks moved. Registry/timeout exclusions respected.
+  - The prior wording nit is corrected as claimed; the diff is otherwise byte-identical in behavior to the first PASS snapshot.
+
+  Residual conditions (non-blocking, for the PR body / future maintainers):
+
+  1. The pin assumes `typescript` stays hoisted to **root** `node_modules/.bin`. A future lockfile/workspace change that un-hoists it (or adds a shadowing `apps/mouth/node_modules/.bin/tsc`) breaks the step in CI, and the test only pins the literal string — it cannot detect hoisting drift. Worth a one-line note in the PR body.
+  2. The disclosed parent-routing narrowing (`run_all:false`, 3 suggested jobs) is out of scope here and unchanged; stated as PR-body content, no action needed in this diff.
+
+  No demonstrable defect found in the supplied snapshot. **PASS.**

--- a/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/pack.yml
@@ -1,0 +1,54 @@
+gear: 3
+brief_ref: evidence/brief.yml
+council_run: council-journal.jsonl
+lanes:
+  - lane: b03b-tidy
+    role: build
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - lane: sol-review
+    role: review
+    seat: codex-gpt-5.6-sol
+  - lane: kimi-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+receipts:
+  - claim: Existing required-context guard suite passes on the final source.
+    cmd: python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider
+    result: 19 passed, including the existing disarmament cases.
+    exit: 0
+    ts: "2026-09-05T13:54:04.819249+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Existing change-map suite passes.
+    cmd: python scripts/ci/test_change_map.py
+    result: 69 passed.
+    exit: 0
+    ts: "2026-09-05T13:54:58.149813+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: The exact repository-local compiler invocation succeeds from mouth.
+    cmd: cd apps/mouth && ../../node_modules/.bin/tsc --noEmit
+    exit: 0
+    ts: "2026-09-05T13:54:58.149813+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+  - claim: Workflow syntax is valid.
+    cmd: actionlint -shellcheck= .github/workflows/tests.yml
+    exit: 0
+    ts: "2026-09-05T13:54:58.149813+00:00"
+    seat: OpenAI GPT-6 (exact backend variant not exposed)
+dissent:
+  - seat: kimi-code/k3
+    objection:
+      The direct path assumes TypeScript remains installed in root node_modules; future workspace relocation
+      needs a command update.
+    status: PLAUSIBLE
+    disposition: Current root binary and exact invocation were verified; the PR body records this dependency.
+  - seat: codex-gpt-5.6-sol
+    objection: The PR must disclose the parent contracts-only routing reduction from six to three jobs.
+    status: CONFIRMED
+    disposition: The PR body explicitly names run_all true to false and all three suggested/skipped jobs.
+notes:
+  - Two source hashes match the immutable final council input; the only correction after first review was docstring
+    wording.
+  - Non-guard check timestamps record capture; guard and council timestamps are actual completion times.
+  - The parent classifier is unchanged here. Registry and timeout work are outside this bounded follow-up.
+  - Corrected-head CI execution and final independent Anthropic grading remain pending.

--- a/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/sol-review.txt
+++ b/evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/sol-review.txt
@@ -1,0 +1,8 @@
+[Air-M5] **PASS**
+
+- `apps/mouth/../../node_modules/.bin/tsc` resolves correctly to the repository-root installed compiler.
+- The exact-command assertion matches the workflow change.
+- Required context, conditions, ordering, failure behavior, and all existing mutation cases remain intact.
+- The docstring now accurately describes the guard’s role.
+
+Residual condition: include the disclosed three-job routing narrowing in the PR body. Final Anthropic grading remains independent.

--- a/scripts/tests/test_required_context_map.py
+++ b/scripts/tests/test_required_context_map.py
@@ -2,12 +2,10 @@
 file/job resolver shared by scripts/ci/snapshot_required_contexts.py and
 scripts/ci/check_required_workflow_conformance.py.
 
-Not a superscar #3 "guard" (it doesn't accept/reject anything — it resolves a
-name to a location), so it is not registered in
-infra/guard-conformance/registry.json; this is plain regression coverage,
-pinning the one real bug found while writing it (matrix boolean values
-stringify as Python `True`/`False`, not GitHub's lowercase `true`/`false`) so
-it cannot silently return.
+Resolver regressions include GitHub's lowercase rendering of matrix booleans.
+This file also guards the required mouth compiler step in tests.yml and
+rejects workflow variants that remove or disarm it. The required antidotes
+job runs these checks from the candidate checkout.
 
 Run:  python3 -m pytest scripts/tests/test_required_context_map.py -q
 """
@@ -43,7 +41,7 @@ def _assert_required_mouth_typecheck(workflow: dict[str, Any]) -> None:
     step = matches[0]
     assert step["if"] == "matrix.app == 'mouth' && steps.decide.outputs.run == 'true'"
     assert step["working-directory"] == "apps/mouth"
-    assert step["run"].strip() == "npx tsc --noEmit"
+    assert step["run"].strip() == "../../node_modules/.bin/tsc --noEmit"
     assert step.get("continue-on-error", False) is False
     names = [entry.get("name") for entry in steps]
     assert names.index("Check GARUDA generated contract") < steps.index(step)


### PR DESCRIPTION
Use the installed repository-local TypeScript binary in the required mouth CI leg and correct the test module's outdated description. From `working-directory: apps/mouth`, `../../node_modules/.bin/tsc --noEmit` resolves to the root installation already populated by the preceding dependency install. The existing exact-command assertion is updated; the step's condition, working directory, required context, ordering, and failure behavior are preserved.

Parent routing disclosure: #5785 changed **contracts-only** edits from `run_all: true` with six suggested jobs to `run_all: false` with **three suggested jobs: backend-tests, frontend-tests, and e2e-tests**. The jobs no longer suggested for that path are `mcp-tests`, `evaluator-critical-tests`, and `packages-core-tests`. A fresh before/after probe against the parent's first parent and current `change_map.py` reproduced those results. This follow-up leaves that classifier unchanged.

Bites: the required [mouth job](https://github.com/Bali-Zero/Teman2/actions/runs/33970418316/job/101317938102) on `3ab2255024d67eaee2e053299f30bc88b394737f` executes `../../node_modules/.bin/tsc --noEmit` successfully in 26 seconds. The whole job passes in 5m53s. Required `antidotes` passes and consumes the existing workflow guard; all 19 local guard tests, including disarmament cases, also pass.

Validation:

- `cd apps/mouth && ../../node_modules/.bin/tsc --noEmit` — exit 0.
- `python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider` — 19 passed.
- `python scripts/ci/test_change_map.py` — 69 passed.
- `actionlint -shellcheck= .github/workflows/tests.yml`, Ruff, Prettier and `git diff --check` — passed.
- Gear floor recomputed as 3 because the workflow is a hotzone. Existing guard cases were reused; no new tests were invented for the docstring.

## Adversarial review

Sol and Kimi each returned PASS via the sanctioned subscription CLI on the same final two-file snapshot. The first Kimi wording nit was corrected and both seats reviewed again; actual final receipts, journal and source hashes are in `evidence/2026-09/agent-air-m5-infra-b03b-review-tidy/`. The command intentionally uses the current root TypeScript installation; a future workspace change relocating that dependency must update the path. Final independent Anthropic grading remains with Fable. Registry and timeout follow-ups are outside this bounded change.

Draft only. No generated maps, classifier edits, dependency changes, ready/arm/merge/deploy.

## Observed CI

[Tests & Coverage 33970418316](https://github.com/Bali-Zero/Teman2/actions/runs/33970418316) is SUCCESS on the exact head above. Backend, E2E, fullstack, both CodeQL analyses, typechecks and all other executed checks pass. No checks remain running.

The sole failure is [Harness floor recompute](https://github.com/Bali-Zero/Teman2/actions/runs/33970418353/job/101317814713): its final-verdict step reports that no `harness/fable-gate` verdict has been posted on this commit. Fable must post the independent pinned verdict and then rerun that existing failed Harness job. No source or pack failure was reported, and no blind rerun was performed.
