### PR TITLE
fix(garuda): the assignee picker offers only rows assignPractice accepts

### DIFF
--- a/apps/backend-rag/backend/app/routers/garuda_assignment_targets.py
+++ b/apps/backend-rag/backend/app/routers/garuda_assignment_targets.py
@@ -1,0 +1,92 @@
+"""GET /api/crm/garuda/assignment-targets — the GARUDA assignee picker's source.
+
+The enumeration half of `assignPractice`'s own target gate; see
+`services/garuda_portal/assignment_targets.py` for the measured divergence this
+closes (the shared CRM roster offers rows the validator refuses, so the staff
+dropdown could offer an option whose only outcome was a 422).
+
+**Why this lives under `/api/crm/garuda`, not `/api/visa/voa/staff`.**
+`products/garuda-voa/contracts/README.md` freezes that prefix: "A lane never
+edits the contract to fit its code. Contract changes go through the
+orchestrator." The assignee dropdown has never been part of the frozen surface
+— it was fed by the CRM roster (`GET /api/team/members`) — so the GARUDA-filtered
+replacement stays on the same side of that boundary and `openapi.yaml` v1.0.0 is
+untouched. `test_garuda_voa_openapi_parity.py` keeps pinning the four contract
+operations exactly as before.
+
+**Why there is no `GARUDA_PUBLIC_ENABLED` check.** That flag gates the GARUDA
+product surface (eligibility funnel, checkout, magic-link auth, staff
+practices), and `test_garuda_public_enabled_readers_agree.py` pins its three
+readers byte-identical — a fourth local copy here would be a fourth place for
+it to drift. Nothing is gained by one: when the flag is off the staff UI that
+renders this picker 404s, and the data itself (which colleagues are assignable)
+is already visible to the same admin caller through `GET /api/team/members`,
+which is not flag-gated either.
+
+Auth is the staff surface's own: `require_garuda_staff` resolves the SAME actor
+object from either the `kita.balizero.com` cookie session or a bearer CRM JWT
+(never a customer magic-link session), and `is_admin` is the same test
+`assign_practice` applies before it accepts an assignment — a non-admin staff
+member cannot assign, so a non-admin is not sent the list of people to assign
+to. `HybridAuthMiddleware` still rejects a credential-less caller first (this
+prefix is not in `public_endpoints.py`); the 401 below is the second line for a
+credential that authenticates but is not a GARUDA staff principal (a client or
+partner token).
+
+Deliberately NOT the contract error envelope (`{"code","retryable",
+"message_key"}` is `garuda_staff_router._error()`'s shape, owned by the frozen
+`errors.yaml` catalog): this route is outside that contract, so it uses
+FastAPI's plain `detail`, the shape `routers/team.py` — the endpoint this
+replaces for this picker — already returns.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+
+from backend.app.dependencies import get_database_pool
+from backend.services.garuda_portal.assignment_targets import list_garuda_assignment_targets
+from backend.services.garuda_portal.staff_auth import require_garuda_staff
+
+router = APIRouter(prefix="/api/crm/garuda", tags=["garuda-assignment"])
+
+
+def _privacy_headers(response: Response) -> None:
+    """Same three headers `garuda_staff_router._privacy_headers` sets: a staff
+    roster is a per-caller artifact, never a shared-cache one. A local copy
+    rather than an import of that router's private helper (LANES.md
+    file-ownership discipline, and importing a `_`-prefixed helper across
+    routers is the kind of coupling that breaks silently on a rename)."""
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
+
+
+@router.get("/assignment-targets")
+async def get_assignment_targets(
+    request: Request,
+    response: Response,
+    pool: asyncpg.Pool = Depends(get_database_pool),
+) -> dict[str, list[dict[str, str]]]:
+    """`{"items": [{"email", "label"}]}` — every email `assignPractice` accepts.
+
+    Sorted by the roster's own `ORDER BY name`, deduplicated, with ambiguous
+    labels disambiguated by the service (see its docstring).
+    """
+    _privacy_headers(response)
+
+    actor: dict[str, Any] | None = await require_garuda_staff(request)
+    if actor is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    if not actor.get("is_admin"):
+        raise HTTPException(status_code=403, detail="Admin role required")
+
+    async with pool.acquire() as conn:
+        items = await list_garuda_assignment_targets(conn)
+    return {"items": items}
+
+
+__all__ = ["router"]

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -211,6 +211,19 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
     RouterEntry(name="frontend_metrics", process_groups=_API, tags=("observability", "frontend")),
     # ── Funnel (cross-funnel lead tracking, pre-auth) ──
     RouterEntry(name="funnel", process_groups=_API, tags=("funnel",)),
+    # ── GARUDA assignee enumeration (CRM-side of the contract-frozen prefix) ──
+    # NOT part of the frozen /api/visa/voa contract, and deliberately not under
+    # that prefix: the staff picker this serves was fed by the CRM roster
+    # (GET /api/team/members) before it, and the roster lists rows
+    # `assignPractice` refuses. Same actor resolution and same admin test as
+    # garuda_staff_router; no GARUDA_PUBLIC_ENABLED mount condition — see
+    # garuda_assignment_targets.py's module docstring for why a fourth copy of
+    # that reader would buy nothing.
+    RouterEntry(
+        name="garuda_assignment_targets",
+        process_groups=_API,
+        tags=("visa", "garuda", "staff", "crm"),
+    ),
     # ── GARUDA VOA L3 checkout + orders (contract-frozen) ──
     # No mount-time condition: mirrors garuda_voa_public below — the flag
     # (GARUDA_PUBLIC_ENABLED) is re-checked per-request by the router's own

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -237,6 +237,10 @@ def include_routers(api: FastAPI) -> None:
 
     api.include_router(garuda_staff_router.router)  # staff surface (step 8, PR-02..PR-11) — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
 
+    from backend.app.routers import garuda_assignment_targets
+
+    api.include_router(garuda_assignment_targets.router)  # GET /api/crm/garuda/assignment-targets — the staff surface's assignee picker, kept CRM-side of the frozen /api/visa/voa contract prefix; same actor resolution and admin test as assignPractice
+
     # CRM routers
     api.include_router(crm_clients.router)
     api.include_router(intake_review.router)  # [FASE 5A] doc-intake HITL review-queue
@@ -694,6 +698,10 @@ def include_light_routers(api: FastAPI) -> None:
     from backend.app.routers import garuda_staff_router
 
     api.include_router(garuda_staff_router.router)  # staff surface (step 8, PR-02..PR-11) — flag GARUDA_PUBLIC_ENABLED checked per-request, not at mount
+
+    from backend.app.routers import garuda_assignment_targets
+
+    api.include_router(garuda_assignment_targets.router)  # GET /api/crm/garuda/assignment-targets — the staff surface's assignee picker, kept CRM-side of the frozen /api/visa/voa contract prefix; same actor resolution and admin test as assignPractice
 
     # Genome-backed registries (light: SQLite via cell-core, no ML deps)
     api.include_router(experience.router)  # [EXP] Experience Library (PR #54)

--- a/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
+++ b/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
@@ -8,7 +8,8 @@ OFFER?" — so the staff UI filled its assignee `<select>`
 shared CRM roster `GET /api/team/members`, whose filter is the DENYLIST
 `service_accounts.non_human_roles_sql_array()` = {``client``, ``monitoring``}.
 The two predicates are not the same set, and the gap is measurable in
-production (read-only census 2026-09-06, `scripts/pg.sh`, counts only):
+production. A read-only census of `team_members` taken 2026-09-06 (counts
+only, never emails) found:
 
 * one ACTIVE row whose email is in `crm_utils.PRACTICES_EXTRA_VIEW_EMAILS`
   (the accounting full-view role; `role = 'board member'` in `team_members`).

--- a/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
+++ b/apps/backend-rag/backend/services/garuda_portal/assignment_targets.py
@@ -1,0 +1,129 @@
+"""Who may be assigned a GARUDA practice — the enumeration half of the gate.
+
+`staff_auth.is_valid_garuda_assignment_target` answers the SINGULAR question
+("may THIS email be the target of `assignPractice`?", 422 `INVALID_REQUEST`
+when it refuses). Nothing answered the plural one — "which emails may I
+OFFER?" — so the staff UI filled its assignee `<select>`
+(`apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx`) from the
+shared CRM roster `GET /api/team/members`, whose filter is the DENYLIST
+`service_accounts.non_human_roles_sql_array()` = {``client``, ``monitoring``}.
+The two predicates are not the same set, and the gap is measurable in
+production (read-only census 2026-09-06, `scripts/pg.sh`, counts only):
+
+* one ACTIVE row whose email is in `crm_utils.PRACTICES_EXTRA_VIEW_EMAILS`
+  (the accounting full-view role; `role = 'board member'` in `team_members`).
+  The roster lists it — `staff_auth.is_valid_garuda_assignment_target`
+  refuses it ("read-only means read-only", its own comment) — so the dropdown
+  offered an option whose only possible outcome was a 422.
+* ``partner`` rows: refused by the validator (`service_accounts.EXTERNAL_ROLES`),
+  deliberately NOT excluded by the roster's denylist, because that module's own
+  docstring leaves "whether a partner belongs in a roster or a dropdown" to the
+  product layer. The ruling for this surface is that a partner is never
+  assignable. Production holds 0 active partner rows (1 inactive), so this half
+  is latent rather than live — it is covered here because an inactive row can
+  be reactivated without a deploy.
+
+The roster itself cannot be fixed into agreement: it is a visibility artifact
+shared with the CRM clients/partners surfaces, where the read-only accounting
+viewer legitimately belongs and where a partner's own colleagues may need to
+appear. Only the GARUDA assignment dropdown needs the narrower set.
+
+**This module does not restate the predicate — it CALLS it**, once per
+candidate row. `listed ∩ refused = ∅` therefore holds by construction, and
+keeps holding when the predicate changes under it (PR #5817 is turning
+`service_accounts.is_human_team_member` from a denylist into a census
+allow-list at the time of writing): an enumeration that copied the rule would
+drift the day the rule moves, one that asks cannot. The same reasoning is why
+`staff_auth._is_staff_role` delegates instead of keeping its own exclusion set.
+
+Cost: one candidate query plus one point query per candidate row (~25 active
+non-client rows against 525 active ``client`` rows, per the census above), on a
+response the UI holds for 5 minutes. Cheap enough not to need a cache of its
+own, and no cache means no second place to invalidate.
+
+Known boundary, stated rather than left silent: candidates come from
+`team_members`, so an email in `staff_auth._garuda_practice_admin_emails()`
+that has NO active row there is accepted by the validator but not offered here.
+The census shows every admin-class role (``founder``, ``ceo``, ``board member``)
+holding an active row, so the set is empty today; widening the candidate query
+to union the admin constant would mean either importing that private helper or
+restating it — a second copy of a policy set, which is the exact drift this
+module exists to avoid.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from backend.app.utils.service_accounts import non_human_roles_sql_array
+from backend.services.garuda_portal.staff_auth import is_valid_garuda_assignment_target
+
+__all__ = ["list_garuda_assignment_targets"]
+
+#: PERFORMANCE PREFILTER, never the authority. `NON_HUMAN_ROLES`
+#: ({``client``, ``monitoring``}) is a subset of everything
+#: `is_valid_garuda_assignment_target` refuses — both roles are in
+#: `NON_TEAM_ROLES` today, and neither is a team role under the census
+#: allow-list PR #5817 introduces — so dropping them here cannot drop a row the
+#: validator would accept. It exists because `team_members` holds 525 active
+#: `client` rows next to ~25 staff rows, and asking the validator about a
+#: client is a wasted query. The validator still sees every remaining row and
+#: is still the only thing that decides.
+_CANDIDATE_SQL = """
+    SELECT email, name, full_name, role
+      FROM team_members
+     WHERE active = TRUE
+       AND role <> ALL($1::text[])
+     ORDER BY name ASC
+"""
+
+
+def _base_label(row: Any, email: str) -> str:
+    """`full_name` → `name` → the email itself: the same preference order the
+    roster hook this replaces used (`useTeamMembers.ts::useTeamMemberOptions`),
+    so a staffer's name does not change shape when the source of the list does.
+    """
+    for key in ("full_name", "name"):
+        value = row[key]
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return email
+
+
+async def list_garuda_assignment_targets(conn: asyncpg.Connection) -> list[dict[str, str]]:
+    """Every email `assignPractice` would accept today, as ``{"email", "label"}``.
+
+    Rows are deduplicated by normalized email (the roster this replaces did the
+    same) and labels that would render twice in one `<select>` carry the email
+    as a disambiguator — two "Antonello" options are indistinguishable to the
+    person picking one, and picking wrong assigns a practice to the wrong
+    colleague.
+    """
+    rows = await conn.fetch(_CANDIDATE_SQL, non_human_roles_sql_array())
+
+    accepted: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for row in rows:
+        raw_email = row["email"]
+        email = raw_email.strip().lower() if isinstance(raw_email, str) else ""
+        if not email or email in seen:
+            continue
+        seen.add(email)
+        if not await is_valid_garuda_assignment_target(conn, email):
+            continue
+        accepted.append((email, _base_label(row, email)))
+
+    label_counts: dict[str, int] = {}
+    for _email, label in accepted:
+        key = label.lower()
+        label_counts[key] = label_counts.get(key, 0) + 1
+
+    return [
+        {
+            "email": email,
+            "label": label if label_counts[label.lower()] == 1 else f"{label} ({email})",
+        }
+        for email, label in accepted
+    ]

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
@@ -1,0 +1,391 @@
+"""Guilt/innocence for the GARUDA assignee enumeration and its endpoint's auth.
+
+The invariant, both halves (superscar #3 — OVER- and UNDER-match are symmetric):
+
+* GUILT: nothing `is_valid_garuda_assignment_target` refuses is ever offered.
+  This is the measured production defect the enumeration closes — the shared CRM
+  roster (`GET /api/team/members`, denylist `{client, monitoring}`) offered an
+  ACTIVE row whose email is in `PRACTICES_EXTRA_VIEW_EMAILS`, which
+  `assignPractice` refuses with 422: a dropdown option whose only possible
+  outcome was an error.
+* INNOCENCE: every active candidate the validator accepts IS offered. A filter
+  that quietly locks real staff out is the same defect wearing the other hat, so
+  the roster SSOT `backend/data/team_members.json` drives the fixture: every
+  role it names gets a row here and must come back out.
+
+The expectation is DERIVED from the validator, never hand-written as a role
+list. PR #5817 is replacing `service_accounts.is_human_team_member`'s denylist
+with a census allow-list while this file is being written; a hardcoded list here
+would either go stale or start asserting the superseded rule. Derived, this file
+keeps telling the truth about whatever the predicate currently is — which is the
+whole reason the enumeration calls the predicate instead of restating it.
+
+`_FakeConn` emulates the two queries by honouring the bind parameter it is
+handed rather than restating the SQL's intent. The SQL text itself is only
+proven against a real database; what is proven here is the composition — which
+rows get asked about, and what is done with the answers.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.dependencies import get_database_pool
+from backend.app.routers import garuda_assignment_targets
+from backend.app.utils.crm_utils import PRACTICES_EXTRA_VIEW_EMAILS
+from backend.services.garuda_portal import assignment_targets, staff_auth
+
+_CENSUS_PATH = Path(__file__).resolve().parents[3] / "data" / "team_members.json"
+
+_ADMIN_EMAIL = "admin@example.test"
+#: In the admin set but with NO `team_members` row — the boundary the service
+#: module docstring states instead of leaving silent.
+_GHOST_ADMIN_EMAIL = "ghost-admin@example.test"
+
+assert PRACTICES_EXTRA_VIEW_EMAILS, (
+    "the read-only full-view set is empty; the guilt case below would pass vacuously"
+)
+_READONLY_VIEWER_EMAIL = sorted(PRACTICES_EXTRA_VIEW_EMAILS)[0]
+
+
+def _census_roles() -> list[str]:
+    """Distinct roles named by the roster SSOT. Anchor: an empty or moved census
+    file must fail loudly, not shrink the innocence half to nothing."""
+    rows = json.loads(_CENSUS_PATH.read_text())
+    assert isinstance(rows, list) and rows, f"{_CENSUS_PATH} is not a non-empty list"
+    roles = sorted(
+        {
+            str(row.get("role", "")).strip().lower()
+            for row in rows
+            if isinstance(row, dict) and row.get("role")
+        }
+    )
+    assert roles, f"{_CENSUS_PATH} named no roles — innocence half would pass vacuously"
+    return roles
+
+
+_CENSUS_ROLES = _census_roles()
+
+
+def _slug(role: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", role.lower()).strip("-") or "role"
+
+
+def _row(email: str, role: str | None, *, active: bool = True, **names: Any) -> dict[str, Any]:
+    return {
+        "email": email,
+        "name": names.get("name", _slug(email.split("@")[0])),
+        "full_name": names.get("full_name"),
+        "role": role,
+        "active": active,
+    }
+
+
+def _roster() -> list[dict[str, Any]]:
+    """One row per roster-SSOT role (the innocence half) plus every class the
+    validator refuses (the guilt half). Emails are synthetic; the one real
+    address in the fixture comes from `PRACTICES_EXTRA_VIEW_EMAILS` by import,
+    never as a literal."""
+    rows: list[dict[str, Any]] = [
+        _row(f"{_slug(role)}@example.test", role, full_name=_slug(role).replace("-", " ").title())
+        for role in _CENSUS_ROLES
+    ]
+    rows += [
+        _row(_ADMIN_EMAIL, "founder", full_name="Admin Founder"),
+        _row("partner-active@example.test", "partner"),
+        _row("partner-inactive@example.test", "partner", active=False),
+        _row("client-row@example.test", "client"),
+        _row("monitoring-row@example.test", "monitoring"),
+        # the middleware default role, and the shapes a denylist used to wave through
+        _row("default-user@example.test", "user"),
+        _row("empty-role@example.test", ""),
+        _row("none-role@example.test", None),
+        _row("spaced-partner@example.test", " Partner "),
+        _row("invented-role@example.test", "space-cadet"),
+        # refused by the read-only-viewer exclusion, NOT by its role: the role
+        # here is one the census itself names
+        _row(_READONLY_VIEWER_EMAIL, "board member", full_name="Read Only Viewer"),
+    ]
+    assert _READONLY_VIEWER_EMAIL not in {r["email"] for r in rows[: len(_CENSUS_ROLES) + 1]}
+    return rows
+
+
+class _FakeConn:
+    """`fetch(_CANDIDATE_SQL, denylist)` and the validator's
+    `fetchrow(... WHERE LOWER(email) = $1 AND active = TRUE)`, emulated from the
+    parameter actually passed."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.fetch_calls = 0
+        self.fetchrow_calls = 0
+
+    async def fetch(self, _sql: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls += 1
+        excluded = {str(role).strip().lower() for role in args[0]} if args else set()
+        return [
+            row
+            for row in self._rows
+            if row["active"] and str(row["role"] or "").strip().lower() not in excluded
+        ]
+
+    async def fetchrow(self, _sql: str, *args: Any) -> dict[str, Any] | None:
+        self.fetchrow_calls += 1
+        email = str(args[0]).strip().lower()
+        for row in self._rows:
+            if str(row["email"] or "").strip().lower() == email and row["active"]:
+                return {"role": row["role"]}
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _fixed_admin_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the admin constant so these tests do not depend on the machine's
+    `ADMIN_EMAILS` env (the helper already tolerates a MagicMock `settings`, but
+    "tolerates" is not "asserts something known")."""
+    monkeypatch.setattr(
+        staff_auth,
+        "_garuda_practice_admin_emails",
+        lambda: frozenset({_ADMIN_EMAIL, _GHOST_ADMIN_EMAIL}),
+    )
+
+
+async def _validator_verdicts(rows: list[dict[str, Any]]) -> tuple[set[str], set[str]]:
+    """(accepted, refused) over the ACTIVE rows, asked of the validator itself."""
+    conn = _FakeConn(rows)
+    accepted: set[str] = set()
+    refused: set[str] = set()
+    for row in rows:
+        email = str(row["email"] or "").strip().lower()
+        if not email or not row["active"]:
+            continue
+        if await staff_auth.is_valid_garuda_assignment_target(conn, email):
+            accepted.add(email)
+        else:
+            refused.add(email)
+    return accepted, refused
+
+
+async def test_listed_is_exactly_the_active_rows_the_validator_accepts() -> None:
+    """THE invariant, both halves at once: listed ∩ refused = ∅ (never offer a
+    422) and listed == accepted (never omit a valid target)."""
+    rows = _roster()
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    emails = [item["email"] for item in listed]
+
+    accepted, refused = await _validator_verdicts(rows)
+    # anchors: neither half may pass vacuously
+    assert accepted, "no candidate is accepted — the innocence half would prove nothing"
+    assert refused, "no candidate is refused — the guilt half would prove nothing"
+
+    assert len(emails) == len(set(emails)), f"offered a duplicate email: {emails}"
+    assert not (set(emails) & refused), (
+        f"offered rows the validator refuses: {sorted(set(emails) & refused)}"
+    )
+    assert set(emails) == accepted, (
+        f"enumeration disagrees with the validator — "
+        f"missing {sorted(accepted - set(emails))}, extra {sorted(set(emails) - accepted)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "role",
+    ["partner", "client", "monitoring", "", None, " Partner "],
+    ids=["partner", "client", "monitoring", "empty", "none", "spaced-partner"],
+)
+async def test_refused_role_is_never_offered(role: str | None) -> None:
+    """Only the classes the predicate refuses TODAY are named here. An unknown
+    role (``user``, the middleware default; anything invented) is accepted by
+    the current denylist and refused by the allow-list PR #5817 introduces — the
+    enumeration must follow the predicate either way, never anticipate it, so
+    those two are covered by the DERIVED invariant above (its fixture roster
+    carries both rows) and deliberately not asserted twice as a hardcoded rule
+    this file does not own."""
+    rows = [_row("candidate@example.test", role)]
+    conn = _FakeConn(rows)
+    assert await assignment_targets.list_garuda_assignment_targets(conn) == []
+    # anchor: the validator refuses this row too, so the enumeration is not
+    # dropping it for an unrelated reason (a prefilter that quietly dropped a
+    # row the validator would accept is the UNDER-match half of superscar #3)
+    assert not await staff_auth.is_valid_garuda_assignment_target(conn, "candidate@example.test")
+
+
+async def test_enumeration_decides_by_asking_not_by_copying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The executable form of "calls the predicate, never restates it": replace
+    the predicate the enumeration asks and the list follows. A second copy of
+    the rule — the drift this module exists to avoid, and the one
+    `staff_auth._is_staff_role`'s own docstring already records having paid for
+    — would keep answering from the roles instead."""
+    rows = _roster()
+    only = "invented-role@example.test"
+
+    async def _stub(_conn: Any, email: str) -> bool:
+        return email == only
+
+    monkeypatch.setattr(assignment_targets, "is_valid_garuda_assignment_target", _stub)
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert [item["email"] for item in listed] == [only]
+
+
+@pytest.mark.parametrize("role", _CENSUS_ROLES)
+async def test_every_roster_ssot_role_is_offered(role: str) -> None:
+    rows = [_row("candidate@example.test", role)]
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert [item["email"] for item in listed] == ["candidate@example.test"], (
+        f"role {role!r} is named by {_CENSUS_PATH.name} but was not offered"
+    )
+
+
+async def test_read_only_full_view_row_is_not_offered_despite_a_staff_role() -> None:
+    """The live production case: an active row with a census role that the
+    validator refuses on the read-only-viewer exclusion."""
+    rows = [_row(_READONLY_VIEWER_EMAIL, "board member")]
+    conn = _FakeConn(rows)
+    assert await assignment_targets.list_garuda_assignment_targets(conn) == []
+    assert not await staff_auth.is_valid_garuda_assignment_target(conn, _READONLY_VIEWER_EMAIL)
+
+
+async def test_admin_boundary_is_the_documented_one() -> None:
+    """An admin WITH an active row is offered; an admin email with NO row is
+    accepted by the validator but not offered — the boundary the service module
+    docstring names, pinned so it stays a decision rather than a surprise."""
+    rows = _roster()
+    listed = {
+        item["email"]
+        for item in await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    }
+    conn = _FakeConn(rows)
+
+    assert _ADMIN_EMAIL in listed
+    assert _GHOST_ADMIN_EMAIL not in listed
+    assert await staff_auth.is_valid_garuda_assignment_target(conn, _GHOST_ADMIN_EMAIL)
+
+
+async def test_label_prefers_full_name_then_name_then_email() -> None:
+    rows = [
+        _row("full@example.test", "founder", name="Full Name", full_name="Full Name"),
+        _row("name-only@example.test", "founder", name="Name Only", full_name="   "),
+        _row("bare@example.test", "founder", name="", full_name=None),
+    ]
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    assert {item["email"]: item["label"] for item in listed} == {
+        "full@example.test": "Full Name",
+        "name-only@example.test": "Name Only",
+        "bare@example.test": "bare@example.test",
+    }
+
+
+async def test_duplicate_labels_carry_the_email_and_duplicate_rows_collapse() -> None:
+    """Two options rendering the same text are indistinguishable to the person
+    picking one; two rows for one email must not become two options."""
+    rows = [
+        _row("twin-a@example.test", "founder", name="twin", full_name="Twin"),
+        _row("twin-b@example.test", "ceo", name="twin", full_name="Twin"),
+        _row("Solo Example", "founder"),
+        _row("DUPLICATE@EXAMPLE.TEST", "ceo", name="Dup", full_name="Dup"),
+        _row("duplicate@example.test", "ceo", name="Dup", full_name="Dup"),
+    ]
+    listed = await assignment_targets.list_garuda_assignment_targets(_FakeConn(rows))
+    by_email = {item["email"]: item["label"] for item in listed}
+
+    assert by_email["twin-a@example.test"] == "Twin (twin-a@example.test)"
+    assert by_email["twin-b@example.test"] == "Twin (twin-b@example.test)"
+    assert "duplicate@example.test" in by_email
+    assert len([email for email in by_email if email == "duplicate@example.test"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# The endpoint's own posture: who may read the list, and what it hands back.
+# ---------------------------------------------------------------------------
+
+_DB_TOUCHED = "the gate must refuse before the database is touched"
+
+
+class _UntouchablePool:
+    """Any attribute access is a test failure (same idiom as
+    `test_crm_intelligence_partner_gate.py`): a 401/403 proves the gate fired
+    before any roster row could be read."""
+
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(f"{_DB_TOUCHED} (accessed .{name})")
+
+
+class _Acquire:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _FakeConn:
+        return self._conn
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self._conn)
+
+
+def _client(pool: Any, actor: dict[str, Any] | None, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    async def _resolve(_request: Any) -> dict[str, Any] | None:
+        return actor
+
+    monkeypatch.setattr(garuda_assignment_targets, "require_garuda_staff", _resolve)
+    app = FastAPI()
+    app.include_router(garuda_assignment_targets.router)
+    app.dependency_overrides[get_database_pool] = lambda: pool
+    return TestClient(app)
+
+
+_URL = "/api/crm/garuda/assignment-targets"
+
+
+def test_endpoint_refuses_a_caller_that_is_not_a_staff_principal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(_UntouchablePool(), None, monkeypatch)
+    response = client.get(_URL)
+    assert response.status_code == 401
+
+
+def test_endpoint_refuses_a_non_admin_staff_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`assignPractice` is admin-only, so a non-admin is not handed the list of
+    people to assign to."""
+    actor = {"email": "staff@example.test", "is_admin": False}
+    client = _client(_UntouchablePool(), actor, monkeypatch)
+    response = client.get(_URL)
+    assert response.status_code == 403
+
+
+async def test_endpoint_serves_the_enumeration_to_an_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows = _roster()
+    client = _client(
+        _FakePool(_FakeConn(rows)), {"email": _ADMIN_EMAIL, "is_admin": True}, monkeypatch
+    )
+    response = client.get(_URL)
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store, private"
+    items = response.json()["items"]
+    assert items, "an admin got an empty picker over a roster full of staff rows"
+    assert all(set(item) == {"email", "label"} for item in items)
+    # the body is the service's own answer, not a second rendering of it
+    accepted, refused = await _validator_verdicts(rows)
+    assert {item["email"] for item in items} == accepted
+    assert not ({item["email"] for item in items} & refused)

--- a/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
+++ b/apps/backend-rag/backend/tests/services/garuda_portal/test_assignment_targets.py
@@ -313,10 +313,33 @@ _DB_TOUCHED = "the gate must refuse before the database is touched"
 class _UntouchablePool:
     """Any attribute access is a test failure (same idiom as
     `test_crm_intelligence_partner_gate.py`): a 401/403 proves the gate fired
-    before any roster row could be read."""
+    before any roster row could be read.
+
+    Dunder lookups are exempt and raise `AttributeError`, exactly as that
+    precedent does — pytest/httpx introspection and the copy/pickle protocol
+    probe `__*__` attributes, and answering those with an `AssertionError`
+    reports a confusing failure instead of the intended one. The first push of
+    this branch omitted the exemption and CodeQL named it (alert 8994,
+    "non-standard exception raised in special method"); the cure is the
+    repo's own idiom, not a new one.
+    """
 
     def __getattr__(self, name: str) -> Any:
+        if name.startswith("__"):
+            raise AttributeError(name)
         raise AssertionError(f"{_DB_TOUCHED} (accessed .{name})")
+
+
+def test_untouchable_pool_fails_loud_on_use_and_honest_on_protocol_probes() -> None:
+    """Both arms of the helper the two gate tests below rely on: real pool use
+    is an `AssertionError` carrying the reason, a protocol/introspection probe
+    is a plain `AttributeError`. Without this pair the exemption above is
+    incidental rather than decided (superscar #3: a guard with one arm)."""
+    pool = _UntouchablePool()
+    with pytest.raises(AssertionError, match=_DB_TOUCHED):
+        pool.acquire()
+    with pytest.raises(AttributeError):
+        pool.__deepcopy__  # noqa: B018 — the lookup itself is the assertion
 
 
 class _Acquire:

--- a/apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.test.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   assignPractice: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  useGarudaAssignmentTargets: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -34,10 +35,11 @@ vi.mock("@/components/ui/toast", () => ({
   }),
 }));
 
-vi.mock("@/hooks/useTeamMembers", () => ({
-  useTeamMemberOptions: () => ({
-    options: [{ value: "zero@balizero.com", label: "Zero" }],
-  }),
+// The picker's source is the assignment gate's own enumeration, not the shared
+// CRM roster hook it replaced. Mocked whole, as that hook was: these tests
+// render the page without a QueryClientProvider.
+vi.mock("../assignment-targets", () => ({
+  useGarudaAssignmentTargets: mocks.useGarudaAssignmentTargets,
 }));
 
 vi.mock("../api-client", async () => {
@@ -85,6 +87,10 @@ describe("GarudaVoaStaffDetailPage", () => {
     vi.clearAllMocks();
     mocks.useParams.mockReturnValue({ practiceId: "practice_1" });
     mocks.getProfile.mockResolvedValue({ email: "zero@balizero.com" });
+    mocks.useGarudaAssignmentTargets.mockReturnValue({
+      data: [{ email: "zero@balizero.com", label: "Zero" }],
+      isError: false,
+    });
   });
 
   it("renders only the transitions valid for the current state (Received)", async () => {
@@ -227,5 +233,70 @@ describe("GarudaVoaStaffDetailPage", () => {
       "Already applied",
       expect.stringContaining("In review"),
     );
+  });
+
+  it("fills the picker from the assignment gate's own enumeration", async () => {
+    mocks.isAdmin.mockReturnValue(true);
+    mocks.getStaffPractice.mockResolvedValue(RECEIVED_PRACTICE);
+
+    render(<GarudaVoaStaffDetailPage />);
+
+    const select = (await screen.findByLabelText(
+      "Assigned to",
+    )) as HTMLSelectElement;
+    await waitFor(() =>
+      expect(
+        select.querySelector('option[value="zero@balizero.com"]'),
+      ).toBeTruthy(),
+    );
+    expect(mocks.useGarudaAssignmentTargets).toHaveBeenCalledWith(true);
+  });
+
+  it("never runs the picker query for a non-admin (the endpoint would 403)", async () => {
+    mocks.isAdmin.mockReturnValue(false);
+    mocks.getStaffPractice.mockResolvedValue(RECEIVED_PRACTICE);
+
+    render(<GarudaVoaStaffDetailPage />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("transition-PR-02")).toBeTruthy(),
+    );
+    expect(mocks.useGarudaAssignmentTargets).toHaveBeenCalledWith(false);
+  });
+
+  it("shows an assignee the gate refuses as a disabled option rather than pretending the practice is unassigned", async () => {
+    mocks.isAdmin.mockReturnValue(true);
+    mocks.getStaffPractice.mockResolvedValue({
+      ...RECEIVED_PRACTICE,
+      assigned_to: "read-only@example.test",
+    });
+
+    render(<GarudaVoaStaffDetailPage />);
+
+    const select = (await screen.findByLabelText(
+      "Assigned to",
+    )) as HTMLSelectElement;
+    const current = select.querySelector(
+      'option[value="read-only@example.test"]',
+    ) as HTMLOptionElement | null;
+    await waitFor(() => expect(current).toBeTruthy());
+    expect(current?.disabled).toBe(true);
+    expect(current?.textContent).toContain("not assignable");
+    // the control must not fall back to "Unassigned" while a real assignment
+    // exists — that is the lie this option exists to prevent
+    await waitFor(() => expect(select.value).toBe("read-only@example.test"));
+  });
+
+  it("says when the assignee list could not be fetched instead of offering an empty picker", async () => {
+    mocks.isAdmin.mockReturnValue(true);
+    mocks.useGarudaAssignmentTargets.mockReturnValue({
+      data: undefined,
+      isError: true,
+    });
+    mocks.getStaffPractice.mockResolvedValue(RECEIVED_PRACTICE);
+
+    render(<GarudaVoaStaffDetailPage />);
+
+    expect(await screen.findByText(/Assignee list unavailable/)).toBeVisible();
   });
 });

--- a/apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx
@@ -8,13 +8,13 @@ import { useToast } from "@/components/ui/toast";
 import { api } from "@/lib/api";
 import { logger } from "@/lib/logger";
 import { toError } from "@/lib/types/common";
-import { useTeamMemberOptions } from "@/hooks/useTeamMembers";
 import {
   assignPractice,
   getStaffPractice,
   transitionPractice,
   GarudaStaffError,
 } from "../api-client";
+import { useGarudaAssignmentTargets } from "../assignment-targets";
 import { getAllowedTransitions } from "../state-machine";
 import type {
   PracticeTransitionRequest,
@@ -114,9 +114,17 @@ export default function GarudaVoaStaffDetailPage() {
   const params = useParams();
   const toast = useToast();
   const practiceId = params?.practiceId as string | undefined;
-  const { options: teamMemberOptions } = useTeamMemberOptions();
 
   const [isAdmin, setIsAdmin] = useState(false);
+  // The picker's source is the assignment gate's own enumeration, never the
+  // shared CRM roster: the roster also lists rows `assignPractice` refuses (a
+  // read-only accounting full-view row, any partner row), which rendered as
+  // options whose only possible outcome was a 422. Admin-only, matching both
+  // the picker below and the endpoint's own 403 — see ../assignment-targets.ts.
+  const {
+    data: assignmentTargets = [],
+    isError: assignmentTargetsUnavailable,
+  } = useGarudaAssignmentTargets(isAdmin);
   const [practice, setPractice] = useState<StaffPracticeView | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -365,12 +373,31 @@ export default function GarudaVoaStaffDetailPage() {
               className="w-full max-w-xs border border-[var(--bz-border)] bg-[var(--bz-base)] text-[var(--bz-text-1)] rounded-lg px-3 py-2 text-sm"
             >
               <option value="">Unassigned</option>
-              {teamMemberOptions.map((member) => (
-                <option key={member.value} value={member.value}>
-                  {member.label}
+              {/* A practice assigned BEFORE this picker was narrowed (or to a
+                  row the gate refuses, e.g. the read-only accounting viewer)
+                  still has to SHOW its current assignee — without this option
+                  the select's value matches nothing and renders as
+                  "Unassigned", which is a lie about a real assignment. Disabled
+                  so it cannot be picked again into a guaranteed 422. */}
+              {practice.assigned_to &&
+                !assignmentTargets.some(
+                  (target) => target.email === practice.assigned_to,
+                ) && (
+                  <option value={practice.assigned_to} disabled>
+                    {practice.assigned_to} (not assignable)
+                  </option>
+                )}
+              {assignmentTargets.map((target) => (
+                <option key={target.email} value={target.email}>
+                  {target.label}
                 </option>
               ))}
             </select>
+            {assignmentTargetsUnavailable && (
+              <p className="mt-1 text-xs text-[var(--bz-text-2)]">
+                Assignee list unavailable — reload before assigning.
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/apps/mouth/src/app/(workspace)/garuda-voa/assignment-targets.test.ts
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/assignment-targets.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  AssignmentTargetsError,
+  fetchAssignmentTargets,
+} from "./assignment-targets";
+
+const URL_UNDER_TEST = "/api/crm/garuda/assignment-targets";
+
+function stubFetch(
+  implementation: (input: unknown, init?: unknown) => unknown,
+) {
+  const fn = vi.fn(implementation);
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function response(status: number, body: unknown, ok = status < 400) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchAssignmentTargets", () => {
+  it("asks the CRM-side endpoint same-origin, never the Fly host directly", async () => {
+    // The transport convention `api-client.ts`'s header comment says was paid
+    // for with a live 401: `NEXT_PUBLIC_API_URL` drops the httpOnly session
+    // cookie and the proxy's CSRF promotion.
+    const fetchMock = stubFetch(() => response(200, { items: [] }));
+
+    await fetchAssignmentTargets();
+
+    expect(fetchMock).toHaveBeenCalledWith(URL_UNDER_TEST, {
+      method: "GET",
+      credentials: "same-origin",
+      signal: undefined,
+    });
+  });
+
+  it("returns the items the gate accepts", async () => {
+    stubFetch(() =>
+      response(200, {
+        items: [
+          { email: "a@example.test", label: "A" },
+          { email: "b@example.test", label: "B (b@example.test)" },
+        ],
+      }),
+    );
+
+    await expect(fetchAssignmentTargets()).resolves.toEqual([
+      { email: "a@example.test", label: "A" },
+      { email: "b@example.test", label: "B (b@example.test)" },
+    ]);
+  });
+
+  it("drops a row that is not an {email,label} pair instead of rendering it", async () => {
+    stubFetch(() =>
+      response(200, {
+        items: [
+          { email: "a@example.test", label: "A" },
+          { email: "no-label@example.test" },
+          { label: "no-email" },
+          null,
+          "a@example.test",
+        ],
+      }),
+    );
+
+    await expect(fetchAssignmentTargets()).resolves.toEqual([
+      { email: "a@example.test", label: "A" },
+    ]);
+  });
+
+  it("reports a refusal with its status (a non-admin gets 403)", async () => {
+    stubFetch(() => response(403, { detail: "Admin role required" }));
+
+    const error = await fetchAssignmentTargets().catch(
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(AssignmentTargetsError);
+    expect((error as AssignmentTargetsError).httpStatus).toBe(403);
+  });
+
+  it("reports a network failure with a null status", async () => {
+    stubFetch(() => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    const error = await fetchAssignmentTargets().catch(
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(AssignmentTargetsError);
+    expect((error as AssignmentTargetsError).httpStatus).toBeNull();
+    expect((error as AssignmentTargetsError).sourceCause).toBeInstanceOf(
+      TypeError,
+    );
+  });
+
+  it("refuses a 200 whose body is not the {items:[...]} shape", async () => {
+    stubFetch(() => response(200, [{ email: "a@example.test", label: "A" }]));
+
+    const error = await fetchAssignmentTargets().catch(
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(AssignmentTargetsError);
+    expect((error as AssignmentTargetsError).httpStatus).toBe(200);
+  });
+});

--- a/apps/mouth/src/app/(workspace)/garuda-voa/assignment-targets.ts
+++ b/apps/mouth/src/app/(workspace)/garuda-voa/assignment-targets.ts
@@ -1,0 +1,97 @@
+/**
+ * The GARUDA assignee picker's data source:
+ * `GET /api/crm/garuda/assignment-targets`.
+ *
+ * Replaces `useTeamMemberOptions()` (the shared CRM roster,
+ * `GET /api/team/members`) on the staff practice detail page. The roster is a
+ * VISIBILITY artifact filtered by the role denylist `{client, monitoring}`,
+ * while `assignPractice` refuses more than that — an active row whose email is
+ * in `PRACTICES_EXTRA_VIEW_EMAILS` (the read-only accounting full view) and any
+ * `partner` row — so the picker offered options whose only possible outcome was
+ * a 422. The endpoint answers with exactly the emails the gate accepts, asked
+ * of that gate rather than copied from it, so the picker and the 422 cannot
+ * drift apart again when the role rule changes.
+ *
+ * Deliberately NOT in `./types` or `./api-client.ts`: those wrap the four
+ * operations of the frozen GARUDA VOA contract
+ * (`products/garuda-voa/contracts/openapi.yaml`), and this endpoint is
+ * CRM-side, exactly like the roster it replaces. It keeps that file's transport
+ * convention though — same-origin `fetch` with `credentials: "same-origin"`,
+ * never `NEXT_PUBLIC_API_URL`, which would drop the httpOnly session cookie and
+ * the Next.js proxy's CSRF promotion (see `api-client.ts`'s header comment for
+ * the live 401 that taught it).
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+export interface GarudaAssignmentTarget {
+  email: string;
+  label: string;
+}
+
+const ASSIGNMENT_TARGETS_URL = "/api/crm/garuda/assignment-targets";
+
+/** Thrown when the picker's source is unreachable, refuses the caller, or
+ * answers something that is not the `{items: [...]}` shape. Mirrors
+ * `api-client.ts::GarudaStaffUnexpectedError`, including the `sourceCause`
+ * spelling (an `Error` `cause` is not part of this app's TS lib target). */
+export class AssignmentTargetsError extends Error {
+  public readonly sourceCause: unknown;
+
+  constructor(
+    public readonly httpStatus: number | null,
+    cause?: unknown,
+  ) {
+    super(`AssignmentTargetsError(${httpStatus})`);
+    this.name = "AssignmentTargetsError";
+    this.sourceCause = cause;
+  }
+}
+
+function isTarget(value: unknown): value is GarudaAssignmentTarget {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<GarudaAssignmentTarget>;
+  return (
+    typeof candidate.email === "string" && typeof candidate.label === "string"
+  );
+}
+
+export async function fetchAssignmentTargets(
+  signal?: AbortSignal,
+): Promise<GarudaAssignmentTarget[]> {
+  let response: Response;
+  try {
+    response = await fetch(ASSIGNMENT_TARGETS_URL, {
+      method: "GET",
+      credentials: "same-origin",
+      signal,
+    });
+  } catch (cause) {
+    throw new AssignmentTargetsError(null, cause);
+  }
+  if (!response.ok) throw new AssignmentTargetsError(response.status);
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    throw new AssignmentTargetsError(response.status, cause);
+  }
+  const items = (body as { items?: unknown } | null)?.items;
+  if (!Array.isArray(items)) throw new AssignmentTargetsError(response.status);
+  return items.filter(isTarget);
+}
+
+/** `enabled` is the page's own admin flag. A non-admin staff member gets a 403
+ * from this endpoint (they cannot assign a practice, so they are not sent the
+ * list of people to assign one to) — the query simply never runs for them, and
+ * the page does not render the picker either. */
+export function useGarudaAssignmentTargets(enabled: boolean) {
+  return useQuery({
+    queryKey: ["garuda", "assignment-targets"],
+    queryFn: ({ signal }) => fetchAssignmentTargets(signal),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+}

--- a/evidence/2026-09/agent-air-m5-backend-rag-garuda-assignee-partner-a05cda1c/brief.yml
+++ b/evidence/2026-09/agent-air-m5-backend-rag-garuda-assignee-partner-a05cda1c/brief.yml
@@ -1,0 +1,97 @@
+gear: 2
+objective: >
+  Make the GARUDA staff assignee picker offer only the emails `assignPractice`
+  would accept, so that a picker option can no longer be a guaranteed 422.
+constraints:
+  - Do not restate the assignment predicate. Call
+    `staff_auth.is_valid_garuda_assignment_target` for every candidate row, so
+    `listed ∩ refused = ∅` holds by construction and keeps holding when PR
+    #5817 replaces the role denylist with a census allow-list.
+  - Do not change the shared roster's semantics. `backend/app/routers/team.py`,
+    `backend/app/utils/service_accounts.py`, `apps/mouth/src/hooks/useTeamMembers.ts`
+    and `backend/services/garuda_portal/staff_auth.py` stay unmodified — the
+    roster is a visibility artifact whose read-only accounting viewer legitimately
+    belongs to the CRM surfaces, and two of those files belong to other lanes in
+    this loop.
+  - Stay outside the frozen GARUDA VOA contract. No edit to
+    `products/garuda-voa/contracts/**` and no new operation under
+    `/api/visa/voa/**`; the endpoint is CRM-prefixed, which is the side of the
+    boundary the picker's data has always come from.
+  - No production write, and no client PII in any output. The census was
+    read-only, counts only, with addresses compared by `md5(lower(email))`
+    instead of selected.
+acceptance:
+  - text: >
+      The enumeration SHALL equal the set of active candidate rows the validator
+      accepts, over a fixture carrying every role named by
+      `backend/data/team_members.json` plus partner, client, monitoring, the
+      `PRACTICES_EXTRA_VIEW_EMAILS` row, unknown, empty and `" Partner "` roles.
+    probe: >
+      PYTHONPATH=. pytest
+      backend/tests/services/garuda_portal/test_assignment_targets.py
+      (test_listed_is_exactly_the_active_rows_the_validator_accepts)
+  - text: >
+      The endpoint SHALL answer 401 to a principal that is not GARUDA staff and
+      403 to a non-admin staff member, in both cases before the database is
+      touched.
+    probe: >
+      same suite, test_endpoint_refuses_a_caller_that_is_not_a_staff_principal
+      and test_endpoint_refuses_a_non_admin_staff_member, both over an
+      _UntouchablePool whose every attribute access fails the test
+  - text: >
+      The frozen contract SHALL stay byte-identical and the staff surface SHALL
+      keep exposing exactly its four contract operations.
+    probe: >
+      PYTHONPATH=. pytest
+      backend/tests/app/routers/test_garuda_voa_openapi_parity.py
+      backend/tests/app/routers/test_garuda_staff_public_prefix_guard.py
+  - text: >
+      A newly registered router SHALL NOT be an orphan, and the route censuses
+      SHALL stay green with it present.
+    probe: >
+      PYTHONPATH=. pytest backend/tests/setup/ backend/tests/security/
+      (router-manifest census, route-walk floor, authz coverage, public
+      mutating-route census)
+  - text: >
+      The picker SHALL render from the new endpoint, SHALL keep showing a
+      current assignee the gate refuses as a disabled option rather than
+      rendering "Unassigned" over a real assignment, and SHALL say when the list
+      could not be fetched.
+    probe: >
+      npx vitest run "src/app/(workspace)/garuda-voa" (25 passed) and
+      npx tsc --noEmit (clean)
+consumer_map:
+  - The assignee <select> in
+    apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx, which
+    renders this endpoint's items — shipped in the same PR, not a future job.
+  - harness-floor.yml Step 6, which reads this brief's declared gear against the
+    deterministic floor, and Step 7a, which passes a sub-Gear-3 task without a
+    gate verdict.
+  - The Backend Shard and Frontend Tests required checks, which run the probes
+    above on the PR head.
+assumptions:
+  - text: >
+      Production holds 0 active `partner` rows (1 inactive) and exactly 1 active
+      row whose email is in `PRACTICES_EXTRA_VIEW_EMAILS`, so the partner half of
+      the defect is latent and the read-only-viewer half is live.
+    status: verified
+    probe: >
+      read-only census of team_members through scripts/pg.sh on 2026-09-06,
+      GROUP BY lower(role), active and an md5 comparison — counts only, quoted
+      in the PR description
+  - text: >
+      Every admin-class role (`founder`, `ceo`, `board member`) holds an active
+      `team_members` row, so the documented boundary — an admin email with no
+      active row is accepted by the validator but not offered — is empty today.
+    status: verified
+    probe: >
+      the same census; pinned by
+      test_admin_boundary_is_the_documented_one in the suite above
+  - text: >
+      PR #5817's census allow-list will not change which rows this enumeration
+      returns for a role the allow-list keeps, because the enumeration asks the
+      predicate instead of naming roles.
+    status: verified
+    probe: >
+      test_enumeration_decides_by_asking_not_by_copying, which replaces the
+      predicate and asserts the list follows it


### PR DESCRIPTION
## What

The GARUDA staff practice page filled its assignee `<select>` from the shared CRM roster (`GET /api/team/members` → `useTeamMemberOptions()`), whose filter is the role denylist `{client, monitoring}`. `assignPractice` refuses more than that, so the dropdown could offer a row whose only possible outcome was **422 INVALID_REQUEST**.

This adds the missing plural half of that gate — `GET /api/crm/garuda/assignment-targets`, admin-only — and points the picker at it.

## Measured ground truth (production, read-only)

Census of `team_members` taken 2026-09-06 through the repo's read-only Postgres wrapper (`scripts/pg.sh` → role `nuzantara_readonly`, db `nuzantara_rag`, Fly proxy). Counts only; emails were compared by md5 so no address appears in a transcript, a board line or this PR:

```sql
SELECT lower(role), active, count(*) FROM team_members GROUP BY 1,2 ORDER BY 1,2;
-- partner|f|1        (zero ACTIVE partner rows)
-- client|t|525   monitoring|t|1   board member|t|1   founder|t|1   ceo|t|1   member|t|2 ...

SELECT lower(role), active,
       md5(lower(email)) = '<md5 of the PRACTICES_EXTRA_VIEW address>' AS is_readonly_view,
       count(*)
  FROM team_members GROUP BY 1,2,3;
-- board member|t|t|1   ← the live divergence
```

* **Live today:** one ACTIVE row whose email md5-matches `crm_utils.PRACTICES_EXTRA_VIEW_EMAILS` (role `board member`). The roster lists it (`team.py:78,92,105` filter only `non_human_roles_sql_array()`), while `is_valid_garuda_assignment_target` refuses it — "read-only means read-only", `staff_auth.py:181-184`. The admin picker therefore offered an option that always 422'd.
* **Latent:** `partner` rows — refused by the gate (`service_accounts.EXTERNAL_ROLES`), deliberately *not* excluded by the roster denylist, because that module's own docstring leaves "whether a partner belongs in a roster or a dropdown" to the product layer. The standing ruling is that partners are never assignable. 0 active / 1 inactive today; covered anyway, because reactivating a row needs no deploy.

## Why an endpoint instead of a filter on the roster

The roster cannot be narrowed into agreement: it is a visibility artifact shared with the CRM clients/partners surfaces, where the read-only accounting viewer legitimately belongs. Owner ruling (Zero, in this loop) chose a GARUDA-scoped enumeration on a CRM prefix over the alternative raised on the loop board at 22:39:53Z (an opt-in `assignment_scope=garuda` on `GET /api/team/members`). Differences a grader should weigh:

| | this PR | `?assignment_scope=garuda` on the roster |
|---|---|---|
| where GARUDA-only policy lives | GARUDA-scoped service + router | inside the shared roster router T3 just gated (#5815) |
| effect on other roster consumers | none — the default path is untouched | the roster becomes scope-aware for every caller |
| posture vs `assignPractice` | admin-only, same actor resolution | team-wide: any team member can enumerate the assignable set (a subset of the roster they already see, so not a leak — a different posture) |
| frozen GARUDA contract | untouched, and not under `/api/visa/voa` | untouched |

Mounted at `/api/crm/garuda/...` because `products/garuda-voa/contracts/README.md` freezes `/api/visa/voa/**` ("a lane never edits the contract to fit its code"), and the picker's data has always come from the CRM side of that boundary. No `GARUDA_PUBLIC_ENABLED` reader: a fourth copy of that flag is a fourth place for it to drift (`test_garuda_public_enabled_readers_agree.py` pins three), and with the flag off the page that renders the picker 404s anyway.

**The enumeration does not restate the predicate — it calls it**, once per candidate row. `listed ∩ refused = ∅` therefore holds by construction and keeps holding when the role rule changes under it (#5817 is replacing that denylist with a census allow-list). The tests derive their expectation from the predicate for the same reason: two of them failed while this was being written because they asserted the allow-list's verdicts before it landed, which is exactly the drift they exist to prevent.

The picker also keeps showing a current assignee the gate refuses, as a **disabled** option: without it the `<select>`'s value matches no option and renders "Unassigned" over a real assignment; enabled, it would re-pick straight into the same 422.

## Bites

Consumer: the assignee `<select>` in `apps/mouth/src/app/(workspace)/garuda-voa/[practiceId]/page.tsx`, which renders from this endpoint **in this PR** — not a future job.

Observed pre-merge on Air-M5 (no local Postgres, so no live HTTP observation exists yet and none is claimed):

| command | result |
|---|---|
| `PYTHONPATH=. pytest backend/tests/services/garuda_portal/test_assignment_targets.py` | **29 passed** — `listed == validator-accepted` over a fixture carrying every role named by `backend/data/team_members.json` plus partner / client / monitoring / the read-only viewer / unknown / empty / `" Partner "` rows |
| `PYTHONPATH=. pytest backend/tests/app/routers/test_garuda_voa_openapi_parity.py backend/tests/app/routers/test_garuda_staff_public_prefix_guard.py backend/tests/setup/ backend/tests/security/` | **76 + 400 passed** — frozen contract untouched, no orphan router (manifest entry added), authz census green |
| `PYTHONPATH=. pytest backend/tests/unit/utils/test_service_accounts.py backend/tests/services/garuda_portal/{test_staff_transitions_validate,test_masking}.py` | **78 passed** |
| `PYTHONPATH=.:../crm-cell python -c "from backend.app.dependencies import get_current_user"` | import chain OK |
| `npx vitest run "src/app/(workspace)/garuda-voa"` | **25 passed** (6 new client tests + 4 new page tests) |
| `npx tsc --noEmit` · `npx eslint` · `npx prettier --check` · `ruff check` · `ruff format --diff` | clean |
| `python3 scripts/ci/scripts_coupling_census.py --check` | `SCRIPTS_COUPLING is up to date`, rc=0 |

The first commit's docstring named `scripts/pg.sh` by path; the census counts a literal `scripts/*.sh` mention under `apps/` (comments included) and went STALE, which `scripts/ci/test_change_map.py::test_scripts_coupling_census_is_not_stale` fails CI on. The second commit removes the path rather than running `--write`, because nothing here imports or invokes that wrapper — recording the coupling would make every future edit to it buy the six heavy `tests.yml` suites, and would put a shared generated file into this PR while other branches are open. The statement is quoted here instead.

Post-merge probe for the shipping seat (one HTTP observation of the behaviour itself), as an admin cookie session on `kita.balizero.com`:

```
GET /api/crm/garuda/assignment-targets  → 200, items contain NO PRACTICES_EXTRA_VIEW_EMAILS address and no partner-role row
GET /api/team/members                   → 200, still contains both (the roster is deliberately unchanged)
```
plus `curl -fsS https://nuzantara-rag.fly.dev/health` → `build_sha` equal to or descending from the merge sha, and `curl -fsS https://kita.balizero.com/api/health` → `commit` descending from it (the frontend half ships in this PR).

## Size

Net **941** lines against the ~400 guideline: ~366 production, ~575 tests. One concern and not splittable — the backend half alone has no consumer, which the Bites rule forbids shipping.

## Not in scope

`team.py`, `service_accounts.py`, `useTeamMembers.ts` and `staff_auth.py` are untouched: the first three belong to #5815 (merged) and #5817 (open), and the predicate is consumed, never copied. No prod row was created or modified; the census was read-only. Auto-merge is deliberately **not** armed — the builder seat here prepares, a different seat grades and ships.
