### PR TITLE
fix(auth): omit principal email from team-denial logs

### DIFF
--- a/apps/backend-rag/backend/app/deps/auth.py
+++ b/apps/backend-rag/backend/app/deps/auth.py
@@ -166,7 +166,7 @@ def require_team_member(user: dict[str, Any] = Depends(get_current_user)) -> dic
         HTTPException 403: If user is a client or a service account
     """
     if not is_human_team_member(user.get("role")):
-        logger.warning(f"Access denied to non-human account: {user.get('email')}")
+        logger.warning("Access denied to non-team account")
         raise HTTPException(
             status_code=403,
             detail="Access denied. This endpoint is only accessible to team members.",

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py
@@ -13,6 +13,7 @@ therefore proves the gate fired BEFORE any client data could be read.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -22,6 +23,7 @@ from fastapi.testclient import TestClient
 from backend.app.deps.auth import get_current_user, require_team_member
 from backend.app.deps.database import get_database_pool
 from backend.app.routers import crm_intelligence
+from backend.app.setup.logging_config import StructuredFormatter
 
 _PARTNER: dict[str, Any] = {
     "email": "partner@example.com",
@@ -87,13 +89,21 @@ def test_every_intelligence_route_is_behind_the_team_gate() -> None:
 
 @pytest.mark.parametrize(("method", "path", "body"), _ROUTES)
 def test_partner_gets_403_before_any_client_data_is_read(
-    method: str, path: str, body: dict[str, Any] | None
+    method: str, path: str, body: dict[str, Any] | None, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Guilt: at the baseline this returned anything but 403."""
     client = TestClient(_app_for(_PARTNER))
     response = client.request(method, path, json=body)
     assert response.status_code == 403, response.text
     assert "team members" in response.json()["detail"]
+    denials = [
+        record
+        for record in caplog.records
+        if record.name == "backend.app.deps.auth" and record.levelno == logging.WARNING
+    ]
+    assert len(denials) == 1  # Keep the operational signal, not the identity.
+    assert _PARTNER["email"] not in caplog.text
+    assert _PARTNER["email"] not in StructuredFormatter().format(denials[0])
 
 
 def test_staff_passes_the_gate_and_reaches_the_data_layer() -> None:


### PR DESCRIPTION
## Summary

Follow-up to the privacy finding on #5755. A denied partner reached an existing
warning in `require_team_member` that interpolated the principal's email. The
standard formatter and production JSON formatter preserved that identifier.

- Replace only that warning with the static message `Access denied to non-team account`.
- Preserve the WARNING level, denial predicate, 403 response, and staff access.
- Extend the existing six-route CRM regression to require a warning and check
  that neither captured text nor production JSON formatting contains the synthetic email.

Bites: `CRM intelligence routes -> require_team_member -> warning/403`: all six real-router HTTP cases return 403, retain one WARNING, and omit the synthetic email from captured text and `StructuredFormatter` output. The existing staff innocence test still reaches the data layer.

## Scope

Exactly two changed files, 12 additions / 2 deletions. The application change is
one log statement. No role-policy, JWT-validation, retry, database, logging-framework,
or frontend changes. No temporary `.frontier/` artifacts are committed.

Base: `2a97d99f610c3c43bae65925ee2978008bc41ec5`.

## Verification — existing implementation-stage executions, reused unchanged

From `apps/backend-rag`, activate `.venv` first:

```sh
source .venv/bin/activate
SKIP_SENTRY_INIT=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python -m pytest backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py backend/tests/unit/app/test_dependencies_critical.py backend/tests/unit/utils/test_service_accounts.py --tb=short
```

Exit 0: **55 passed**, 5.13 seconds.

```sh
SKIP_SENTRY_INIT=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python -c 'from backend.app.dependencies import get_current_user; print("Dependency import: OK")'
SKIP_SENTRY_INIT=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python -m pytest backend/tests/services/rag/test_kg_langgraph.py backend/tests/services/rag/test_kg_subgraphs.py backend/tests/services/rag/test_confidence.py --tb=short
```

Exit 0: import OK; **91 passed**, 3.13 seconds. These are the lightweight checks
required by the backend instructions, not a new full-backend-suite execution.

```sh
python -m ruff check backend/app/deps/auth.py backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py
python -m ruff format --check backend/app/deps/auth.py backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py
git diff --check
```

Exit 0 for lint, format, and diff checks. Commit hooks also passed.

Local invocation notes: the first targeted pytest command included an extra `-q`;
the repository verbosity guard refused it before collection (exit 4). Removing
only that redundant flag allowed the meaningful baseline and fixed runs above.
The initial push's advisory quickcheck selected 890 modules via the shared auth
dependency. It was deliberately stopped (owned process tree only, push exit 143)
to respect Air-M5 thin-client routing; no result from that interrupted run is used.
The push uses the documented `QUICKCHECK_SKIP=1` for that advisory helper only;
mandatory pre-commit/pre-push hooks and GitHub required checks remain enabled.

## Adversarial review

Independent read-only Claude-session review returned PASS on head
`a3ab3a7f885e158c884f185db23dd6973f2e6919`, conditional on required CI.
The [pinned review record](https://github.com/Bali-Zero/Teman2/pull/5800#pullrequestreview-5122817150)
distinguishes independent source inspection from reused test executions; no tests
were rerun by the reviewer. The following is author-side falsification, not self-approval:

- Before the application edit, the enhanced existing router test produced
  **6 failed / 2 passed**: every denial failed specifically because its log
  retained the synthetic email. The response was already 403. This rules out
  a test that merely rechecks the existing authorization behavior.
- Silencing the warning is not an acceptable fix: the regression requires one
  WARNING from the actual auth dependency before inspecting its output.
- Keeping the email in structured output is not acceptable: the test checks
  both captured text and the application's production JSON formatter.
- Removing the team gate is not acceptable: the existing route-wiring assertion,
  six HTTP-denial cases, and staff innocence case remain in force.

## Evidence provenance and limits

The #5755 review is the source of the finding, not evidence that this new commit
passed CI. Old full-suite results were not rerun or relabeled as new executions.
GitHub checks on this PR must be evaluated on its own head SHA.

The HTTP regression uses the real router and dependency, with synthetic identity
and database dependency overrides. It does not exercise browser login, real JWT
validation, a production app lifespan, or deployed handlers. Production registration
was verified in source (`router_registration.py`, both API and monolithic paths).
The JSON assertion uses the actual formatter but does not write a production log.
This fixes this denial message, not every possible PII-bearing log in the system.

No production data, credentials, or client records were accessed during implementation
or independent review. The owner subsequently explicitly authorized merge, auto-merge
and deployment. Shipping remains gated on independent review and all required CI;
authorization does not bypass either. No application code changed after the reviewed commit.
