### PR TITLE
docs(evidence): clarify legacy Codex trailer attribution

### DIFF
--- a/evidence/2026-09/agent-air-m5-ops-codex-trailer-note/attribution.md
+++ b/evidence/2026-09/agent-air-m5-ops-codex-trailer-note/attribution.md
@@ -1,0 +1,63 @@
+# Codex trailer attribution correction
+
+This one-time note corrects the interpretation of five historical commits. It
+preserves their Git messages and the original evidence. The declared builder seat
+for this correction is **Codex Astra-2 (OpenAI; runtime variant not exposed)**.
+
+## Observed records
+
+On 2026-09-05 UTC, GitHub reported the five PRs below as `MERGED` with the listed
+merge commits. All five commits are ancestors of the fetched `origin/main`
+snapshot `2a97d99f610c3c43bae65925ee2978008bc41ec5`.
+
+Each merge message contains this exact line, including its lowercase casing:
+
+```text
+Co-authored-by: Codex Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+The #5778 message additionally retains two embedded copies with the prefix
+`Co-Authored-By:`. These are observations of message text, not proof of which
+provider or model executed the work.
+
+| PR                                                     | Verified merge commit                      | Evidence path beneath `evidence/2026-09/`                   | Build-seat line |
+| ------------------------------------------------------ | ------------------------------------------ | ----------------------------------------------------------- | --------------- |
+| [#5785](https://github.com/Bali-Zero/Teman2/pull/5785) | `5c20db71243a5bc10e32d355558e7540807f9594` | `agent-air-m5-infra-b03b-required-contract-checks/pack.yml` | 7               |
+| [#5782](https://github.com/Bali-Zero/Teman2/pull/5782) | `12e3871175e2288bee7bacfceadb84a469450e5d` | `agent-air-m5-mouth-v01b-fallback-edit/pack.yml`            | 6               |
+| [#5781](https://github.com/Bali-Zero/Teman2/pull/5781) | `7efca77f245dbadcb0c2f9a4c71cf54c9fb70294` | `agent-air-m5-mouth-s01b-consent-reservation/pack.yml`      | 5               |
+| [#5778](https://github.com/Bali-Zero/Teman2/pull/5778) | `cd407c561304c6b0ea9b1318aa1103ba12d7c49a` | `agent-air-m5-mouth-b04b-category-boundary/pack.yml`        | 5               |
+| [#5777](https://github.com/Bali-Zero/Teman2/pull/5777) | `5011c114ea4353ea933cba54837a49e85b656d4f` | `agent-air-m5-mouth-x03-article-claims/pack.yml`            | 6               |
+
+At those exact commits, each listed `lanes` entry has `role: build` and a seat
+beginning `OpenAI GPT-6`, followed by an explicit qualification that the exact
+variant is not exposed. That is the historical pack's declaration; this note does
+not endorse its specific model label as independently verified runtime metadata.
+
+## Interpretation and limits
+
+The correction's session/dispatch attribution is **Codex Astra-2 (OpenAI; runtime
+variant not exposed)**. It identifies the collaborating builder seat and is a
+declared attribution. The Git messages and historical pack fields can be verified
+independently as text; neither authenticates a runtime model. Treat the legacy
+Anthropic-addressed trailer as a mislabel for these Codex-attributed lanes, not as
+evidence of an Anthropic build. Independent reviewers remain distinct from the
+builder. This note makes no finding about other commits or their authors.
+
+## Reproduce
+
+Use a clone with the history of `main` available. For each row, set `SHA`, `PR`
+and `PACK` to its exact values (`PACK` includes `evidence/2026-09/`), then run:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor "$SHA" origin/main
+git show -s --format=%B "$SHA"
+git show "$SHA:$PACK"
+gh pr view "$PR" --json number,state,mergeCommit,url
+```
+
+The ancestry command must exit zero; the PR must be `MERGED` with `mergeCommit.oid`
+equal to `SHA`; the Git message and build-seat declaration must match the records
+above. The message command displays the original commit metadata locally. The
+note reproduces only the relevant machine-attribution trailer. Existing commits
+are immutable inputs to this correction; no history rewrite is requested.

--- a/evidence/2026-09/agent-air-m5-ops-codex-trailer-note/brief.yml
+++ b/evidence/2026-09/agent-air-m5-ops-codex-trailer-note/brief.yml
@@ -1,0 +1,12 @@
+task_id: codex-trailer-note
+gear: 1
+objective: Correct the interpretation of five verified legacy Codex co-author trailers without rewriting Git history.
+constraints:
+  - Evidence only; preserve historical commits and lane packs.
+  - Distinguish observed Git text from declared session attribution.
+acceptance:
+  - text: All five PR mappings, main ancestry checks, legacy trailers and historical build-seat declarations reproduce at the named merge commits.
+    probe: evidence/2026-09/agent-air-m5-ops-codex-trailer-note/attribution.md
+consumer_map:
+  - An independent reviewer can replay the named Git and GitHub reads before interpreting the historical builder attribution.
+pii: none

--- a/evidence/2026-09/agent-air-m5-ops-codex-trailer-note/pack.yml
+++ b/evidence/2026-09/agent-air-m5-ops-codex-trailer-note/pack.yml
@@ -1,0 +1,28 @@
+brief_ref: evidence/2026-09/agent-air-m5-ops-codex-trailer-note/brief.yml
+lanes:
+  - lane: codex-trailer-note
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: codex-trailer-note-review
+    role: review
+    seat: kimi-code/k3 via existing OAuth CLI
+dissent: []
+pii_scan: clean
+receipts:
+  - claim: All five PR-to-merge mappings, main ancestry checks, legacy trailer lines and historical build-seat lines match the note.
+    cmd: For each attribution.md row, run git merge-base --is-ancestor SHA origin/main; git show -s --format=%B SHA; git show SHA:PACK; gh pr view PR --json number,state,mergeCommit,url.
+    result: Five merged PRs, five reachable merge commits, five exact trailer matches and five matching build-seat declarations; main snapshot 2a97d99f610c3c43bae65925ee2978008bc41ec5.
+    exit: 0
+    ts: "2026-09-05T19:51:36.996407+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: A separate Kimi reviewer found the note consistent with the supplied verified records and explicit attribution limits.
+    cmd: kimi -m kimi-code/k3 -p <note and filtered Git/GitHub fact table>
+    result: PASS; static supplied-text review only. The additional uppercase copies in PR5778 were not in the supplied table; the builder separately replayed that Git read and confirmed exactly two copies.
+    exit: 0
+    ts: "2026-09-05T19:52:19.970451+00:00"
+    seat: kimi-code/k3
+review_scope:
+  - The reviewer did not re-execute Git or GitHub queries. Subsequent formatting changed table alignment only; this receipt was added after the review.
+limits:
+  - Git and GitHub prove the text, ancestry and PR mapping; historical pack labels and session attribution do not authenticate a model runtime.
+  - This is a bounded five-commit correction, not an exhaustive repository attribution audit.


### PR DESCRIPTION
Five merged PRs (#5785, #5782, #5781, #5778, #5777) carry an Anthropic-addressed legacy Codex trailer while their historical evidence declares an OpenAI builder. Add one bounded attribution note with exact main merge SHAs, pack paths and replay commands. Preserve every historical commit and pack, and distinguish observable Git text from declared session attribution; the runtime variant is not authenticated by either.

Bites: An independent reviewer reads `evidence/2026-09/agent-air-m5-ops-codex-trailer-note/attribution.md` and replays its Git/GitHub commands. Observed: all five PRs are MERGED at the named SHAs, all five merge commits are reachable from main snapshot `2a97d99f610c3c43bae65925ee2978008bc41ec5`, and all five trailer/build-seat records match. The two additional uppercase trailer copies in #5778 were separately confirmed.

Validation: five exact PR mappings, five ancestry checks, five message matches and five historical build-seat line checks passed. Evidence-pack lint, Prettier and normal pre-commit checks passed. Kimi `kimi-code/k3` returned PASS on supplied note/fact records; it did not re-execute Git/GitHub. Its minor observation about #5778's additional copies was resolved by an actual Git read. Only subsequent table formatting and review receipt recording followed that review.

Gear 1, three evidence files, 103 added lines. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed). Draft prepared for the independent Claude gate; no ready, arm, merge or deploy action taken.
