### PR TITLE
chore(visa): annotate the pinned public verification key

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
@@ -91,7 +91,7 @@ REPORT_SCHEMA_VERSION = "1.0.0"
 _REPOSITORY_PRODUCTION_SIGNING_KEYS: tuple[dict[str, str | None], ...] = (
     {
         "kid": "prod-2026-07-1",
-        "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",
+        "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",  # pragma: allowlist secret - pinned Ed25519 public verification key, not a credential
         "environment": "PRODUCTION",
         "valid_from": "2026-07-19T00:00:00Z",
         "valid_to": None,

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_prod_sequence2_bundle.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_prod_sequence2_bundle.py
@@ -40,7 +40,7 @@ PROD_TRUST_STORE_JSON = json.dumps(
     [
         {
             "kid": "prod-2026-07-1",
-            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",
+            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",  # pragma: allowlist secret - pinned Ed25519 public verification key, not a credential
             "environment": "PRODUCTION",
             "valid_from": "2026-07-19T00:00:00Z",
             "valid_to": None,

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq17_freshness_restamp.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq17_freshness_restamp.py
@@ -73,7 +73,7 @@ PROD_TRUST_STORE_JSON = json.dumps(
     [
         {
             "kid": "prod-2026-07-1",
-            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",
+            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",  # pragma: allowlist secret - pinned Ed25519 public verification key, not a credential
             "environment": "PRODUCTION",
             "valid_from": "2026-07-19T00:00:00Z",
             "valid_to": None,

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq18_freshness_window.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq18_freshness_window.py
@@ -93,7 +93,7 @@ PROD_TRUST_STORE_JSON = json.dumps(
     [
         {
             "kid": "prod-2026-07-1",
-            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",
+            "public_key": "gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA",  # pragma: allowlist secret - pinned Ed25519 public verification key, not a credential
             "environment": "PRODUCTION",
             "valid_from": "2026-07-19T00:00:00Z",
             "valid_to": None,

--- a/evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/brief.yml
@@ -1,0 +1,12 @@
+gear: 1
+objective: Annotate four identical pinned public Ed25519 verification keys for the existing secret scanner.
+constraints:
+  - Only same-line comments on the four assigned public key literals; no logic, key, trust-store or baseline changes.
+  - No private key access, signing or runtime module execution.
+acceptance:
+  - WHEN the scanner reads the four existing files, the four public-key findings SHALL disappear and other findings
+    SHALL remain unchanged.
+  - WHEN a separate synthetic unannotated canary is scanned, its findings SHALL remain detectable.
+  - WHEN source meaning is compared with the parent, AST, compiled code and public-key bytes SHALL remain identical.
+consumer_map:
+  - Detect Secrets scans the changed files and honors each existing same-line allowlist pragma.

--- a/evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/kimi-review.md
+++ b/evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/kimi-review.md
@@ -1,0 +1,24 @@
+• PASS — no blocking findings. Static review only; no tools run, no files touched.
+
+## Scope and wording
+
+- **Pragma syntax correct for detect-secrets 1.5.0**: `# pragma: allowlist secret` is the documented same-line directive; placement on the same physical line as the flagged literal is required and satisfied in all four hunks. Trailing free text after the pragma is permitted and ignored by the scanner.
+- **Scope is line-minimal**: the directive suppresses only findings on that line; nothing else shares those lines. No baseline edit, no global suppression, no `.secrets.baseline` or config change in the diff — consistent with the declaration.
+- **Wording is accurate for scanner triage**: "pinned Ed25519 public verification key, not a credential" is correct in the secrets-scanning sense (a public key is not a secret). Nit: in strict cryptographic vocabulary a public key _is_ a public credential; "not a secret" would be marginally more precise. Non-blocking.
+- **Inherent residual (accepted, worth one line in the PR body)**: the pragma suppresses _all_ detector types on that line, not just Base64 High Entropy. If a real secret were ever concatenated onto that exact line, it would be silently allowlisted. This is a property of detect-secrets line-granularity, not of this change.
+
+## Trust semantics
+
+- Unchanged. The edit is comment-only on existing lines; no code, string, or structural token moves. Line numbers are preserved (comment appended, not inserted), so tracebacks, the `line:` values in the proof metadata, and any line-anchored tooling remain valid.
+- Line arithmetic checks out against the hunks: `@@ -91` key at offset +4 → line 94; `@@ -40` → 43; `@@ -73` → 76; `@@ -93` → 96. All match the metadata.
+- The key sits in a trust store feeding `StaticTrustStore` — but it is a _verification_ key; annotating it does not alter what is trusted, only how the scanner classifies a public artifact. No signing path, key material, or decoder logic is touched.
+
+## Evidence vs. claims
+
+- **Supported by metadata**: four targeted Base64 findings → 0; five other findings unchanged (counts only); AST/compiled byte-identity (plausible by construction for comment-only edits — `compile()` output excludes comments); per-file hashes and identical `key_sha256` across all four files corroborate the "identical literal" claim without exposing the key.
+- **Asserted but not independently evidenced in the metadata** (consistent, non-blocking, but the PR should not present them as machine-verified): (a) CI triage auto-approving the five pre-existing payload-hash findings "with zero residue" — only the counts 5→5 are shown; (b) the production decoder's use of `urlsafe_b64decode` + `from_public_bytes` — contextual, outside the diff; (c) the canary result — `canary_detected: true` with plausible types, but the canary file/line is not identified. None of these affect the diff's correctness; they are provenance claims a reviewer cannot re-derive from what is shown here.
+- **Redaction discipline respected**: key bytes appear nowhere; only a hash and a length (32 bytes, correct for Ed25519). I did not and cannot reconstruct the key, per instructions.
+
+## Verdict
+
+PASS. Comment-only, scope-precise, semantics-preserving annotation with internally consistent proof metadata. Two advisory items for the PR body: note the line-granularity residual of the pragma, and label the CI-triage/decoder/canary claims as asserted context rather than hashed evidence. Final Anthropic gate remains separate, as stated.

--- a/evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/pack.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/pack.yml
@@ -1,0 +1,76 @@
+gear: 1
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: public-key-hygiene
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: comment-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+seat_override:
+  "R8 applicability: scanner comments only. No immigration rule, eligibility, claim or price is authored;
+  no NotebookLM query is claimed."
+receipts:
+  - claim: Four identical 32-byte Ed25519 public verification keys retain the same literal, AST and compiled code.
+    cmd:
+      AST parse including locations; Ed25519PublicKey.from_public_bytes; compile and marshal equality against parent.
+      No source module executed.
+    result: All four source ASTs and compiled bytes identical; public key SHA-256 identical across all four files.
+    exit: 0
+    ts: "2026-09-05T20:29:36.935716+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: The real scanner removes exactly the four assigned public-key findings and still detects a separate canary.
+    cmd:
+      detect-secrets 1.5.0 SecretsCollection.scan_file under default_settings, before and after four comments;
+      scan synthetic canary separately.
+    result:
+      Four targeted Base64 findings become zero; five other findings remain unchanged. Canary line 1 still emits
+      Hex High Entropy and Secret Keyword.
+    exit: 0
+    ts: "2026-09-05T20:29:36.935716+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: Existing CI auto-triage already accepts the five unchanged payload-hash findings.
+    cmd:
+      scripts/detect_secrets_auto_triage.py::triage on an isolated copy of the five scanner findings; no baseline
+      file written.
+    result: auto_approved=5, hard_blocked=0, no_rule=0, residue=0.
+    exit: 0
+    ts: "2026-09-05T20:29:56.223382+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: Independent bounded static review PASS.
+    cmd: kimi -m kimi-code/k3 -p <supplied redacted diff and proof metadata>
+    exit: 0
+    ts: "2026-09-05T20:31:21.776871+00:00"
+    seat: kimi-code/k3
+dissent:
+  - seat: kimi-code/k3
+    objection: The same-line pragma suppresses all detector types on that line.
+    status: CONFIRMED
+    disposition: Accepted line-level scope, stated in PR. Future edits to these lines still need review.
+  - seat: kimi-code/k3
+    objection: Reviewer did not independently verify decoder, triage or canary execution from the supplied excerpt.
+    status: CONFIRMED
+    disposition:
+      These are builder-executed checks, with local receipt hashes below; no independent execution by Kimi
+      is claimed.
+parent: 6d296f6707abd3e3b9d33aee58df204c42a6a2c3 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+key_sha256: f189e13b8e8a02e7ed5910223f3c96689662de01ea11b63bf7886eb6ee6a57e9 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+source_sha256:
+  apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py: 1557e579618088f09d5876edd1d4347e7b99f31e277210c6ddef9cddf2cf1065 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+  apps/backend-rag/backend/tests/services/visa_engine/test_prod_sequence2_bundle.py: 5b5103302533a9da854e1aea351e7b18d70502170eef5da329eb45ae6aa8dd55 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+  apps/backend-rag/backend/tests/services/visa_engine/test_seq17_freshness_restamp.py: 35d2fc660d55de04dd9c2b3e04098779c0d658037bcdd3a0f845670b6cfcd42e # pragma: allowlist secret - verified public Git or artifact hash, not credential
+  apps/backend-rag/backend/tests/services/visa_engine/test_seq18_freshness_window.py: 0604062c963a3ee9bdd035316012453cf586a6ecc6de3ec1d794c7e8f284320d # pragma: allowlist secret - verified public Git or artifact hash, not credential
+local_receipt_sha256:
+  proof.json: 21858803cb5659c63e4e7bf9d8be0329e98612a5e70992837b55c40c274b5841 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+  existing-hashes-triage.json: 87dfd5d981cb748d503669f1f1b8b822280964254b433f84d89d8dbb9279bd90 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+  canary-findings.json: b005a283b1d7e27a45ac0ecd11fe35854646c71a054c1732108d8a7ac7e95913 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+review_artifacts:
+  committed_answer_sha256: e5fad0930d27c0a4b1ad3d670f7a9e7ad928b3777dc46805555d064e0fc0f09e # pragma: allowlist secret - verified formatted artifact hash, not credential
+  prompt_sha256: 01e4291ac01cc632dd7e82732545ec533f5cfbf6947c4e0671649b64b7c4d82c # pragma: allowlist secret - verified public Git or artifact hash, not credential
+  raw_stdout_sha256: 18517ffa740b1738a8a9ea6b2e81390585f11c5f43ece89ff43b674ef2ba2743 # pragma: allowlist secret - verified public Git or artifact hash, not credential
+notes:
+  - Local receipts are under .agent/public-key/; only hashes are carried here. No public key value is transcribed
+    into this evidence.
+  - No new tests were added for comments. Ruff and whitespace checks passed. Final CI and independent Anthropic gate
+    remain separate.


### PR DESCRIPTION
The existing secret scanner flags the same pinned public Ed25519 verification key in four Python files. Add a same-line allowlist comment to those four literals so scanner output reflects that they are public verification material. All key bytes, trust-store behavior and Python logic remain unchanged.

Bites: detect-secrets 1.5.0 scanned the actual four files before and after the comments. Exactly four Base64 High Entropy findings on the assigned public-key lines disappeared; all five unrelated existing payload-hash findings remained unchanged. The existing CI triage function auto-approved those five findings with zero residue. A separate synthetic unannotated canary still triggered Hex High Entropy and Secret Keyword findings. On head `5b9564d8a10b5f50565b9c439378c4b736e80ba5`, [Detect Secrets job 101371703377](https://github.com/Bali-Zero/Teman2/actions/runs/33990481338/job/101371703377) completed SUCCESS at 20:34:18Z. Its real CI log records exactly five findings, five auto-approved and zero unaudited residue.

Validation: all four keys decode to the same 32-byte public key and are accepted by Ed25519PublicKey.from_public_bytes; ASTs including location attributes and marshaled compiled code are identical before/after for all four files. Modules were not executed. Ruff, Prettier, whitespace checks and the canonical evidence linter passed. Floor Gear1; no new mirror tests for comments.

## Adversarial review

Kimi K3 through the installed OAuth CLI returned PASS on the redacted diff and proof metadata. It did not independently execute the scanner, canary or triage; these are builder-executed checks whose local receipt hashes are in the pack. The same-line pragma applies to all detector types on that physical line, so future edits to those lines still require review. The complete review is included. Final independent Anthropic grading remains separate.

Scope: only four same-line comments plus this lane's evidence. No baseline, scanner policy, payload hash, environment file, dataset, key value or signing operation changed. The public key itself is omitted from the evidence; its SHA-256 binds the equality check.

Evidence: `evidence/2026-09/agent-air-m5-backend-rag-public-key-hygiene-efd00d30/`.

Fresh parent: `6d296f6707abd3e3b9d33aee58df204c42a6a2c3`. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed).
