### PR TITLE
fix(team): gate GET /api/team/members behind require_team_member

### DIFF
--- a/apps/backend-rag/backend/app/routers/team.py
+++ b/apps/backend-rag/backend/app/routers/team.py
@@ -9,7 +9,7 @@ import asyncpg
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.dependencies import get_database_pool, require_team_member
 from backend.app.utils.service_accounts import non_human_roles_sql_array
 
 router = APIRouter(prefix="/api/team", tags=["team"])
@@ -30,11 +30,17 @@ class TeamMember(BaseModel):
 
 @router.get("/members", response_model=list[TeamMember])
 async def get_team_members(
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_team_member),
     pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> list[Any]:
     """
     Get list of team members visible to the current user.
+
+    Access: team members only (``require_team_member``). Clients, service
+    accounts and external partners get 403 — no partner-portal page consumes
+    this roster (it is the staff workspace's people list), so a partner JWT
+    previously received 200 with an empty or department-scoped list, which
+    answered "what does the team look like" to a caller who is not on it.
 
     Visibility rules:
     1. User-specific visibility rules (team_member_visibility_rules table)

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_team_members_partner_gate.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_team_members_partner_gate.py
@@ -1,0 +1,105 @@
+"""Guilt/innocence for the team gate on ``GET /api/team/members``.
+
+Loop loop-20260906-partner-gate-followups, task T3: at baseline a partner JWT
+received 200 with an empty list here (the partner's ``team_members`` row has no
+staff department, so the department-default branch matched nothing). No
+partner-portal page consumes this endpoint — it feeds the staff workspace's
+``useTeamMembers`` — so the correct follow-up is the team gate, not a partner
+view: partner/client/service-account JWTs now get 403 BEFORE the database is
+touched, while a staff role still gets 200 with a non-empty roster.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.routers import team
+
+_NON_TEAM_PRINCIPALS: list[dict[str, Any]] = [
+    {"email": "partner@example.com", "user_id": "partner@example.com", "role": "partner"},
+    {"email": "client@example.com", "user_id": "client@example.com", "role": "client"},
+    {"email": "probe@balizero.com", "user_id": "probe@balizero.com", "role": "monitoring"},
+]
+
+_STAFF: dict[str, Any] = {
+    "email": "surya@balizero.com",
+    "user_id": "surya@balizero.com",
+    "role": "Tax Care",
+}
+
+_STAFF_ROW: dict[str, Any] = {
+    "id": "1",
+    "email": "surya@balizero.com",
+    "name": "Surya",
+    "full_name": "Surya",
+    "role": "Tax Care",
+    "department": "tax",
+    "active": True,
+    "avatar": None,
+}
+
+_DB_TOUCHED = "the gate must refuse before the database is touched"
+
+
+class _UntouchablePool:
+    """Any attribute access is a test failure: the gate must fire first."""
+
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("__"):
+            raise AttributeError(name)
+        raise AssertionError(f"{_DB_TOUCHED}: pool.{name}")
+
+
+class _StaffConn:
+    """Minimal asyncpg stand-in returning a one-person roster for staff."""
+
+    async def fetchrow(self, _query: str, *_params: Any) -> dict[str, Any] | None:
+        return {"department": "tax", "role": "Tax Care"}
+
+    async def fetch(self, query: str, *_params: Any) -> list[dict[str, Any]]:
+        if "team_member_visibility_rules" in query:
+            return []
+        return [_STAFF_ROW]
+
+
+class _StaffPool:
+    def acquire(self) -> Any:
+        @asynccontextmanager
+        async def _acquire() -> Any:
+            yield _StaffConn()
+
+        return _acquire()
+
+
+def _app_for(principal: dict[str, Any], pool: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(team.router)
+    app.dependency_overrides[get_current_user] = lambda: principal
+    app.dependency_overrides[get_database_pool] = lambda: pool
+    return app
+
+
+@pytest.mark.parametrize("principal", _NON_TEAM_PRINCIPALS, ids=lambda p: p["role"])
+def test_non_team_jwt_gets_403_before_the_database_is_touched(
+    principal: dict[str, Any],
+) -> None:
+    """Guilt: at the baseline a partner JWT passed with 200 and an empty list."""
+    client = TestClient(_app_for(principal, _UntouchablePool()))
+    response = client.get("/api/team/members")
+    assert response.status_code == 403, response.text
+    assert "team members" in response.json()["detail"]
+
+
+def test_staff_jwt_gets_200_with_a_non_empty_roster() -> None:
+    """Innocence: a real free-text staff role passes the gate and is served."""
+    client = TestClient(_app_for(_STAFF, _StaffPool()))
+    response = client.get("/api/team/members")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert [m["email"] for m in body] == ["surya@balizero.com"]


### PR DESCRIPTION
## What

`GET /api/team/members` answered any valid JWT. A partner token (role `partner`, issued by the same door as staff and routed to `/portal/partner`) got **200 with an empty list**: the partner's `team_members` row has no staff department, so the department-default branch matched nothing.

## Investigation (spec decision rule)

Grep over `apps/mouth/src/app/portal/(authenticated)/partner/**` for `useTeamMember` / `team/members` / `team-members`: **zero references**. Every consumer of `/api/team/members` is a staff `(workspace)` page via `apps/mouth/src/hooks/useTeamMembers.ts` (assignee dropdowns, HR, process pages). No partner UI consumes this endpoint.

Per the task spec's decision rule, the path taken is therefore **gate, not a partner view**: the endpoint now uses `require_team_member` — partner/client/monitoring JWTs get **403 before the database is touched**; staff keep 200 with the roster. No field gating needed because no partner surface exposes them.

## Tests

New `backend/tests/unit/app/routers/test_team_members_partner_gate.py` at the HTTP boundary (real router, dependency overrides):

- **Guilt**: partner, client and monitoring principals → 403 with an *untouchable* pool (any pool attribute access fails the test — the gate fires before the DB).
- **Innocence**: a free-text staff role (`Tax Care`) → 200 with a non-empty roster through a fake pool.

`test_team.py`'s direct-call tests still pass unchanged (the gate lives in the `Depends`, invisible to direct calls).

Bites: `useTeamMembers` (staff workspace pages) consumes `GET /api/team/members`. The observation proving the change is in force: `PYTHONPATH=. pytest backend/tests/unit/app/routers/test_team_members_partner_gate.py` → partner/client/monitoring principals receive 403 against a pool that fails on any access, staff receives 200 non-empty. Post-deploy live check (shipper): a partner JWT on `GET https://nuzantara-rag.fly.dev/api/team/members` returns 403 (baseline: 200 with `[]`).

## Validation (all run this session, M5 worktree)

- `python -c "from backend.app.dependencies import get_current_user"` → OK
- `pytest backend/tests/unit/app/routers/test_team_members_partner_gate.py backend/tests/unit/app/routers/test_team.py backend/tests/unit/app/routers/test_crm_intelligence_partner_gate.py` → **16 passed**
- `pytest backend/tests/unit/app/test_dependencies_critical.py backend/tests/unit/utils/test_service_accounts.py` → **47 passed**
- `ruff check` + `ruff format --check` on both files → clean

No schema, migration, manifest or public-endpoints change: the route was already authenticated; only the gate tightened. Hot-zone floor: not triggered (`routers/team.py` + tests are outside every HOTZONE_PATTERN).
