### PR TITLE
docs(auth): describe cookie-primary session gates

### DIFF
--- a/apps/mouth/DOCUMENTATION.md
+++ b/apps/mouth/DOCUMENTATION.md
@@ -1045,26 +1045,42 @@ const imageUrl = `https://image.pollinations.ai/prompt/${encodeURIComponent(prom
    - nz_access_token (HttpOnly)
    - nz_csrf_token
                      ↓
-3. Frontend stores in localStorage:
-   - auth_token (for API calls)
+3. Frontend caches auth_token via safeStorage (optional bearer support):
+   - localStorage when available; memory fallback when unavailable
                      ↓
-4. Subsequent requests include:
-   - Authorization: Bearer {token}
-   - X-CSRF-Token: {csrf}
-   - Cookie: nz_access_token=...
+4. Subsequent requests use credentials: "include":
+   - Cookie: nz_access_token=... (primary session)
+   - Authorization: Bearer {token} (when available)
+   - X-CSRF-Token: {csrf} (state-changing requests, when available)
 ```
 
 ### Protected Routes
 
-```typescript
-// Middleware pattern (in page components)
-useEffect(() => {
-  const token = localStorage.getItem("auth_token");
-  if (!token) {
-    router.push("/login");
-  }
-}, []);
+Client pages use `useSessionState()`, backed by `api.hasSession()`, so a missing
+bearer token does not eject a valid cookie-only session. The hook starts at
+`pending`; only `anonymous` redirects to login. `pending` and `unknown` keep
+protected data loads gated until the session is `authenticated`.
 
+```typescript
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSessionState } from "@/hooks/useSessionState";
+
+// Inside a client page component (abridged from src/app/agents/page.tsx).
+const router = useRouter();
+const session = useSessionState();
+
+useEffect(() => {
+  if (session === "anonymous") {
+    router.push("/login");
+    return;
+  }
+  if (session !== "authenticated") return;
+  // Apply page-specific authorization and load protected data here.
+}, [session, router]);
+```
+
+```typescript
 // Server-side (API routes)
 const token = request.cookies.get("nz_access_token");
 if (!token) {

--- a/evidence/2026-09/agent-air-m5-mouth-auth-flow-docs/brief.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-auth-flow-docs/brief.yml
@@ -1,0 +1,12 @@
+task_id: auth-flow-docs
+gear: 1
+objective: Describe the actual cookie-primary token flow and existing protected-page session gates in the two affected documentation fragments.
+constraints:
+  - Documentation only; preserve runtime source, tests, the existing server example and unrelated sections.
+  - Reuse useSessionState and the production access guards; no new hook or authentication behavior.
+acceptance:
+  - text: Imports and guards match the existing page; only anonymous redirects and only authenticated permits protected loading; storage fallback matches actual source.
+    probe: apps/mouth/DOCUMENTATION.md
+consumer_map:
+  - A developer reading Token Flow and Protected Routes sees optional bearer storage and the existing cookie-primary session gate.
+pii: none

--- a/evidence/2026-09/agent-air-m5-mouth-auth-flow-docs/pack.yml
+++ b/evidence/2026-09/agent-air-m5-mouth-auth-flow-docs/pack.yml
@@ -1,0 +1,35 @@
+brief_ref: evidence/2026-09/agent-air-m5-mouth-auth-flow-docs/brief.yml
+lanes:
+  - lane: auth-flow-docs
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: auth-flow-docs-review
+    role: review
+    seat: kimi-code/k3 via existing OAuth CLI
+dissent: []
+pii_scan: clean
+receipts:
+  - claim: The documented gates and storage description match existing source; all four session states preserve the production access decisions.
+    cmd: node .agent/verify-auth-docs.cjs
+    result: AST guards match agents/page.tsx; imports, SessionState and initial pending state checked; parse/transpile passed. Pending/unknown neither redirect nor reach the protected-load position; anonymous redirects only; authenticated reaches it. Six runtime-source blobs and all unrelated documentation bytes are unchanged.
+    exit: 0
+    ts: "2026-09-05T20:36:48.425Z"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: An independent Kimi reader found the documentation accurate against the supplied production source excerpts.
+    cmd: python .agent/run-kimi-review.py
+    result: PASS; no in-scope errors. Static supplied-source review, not probe re-execution. The documentation has not changed since review; only evidence receipts and reference line anchors were completed afterward.
+    exit: 0
+    ts: "2026-09-05T20:38:08.889002+00:00"
+    seat: kimi-code/k3
+references:
+  - apps/mouth/src/app/agents/page.tsx:105
+  - apps/mouth/src/hooks/useSessionState.ts:28
+  - apps/mouth/src/lib/api/types/api-client.types.ts:16
+  - apps/mouth/src/lib/api/client.ts:251
+  - apps/mouth/src/lib/api/client.ts:369
+  - apps/mouth/src/lib/api/public-auth.ts:86
+  - apps/mouth/src/lib/utils/storage.ts:64
+limits:
+  - The one-time local probe under .agent is not a repository test; its state smoke checks the documented guards, not a mounted page or network session.
+  - The snippet is explicitly an in-component fragment. Page-specific role checks, data loading and rendering remain with each actual page.
+  - The existing server-side cookie example is outside this correction and remains byte-identical.


### PR DESCRIPTION
The authentication documentation treated browser storage as mandatory and redirected to login when no local bearer token existed. The current implementation supports cookie-only sessions through `useSessionState()` and `api.hasSession()`. Correct the Token Flow diagram and copy the existing protected-page guard pattern, preserving runtime code, tests, the server example and unrelated documentation.

Bites: A developer reading Token Flow and Protected Routes sees optional bearer caching via `safeStorage`, cookie-primary requests, and redirects only for a confirmed anonymous session. The copied access guards match `src/app/agents/page.tsx`: pending/unknown do not reach protected loading; anonymous redirects to `/login`; authenticated proceeds.

Validation: TypeScript AST comparison of both access guards passed against the real page. Import names, the SessionState union and the hook's initial pending state were checked against existing source. Parsing/transpilation and four-state isolated guard smoke passed. Six runtime-source blobs, the existing server example, and all documentation outside the two fragments remain byte-identical to fresh main. Prettier, evidence-pack lint and the local three-file detect-secrets scan passed. The one-time `.agent` probe is not a new repository test and does not claim mounted-page or network validation.

Gear 1. Created from fresh main only after #5804 merged at `8e09a6c6814dfed5f130d4cb3eb88cbe452595d1`. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed). Draft prepared for the independent Claude gate.

## Adversarial review

Kimi `kimi-code/k3` returned PASS at 20:38:08Z on the supplied diff, production source excerpts and local proof. It found no in-scope errors and did not re-execute the probe. The reviewed documentation is unchanged; only evidence receipts and reference line anchors were completed afterward.
