### PR TITLE
docs(api): align constructor token storage example

### DIFF
--- a/apps/mouth/DOCUMENTATION.md
+++ b/apps/mouth/DOCUMENTATION.md
@@ -570,14 +570,17 @@ import { Toast } from "@/components/ui/toast";
 
 ```typescript
 // src/lib/api/client.ts (abridged)
+import { safeStorage } from "@/lib/utils/storage";
 
 class ApiClientBase {
   protected baseUrl: string;
-  protected token: string | null;
+  protected token: string | null = null;
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
-    this.token = localStorage.getItem("auth_token");
+    if (typeof window !== "undefined") {
+      this.token = safeStorage.getItem("auth_token");
+    }
   }
 
   protected async fetch<T>(

--- a/evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/brief.yml
@@ -1,0 +1,12 @@
+task_id: x01-storage-docs
+gear: 1
+objective: Align the abridged API-client constructor example with its actual browser-guarded token initialization.
+constraints:
+  - Documentation only; preserve application code, fetch example and existing tests.
+  - Fresh main after PR5775 merged; its branch stays frozen.
+acceptance:
+  - text: The example matches the actual safeStorage import, null token initialization and guarded auth_token read; its constructor performs no storage read without window.
+    probe: apps/mouth/DOCUMENTATION.md
+consumer_map:
+  - A developer reading API Client Base sees the actual constructor token path, including server-side initialization.
+pii: none

--- a/evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/pack.yml
@@ -23,8 +23,8 @@ receipts:
     seat: kimi-code/k3
 source:
   path: apps/mouth/src/lib/api/client.ts
-  blob: 31f5c2881a41ce52d8de0f6b97bcf40eb46abf6a
-  base: 2421a3dd053cf9cab97665114bb4f5496d06ab44
+  blob: 31f5c2881a41ce52d8de0f6b97bcf40eb46abf6a # pragma: allowlist secret - verified public source Git blob, not credential
+  base: 2421a3dd053cf9cab97665114bb4f5496d06ab44 # pragma: allowlist secret - verified public main Git commit, not credential
 limits:
   - The comparison covers the abridged constructor token path; profile and impersonation initialization remain omitted by the existing abridgement.
   - Syntax and isolated constructor smoke do not claim full application typechecking, runtime tests or production behavior.

--- a/evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/pack.yml
@@ -1,0 +1,30 @@
+brief_ref: evidence/2026-09/agent-air-m5-mouth-x01-storage-docs/brief.yml
+lanes:
+  - lane: x01-storage-docs
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: x01-storage-docs-review
+    role: review
+    seat: kimi-code/k3 via existing OAuth CLI
+dissent: []
+pii_scan: clean
+receipts:
+  - claim: The documented token path matches the actual constructor and behaves as documented in server and browser contexts.
+    cmd: node .agent/verify-snippet.cjs
+    result: TypeScript 6.0.3 AST comparison and parse/transpile passed; server smoke returned null with zero storage calls; browser smoke read auth_token once. The old snippet fails the same verification. This one-time local probe is not a new repository test.
+    exit: 0
+    ts: "2026-09-05T19:58:24.796Z"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: An independent Kimi reader found the documentation change accurate and within the abridged token-path scope.
+    cmd: kimi -m kimi-code/k3 -p <documentation diff, actual source excerpt and probe result>
+    result: PASS; no factual errors or scope creep. Static supplied-source review; the reviewer did not re-execute the probe. Only this review receipt followed the review.
+    exit: 0
+    ts: "2026-09-05T19:59:16.969816+00:00"
+    seat: kimi-code/k3
+source:
+  path: apps/mouth/src/lib/api/client.ts
+  blob: 31f5c2881a41ce52d8de0f6b97bcf40eb46abf6a
+  base: 2421a3dd053cf9cab97665114bb4f5496d06ab44
+limits:
+  - The comparison covers the abridged constructor token path; profile and impersonation initialization remain omitted by the existing abridgement.
+  - Syntax and isolated constructor smoke do not claim full application typechecking, runtime tests or production behavior.


### PR DESCRIPTION
The abridged `ApiClientBase` example read `localStorage` unconditionally and left `token` uninitialized, while the actual constructor initializes it to `null` and uses `safeStorage` inside a browser guard. Align those lines and add the real import. The existing fetch example, runtime implementation and tests remain unchanged.

Bites: A developer reading `apps/mouth/DOCUMENTATION.md` under API Client Base sees the actual token initialization path: server-side construction keeps `token = null` without reading browser storage, and browser construction reads `auth_token` through `safeStorage`.

Validation: TypeScript AST comparison of the import, token field, required baseUrl, base assignment, browser condition and token read passed against `src/lib/api/client.ts`. Parsing/transpilation and isolated constructor smoke passed for server and browser contexts; the old snippet is rejected by the same check. Documentation Prettier and evidence-pack lint passed. These are targeted documentation checks, not a claim of full application typechecking or production behavior.

Gear 1. Fresh branch after #5775 merged. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed). Prepared as draft for the independent Claude gate.

## Adversarial review

Kimi `kimi-code/k3` returned PASS on the supplied diff, actual source excerpt and probe result at 19:59:16Z. It did not re-execute the probe. No documentation changes followed that review.


Evidence correction: the first Detect Secrets job (101367105418) reported two entropy findings, exactly the verified public Git blob and base commit in pack.yml. A follow-up commit adds only two inline audited annotations. Parsed YAML data, the reviewed document blob `5e5fc8affa8fd986c0d57344ed5a671c678a2949`, and runtime source remain unchanged. Local detect-secrets 1.5.0 reproduced the two findings; the corrected three-file scan using CI baseline settings reports zero, and a synthetic canary still triggers the detector. The old failed job was not blindly rerun.
