### PR TITLE
fix(visa-engine): seq-19 gate follow-ups — evidence numbers, prettier wording, observe PYTHONPATH, no-skip on missing bundle

### DIFF
--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq19_signed_bundle.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq19_signed_bundle.py
@@ -53,12 +53,24 @@ _PACKS_DIR = (
 _SEQ19_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-019.signed.json"
 _SEQ19_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-019.source.json"
 
-pytestmark = pytest.mark.skipif(
-    not _SEQ19_SIGNED_PATH.exists(),
-    reason="rulepack-prod-019.signed.json does not exist on disk — the "
-    "operator's offline signing ceremony (sign_pack.py) has not produced "
-    "it yet",
-)
+
+def test_signed_bundle_is_present_on_disk() -> None:
+    """A deleted/missing artifact must turn this gate RED, never skip it.
+
+    This module previously carried a module-level
+    ``pytestmark = pytest.mark.skipif(not _SEQ19_SIGNED_PATH.exists(), ...)``,
+    which meant an accidentally deleted (or never-landed) signed bundle
+    produced a silent, all-green-looking SKIP rather than a failure — the
+    gate would not have noticed its own consumer disappearing. This hard
+    assertion replaces that skip: no file on disk means this test (and every
+    other test below, which will error out trying to read it) fails loudly.
+    """
+    assert _SEQ19_SIGNED_PATH.exists(), (
+        "rulepack-prod-019.signed.json does not exist on disk — the "
+        "operator's offline signing ceremony (sign_pack.py) has not "
+        "produced it, or it was deleted. This must FAIL, not skip."
+    )
+
 
 #: The pinned production Ed25519 public key — the same one that verifies
 #: seq-17/seq-18 (see ``test_seq18_freshness_window.py``/``test_seq19_pack.py``).

--- a/evidence/2026-09/agent-air-m5-backend-rag-visa-seq19-sign-b2487964/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-visa-seq19-sign-b2487964/brief.yml
@@ -4,9 +4,10 @@ l_level: L2
 gate_class: opus
 # Floor computed this run: `python3 scripts/evidence_pack_lint.py --print-floor
 # --numstat-file ... --changed-files-file ...` returns `size` — the SIGNED
-# bundle (rulepack-prod-019.signed.json) is 10,355 lines (pretty-printed,
-# never hand-authored; the operator's sign_pack.py wrote it byte-for-byte
-# from rulepack-prod-019.source.json). Size alone floors this at Gear 3
+# bundle (rulepack-prod-019.signed.json) is 9,285 lines (pretty-printed by
+# the repo's prettier gate after signing, never hand-authored; content, JCS
+# canonical bytes and signature are identical to the operator's
+# sign_pack.py output from rulepack-prod-019.source.json). Size alone floors this at Gear 3
 # regardless of the change's actual authored-logic footprint (one new ~300
 # line test file + a ~30 line secrets-triage rule).
 objective: >-

--- a/evidence/2026-09/agent-air-m5-backend-rag-visa-seq19-sign-b2487964/pack.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-visa-seq19-sign-b2487964/pack.yml
@@ -11,8 +11,10 @@ lanes:
     seat: claude-sonnet-5 (this worktree session on M5, branch agent/air-m5/backend-rag/visa-seq19-sign)
     note: >-
       Landed the operator's offline-signed rulepack-prod-019.signed.json (sign_pack.py
-      output, kid=prod-2026-07-1) exactly as produced — never modified, re-signed, or
-      regenerated. Added test_seq19_signed_bundle.py, which independently verifies the
+      output, kid=prod-2026-07-1) — unmodified in content, never re-signed or
+      regenerated; the repo's prettier pre-commit gate whitespace-normalised the file
+      after signing (content, JCS canonical bytes and signature all identical). Added
+      test_seq19_signed_bundle.py, which independently verifies the
       bundle with the repo's own bundle.verify_rule_pack against the pinned production
       Ed25519 public key (never trusting the signer's self-reported digest/kid/sequence):
       real cryptographic verification, digest recomputation straight from disk via
@@ -61,9 +63,12 @@ seat_override: >-
   added.
 
 outcome: >-
-  rulepack-prod-019.signed.json is landed byte-for-byte as the operator produced it
-  (sign_pack.py, offline, M5) and independently verified with the repo's own Ed25519
-  code: bundle.verify_rule_pack succeeds against the pinned production trust store
+  rulepack-prod-019.signed.json is landed unmodified in content from what the operator
+  produced (sign_pack.py, offline, M5) — the repo's prettier pre-commit gate
+  whitespace-normalised the file after signing (content, JCS canonical bytes and
+  signature all identical, same state as seq-18 on main) — and independently verified
+  with the repo's own Ed25519 code: bundle.verify_rule_pack succeeds against the pinned
+  production trust store
   (kid=prod-2026-07-1), payload_sha256 recomputed from BOTH the signed envelope and the
   standalone source.json equals bac5da8e4727e7f639c947c50211e6f95e15c1403cf6aef0dd57a92
   014d6e6ea, previous_payload_sha256 equals seq-18's own re-derived digest
@@ -76,7 +81,7 @@ outcome: >-
   is a separate, Zero-only ceremony this PR does not touch.
 diff:
   files: 9
-  net_lines: "10355/0 rulepack-prod-019.signed.json (generated, byte-for-byte the operator's sign_pack.py output — not hand-authored), 295/0 test_seq19_signed_bundle.py, 63/0 scripts/ci/observe_visa_seq19_sign.py (new, bites-observable), 30/0 scripts/detect_secrets_auto_triage.py, 3/2 scripts/tests/test_detect_secrets_auto_triage.py, 88/0 this per-task brief.yml (copy), 248/0 this pack.yml (measured after staging final content, per its own self-reference), 2/0 council-journal.jsonl, 78/101 root evidence/brief.yml (repo convention — one root file, overwritten per PR)"
+  net_lines: "9285/0 rulepack-prod-019.signed.json (generated, content unmodified from the operator's sign_pack.py output — not hand-authored; prettier whitespace-normalised the file after signing), 295/0 test_seq19_signed_bundle.py, 63/0 scripts/ci/observe_visa_seq19_sign.py (new, bites-observable), 30/0 scripts/detect_secrets_auto_triage.py, 3/2 scripts/tests/test_detect_secrets_auto_triage.py, 88/0 this per-task brief.yml (copy), 248/0 this pack.yml (measured after staging final content, per its own self-reference), 2/0 council-journal.jsonl, 78/101 root evidence/brief.yml (repo convention — one root file, overwritten per PR)"
   measured_at: >-
     `git diff f187acea1a0dbe3b1b3482f8341e6306a24379aa --numstat` (f187acea = this branch's
     actual base commit, the seq-19 fold PR's merge; `git merge-base HEAD origin/main` ==

--- a/evidence/brief.yml
+++ b/evidence/brief.yml
@@ -4,9 +4,10 @@ l_level: L2
 gate_class: opus
 # Floor computed this run: `python3 scripts/evidence_pack_lint.py --print-floor
 # --numstat-file ... --changed-files-file ...` returns `size` — the SIGNED
-# bundle (rulepack-prod-019.signed.json) is 10,355 lines (pretty-printed,
-# never hand-authored; the operator's sign_pack.py wrote it byte-for-byte
-# from rulepack-prod-019.source.json). Size alone floors this at Gear 3
+# bundle (rulepack-prod-019.signed.json) is 9,285 lines (pretty-printed by
+# the repo's prettier gate after signing, never hand-authored; content, JCS
+# canonical bytes and signature are identical to the operator's
+# sign_pack.py output from rulepack-prod-019.source.json). Size alone floors this at Gear 3
 # regardless of the change's actual authored-logic footprint (one new ~300
 # line test file + a ~30 line secrets-triage rule).
 objective: >-

--- a/scripts/ci/observe_visa_seq19_sign.py
+++ b/scripts/ci/observe_visa_seq19_sign.py
@@ -42,7 +42,7 @@ def _backend_rag_python() -> str:
 
 def main() -> int:
     python_env = dict(os.environ)
-    python_env["PYTHONPATH"] = "backend"
+    python_env["PYTHONPATH"] = "."
     cmd = [
         _backend_rag_python(),
         "-m",


### PR DESCRIPTION
## Summary

Closes the four **non-blocking** conditions from PR #5812's gate read (comment [#5554915197](https://github.com/Bali-Zero/Teman2/pull/5812#issuecomment-5554915197)), opened from fresh `origin/main` (which already contains #5812 merged as `4b06438363`) per that comment's own instruction ("follow-up PR from fresh origin/main — this branch is frozen at arming").

### 1. Stale `net_lines` figure (evidence numbers)
`evidence/2026-09/agent-air-m5-backend-rag-visa-seq19-sign-b2487964/pack.yml`'s `diff.net_lines` claimed `10355/0` for `rulepack-prod-019.signed.json`. **Measured**: `git diff --numstat 4b06438363~1 4b06438363 -- apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-019.signed.json` → `9285/0` (10355 was the pre-prettier line count). Fixed in `pack.yml`, and the same stale "10,355 lines" floor-comment figure fixed in both `evidence/2026-09/.../brief.yml` and the root `evidence/brief.yml` (byte-identical files, both carried it). Every other number in these files left unchanged.

### 2. Inaccurate "byte-for-byte" / "never modified" wording
`pack.yml` said the bundle landed "byte-for-byte as the operator produced it" / "never modified" — inaccurate: the repo's prettier pre-commit gate whitespace-normalised the file after signing (content, JCS canonical bytes, and the signature are all identical — same state as seq-18 on main). Reworded in the lane note, `outcome:`, and `diff.net_lines` description to mirror the honest phrasing already in commit `4b06438363`'s own message.

### 3. `observe_visa_seq19_sign.py` PYTHONPATH
`scripts/ci/observe_visa_seq19_sign.py` set `PYTHONPATH=backend`; the import root is `.` (apps/backend-rag), matching `pytest.ini`'s own `pythonpath = .` — the old value only worked by accident because pytest.ini supplied the correct value underneath it. Changed to `"."`.

### 4. Silent skip on missing signed bundle
`test_seq19_signed_bundle.py` carried a module-level `pytestmark = pytest.mark.skipif(not _SEQ19_SIGNED_PATH.exists(), ...)` — a deleted/never-landed artifact produced a silent, all-green-looking SKIP instead of a failure. Replaced with a hard-failing `test_signed_bundle_is_present_on_disk` module-level test; the skipif is gone, so a missing bundle now fails loudly. All 17 pre-existing tests kept intact.

## Measurements made

- `git diff --numstat 4b06438363~1 4b06438363 -- .../rulepack-prod-019.signed.json` → `9285\t0` (this session, this run).
- `git show 4b06438363 --format=%B -s` → confirmed the honest prettier-normalisation phrasing already exists in the merge commit's own message; mirrored it into `pack.yml`.
- `python3 scripts/ci/observe_visa_seq19_sign.py` (from worktree root, after the PYTHONPATH fix) → exit 0, `18 passed`, `observe_visa_seq19_sign: consumer green`.
- `PYTHONPATH=. pytest backend/tests/services/visa_engine/test_seq19_signed_bundle.py` (from `apps/backend-rag`) → `18 passed` (17 pre-existing + 1 new presence test).
- **Mutation check** (in a scratch copy — a symlink-overlay tree built under `/private/tmp/.../scratchpad`, never the tracked file): with `rulepack-prod-019.signed.json` renamed away in the scratch copy only, the suite goes **RED** — `test_signed_bundle_is_present_on_disk` fails with an explicit `AssertionError`, and 14 other tests error out (`2 failed, 14 errors`) — instead of the old silent all-green skip. Tracked file confirmed untouched (`git status` clean) throughout.
- `python3 scripts/evidence_pack_lint.py evidence/2026-09/.../pack.yml --repo-root <worktree> --numstat-file <numstat of 4b06438363~1..4b06438363> --changed-files-file <its changed files>` → `evidence_pack_lint: clean`.
- `PYTHONPATH=. pytest scripts/tests/test_detect_secrets_auto_triage.py` (worktree root) → `107 passed`.

## Bites

**Consumer**: `scripts/ci/observe_visa_seq19_sign.py` — exits 0 with `"consumer green"` (18 passed) from the worktree root today, which is what the PYTHONPATH fix (condition 3) makes possible rather than an import error. **Observation**: the mutation check above — renaming the bundle away in a scratch copy turns this same consumer's suite RED via the new presence test (condition 4), rather than silently skipping.

## Test plan

- [x] `python3 scripts/ci/observe_visa_seq19_sign.py` exits 0, "consumer green"
- [x] `test_seq19_signed_bundle.py`: 18 passed
- [x] Mutation check (scratch copy only): bundle renamed away → suite RED (2 failed, 14 errors), tracked file untouched
- [x] `evidence_pack_lint.py` on the edited pack: clean
- [x] `scripts/tests/test_detect_secrets_auto_triage.py`: 107 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8kvGP2hoVybnGJBSUQShh