### PR TITLE
test(ci): pin the required frontend job timeout

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/brief.yml
@@ -1,0 +1,12 @@
+gear: 1
+objective: Pin the existing required frontend job timeout at 16 minutes.
+constraints:
+  - Change only the existing context guard test and lane evidence.
+  - Preserve workflow, classifier, required contexts and policy.
+acceptance:
+  - WHEN the real workflow is checked, its existing 16-minute timeout SHALL pass.
+  - WHEN the timeout is missing or widened to 30 minutes, the guard SHALL reject it.
+  - WHEN the new timeout assertion is removed, both new mutation cases SHALL fail.
+consumer_map:
+  - The existing required antidotes job executes scripts/tests/test_required_context_map.py from the candidate
+    checkout.

--- a/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/kimi-review.md
+++ b/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/kimi-review.md
@@ -1,0 +1,25 @@
+• **PASS**
+
+Reviewed the diff against the supplied full test file only. Findings:
+
+**Correctness of the pin**
+
+- `assert job.get("timeout-minutes") == 16` (new line in `_assert_required_mouth_typecheck`) pins exactly the assigned value, and uses `.get` so a missing key yields `None == 16 → False → AssertionError` rather than a `KeyError` crash. That gives the intended fail-closed behavior for the `missing-timeout` mutation, and matches the sibling style two lines up (`job.get("continue-on-error", False) is False`).
+- Placement is consistent: it sits with the other job-level pins (`needs`, `if`, `continue-on-error`), before the step-level pins. No reordering of existing assertions.
+
+**Mutation validity**
+
+- `missing-timeout`: `job.pop("timeout-minutes")` removes the key; the new assertion is the only one referencing `timeout-minutes`, so it is the sole catcher. Confirmed by your stated control run (deleting the assertion → exactly those 2 fail, 19 pass).
+- `widened-timeout`: `30 != 16` trips the same assertion. Both mutations are rejected via `pytest.raises(AssertionError)` — same mechanism as all 11 pre-existing mutations, no new harness.
+- Arithmetic checks out: 11 old mutations + 2 new = 13 parametrized cases + 8 other tests = 21, matching your reported totals in both directions.
+
+**Minimality / scope**
+
+- The diff touches exactly one file, adds exactly one assertion and two mutation entries/branches. No workflow file, no timing value, no routing/policy change. Nothing in the resolver tests or the live-context list was touched. Scope did not expand.
+
+**Non-blocking nits (not failures)**
+
+- `job.pop("timeout-minutes")` has no default: if the workflow ever lost the key upstream, the mutation case would `KeyError` (test error) instead of cleanly proving the assertion catches it. Acceptable here since the parent workflow is stated to carry `timeout-minutes: 16`, and a loud error on drift is arguably desirable.
+- The pin hardcodes `16` rather than reading it from a constant — but that is the assignment ("pin the value 16"), and the file already hardcodes `needs == ["changes"]` etc., so it's idiomatic for this guard.
+
+No generic infrastructure observations; review stayed inside the supplied diff and file. Final Anthropic gate remains independent, as noted.

--- a/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/pack.yml
@@ -1,0 +1,52 @@
+gear: 1
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: b03-timeout-pin
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: timeout-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+receipts:
+  - claim: The candidate guard suite passes against the real workflow; Ruff and diff checks pass.
+    cmd:
+      python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider; ruff check scripts/tests/test_required_context_map.py;
+      git diff --check
+    result: 21 passed; Ruff clean; no whitespace errors.
+    exit: 0
+    ts: "2026-09-05T19:57:18.309230+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: Deleting only the new timeout assertion makes both new mutation cases fail.
+    cmd: Delete the single timeout assertion, then run the same pytest command.
+    result: 2 failed (missing-timeout, widened-timeout), 19 passed. Source restored immediately.
+    exit: 1
+    ts: "2026-09-05T19:57:26.986073+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: Restored source passes again.
+    cmd: python -m pytest scripts/tests/test_required_context_map.py -q -p no:cacheprovider
+    result: 21 passed.
+    exit: 0
+    ts: "2026-09-05T19:57:36.096526+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: Independent bounded source review PASS.
+    cmd: /Users/balizero/.kimi-code/bin/kimi -m kimi-code/k3 -p <supplied full test file and diff>
+    exit: 0
+    ts: "2026-09-05T19:58:10.774683+00:00"
+    seat: kimi-code/k3
+dissent: []
+source_identity:
+  parent: 2421a3dd053cf9cab97665114bb4f5496d06ab44
+  test_sha256: c0e6997a1b27c204de12f123844ff03b820a371bb8e40d6ed9f183105d2e3ac6 # pragma: allowlist secret - verified source or artifact SHA-256, not credential
+review_artifacts:
+  committed_answer_sha256: 83171e7439ccbeb815ec080088d068a1d40ba836cc32f3a6435ac8fa1ef26025 # pragma: allowlist secret - verified artifact SHA-256, not credential
+  started_at: "2026-09-05T19:57:49.030462+00:00"
+  prompt_sha256: 25366d373a1bee01aacb8770a0e478020935921e5ad128feac96b6c390df59b6 # pragma: allowlist secret - verified source or artifact SHA-256, not credential
+  stdout_sha256: 26532677154ae74e4a7c9f6a5931b581b6bca52bf21618b2c8e003d375d1bcc9 # pragma: allowlist secret - verified source or artifact SHA-256, not credential
+notes:
+  - "Parent PR5792 merged before this fresh-main worktree was created. The workflow already has timeout-minutes:
+    16."
+  - The reader received source, diff and stated local results; it did not independently execute the tests. Raw
+    stdout is preserved in kimi-review.md.
+  - The two additions reuse the existing parametrized mutations. No timeout or infrastructure change is proposed.
+  - Final Anthropic grading remains separate.

--- a/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/pack.yml
@@ -36,7 +36,7 @@ receipts:
     seat: kimi-code/k3
 dissent: []
 source_identity:
-  parent: 2421a3dd053cf9cab97665114bb4f5496d06ab44
+  parent: 2421a3dd053cf9cab97665114bb4f5496d06ab44 # pragma: allowlist secret - verified public parent Git commit, not credential
   test_sha256: c0e6997a1b27c204de12f123844ff03b820a371bb8e40d6ed9f183105d2e3ac6 # pragma: allowlist secret - verified source or artifact SHA-256, not credential
 review_artifacts:
   committed_answer_sha256: 83171e7439ccbeb815ec080088d068a1d40ba836cc32f3a6435ac8fa1ef26025 # pragma: allowlist secret - verified artifact SHA-256, not credential
@@ -46,7 +46,7 @@ review_artifacts:
 notes:
   - "Parent PR5792 merged before this fresh-main worktree was created. The workflow already has timeout-minutes:
     16."
-  - The reader received source, diff and stated local results; it did not independently execute the tests. Raw
-    stdout is preserved in kimi-review.md.
+  - The reader received source, diff and stated local results; it did not independently execute the tests.
+    The committed review has Markdown formatting; raw stdout remains in the local receipt.
   - The two additions reuse the existing parametrized mutations. No timeout or infrastructure change is proposed.
   - Final Anthropic grading remains separate.

--- a/scripts/tests/test_required_context_map.py
+++ b/scripts/tests/test_required_context_map.py
@@ -35,6 +35,7 @@ def _assert_required_mouth_typecheck(workflow: dict[str, Any]) -> None:
     assert job["needs"] == ["changes"]
     assert job["if"] == "${{ !cancelled() }}"
     assert job.get("continue-on-error", False) is False
+    assert job.get("timeout-minutes") == 16
     steps = job["steps"]
     matches = [step for step in steps if step.get("id") == "mouth-typecheck"]
     assert len(matches) == 1
@@ -62,6 +63,7 @@ def test_required_mouth_job_compiles_contract_consumers() -> None:
         "remove", "move-to-advisory", "after-tests", "wrong-matrix",
         "wrong-condition", "wrong-cwd", "step-advisory", "job-advisory",
         "swallow-error", "missing-needs", "success-only-job",
+        "missing-timeout", "widened-timeout",
     ],
 )
 def test_required_mouth_typecheck_rejects_disarmed_mutations(mutation: str) -> None:
@@ -94,6 +96,10 @@ def test_required_mouth_typecheck_rejects_disarmed_mutations(mutation: str) -> N
         job["needs"] = []
     elif mutation == "success-only-job":
         job["if"] = "${{ success() }}"
+    elif mutation == "missing-timeout":
+        job.pop("timeout-minutes")
+    elif mutation == "widened-timeout":
+        job["timeout-minutes"] = 30
     with pytest.raises(AssertionError):
         _assert_required_mouth_typecheck(workflow)
 


### PR DESCRIPTION
The required frontend job already has a 16-minute timeout, but its candidate-checkout guard did not pin that value. Reuse the existing helper to require 16 and extend its existing parametrized mutations with a missing timeout and a widened 30-minute timeout. The workflow and its current timeout are unchanged.

Bites: the existing required `antidotes` job executes `scripts/tests/test_required_context_map.py` from the candidate checkout. The candidate suite passed 21 tests; deleting only the new timeout assertion caused exactly the two new cases (`missing-timeout`, `widened-timeout`) to fail while the other 19 passed. Restoring it returned all 21 to green. On final head `951333bbe45325a334ad8f6f88d67f372d7b5780`, [required antidotes job 101367429574](https://github.com/Bali-Zero/Teman2/actions/runs/33988885189/job/101367429574) passed at 20:07:35Z and its real log records `21 passed` for this exact test file. Detect Secrets and Harness floor recompute also passed on that head.

Validation: targeted pytest 21 passed; mutation control 2 failed/19 passed; restored pytest 21 passed; Ruff, Prettier, `git diff --check`, and the canonical evidence linter passed. The measured floor is Gear 1. The only source change is six added lines in the existing test file.

## Adversarial review

Kimi K3 through the installed OAuth CLI returned PASS on the full test file and diff. The reviewer received the local results as evidence and did not independently execute tests. Its minor observation is that `job.pop` would raise on an already-missing upstream key; the real-workflow positive test also rejects that drift. Exact source and review hashes are in the pack. Final independent Anthropic grading remains separate.

Evidence: `evidence/2026-09/agent-air-m5-infra-b03-timeout-pin-3fa5a2f5/`.

Fresh parent: `2421a3dd053cf9cab97665114bb4f5496d06ab44`, after #5792 merged. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed). No claim about a more specific runtime model is made.
