### PR TITLE
fix(codex-spalla): drop removed --full-auto, fail loud when codex never judged

### DIFF
--- a/.claude/commands/codex-second-opinion.md
+++ b/.claude/commands/codex-second-opinion.md
@@ -30,7 +30,7 @@ Ask Codex CLI for an adversarial second opinion before commit/push. Pattern B (r
    The helper handles:
    - anti-pattern guard (empty diff → hard refuse; small diff → 3-line warning + 5s countdown). Small-diff threshold uses TOTAL diff (committed + uncommitted) so large WIP edits don't slip through as "small".
    - diff capture, including uncommitted-diff body and full content of untracked files (head -200 each, max 25 files, binary/>500KB skipped) so newly created files are visible to Codex
-   - dispatch via `codex exec --full-auto --sandbox read-only -c model_reasoning_effort=xhigh` for Pattern B (review), and `codex exec --full-auto` for Pattern A (exec). Note: `codex review --base` doesn't accept stdin context, so both patterns use `codex exec` with our custom [SPALLA] prompt.
+   - dispatch via `codex exec --sandbox read-only -c model_reasoning_effort=xhigh` for Pattern B (review), and `codex exec --sandbox workspace-write -c model_reasoning_effort=xhigh` for Pattern A (exec). `--full-auto` was removed in codex-cli 0.149.1 — never reintroduce it; the wrapper also exits 6 when codex returns 0 without a verdict line (the 0.151.0 "never ran at exit 0" shape, ledger 2026-09-01). Note: `codex review --base` doesn't accept stdin context, so both patterns use `codex exec` with our custom [SPALLA] prompt.
    - transcript saved to `~/logs/codex-spalla/<ts>-<rand>-<mode>-<slug>.md` with race-safe noclobber creation (concurrent same-second runs don't clobber each other)
    - BLOCKER-grade transcripts also copied to `docs/codex-reviews/<ts>-<rand>-blocker-<slug>.md`
    - telemetry one-line JSON to `~/logs/codex-spalla.jsonl`

--- a/.claude/scripts/codex-spalla.sh
+++ b/.claude/scripts/codex-spalla.sh
@@ -3,23 +3,35 @@
 #
 # Usage:
 #   .claude/scripts/codex-spalla.sh <mode> <base_branch> [focus_brief]
+#   .claude/scripts/codex-spalla.sh --self-test
 #
 # Args:
 #   mode:        "review" (default) | "exec"
 #   base_branch: base for diff comparison (default: main)
 #   focus_brief: optional free-text focus area passed to Codex
+#   --self-test: liveness probe, no diff needed — dispatches a trivial prompt
+#                through the real `codex exec` path and requires a verdict line
+#                back. Exit 0 proves flags, seat and auth are all live.
 #
 # Behavior contract: see docs/superpowers/specs/2026-05-03-codex-spalla-design.md §4.3.
 # Hard rules: see docs/decisions/2026-05-03-codex-spalla-architecture.md.
 #
+# codex-cli drift: `--full-auto` was removed in codex-cli 0.149.1 and every
+# wrapper run after that judged NOTHING — worse, codex-cli 0.151.0 printed the
+# usage error at exit 0, so callers judging by return code read "never ran" as
+# "clean" (ledger 2026-09-01, PENDING-ARMS). Two rules follow: never pass a
+# removed flag again, and never trust exit 0 without a verdict line (see
+# verdict_present below).
+#
 # Exit codes:
-#   0  = dispatch completed (regardless of Codex verdict)
-#   1  = invalid args or git error
+#   0  = dispatch completed AND a verdict line landed (regardless of verdict)
+#   1  = invalid args, git error, or codex seat lib missing
 #   2  = hard refused (empty diff)
 #   3  = anti-pattern guard cancelled by user (Ctrl-C during countdown)
 #   4  = codex CLI not installed
 #   5  = codex CLI not logged in
-#   >5 = codex non-zero exit propagated
+#   6  = codex returned 0 but produced no verdict line — never judged
+#   >6 = codex non-zero exit propagated (2/6 by value may also be codex's own)
 
 set -euo pipefail
 
@@ -27,8 +39,17 @@ MODE="${1:-review}"
 BASE="${2:-main}"
 FOCUS="${3:-}"
 
-if [[ "$MODE" != "review" && "$MODE" != "exec" ]]; then
-    echo "ERROR: mode must be 'review' or 'exec' (got: '$MODE')" >&2
+SELF_TEST="false"
+if [[ "$MODE" == "--self-test" ]]; then
+    SELF_TEST="true"
+    # MODE flows into the transcript filename and telemetry; the self-test
+    # block below dispatches explicitly with --sandbox read-only regardless.
+    MODE="self-test"
+    FOCUS="self-test"
+fi
+
+if [[ "$MODE" != "review" && "$MODE" != "exec" && "$SELF_TEST" != "true" ]]; then
+    echo "ERROR: mode must be 'review', 'exec' or '--self-test' (got: '$MODE')" >&2
     exit 1
 fi
 
@@ -48,21 +69,37 @@ if ! command -v codex >/dev/null 2>&1; then
     exit 4
 fi
 
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "ERROR: not inside a git repo" >&2
+    exit 1
+fi
+cd "$REPO_ROOT"
+
 # Pick a seat that is actually logged in, alternating between the two ChatGPT
 # Pro subscriptions, BEFORE asking codex whether it is logged in — the question
 # is answered per CODEX_HOME. Measured 2026-08-12 on Pro: the default ~/.codex
 # answers 401 while ~/.codex-acct2 is live, so the gate below would have
-# refused with a paid seat one variable away. A `source` of a missing file is a
-# special builtin and would EXIT under this file's set -e, hence [ -f ].
-CODEX_SEAT_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../scripts/lib" 2>/dev/null && pwd)/codex_seat.sh"
-if [ -f "$CODEX_SEAT_LIB" ]; then
-    # shellcheck disable=SC1090
-    . "$CODEX_SEAT_LIB"
-    CODEX_SEAT="$(codex_seat_pick 2>/dev/null || true)"
-    if [ -n "$CODEX_SEAT" ]; then
-        export CODEX_HOME="$CODEX_SEAT"
-        echo "[spalla] codex seat: $CODEX_SEAT" >&2
-    fi
+# refused with a paid seat one variable away.
+#
+# The lib is resolved from the REPO ROOT, not from this script's own path: the
+# old `dirname BASH_SOURCE/../../scripts/lib` resolution silently skipped
+# seat-picking for any copy of the script sitting at a different depth — the
+# [ -f ] guard dodged a `source`-of-missing-file exit under set -e, at the
+# price of dispatching on the default, possibly 401-dead, seat without saying
+# so. A missing lib is now a loud refusal.
+CODEX_SEAT_LIB="$REPO_ROOT/scripts/lib/codex_seat.sh"
+if [[ ! -f "$CODEX_SEAT_LIB" ]]; then
+    echo "ERROR: codex seat lib not found: $CODEX_SEAT_LIB" >&2
+    echo "(resolved from the repo root; refusing to dispatch on an unpicked, possibly dead, default seat)" >&2
+    exit 1
+fi
+# shellcheck disable=SC1090
+. "$CODEX_SEAT_LIB"
+CODEX_SEAT="$(codex_seat_pick 2>/dev/null || true)"
+if [ -n "$CODEX_SEAT" ]; then
+    export CODEX_HOME="$CODEX_SEAT"
+    echo "[spalla] codex seat: $CODEX_SEAT" >&2
 fi
 
 if ! codex login status 2>&1 | grep -qi "Logged in using ChatGPT"; then
@@ -70,13 +107,6 @@ if ! codex login status 2>&1 | grep -qi "Logged in using ChatGPT"; then
     echo "(Hard rule: do NOT set OPENAI_API_KEY — use OAuth only.)" >&2
     exit 5
 fi
-
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-if [[ -z "$REPO_ROOT" ]]; then
-    echo "ERROR: not inside a git repo" >&2
-    exit 1
-fi
-cd "$REPO_ROOT"
 
 HEAD_REF="$(git rev-parse HEAD 2>/dev/null || echo HEAD)"
 
@@ -114,7 +144,7 @@ TOTAL_DIFF_LINES=$((DIFF_LINES + UNCOMMITTED_LINES))
 WARNED="false"
 CANCELLED="false"
 
-if [[ "$TOTAL_DIFF_LINES" -eq 0 ]] && [[ "$UNTRACKED_FILES" -eq 0 ]]; then
+if [[ "$SELF_TEST" != "true" ]] && [[ "$TOTAL_DIFF_LINES" -eq 0 ]] && [[ "$UNTRACKED_FILES" -eq 0 ]]; then
     echo "REFUSED: diff is empty against base '$BASE', no uncommitted changes, no untracked files." >&2
     echo "Nothing to review. Make some changes first." >&2
     exit 2
@@ -166,6 +196,48 @@ record_telemetry() {
         "$WARNED" "$CANCELLED" "$exit_code" "$blocker" \
         "$TRANSCRIPT" >> "$TELEMETRY_FILE"
 }
+
+# A dispatch only counts as a review when a verdict line landed in the
+# transcript. codex-cli has shipped two "never ran" shapes that both looked
+# clean from outside: a clap usage error at exit 2 (0.149.1, honest) and the
+# same error at exit 0 (0.151.0, silent — every caller judging by return code
+# read it as "clean"; ledger 2026-09-01). The exit code alone cannot
+# distinguish "ran and found nothing" from "never ran"; the verdict line can.
+verdict_present() {
+    head -50 "$1" 2>/dev/null | grep -qiE '^[[:space:]]*(BLOCKER|MEDIUM|LOW|LGTM)\b'
+}
+
+# --self-test: liveness probe for the dispatch path itself. The diff guards
+# above are skipped (there is nothing to review); a trivial prompt goes through
+# the real codex exec invocation and a verdict line must come back. Exists so
+# the wrapper's own health is provable on demand, instead of being discovered
+# by the next review that silently never happened.
+if [[ "$SELF_TEST" == "true" ]]; then
+    SELFTEST_PROMPT="[SPALLA-SELFTEST]
+
+Liveness probe for the codex-spalla dispatch path — not a review. Do not
+inspect the repository or run any tool. Reply with exactly one line whose first
+word is one of: BLOCKER, MEDIUM, LOW, LGTM — then one short sentence
+confirming the CLI answered."
+    echo "[spalla] self-test: codex exec --sandbox read-only -c model_reasoning_effort=xhigh (trivial prompt)" >&2
+    CODEX_EXIT=0
+    printf '%s' "$SELFTEST_PROMPT" | codex exec --sandbox read-only \
+        -c model_reasoning_effort=xhigh - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
+    if [[ "$CODEX_EXIT" -eq 0 ]] && ! verdict_present "$TRANSCRIPT"; then
+        echo "ERROR: self-test got exit 0 but no verdict line — codex never judged." >&2
+        CODEX_EXIT=6
+    fi
+    if [[ "$CODEX_EXIT" -ne 0 ]]; then
+        echo "ERROR: self-test failed (exit $CODEX_EXIT). Transcript: $TRANSCRIPT" >&2
+        record_telemetry "$CODEX_EXIT" false
+        echo "RESULT_PATH=$TRANSCRIPT"
+        exit "$CODEX_EXIT"
+    fi
+    grep -iE -m 1 '^[[:space:]]*(BLOCKER|MEDIUM|LOW|LGTM)\b' "$TRANSCRIPT" | sed 's/^/[spalla] self-test verdict: /' >&2
+    record_telemetry 0 false
+    echo "RESULT_PATH=$TRANSCRIPT"
+    exit 0
+fi
 
 # Install INT trap BEFORE the small-diff countdown so Ctrl-C during sleep
 # records cancelled=true telemetry and exits cleanly with code 3.
@@ -263,11 +335,23 @@ if [[ "$MODE" == "review" ]]; then
     # "argument '--base <BRANCH>' cannot be used with '[PROMPT]'".
     # Use `codex exec --sandbox read-only` instead — it accepts our
     # custom [SPALLA] prompt while staying read-only on the workspace.
-    printf '%s' "$PROMPT" | codex exec --full-auto --sandbox read-only \
+    # NEVER `--full-auto`: removed in codex-cli 0.149.1 (see the header drift
+    # note); exec mode's old full-auto semantics are spelled out below as an
+    # explicit workspace-write sandbox.
+    printf '%s' "$PROMPT" | codex exec --sandbox read-only \
         -c model_reasoning_effort=xhigh - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
 else
-    printf '%s' "$PROMPT" | codex exec --full-auto -c model_reasoning_effort=xhigh - \
-        >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
+    printf '%s' "$PROMPT" | codex exec --sandbox workspace-write \
+        -c model_reasoning_effort=xhigh - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
+fi
+
+# The exit code, not only the transcript, must distinguish "ran and found
+# nothing" from "never ran" (ledger 2026-09-01: codex-cli 0.151.0 printed a
+# clap usage error at exit 0 and every caller read the run as a clean review).
+if [[ "$CODEX_EXIT" -eq 0 ]] && ! verdict_present "$TRANSCRIPT"; then
+    echo "ERROR: codex exited 0 but no verdict line (BLOCKER/MEDIUM/LOW/LGTM) in the first 50 transcript lines — codex never judged this diff." >&2
+    echo "Transcript: $TRANSCRIPT" >&2
+    CODEX_EXIT=6
 fi
 
 BLOCKER="false"

--- a/.claude/scripts/codex-spalla.sh
+++ b/.claude/scripts/codex-spalla.sh
@@ -184,6 +184,11 @@ while ! ( set -C; : > "$TRANSCRIPT" ) 2>/dev/null; do
 done
 # Empty file now exclusively owned; codex output below appends via >> not >.
 
+# Assistant-only final output, written by codex itself (--output-last-message),
+# derived from the same race-safe base as the transcript. This file — not the
+# combined transcript — is the verdict source (see verdict_present below).
+LAST_MESSAGE="${TRANSCRIPT_BASE}.last.md"
+
 record_telemetry() {
     local exit_code="$1"
     local blocker="${2:-false}"
@@ -198,13 +203,23 @@ record_telemetry() {
 }
 
 # A dispatch only counts as a review when a verdict line landed in the
-# transcript. codex-cli has shipped two "never ran" shapes that both looked
-# clean from outside: a clap usage error at exit 2 (0.149.1, honest) and the
-# same error at exit 0 (0.151.0, silent — every caller judging by return code
-# read it as "clean"; ledger 2026-09-01). The exit code alone cannot
-# distinguish "ran and found nothing" from "never ran"; the verdict line can.
+# assistant's FINAL message. codex-cli has shipped two "never ran" shapes that
+# both looked clean from outside: a clap usage error at exit 2 (0.149.1,
+# honest) and the same error at exit 0 (0.151.0, silent — every caller judging
+# by return code read it as "clean"; ledger 2026-09-01). The exit code alone
+# cannot distinguish "ran and found nothing" from "never ran"; the verdict
+# line can — but only when read from the assistant-only output, not the
+# combined transcript (review loop-20260906-partner-gate-followups, comment
+# 5555186204): the transcript carries diagnostics and an echo of the prompt
+# (which embeds the untrusted diff), so a transcript scan both misses a
+# verdict landing past the first 50 lines (false "never judged") and accepts a
+# verdict-shaped line in the echoed prompt (false "judged" — the
+# never-judged-as-success defect). `--output-last-message` makes codex itself
+# write the final assistant message to $LAST_MESSAGE; that file is the only
+# verdict source. A missing or empty file = never judged, however clean the
+# transcript looks.
 verdict_present() {
-    head -50 "$1" 2>/dev/null | grep -qiE '^[[:space:]]*(BLOCKER|MEDIUM|LOW|LGTM)\b'
+    [[ -s "$1" ]] && grep -qiE '^[[:space:]]*(BLOCKER|MEDIUM|LOW|LGTM)\b' "$1"
 }
 
 # --self-test: liveness probe for the dispatch path itself. The diff guards
@@ -222,9 +237,10 @@ confirming the CLI answered."
     echo "[spalla] self-test: codex exec --sandbox read-only -c model_reasoning_effort=xhigh (trivial prompt)" >&2
     CODEX_EXIT=0
     printf '%s' "$SELFTEST_PROMPT" | codex exec --sandbox read-only \
-        -c model_reasoning_effort=xhigh - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
-    if [[ "$CODEX_EXIT" -eq 0 ]] && ! verdict_present "$TRANSCRIPT"; then
-        echo "ERROR: self-test got exit 0 but no verdict line — codex never judged." >&2
+        -c model_reasoning_effort=xhigh --output-last-message "$LAST_MESSAGE" \
+        - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
+    if [[ "$CODEX_EXIT" -eq 0 ]] && ! verdict_present "$LAST_MESSAGE"; then
+        echo "ERROR: self-test got exit 0 but no verdict line in the assistant-only output — codex never judged." >&2
         CODEX_EXIT=6
     fi
     if [[ "$CODEX_EXIT" -ne 0 ]]; then
@@ -233,7 +249,7 @@ confirming the CLI answered."
         echo "RESULT_PATH=$TRANSCRIPT"
         exit "$CODEX_EXIT"
     fi
-    grep -iE -m 1 '^[[:space:]]*(BLOCKER|MEDIUM|LOW|LGTM)\b' "$TRANSCRIPT" | sed 's/^/[spalla] self-test verdict: /' >&2
+    grep -iE -m 1 '^[[:space:]]*(BLOCKER|MEDIUM|LOW|LGTM)\b' "$LAST_MESSAGE" | sed 's/^/[spalla] self-test verdict: /' >&2
     record_telemetry 0 false
     echo "RESULT_PATH=$TRANSCRIPT"
     exit 0
@@ -339,27 +355,32 @@ if [[ "$MODE" == "review" ]]; then
     # note); exec mode's old full-auto semantics are spelled out below as an
     # explicit workspace-write sandbox.
     printf '%s' "$PROMPT" | codex exec --sandbox read-only \
-        -c model_reasoning_effort=xhigh - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
+        -c model_reasoning_effort=xhigh --output-last-message "$LAST_MESSAGE" \
+        - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
 else
     printf '%s' "$PROMPT" | codex exec --sandbox workspace-write \
-        -c model_reasoning_effort=xhigh - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
+        -c model_reasoning_effort=xhigh --output-last-message "$LAST_MESSAGE" \
+        - >> "$TRANSCRIPT" 2>&1 || CODEX_EXIT=$?
 fi
 
 # The exit code, not only the transcript, must distinguish "ran and found
 # nothing" from "never ran" (ledger 2026-09-01: codex-cli 0.151.0 printed a
 # clap usage error at exit 0 and every caller read the run as a clean review).
-if [[ "$CODEX_EXIT" -eq 0 ]] && ! verdict_present "$TRANSCRIPT"; then
-    echo "ERROR: codex exited 0 but no verdict line (BLOCKER/MEDIUM/LOW/LGTM) in the first 50 transcript lines — codex never judged this diff." >&2
-    echo "Transcript: $TRANSCRIPT" >&2
+# The verdict is judged from the assistant-only file only — a verdict-shaped
+# line in the echoed prompt or diff is not a judge (loop
+# 20260906-partner-gate-followups, comment 5555186204).
+if [[ "$CODEX_EXIT" -eq 0 ]] && ! verdict_present "$LAST_MESSAGE"; then
+    echo "ERROR: codex exited 0 but no verdict line (BLOCKER/MEDIUM/LOW/LGTM) in its final assistant message — codex never judged this diff." >&2
+    echo "Transcript: $TRANSCRIPT (assistant-only output: $LAST_MESSAGE)" >&2
     CODEX_EXIT=6
 fi
 
 BLOCKER="false"
-# Codex spalla self-review #8: BLOCKER detection scans only the first 50
-# lines (the verdict header per output template). Scanning the entire
-# transcript would false-positive on bullets that quote earlier BLOCKER
-# verdicts (verify-after-fix runs cite previous transcripts).
-if head -50 "$TRANSCRIPT" 2>/dev/null | grep -qiE '^[[:space:]]*BLOCKER\b'; then
+# Codex spalla self-review #8: BLOCKER detection scans only the head of the
+# assistant-only final message (the verdict header per output template).
+# Scanning the whole final message would false-positive on bullets that quote
+# earlier BLOCKER verdicts (verify-after-fix runs cite previous transcripts).
+if head -50 "$LAST_MESSAGE" 2>/dev/null | grep -qiE '^[[:space:]]*BLOCKER\b'; then
     BLOCKER="true"
     REVIEWS_DIR="$REPO_ROOT/docs/codex-reviews"
     mkdir -p "$REVIEWS_DIR"

--- a/evidence/2026-09/agent-air-m5-infra-codex-spalla-cli-0153-37604d40/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-codex-spalla-cli-0153-37604d40/brief.yml
@@ -1,0 +1,96 @@
+task_id: codex-spalla-cli-0153
+gear: 2
+l_level: L1
+gate_class: opus
+# Floor recomputed on THIS PR's final changed-file list (this brief
+# included): `python3 scripts/evidence_pack_lint.py --print-floor
+# --numstat-file <numstat> --changed-files-file <files>` -> 2, source
+# "size" (net lines >= 400, most of it the new 306-line test file).
+# No hot-zone path is touched: .claude/scripts/, .claude/commands/,
+# scripts/tests/ and evidence/ are all outside HOTZONE_PATTERNS.
+# Declared gear 2 == floor.
+objective: |
+  Un-break the codex second-opinion dispatch path after codex-cli removed
+  `--full-auto` (removed in 0.149.1; current 0.153.x). Ledger 2026-09-01
+  (.claude/skills/modus/PENDING-ARMS.md): on 0.151.0 the clap usage error
+  printed AT EXIT 0, so every caller judging by return code read "codex
+  never ran" as a clean review — every spalla verdict since the removal
+  was un-judged.
+
+  The fix: review mode dispatches `codex exec --sandbox read-only -c
+  model_reasoning_effort=xhigh -`; exec mode `--sandbox workspace-write`
+  (full-auto's old semantics spelled out); prompt on stdin unchanged. A
+  verdict guard makes the exit code carry the truth: codex exit 0 without
+  a verdict line (BLOCKER|MEDIUM|LOW|LGTM at line start in the first 50
+  transcript lines) exits the wrapper 6, so "ran and found nothing" and
+  "never ran" are distinguishable independent of future CLI drift. The
+  seat lib resolves from `git rev-parse --show-toplevel`, and a missing
+  lib is a loud exit 1 instead of a silent dispatch on a possibly-401-dead
+  default seat. A `--self-test` mode pushes a trivial prompt through the
+  real dispatch path and requires a verdict line — proving flags, seat
+  and auth on demand, no diff needed.
+constraints:
+  - "Never reintroduce `--full-auto`; the invocation is spelled out for
+    codex-cli 0.153.x and the argv-pin tests make a regression red."
+  - "The verdict guard keys on the wrapper EXIT CODE, never on transcript
+    prose alone — a caller must be able to judge by `$?` only."
+  - "Tests run against a fake `codex` shim on PATH inside a tmp git repo
+    with HOME redirected — they never touch real `~/logs`, a real seat, or
+    a real dispatch. The ONE live call is the explicit `--self-test`,
+    separately recorded."
+  - "Known debt deliberately NOT in this PR (one PR, one concern):
+    MODEL_TOPOLOGY.json's `codex_fix` (consumed by
+    scripts/sentinel_lib/repairer.py::dispatch_codex_fix) carries the same
+    removed flag, and .claude/agents/wr2-design-architect.md,
+    .claude/agents/wr2-external-bench.md and docs/codex/CODEX_SPALLA.md
+    still document the dead flag."
+acceptance:
+  - text: >-
+      WHEN the wrapper dispatches in review mode, `--full-auto` SHALL NOT
+      appear on the codex argv and `--sandbox read-only` SHALL; in exec
+      mode `--sandbox workspace-write` SHALL appear instead.
+    probe: >-
+      python3 -m pytest scripts/tests/test_codex_spalla.py -q -k "review_mode or exec_mode"
+  - text: >-
+      IF codex exits 0 having printed only a clap usage error (the 0.151.0
+      shape that produced un-judged "clean" reviews), THEN the wrapper
+      SHALL exit 6 — and a prompt ECHO containing a verdict word SHALL NOT
+      count as a verdict.
+    probe: >-
+      python3 -m pytest scripts/tests/test_codex_spalla.py -q -k "zero_exit_without_verdict or prompt_echo or self_test_without_verdict"
+  - text: >-
+      WHEN the seat lib is missing, the wrapper SHALL fail loud at exit 1
+      rather than dispatch on a possibly-dead default seat; an empty diff
+      SHALL still be refused at exit 2.
+    probe: >-
+      python3 -m pytest scripts/tests/test_codex_spalla.py -q -k "missing_seat_lib or empty_diff"
+  - text: >-
+      WHEN the full test file runs, 11 tests SHALL pass, including the
+      guilt cases above and the fixture-honesty self-check.
+    probe: >-
+      python3 -m pytest scripts/tests/test_codex_spalla.py -q
+  - text: >-
+      WHEN `.claude/scripts/codex-spalla.sh --self-test` runs against the
+      REAL codex CLI, it SHALL exit 0 and record a verdict line in a
+      transcript under ~/logs/codex-spalla/ — proving flags, seat and auth
+      end to end with no diff needed.
+    probe: >-
+      .claude/scripts/codex-spalla.sh --self-test — recorded runs:
+      builder 20260905T221542Z-8b79 (LGTM, codex 0.153.4, M5); independent
+      review seat 20260906T022748Z-8a70 (LGTM, from the detached review
+      worktree infra-cli-dispatch-review-20260906); brief-author re-run
+      20260906T041128Z-12677 (LGTM, seat ~/.codex-acct2, from THIS branch's
+      worktree at the pushed HEAD)
+  - text: >-
+      WHEN the deterministic floor is recomputed on this PR's final
+      changed-file list (this brief included), it SHALL be 2 via the size
+      term alone, and the declared gear SHALL satisfy gear >= floor.
+    probe: >-
+      git diff --numstat/--name-only origin/main...HEAD into
+      scripts/evidence_pack_lint.py --print-floor / --print-floor-source
+grader: |
+  Generator != grader: this brief's author is a builder seat (Kimi, M5).
+  The grader should re-run the pytest probes and the floor recompute
+  verbatim rather than re-read this file's claims, and confirm the two
+  --self-test transcripts named above exist on M5 and carry a verdict
+  line.

--- a/scripts/tests/test_codex_spalla.py
+++ b/scripts/tests/test_codex_spalla.py
@@ -1,0 +1,232 @@
+"""Guilt/innocence for `.claude/scripts/codex-spalla.sh` against codex-cli 0.153.x.
+
+Ledger 2026-09-01 (`.claude/skills/modus/PENDING-ARMS.md`): the wrapper passed
+`--full-auto`, removed in codex-cli 0.149.1 — and 0.151.0 printed the usage
+error at EXIT 0, so every caller judging by return code read "codex never ran"
+as a clean review. The wrapper's exit code, not only its transcript, must
+distinguish "ran and found nothing" from "never ran".
+
+Pinned here, against a fake `codex` on PATH:
+
+1. argv pin: the wrapper never passes `--full-auto`, in either mode.
+2. rc propagation: a codex that exits 2 makes the WRAPPER exit 2.
+3. the 0.151.0 disease: codex prints a clap usage error at exit 0 → wrapper
+   exits 6 (no verdict line), never 0.
+4. fail-loud seat lib: a repo without `scripts/lib/codex_seat.sh` → exit 1.
+5. innocence: the empty-diff refuse (exit 2) and a clean review (exit 0)
+   behave exactly as before.
+6. `--self-test`: verdict → 0; garbage-at-0 → 6; and it needs no diff.
+
+Every run sets HOME=<tmp> (telemetry/transcripts land in the tmpdir, never in
+the real ~/logs) and drives the wrapper from a tmp git repo, so the wrapper's
+repo-root resolution finds a controlled tree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPALLA = REPO_ROOT / ".claude" / "scripts" / "codex-spalla.sh"
+SEAT_LIB = REPO_ROOT / "scripts" / "lib" / "codex_seat.sh"
+
+FAKE_CODEX = """#!/usr/bin/env bash
+# Fake codex CLI for codex-spalla tests. Behaviour via $FAKE_CODEX_SCENARIO.
+printf '%s\\n' "$*" >> "$FAKE_CODEX_ARGV_LOG"
+if [[ "${1:-}" == "login" ]]; then
+    echo "Logged in using ChatGPT"
+    exit 0
+fi
+case "${FAKE_CODEX_SCENARIO:-verdict}" in
+    verdict)
+        echo "LGTM"
+        echo "fake codex answered"
+        ;;
+    usage-error-rc0)
+        # The 0.151.0 shape: a clap usage error printed at exit ZERO.
+        echo "error: unexpected argument '--full-auto' found"
+        exit 0
+        ;;
+    fail2)
+        # The 0.149.1/0.153.x shape: same error, honest exit 2.
+        echo "error: unexpected argument '--full-auto' found"
+        exit 2
+        ;;
+esac
+"""
+
+
+def _make_fake_codex(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "codex"
+    fake.write_text(FAKE_CODEX)
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _make_repo(
+    tmp_path: Path, *, with_seat_lib: bool = True, dirty: bool = True
+) -> Path:
+    """A git repo on branch `main`; optionally the real seat lib committed in,
+    optionally three tracked files dirtied (enough diff lines/files to clear
+    both anti-pattern guards without the 5s countdown)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for cmd in (
+        ["git", "init", "-b", "main"],
+        ["git", "config", "user.email", "test@example.com"],
+        ["git", "config", "user.name", "Test"],
+    ):
+        subprocess.run(cmd, cwd=repo, check=True, capture_output=True)
+    if with_seat_lib:
+        lib_dir = repo / "scripts" / "lib"
+        lib_dir.mkdir(parents=True)
+        shutil.copy(SEAT_LIB, lib_dir / "codex_seat.sh")
+    tracked = []
+    for i in range(3):
+        f = repo / f"file{i}.txt"
+        f.write_text("baseline\n")
+        tracked.append(f)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "baseline"], cwd=repo, check=True, capture_output=True
+    )
+    if dirty:
+        for f in tracked:
+            f.write_text("baseline\n" + "".join(f"change {n}\n" for n in range(4)))
+    return repo
+
+
+def _run_spalla(
+    tmp_path: Path, repo: Path, scenario: str, *args: str
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    bin_dir = _make_fake_codex(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    argv_log = tmp_path / "argv.log"
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "FAKE_CODEX_SCENARIO": scenario,
+            "FAKE_CODEX_ARGV_LOG": str(argv_log),
+            # No seats on purpose: seat-picking must find nothing and leave
+            # CODEX_HOME unset; the login probe is answered by the fake.
+            "CODEX_SEAT_DIRS": str(tmp_path / "no-seats"),
+        }
+    )
+    proc = subprocess.run(
+        [str(SPALLA), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return proc, argv_log, home
+
+
+def _telemetry(home: Path) -> dict[str, object]:
+    lines = (home / "logs" / "codex-spalla.jsonl").read_text().strip().splitlines()
+    assert lines, "telemetry line missing"
+    return json.loads(lines[-1])
+
+
+def test_review_mode_never_passes_full_auto_and_succeeds(tmp_path: Path) -> None:
+    """Argv pin + innocence: review mode dispatches read-only, no removed flag,
+    and a verdict-bearing answer is a clean exit 0."""
+    repo = _make_repo(tmp_path)
+    proc, argv_log, home = _run_spalla(tmp_path, repo, "verdict", "review")
+    assert proc.returncode == 0, proc.stderr
+    argv = argv_log.read_text()
+    assert "--full-auto" not in argv
+    assert "exec --sandbox read-only" in argv
+    assert "RESULT_PATH=" in proc.stdout
+    assert _telemetry(home)["exit_code"] == 0
+
+
+def test_exec_mode_uses_workspace_write_without_full_auto(tmp_path: Path) -> None:
+    """Argv pin: exec mode keeps full-auto's old semantics as an explicit
+    workspace-write sandbox, without the removed flag."""
+    repo = _make_repo(tmp_path)
+    proc, argv_log, _home = _run_spalla(tmp_path, repo, "verdict", "exec")
+    assert proc.returncode == 0, proc.stderr
+    argv = argv_log.read_text()
+    assert "--full-auto" not in argv
+    assert "exec --sandbox workspace-write" in argv
+
+
+def test_codex_exit_2_propagates(tmp_path: Path) -> None:
+    """Guilt: codex failing honestly (exit 2) must make the wrapper exit 2 —
+    'ran and failed' is never read as 'clean'."""
+    repo = _make_repo(tmp_path)
+    proc, _argv_log, home = _run_spalla(tmp_path, repo, "fail2", "review")
+    assert proc.returncode == 2, proc.stderr
+    assert _telemetry(home)["exit_code"] == 2
+
+
+def test_zero_exit_without_verdict_exits_6(tmp_path: Path) -> None:
+    """Guilt, the 0.151.0 disease: a usage error printed at exit 0 is the
+    'never ran' shape — the wrapper must answer 6, never 0."""
+    repo = _make_repo(tmp_path)
+    proc, _argv_log, home = _run_spalla(tmp_path, repo, "usage-error-rc0", "review")
+    assert proc.returncode == 6, proc.stderr
+    assert "never judged" in proc.stderr
+    assert _telemetry(home)["exit_code"] == 6
+
+
+def test_missing_seat_lib_fails_loud(tmp_path: Path) -> None:
+    """Guilt: without scripts/lib/codex_seat.sh the wrapper refuses loudly
+    instead of silently dispatching on an unpicked default seat."""
+    repo = _make_repo(tmp_path, with_seat_lib=False)
+    proc, _argv_log, _home = _run_spalla(tmp_path, repo, "verdict", "review")
+    assert proc.returncode == 1, proc.stderr
+    assert "codex seat lib" in proc.stderr
+
+
+def test_empty_diff_still_refused(tmp_path: Path) -> None:
+    """Innocence: the pre-existing empty-diff hard refuse is unchanged."""
+    repo = _make_repo(tmp_path, dirty=False)
+    proc, _argv_log, _home = _run_spalla(tmp_path, repo, "verdict", "review")
+    assert proc.returncode == 2, proc.stderr
+    assert "REFUSED" in proc.stderr
+
+
+def test_self_test_needs_no_diff_and_returns_0_on_verdict(tmp_path: Path) -> None:
+    """Innocence: --self-test runs on a clean tree (no diff required) and a
+    verdict-bearing answer is exit 0."""
+    repo = _make_repo(tmp_path, dirty=False)
+    proc, _argv_log, home = _run_spalla(tmp_path, repo, "verdict", "--self-test")
+    assert proc.returncode == 0, proc.stderr
+    assert "RESULT_PATH=" in proc.stdout
+    entry = _telemetry(home)
+    assert entry["mode"] == "self-test"
+    assert entry["exit_code"] == 0
+
+
+def test_self_test_without_verdict_exits_6(tmp_path: Path) -> None:
+    """Guilt: --self-test must catch the silent never-ran shape on its own."""
+    repo = _make_repo(tmp_path, dirty=False)
+    proc, _argv_log, home = _run_spalla(
+        tmp_path, repo, "usage-error-rc0", "--self-test"
+    )
+    assert proc.returncode == 6, proc.stderr
+    entry = _telemetry(home)
+    assert entry["mode"] == "self-test"
+    assert entry["exit_code"] == 6
+
+
+def test_fixtures_are_honest() -> None:
+    """Sanity on the fixture itself: the fake distinguishes the three shapes,
+    and the real seat lib the tests copy actually exists in this checkout."""
+    assert SPALLA.is_file()
+    assert SEAT_LIB.is_file()
+    for scenario in ("verdict", "usage-error-rc0", "fail2"):
+        assert f"    {scenario})" in FAKE_CODEX

--- a/scripts/tests/test_codex_spalla.py
+++ b/scripts/tests/test_codex_spalla.py
@@ -16,6 +16,12 @@ Pinned here, against a fake `codex` on PATH:
 5. innocence: the empty-diff refuse (exit 2) and a clean review (exit 0)
    behave exactly as before.
 6. `--self-test`: verdict → 0; garbage-at-0 → 6; and it needs no diff.
+7. verdict source (review comment 5555186204): the wrapper asks codex for the
+   assistant-only final message (`--output-last-message`) and judges only
+   that file — a verdict landing after 60 transcript lines of diagnostics is
+   accepted (no false 'never judged'), while a verdict-shaped line in the
+   echoed prompt with no assistant message is refused (exit 6). The fake
+   records stdin so tests assert the prompt really reached the CLI.
 
 Every run sets HOME=<tmp> (telemetry/transcripts land in the tmpdir, never in
 the real ~/logs) and drives the wrapper from a tmp git repo, so the wrapper's
@@ -42,10 +48,43 @@ if [[ "${1:-}" == "login" ]]; then
     echo "Logged in using ChatGPT"
     exit 0
 fi
+# The dispatch contract is a prompt on stdin — record it so tests can assert
+# the wrapper actually piped it.
+cat > "$FAKE_CODEX_STDIN_LOG"
+# Parse -o/--output-last-message: the wrapper judges ONLY the file codex
+# writes there (the assistant-only final message), never this stdout.
+LAST_MSG=""
+PREV=""
+for a in "$@"; do
+    if [[ "$PREV" == "-o" || "$PREV" == "--output-last-message" ]]; then
+        LAST_MSG="$a"
+    fi
+    PREV="$a"
+done
+write_last() { if [[ -n "$LAST_MSG" ]]; then printf '%s\\n' "$1" > "$LAST_MSG"; fi; }
 case "${FAKE_CODEX_SCENARIO:-verdict}" in
     verdict)
-        echo "LGTM"
-        echo "fake codex answered"
+        echo "codex diagnostics: reading diff"
+        write_last "LGTM
+fake codex answered"
+        ;;
+    late-verdict)
+        # Review comment 5555186204 case (1): 60 transcript lines of
+        # diagnostics/prompt echo before any answer — a transcript-scanning
+        # guard (the old head -50) misses the verdict and exits 6.
+        for i in $(seq 1 30); do
+            echo "codex diagnostic line $i"
+            echo "user prompt echo line $i"
+        done
+        write_last "LGTM valid final answer"
+        ;;
+    echo-only)
+        # Review comment 5555186204 case (2): a verdict-shaped line in the
+        # echoed prompt and NO assistant message — a transcript scan calls
+        # this judged; it is the never-judged-as-success defect.
+        echo "user"
+        echo "LGTM copied from untrusted prompt"
+        echo "ERROR: no assistant output"
         ;;
     usage-error-rc0)
         # The 0.151.0 shape: a clap usage error printed at exit ZERO.
@@ -117,6 +156,7 @@ def _run_spalla(
             "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
             "FAKE_CODEX_SCENARIO": scenario,
             "FAKE_CODEX_ARGV_LOG": str(argv_log),
+            "FAKE_CODEX_STDIN_LOG": str(tmp_path / "stdin.log"),
             # No seats on purpose: seat-picking must find nothing and leave
             # CODEX_HOME unset; the login probe is answered by the fake.
             "CODEX_SEAT_DIRS": str(tmp_path / "no-seats"),
@@ -141,13 +181,16 @@ def _telemetry(home: Path) -> dict[str, object]:
 
 def test_review_mode_never_passes_full_auto_and_succeeds(tmp_path: Path) -> None:
     """Argv pin + innocence: review mode dispatches read-only, no removed flag,
-    and a verdict-bearing answer is a clean exit 0."""
+    asks codex for the assistant-only output file, pipes the prompt on stdin,
+    and a verdict-bearing final message is a clean exit 0."""
     repo = _make_repo(tmp_path)
     proc, argv_log, home = _run_spalla(tmp_path, repo, "verdict", "review")
     assert proc.returncode == 0, proc.stderr
     argv = argv_log.read_text()
     assert "--full-auto" not in argv
     assert "exec --sandbox read-only" in argv
+    assert "--output-last-message" in argv
+    assert "[SPALLA]" in (tmp_path / "stdin.log").read_text()
     assert "RESULT_PATH=" in proc.stdout
     assert _telemetry(home)["exit_code"] == 0
 
@@ -182,6 +225,30 @@ def test_zero_exit_without_verdict_exits_6(tmp_path: Path) -> None:
     assert _telemetry(home)["exit_code"] == 6
 
 
+def test_late_verdict_accepted_from_assistant_only_file(tmp_path: Path) -> None:
+    """Review comment 5555186204, case (1): 60 transcript lines of diagnostics
+    and prompt echo before the answer must NOT read as 'never judged' — the
+    verdict comes from codex's own --output-last-message file, however long the
+    transcript runs."""
+    repo = _make_repo(tmp_path)
+    proc, argv_log, home = _run_spalla(tmp_path, repo, "late-verdict", "review")
+    assert proc.returncode == 0, proc.stderr
+    assert "--output-last-message" in argv_log.read_text()
+    assert "[SPALLA]" in (tmp_path / "stdin.log").read_text()
+    assert _telemetry(home)["exit_code"] == 0
+
+
+def test_prompt_echo_is_not_a_verdict(tmp_path: Path) -> None:
+    """Review comment 5555186204, case (2): a verdict-shaped line in the echoed
+    prompt with NO assistant final message is 'never judged' — exit 6, never 0.
+    This is the never-judged-as-success defect the transcript scan preserved."""
+    repo = _make_repo(tmp_path)
+    proc, _argv_log, home = _run_spalla(tmp_path, repo, "echo-only", "review")
+    assert proc.returncode == 6, proc.stderr
+    assert "never judged" in proc.stderr
+    assert _telemetry(home)["exit_code"] == 6
+
+
 def test_missing_seat_lib_fails_loud(tmp_path: Path) -> None:
     """Guilt: without scripts/lib/codex_seat.sh the wrapper refuses loudly
     instead of silently dispatching on an unpicked default seat."""
@@ -201,11 +268,12 @@ def test_empty_diff_still_refused(tmp_path: Path) -> None:
 
 def test_self_test_needs_no_diff_and_returns_0_on_verdict(tmp_path: Path) -> None:
     """Innocence: --self-test runs on a clean tree (no diff required) and a
-    verdict-bearing answer is exit 0."""
+    verdict-bearing final message is exit 0; the probe prompt reaches stdin."""
     repo = _make_repo(tmp_path, dirty=False)
     proc, _argv_log, home = _run_spalla(tmp_path, repo, "verdict", "--self-test")
     assert proc.returncode == 0, proc.stderr
     assert "RESULT_PATH=" in proc.stdout
+    assert "[SPALLA-SELFTEST]" in (tmp_path / "stdin.log").read_text()
     entry = _telemetry(home)
     assert entry["mode"] == "self-test"
     assert entry["exit_code"] == 0
@@ -228,5 +296,11 @@ def test_fixtures_are_honest() -> None:
     and the real seat lib the tests copy actually exists in this checkout."""
     assert SPALLA.is_file()
     assert SEAT_LIB.is_file()
-    for scenario in ("verdict", "usage-error-rc0", "fail2"):
+    for scenario in (
+        "verdict",
+        "late-verdict",
+        "echo-only",
+        "usage-error-rc0",
+        "fail2",
+    ):
         assert f"    {scenario})" in FAKE_CODEX


### PR DESCRIPTION
## What

`.claude/scripts/codex-spalla.sh` passed `--full-auto`, removed in codex-cli 0.149.1 (current: 0.153.x). Ledger 2026-09-01 (`.claude/skills/modus/PENDING-ARMS.md`): on 0.151.0 the clap usage error printed **at exit 0**, so every caller judging by return code read "codex never ran" as a clean review. Every spalla verdict since the removal was un-judged.

## Fix

- **Flags**: review → `codex exec --sandbox read-only -c model_reasoning_effort=xhigh -`; exec → `--sandbox workspace-write` (full-auto's old semantics spelled out); prompt on stdin unchanged.
- **Verdict guard**: codex exit 0 without a verdict line (`BLOCKER|MEDIUM|LOW|LGTM` at line start in the first 50 transcript lines) → wrapper exits **6**. The exit code, not only the transcript, now distinguishes "ran and found nothing" from "never ran" — independent of future CLI drift.
- **Seat lib**: resolved from the repo root (`git rev-parse --show-toplevel`) instead of the script's own path; missing lib is a loud exit 1. A copied script previously skipped seat-picking silently and dispatched on the possibly-401-dead default seat.
- **`--self-test`**: trivial prompt through the real dispatch path, requires a verdict line; proves flags/seat/auth on demand, no diff needed.
- `.claude/commands/codex-second-opinion.md` documents the current invocation.

## Tests

`scripts/tests/test_codex_spalla.py` — 9 cases against a fake `codex` on PATH, each run in a tmp git repo with `HOME` redirected (no real `~/logs` touched):

- argv pin (both modes): `--full-auto` never passed; review carries `--sandbox read-only`, exec `--sandbox workspace-write`.
- guilt: codex exits 2 → wrapper 2; codex prints usage error **at exit 0** (the 0.151.0 shape) → wrapper 6; missing seat lib → 1 loud.
- innocence: empty-diff refuse still exit 2; clean review still exit 0; `--self-test` needs no diff and returns 0 on a verdict.

Bites: the consumer is any session dispatching a second opinion via `/codex-second-opinion`. The observation proving the change is in force: `.claude/scripts/codex-spalla.sh --self-test` exits 0 with a verdict line from the real CLI (run this session on M5, codex-cli 0.153.4, seat `~/.codex`: verdict `LGTM The CLI answered successfully.`, transcript `~/logs/codex-spalla/20260905T221542Z-8b79-self-test-self-test.md`); and `pytest scripts/tests/test_codex_spalla.py` → 9 passed, including the usage-error-at-exit-0 guilt case → wrapper exit 6.

## Validation (all run this session)

- `pytest scripts/tests/test_codex_spalla.py` → **9 passed** (before and after `ruff format`)
- `ruff check` + `ruff format` on the test file → clean
- `bash -n .claude/scripts/codex-spalla.sh` → clean; shellcheck: only the pre-existing SC2034 (`UNTRACKED_TOTAL_FOR_DUMP`, untouched by this diff)
- live `--self-test` on M5 → exit 0 (output above)

## Known debt (deliberately NOT in this PR — one PR, one concern)

- `MODEL_TOPOLOGY.json`'s `codex_fix` (`codex --full-auto`, consumed by `scripts/sentinel_lib/repairer.py::dispatch_codex_fix`) carries the same removed flag.
- Agent/prompt docs with the dead flag: `.claude/agents/wr2-design-architect.md`, `.claude/agents/wr2-external-bench.md`; `docs/codex/CODEX_SPALLA.md` is a dated 2026-05 design record.

No hot-zone path touched (script + its test + one command doc).
