### PR TITLE
fix(e2e): allow five minutes for web server startup

### DIFF
--- a/apps/mouth/playwright.config.ts
+++ b/apps/mouth/playwright.config.ts
@@ -102,7 +102,7 @@ export default defineConfig({
           NEXT_PUBLIC_VISA_ORACLE_WHATSAPP_NUMBER: "628123456789",
         },
         reuseExistingServer: !process.env.CI,
-        timeout: 180 * 1000,
+        timeout: 300 * 1000,
         stdout: "pipe",
         stderr: "pipe",
       },

--- a/evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/brief.yml
@@ -1,0 +1,24 @@
+task_id: e2e-startup-budget
+gear: 2
+objective:
+  Allow the existing Playwright production build and startup command 300 seconds before reporting a webServer
+  startup timeout.
+constraints:
+  - Change only webServer.timeout from 180000 to 300000 ms in apps/mouth/playwright.config.ts.
+  - Keep build/start command, test timeouts, URL, environment and workflow unchanged.
+  - GitHub CI performs the production build; no heavy build on Air-M5.
+acceptance:
+  - text:
+      WHEN the config is collected without starting a server, Playwright SHALL load the same test suite with a 300000 ms
+      webServer budget.
+    probe: config-collection
+  - text:
+      WHEN this PR runs its E2E job, its downloaded log SHALL show Next Ready within 300 seconds of the Run E2E
+      tests environment-end marker.
+    probe: own-pr-e2e-log
+consumer_map:
+  - The required E2E Tests (Playwright) job starts npm run build && npm run start through apps/mouth/playwright.config.ts.
+risks:
+  - A failed startup can take 120 seconds longer to time out; individual test limits are unchanged.
+  - Historical timings use the step environment-end marker; they do not instrument the internal Playwright timer.
+pii: none

--- a/evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/kimi-review.txt
@@ -1,0 +1,13 @@
+• **PASS**
+
+  Scope check — exact one-line change, `180 * 1000` → `300 * 1000` in `webServer.timeout`, matching the Fable-authorized edit. Build/start command, URL, env, `reuseExistingServer`, test timeouts, retries, workers, reporters all byte-identical. Nothing outside the authorized line.
+
+  Units — Playwright `webServer.timeout` is milliseconds; 300000ms = 300s. Correct.
+
+  Behavior — the timeout governs time from process spawn (build included, since command is `npm run build && npm run start`) to URL responding. Worst observed success: 174.4s; failure Ready at 180.03s, 0.876s before the timeout error — consistent with the 180s ceiling being the cause. 300s yields ~125s headroom over the max observed, and failed startups now take up to 120s longer to surface — disclosed in `risks`. Per-test 60s limit unchanged. No behavioral change outside the startup wait.
+
+  Truthfulness — log-proxy caveat honestly stated in both `measurement_method` and `failed_run_observation` (not the internal Playwright timer). Own-PR E2E proof correctly declared pending with an explicit completion requirement before the Fable gate — no false claim of closure. Source attribution (four independent downloads + root-verified failing log, SHA-256 digests) is sound. Generator≠grader holds (Codex build / Kimi review).
+
+  Non-blocking observations:
+  - The `config-collection` receipt bundles byte-comparison and Prettier claims under a single listed `playwright test --list` command; those two verifications aren't entailed by that command's exit 0. Unverifiable here; root should confirm before gate.
+  - 300s is a fixed budget; CI build-time growth will erode headroom silently. Acceptable now, worth watching.

--- a/evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/pack.yml
@@ -1,0 +1,93 @@
+gear: 2
+brief_ref: evidence/brief.yml
+gear_reason: Fable explicitly assigned E2E-1 as Gear 2 after the measured startup-budget failure.
+lanes:
+  - lane: e2e-1
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: e2e-1-review
+    role: review
+    seat: kimi-code/k3 via existing OAuth CLI
+pii_scan: clean
+dissent: []
+receipts:
+  - probe: config-collection
+    claim: "config-collection: Playwright loads the corrected config without starting a webServer."
+    cmd: cd apps/mouth && npx --no-install playwright test --list --config=playwright.config.ts
+    result: "Total: 1064 tests in 52 files."
+    exit: 0
+    ts: "2026-09-05T20:03:20.043090+00:00"
+    seat: Codex Astra-2 executing the existing Playwright CLI
+measurement_method:
+  GitHub Run E2E tests environment endgroup to Next WebServer Ready; not the instrumented Playwright
+  internal timer
+measurement_source:
+  Independently downloaded four successful E2E job logs; failing log from root verified at the
+  supplied path. Fable diagnostic identified the sample.
+historical_runs:
+  - run_id: 33988044153
+    job_id: 101365283831
+    event: merge_group
+    conclusion: success
+    step_environment_end: "2026-09-05T19:49:44.4061770Z"
+    next_ready: "2026-09-05T19:51:55.5213012Z"
+    elapsed_seconds: 131.115124
+    log_sha256: 4040e3692f30c41f63fdbdff4df46a2e0c867b77a92067ed135eff54197e2d1a # pragma: allowlist secret - downloaded CI log digest
+    job_url: https://github.com/Bali-Zero/Teman2/actions/runs/33988044153/job/101365283831
+  - run_id: 33983782467
+    job_id: 101353541219
+    event: schedule
+    conclusion: success
+    step_environment_end: "2026-09-05T18:24:03.9027561Z"
+    next_ready: "2026-09-05T18:26:38.1863270Z"
+    elapsed_seconds: 154.283571
+    log_sha256: a87308fec903b055e4222cc165afb3e5da26740104e12e2f087009407cf6fe68 # pragma: allowlist secret - downloaded CI log digest
+    job_url: https://github.com/Bali-Zero/Teman2/actions/runs/33983782467/job/101353541219
+  - run_id: 33988095719
+    job_id: 101365417656
+    event: pull_request
+    conclusion: success
+    step_environment_end: "2026-09-05T19:49:57.2552267Z"
+    next_ready: "2026-09-05T19:52:49.8183252Z"
+    elapsed_seconds: 172.563099
+    log_sha256: 1c24727400e4c6832510dd13ed8f8364e7b1b9daa4ff1de4652424e87fb69213 # pragma: allowlist secret - downloaded CI log digest
+    job_url: https://github.com/Bali-Zero/Teman2/actions/runs/33988095719/job/101365417656
+  - run_id: 33985225179
+    job_id: 101357674423
+    event: pull_request
+    conclusion: success
+    step_environment_end: "2026-09-05T18:53:51.2757665Z"
+    next_ready: "2026-09-05T18:56:45.7236183Z"
+    elapsed_seconds: 174.447852
+    log_sha256: 66e7694185c34174b69f0c00f06b406a32bda2ed30289d2714e04bf211613eb4 # pragma: allowlist secret - downloaded CI log digest
+    job_url: https://github.com/Bali-Zero/Teman2/actions/runs/33985225179/job/101357674423
+  - run_id: 33988016350
+    job_id: 101365269696
+    event: merge_group
+    conclusion: failure
+    step_environment_end: "2026-09-05T19:49:22.4772981Z"
+    next_ready: "2026-09-05T19:52:22.5100296Z"
+    elapsed_seconds: 180.032731
+    log_sha256: 64f7618d171dcceef0281be943128a98b7a8f9bfc49eba37b1143b8b68b1eb89 # pragma: allowlist secret - downloaded CI log digest
+    job_url: https://github.com/Bali-Zero/Teman2/actions/runs/33988016350/job/101365269696
+failed_run_observation:
+  ready_line: 2026-09-05T19:52:22.5100296Z [WebServer] ✓ Ready in 137ms
+  timeout_line: "2026-09-05T19:52:23.3860270Z Error: Timed out waiting 180000ms from config.webServer."
+  interpretation:
+    Next Ready precedes the timeout error; the 180.032731 seconds is measured from the environment-end marker,
+    not an instrumented internal timer.
+completion_requirement:
+  Own PR E2E log proof is pending until CI runs. Record its run/job IDs, timestamps, Ready
+  line and elapsed time in the PR body and local handoff before requesting the final Fable gate.
+additional_verification:
+  source_scope: An independent byte comparison against base 2421a3dd permits only the webServer timeout 180→300 replacement; every other config byte matches.
+  formatting_command: npx --no-install prettier --check apps/mouth/playwright.config.ts
+  formatting_result: PASS
+review:
+  verdict: PASS, independent static source review; reviewer executed no commands.
+  finished_at: "2026-09-05T20:03:44.263254+00:00"
+  artifact: evidence/2026-09/agent-air-m5-mouth-e2e-startup-budget/kimi-review.txt
+  prompt_sha256: cb452652bf5e2399c9facec7d8eb47e1884958e54db451279b149b8e6ce304b0 # pragma: allowlist secret - review prompt digest
+  review_sha256: b269f57cdbd5ae24583f2015e0e31c4dea76b23c1e85f5b3f41c244b56827e4a # pragma: allowlist secret - review artifact digest
+  output_format: CLI text with trailing blank lines removed.
+  post_review_changes: Prose spacing only; moved the byte-comparison and formatting claims out of the config-collection result as requested. Source unchanged. Appended this receipt and the review artifact.


### PR DESCRIPTION
The required Playwright E2E job runs the production build and server startup inside a 180-second webServer budget. Four recent successful jobs consumed 131–174 seconds, and merge-group run 33988016350 timed out at that boundary before any product assertions ran. This changes only `apps/mouth/playwright.config.ts`'s `webServer.timeout` from `180 * 1000` to `300 * 1000`. The build/start command, test timeouts, retries, environment and workflow are unchanged.

Fable assigned this measured budget correction as Gear 2. A failed startup can now take 120 seconds longer to report failure.

The following values were independently extracted from the downloaded E2E job logs; the failed log was read from the root session's retained download. The metric is the GitHub Run E2E tests environment-end marker to the Next WebServer Ready line, **not an instrumented Playwright internal timer**. Fable's diagnostic selected the historical sample.

| E2E run and job log | Outcome | Environment end → Next Ready |
|---|---|---|
| [33988044153](https://github.com/Bali-Zero/Teman2/actions/runs/33988044153/job/101365283831) | success | 131.115124 s |
| [33983782467](https://github.com/Bali-Zero/Teman2/actions/runs/33983782467/job/101353541219) | success | 154.283571 s |
| [33988095719](https://github.com/Bali-Zero/Teman2/actions/runs/33988095719/job/101365417656) | success | 172.563099 s |
| [33985225179](https://github.com/Bali-Zero/Teman2/actions/runs/33985225179/job/101357674423) | success | 174.447852 s |
| [33988016350](https://github.com/Bali-Zero/Teman2/actions/runs/33988016350/job/101365269696) | failure | 180.032731 s |

In the failing job 101365269696, the environment marker is `2026-09-05T19:49:22.4772981Z`, Next Ready is `2026-09-05T19:52:22.5100296Z`, and the `Timed out waiting 180000ms from config.webServer` error is at `2026-09-05T19:52:23.3860270Z`. Ready precedes the error by 0.876 seconds; 180.032731 seconds refers to the environment-marker clock. Exact timestamps, job URLs and downloaded-log hashes are in the pack.

Bites: this PR's own [E2E Tests (Playwright) job 101368047866, run 33989072151](https://github.com/Bali-Zero/Teman2/actions/runs/33989072151/job/101368047866) finished **SUCCESS on attempt 1**, against head `15c825b646e0dedd8873307a444262c7c7478246`. The downloaded log gives **191.946306 seconds** from the Run E2E tests environment-end marker to Next Ready, within the new 300-second budget and above the old 180-second reference. Its product tests completed with **58 passed, 1 skipped**.

Actual downloaded log lines:

```text
2026-09-05T20:10:29.6436652Z ##[endgroup]
2026-09-05T20:13:41.5899710Z [WebServer] ✓ Ready in 113ms
2026-09-05T20:14:51.9707195Z   1 skipped
2026-09-05T20:14:51.9707582Z   58 passed (4.4m)
```

The `113ms` is Next's server phase; 191.946306 seconds includes the preceding production build. This remains a log-reference measurement, not a direct instrument of Playwright's internal timer. Downloaded-log SHA-256: `1eefdd7ef5a01ac91ed3a992fe0b885e9dd27589f81a506a0000863b80011ffb`. Obtained with the literal command `gh api --allow-escape-sequences repos/Bali-Zero/Teman2/actions/jobs/101368047866/logs > .agent/e2e-1/logs/101368047866.log`; timestamp extraction is retained at `.agent/e2e-1/own-pr-e2e-proof.json` in the lane worktree. The committed pack's pending-CI requirement was satisfied after this run and recorded here without another source push.

Local validation: exact comparison with base 2421a3dd allows only the timeout 180→300 source-line change; `cd apps/mouth && npx --no-install playwright test --list --config=playwright.config.ts` succeeds with 1064 tests in 52 files without starting a server. Prettier, whitespace, Gear 2 evidence lint, full mouth tsc and canary-verified secret scan pass. GitHub CI performs the actual production build.

## Adversarial review

Kimi K3 through the existing OAuth CLI returned PASS at 2026-09-05T20:03:44Z. Static review only; Kimi executed no commands. It reviewed the source change and historical/pending proof scope. After review, prose spacing and receipt presentation were corrected, and the review receipt/artifact were appended; source remains unchanged. Full prompt/output hashes and limits are in the evidence pack. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed).

Draft and unarmed. Fable independently gates the final head and owns shipping.
