### PR TITLE
test(ci): handle an already missing timeout in the negative fixture

### DIFF
--- a/evidence/2026-09/agent-air-m5-infra-timeout-pop-default/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-timeout-pop-default/brief.yml
@@ -1,0 +1,13 @@
+gear: 1
+objective:
+  Let the missing-timeout negative fixture reach the existing guard when the workflow already
+  lacks the key.
+constraints:
+  - Change only the existing pop call to supply None as default.
+  - Keep the workflow, timeout assertion and application behavior unchanged.
+acceptance:
+  - The existing suite SHALL pass all 21 cases.
+  - With timeout absent upstream, the negative fixture SHALL reach its expected assertion without KeyError.
+  - The real workflow guard SHALL still reject a missing timeout.
+consumer_map:
+  - The required antidotes job executing scripts/tests/test_required_context_map.py from its candidate checkout.

--- a/evidence/2026-09/agent-air-m5-infra-timeout-pop-default/kimi-review.txt
+++ b/evidence/2026-09/agent-air-m5-infra-timeout-pop-default/kimi-review.txt
@@ -1,0 +1,12 @@
+• **PASS**
+
+  Static findings:
+
+  - The delta is exactly the stated one line: `job.pop("timeout-minutes")` → `job.pop("timeout-minutes", None)` in the `missing-timeout` branch of `test_required_mouth_typecheck_rejects_disarmed_mutations`. Semantics are correct: `pop` with a default no longer raises `KeyError` when the upstream workflow already lacks the key, so the mutation setup completes and control reaches `_assert_required_mouth_typecheck` inside the `pytest.raises(AssertionError)` block.
+  - The real guard is intact: `_assert_required_mouth_typecheck` still asserts `job.get("timeout-minutes") == 16`. Whether the key was present-then-popped or already absent, the mutated dict yields `None != 16` → `AssertionError`. The mutation is therefore still a *genuine* disarming probe (it fails for the reason the guard exists, not for a setup artifact) and still catches a real timeout removal or absence.
+  - No collateral change: all other mutation branches, the non-mutated positive test, and the unrelated resolver tests are untouched. `deepcopy` + in-memory loader means no workflow file mutation, consistent with the builder proof's stated limit.
+  - No false-green risk introduced: with the default-`pop` form, a hypothetical future `tests.yml` that drops `timeout-minutes` would fail the *positive* test (`test_required_mouth_job_compiles_contract_consumers`) at the `== 16` assertion — so guard strength is unchanged; the parametrize case just stops erroring at setup with `KeyError`.
+
+  Builder proof claims (21 passed, in-memory probe, sha256) treated as claims per instructions; nothing in the static reading contradicts them.
+
+  **Static scope:** I reviewed only the supplied candidate test source and the one-line delta as text. I did not execute the suite, did not read `scripts/ci/required_context_map.py` or `.github/workflows/tests.yml` from disk, and cannot independently confirm that the live workflow currently contains `timeout-minutes: 16`.

--- a/evidence/2026-09/agent-air-m5-infra-timeout-pop-default/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-timeout-pop-default/pack.yml
@@ -1,0 +1,77 @@
+gear: 1
+brief_ref: evidence/brief.yml
+lanes:
+  - lane: timeout-pop-default
+    role: build
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - lane: timeout-fixture-review
+    role: review
+    seat: kimi-code/k3
+pii_scan: clean
+seat_override:
+  "R8 applicability: test setup hygiene only; no immigration rule, claim, eligibility or
+  price is authored. No NotebookLM query is claimed."
+receipts:
+  - claim: The existing workflow-guard suite passes all 21 cases.
+    cmd: apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_required_context_map.py -q
+    result: 21 passed; executed in the existing backend virtualenv.
+    exit: 0
+    ts: "2026-09-05T20:38:00.890471+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim:
+      With timeout removed from the actual loaded workflow in memory, the negative fixture reaches
+      its assertion and the real guard still rejects absence.
+    cmd: |-
+      apps/backend-rag/.venv/bin/python - <<'PY'
+      from pathlib import Path
+      from types import ModuleType
+      p = Path("scripts/tests/test_required_context_map.py").resolve()
+      m = ModuleType("timeout_probe")
+      m.__file__ = str(p)
+      exec(compile(p.read_text(), str(p), "exec"), m.__dict__)
+      loader = m.mod.load_workflow
+      def without_timeout(path):
+          workflow = loader(path)
+          workflow["jobs"]["frontend-tests"].pop("timeout-minutes")
+          return workflow
+      m.mod.load_workflow = without_timeout
+      m.test_required_mouth_typecheck_rejects_disarmed_mutations("missing-timeout")
+      try:
+          m.test_required_mouth_job_compiles_contract_consumers()
+      except AssertionError:
+          pass
+      else:
+          raise AssertionError("The real guard failed to reject missing timeout")
+      print("PASS: negative mutation reaches assertion; real guard rejects missing timeout")
+      PY
+    result: "PASS: negative mutation reaches assertion; real guard rejects missing timeout"
+    exit: 0
+    ts: "2026-09-05T20:38:00.890471+00:00"
+    seat: Codex Astra-2 (OpenAI; runtime variant not exposed)
+  - claim: Independent static reading of the complete supplied test source returns PASS.
+    cmd: kimi -m kimi-code/k3 -p "$(cat .agent/pop-default/kimi-prompt.txt)"
+    result: PASS; review did not execute tests or inspect the live workflow.
+    exit: 0
+    ts: "2026-09-05T20:36:30.708802+00:00"
+    seat: kimi-code/k3
+dissent: []
+source_scope:
+  parent: 8e09a6c6814dfed5f130d4cb3eb88cbe452595d1 # pragma: allowlist secret - verified public Git or artifact digest
+  path: scripts/tests/test_required_context_map.py
+  change:
+    One default argument, None, in the existing missing-timeout mutation; no other source bytes
+    change.
+  source_sha256: 6a2ab486d2fefbbb7afc8397afc1b7054a34cfbc9222025864284967e97a896a # pragma: allowlist secret - verified public Git or artifact digest
+review_scope:
+  artifact: evidence/2026-09/agent-air-m5-infra-timeout-pop-default/kimi-review.txt
+  artifact_sha256: 919bbb40816acbc1003f1817fe220e1bdd613bf9f63d328a3921777743cbf3fd # pragma: allowlist secret - verified public Git or artifact digest
+  prompt_sha256: 80e91bcfb23685934f92055e5927f6f96974733ac824c3e803ee0e5307d88c5c # pragma: allowlist secret - verified public Git or artifact digest
+  raw_stdout_sha256: 806957deb2013c041b4d331e6a2b186ca59a7ab1d4062b9ab5eaf7abbf870393 # pragma: allowlist secret - verified public Git or artifact digest
+  limits:
+    Static supplied-source reading only. Local prompt and raw stdout retained in .agent/pop-default;
+    the committed answer trims final blank lines only. Evidence assembled afterward; independent Fable
+    gate remains separate.
+counterfactual:
+  Before the change, the same missing-key loader scenario raised KeyError; the parent source
+  was read with git show and compared byte-for-byte after reversing this single call change. No workflow
+  file was mutated.

--- a/scripts/tests/test_required_context_map.py
+++ b/scripts/tests/test_required_context_map.py
@@ -97,7 +97,7 @@ def test_required_mouth_typecheck_rejects_disarmed_mutations(mutation: str) -> N
     elif mutation == "success-only-job":
         job["if"] = "${{ success() }}"
     elif mutation == "missing-timeout":
-        job.pop("timeout-minutes")
+        job.pop("timeout-minutes", None)
     elif mutation == "widened-timeout":
         job["timeout-minutes"] = 30
     with pytest.raises(AssertionError):


### PR DESCRIPTION
An already-missing `timeout-minutes` key made the negative fixture raise `KeyError` before it reached the intended guard. Supplying `None` to the existing `pop` call lets the fixture exercise the assertion while the positive guard continues to reject a missing timeout.

One test-source line changes. The workflow, its 16-minute timeout, the guard assertion and all other test cases are unchanged. Three evidence files record the bounded review and replay commands.

Validation: the existing suite passes all 21 cases in the backend virtualenv. A probe using the actual workflow loader with the key removed in memory reproduces the parent's `KeyError`; the candidate reaches the expected negative assertion, while the real positive guard still raises `AssertionError`. Reversing only this call change recovers the parent source byte-for-byte. Ruff, Prettier, canary-verified four-file secret scan, complete-diff evidence lint and ordinary commit/push hooks pass. Kimi K3 returned PASS from a static reading of the complete supplied test source at 20:36:30Z; it did not execute the checks.

Bites: the required [antidotes job 101372445692](https://github.com/Bali-Zero/Teman2/actions/runs/33990761602/job/101372445692) completed SUCCESS at 2026-09-05T20:46:38Z on this exact head, `ac2b17ec9b68dac297edca8f17949348321d6de6`. Its downloaded log identifies the `scripts/tests/test_required_context_map.py` group at 20:43:21Z and records **21 passed in 23.35s** at 20:43:44Z. Root independently read the completed job metadata and that log section. The job reports this PR head; its checkout is the test merge `c2abc5dcbfa61a1ac3bfd77da72b7df43cb7c6bf`, whose second parent is this head and whose test-file blob `0428e609cdc75afa611e91ee2fdbc56592e42a41` is identical to the PR source (both bindings independently verified). The local missing-key replay additionally confirms that the setup reaches the expected assertion while the real guard still rejects absence.

Evidence: `evidence/2026-09/agent-air-m5-infra-timeout-pop-default/`. Builder seat: Codex Astra-2 (OpenAI; runtime variant not exposed). Prepared as a draft for Fable's independent final gate; the external builder has not readied, armed, merged or deployed it.
