### PR TITLE
feat(consul): implement v4 synthetic lifecycle and adapter contracts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -59967,6 +59967,620 @@
         "line_number": 1158,
         "is_secret": false
       }
+    ],
+    "evidence/dual-consul-v4/design/consultation-observations.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/consultation-observations.json",
+        "hashed_secret": "f0ff3e268b95164560c0a3ee76be16614e158105",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/consultation-observations.json",
+        "hashed_secret": "e164cf32869eaa52fcafaa390690a596e240fffb",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/consultation-observations.json",
+        "hashed_secret": "b3a11626aca214407f779a4fd76f2b54577fd442",
+        "is_verified": false,
+        "line_number": 26,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/consultation-observations.json",
+        "hashed_secret": "a38adc88bf9334d1b9b75c76687adb087836f969",
+        "is_verified": false,
+        "line_number": 35,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/consultation-observations.json",
+        "hashed_secret": "7c11def01c70d7fdba2706a1fac303951403a051",
+        "is_verified": false,
+        "line_number": 44,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/design/gemini-metadata.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/gemini-metadata.json",
+        "hashed_secret": "d871b906687799d3d92c8b02b70dc88a979aa34b",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/design/manifest.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "ac33d7cf6067206e27cd344105285a3bc0c7691b",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "7d17e42772a6e5969552d637b849a20cf0f7ddd5",
+        "is_verified": false,
+        "line_number": 33,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "98ce7eab9f403b9099c80a0115e9bc7a91e75995",
+        "is_verified": false,
+        "line_number": 45,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "16fe2eefc4f17f9ed10e464de3161ba9a78f6193",
+        "is_verified": false,
+        "line_number": 57,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "f0ff3e268b95164560c0a3ee76be16614e158105",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "167589d0ed158dd1d0d0b8f066495ce381417e5b",
+        "is_verified": false,
+        "line_number": 75,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "e164cf32869eaa52fcafaa390690a596e240fffb",
+        "is_verified": false,
+        "line_number": 85,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "41a4badbe338e604314ebf7ea7112da155fe6c39",
+        "is_verified": false,
+        "line_number": 97,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "b3a11626aca214407f779a4fd76f2b54577fd442",
+        "is_verified": false,
+        "line_number": 107,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "346e99e73191594338c7f0fb8f1010ed0af86729",
+        "is_verified": false,
+        "line_number": 119,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "a38adc88bf9334d1b9b75c76687adb087836f969",
+        "is_verified": false,
+        "line_number": 129,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "69d06e2a878d6399be65dc33c3a351ceab9a2044",
+        "is_verified": false,
+        "line_number": 141,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "7c11def01c70d7fdba2706a1fac303951403a051",
+        "is_verified": false,
+        "line_number": 151,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/manifest.json",
+        "hashed_secret": "21e41594d060ac2ebf70ef4bf38c2b23955cccbe",
+        "is_verified": false,
+        "line_number": 163,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/design/tp1-deepseek-metadata.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/tp1-deepseek-metadata.json",
+        "hashed_secret": "0fa678e969c073e03ccbde519e968d738c817f22",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/tp1-deepseek-metadata.json",
+        "hashed_secret": "e164cf32869eaa52fcafaa390690a596e240fffb",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/design/tp1-glm-metadata.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/tp1-glm-metadata.json",
+        "hashed_secret": "6b163d8595cc3ec3a04821192ab2bb676e82ed35",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/tp1-glm-metadata.json",
+        "hashed_secret": "b3a11626aca214407f779a4fd76f2b54577fd442",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/design/tp1-qwen-metadata.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/tp1-qwen-metadata.json",
+        "hashed_secret": "3e741f65722026bc2434ae703816054c5f682217",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/design/tp1-qwen-metadata.json",
+        "hashed_secret": "f0ff3e268b95164560c0a3ee76be16614e158105",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/implementation/fable-review-round-1.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "4c9a85e2db5dcfce23015b6bf7e62c7534962836",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "074f12688f5e599d530d889952784125b5ffbcd2",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "87212c64e41009a54ba31cae52c42099af98020b",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "d84bb97c966c9e7c1d76679c262d40affdcca78d",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "9f355da1574b008f4c27139b1973cde135787aed",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "d5c5b00490812d41a4c7a78d8531f3f0a2b851b5",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-1.json",
+        "hashed_secret": "c86faa81580763b4f00b4fd30c615624f3aba7fb",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/implementation/fable-review-round-2.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "c99ae72a11239aca956f53478aef12681474105f",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "f7443d10c40f7deaf57202d721915cb1d0275695",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "3c0eb402ba791f1298c62d58c33f6898d7fb9dec",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "d84bb97c966c9e7c1d76679c262d40affdcca78d",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "0db20bcaefd6b582d88d012f08111067234187b3",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "7c443bddec53480763a8d62b667e968e535ba8c6",
+        "is_verified": false,
+        "line_number": 21,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "379b9bd44e57750076c17e3934acdb7445ba498f",
+        "is_verified": false,
+        "line_number": 22,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "c424136cc9469c6bb1b79be7aa3436e3eca08c3b",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "525a4d5d7fa8cd18a942610b6b4e03667c549320",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-2.json",
+        "hashed_secret": "466f115077c89a5dc10dc65eb6ca11e22ba1f204",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/implementation/fable-review-round-3.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-3.json",
+        "hashed_secret": "95dd681d32d52bca4ff01786c8d57a11676f75d9",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-3.json",
+        "hashed_secret": "d12af1c5767af03adedf632db7c74f0f9dd76741",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-3.json",
+        "hashed_secret": "211b0af8f48732fcb106d795fa6f1146e8d9bba0",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-3.json",
+        "hashed_secret": "8f0aa186eecda34c3ccfe710167a2e299c39d669",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/implementation/fable-review-round-4.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-4.json",
+        "hashed_secret": "db2a780111dda33a155919d49f39965469ebd59b",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-4.json",
+        "hashed_secret": "b1895cd93e894f59d8acbb99c95125f28acaaeac",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-4.json",
+        "hashed_secret": "517cf015dab7e21fddc5fcdf082b1cb38eb09c83",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/fable-review-round-4.json",
+        "hashed_secret": "7bf9a1b05c6fc50ca8257e9b793264bba3f867dc",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      }
+    ],
+    "evidence/dual-consul-v4/implementation/manifest.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "c6cc14c66f27475332cdbf1673382dd7150b270d",
+        "is_verified": false,
+        "line_number": 6,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "074f12688f5e599d530d889952784125b5ffbcd2",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "8e7401cee90567e23df78d740cf452e7327b643b",
+        "is_verified": false,
+        "line_number": 8,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "4c9a85e2db5dcfce23015b6bf7e62c7534962836",
+        "is_verified": false,
+        "line_number": 9,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "f7443d10c40f7deaf57202d721915cb1d0275695",
+        "is_verified": false,
+        "line_number": 10,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "ff738ee51fc1d0f11e1732c0df187247f989ac49",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "c99ae72a11239aca956f53478aef12681474105f",
+        "is_verified": false,
+        "line_number": 12,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "d12af1c5767af03adedf632db7c74f0f9dd76741",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "1590cdb2d0962511b96b931723e6b7d0a5d35238",
+        "is_verified": false,
+        "line_number": 14,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "95dd681d32d52bca4ff01786c8d57a11676f75d9",
+        "is_verified": false,
+        "line_number": 15,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "b1895cd93e894f59d8acbb99c95125f28acaaeac",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "edfdb8ea0f3f64636319e8beda10ed06c799ee93",
+        "is_verified": false,
+        "line_number": 17,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "db2a780111dda33a155919d49f39965469ebd59b",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "4d930e455e8e9bdf12479d6a85273597100cf624",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "250e31d424bbc41c4bf88035d531a6e6c5a16afa",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "3c0eb402ba791f1298c62d58c33f6898d7fb9dec",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "517cf015dab7e21fddc5fcdf082b1cb38eb09c83",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "0db20bcaefd6b582d88d012f08111067234187b3",
+        "is_verified": false,
+        "line_number": 25,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "7c443bddec53480763a8d62b667e968e535ba8c6",
+        "is_verified": false,
+        "line_number": 26,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "379b9bd44e57750076c17e3934acdb7445ba498f",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "c424136cc9469c6bb1b79be7aa3436e3eca08c3b",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "525a4d5d7fa8cd18a942610b6b4e03667c549320",
+        "is_verified": false,
+        "line_number": 29,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "evidence/dual-consul-v4/implementation/manifest.json",
+        "hashed_secret": "7bf9a1b05c6fc50ca8257e9b793264bba3f867dc",
+        "is_verified": false,
+        "line_number": 30,
+        "is_secret": false
+      }
     ]
   },
   "version": "1.5.0"

--- a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
@@ -3,6 +3,7 @@
 -- Broker connections own admission; model processes receive no database connection.
 -- Retained approval tombstones prevent revoke A -> bind B -> resurrect A.
 SET LOCAL lock_timeout = '5s';
+SET LOCAL search_path = public, pg_catalog;
 
 -- The legacy Python migration 124 is not guaranteed to have run before the SQL
 -- migration chain. Backfill its canonical Lab tables/indexes before the lease FK.

--- a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
@@ -1,0 +1,27 @@
+-- Synthetic Dual Consul slice; ownership belongs to the existing Lab run.
+-- Slot 306 was free on origin/main and Pro HEAD at implementation. Recheck at merge.
+-- Broker connections own admission; model processes receive no database connection.
+-- Retained approval tombstones prevent revoke A -> bind B -> resurrect A.
+SET LOCAL lock_timeout = '5s';
+
+CREATE TABLE public.autonomous_lab_consul_leases (
+    run_id TEXT PRIMARY KEY REFERENCES public.autonomous_lab_runs(run_id),
+    owner_id TEXT NOT NULL CHECK (owner_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$'),
+    generation BIGINT NOT NULL CHECK (generation > 0),
+    resource TEXT NOT NULL CHECK (resource ~ '^synthetic:[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$'),
+    intent_hash TEXT NOT NULL CHECK (intent_hash ~ '^[a-f0-9]{64}$'),
+    approval_hash TEXT NOT NULL CHECK (approval_hash ~ '^[a-f0-9]{64}$'),
+    review_hash TEXT NOT NULL CHECK (review_hash ~ '^[a-f0-9]{64}$'),
+    packet_hash TEXT NOT NULL CHECK (packet_hash ~ '^[a-f0-9]{64}$'),
+    lease_expires_at TIMESTAMPTZ NOT NULL CHECK (isfinite(lease_expires_at)),
+    grant_expires_at TIMESTAMPTZ NOT NULL CHECK (isfinite(grant_expires_at)),
+    revoked_at TIMESTAMPTZ CHECK (revoked_at IS NULL OR isfinite(revoked_at)),
+    revoked_approval_hashes TEXT[] NOT NULL DEFAULT '{}'
+        CHECK (array_position(revoked_approval_hashes, NULL) IS NULL
+            AND array_to_string(revoked_approval_hashes, ',') ~ '^([a-f0-9]{64}(,[a-f0-9]{64})*)?$'),
+    CHECK (lease_expires_at <= grant_expires_at),
+    CHECK (revoked_at IS NULL OR approval_hash = ANY (revoked_approval_hashes))
+);
+
+-- === ROLLBACK ===
+DROP TABLE IF EXISTS public.autonomous_lab_consul_leases;

--- a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
@@ -4,6 +4,125 @@
 -- Retained approval tombstones prevent revoke A -> bind B -> resurrect A.
 SET LOCAL lock_timeout = '5s';
 
+-- The legacy Python migration 124 is not guaranteed to have run before the SQL
+-- migration chain. Backfill its canonical Lab tables/indexes before the lease FK.
+-- This immutable snapshot reuses every apply() statement verbatim after dedent;
+-- the focused parity test detects drift. No worker or scheduler is activated.
+-- BEGIN LEGACY 124 APPLY SNAPSHOT
+CREATE TABLE IF NOT EXISTS autonomous_lab_runs (
+    run_id TEXT PRIMARY KEY,
+    idempotency_key TEXT NOT NULL UNIQUE,
+
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN (
+            'pending',
+            'running',
+            'paused',
+            'succeeded',
+            'failed',
+            'cancelled'
+        )),
+    priority INTEGER NOT NULL DEFAULT 0,
+
+    -- Machine placement and worker ownership.
+    machine_role TEXT
+        CHECK (
+            machine_role IS NULL
+            OR machine_role IN (
+                'air_m5_cockpit',
+                'pro_runtime',
+                'mini_scheduler',
+                'unknown'
+            )
+        ),
+    worker_id TEXT,
+
+    -- Receipt-safe control-plane payloads only.
+    objective TEXT NOT NULL,
+    receipt JSONB NOT NULL,
+    target_paths TEXT[] NOT NULL DEFAULT '{}',
+    metadata JSONB NOT NULL DEFAULT '{}',
+
+    -- Retry and lease state.
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_at TIMESTAMPTZ,
+    heartbeat_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    last_error TEXT,
+
+    -- Audit.
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_claimable
+    ON autonomous_lab_runs (priority DESC, created_at ASC)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_status_updated
+    ON autonomous_lab_runs (status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_worker
+    ON autonomous_lab_runs (worker_id)
+    WHERE worker_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS autonomous_lab_events_outbox (
+    event_id BIGSERIAL PRIMARY KEY,
+    run_id TEXT NOT NULL
+        REFERENCES autonomous_lab_runs(run_id)
+        ON DELETE CASCADE,
+    event_type TEXT NOT NULL
+        CHECK (event_type IN (
+            'run_enqueued',
+            'run_claimed',
+            'run_checkpointed',
+            'run_paused',
+            'run_succeeded',
+            'run_failed',
+            'run_cancelled',
+            'material_ingested',
+            'run_drafted',
+            'experiment_ready',
+            'verification_failed',
+            'candidate_ready',
+            'evaluation_recorded',
+            'curator_decision_recorded',
+            'shadow_run_completed'
+        )),
+    payload JSONB NOT NULL,
+
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN (
+            'pending',
+            'in_progress',
+            'consumed',
+            'failed_dlq'
+        )),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 5,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_by TEXT,
+    claimed_at TIMESTAMPTZ,
+    consumed_at TIMESTAMPTZ,
+    last_error TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_claimable
+    ON autonomous_lab_events_outbox (created_at ASC)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_run_id
+    ON autonomous_lab_events_outbox (run_id);
+
+CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_status_updated
+    ON autonomous_lab_events_outbox (status, updated_at);
+-- END LEGACY 124 APPLY SNAPSHOT
+
 CREATE TABLE public.autonomous_lab_consul_leases (
     run_id TEXT PRIMARY KEY REFERENCES public.autonomous_lab_runs(run_id),
     owner_id TEXT NOT NULL CHECK (owner_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$'),
@@ -24,4 +143,6 @@ CREATE TABLE public.autonomous_lab_consul_leases (
 );
 
 -- === ROLLBACK ===
+-- Preserve shared Lab tables and their data, including tables bootstrapped above.
+-- Reverting this slice removes only its lease table.
 DROP TABLE IF EXISTS public.autonomous_lab_consul_leases;

--- a/apps/backend-rag/backend/services/autonomous_lab/consul_executor.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/consul_executor.py
@@ -1,0 +1,361 @@
+"""Dual Consul's first slice: one fenced, same-database synthetic effect.
+
+The caller is a trusted broker, not a model-facing API. It supplies authenticated
+grants and reviewer observations. This does not establish service-UID isolation
+or qualify a shell, remote tool, model invocation, or production effect.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from typing import Any, Literal, TypeVar
+from uuid import NAMESPACE_URL, uuid5
+
+import asyncpg
+
+from backend.services.research_os import _core_path as _core_path
+
+# isort: split
+
+from research_os.hashing import canonicalize, object_hash
+from research_os.models.action_intent import ActionIntent
+from research_os.models.approval_receipt import ApprovalReceipt, authorizes_action_intent
+from research_os.models.execution_attempt import (
+    ExecutionAttempt,
+    validate_execution_attempt_authorization,
+)
+from research_os.models.operational_receipt import OperationalReceipt, close_execution_attempt
+from research_os.models.verification_receipt import VerificationReceipt
+from research_os.primitives import FrozenCoreModel
+
+from backend.services.autonomous_lab import consul_store
+from backend.services.autonomous_lab.runtime_contracts import (
+    LabArtifactKind,
+    LabStageName,
+    LabStageStatus,
+)
+from backend.services.autonomous_lab.stages import LabStageRiskClass, StageResult
+from backend.services.autonomous_lab.state_store import (
+    LabRunRecord,
+)
+
+EFFECT = "com.balizero.consul.synthetic_checkpoint"
+CRITERIA = "dual-consul/v4-synthetic"
+PRODUCER = {"name": "com.balizero.consul.synthetic_executor", "version": "4.0.0"}
+Model = TypeVar("Model", bound=FrozenCoreModel)
+
+
+@dataclass(frozen=True)
+class FrozenInputs:
+    """Actual bytes received by the executor; only their digests are persisted."""
+
+    run_id: str
+    artifact: bytes
+    effective_input: bytes
+    configuration: bytes
+    evidence: bytes
+    runtime_binding: bytes
+    builder: Literal["astra", "fable"]
+    reviewer: Literal["astra", "fable"]
+
+    @property
+    def digest(self) -> str:
+        packet = {
+            "run_id": self.run_id,
+            "builder": self.builder,
+            "reviewer": self.reviewer,
+            **{
+                key: sha256(getattr(self, key)).hexdigest()
+                for key in (
+                    "artifact",
+                    "effective_input",
+                    "configuration",
+                    "evidence",
+                    "runtime_binding",
+                )
+            },
+        }
+        return sha256(canonicalize(packet)).hexdigest()
+
+    @property
+    def arguments_hash(self) -> str:
+        return sha256(canonicalize({"run_id": self.run_id, "effect": EFFECT})).hexdigest()
+
+
+@dataclass(frozen=True)
+class ConsulRequest:
+    inputs: FrozenInputs
+    intent: ActionIntent
+    approval: ApprovalReceipt
+    review: VerificationReceipt
+
+    @property
+    def pins(self) -> dict[str, str]:
+        return {
+            "resource": f"synthetic:{self.inputs.run_id}",
+            "intent_hash": self.intent.object_hash,
+            "approval_hash": self.approval.object_hash,
+            "review_hash": self.review.object_hash,
+            "packet_hash": self.inputs.digest,
+        }
+
+    def validate(self, at: datetime) -> None:
+        """Check canonical grants plus the effect, resource, and frozen review."""
+        intent, approval, review, inputs = self.intent, self.approval, self.review, self.inputs
+        # Frozen Pydantic models still permit nested mutation / model_copy(update).
+        # Revalidate their wire forms at the trust boundary, including every hash.
+        for model in (intent, approval, review):
+            type(model).model_validate_json(model.model_dump_json(exclude_unset=True))
+        authorizes_action_intent(approval, intent, at=at)
+        if (
+            inputs.builder not in {"astra", "fable"}
+            or {inputs.builder, inputs.reviewer}
+            != {
+                "astra",
+                "fable",
+            }
+            or intent.producer.name != f"com.balizero.consul.{inputs.builder}"
+        ):
+            raise PermissionError("independent_consul_required")
+        if (
+            intent.action_type != EFFECT
+            or approval.authorized_effects != (EFFECT,)
+            or intent.target.system != "com.balizero.autonomous_lab"
+            or intent.target.object_ref is None
+            or intent.target.object_ref.object_kind != "com.balizero.lab_run"
+            or intent.target.object_ref.object_id != inputs.run_id
+            or intent.target.object_ref.object_hash != inputs.digest
+            or intent.input_revision_hash != inputs.digest
+            or intent.arguments_hash != inputs.arguments_hash
+            or intent.risk_class != "green"
+            or intent.sensitivity != "internal"
+        ):
+            raise PermissionError("synthetic_scope_or_input_mismatch")
+        if (
+            approval.authority.role != "consul.synthetic_broker"
+            or intent.authority_required.role != approval.authority.role
+            or approval.authority.scope != inputs.run_id
+            or intent.authority_required.scope != inputs.run_id
+            or not (approval.authority.verified_at <= approval.issued_at <= at)
+            or (approval.expires_at - approval.issued_at).total_seconds()
+            > intent.authority_required.expires_after_seconds
+        ):
+            raise PermissionError("authority_scope_mismatch")
+        target = _ref("action_intent", intent.action_intent_id, intent.object_hash)
+        if (
+            review.verdict != "pass"
+            or review.limits
+            or not review.checks
+            or any(check.result != "pass" for check in review.checks)
+            or [ref.model_dump(mode="json") for ref in review.target_objects] != [target]
+            or review.verifier.name != f"com.balizero.consul.{inputs.reviewer}"
+            or review.verifier.independence_class != "cross_family"
+            or review.criteria_version != CRITERIA
+            or review.classification != approval.classification
+            or review.expires_at is None
+            or not (review.issued_at <= review.recorded_at <= at < review.expires_at)
+            or not (intent.created_at <= review.temporal_scope.checked_at <= review.issued_at)
+        ):
+            raise PermissionError("review_missing_stale_or_mismatched")
+
+
+def _ref(kind: str, identifier: object, digest: str) -> dict[str, str]:
+    return {"object_kind": kind, "object_id": str(identifier), "object_hash": digest}
+
+
+def seal(model: type[Model], payload: dict[str, Any]) -> Model:
+    """Create a canonical ROS object without bypassing its validators."""
+    return model.model_validate({**payload, "object_hash": object_hash(payload)})
+
+
+async def _persist(
+    conn: asyncpg.Connection, kind: str, identifier: object, model: FrozenCoreModel
+) -> None:
+    payload = model.model_dump(mode="json", exclude_unset=True)
+    await conn.execute(
+        """INSERT INTO research_os_objects
+           (object_kind, object_id, object_hash, contract_version, tenant, payload)
+           VALUES ($1, $2, $3, $4, 'bali-zero', $5::text::jsonb)
+           ON CONFLICT (object_id) DO NOTHING""",
+        kind,
+        str(identifier),
+        payload["object_hash"],
+        payload["contract_version"],
+        json.dumps(payload),
+    )
+    stored = await conn.fetchval(
+        "SELECT object_hash FROM research_os_objects WHERE object_id = $1", str(identifier)
+    )
+    if stored != payload["object_hash"]:
+        raise PermissionError("immutable_object_collision")
+
+
+async def execute_synthetic(
+    conn: asyncpg.Connection, *, lease: consul_store.Lease, request: ConsulRequest
+) -> OperationalReceipt:
+    """Commit attempt, synthetic checkpoint and result atomically under PG locks.
+
+    No external callback is accepted: a local timeout cannot be misrepresented as
+    remote cancellation. On a lost commit acknowledgement, replay reads the same
+    immutable receipt instead of repeating the effect.
+    """
+    if lease.run_id != request.inputs.run_id:
+        raise PermissionError("mission_mismatch")
+    async with consul_store.guard(conn, lease=lease, **request.pins) as at:
+        request.validate(at)
+        intent, approval, review = request.intent, request.approval, request.review
+        identity = f"dual-consul:{intent.action_intent_id}:{intent.object_hash}"
+        result_id = uuid5(NAMESPACE_URL, identity + ":result")
+        existing = await conn.fetchval(
+            "SELECT payload FROM research_os_objects WHERE object_id = $1", str(result_id)
+        )
+        if existing is not None:
+            return (
+                OperationalReceipt.model_validate(existing)
+                if isinstance(existing, Mapping)
+                else OperationalReceipt.model_validate_json(existing)
+            )
+        for kind, identifier, obj in (
+            ("action_intent", intent.action_intent_id, intent),
+            ("approval_receipt", approval.approval_receipt_id, approval),
+            ("verification_receipt", review.verification_receipt_id, review),
+        ):
+            await _persist(conn, kind, identifier, obj)
+        stamp = at.isoformat().replace("+00:00", "Z")
+        base = {
+            "contract_version": "research-os/v1.0.0",
+            "tenant": "bali-zero",
+            "producer": PRODUCER,
+            "lineage": {"input_hashes": [intent.object_hash]},
+            "retention": {"retention_class": "audit", "legal_hold": False},
+        }
+        attempt = seal(
+            ExecutionAttempt,
+            {
+                **base,
+                "execution_attempt_id": str(uuid5(NAMESPACE_URL, identity + ":attempt")),
+                "action_intent_ref": {
+                    "action_intent_id": str(intent.action_intent_id),
+                    "object_hash": intent.object_hash,
+                },
+                "approval_receipt_ref": {
+                    "approval_receipt_id": str(approval.approval_receipt_id),
+                    "object_hash": approval.object_hash,
+                },
+                "attempt_number": 1,
+                "state": "started",
+                "idempotency_key": identity,
+                "executor": PRODUCER,
+                "started_at": stamp,
+                "extensions": {
+                    "com.balizero.dual-consul": {
+                        "extension_version": "1.0.0",
+                        "payload": {
+                            "lease_generation": lease.generation,
+                            "bound_context_digest": request.inputs.digest,
+                        },
+                    }
+                },
+            },
+        )
+        validate_execution_attempt_authorization(attempt, intent=intent, receipt=approval)
+        await _persist(conn, "execution_attempt", attempt.execution_attempt_id, attempt)
+        # This is the ONLY effect this implementation can perform.
+        # Expiry remains live while locks are held. Recheck it in the effect
+        # statement itself, even if an earlier receipt insert was delayed.
+        effect_at = await conn.fetchval(
+            """INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+               SELECT run_id, 'run_checkpointed', $3::text::jsonb
+               FROM autonomous_lab_consul_leases
+               WHERE run_id = $1 AND generation = $2 AND revoked_at IS NULL
+                 AND clock_timestamp() < lease_expires_at
+                 AND clock_timestamp() < grant_expires_at
+               RETURNING clock_timestamp()""",
+            lease.run_id,
+            lease.generation,
+            json.dumps(
+                {
+                    "run_id": lease.run_id,
+                    "stage": "experiment",
+                    "result": "synthetic_confirmed",
+                    "checkpoint_fingerprint": request.inputs.digest,
+                }
+            ),
+        )
+        if effect_at is None:
+            raise PermissionError("lease_expired_before_effect")
+        stamp = effect_at.isoformat().replace("+00:00", "Z")
+        receipt = seal(
+            OperationalReceipt,
+            {
+                **base,
+                "operational_receipt_id": str(result_id),
+                "operational_receipt_family_id": "com.balizero.consul.synthetic_result",
+                "receipt_type": "execution.result",
+                "subject_refs": [
+                    _ref("action_intent", intent.action_intent_id, intent.object_hash)
+                ],
+                "execution_attempt_ref": {
+                    "execution_attempt_id": str(attempt.execution_attempt_id),
+                    "object_hash": attempt.object_hash,
+                },
+                "classification": approval.classification.model_dump(mode="json"),
+                "actor_or_executor": {"producer": PRODUCER},
+                "terminal_outcome": "succeeded",
+                "outcome_code": "com.balizero.consul.synthetic_confirmed",
+                "effects": [{"effect_type": EFFECT, "status": "confirmed"}],
+                "artifact_refs": [],
+                "evidence_refs": [
+                    _ref("verification_receipt", review.verification_receipt_id, review.object_hash)
+                ],
+                "observed_at": stamp,
+                "recorded_at": stamp,
+                "idempotency_key": identity + ":result",
+                "reconciliation": {"state": "confirmed", "checked_at": stamp, "evidence_refs": []},
+            },
+        )
+        close_execution_attempt(receipt, attempt)
+        await _persist(conn, "operational_receipt", result_id, receipt)
+        return receipt
+
+
+@dataclass
+class ConsulSyntheticStage:
+    """Opt-in stage for AutonomousLabWorker; no scheduler or default activation."""
+
+    conn: asyncpg.Connection
+    request: ConsulRequest
+    owner_id: str
+    name = LabStageName.EXPERIMENT
+    input_data_class = "ConsulRequest"
+    output_data_class = "OperationalReceipt"
+    risk_class = LabStageRiskClass.LOW
+
+    async def run(self, run: LabRunRecord, context: Mapping[str, Any]) -> StageResult:
+        if run.run_id != self.request.inputs.run_id:
+            raise PermissionError("mission_mismatch")
+        at = await self.conn.fetchval("SELECT clock_timestamp()")
+        self.request.validate(at)
+        lease = await consul_store.bind(
+            self.conn,
+            run_id=run.run_id,
+            owner_id=self.owner_id,
+            **self.request.pins,
+            grant_expires_at=min(self.request.approval.expires_at, self.request.review.expires_at),
+        )
+        result = await execute_synthetic(self.conn, lease=lease, request=self.request)
+        return StageResult(
+            stage=self.name,
+            status=LabStageStatus.SUCCEEDED,
+            artifact_kind=LabArtifactKind.SANDBOX_RUN_RESULT,
+            summary="synthetic checkpoint confirmed under current ownership",
+            payload={
+                "run_id": run.run_id,
+                "result": "synthetic_confirmed",
+                "checkpoint_fingerprint": result.object_hash,
+            },
+        )

--- a/apps/backend-rag/backend/services/autonomous_lab/consul_store.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/consul_store.py
@@ -1,0 +1,176 @@
+"""PostgreSQL fencing for the synthetic Dual Consul lifecycle slice.
+
+Only the trusted broker calls ``bind``, after validating authority and the frozen
+review; hashes supplied by a model are not admission. ``guard`` encloses ONLY a
+same-connection synthetic receipt write. Its locks give no remote-effect atomicity
+and this module does not establish a separate operating-system service identity.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import asyncpg
+
+
+@dataclass(frozen=True)
+class Lease:
+    run_id: str
+    owner_id: str
+    generation: int
+
+
+async def _lock_parent(conn: asyncpg.Connection, run_id: str) -> asyncpg.Record | None:
+    return await conn.fetchrow(
+        "SELECT worker_id, status FROM autonomous_lab_runs WHERE run_id = $1 FOR UPDATE",
+        run_id,
+    )
+
+
+async def bind(
+    conn: asyncpg.Connection,
+    *,
+    run_id: str,
+    owner_id: str,
+    resource: str,
+    intent_hash: str,
+    approval_hash: str,
+    review_hash: str,
+    packet_hash: str,
+    grant_expires_at: datetime,
+    lease_seconds: int = 60,
+) -> Lease:
+    """Bind a freshly authorized grant; rebind fences every earlier generation."""
+    if not 1 <= lease_seconds <= 3600:
+        raise ValueError("lease_seconds must be between 1 and 3600")
+    if grant_expires_at.utcoffset() is None:
+        raise ValueError("grant expiry must be timezone-aware")
+    async with conn.transaction():
+        parent = await _lock_parent(conn, run_id)
+        if not parent or parent["status"] != "running" or parent["worker_id"] != owner_id:
+            raise PermissionError("run is not owned by this running worker")
+        previous = await conn.fetchrow(
+            "SELECT revoked_approval_hashes FROM autonomous_lab_consul_leases "
+            "WHERE run_id = $1 FOR UPDATE",
+            run_id,
+        )
+        if previous and approval_hash in previous["revoked_approval_hashes"]:
+            raise PermissionError("approval was revoked")
+        now = await conn.fetchval("SELECT clock_timestamp()")
+        if grant_expires_at <= now:
+            raise PermissionError("grant has expired")
+        generation = await conn.fetchval(
+            """
+            INSERT INTO autonomous_lab_consul_leases
+                (run_id, owner_id, generation, resource, intent_hash, approval_hash,
+                 review_hash, packet_hash, lease_expires_at, grant_expires_at)
+            VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (run_id) DO UPDATE SET
+                owner_id = EXCLUDED.owner_id,
+                generation = autonomous_lab_consul_leases.generation + 1,
+                resource = EXCLUDED.resource, intent_hash = EXCLUDED.intent_hash,
+                approval_hash = EXCLUDED.approval_hash, review_hash = EXCLUDED.review_hash,
+                packet_hash = EXCLUDED.packet_hash,
+                lease_expires_at = EXCLUDED.lease_expires_at,
+                grant_expires_at = EXCLUDED.grant_expires_at, revoked_at = NULL
+            RETURNING generation
+            """,
+            run_id,
+            owner_id,
+            resource,
+            intent_hash,
+            approval_hash,
+            review_hash,
+            packet_hash,
+            min(now + timedelta(seconds=lease_seconds), grant_expires_at),
+            grant_expires_at,
+        )
+        return Lease(run_id, owner_id, generation)
+
+
+async def revoke(conn: asyncpg.Connection, lease: Lease) -> bool:
+    """Revoke this generation and remember its approval across future rebinds."""
+    async with conn.transaction():
+        await _lock_parent(conn, lease.run_id)
+        row = await conn.fetchrow(
+            """
+            UPDATE autonomous_lab_consul_leases
+            SET revoked_at = clock_timestamp(),
+                revoked_approval_hashes = array_append(revoked_approval_hashes, approval_hash)
+            WHERE run_id = $1 AND owner_id = $2 AND generation = $3 AND revoked_at IS NULL
+            RETURNING run_id
+            """,
+            lease.run_id,
+            lease.owner_id,
+            lease.generation,
+        )
+        return row is not None
+
+
+async def revoke_approval(conn: asyncpg.Connection, *, run_id: str, approval_hash: str) -> bool:
+    """Trusted broker revocation, including superseded grants; False if unchanged."""
+    if not re.fullmatch(r"[a-f0-9]{64}", approval_hash):
+        raise ValueError("approval_hash must be lowercase SHA-256 hex")
+    async with conn.transaction():
+        if await _lock_parent(conn, run_id) is None:
+            return False
+        row = await conn.fetchrow(
+            """
+            UPDATE autonomous_lab_consul_leases
+            SET revoked_approval_hashes = array_append(revoked_approval_hashes, $2),
+                revoked_at = CASE WHEN approval_hash = $2
+                    THEN COALESCE(revoked_at, clock_timestamp()) ELSE revoked_at END
+            WHERE run_id = $1 AND NOT ($2 = ANY (revoked_approval_hashes))
+            RETURNING run_id
+            """,
+            run_id,
+            approval_hash,
+        )
+        return row is not None
+
+
+@asynccontextmanager
+async def guard(
+    conn: asyncpg.Connection,
+    *,
+    lease: Lease,
+    resource: str,
+    intent_hash: str,
+    approval_hash: str,
+    review_hash: str,
+    packet_hash: str,
+) -> AsyncIterator[datetime]:
+    """Hold parent/lease locks and recheck all authority pins before a DB effect."""
+    async with conn.transaction():
+        parent = await _lock_parent(conn, lease.run_id)
+        row = await conn.fetchrow(
+            "SELECT * FROM autonomous_lab_consul_leases WHERE run_id = $1 FOR UPDATE",
+            lease.run_id,
+        )
+        now = await conn.fetchval("SELECT clock_timestamp()")
+        expected = {
+            "owner_id": lease.owner_id,
+            "generation": lease.generation,
+            "resource": resource,
+            "intent_hash": intent_hash,
+            "approval_hash": approval_hash,
+            "review_hash": review_hash,
+            "packet_hash": packet_hash,
+        }
+        if (
+            not parent
+            or parent["status"] != "running"
+            or parent["worker_id"] != lease.owner_id
+            or not row
+            or any(row[key] != value for key, value in expected.items())
+            or row["revoked_at"] is not None
+            or approval_hash in row["revoked_approval_hashes"]
+            or row["lease_expires_at"] <= now
+            or row["grant_expires_at"] <= now
+        ):
+            raise PermissionError("lease, authorization or frozen review is no longer current")
+        yield now

--- a/apps/backend-rag/backend/services/autonomous_lab/state_store.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/state_store.py
@@ -294,7 +294,7 @@ WITH inserted AS (
         priority,
         max_attempts
     )
-    VALUES ($1, $2, $3, $4::jsonb, $5::text[], $6::jsonb, $7, $8)
+    VALUES ($1, $2, $3, $4::text::jsonb, $5::text[], $6::text::jsonb, $7, $8)
     ON CONFLICT (idempotency_key) DO NOTHING
     RETURNING
         run_id,
@@ -415,7 +415,7 @@ WITH updated AS (
 ),
 event_insert AS (
     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
-    SELECT run_id, 'run_succeeded', $3::jsonb
+    SELECT run_id, 'run_succeeded', $3::text::jsonb
     FROM updated
     RETURNING event_id
 )
@@ -429,7 +429,7 @@ WITH updated AS (
     UPDATE autonomous_lab_runs
     SET
         status = 'paused',
-        metadata = metadata || $3::jsonb,
+        metadata = metadata || $3::text::jsonb,
         worker_id = NULL,
         updated_at = NOW(),
         last_error = NULL
@@ -440,7 +440,7 @@ WITH updated AS (
 ),
 event_insert AS (
     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
-    SELECT run_id, 'run_paused', $4::jsonb
+    SELECT run_id, 'run_paused', $4::text::jsonb
     FROM updated
     RETURNING event_id
 )
@@ -468,7 +468,7 @@ WITH updated AS (
 ),
 event_insert AS (
     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
-    SELECT run_id, 'run_failed', $5::jsonb
+    SELECT run_id, 'run_failed', $5::text::jsonb
     FROM updated
     RETURNING event_id
 )
@@ -551,7 +551,7 @@ updated AS (
     UPDATE autonomous_lab_runs
     SET
         status = $4,
-        metadata = metadata || $5::jsonb,
+        metadata = metadata || $5::text::jsonb,
         worker_id = NULL,
         next_attempt_at = CASE WHEN $4 = 'pending' THEN NOW() ELSE next_attempt_at END,
         updated_at = NOW()
@@ -565,7 +565,7 @@ updated AS (
 ),
 event_insert AS (
     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
-    SELECT run_id, 'curator_decision_recorded', $6::jsonb
+    SELECT run_id, 'curator_decision_recorded', $6::text::jsonb
     FROM updated
     RETURNING event_id
 )
@@ -591,7 +591,7 @@ updated AS (
     UPDATE autonomous_lab_runs
     SET
         status = 'cancelled',
-        metadata = metadata || $3::jsonb,
+        metadata = metadata || $3::text::jsonb,
         worker_id = NULL,
         updated_at = NOW()
     WHERE run_id = $1
@@ -604,7 +604,7 @@ updated AS (
 ),
 event_insert AS (
     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
-    SELECT run_id, 'run_cancelled', $4::jsonb
+    SELECT run_id, 'run_cancelled', $4::text::jsonb
     FROM updated
     RETURNING event_id
 )
@@ -990,7 +990,7 @@ class AutonomousLabStateStore:
                 payload,
                 max_attempts
             )
-            VALUES ($1, $2, $3::jsonb, $4)
+            VALUES ($1, $2, $3::text::jsonb, $4)
             RETURNING event_id
             """,
             run_id,
@@ -1149,6 +1149,8 @@ def _optional_note_reference(note: str | None) -> str | None:
 
 
 def _jsonb(value: Mapping[str, Any]) -> str:
+    # Bind these serialized values as SQL text, then cast to jsonb. Passing
+    # them as jsonb parameters would run the pool's JSON encoder a second time.
     return json.dumps(dict(value), allow_nan=False, ensure_ascii=False, sort_keys=True)
 
 

--- a/apps/backend-rag/backend/services/autonomous_lab/worker.py
+++ b/apps/backend-rag/backend/services/autonomous_lab/worker.py
@@ -103,9 +103,7 @@ class LabWorkerDryRun:
             "created_at": self.created_at.isoformat(),
             "placement": self.placement.to_receipt(),
             "sandbox_policy": self.sandbox_policy.to_receipt(),
-            "checkpoints": [
-                checkpoint.to_receipt() for checkpoint in self.checkpoints
-            ],
+            "checkpoints": [checkpoint.to_receipt() for checkpoint in self.checkpoints],
             "paused_at_stage": self.paused_at_stage.value,
             "execution_allowed": self.execution_allowed,
             "manual_promotion_required": self.manual_promotion_required,
@@ -142,11 +140,12 @@ class AutonomousLabWorker:
 
         checkpoints: list[LabCheckpoint] = []
         try:
-            await self.state_store.heartbeat_run(
+            if not await self.state_store.heartbeat_run(
                 conn,
                 run_id=record.run_id,
                 worker_id=worker_id,
-            )
+            ):
+                raise PermissionError("worker no longer owns the run")
             context: dict[str, Any] = {}
             for node in _nodes_after_resume(self.stage_nodes, record):
                 result = await node.run(record, context)
@@ -160,13 +159,14 @@ class AutonomousLabWorker:
                 )
                 context[result.stage.value] = checkpoint.fingerprint
                 if result.status is LabStageStatus.PAUSED:
-                    await self.state_store.mark_run_paused(
+                    if not await self.state_store.mark_run_paused(
                         conn,
                         run_id=record.run_id,
                         worker_id=worker_id,
                         stage=result.stage.value,
                         checkpoint=checkpoint.to_receipt(),
-                    )
+                    ):
+                        raise PermissionError("worker lost ownership before pause")
                     return LabWorkerTickResult.paused(
                         worker_id=worker_id,
                         record=record,
@@ -174,12 +174,13 @@ class AutonomousLabWorker:
                         paused_at_stage=result.stage,
                     )
 
-            await self.state_store.mark_run_succeeded(
+            if not await self.state_store.mark_run_succeeded(
                 conn,
                 run_id=record.run_id,
                 worker_id=worker_id,
                 summary={"checkpoint_count": len(checkpoints)},
-            )
+            ):
+                raise PermissionError("worker lost ownership before completion")
             return LabWorkerTickResult.succeeded(
                 worker_id=worker_id,
                 record=record,

--- a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+++ b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
@@ -163,7 +163,13 @@ async def test_migration_306_bootstraps_absent_lab_and_preserves_rows_on_rollbac
         (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
     )
     async with dual_db.transaction():
+        await dual_db.execute("CREATE SCHEMA IF NOT EXISTS dual_consul_alternate")
+        await dual_db.execute("SET LOCAL search_path = dual_consul_alternate, public")
         await dual_db.execute(forward)
+        assert await dual_db.fetchval(
+            "SELECT to_regclass('public.autonomous_lab_runs') IS NOT NULL "
+            "AND to_regclass('dual_consul_alternate.autonomous_lab_runs') IS NULL"
+        )
     run_id = "consul-bootstrap-proof"
     store = await _enqueue(dual_db, run_id)
     request = make_request(await dual_db.fetchval("SELECT clock_timestamp()"), run_id)

--- a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+++ b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
@@ -1,0 +1,395 @@
+"""Opt-in real PostgreSQL proof; exact disposable database only, never models.
+
+DUAL_CONSUL_TEST_DSN must explicitly name dual_consul_test. The fixture resets
+only this slice's tables there and serializes schema setup with an advisory lock.
+Run on Pro against a disposable PostgreSQL instance, not an operational database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+import asyncpg
+import pytest
+
+from backend.app.core.database import init_asyncpg_connection
+from backend.db.migration_base import split_migration_sql
+from backend.migrations.migration_124_autonomous_lab_runtime import apply as apply_lab
+from backend.services.autonomous_lab import consul_executor, consul_store
+from backend.services.autonomous_lab.consul_executor import ConsulSyntheticStage, execute_synthetic
+from backend.services.autonomous_lab.state_store import (
+    AutonomousLabStateStore,
+    LabRunQueueItem,
+    resolve_runtime_placement,
+)
+from backend.services.autonomous_lab.worker import AutonomousLabWorker
+from backend.tests.unit.services.autonomous_lab.consul_fixtures import make_request
+
+pytestmark = pytest.mark.integration
+MIGRATIONS = Path(__file__).resolve().parents[2] / "db" / "migrations_v2"
+OWNER = "consul-astra"
+
+
+def _dsn() -> str:
+    value = os.environ.get("DUAL_CONSUL_TEST_DSN")
+    if not value:
+        pytest.skip("DUAL_CONSUL_TEST_DSN is required for isolated PostgreSQL proof")
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme not in {"postgres", "postgresql"}
+        or unquote(parsed.path) != "/dual_consul_test"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Dual Consul tests require exactly dual_consul_test without DSN overrides")
+    return value
+
+
+@pytest.fixture
+async def dual_db() -> AsyncIterator[asyncpg.Connection]:
+    conn = await asyncpg.connect(_dsn())
+    try:
+        await init_asyncpg_connection(conn)
+        if await conn.fetchval("SELECT current_database()") != "dual_consul_test":
+            raise RuntimeError("connected database is not dual_consul_test")
+        await conn.execute("SELECT pg_advisory_lock(hashtext('dual-consul-test-schema'))")
+        await conn.execute("""
+            DROP TABLE IF EXISTS autonomous_lab_consul_leases,
+                autonomous_lab_events_outbox, autonomous_lab_runs, research_os_objects CASCADE;
+            DROP FUNCTION IF EXISTS public.reject_research_os_objects_mutation();
+        """)
+        async with conn.transaction():
+            await apply_lab(conn)
+            for name in (
+                "279_research_os_contract_core.sql",
+                "280_research_os_objects_truncate_guard.sql",
+                "306_autonomous_lab_consul_leases.sql",
+            ):
+                forward, _ = split_migration_sql((MIGRATIONS / name).read_text())
+                await conn.execute(forward)
+        yield conn
+    finally:
+        await conn.close()
+
+
+def _store() -> AutonomousLabStateStore:
+    store = AutonomousLabStateStore()
+    store.placement = resolve_runtime_placement("Nuzantara", "nuzantara")
+    return store
+
+
+async def _enqueue(conn: asyncpg.Connection, run_id: str) -> AutonomousLabStateStore:
+    store = _store()
+    await store.enqueue_run(
+        conn,
+        LabRunQueueItem(
+            run_id=run_id,
+            idempotency_key=run_id,
+            objective="Synthetic Consul ownership proof",
+            receipt={"run_id": run_id, "blocked": False, "summary": "Synthetic proof only"},
+        ),
+    )
+    return store
+
+
+async def _admit(conn: asyncpg.Connection, run_id: str = "consul-db-proof") -> tuple[Any, Any]:
+    store = await _enqueue(conn, run_id)
+    assert await store.claim_next_run(conn, worker_id=OWNER) is not None
+    request = make_request(await conn.fetchval("SELECT clock_timestamp()"), run_id)
+    request.validate(await conn.fetchval("SELECT clock_timestamp()"))
+    lease = await consul_store.bind(
+        conn,
+        run_id=run_id,
+        owner_id=OWNER,
+        **request.pins,
+        grant_expires_at=request.review.expires_at,
+    )
+    return request, lease
+
+
+async def _counts(conn: asyncpg.Connection) -> tuple[int, int, int]:
+    return (
+        await conn.fetchval(
+            "SELECT count(*) FROM research_os_objects WHERE object_kind='execution_attempt'"
+        ),
+        await conn.fetchval(
+            "SELECT count(*) FROM research_os_objects WHERE object_kind='operational_receipt'"
+        ),
+        await conn.fetchval(
+            "SELECT count(*) FROM autonomous_lab_events_outbox WHERE payload->>'result'='synthetic_confirmed'"
+        ),
+    )
+
+
+async def test_migration_306_rollback_and_reapply_preserve_existing_lifecycle(
+    dual_db: asyncpg.Connection,
+) -> None:
+    forward, rollback = split_migration_sql(
+        (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
+    )
+    assert rollback is not None
+    async with dual_db.transaction():
+        await dual_db.execute(rollback)
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_consul_leases') IS NULL"
+    )
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_runs') IS NOT NULL "
+        "AND to_regclass('public.research_os_objects') IS NOT NULL"
+    )
+    async with dual_db.transaction():
+        await dual_db.execute(forward)
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_consul_leases') IS NOT NULL"
+    )
+    request, lease = await _admit(dual_db, "consul-after-reapply")
+    await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (1, 1, 1)
+
+
+@pytest.mark.parametrize("builder", ["astra", "fable"])
+async def test_worker_tick_commits_started_attempt_result_and_one_effect(
+    dual_db: asyncpg.Connection, builder: Any
+) -> None:
+    run_id = f"consul-worker-{builder}"
+    store = await _enqueue(dual_db, run_id)
+    request = make_request(
+        await dual_db.fetchval("SELECT clock_timestamp()"), run_id, builder=builder
+    )
+    stage = ConsulSyntheticStage(dual_db, request, OWNER)
+    worker = AutonomousLabWorker(placement=store.placement, state_store=store, stage_nodes=(stage,))
+    result = await worker.tick(dual_db, worker_id=OWNER)
+    assert result.status.value == "succeeded"
+    assert await _counts(dual_db) == (1, 1, 1)
+    assert (
+        await dual_db.fetchval("SELECT status FROM autonomous_lab_runs WHERE run_id=$1", run_id)
+        == "succeeded"
+    )
+    assert (
+        await dual_db.fetchval(
+            "SELECT payload->>'state' FROM research_os_objects WHERE object_kind='execution_attempt'"
+        )
+        == "started"
+    )
+
+
+async def test_exact_replay_returns_same_receipt_without_duplicate_effect(
+    dual_db: asyncpg.Connection,
+) -> None:
+    request, lease = await _admit(dual_db)
+    first = await execute_synthetic(dual_db, lease=lease, request=request)
+    second = await execute_synthetic(dual_db, lease=lease, request=request)
+    assert first == second
+    assert await _counts(dual_db) == (1, 1, 1)
+
+
+@pytest.mark.parametrize("new_owner", [OWNER, "consul-fable"])
+async def test_takeover_fences_old_generation_even_when_owner_name_is_reused(
+    dual_db: asyncpg.Connection, new_owner: str
+) -> None:
+    request, stale = await _admit(dual_db)
+    await dual_db.execute(
+        "UPDATE autonomous_lab_runs SET worker_id=$1 WHERE run_id=$2", new_owner, stale.run_id
+    )
+    current = await consul_store.bind(
+        dual_db,
+        run_id=stale.run_id,
+        owner_id=new_owner,
+        **request.pins,
+        grant_expires_at=request.review.expires_at,
+    )
+    assert current.generation == stale.generation + 1
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=stale, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+
+
+@pytest.mark.parametrize("condition", ["lease_expired", "grant_expired", "revoked", "cancelled"])
+async def test_lapsed_authority_never_reaches_effect(
+    dual_db: asyncpg.Connection, condition: str
+) -> None:
+    request, lease = await _admit(dual_db)
+    if condition == "revoked":
+        assert await consul_store.revoke(dual_db, lease)
+    elif condition == "cancelled":
+        await dual_db.execute(
+            "UPDATE autonomous_lab_runs SET status='cancelled' WHERE run_id=$1", lease.run_id
+        )
+    elif condition == "grant_expired":
+        await dual_db.execute(
+            "UPDATE autonomous_lab_consul_leases SET lease_expires_at=clock_timestamp()-interval '2 seconds', grant_expires_at=clock_timestamp()-interval '1 second'"
+        )
+    else:
+        await dual_db.execute(
+            "UPDATE autonomous_lab_consul_leases SET lease_expires_at=clock_timestamp()-interval '1 second'"
+        )
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+
+
+async def test_revoked_approval_cannot_return_after_new_grant(dual_db: asyncpg.Connection) -> None:
+    request, lease = await _admit(dual_db)
+    assert await consul_store.revoke(dual_db, lease)
+    fresh = make_request(
+        await dual_db.fetchval("SELECT clock_timestamp()"), lease.run_id, grant_revision=2
+    )
+    await consul_store.bind(
+        dual_db,
+        run_id=lease.run_id,
+        owner_id=OWNER,
+        **fresh.pins,
+        grant_expires_at=fresh.review.expires_at,
+    )
+    with pytest.raises(PermissionError, match="revoked"):
+        await consul_store.bind(
+            dual_db,
+            run_id=lease.run_id,
+            owner_id=OWNER,
+            **request.pins,
+            grant_expires_at=request.review.expires_at,
+        )
+
+
+async def test_broker_revokes_superseded_approval_without_revoking_current_grant(
+    dual_db: asyncpg.Connection,
+) -> None:
+    previous, old_lease = await _admit(dual_db)
+    current = make_request(
+        await dual_db.fetchval("SELECT clock_timestamp()"), old_lease.run_id, grant_revision=2
+    )
+    new_lease = await consul_store.bind(
+        dual_db,
+        run_id=old_lease.run_id,
+        owner_id=OWNER,
+        **current.pins,
+        grant_expires_at=current.review.expires_at,
+    )
+    assert new_lease.generation == old_lease.generation + 1
+    assert not await consul_store.revoke(dual_db, old_lease)
+    assert await consul_store.revoke_approval(
+        dual_db, run_id=old_lease.run_id, approval_hash=previous.approval.object_hash
+    )
+    assert not await consul_store.revoke_approval(
+        dual_db, run_id=old_lease.run_id, approval_hash=previous.approval.object_hash
+    )
+    with pytest.raises(PermissionError, match="revoked"):
+        await consul_store.bind(
+            dual_db,
+            run_id=old_lease.run_id,
+            owner_id=OWNER,
+            **previous.pins,
+            grant_expires_at=previous.review.expires_at,
+        )
+    result = await execute_synthetic(dual_db, lease=new_lease, request=current)
+    assert result.terminal_outcome == "succeeded"
+    assert await _counts(dual_db) == (1, 1, 1)
+    assert await dual_db.fetchval(
+        "SELECT revoked_approval_hashes FROM autonomous_lab_consul_leases WHERE run_id=$1",
+        old_lease.run_id,
+    ) == [previous.approval.object_hash]
+
+
+async def test_broker_revocation_of_current_approval_refuses_effect(
+    dual_db: asyncpg.Connection,
+) -> None:
+    request, lease = await _admit(dual_db)
+    assert await consul_store.revoke_approval(
+        dual_db, run_id=lease.run_id, approval_hash=request.approval.object_hash
+    )
+    assert not await consul_store.revoke(dual_db, lease)
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+
+
+async def test_failure_after_effect_rolls_back_all_ros_objects_and_effect(
+    dual_db: asyncpg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request, lease = await _admit(dual_db)
+    original = consul_executor._persist
+
+    async def fail_result(
+        conn: asyncpg.Connection, kind: str, identifier: object, model: Any
+    ) -> None:
+        if kind == "operational_receipt":
+            raise RuntimeError("synthetic injected result-store failure")
+        await original(conn, kind, identifier, model)
+
+    monkeypatch.setattr(consul_executor, "_persist", fail_result)
+    with pytest.raises(RuntimeError, match="injected"):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+    assert await dual_db.fetchval("SELECT count(*) FROM research_os_objects") == 0
+
+
+async def test_expiry_between_guard_and_effect_rolls_back(
+    dual_db: asyncpg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request, lease = await _admit(dual_db)
+    original = consul_executor._persist
+
+    async def expire_after_attempt(
+        conn: asyncpg.Connection, kind: str, identifier: object, model: Any
+    ) -> None:
+        await original(conn, kind, identifier, model)
+        if kind == "execution_attempt":
+            await conn.execute(
+                "UPDATE autonomous_lab_consul_leases SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE run_id=$1",
+                lease.run_id,
+            )
+
+    monkeypatch.setattr(consul_executor, "_persist", expire_after_attempt)
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+    assert await dual_db.fetchval("SELECT count(*) FROM research_os_objects") == 0
+
+
+async def test_concurrent_takeover_waits_for_guard_then_fences_it(
+    dual_db: asyncpg.Connection,
+) -> None:
+    request, lease = await _admit(dual_db)
+    other = await asyncpg.connect(_dsn())
+    await init_asyncpg_connection(other)
+    started = asyncio.Event()
+    task: asyncio.Task[Any] | None = None
+
+    async def takeover() -> Any:
+        started.set()
+        return await consul_store.bind(
+            other,
+            run_id=lease.run_id,
+            owner_id=OWNER,
+            **request.pins,
+            grant_expires_at=request.review.expires_at,
+        )
+
+    try:
+        async with consul_store.guard(dual_db, lease=lease, **request.pins):
+            task = asyncio.create_task(takeover())
+            await started.wait()
+            async with asyncio.timeout(5):
+                while not await dual_db.fetchval(
+                    "SELECT $1::int = ANY(pg_blocking_pids($2::int))",
+                    dual_db.get_server_pid(),
+                    other.get_server_pid(),
+                ):
+                    assert not task.done(), "takeover passed a held owner lock"
+            assert not task.done()
+        newer = await asyncio.wait_for(task, timeout=5)
+        assert newer.generation == lease.generation + 1
+        with pytest.raises(PermissionError):
+            await execute_synthetic(dual_db, lease=lease, request=request)
+    finally:
+        if task and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        await other.close()

--- a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+++ b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
@@ -12,6 +12,7 @@ import os
 from collections.abc import AsyncIterator
 from contextlib import suppress
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 from urllib.parse import unquote, urlsplit
 
@@ -125,6 +126,65 @@ async def _counts(conn: asyncpg.Connection) -> tuple[int, int, int]:
             "SELECT count(*) FROM autonomous_lab_events_outbox WHERE payload->>'result'='synthetic_confirmed'"
         ),
     )
+
+
+async def test_migration_306_reuses_every_canonical_124_statement() -> None:
+    statements: list[str] = []
+
+    class Recorder:
+        async def execute(self, sql: str) -> None:
+            statements.append(dedent(sql).strip())
+
+    await apply_lab(Recorder())
+    forward, _ = split_migration_sql(
+        (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
+    )
+    snapshot = (
+        forward.split("-- BEGIN LEGACY 124 APPLY SNAPSHOT\n", 1)[1]
+        .split("-- END LEGACY 124 APPLY SNAPSHOT", 1)[0]
+        .strip()
+    )
+    assert statements
+    assert snapshot == "\n\n".join(statements)
+
+
+async def test_migration_306_bootstraps_absent_lab_and_preserves_rows_on_rollback(
+    dual_db: asyncpg.Connection,
+) -> None:
+    await dual_db.execute(
+        "DROP TABLE public.autonomous_lab_consul_leases, "
+        "public.autonomous_lab_events_outbox, public.autonomous_lab_runs"
+    )
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_runs') IS NULL "
+        "AND to_regclass('public.autonomous_lab_events_outbox') IS NULL"
+    )
+    forward, rollback = split_migration_sql(
+        (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
+    )
+    async with dual_db.transaction():
+        await dual_db.execute(forward)
+    run_id = "consul-bootstrap-proof"
+    store = await _enqueue(dual_db, run_id)
+    request = make_request(await dual_db.fetchval("SELECT clock_timestamp()"), run_id)
+    worker = AutonomousLabWorker(
+        placement=store.placement,
+        state_store=store,
+        stage_nodes=(ConsulSyntheticStage(dual_db, request, OWNER),),
+    )
+    assert (await worker.tick(dual_db, worker_id=OWNER)).status.value == "succeeded"
+    assert await _counts(dual_db) == (1, 1, 1)
+    assert rollback is not None
+    async with dual_db.transaction():
+        await dual_db.execute(rollback)
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_consul_leases') IS NULL"
+    )
+    assert (
+        await dual_db.fetchval("SELECT status FROM autonomous_lab_runs WHERE run_id=$1", run_id)
+        == "succeeded"
+    )
+    assert await _counts(dual_db) == (1, 1, 1)
 
 
 async def test_migration_306_rollback_and_reapply_preserve_existing_lifecycle(

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/consul_fixtures.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/consul_fixtures.py
@@ -1,0 +1,176 @@
+"""Synthetic canonical ROS inputs shared by the focused Consul tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timedelta
+from typing import Any, Literal, TypeVar
+from uuid import NAMESPACE_URL, uuid5
+
+from backend.services.autonomous_lab.consul_executor import (
+    CRITERIA,
+    EFFECT,
+    ConsulRequest,
+    FrozenInputs,
+    seal,
+)
+
+# isort: split
+from research_os.cli import FIXTURES_ROOT
+from research_os.models.action_intent import ActionIntent
+from research_os.models.approval_receipt import ApprovalReceipt
+from research_os.models.verification_receipt import VerificationReceipt
+from research_os.primitives import FrozenCoreModel
+
+Model = TypeVar("Model", bound=FrozenCoreModel)
+
+
+def reseal(model: Model, **changes: Any) -> Model:
+    payload = model.model_dump(mode="json", exclude_unset=True)
+    payload.pop("object_hash")
+    return seal(type(model), {**payload, **changes})
+
+
+def _base(kind: str, filename: str = "valid_minimal.json") -> dict[str, Any]:
+    payload = json.loads((FIXTURES_ROOT / kind / filename).read_text())
+    payload.pop("object_hash")
+    payload["retention"] = {"retention_class": "audit", "legal_hold": False}
+    return payload
+
+
+def make_request(
+    now: datetime,
+    run_id: str = "dual-consul-synthetic",
+    *,
+    builder: Literal["astra", "fable"] = "astra",
+    reviewer: Literal["astra", "fable"] | None = None,
+    grant_revision: int = 1,
+) -> ConsulRequest:
+    reviewer = reviewer or ("fable" if builder == "astra" else "astra")
+    inputs = FrozenInputs(
+        run_id=run_id,
+        artifact=b"synthetic artifact",
+        effective_input=b"synthetic objective",
+        configuration=b"synthetic config v4",
+        evidence=b"synthetic evidence",
+        runtime_binding=b"synthetic runtime v1",
+        builder=builder,
+        reviewer=reviewer,
+    )
+
+    def identifier(kind: str) -> str:
+        return str(uuid5(NAMESPACE_URL, f"{run_id}:{kind}:{grant_revision}"))
+
+    intent_payload = _base("action_intent")
+    intent_payload.update(
+        {
+            "action_intent_id": identifier("intent"),
+            "action_type": EFFECT,
+            "target": {
+                "system": "com.balizero.autonomous_lab",
+                "object_ref": {
+                    "object_kind": "com.balizero.lab_run",
+                    "object_id": run_id,
+                    "object_hash": inputs.digest,
+                },
+            },
+            "arguments_ref": f"synthetic:{run_id}",
+            "arguments_hash": inputs.arguments_hash,
+            "input_revision_hash": inputs.digest,
+            "risk_class": "green",
+            "sensitivity": "internal",
+            "authority_required": {
+                "role": "consul.synthetic_broker",
+                "scope": run_id,
+                "expires_after_seconds": 3600,
+            },
+            "idempotency_key": identifier("intent"),
+            "expected_outcome_types": [EFFECT],
+            "created_at": (now - timedelta(seconds=20)).isoformat().replace("+00:00", "Z"),
+            "producer": {"name": f"com.balizero.consul.{builder}", "version": "4.0.0"},
+        }
+    )
+    intent = seal(ActionIntent, intent_payload)
+    approval_payload = _base("approval_receipt", "valid_action_intent_approve.json")
+    approval_payload.update(
+        {
+            "approval_receipt_id": identifier("approval"),
+            "subject": {
+                "kind": "action_intent",
+                "object_id": str(intent.action_intent_id),
+                "object_hash": intent.object_hash,
+            },
+            "context": {"action_item_ref": intent.action_item_ref.model_dump(mode="json")},
+            "authority": {
+                "role": "consul.synthetic_broker",
+                "scope": run_id,
+                "verified_at": (now - timedelta(seconds=12)).isoformat().replace("+00:00", "Z"),
+            },
+            "bindings": {
+                "input_revision_hash": inputs.digest,
+                "arguments_hash": inputs.arguments_hash,
+            },
+            "authorized_effects": [EFFECT],
+            "classification": {"risk_class": "green", "sensitivity": "internal"},
+            "issued_at": (now - timedelta(seconds=10)).isoformat().replace("+00:00", "Z"),
+            "expires_at": (now + timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+            "idempotency_key": identifier("approval"),
+        }
+    )
+    approval = seal(ApprovalReceipt, approval_payload)
+    review_payload = _base("verification_receipt")
+    review_payload.update(
+        {
+            "verification_receipt_id": identifier("review"),
+            "target_objects": [
+                {
+                    "object_kind": "action_intent",
+                    "object_id": str(intent.action_intent_id),
+                    "object_hash": intent.object_hash,
+                }
+            ],
+            "verifier": {
+                "name": f"com.balizero.consul.{reviewer}",
+                "version": "4.0.0",
+                "independence_class": "cross_family",
+            },
+            "criteria_version": CRITERIA,
+            "temporal_scope": {
+                "checked_at": (now - timedelta(seconds=8)).isoformat().replace("+00:00", "Z")
+            },
+            "issued_at": (now - timedelta(seconds=7)).isoformat().replace("+00:00", "Z"),
+            "recorded_at": (now - timedelta(seconds=6)).isoformat().replace("+00:00", "Z"),
+            "expires_at": (now + timedelta(minutes=4)).isoformat().replace("+00:00", "Z"),
+        }
+    )
+    return ConsulRequest(inputs, intent, approval, seal(VerificationReceipt, review_payload))
+
+
+def with_intent(request: ConsulRequest, **changes: Any) -> ConsulRequest:
+    """Repin approvals/review so a test reaches semantic, rather than hash, checks."""
+    intent = reseal(request.intent, **changes)
+    subject = {
+        "kind": "action_intent",
+        "object_id": str(intent.action_intent_id),
+        "object_hash": intent.object_hash,
+    }
+    approval = reseal(
+        request.approval,
+        subject=subject,
+        bindings={
+            "input_revision_hash": intent.input_revision_hash,
+            "arguments_hash": intent.arguments_hash,
+        },
+    )
+    review = reseal(
+        request.review,
+        target_objects=[
+            {
+                "object_kind": "action_intent",
+                "object_id": str(intent.action_intent_id),
+                "object_hash": intent.object_hash,
+            }
+        ],
+    )
+    return replace(request, intent=intent, approval=approval, review=review)

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_consul_executor.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_consul_executor.py
@@ -1,0 +1,169 @@
+"""Admission tests use canonical ROS objects; no model or database calls."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from backend.tests.unit.services.autonomous_lab.consul_fixtures import (
+    make_request,
+    reseal,
+    with_intent,
+)
+
+NOW = datetime(2026, 9, 6, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("builder", ["astra", "fable"])
+def test_both_consuls_can_build_with_independent_review(builder: Any) -> None:
+    assert make_request(NOW, builder=builder).validate(NOW) is None
+
+
+@pytest.mark.parametrize(
+    "field", ["artifact", "effective_input", "configuration", "evidence", "runtime_binding"]
+)
+def test_changed_effective_bytes_invalidate_the_frozen_review(field: str) -> None:
+    request = make_request(NOW)
+    inputs = replace(request.inputs, **{field: b"changed"})
+    assert inputs.digest != request.inputs.digest
+    with pytest.raises(PermissionError, match="input_mismatch"):
+        replace(request, inputs=inputs).validate(NOW)
+
+
+def test_a_consul_cannot_review_its_own_artifact() -> None:
+    request = make_request(NOW, builder="astra", reviewer="astra")
+    with pytest.raises(PermissionError, match="independent_consul"):
+        request.validate(NOW)
+
+
+def test_declared_builder_must_match_the_intent_producer() -> None:
+    request = with_intent(
+        make_request(NOW), producer={"name": "com.balizero.consul.fable", "version": "4.0.0"}
+    )
+    with pytest.raises(PermissionError, match="independent_consul"):
+        request.validate(NOW)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"authorized_effects": ["com.example.effect.publish"]},
+        {
+            "authority": {
+                "role": "other.role",
+                "scope": "dual-consul-synthetic",
+                "verified_at": (NOW - timedelta(seconds=12)).isoformat().replace("+00:00", "Z"),
+            }
+        },
+        {
+            "authority": {
+                "role": "consul.synthetic_broker",
+                "scope": "other-run",
+                "verified_at": (NOW - timedelta(seconds=12)).isoformat().replace("+00:00", "Z"),
+            }
+        },
+    ],
+)
+def test_approval_must_authorize_exact_effect_role_and_scope(changes: dict[str, Any]) -> None:
+    request = make_request(NOW)
+    with pytest.raises(PermissionError):
+        replace(request, approval=reseal(request.approval, **changes)).validate(NOW)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"action_type": "com.example.effect.publish"},
+        {
+            "authority_required": {
+                "role": "other.role",
+                "scope": "dual-consul-synthetic",
+                "expires_after_seconds": 3600,
+            }
+        },
+        {
+            "authority_required": {
+                "role": "consul.synthetic_broker",
+                "scope": "other-run",
+                "expires_after_seconds": 3600,
+            }
+        },
+        {
+            "authority_required": {
+                "role": "consul.synthetic_broker",
+                "scope": "dual-consul-synthetic",
+                "expires_after_seconds": 10,
+            }
+        },
+    ],
+)
+def test_intent_cannot_expand_the_grant(changes: dict[str, Any]) -> None:
+    with pytest.raises(PermissionError):
+        with_intent(make_request(NOW), **changes).validate(NOW)
+
+
+@pytest.mark.parametrize("field", ["approval", "review"])
+def test_expiry_is_exclusive(field: str) -> None:
+    request = make_request(NOW)
+    expired = reseal(getattr(request, field), expires_at=NOW.isoformat().replace("+00:00", "Z"))
+    with pytest.raises((ValueError, PermissionError)):
+        replace(request, **{field: expired}).validate(NOW)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"verdict": "pass_with_limits"},
+        {"limits": ["synthetic-limitation"]},
+        {"checks": []},
+        {"criteria_version": "outdated"},
+        {
+            "verifier": {
+                "name": "com.balizero.consul.astra",
+                "version": "4",
+                "independence_class": "cross_family",
+            }
+        },
+        {
+            "verifier": {
+                "name": "com.balizero.consul.fable",
+                "version": "4",
+                "independence_class": "self",
+            }
+        },
+    ],
+)
+def test_review_must_be_current_independent_and_unrestricted(changes: dict[str, Any]) -> None:
+    request = make_request(NOW)
+    with pytest.raises(PermissionError, match="review"):
+        replace(request, review=reseal(request.review, **changes)).validate(NOW)
+
+
+@pytest.mark.parametrize("field", ["intent", "approval", "review"])
+def test_model_copy_cannot_bypass_canonical_hash_checks(field: str) -> None:
+    request = make_request(NOW)
+    modified = getattr(request, field).model_copy(update={"object_hash": "0" * 64})
+    with pytest.raises(ValidationError, match="object_hash"):
+        replace(request, **{field: modified}).validate(NOW)
+
+
+def test_nested_extension_mutation_is_revalidated_at_admission() -> None:
+    request = make_request(NOW)
+    review = reseal(
+        request.review,
+        extensions={
+            "com.balizero.test": {
+                "extension_version": "1.0.0",
+                "payload": {"synthetic_tags": ["before"]},
+            }
+        },
+    )
+    request = replace(request, review=review)
+    request.validate(NOW)
+    review.extensions["com.balizero.test"].payload["synthetic_tags"].append("after")
+    with pytest.raises(ValidationError, match="object_hash"):
+        request.validate(NOW)

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_consul_store.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_consul_store.py
@@ -1,0 +1,177 @@
+"""Control-flow tests; PostgreSQL locking is proved by the synthetic DB smoke."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from backend.services.autonomous_lab.consul_store import Lease, bind, guard, revoke, revoke_approval
+
+NOW = datetime(2026, 9, 6, tzinfo=timezone.utc)
+LEASE = Lease("synthetic-run", "consul-astra", 2)
+PINS = {
+    "resource": "synthetic:receipt",
+    "intent_hash": "a" * 64,
+    "approval_hash": "b" * 64,
+    "review_hash": "c" * 64,
+    "packet_hash": "d" * 64,
+}
+
+
+class Connection:
+    def __init__(self, rows: list[Any], values: list[Any] | None = None) -> None:
+        self.rows = rows
+        self.values = list(values if values is not None else [NOW])
+        self.active = False
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    @asynccontextmanager
+    async def transaction(self) -> Any:
+        self.active = True
+        try:
+            yield
+        finally:
+            self.active = False
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        assert self.active
+        self.calls.append((query, args))
+        return self.rows.pop(0)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        assert self.active
+        self.calls.append((query, args))
+        return self.values.pop(0)
+
+
+def parent(**changes: Any) -> dict[str, Any]:
+    return {"worker_id": LEASE.owner_id, "status": "running", **changes}
+
+
+def row(**changes: Any) -> dict[str, Any]:
+    return {
+        **PINS,
+        "owner_id": LEASE.owner_id,
+        "generation": LEASE.generation,
+        "lease_expires_at": NOW + timedelta(seconds=60),
+        "grant_expires_at": NOW + timedelta(minutes=5),
+        "revoked_at": None,
+        "revoked_approval_hashes": [],
+        **changes,
+    }
+
+
+@pytest.mark.asyncio
+async def test_guard_holds_locks_through_effect_and_reads_clock_after_locks() -> None:
+    conn = Connection([parent(), row()])
+    async with guard(conn, lease=LEASE, **PINS) as timestamp:
+        assert conn.active
+        assert timestamp == NOW
+        assert all("FOR UPDATE" in query for query, _ in conn.calls[:2])
+        assert conn.calls[2][0] == "SELECT clock_timestamp()"
+    assert not conn.active
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"owner_id": "consul-fable"},
+        {"generation": 3},
+        {"resource": "synthetic:other"},
+        *[{name: "e" * 64} for name in PINS if name.endswith("_hash")],
+        {"lease_expires_at": NOW},
+        {"grant_expires_at": NOW},
+        {"revoked_at": NOW},
+        {"revoked_approval_hashes": [PINS["approval_hash"]]},
+    ],
+)
+async def test_guard_refuses_before_effect_for_every_stale_pin(changes: dict[str, Any]) -> None:
+    conn = Connection([parent(), row(**changes)])
+    with pytest.raises(PermissionError):
+        async with guard(conn, lease=LEASE, **PINS):
+            pytest.fail("unauthorized effect entered")
+    assert not conn.active
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("run", [None, parent(status="cancelled"), parent(worker_id="other")])
+async def test_guard_refuses_missing_or_no_longer_owned_run(run: Any) -> None:
+    with pytest.raises(PermissionError):
+        async with guard(Connection([run, row()]), lease=LEASE, **PINS):
+            pytest.fail("unauthorized effect entered")
+
+
+@pytest.mark.asyncio
+async def test_bind_uses_new_db_generation_and_clamps_lease_to_grant() -> None:
+    expiry = NOW + timedelta(seconds=20)
+    conn = Connection([parent(), {"revoked_approval_hashes": []}], [NOW, 3])
+    lease = await bind(
+        conn, run_id=LEASE.run_id, owner_id=LEASE.owner_id, **PINS, grant_expires_at=expiry
+    )
+    assert lease == Lease(LEASE.run_id, LEASE.owner_id, 3)
+    assert conn.calls[-1][1][-2:] == (expiry, expiry)
+    assert not conn.active
+
+
+@pytest.mark.asyncio
+async def test_bind_never_resurrects_an_older_revoked_approval() -> None:
+    conn = Connection([parent(), {"revoked_approval_hashes": [PINS["approval_hash"]]}])
+    with pytest.raises(PermissionError, match="revoked"):
+        await bind(
+            conn,
+            run_id=LEASE.run_id,
+            owner_id=LEASE.owner_id,
+            **PINS,
+            grant_expires_at=NOW + timedelta(minutes=5),
+        )
+    assert len(conn.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_bind_refuses_expired_grant_before_write() -> None:
+    conn = Connection([parent(), None])
+    with pytest.raises(PermissionError, match="expired"):
+        await bind(conn, run_id=LEASE.run_id, owner_id=LEASE.owner_id, **PINS, grant_expires_at=NOW)
+    assert len(conn.calls) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("updated, expected", [(None, False), ({"run_id": LEASE.run_id}, True)])
+async def test_revoke_returns_actual_owner_scoped_update(updated: Any, expected: bool) -> None:
+    conn = Connection([parent(), updated])
+    assert await revoke(conn, LEASE) is expected
+    assert conn.calls[1][1] == (LEASE.run_id, LEASE.owner_id, LEASE.generation)
+    assert not conn.active
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("digest", ["", "a" * 63, "a" * 65, "A" * 64, "g" * 64])
+async def test_revoke_approval_rejects_invalid_hash_before_database(digest: str) -> None:
+    conn = Connection([])
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        await revoke_approval(conn, run_id=LEASE.run_id, approval_hash=digest)
+    assert conn.calls == []
+
+
+@pytest.mark.asyncio
+async def test_revoke_approval_does_not_invent_a_missing_mission() -> None:
+    conn = Connection([None])
+    assert not await revoke_approval(conn, run_id=LEASE.run_id, approval_hash=PINS["approval_hash"])
+    assert len(conn.calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("updated, expected", [(None, False), ({"run_id": LEASE.run_id}, True)])
+async def test_revoke_approval_reports_whether_a_new_tombstone_was_added(
+    updated: Any, expected: bool
+) -> None:
+    conn = Connection([parent(), updated])
+    assert (
+        await revoke_approval(conn, run_id=LEASE.run_id, approval_hash=PINS["approval_hash"])
+        is expected
+    )
+    assert not conn.active

--- a/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_worker.py
+++ b/apps/backend-rag/backend/tests/unit/services/autonomous_lab/test_worker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -49,6 +49,41 @@ class FailingStageNode:
 
     async def run(self, _run: LabRunRecord, _context: dict[str, Any]) -> Any:
         raise RuntimeError("token=abcdef1234567890 RAW_PRIVATE_SENTENCE_SHOULD_NOT_APPEAR")
+
+
+@pytest.mark.asyncio
+async def test_lost_heartbeat_prevents_stage_execution() -> None:
+    store = _pro_store()
+    stage = FailingStageNode()
+    with (
+        patch.object(store, "heartbeat_run", new=AsyncMock(return_value=False)),
+        patch.object(stage, "run", new=AsyncMock()) as execute,
+    ):
+        result = await AutonomousLabWorker(state_store=store, stage_nodes=(stage,)).tick(
+            FakeAsyncConnection(fetchrow_results=[_row(), {"updated_count": 0}]),
+            worker_id="old-owner",
+        )
+    assert result.status is LabStageStatus.FAILED
+    execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lost_completion_cannot_report_success() -> None:
+    store = _pro_store()
+    node = NoopLabStageNode(
+        LabStageName.WATCH,
+        "input",
+        "output",
+        LabStageRiskClass.LOW,
+        LabArtifactKind.FRONTIER_SIGNAL,
+        "synthetic stage complete",
+    )
+    conn = FakeAsyncConnection(fetchrow_results=[_row(), {"event_id": 1}, {"updated_count": 0}])
+    with patch.object(store, "mark_run_succeeded", new=AsyncMock(return_value=False)):
+        result = await AutonomousLabWorker(state_store=store, stage_nodes=(node,)).tick(
+            conn, worker_id="old-owner"
+        )
+    assert result.status is LabStageStatus.FAILED
 
 
 def _row(**overrides: Any) -> dict[str, Any]:

--- a/docs/architecture/dual-consul/adapters.md
+++ b/docs/architecture/dual-consul/adapters.md
@@ -1,0 +1,56 @@
+# Five route-specific adapters v4
+
+**Contributors:** Kimi, Qwen, DeepSeek, Gemini, and GLM. **Synthesis:** Astra; reviewed by Fable 5.1.
+**Attribution boundary:** the sections below are editorial synthesis, not verbatim model replies. [Selected consultation observations](../../../evidence/dual-consul-v4/design/consultation-observations.json) index final answers and allowlisted metadata recovered from the original recorded tool outputs. Qwen, DeepSeek, GLM, and Kimi answer hashes match the design packet. Gemini's text and parsed result are recovered, but its original stdout-byte hash cannot be recomputed from the re-serialized record; its newly computed selected-text hash is labeled separately. [Fable's final synthesis](../../../evidence/dual-consul-v4/design/fable-v4-final.txt) is recovered verbatim with verified native provenance.
+
+## Common surface and reported request parameters
+
+Use `discover`, `admit`, `invoke`, `checkpoint/handoff`, and `cancel` through the existing Research OS contracts and route-specific extensions. Admission covers scoped data egress and quota even for a no-tools request. Preserve native definitions of usage counters, unknown completeness, and separate local/remote cancellation. Locally validate structured outputs when required; no route below has a qualified native schema guarantee.
+
+The table describes historical consultations, not current executable qualification. TP1 request/response fields and Kimi request metadata were recovered from recorded tool output; Kimi CLI version and Gemini requested-model/CLI syntax are retained from the design packet. Shared transport does not mean shared parameter support.
+
+| Binding                          | Model sent or resolved                   | Effort sent                                      | Other reported controls                                              | Identity reported   |
+| -------------------------------- | ---------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------- | ------------------- |
+| Kimi no-tools CLI 0.41.0 profile | Alias `kimi-code/k3`, request model `k3` | Inherited `max`; no verified per-mission setting | `tools: []`; request `maxTokens=1048576`                             | `request_observed`  |
+| Qwen TP1                         | `qwen3.8-max`                            | `medium`                                         | `max_tokens=4096`; local deadline 180 s; one request                 | `response_observed` |
+| DeepSeek TP1                     | `deepseek-v4-pro`                        | Omitted                                          | `max_tokens=4096`; local deadline 180 s; one request; user-only body | `response_observed` |
+| Gemini `agy`                     | Requested `gemini-3.1-pro-high`          | No separately qualified override                 | Plan mode; boolean `--sandbox`; `--conversation <ID>` for resume     | `unknown`           |
+| GLM TP1                          | `glm-5.2`                                | Omitted                                          | `max_tokens=4096`; local deadline 180 s; one request                 | `response_observed` |
+
+The three original TP1 tool records carry HTTP 200, matching model fields, and `finish_reason=stop`. This directly confirms the final user plan. Fable's final review had received a packet without those finish fields and consequently requested them; its historical missing-field premise is corrected here, not silently rewritten in the preserved evidence.
+
+One consultation per family and no retries are reported. Durations, task contexts, and provider counters differ, so these observations are not a comparative benchmark. Request-side identity is insufficient for an exact-model mission. Unknown identity cannot silently pass admission.
+
+## Kimi contribution and binding
+
+[Kimi's original contribution](../../../evidence/dual-consul-v4/design/kimi-answer.txt) distinguished no-tools consultation through the existing profile from future native agentic CLI/ACP use. Preserve these as separate bindings. The observed empty active tool inventory validates participation in that specific consultation only; native tool use, ACP, and mission-governed cancellation remain unqualified.
+
+Record both alias and request-resolved model; do not label request metadata as response identity. Inherited `max` effort and a 1,048,576-token request ceiling do not implement an ordinary mission budget. No `--effort` flag is invented. Both Kimi bindings are ineligible for missions requiring a verified hard output cap until a setting is discovered and tested on the installed surface. Native transcript retention remains product state, separate from shared redacted evidence. A no-tools binding still needs scoped egress and consumption authorization.
+
+## Qwen contribution and binding
+
+Reuse TP1 for `qwen3.8-max`; keep native Qwen CLI qualification separate. The consultation accepted `medium` on the wire. [Qwen's original contribution](../../../evidence/dual-consul-v4/design/tp1-qwen-answer.txt) explicitly left its reasoning semantics, tool calling, native JSON-schema enforcement, and mid-generation cancellation unvalidated. Parameter acceptance does not prove enforcement. Preserve response-model metadata and finish reason when present; unknown or truncated output is not automatically an ambiguous external effect.
+
+Reject costly deliberate timeout/large-output experiments proposed during design. Use bounded fixtures first. Removing reasoning fields from shared output limits retention, not generated token consumption.
+
+## DeepSeek contribution and binding
+
+Reuse TP1 for `deepseek-v4-pro` with effort omitted. The current request body is user-only; do not introduce a fictitious system-directive option. The retired direct API remains excluded. Local `deepseek-r1:32b` is a distinct host-local binding with separate capabilities, never an equivalent fallback.
+
+[DeepSeek's original contribution](../../../evidence/dual-consul-v4/design/tp1-deepseek-answer.txt) described this route as a bounded text transport without native conversation-history, multi-turn, or cancellation management. Exact pre-flight consumption and remote cancellation remain unproven. A mission requiring a total-consumption ceiling is ineligible until enforceable evidence exists. An output cap or local deadline cannot supply that evidence.
+
+## Gemini contribution and binding
+
+Use `agy` with IDs actually exposed by the installed runtime. The successful turn requested `gemini-3.1-pro-high` according to the design packet; the recovered parsed output omitted the served identifier. Record identity as unknown and refuse exact-model admission. [Gemini's original contribution](../../../evidence/dual-consul-v4/design/gemini-answer.txt) invented arguments: the design packet's verified command syntax uses boolean `--sandbox` and `--conversation <ID>`; neither `--sandbox terminal` nor `--conversation resume` is supported by the design evidence.
+
+Do not combine a high-suffixed model with a separate effort override without validation. A successful JSON response does not prove strict schema enforcement, sandbox containment, tool denial, or governed resume. Retain cached usage under its native field definition without adding it to a total again. These operational capabilities remain qualification gaps.
+
+## GLM contribution and binding
+
+Reuse TP1 for `glm-5.2` with effort omitted. Its qualified participation surface is text. Protocol compatibility conveys no native Claude tools, identity, or permissions. [GLM's original contribution](../../../evidence/dual-consul-v4/design/tp1-glm-answer.txt) explicitly rejected treating the local 180-second deadline as provider-side cancellation and treating `max_tokens=4096` as a verified reasoning/total budget. Preserve those limitations at admission and report late replies without restoring cancelled attempts.
+
+## Focused qualification and staged use
+
+Share executor conformance proofs. Per-route fixtures cover incompatible parameters, model mismatch, request-only or missing identity, missing finish reason, truncated text, structural exclusion of reasoning fields, and timeout/late-response behavior. Unknown tool support means unqualified, not proof the model fundamentally lacks it. Retain provider-native usage fields without reasoning double count.
+
+Use a bounded real smoke on introduction or a relevant runtime/configuration/authentication change, within existing authorization. Do not run a full campaign on every PR or force a long response to test a timeout. Promotion follows local, shadow without external effects, staging, authorized canary, and operations under the [common contract](common-contract.md). Initial synthetic executor tests grant none of the native runtime or remote effect capabilities above.

--- a/docs/architecture/dual-consul/astra-native.md
+++ b/docs/architecture/dual-consul/astra-native.md
@@ -1,0 +1,34 @@
+# Astra native integration v4
+
+**Design author:** Astra. **Design reviewer:** Fable 5.1, with accepted v3 comments and final v4 amendments.
+**Editorial provenance:** this document implements the owner's consolidated Astra specification; it is not a verbatim recovered Astra response. Fable's cross-review is preserved in [v3 evidence](../../../evidence/dual-consul-v4/design/fable-v3-revised.txt).
+
+## Native surface
+
+Use Codex App Server for the consul integration, preserving native instructions, permissions, sessions, compaction, and agent events. The official protocol exposes `model/list` for discovery, `config/read` for effective configuration, and native thread/turn operations. Its role here is an interactive integration rather than a replacement scheduler. [Official App Server documentation](https://learn.chatgpt.com/docs/app-server), checked 2026-09-06.
+
+Before initial admission, discover the installed runtime's available models and supported efforts, read its effective layered configuration, and record the observed schema/version. Reuse current observations under the cache rules in the [common contract](common-contract.md). Never infer availability on Pro or Mini from a successful M5 consultation or a configuration file.
+
+The execution extension records requested model, observed model and assurance, provider, requested and effective effort, runtime version, host/authentication-context digest, effective configuration digest, native thread/turn identifiers, actual input artifact hash, and mission/grant references. Record missing fields as unknown. A model change invalidates the binding-dependent review and triggers fresh admission.
+
+## Profiles, permissions, and workers
+
+Maintain distinct logical profiles for difficult design, ordinary operation, review, and workers. Set effort from the mission class and discovered runtime support. Reserve `ultra` for a justified difficult task on a surface that supports it. No cross-provider effort equivalence is implied.
+
+Launch with a minimal explicit environment and verify the environment actually seen by the child. `inherit=none` alone is insufficient when layered `env.set` entries survive. Strip disallowed global entries before applying the narrowly approved mission environment; do not log values or copy general service credentials. Keep filesystem/network confinement evidence separate from credential-isolation evidence.
+
+Use scoped native permissions. The broker answers native approval requests from the actual grant and records an `ApprovalReceipt` with that grant reference. The distinct-service-identity executor remains authoritative immediately before effects. An App Server approval response or hook is not proof of external authorization enforcement.
+
+Track observable delegation modes by binary version. The global maximum of four workers applies only when all admitted delegation is observable and controllable. Disable unobservable worker expansion rather than allow hidden delegation to bypass the limit. Four workers is a ceiling, not a default allocation.
+
+## Continuity, cancellation, and evidence
+
+Preserve native compaction and same-mission resume, repeating authorization, fence, config, and input checks first. Thread continuity confers no company-memory authority. A new mission gets a new binding and context boundary.
+
+On cancellation, revoke the mission grant/ownership in PostgreSQL, interrupt the native turn, and terminate supervised processes. Record local interruption independently from remote operation status. Retain bounded, selected, redacted provider evidence for reconciliation; never retain full streams or hidden reasoning by default. Late replies cannot revive a cancelled or superseded attempt.
+
+## Qualification still required
+
+The initial synthetic slice exercises common lifecycle and ownership rules. Operational App Server launch, environment isolation, broker approval handling, delegation observability, native resume, process-group cancellation, and host eligibility require their own versioned evidence. The prior plan reports M5 discovery and narrow sandbox observations; this document does not upgrade them into a fresh runtime attestation.
+
+Focused qualification covers layered `env.set` leakage, identity/config changes, unsupported effort, stale-owner effect refusal despite hook bypass, changed-artifact review invalidation, revoked resume, and local interruption with a late remote response. Share common executor proofs and use protocol fixtures before bounded real smoke tests. Fleet activation is a later stage in the common contract.

--- a/docs/architecture/dual-consul/claude-native.md
+++ b/docs/architecture/dual-consul/claude-native.md
@@ -1,0 +1,43 @@
+# Claude native integration v4
+
+**Specification author:** Fable 5.1. **Design reviewer:** Astra.
+**Editorial assembly:** verified v3 native-spec text plus Fable's final v4 amendments, followed by clearly separated implementation notes.
+
+## Authorship and precedence
+
+The two specification sections below reproduce Fable's own text verbatim from native session `433c29dd-e09f-4070-b1e9-a8da0136970c`. The locally inspected assistant records identify `message.model=claude-fable-5-1`, runtime `2.1.261`, and `stop_reason=end_turn`. Full selected responses and byte hashes are in the [design manifest](../../../evidence/dual-consul-v4/design/manifest.json).
+
+The v4 amendments govern where they narrow or correct v3. In particular, "interactive" eligibility in v3 means only **interactive, tools-empty, plan-mode design text** after the v4 correction. Neither this historical review nor its native model metadata qualifies the implementation being built now. Session links and commit trailers authenticate nothing.
+
+- [V3 source](../../../evidence/dual-consul-v4/design/fable-v3-revised.txt): `715a665f9ae3f90d7d4ead019bef7cb8796d0afe9085b02f389e3bb8c669bf43`.
+- [Final v4 source](../../../evidence/dual-consul-v4/design/fable-v4-final.txt): `2a6af479053f98e6da77366e4e9538bab66afc2032ac6f6cccbb96af17af616f`.
+
+## Revised native specification: Fable v3, verbatim
+
+- **Entry.** Version-pinned CLI launched by the trusted launcher, which records the native model identifier, session identifier, CLI version, host, and auth class. Interactive is the current eligible surface. Headless print mode becomes eligible only after the entitlement check passes and is cached by CLI version, account, and host digest. Ambiguity fails closed. The exact flag set is verified from the installed CLI help output and docs, never from my assertion.
+- **Binding.** The execution extension under the Claude namespace records requested and resolved model, effort actual, session identifier, config digest, admission budget, and artifact input hash. Assurance level is runtime_observed. Model changes inherit no authorization or prior review.
+- **Enforcement.** The distinct-UID executor is authoritative for effects, fencing, and revocation. The hook denies obvious violations early and writes started journal entries. Tools that cannot meet the boundary are disabled for effects and may emit ActionIntents. Review missions get read-only tools. Design missions get none. No claim of OS confinement for the Claude surface until allowed and denied probes exist, which they do not today.
+- **Effort, context, cache.** Effort comes from a policy table keyed by mission class. Top levels require a stated reason. Stable contract text precedes variable packet text for cache benefit. Fast mode runs a different model and is excluded from consul verdicts. Capability lookups are cached, not probed per mission.
+- **Sessions.** Ephemeral when no resume is needed. Same-mission resume permitted after fresh checks. Native compaction is convenience. Company authority remains PG and provenance records.
+- **Cancellation.** Revoke in PG, interrupt the native turn, terminate the supervised process group, mark ambiguous effects reconcile_required, and keep any provider response evidence.
+- **Economy.** Observed counters for input, cached, reasoning, and output, with unknown fields explicit. Provider max-output is not a total cap.
+- **Tests.** CLI flag capture. Executor deny on stale fence with hook bypass attempted. Journal transitions including timeout after remote commit. Entitlement check with fail-closed ambiguity. Env allowlist. Process-group kill with reconciliation. Receipt invalidation on artifact change. Native usage fields matched to the ledger. Resume with revoked authorization must fail.
+
+## Final amendments: Fable v4, verbatim
+
+- **Validated surface.** Interactive, tools empty, plan mode, design text. Recorded as response_observed identity from the native model field in this session.
+- **Unqualified surfaces.** Headless entitlement, interactive tool use under the executor boundary, native resume with fresh checks, hook deny path, env isolation, process-group cancellation. Each stays a recorded gap until its fixture or smoke passes.
+- **Identity.** Assurance level runtime_observed, sub-level response_observed. No trailer or link claim.
+- **Budget.** Effort from the mission-class table. Where a hard output cap is required and no verified setting exists for the installed CLI version, the binding is ineligible for that requirement rather than silently weakened.
+- **Cancellation reporting.** Local interruption and remote cancellation are separate fields. Ambiguous effects only become reconcile_required. Truncated or unfinished text is incomplete.
+- **Tests.** As in v3, plus one fixture for unknown completeness and one for request-observed identity mismatch.
+
+## Implementation notes: editorial, not Fable-authored text
+
+The [common contract](common-contract.md) defines canonical receipt semantics. A hook may annotate a local started journal, but a model-side hook cannot issue an authoritative successful receipt or replace the executor's immediate grant/fence/resource checks. The distinct-identity executor is a required operational boundary, not a property established by the first synthetic test.
+
+Headless remains disabled until version-, host-, configuration-, and authentication-specific entitlement and consumption evidence is sufficient. Ambiguity fails admission. Existing authorization can satisfy the check; the design creates no new mandatory human confirmation. A call requiring new spending still needs the owner's authorization. Current Claude documentation states that non-interactive `-p` and Agent SDK requests can bill usage credits without the interactive consent prompt. [Official Fable usage-credit documentation](https://code.claude.com/docs/en/model-config#fable-and-usage-credits), checked 2026-09-06.
+
+Preserve native instructions, permissions, and same-mission continuity without treating them as company authority. Do not equate effort names with another provider or substitute a different model without a fresh binding. Discover exact CLI flags from the installed runtime before use. Evidence retention is selected and redacted under an explicit storage budget; full native transcripts and internal reasoning are excluded from shared evidence by default.
+
+The first synthetic increment does not launch Claude, test entitlement, exercise its tools, resume a native session, or cancel a remote operation. The outstanding fixtures and bounded smoke tests in Fable's text remain a qualification checklist for later stages; they are not an all-PR test requirement. Promotion uses the common staged rollout with per-host evidence and rollback to the prior binding.

--- a/docs/architecture/dual-consul/common-contract.md
+++ b/docs/architecture/dual-consul/common-contract.md
@@ -1,0 +1,64 @@
+# Dual Consul Harness: common contract v4
+
+**Design:** Astra and Fable; consolidated from the owner's accepted v4 plan, 2026-09-06.
+**Implementation status:** initial synthetic slice; operational qualification and fleet activation remain separate.
+
+This contract defines one governance layer with two native consul integrations and route-specific adapters. Either consul may lead a mission; the other reviews the frozen artifact. A model, account, runtime, or role change confers no authority and preserves no review automatically. Environment permissions and the owner's scope, interruption, and revocation remain effective. This design adds no mandatory human reapproval or general CI gate.
+
+## Reuse and ownership
+
+Autonomous Lab owns mission state and lifecycle. Research OS owns canonical intents, attempts, handoffs, evidence, and receipts. The existing conductor owns binding discovery and registry integration. There is no second scheduler or parallel canonical ledger.
+
+Reuse the [Research OS canonical contracts](../../../research/operations/specs/evidence-to-action-freeze-2026-08-15/CONTRACTS.md) unchanged. Add route-specific data through versioned reverse-DNS extensions. An extension cannot weaken canonical semantics, become an authorization, or acquire release-gate authority by itself. Canonical semantic changes follow the existing freeze-change protocol.
+
+PostgreSQL is authoritative for mission ownership, scoped grants, expiry, revocation, and monotonically increasing fencing versions. Redis is auxiliary. A trusted executor under a distinct service identity rechecks the grant, current owner and fence, exact resource, action, and input immediately before every effect. The model process receives no general service credentials. Hooks, worktree conventions, and a local lease check alone do not establish this boundary.
+
+An ownership claim succeeds only if its authoritative transaction succeeds. Renewal, takeover, cancellation, and resume never restore a stale owner or expired grant. Tests of simulated ownership are identified as synthetic tests, not evidence of a deployed distinct-identity executor.
+
+## Admission and binding evidence
+
+A binding records requested and observed model, provider and route, runtime version, host, authentication-context digest, effective configuration digest, supported schema, tested capabilities, evidence references, and expiry. Capability eligibility is computed for the specific mission; configured or participation-observed does not imply effects-qualified.
+
+| Identity assurance  | Evidence                                               | Exact-model requirement                            |
+| ------------------- | ------------------------------------------------------ | -------------------------------------------------- |
+| `response_observed` | Native response metadata matches the requested binding | May satisfy the identity requirement while current |
+| `request_observed`  | Requested/resolved alias seen on the request wire only | Insufficient                                       |
+| `unknown`           | Effective identity absent or unverified                | Insufficient                                       |
+
+These are observation levels, not cryptographic model signatures. Self-assertions, commit trailers, and session links do not authenticate a model. A historical report of metadata is distinguished from original metadata inspected during qualification.
+
+Cache discovery by runtime version, configuration, host, and authentication context, with an explicit expiry. Revalidate after a relevant change. A mission demanding a hard output, total-consumption, tool, identity, or cancellation bound is ineligible when the adapter cannot enforce that requirement; never silently lower the requirement.
+
+## Execution, outcomes, and review
+
+Record an `ActionIntent`, scoped authorization through the existing grant and receipt contracts, and an immutable started `ExecutionAttempt`. Record the actual result separately through `OperationalReceipt`. A local action journal may project `pending`, `started`, `confirmed`, and `reconcile_required`; these names do not redefine canonical closed enums. Journal entries bind action, exact resource, input, and idempotency key.
+
+Text completeness is separate: `complete`, `incomplete`, or `unknown`, based on provider termination evidence. Missing finish metadata means unknown completeness; short length or HTTP 200 does not prove completion. Truncated text is incomplete. An uncertain consequential effect requires reconciliation against the remote system where possible. A local timeout proves neither remote cancellation nor absence of an effect. Replay requires authoritative status/idempotency checks, not an optimistic retry.
+
+A review receipt binds the artifact/tree hash, actual input packet, effective binding/configuration, tool/runtime versions, and evidence set. Material changes invalidate it. The reviewer must be independent of the artifact's generator; receipt construction is not evidence that a review occurred. Resolve disagreements in at most two cycles, suspend the disputed point, and continue independent work.
+
+Resume the same native mission/session only after fresh authorization, ownership/fence, configuration, and input checks. Do not reuse sessions across unrelated missions. Native compaction is context management, not company memory authority. Keep transactional state, working context, episodes, and documentary knowledge separate; retrieved prose and summaries remain untrusted evidence.
+
+## Adapter surface and economy
+
+Each adapter implements discovery, mission admission, invocation, checkpoint/handoff, and cancellation through the existing contracts. Native runtimes retain their own session and tool semantics. Cancellation reports local interruption and remote cancellation separately.
+
+Use one lead, a narrow review packet, and at most four workers: a ceiling, not a target. Admit native delegation only when observable and controllable under that ceiling. Avoid repeated unchanged discovery and context reads. Preserve provider-native usage counters with unknown fields explicit; reasoning already included in output is never added again. An output-token limit is not a total-spend limit, and hiding reasoning does not save generated tokens.
+
+Share executor conformance tests. Add focused adapter fixtures for incompatible parameters, identity gaps, incomplete/unknown responses, excluded fields, and late responses. Run bounded real smoke tests on introduction or relevant changes, not on every PR or every host. Preserve `change_map`, `impact_map`, and advisory exclusions from `merge_group`. Delete tests only for demonstrated redundancy or lack of useful coverage; do not relocate a general harness suite into every PR.
+
+## First slice and rollout boundaries
+
+The first slice connects a synthetic mission through the existing `AutonomousLabWorker(stage_nodes=...)` lifecycle, uses a narrow synthetic grant, binds a review receipt to a frozen packet, and rejects an expired or superseded owner. PostgreSQL parent/lease locks serialize resource, packet hash, owner, epoch, expiry, and revocation checks with a same-database synthetic receipt effect. Canonical `ActionIntent.input_revision_hash` binds the artifact, effective input, configuration, evidence, toolchain, builder, and reviewer identifiers; `VerificationReceipt` targets the exact intent hash. Extensions remain observational.
+
+Acceptance evidence must distinguish the successful path, stale-owner refusal, changed-artifact refusal, and revoked-authority refusal. Synthetic reviewer identifiers exercise independence checks but do not claim an actual model performed a semantic review. Pure adapter admission/normalization fixtures establish only their tested rules. This increment does not qualify remote effects, native launch/resume/cancellation, a distinct-service-identity boundary, provider entitlement, or production reliability.
+
+The [implementation evidence and reproduction commands](../../../evidence/dual-consul-v4/implementation/README.md) identify the opt-in consumer, real PostgreSQL proof, and remaining activation boundaries.
+
+Activation progresses through local development, shadow without external effects, staging, an authorized canary, and operations. Each transition requires versioned bindings, comparable metrics, evidence for the required capabilities, and rollback to the prior binding. Rollback does not revive revoked ownership or authorization. Pro hosts the authoritative broker; Air-M5 remains a thin client; Mini runs executors only where required and qualified. Host eligibility is verified independently, never inferred from another host's configuration.
+
+## Design provenance
+
+The [evidence manifest](../../../evidence/dual-consul-v4/design/manifest.json) verifies three Fable assistant text blocks from native session `433c29dd-e09f-4070-b1e9-a8da0136970c`, with `message.model=claude-fable-5-1` and runtime `2.1.261`. The final response accepts the design with five corrections. This is historical design review, not review of the implementation.
+
+[Astra](astra-native.md), [Claude](claude-native.md), and the [five adapters](adapters.md) specify their own surfaces. Selected original tool outputs preserve the other-family contributions and their metadata. Four original answer hashes match the packet; Gemini's selected response has its own computed hash because its original stdout bytes are unavailable. Remaining observation gaps are explicit. No consultation is presented as a comparable benchmark.

--- a/evidence/2026-09/agent-air-m5-infra-dual-consul-v4-caf4cc71/brief.yml
+++ b/evidence/2026-09/agent-air-m5-infra-dual-consul-v4-caf4cc71/brief.yml
@@ -1,0 +1,52 @@
+task_id: dual-consul-v4
+gear: 3
+gear_reason:
+  Adds PostgreSQL migration 306 and a fenced Autonomous Lab executor stage; database migration
+  and authorization checks are the hot-zone floor.
+objective:
+  Version the accepted Dual Consul v4 design and selected authentic evidence, repair the MIR
+  projection from its cards, and connect a synthetic mission stage to the existing Autonomous Lab lifecycle
+  without another scheduler.
+scope:
+  - Same-database synthetic receipt effect serialized with current lease, scoped grant, resource, frozen
+    packet, expiry, and revocation checks.
+  - Canonical Research OS ActionIntent and VerificationReceipt binding; runtime extensions remain observational
+    rather than authorization.
+  - Pure adapter admission and response normalization with explicit identity, budget, completeness, and
+    cancellation limits.
+constraints:
+  - Prepare-only external builder; no own merge, auto-merge, deploy, or fleet activation.
+  - No operational provider launch, service-identity provisioning, or remote effect qualification by the
+    implemented adapter.
+  - No production database mutation; real PostgreSQL verification uses an isolated temporary cluster on
+    Pro with synthetic records.
+  - Preserve selected original design-answer bytes and hashes.
+  - Preserve change_map, impact_map, and advisory merge_group exclusions; no general harness suite added
+    to unrelated PRs.
+acceptance:
+  - text:
+      WHEN a synthetic owner is stale or revoked, the executor SHALL reject the protected same-database
+      effect; changed frozen packets SHALL invalidate review.
+    probe: backend/tests/integration/test_dual_consul_postgres.py
+  - text:
+      WHEN identity or hard budget requirements are unsupported, adapter admission SHALL refuse rather
+      than weaken them; incomplete replies SHALL retain their incomplete status.
+    probe: scripts/tests/test_conductor_adapter_contracts.py
+  - text: The model capability index SHALL match its source cards without promoting runtime eligibility.
+    probe: python -m scripts.conductor.build_model_capability_index --check
+  - text: The final executor, admission and migration source SHALL receive independent native consul review.
+    status: verified
+    probe:
+      Read native session 9db691ab-8167-459b-a921-54857dde0d49 assistant text and compare selected
+      input packets and final source SHA-256; no thinking blocks selected.
+risks:
+  - A same-database transaction does not establish a distinct OS service identity or qualify native tool
+    use, provider entitlement, resume, or remote cancellation.
+  - Production deployment and operational reliability remain unmeasured.
+  - Historical design consultations are not implementation review or runtime certification.
+pii: none
+instruction_to_the_grader:
+  Review the frozen implementation and actual test evidence, especially row-lock
+  ordering, fencing and revocation at the effect boundary, exact input binding, replay under current authority,
+  and JSON storage through the real asyncpg codec. Synthetic success cannot establish remote or distinct-identity
+  enforcement.

--- a/evidence/2026-09/agent-air-m5-infra-dual-consul-v4-caf4cc71/pack.yml
+++ b/evidence/2026-09/agent-air-m5-infra-dual-consul-v4-caf4cc71/pack.yml
@@ -1,0 +1,132 @@
+brief_ref: evidence/brief.yml
+recorded_at: "2026-09-05T23:37:18Z"
+timestamp_semantics:
+  Test timestamps come from the clock at invocation or while the final PostgreSQL command
+  was running; no exact PostgreSQL start is claimed. The earlier MIR receipt timestamp is its recording
+  time. Full output is preserved in test-results.json.
+scope_status: prepare-only-synthetic-slice
+gate_status: source-review-passed; release-gate-not-published
+review:
+  native_session: 9db691ab-8167-459b-a921-54857dde0d49
+  expected_model: claude-fable-5-1
+  final_delta_status: PASS
+  note:
+    "Four authentic native text responses: two source rounds plus the new missing-foundation prerequisite
+    and its prescribed schema-pin acknowledgment. Review is scoped to recorded file hashes. No release
+    gate is published."
+  observed_model: claude-fable-5-1
+  evidence: evidence/dual-consul-v4/implementation/manifest.json
+seat_override:
+  The owner's accepted v4 mandate uses one lead and the other consul for narrow frozen-artifact
+  review, with no duplicated routine council. This prepare-only packet uses the independent Fable review
+  on the frozen artifact; historical design consultations are not counted as implementation council quorum.
+  This schema exception confers no gate verdict, merge, or deployment authority.
+lanes:
+  - lane: dual-consul-implementation
+    role: build
+    seat: codex (OpenAI root conductor)
+  - lane: lifecycle-ground
+    role: build
+    seat: codex (OpenAI delegated PostgreSQL lifecycle verification)
+  - lane: spec-artifacts
+    role: build
+    seat: codex (OpenAI selected evidence and documentation)
+  - lane: independent-native-review
+    role: review
+    seat: claude-fable-5-1 (observed native model; bounded tools-empty source reviews)
+diff:
+  scope:
+    Design documents and selected provenance; MIR projection repair; common adapter capability contracts;
+    additive PostgreSQL lease migration and the injected Autonomous Lab synthetic stage with targeted
+    tests.
+  authority_boundary:
+    PostgreSQL checks and the synthetic receipt effect share a transaction. Native launch,
+    remote effects, and distinct service identity are not enabled.
+pii_scan: clean
+pii_scan_scope:
+  This packet contains technical paths, synthetic database identifiers, and selected design
+  provenance. No client rows, credentials, or raw reasoning.
+receipts:
+  - claim: Existing and new Autonomous Lab unit tests passed.
+    cmd: ". /Users/balizero/nuzantara/apps/backend-rag/.venv/bin/activate
+
+      PYTHONPATH=apps/backend-rag python -m pytest apps/backend-rag/backend/tests/unit/services/autonomous_lab/
+      --tb=short --color=no"
+    cwd: /Users/balizero/nuzantara/.worktrees/infra-dual-consul-v4
+    exit: 0
+    result: 231 passed in 1.03s
+    ts: 2026-09-05 23:37:54 UTC
+    seat: codex root conductor (actual captured tool output)
+    evidence: evidence/dual-consul-v4/implementation/test-results.json
+  - claim: Registry, host identity, seat mapping, calibration, and adapter tests passed.
+    cmd: ". /Users/balizero/nuzantara/.venv/bin/activate
+
+      python -m pytest scripts/tests/test_conductor_model_registry.py scripts/tests/test_conductor_host_identity.py
+      scripts/tests/test_conductor_host_seat_maps.py scripts/tests/test_conductor_calibration.py scripts/tests/test_conductor_adapter_contracts.py
+      -q --tb=short"
+    cwd: /Users/balizero/nuzantara/.worktrees/infra-dual-consul-v4
+    exit: 0
+    result: 89 passed, 798 subtests passed in 4.41s
+    ts: 2026-09-05 23:37:54 UTC
+    seat: codex root conductor (actual captured tool output)
+    evidence: evidence/dual-consul-v4/implementation/test-results.json
+  - claim: The MIR generator confirms the checked-in capability index matches its cards.
+    cmd: python -m scripts.conductor.build_model_capability_index --check
+    environment: Existing activated repository virtualenv from the prior scripts test run.
+    cwd: /Users/balizero/nuzantara/.worktrees/infra-dual-consul-v4
+    exit: 0
+    result: Silent success
+    ts: "2026-09-05T23:37:18Z"
+    seat: codex root conductor (observed output; recording relayed to spec-artifacts)
+  - claim: Real PostgreSQL synthetic lifecycle and fencing integration tests passed.
+    cmd:
+      ssh pro 'cd /Users/nuzantara/nuzantara/.worktrees/infra-dual-consul-proof/apps/backend-rag && source
+      .venv/bin/activate && PGHOST=/tmp/dual-consul-pg.aoqbxz PGPORT=55487 DUAL_CONSUL_TEST_DSN=postgresql:///dual_consul_test
+      PYTHONPATH=. python -m pytest backend/tests/integration/test_dual_consul_postgres.py --tb=short --color=no'
+    exit: 0
+    result: 18 passed in 1.96s
+    environment:
+      Isolated temporary PostgreSQL 17.8 cluster on Pro using a Unix socket and the current implementation
+      worktree; synthetic records only.
+    ts: 2026-09-05 23:47:46 UTC
+    seat: codex root conductor (actual captured tool output)
+    evidence: evidence/dual-consul-v4/implementation/test-results.json
+  - claim:
+      Final independent source review PASS, bound to current covered source hashes; no release authorization
+      implied.
+    cmd:
+      Read native session 9db691ab-8167-459b-a921-54857dde0d49 assistant text and compare selected input
+      packets and final source SHA-256; no thinking blocks selected.
+    exit: 0
+    ts: "2026-09-05T23:48:16.924Z"
+    seat: claude-fable-5-1
+    evidence: evidence/dual-consul-v4/implementation/manifest.json
+dissent:
+  - seat: claude-fable-5-1 (verified historical v4 design review)
+    status: CONFIRMED
+    objection:
+      Model-side hooks and worktrees cannot establish the required distinct-service identity. This
+      increment proves only the synthetic same-database boundary; native invocation, remote effects, and
+      OS identity separation remain unqualified.
+  - seat: codex lifecycle-ground (real PostgreSQL verification)
+    status: CONFIRMED
+    objection:
+      Unit-test fakes missed JSON double encoding under the real asyncpg codec. The implementation
+      was corrected and the recorded real PostgreSQL run passed. The correction demonstrates why fake-only
+      success was insufficient.
+  - seat: claude-fable-5-1 (first-round native review, reported by root conductor)
+    status: CONFIRMED
+    objection:
+      "Receipt replay still requires fresh live lease authority. This is retained intentionally:
+      old execution evidence cannot restore expired or revoked authority. Final native source review accepted
+      this retained boundary."
+  - seat: claude-fable-5-1 (second source review prompted empirical preflight)
+    status: CONFIRMED
+    objection:
+      Checking historical JSON rows found both Lab foundation tables absent in production. The
+      previous FK-only migration would have failed. Migration306 now backfills the exact legacy124 SQL before
+      the FK; new absence-path and parity tests pass. The prerequisite and exact schema-pin correction both
+      received native PASS.
+remaining:
+  - Independent release session verifies the complete PR and existing required checks before merge/deploy.
+  - Native runtime effects and fleet staging/canary qualification remain separate from this increment.

--- a/evidence/dual-consul-v4/design/consultation-observations.json
+++ b/evidence/dual-consul-v4/design/consultation-observations.json
@@ -1,0 +1,62 @@
+{
+  "status": "selected_original_recorded_tool_outputs_recovered",
+  "routes": [
+    {
+      "family": "Qwen",
+      "evidence_status": "original_recorded_tool_output_recovered",
+      "answer_path": "tp1-qwen-answer.txt",
+      "answer_sha256": "11c735dd1e741f1ba5aea9dee3aa49c986e82a55cb15726f3e53ec97d0bd7074",
+      "metadata_path": "tp1-qwen-metadata.json",
+      "identity_assurance": "response_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "family": "DeepSeek",
+      "evidence_status": "original_recorded_tool_output_recovered",
+      "answer_path": "tp1-deepseek-answer.txt",
+      "answer_sha256": "d0eac772539f324e759a6ed6095ecd62cbe6202d7d6ab210b05c1db9aadd0f50",
+      "metadata_path": "tp1-deepseek-metadata.json",
+      "identity_assurance": "response_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "family": "GLM",
+      "evidence_status": "original_recorded_tool_output_recovered",
+      "answer_path": "tp1-glm-answer.txt",
+      "answer_sha256": "2d30f0dcb3b74959601c2cea721a80413216687aca502b5c55d8faa4c9ae7067",
+      "metadata_path": "tp1-glm-metadata.json",
+      "identity_assurance": "response_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "family": "Kimi",
+      "evidence_status": "original_recorded_tool_output_recovered",
+      "answer_path": "kimi-answer.txt",
+      "answer_sha256": "165cf07b9f6e5617e11b4b7f2b8717a073aa6db0d1c643b92d4ff02b6c27cf81",
+      "metadata_path": "kimi-metadata.json",
+      "identity_assurance": "request_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "family": "Gemini",
+      "evidence_status": "response_and_parsed_result_recovered_original_stdout_bytes_unavailable",
+      "answer_path": "gemini-answer.txt",
+      "answer_sha256": "3e17794372af183688e3a2ac56b1bede5804ac03b08d1ddb44641ebc87d61061",
+      "metadata_path": "gemini-metadata.json",
+      "identity_assurance": "unknown",
+      "original_stdout_sha256_verified": false
+    }
+  ],
+  "qualification": "Historical text participation only. Recorded tool metadata is observation evidence, not a cryptographic provider attestation or operational effect qualification.",
+  "consultation_count": {
+    "Kimi": 1,
+    "Qwen": 1,
+    "DeepSeek": 1,
+    "Gemini": 1,
+    "GLM": 1
+  },
+  "new_live_calls_during_document_extraction": 0,
+  "benchmark_comparability": false,
+  "finish_reason_correction": "All three original TP1 tool records carry finish_reason=stop. This directly confirms the user plan correction to the missing-field premise in Fable final review.",
+  "retention": "Selected final answer text and allowlisted metadata only. Original output proposals are not instructions; rejected flags, costly probes, and governance claims remain historical."
+}

--- a/evidence/dual-consul-v4/design/fable-v2-review.txt
+++ b/evidence/dual-consul-v4/design/fable-v2-review.txt
@@ -1,0 +1,59 @@
+Design-only review per packet DC-20260906-v2. No tools were run, no files read or written, and I rely only on the supplied evidence.
+
+**A. Verdict and corrections**
+
+The hybrid shape is acceptable. Reusing the Lab queue, Research OS records, and conductor registry is the right call, and the "no second scheduler" constraint should be treated as binding. The plan overstates three things and underspecifies two.
+
+- **Proven from supplied evidence: Astra is validated only on M5.** The plan makes Pro the authoritative broker, but Pro and Mini only have a configured model, not a validated one. Correction: the broker schedules missions by capability state, and Astra execution is placed only on hosts whose registry entry is in the tested state. Configured and validated must be distinct enum values in the host card, never inferred from config.toml.
+- **Proven gap: no fencing exists anywhere today.** The Lab lacks epochs and stale-claim reclaim, and the Redis lease is advisory with fail-open paths. Correction: the fencing token is issued by the PG lease row and copied into every ExecutionAttempt extension. The local executor rejects any effectful action whose token is older than the current epoch. Until that check has a passing test, no record may claim exclusive ownership.
+- **Proven gap: SECURITY.md describes enforcement that has no implementation.** Correction: every enforcement claim carries a state of documented, implemented, or tested. Documented-only items cannot be cited as controls in a mission or review receipt.
+- **Proposal, unverified: sandbox claims for both runtimes are policy, not confinement.** The Codex profile inherits global env.set, and the Lab sandbox_runner is argv and cwd policy. Correction: managed launch with an explicit env allowlist, plus an effective-audit receipt holding a hash of the actual env keys and cwd seen by the child. Neither native sandbox may be described as OS confinement until a test proves the boundary.
+- **Proposal: Fable automation is asymmetric today and the spec should say so.** Interactive Fable on Max is observed. Headless is unvalidated and may bill credits. Until the guard in section B passes, Fable participates through operator-launched sessions only. The harness_fable_gate script publishes a caller verdict and must never be cited as a Fable review.
+- **MIR repair** stays a projection fix. Rebuild the index from cards, keep fail-closed on mismatch, and fix stale counts in tests without promoting any card.
+
+**B. Claude-native candidate spec**
+
+- **Entrypoint and session lifecycle.** One mission per session. Stage one is the interactive CLI, launched by an operator on the host account, with the mission packet supplied by paste or a single file. Stage two is headless print mode, activated only after the credit guard passes. Each session emits a ConductorHandoff at start and a VerificationReceipt or OperationalReceipt at end, both carrying the session URL, CLI version, model id, and effort actual. Sessions do not resume across missions. Long missions checkpoint through the Lab, not through CLI resume.
+- **Auth and credit guard.** The observed picker shows Fable on Max without a credits requirement for interactive use. Official docs warn that headless mode may consume usage credits. Guard: headless is off by default in the registry. Activation requires Zero to confirm entitlement in the native UI, a single trivial headless invocation with a hard turn limit, and an operator check that no credit charge appeared. The result is written to the host card as a capability state keyed by CLI version, account, and host. Any change to those keys invalidates the state. Failure or ambiguity falls back to interactive only.
+- **Permissions enforcement boundary.** Claude permission modes are enforced by the CLI harness, not by the OS. Interactive mode gives a human prompt per action. Headless mode relies on tool allow and deny lists, which are policy. The company boundary therefore lives in a PreToolUse hook, which is a documented interception point. The hook checks the fencing token, the mission tool allowlist, and the workspace path, denies on any mismatch, and appends a receipt before the action runs. Effectful missions run in a dedicated git worktree on a mission branch. Review missions get read-only tools. Design missions get no tools, as in this session.
+- **Effort, context, cache, tools.** Effort is chosen from a policy table keyed by mission class, not by name matching to Codex ultra. Default is medium for reviews and high for lead work. The top two levels are reserved for the difficult class and require a stated reason in the Mission record. Reviewer context is a frozen packet: diff, evidence hashes, and questions, with an explicit token ceiling. Stable content such as the contract and mission header goes first so provider caching can apply, and variable content goes last. Fast mode runs Opus, not Fable, so it may not be used for a consul verdict. Repeated file reads are counted as retry waste.
+- **Handoff and review identity.** Identity is attested by the session URL, the commit trailer format observed in this session, the host account, and the launching operator. The CLI provides no cryptographic signature. The contract records identity assurance as operator-rooted, not model-rooted. A review receipt binds the hash of the diff, the packet, and the toolchain versions. Any material change invalidates it and requires a new narrow packet.
+- **Cancellation.** Interactive: operator interrupt, then a cancellation record. Headless: revoke in PG first, then kill the process group of the CLI child. Because the hook writes a receipt before each action, the set of unknown in-flight effects is bounded to actions between the last receipt and the kill. Reconciliation compares receipts to the worktree state.
+- **Tests needed.** Capture the exact flag set from the installed CLI help output before any flag is pinned. Hook-deny test with a stale fencing token. Hook receipt ordering test. Headless credit guard test with a one-turn limit. Env allowlist test proving no inherited secrets. Process-group kill test with reconciliation. Review receipt invalidation test on a one-line diff change. Token accounting test that reads usage from the native output and matches the mission ledger.
+
+**C. Common-contract amendments and staged protocol**
+
+Amendments to the shared contract:
+
+- **Capability state** enum on every host and model card: configured, validated, tested. Only tested entries are schedulable.
+- **Enforcement state** enum on every control: documented, implemented, tested.
+- **Namespaces** by reverse DNS, one per runtime, with core fields identical. Adapters write only under their own namespace.
+- **Evidence key** is the tested tree hash plus test, config, tool, and runtime versions. A PR SHA alone does not satisfy it.
+- **Identity assurance** field with values operator-rooted or runtime-signed. All current runtimes are operator-rooted.
+- **Ceilings** recorded in the Mission record with the phrase "ceiling, not target".
+
+Staged protocol for Kimi, Qwen, DeepSeek, Gemini, and GLM:
+
+1. **Freeze contract v1** between Astra and Fable, with disagreements closed in at most two cycles.
+2. **One bounded consultation per model.** Identical packet, capped at fifteen hundred words, asking for its real entrypoint, auth and billing behavior, permission boundary, effort and cache controls, cancellation behavior, identity attestation, and an explicit list of what it cannot claim. Each response is stored verbatim with a hash. No response is paraphrased into the adapter without the hash reference.
+3. **Adapter draft** per model by one lead consul, reviewed by the other with a narrow packet.
+4. **Delta-only follow-up** only where the response contradicts the contract or leaves a required field empty.
+5. **One smoke per adapter** on a host with existing credentials, moving the card to validated. No new account or paid activation without a Zero decision.
+
+Order follows credential availability. Any model without existing access stays at stage two.
+
+**D. Amendment decision**
+
+Accepted in full. Two clarifications. Test deletion requires impact-map evidence that no unique coverage is lost, recorded in the PR. The capability cache invalidation keys must include the account and auth state, since the credit guard depends on them.
+
+Still unvalidated:
+
+- Astra availability on Pro and Mini.
+- Fable headless entitlement and billing behavior.
+- Hook-based fencing enforcement, which does not exist yet.
+- Env isolation of both native launchers.
+- The exact CLI flag set on version 2.1.261.
+- Whether the broker under a separate UID can run on Pro alongside its dirty work without interference.
+- All five external model consultations, which have not happened.
+
+END_FABLE_DC_V2

--- a/evidence/dual-consul-v4/design/fable-v3-revised.txt
+++ b/evidence/dual-consul-v4/design/fable-v3-revised.txt
@@ -1,0 +1,37 @@
+Revised Claude spec, round 3. No tools, no evidence inspected.
+
+**Corrections**
+
+1. **Accept.** The PreToolUse hook is same-UID and bypassable by direct shell or network. It becomes defense-in-depth plus UX. The authoritative boundary is the trusted executor under a distinct UID, which rechecks authorization, current fence, and resource immediately before each effect. The model process holds no broad service credentials. Worktree is convention only.
+2. **Accept.** Pre-action receipts record intent or started, never success. The journal is pending, started, confirmed, or reconcile_required, keyed by action plus idempotency key. Remote status queries resolve ambiguity where available. Git state alone is not reconciliation.
+3. **Accept, with one factual note.** My system context in this session contains an attribution instruction for commit trailers, but I observed no actual commit, and a trailer authenticates nothing. Identity assurance uses the native model and session identifiers captured by the trusted launcher, compared to the requested binding, and marked runtime_observed. Links are optional metadata.
+4. **Accept.** The Codex named sandbox has narrow but real filesystem and network confinement evidence. The inherited env.set is a separate unresolved credential-isolation defect. Both are tracked as distinct items.
+5. **Accept.** My three-state enum contradicted itself. Replace it with observed identity, schema compatibility, smoke evidence, tested capability set, and expiry. Eligibility is derived per required capability, host, and auth context. The headless credit guard is a verifiable entitlement check that fails closed on ambiguity. No extra human gate when product or account evidence suffices. Only a call that would require new spending pauses.
+6. **Accept.** Interactive mode is not a per-action human prompt. Preauthorized work proceeds under runtime and broker policy. No new mandatory reapproval or CI.
+7. **Accept.** Same-mission native resume is allowed after fresh authorization, fence, config, and input checks. No reuse across unrelated missions.
+8. **Accept.** Only duplicate unchanged reads count as waste. Test deletion needs concrete coverage or redundancy reasoning, not impact-map output alone, and no large audit suite.
+
+**Revised Claude-native spec**
+
+- **Entry.** Version-pinned CLI launched by the trusted launcher, which records the native model identifier, session identifier, CLI version, host, and auth class. Interactive is the current eligible surface. Headless print mode becomes eligible only after the entitlement check passes and is cached by CLI version, account, and host digest. Ambiguity fails closed. The exact flag set is verified from the installed CLI help output and docs, never from my assertion.
+- **Binding.** The execution extension under the Claude namespace records requested and resolved model, effort actual, session identifier, config digest, admission budget, and artifact input hash. Assurance level is runtime_observed. Model changes inherit no authorization or prior review.
+- **Enforcement.** The distinct-UID executor is authoritative for effects, fencing, and revocation. The hook denies obvious violations early and writes started journal entries. Tools that cannot meet the boundary are disabled for effects and may emit ActionIntents. Review missions get read-only tools. Design missions get none. No claim of OS confinement for the Claude surface until allowed and denied probes exist, which they do not today.
+- **Effort, context, cache.** Effort comes from a policy table keyed by mission class. Top levels require a stated reason. Stable contract text precedes variable packet text for cache benefit. Fast mode runs a different model and is excluded from consul verdicts. Capability lookups are cached, not probed per mission.
+- **Sessions.** Ephemeral when no resume is needed. Same-mission resume permitted after fresh checks. Native compaction is convenience. Company authority remains PG and provenance records.
+- **Cancellation.** Revoke in PG, interrupt the native turn, terminate the supervised process group, mark ambiguous effects reconcile_required, and keep any provider response evidence.
+- **Economy.** Observed counters for input, cached, reasoning, and output, with unknown fields explicit. Provider max-output is not a total cap.
+- **Tests.** CLI flag capture. Executor deny on stale fence with hook bypass attempted. Journal transitions including timeout after remote commit. Entitlement check with fail-closed ambiguity. Env allowlist. Process-group kill with reconciliation. Receipt invalidation on artifact change. Native usage fields matched to the ledger. Resume with revoked authorization must fail.
+
+**Cross-review of the Astra spec**
+
+The spec is compatible with the shared contract. Three notes, all proposals:
+
+- **Unobservable delegation.** Disabling automatic worker expansion when native delegation is unobservable is correct. The card should record which delegation modes are observable per binary version, since this changes across releases.
+- **On-request approvals.** The broker deciding native approval requests is the right boundary. Record each decision as an ApprovalReceipt with the grant reference, so later review can distinguish policy grants from human grants.
+- **Provider evidence retention.** Keeping stream evidence when the client transport breaks needs a storage budget and redaction rule, otherwise it conflicts with the no-raw-client-data policy.
+
+**Other-family routes.** Accepted as stated. Each adapter records its route type, wrapper or native CLI or gateway, and the slug actually resolved. MIR slug mismatches and the gateway effort translation stay per-route facts. Any native CLI flag is verified by tooling or docs before it enters an adapter.
+
+**Shared v3.** Accepted. Still unvalidated: Astra on Pro and Mini, Claude headless entitlement, the distinct-UID executor, env isolation for both launchers, the installed CLI flag set, and all five external consultations.
+
+END_FABLE_DC_V3

--- a/evidence/dual-consul-v4/design/fable-v4-final.txt
+++ b/evidence/dual-consul-v4/design/fable-v4-final.txt
@@ -1,0 +1,38 @@
+Design-only review, no tools, no evidence inspected beyond the supplied text.
+
+**Verdict: ACCEPTED with five corrections.** None reopen governance. All are precision fixes against the supplied contributions.
+
+1. **Claude validated scope is narrower than stated.** What is validated is interactive, tools-empty, plan-mode text collaboration. Interactive tool use under mission governance, native resume under fresh checks, and any effect path remain unqualified. The consolidated line should say so rather than "interactive text collaboration validated".
+2. **Identity assurance needs a request-side versus response-side distinction.** The three gateway routes returned an exact model field in the response. The Kimi evidence shows alias resolution on the request wire, with no response model field cited. Gemini shows no effective identifier at all. Record three levels: response_observed, request_observed, and unknown. Only response_observed satisfies a mission that requires an attested model.
+3. **Incomplete state must derive from provider signals, not length.** The gateway evidence gives completion counts under the cap but no finish reason. Adapters capture the native finish or stop field where the provider supplies one. A missing field is recorded as unknown completeness, which is distinct from both incomplete and reconcile_required.
+4. **Kimi hard-cap eligibility should be explicit, not implied.** The observed one-million-token request ceiling means no per-mission output bound exists until a verified setting is found by tooling or docs. Until then the Kimi native binding is ineligible for any mission that requires an enforced output cap. The no-tools text binding shares this limit.
+5. **Gateway shared parameters need an explicit per-route parameter table.** The spec says the transport is shared but not the parameters. The table should list, per route, which fields were sent and accepted in the actual request. Currently that is effort medium for Qwen, and effort omitted for DeepSeek and GLM. Anything else is unvalidated.
+
+**FINAL CLAUDE SPEC, changes from accepted v3 only**
+
+- **Validated surface.** Interactive, tools empty, plan mode, design text. Recorded as response_observed identity from the native model field in this session.
+- **Unqualified surfaces.** Headless entitlement, interactive tool use under the executor boundary, native resume with fresh checks, hook deny path, env isolation, process-group cancellation. Each stays a recorded gap until its fixture or smoke passes.
+- **Identity.** Assurance level runtime_observed, sub-level response_observed. No trailer or link claim.
+- **Budget.** Effort from the mission-class table. Where a hard output cap is required and no verified setting exists for the installed CLI version, the binding is ineligible for that requirement rather than silently weakened.
+- **Cancellation reporting.** Local interruption and remote cancellation are separate fields. Ambiguous effects only become reconcile_required. Truncated or unfinished text is incomplete.
+- **Tests.** As in v3, plus one fixture for unknown completeness and one for request-observed identity mismatch.
+
+**FINAL FIVE-ADAPTER SPEC**
+
+Common to all five. One adapter interface: discover with observations and expiry, admit with mission, binding, budget, and scoped grant, invoke a bounded prompt or native turn, checkpoint or handoff, cancel with local and remote fields reported separately. Records use existing Research OS types with route-specific reverse-DNS extensions. Scope covers data egress and quota even with no tools. Usage fields are logged under native definitions with unknowns explicit and no reasoning double count. Deadline bounds local wait only. Identity from response metadata, never self-assertion. Unknown tool support is unvalidated, not absent. Local schema validation applies when a task requires structure, since no native structured guarantee is tested on any route.
+
+- **Kimi.** Two bindings. No-tools text through the existing wrapper is participation-validated with an empty tool inventory observed. Native agentic CLI and ACP are unqualified. Preserve alias and resolved model. Identity request_observed until a response model field is captured. Effort default max is excluded from ordinary admission. No invented effort flag. Ineligible for enforced output caps until a verified setting exists. Transcript retention is native product state, separate from shared evidence.
+- **Gemini.** Native CLI binding with the observed model list, boolean sandbox flag, plan mode, and conversation identifier for resume. One successful turn recorded as participation only. Identity unknown because the effective identifier was absent, so exact-model missions cannot pass on this route. Cached usage logged in the native field. Sandbox, tool denial, schema, and effort override are unqualified. No suffix-plus-override combination.
+- **Qwen.** Gateway binding for the exact resolved model. Effort medium was accepted on the wire, with semantics unproven. Tool calling, schema enforcement, and mid-generation cancellation are unvalidated. Truncation tests are fixture-first. The separate native CLI remains unqualified.
+- **DeepSeek.** Gateway binding for the exact resolved model, effort omitted. User-only body, no system directive option. Pre-flight exact cost absent, so overspend before evidence is a recorded limitation and hard-cap missions are ineligible. Adapter does not manage history, multi-turn state, or cancellation. Local R1 is a distinct binding with its own card, never a fallback equivalent.
+- **GLM.** Gateway binding for the exact resolved model, effort omitted. Text-only surface. Compatibility routing grants no Claude tools, permissions, or identity. Provider-side cancellation and reasoning budget are unproven, exactly as the model stated.
+
+**Tests.** One shared executor conformance run. Cheap parameterized fixtures per route for unsupported parameter, truncated response, unknown completeness, unknown identity, reasoning sentinel exclusion, and late response. One route smoke on installation or relevant change. No all-PR or all-host suite, no deliberate long generation, no implementation-mirroring tests.
+
+**Rollout.** Pro broker, M5 thin client, Mini executor where needed, with per-host attestation. No repo edits made. The unrelated dirty files stay untouched. Persistence and activation are outside this session.
+
+**Deliverables when implementation is allowed.** One common contract. Astra native spec by Astra. Claude native spec by me. One adapter document with five attributed sections. Existing MIR and Research OS files for schemas and registries. Author, review, and test evidence labeled separately.
+
+**Still unvalidated.** Astra on Pro and Mini. Claude headless and effect paths. The distinct-UID executor. Env isolation for both native launchers. Gemini effective identity. Kimi output cap and response identity. Tool and cancellation behavior on all three gateway routes.
+
+END_FABLE_DC_V4_FINAL

--- a/evidence/dual-consul-v4/design/gemini-answer.txt
+++ b/evidence/dual-consul-v4/design/gemini-answer.txt
@@ -1,0 +1,28 @@
+**Acceptance**: All constraints accepted. No disagreements with the specified Nuzantara DC-v3 architecture, PG Autonomous Lab lifecycle, or security fencing.
+
+**Supplied Observation**: 
+The `agy` CLI surface provides: `--model`, `--effort low|medium|high`, `--mode plan`, `--sandbox terminal`, `--output-format json|stream-json`, `--json-schema`, `--conversation resume`, and `--print-timeout`. Available models are `gemini-3.1-pro-high`, `gemini-3.1-pro-low`, and `gemini-3.8-flash-[high|medium|low]`. Roster bare model IDs are stale. CLI model selection does not guarantee served identity. Agent/tool denial, schema fidelity, cancellation, and resume behaviors are currently unqualified.
+
+**Proposal: Gemini-Native Adapter Lifecycle**
+*   **Mission**: Map PG Lab phases natively to the `agy` CLI. Decouple capabilities: model selection (`gemini-3.1-pro-high`), effort (`--effort`), route/mode (`--mode plan`), and privilege (`--sandbox terminal`).
+*   **Execution**: A trusted executor under a distinct UID invokes the CLI. Scope, epoch, and resource fences are verified immediately before execution. The adapter consumes `--output-format stream-json` for intent receipt. If an ambiguous timeout occurs (e.g., via `--print-timeout`), the adapter forces state reconciliation rather than a blind retry. 
+*   **Handoff/Evidence**: Raw reasoning and client PII are aggressively stripped from the JSON stream. Evidence is explicitly keyed to the exact tree, input, tests, config, and environment hash.
+*   **Authorization & Resume**: Resuming a mission utilizes `--conversation resume`, but only after a mandatory recheck of auth, fencing, and config. Cross-mission context reuse is strictly prohibited. 
+*   **Token Economy**: Confine broad reviews. Dispatch narrow, frozen diffs and specific evidence to a ceiling of four `gemini-3.8-flash-low` workers. Reserve `gemini-3.1-pro-high` for the lead execution planner.
+
+**Unverified / Unknowns**:
+*   The true served identity versus the requested CLI model.
+*   The stability of `agy` when a long-running execution is externally cancelled.
+*   The precise definition and enforcement mechanism of `--print-timeout`.
+
+**Hypotheses (Capabilities & Pitfalls)**:
+*   *Pitfall*: Strict adherence to `--json-schema` degrades when the model encounters terminal sandbox denials, potentially leaking raw reasoning into the structured output.
+*   *Capability*: `--conversation resume` maintains high fidelity of the execution state without requiring token-heavy replays of prior evidence.
+*   *Pitfall*: Utilizing `--effort high` increases latency between intent receipt and execution, elevating the risk of ambiguous timeouts during complex routing.
+
+**Contract Tests (Outside PR Path)**:
+1.  **Schema Fidelity under Denial**: Invoke `agy` with `--sandbox terminal`, `--json-schema`, and an instruction requiring network access. Verify the output remains valid JSON without schema drift when the action is denied.
+2.  **Ambiguous Timeout Reconciliation**: Inject an artificial timeout during a `gemini-3.1-pro-high` execution. Assert that the adapter suspends, queries external state for side effects, and halts without retrying.
+3.  **Strict Resume Fencing**: Execute an initial task, advance the fencing epoch or alter the executing UID, and attempt `--conversation resume`. Assert that the executor rejects the resume attempt before initiating model inference.
+
+END_ADAPTER_GEMINI

--- a/evidence/dual-consul-v4/design/gemini-metadata.json
+++ b/evidence/dual-consul-v4/design/gemini-metadata.json
@@ -1,0 +1,26 @@
+{
+  "route": "agy",
+  "requested_model_reported_in_design_packet": "gemini-3.1-pro-high",
+  "identity_assurance": "unknown",
+  "effective_model": null,
+  "native_result": {
+    "conversation_id": "39d1d8e1-50d0-44ff-887c-92cb02b9df3d",
+    "status": "SUCCESS",
+    "duration_seconds": 55.269967,
+    "num_turns": 1,
+    "usage": {
+      "input_tokens": 11375,
+      "output_tokens": 2552,
+      "cache_read_tokens": 8120,
+      "total_tokens": 13927
+    }
+  },
+  "invocation_result": {
+    "exit": 0,
+    "seconds": 59.27,
+    "stdout_sha256": "3e07de9b102108c1dc35f0cce27f896d761b8610102f0877bb9e3edecde5f73c",
+    "stderr_bytes": 0
+  },
+  "original_stdout_sha256_verified": false,
+  "hash_scope_note": "The original stdout hash was recorded before the result was parsed/re-serialized in tool output. The original stdout bytes are unavailable; the selected response hash is independently computed, not substituted for that stdout hash."
+}

--- a/evidence/dual-consul-v4/design/kimi-answer.txt
+++ b/evidence/dual-consul-v4/design/kimi-answer.txt
@@ -1,0 +1,28 @@
+**Kimi adapter candidate — design only, from supplied evidence (no repo inspection).**
+
+**(a) Minimal lifecycle, two modes.**
+
+*Headless consultation seat (current wrapper, `tools:[]`).* Mission → wrapper sanitizes input (credential-env drop, numeric-PII backstop) → single-shot candidate reply → Handoff with reply as Evidence. No Authorization needed for effects (none possible); seat is advisory-only. Stateless per invocation, so no-cross-mission-context holds trivially. Provenance tags: wrapper version, prompt hash, resolved alias (kimi-code/k3) recorded as metadata, never as privilege.
+
+*Native agentic CLI (future, unqualified).* Mission → `--plan` draft → `--agent-file`-scoped execution → `--output-format stream-json` events as the Evidence stream. Before every effect-ful tool call, a distinct-UID executor re-checks scoped grant + current fencing epoch + resource at effect time; hooks remain defense-in-depth. Timeout after possible effect → mandatory reconciliation: compare declared intent vs observed state, emit divergent Handoff, never claim completion from pre-action intent. Resume via `--session/--continue` only same-mission, after re-checking authorization/fence/config/input hash. CLI session transcripts are scoped, provenance-tagged, PII-stripped; no raw reasoning retained. No second scheduler; PG Autonomous Lab lifecycle governs.
+
+**(b) Kimi-specific caveats/hypotheses.**
+- `stream-json` schema unknown — evidence mapping is a hypothesis until qualified live.
+- Cancellation semantics unknown; assume partial effects possible → reconciliation path is mandatory, not optional.
+- Whether `tools:[]` in an agent file is *enforced* by CLI 0.41.0 or merely advisory is untested.
+- Transcript storage location/retention controls unknown → privacy boundary incomplete; the wrapper's backstop is numeric-only, so raw client-adjacent text should not reach this seat yet.
+- ACP subcommand untested — route nothing through it.
+- Alias→model resolution may drift; pin and record resolved metadata per mission.
+
+**(c) Three cheap discriminating contract tests (outside PR path).**
+1. *Stale-epoch denial:* grant scope, advance fencing epoch mid-session, attempt a trivial scratch-dir effect; contract: executor denies at effect time and logs denial evidence.
+2. *Timeout reconciliation:* induce timeout around a known side effect (file create + sleep); contract: adapter enters reconciliation, reports actual filesystem state, never auto-claims completion.
+3. *Resume re-check:* persist session, revoke grant (or mutate input/config), attempt `--continue`; contract: adapter refuses silent resume and demands fresh authorization.
+
+**(d) Token economy.**
+One lead (Astra *or* Fable); Kimi seat receives narrow frozen diffs plus scoped evidence excerpts, never whole histories. Evidence reuse keyed by actual input tree + tool/test/config/environment hash; adapter qualified once per relevant change, not per PR. Workers ≤4 as ceiling; headless seat is single-shot, zero parallelism. Reuse existing change_map/impact_map and advisory merge_group exclusions; no all-PR harness. Parse stream-json incrementally; retain summarized events only.
+
+**(e) Unknowns; acceptance/disagreement.**
+*Accept:* equal lead/reviewer split, effect-time checks, intent≠completion, reconciliation, same-mission-only resume, metadata≠privilege, 4-worker ceiling, evidence-reuse keying. *Unknowns:* stream-json schema, cancellation/partial-effect behavior, `tools:[]` enforcement, transcript retention controls, ACP viability, env-drop denylist completeness. *Mild disagreement:* "no routine human reapproval" is fine for the advisory seat, but the *first* live qualification of agentic mode with real effects should be human-witnessed — a one-time qualification gate, not a reapproval loop.
+
+END_ADAPTER_KIMI

--- a/evidence/dual-consul-v4/design/kimi-metadata.json
+++ b/evidence/dual-consul-v4/design/kimi-metadata.json
@@ -1,0 +1,43 @@
+{
+  "route": "existing Kimi CLI no-tools profile",
+  "runtime_version_reported_in_design_packet": "0.41.0",
+  "identity_assurance": "request_observed",
+  "profile_binding": {
+    "modelAlias": "kimi-code/k3",
+    "thinkingEffort": "max",
+    "activeToolNames": [],
+    "disallowedTools": []
+  },
+  "request_metadata": {
+    "type": "llm.request",
+    "model": "k3",
+    "provider": "openai",
+    "modelAlias": "kimi-code/k3",
+    "thinkingEffort": "max",
+    "maxTokens": 1048576,
+    "toolSelect": false
+  },
+  "usage_metadata": {
+    "type": "usage.record",
+    "model": "kimi-code/k3",
+    "usage": {
+      "inputOther": 962,
+      "output": 2387,
+      "inputCacheRead": 0,
+      "inputCacheCreation": 0
+    }
+  },
+  "finish_metadata": {
+    "finishReason": "end_turn",
+    "usage": {
+      "inputOther": 962,
+      "output": 2387,
+      "inputCacheRead": 0,
+      "inputCacheCreation": 0
+    },
+    "providerFinishReason": "completed"
+  },
+  "request_metadata_source_jsonl_line": 624,
+  "request_metadata_source_tool_call_id": "call_yOg21BPvq8LSrL5WoXaYA8hm",
+  "original_answer_sha256_verified": true
+}

--- a/evidence/dual-consul-v4/design/manifest.json
+++ b/evidence/dual-consul-v4/design/manifest.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": "1.0.0",
+  "recorded_date": "2026-09-06",
+  "source_session_id": "433c29dd-e09f-4070-b1e9-a8da0136970c",
+  "source_locator": "native Claude transcript named <source_session_id>.jsonl; private absolute path intentionally omitted",
+  "source_of_authority": "user consolidated v4 design intent; evidence records authenticate selected historical text only",
+  "retention": {
+    "scope": "selected design assistant text plus redacted provenance",
+    "excluded": [
+      "thinking blocks",
+      "reasoning streams",
+      "credentials",
+      "account identifiers",
+      "full native transcript"
+    ],
+    "selected_artifact_budget_bytes": 65536
+  },
+  "artifacts": [
+    {
+      "path": "fable-v2-review.txt",
+      "sha256": "1632ae11ca7bbb1326a97386e2c12e3f3c1b134da5371b6b384bc3ba6f700029",
+      "bytes": 8816,
+      "source_jsonl_line": 15,
+      "selection": "assistant.message.content[type=text] only; exact UTF-8 bytes, no appended newline",
+      "model": "claude-fable-5-1",
+      "runtime_version": "2.1.261",
+      "native_stop_reason": "end_turn",
+      "identity_assurance": "response_observed",
+      "scope": "historical design response; not an implementation review or runtime qualification"
+    },
+    {
+      "path": "fable-v3-revised.txt",
+      "sha256": "715a665f9ae3f90d7d4ead019bef7cb8796d0afe9085b02f389e3bb8c669bf43",
+      "bytes": 6040,
+      "source_jsonl_line": 28,
+      "selection": "assistant.message.content[type=text] only; exact UTF-8 bytes, no appended newline",
+      "model": "claude-fable-5-1",
+      "runtime_version": "2.1.261",
+      "native_stop_reason": "end_turn",
+      "identity_assurance": "response_observed",
+      "scope": "historical design response; not an implementation review or runtime qualification"
+    },
+    {
+      "path": "fable-v4-final.txt",
+      "sha256": "2a6af479053f98e6da77366e4e9538bab66afc2032ac6f6cccbb96af17af616f",
+      "bytes": 7001,
+      "source_jsonl_line": 34,
+      "selection": "assistant.message.content[type=text] only; exact UTF-8 bytes, no appended newline",
+      "model": "claude-fable-5-1",
+      "runtime_version": "2.1.261",
+      "native_stop_reason": "end_turn",
+      "identity_assurance": "response_observed",
+      "scope": "historical design response; not an implementation review or runtime qualification"
+    },
+    {
+      "path": "consultation-observations.json",
+      "sha256": "d5eeeba0e2d8bed04e10a1ef26eda3c5a0308bc5f41f0d2cb1916aee05d9d76f",
+      "bytes": 2797,
+      "selection": "index of original final answers and allowlisted metadata recovered from recorded tool outputs"
+    },
+    {
+      "path": "tp1-qwen-answer.txt",
+      "sha256": "11c735dd1e741f1ba5aea9dee3aa49c986e82a55cb15726f3e53ec97d0bd7074",
+      "bytes": 3434,
+      "source_session_id": "01a073b2-70a5-7ff2-b25b-25d4f5f03a73",
+      "source_file": "rollout-2026-09-06T06-31-09-01a073b2-70a5-7ff2-b25b-25d4f5f03a73.jsonl",
+      "source_jsonl_line": 470,
+      "source_tool_call_id": "call_zK2hizCCI8loNK11cawuztWa",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream",
+      "identity_assurance": "response_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "path": "tp1-qwen-metadata.json",
+      "sha256": "98c3516240769244eb5a51a3f18f6694941e5d64df1744a033ecaad0a99df516",
+      "bytes": 1019,
+      "source_session_id": "01a073b2-70a5-7ff2-b25b-25d4f5f03a73",
+      "source_file": "rollout-2026-09-06T06-31-09-01a073b2-70a5-7ff2-b25b-25d4f5f03a73.jsonl",
+      "source_jsonl_line": 470,
+      "source_tool_call_id": "call_zK2hizCCI8loNK11cawuztWa",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream"
+    },
+    {
+      "path": "tp1-deepseek-answer.txt",
+      "sha256": "d0eac772539f324e759a6ed6095ecd62cbe6202d7d6ab210b05c1db9aadd0f50",
+      "bytes": 3658,
+      "source_session_id": "01a073b2-70a5-7ff2-b25b-25d4f5f03a73",
+      "source_file": "rollout-2026-09-06T06-31-09-01a073b2-70a5-7ff2-b25b-25d4f5f03a73.jsonl",
+      "source_jsonl_line": 494,
+      "source_tool_call_id": "call_hZ3G70mmwODnwiLbqNpyUfru",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream",
+      "identity_assurance": "response_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "path": "tp1-deepseek-metadata.json",
+      "sha256": "3120dc97bc04d95a676163bc51840f59f35eccb2a79f5e0b5f9d3f80ef489642",
+      "bytes": 971,
+      "source_session_id": "01a073b2-70a5-7ff2-b25b-25d4f5f03a73",
+      "source_file": "rollout-2026-09-06T06-31-09-01a073b2-70a5-7ff2-b25b-25d4f5f03a73.jsonl",
+      "source_jsonl_line": 494,
+      "source_tool_call_id": "call_hZ3G70mmwODnwiLbqNpyUfru",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream"
+    },
+    {
+      "path": "tp1-glm-answer.txt",
+      "sha256": "2d30f0dcb3b74959601c2cea721a80413216687aca502b5c55d8faa4c9ae7067",
+      "bytes": 2510,
+      "source_session_id": "01a073b2-70a5-7ff2-b25b-25d4f5f03a73",
+      "source_file": "rollout-2026-09-06T06-31-09-01a073b2-70a5-7ff2-b25b-25d4f5f03a73.jsonl",
+      "source_jsonl_line": 523,
+      "source_tool_call_id": "call_5XcEKRCRKlrZRB0O5xK2YzoP",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream",
+      "identity_assurance": "response_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "path": "tp1-glm-metadata.json",
+      "sha256": "355807e5128bddd7aba6c64418e923fe554f3cefb423e292f2bc5049cf2e17e8",
+      "bytes": 955,
+      "source_session_id": "01a073b2-70a5-7ff2-b25b-25d4f5f03a73",
+      "source_file": "rollout-2026-09-06T06-31-09-01a073b2-70a5-7ff2-b25b-25d4f5f03a73.jsonl",
+      "source_jsonl_line": 523,
+      "source_tool_call_id": "call_5XcEKRCRKlrZRB0O5xK2YzoP",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream"
+    },
+    {
+      "path": "kimi-answer.txt",
+      "sha256": "165cf07b9f6e5617e11b4b7f2b8717a073aa6db0d1c643b92d4ff02b6c27cf81",
+      "bytes": 3838,
+      "source_session_id": "01a073b1-a3a4-7521-9a14-4586f9cc0213",
+      "source_file": "rollout-2026-09-06T06-30-16-01a073b1-a3a4-7521-9a14-4586f9cc0213.jsonl",
+      "source_jsonl_line": 631,
+      "source_tool_call_id": "call_v7MDKCFgN0KpwHBulXxA7ypg",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream",
+      "identity_assurance": "request_observed",
+      "original_answer_sha256_verified": true
+    },
+    {
+      "path": "kimi-metadata.json",
+      "sha256": "23c1de449a1715befa82eea980f33b24ea568035c0ed078c3a1ffaf4f2803b80",
+      "bytes": 1109,
+      "source_session_id": "01a073b1-a3a4-7521-9a14-4586f9cc0213",
+      "source_file": "rollout-2026-09-06T06-30-16-01a073b1-a3a4-7521-9a14-4586f9cc0213.jsonl",
+      "source_jsonl_line": 631,
+      "source_tool_call_id": "call_v7MDKCFgN0KpwHBulXxA7ypg",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream"
+    },
+    {
+      "path": "gemini-answer.txt",
+      "sha256": "3e17794372af183688e3a2ac56b1bede5804ac03b08d1ddb44641ebc87d61061",
+      "bytes": 3420,
+      "source_session_id": "01a073b1-a3a4-7521-9a14-4586f9cc0213",
+      "source_file": "rollout-2026-09-06T06-30-16-01a073b1-a3a4-7521-9a14-4586f9cc0213.jsonl",
+      "source_jsonl_line": 671,
+      "source_tool_call_id": "call_gCYByrc8Rxk9gtb9yGS424g2",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream",
+      "identity_assurance": "unknown",
+      "original_stdout_sha256_verified": false
+    },
+    {
+      "path": "gemini-metadata.json",
+      "sha256": "b944d9c26cbe82043f5e1049108b6e0d4a4e774b5a4428f0a272c89c5f137190",
+      "bytes": 940,
+      "source_session_id": "01a073b1-a3a4-7521-9a14-4586f9cc0213",
+      "source_file": "rollout-2026-09-06T06-30-16-01a073b1-a3a4-7521-9a14-4586f9cc0213.jsonl",
+      "source_jsonl_line": 671,
+      "source_tool_call_id": "call_gCYByrc8Rxk9gtb9yGS424g2",
+      "selection": "selected final-answer text or allowlisted metadata from original recorded tool output; no reasoning stream"
+    }
+  ],
+  "supersession": "v2 is historical. v3 corrections supersede v2; v4 final amendments supersede v3. Original TP1 tool outputs recovered during implementation confirm finish_reason=stop, correcting the missing-field premise in the final Fable review.",
+  "qualification": "No deployment, host eligibility promotion, paid model call, or independent implementation review is implied."
+}

--- a/evidence/dual-consul-v4/design/tp1-deepseek-answer.txt
+++ b/evidence/dual-consul-v4/design/tp1-deepseek-answer.txt
@@ -1,0 +1,25 @@
+**Minimal adapter surface and unknowns**  
+The adapter wraps `scripts/tp1_call.py` to present a text-completion-only facade. It accepts a prompt, an optional system directive, and a `max_tokens` bound (default 4096). It forwards these to the Alibaba TP1 gateway, strips the response to `choices[0].message.content` only, never exposing raw reasoning, tool calls, or structured output. It records bounded redacted protocol metadata (request ID, latency, token usage from the API response) and attaches provenance-bearing memory scoped by the shared lifecycle. The adapter does **not** manage conversation history, multi-turn state, or cancellation; it does **not** impersonate a native agent runtime.  
+
+**Unknowns:**  
+- Whether `reasoning_effort` (omitted) is actually supported by the route, and if the model emits hidden reasoning tokens that the API surfaces in a separate field (e.g., `reasoning_content`).  
+- How the provider’s usage object counts reasoning tokens vs. output tokens (output cap is not reasoning cap).  
+- The exact error and timeout semantics of the gateway beyond the 180 s wall deadline.
+
+**Model-specific strengths / pitfalls (hypotheses)**  
+1. **Strength:** DeepSeek‑v4‑Pro likely possesses strong chain‑of‑thought capabilities, which can yield more accurate, verifiable outputs for complex Nuzantara tasks without extra prompting.  
+2. **Pitfall:** If the model autonomously generates internal reasoning tokens and the route passes them through, the adapter may inadvertently consume excessive tokens (blowing budget) and could leak raw reasoning if not aggressively stripped, violating the “no raw reasoning retained” policy.
+
+**Three cheap discriminating smoke/contract tests**  
+1. **Reasoning‑leak guard:** Send a trivial prompt (“echo ‘test’”) and verify the adapter’s output contains exactly the expected content, with no `reasoning` substring in the bounded evidence log.  
+2. **Timeout→reconcile:** Issue a request with `max_tokens=4096` and a deliberately slow‑to‑resolve prompt; let the wall clock reach 180 s. Confirm the adapter returns a `reconcile_required` status (not a retry) and the evidence records the timeout without raw model internals.  
+3. **Budget‑overflow detection:** Craft a prompt that causes the model to reply with a known‑large token count (but still within the 4096 output cap). Check that the adapter logs the actual usage from the response metadata, and if the configured budget is exceeded, the executor can reconcile (pre‑call budget enforcement is not possible, but post‑call measurement is).  
+
+**Minimizing tokens without silent capability degradation**  
+The adapter adds no extra tokens. Token minimization is achieved by the invoker: set `max_tokens` to the smallest value the task contract allows, and craft prompts as concisely as possible. The adapter does not enlarge the prompt or response, and it strips any reasoning token bloat from the output (keeping only the final `content`). The real burden lies with the upstream system, not the adapter.
+
+**Acceptance of contract**  
+We accept the supplied constraints (shared governance, DC‑v3 terms, bounded redacted evidence, no direct service credentials, etc.).  
+**Explicit disagreement:** The phrase “budgets enforced where measurable” is partially realizable only post‑call. The adapter cannot pre‑emptively cap cost because it lacks a pre‑flight cost API and cannot abort generation mid‑stream. It can measure and report token usage, but overspend may occur before the executor sees the evidence. This is the limit of enforcement at the adapter layer.
+
+END_ADAPTER_MODEL

--- a/evidence/dual-consul-v4/design/tp1-deepseek-metadata.json
+++ b/evidence/dual-consul-v4/design/tp1-deepseek-metadata.json
@@ -1,0 +1,31 @@
+{
+  "requested_model": "deepseek-v4-pro",
+  "requested_effort": null,
+  "max_tokens_requested": 4096,
+  "absolute_deadline_seconds": 180,
+  "retry_count": 0,
+  "prompt_sha256": "42e964efe8e2c33a37266a66e991ead500bb3f82185ad10606edb04d7a965df3",
+  "started_at_utc": "2026-09-05T23:10:37.486299+00:00",
+  "http_status": 200,
+  "provider_model": "deepseek-v4-pro",
+  "provider_model_matches_requested": true,
+  "usage": {
+    "prompt_tokens": 550,
+    "total_tokens": 3634,
+    "completion_tokens": 3084,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 2300
+    }
+  },
+  "finish_reason": "stop",
+  "status": "completed",
+  "answer_sha256": "d0eac772539f324e759a6ed6095ecd62cbe6202d7d6ab210b05c1db9aadd0f50",
+  "wall_seconds": 56.301,
+  "finished_at_utc": "2026-09-05T23:11:33.787536+00:00",
+  "route": "TP1",
+  "identity_assurance": "response_observed",
+  "original_answer_sha256_verified": true
+}

--- a/evidence/dual-consul-v4/design/tp1-glm-answer.txt
+++ b/evidence/dual-consul-v4/design/tp1-glm-answer.txt
@@ -1,0 +1,19 @@
+I accept the contract, shared governance with Astra and Fable, and the supplied DC-v3 terms. Explicit disagreement: I dispute treating the 180s local wall deadline as proof of provider-side cancellation, and I reject assuming `max_tokens=4096` bounds server-side reasoning budgets.
+
+**(a) Minimal Adapter Surface & Unknowns**
+*Surface:* A stateless text-completion bridge. A Distinct-UID executor checks the scoped grant + live fencing epoch before invoking `scripts/tp1_call.py`. It emits a `pre-action_intent` record, executes the completion, and enforces the local 180s wall clock. It parses only bounded redacted protocol metadata for provider identity, preserving change_map/impact_map for Astra/Fable's frozen diff review.
+*Unknowns:* The provider's native cancellation mechanism, actual server-side reasoning consumption, and whether omitted `reasoning_effort` maps to a native default or silently degrades output.
+
+**(b) Native Strengths/Pitfalls (Hypotheses)**
+1. *Strength:* GLM-5.2 may exhibit high fidelity in zero-shot structural adherence (e.g., emitting strict JSON-like text), potentially minimizing prompt overhead.
+2. *Pitfall:* Because tool-calling is unvalidated, parsing structured delegation protocols from raw text risks silent failures if the 4096 token limit truncates mid-payload, yielding an illusion of a completed action without valid evidence.
+
+**(c) Cheap Smoke/Contract Tests (Outside PR Path)**
+1. *Timeout Reconciliation Contract:* Issue a request with a 1s local deadline. Assert the adapter yields `reconcile_required` and aborts without blind retry.
+2. *Metadata Identity Test:* Submit a prompt instructing the model to self-assert provider identity in text. Assert the adapter sources identity exclusively from response metadata, ignoring the payload text.
+3. *Truncation Boundary Test:* Issue a prompt designed to hit the 4096 `max_tokens` limit. Assert the adapter flags the response as incomplete (intent != completed action) and triggers a fencing check rather than committing a partial state.
+
+**(d) Minimizing Tokens Without Silent Degradation**
+Enforce strict output constraints (e.g., "Return only the final JSON object, no prose") to minimize completion tokens. Cache immutable, provenance-bearing execution state locally so failed delegations do not require resending full history. Do not attempt to extract simulated chain-of-thought into the text surface; rely on native server-side reasoning to avoid exceeding the 4096 output cap silently.
+
+END_ADAPTER_MODEL

--- a/evidence/dual-consul-v4/design/tp1-glm-metadata.json
+++ b/evidence/dual-consul-v4/design/tp1-glm-metadata.json
@@ -1,0 +1,31 @@
+{
+  "requested_model": "glm-5.2",
+  "requested_effort": null,
+  "max_tokens_requested": 4096,
+  "absolute_deadline_seconds": 180,
+  "retry_count": 0,
+  "prompt_sha256": "65763de263719418bf8dcc72224b2a1606933f9bbc80ec854d3adc42446d0063",
+  "started_at_utc": "2026-09-05T23:11:38.292021+00:00",
+  "http_status": 200,
+  "provider_model": "glm-5.2",
+  "provider_model_matches_requested": true,
+  "usage": {
+    "prompt_tokens": 547,
+    "total_tokens": 3820,
+    "completion_tokens": 3273,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 2742
+    }
+  },
+  "finish_reason": "stop",
+  "status": "completed",
+  "answer_sha256": "2d30f0dcb3b74959601c2cea721a80413216687aca502b5c55d8faa4c9ae7067",
+  "wall_seconds": 50.341,
+  "finished_at_utc": "2026-09-05T23:12:28.634268+00:00",
+  "route": "TP1",
+  "identity_assurance": "response_observed",
+  "original_answer_sha256_verified": true
+}

--- a/evidence/dual-consul-v4/design/tp1-qwen-answer.txt
+++ b/evidence/dual-consul-v4/design/tp1-qwen-answer.txt
@@ -1,0 +1,20 @@
+**Nuzantara Adapter Candidate — qwen3.8-max via Alibaba TP1**
+
+**(a) Minimal adapter surface and unknowns.**
+The adapter exposes exactly one validated operation: synchronous text completion through `scripts/tp1_call.py`, accepting a prompt string and receiving a completion string. Parameters observed in route evidence: `requested_model`, `reasoning_effort=medium`, `max_tokens=4096`, wall deadline 180 s. No temperature, top-p, stop sequences, or streaming flags are supplied; the adapter must not assume them. Tool calling, structured-JSON schema enforcement, and mid-generation cancellation are **not validated** and must be treated as absent until a separate contract test proves otherwise. Unknown: whether the TP1 gateway propagates a provider-side cancellation signal or simply drops the TCP connection at deadline; whether `reasoning_effort` is honored, ignored, or mapped server-side; actual context-window ceiling; whether retries are idempotent at the gateway. The adapter records `provider_identity` from response metadata, never from self-assertion.
+
+**(b) Two hypotheses (not certified facts).**
+*Hypothesis 1 – strength:* A medium-effort reasoning mode, if genuinely honored by the gateway, may allow the model to allocate internal deliberation tokens disproportionate to the 4 096 output cap, improving multi-step plan coherence without inflating visible token cost. This is untested; the adapter must log whether output quality degrades when `reasoning_effort` is lowered in a controlled probe.
+*Hypothesis 2 – pitfall:* Because the TP1 surface is text-completion-only, any structured-output requirement (change_map, impact_map) must be enforced by post-hoc parsing on the caller side. If the model emits malformed or partial structure under token pressure, the adapter has no native schema-fallback. Silent degradation risk is highest here.
+
+**(c) Three cheap discriminating smoke/contract tests (outside ordinary PR path).**
+1. **Echo-fence test:** Submit a prompt requesting the model to reproduce a nonce and the literal string `reconcile_required`. Assert exact substring presence. Cost: one small call. Validates round-trip integrity and that the adapter does not swallow gateway errors into empty success.
+2. **Timeout-boundary probe:** Set a prompt engineered to approach the 180 s wall deadline with `max_tokens=4096`. Assert the adapter returns either a complete completion or an explicit `reconcile_required` status—never a silent partial treated as final. No retry is issued.
+3. **Structure-absence probe:** Request a JSON-shaped change_map in a text-completion call. Assert the adapter tags the output `unvalidated_structure` rather than parsing it as authoritative, confirming no false native-schema claim.
+
+**(d) Token minimization without silent capability degradation.**
+Cap visible output at the supplied 4 096; do not conflate this with a reasoning budget. Strip redundant preamble in system prompts; pass only the frozen diff, relevant change_map keys, and advisory exclusions. Omit full history. If a response is truncated, mark `reconcile_required` rather than re-issuing blindly. Log token counts from gateway metadata when available; do not invent pricing.
+
+Disagreements: none material; I accept DC-v3 terms as stated. I flag that observable native delegation remains unproven on this route and the four-worker ceiling must not be asserted from this adapter alone.
+
+END_ADAPTER_MODEL

--- a/evidence/dual-consul-v4/design/tp1-qwen-metadata.json
+++ b/evidence/dual-consul-v4/design/tp1-qwen-metadata.json
@@ -1,0 +1,33 @@
+{
+  "requested_model": "qwen3.8-max",
+  "requested_effort": "medium",
+  "max_tokens_requested": 4096,
+  "absolute_deadline_seconds": 180,
+  "retry_count": 0,
+  "prompt_sha256": "d25f29f6ed0bd3bc1b7b6d4011ecf5656733701a8640d7babbb39e6a539d1887",
+  "started_at_utc": "2026-09-05T23:10:06.215021+00:00",
+  "http_status": 200,
+  "provider_model": "qwen3.8-max",
+  "provider_model_matches_requested": true,
+  "usage": {
+    "prompt_tokens": 558,
+    "total_tokens": 1677,
+    "completion_tokens": 1119,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "text_tokens": 558
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 388,
+      "text_tokens": 1119
+    }
+  },
+  "finish_reason": "stop",
+  "status": "completed",
+  "answer_sha256": "11c735dd1e741f1ba5aea9dee3aa49c986e82a55cb15726f3e53ec97d0bd7074",
+  "wall_seconds": 27.085,
+  "finished_at_utc": "2026-09-05T23:10:33.300323+00:00",
+  "route": "TP1",
+  "identity_assurance": "response_observed",
+  "original_answer_sha256_verified": true
+}

--- a/evidence/dual-consul-v4/implementation/README.md
+++ b/evidence/dual-consul-v4/implementation/README.md
@@ -1,0 +1,109 @@
+# Dual Consul v4: reproducible first slice
+
+This increment implements an opt-in synthetic mission inside the existing
+Autonomous Lab lifecycle. It prepares code and evidence for independent release
+review. It does not activate a fleet service or qualify provider effects.
+
+## Consumers and observable behavior
+
+- `AutonomousLabWorker(stage_nodes=(ConsulSyntheticStage(...),))` consumes the new
+  stage. Both Astra-builder/Fable-reviewer and Fable-builder/Astra-reviewer cases
+  enqueue, claim, execute, checkpoint, and finish through the existing worker.
+- `consul_store` binds PostgreSQL ownership and generation to the exact mission,
+  synthetic resource, intent, authorization, review, and input-packet digests.
+  Its transaction locks the Lab parent before the lease. The effect statement
+  rechecks expiry using PostgreSQL's live clock.
+- `consul_executor` accepts only `com.balizero.consul.synthetic_checkpoint`.
+  A canonical `ActionIntent`, `ApprovalReceipt`, `VerificationReceipt`, started
+  `ExecutionAttempt`, outbox checkpoint, and confirmed `OperationalReceipt`
+  share the existing Research OS and Lab stores. The attempt, checkpoint, and
+  result commit together; a failed result write rolls everything back.
+- `python -m scripts.conductor.adapter_contracts` consumes a JSON admission
+  packet on stdin and emits only admission/rejection metadata. Exit 0 admits
+  text preparation, exit 2 denies it, and exit 1 identifies malformed input.
+  It launches no provider. Its module docstring and `main()` document the packet.
+- The existing MIR generator now reproduces the checked-in capability projection.
+  Model cards and endpoint profiles are unchanged. Text observations do not
+  promote an endpoint to operational eligibility.
+
+The authorization and reviewer fields in the executable tests are synthetic.
+They test exact binding and independence checks, not semantic model judgment.
+The separate Fable review files record actual native model responses to frozen
+implementation packets. Their metadata identifies the files and hashes reviewed.
+
+## Focused verification
+
+From the worktree root, activate the repository's existing virtualenv:
+
+```sh
+source apps/backend-rag/.venv/bin/activate
+PYTHONPATH=apps/backend-rag python -m pytest \
+  apps/backend-rag/backend/tests/unit/services/autonomous_lab/ \
+  --tb=short --color=no
+python -m pytest \
+  scripts/tests/test_conductor_model_registry.py \
+  scripts/tests/test_conductor_host_identity.py \
+  scripts/tests/test_conductor_host_seat_maps.py \
+  scripts/tests/test_conductor_calibration.py \
+  scripts/tests/test_conductor_adapter_contracts.py -q --tb=short
+python -m scripts.conductor.build_model_capability_index --check
+```
+
+Run the PostgreSQL proof on Pro, against a newly initialized disposable instance
+and the dedicated database **`dual_consul_test`**. Supply its Unix socket directory
+and port through `PGHOST` and `PGPORT`; the DSN deliberately accepts no query
+overrides. The fixture resets only this slice's tables in that database and
+serializes fixture setup with an advisory lock. Never point it at an operational
+database. With the disposable instance already prepared:
+
+```sh
+source apps/backend-rag/.venv/bin/activate
+DUAL_CONSUL_TEST_DSN=postgresql:///dual_consul_test \
+  PYTHONPATH=apps/backend-rag python -m pytest \
+  apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py \
+  --tb=short --color=no
+```
+
+The integration proof uses the existing production JSON codec and actual Lab,
+Research OS, and lease migrations. It covers both consul directions, current
+owner success, stale generations, takeover, expiry, revocation, cancellation,
+idempotent replay, atomic rollback, delayed writes crossing the expiry boundary,
+and real two-connection lock serialization. Migration 306 is also rolled back,
+reapplied, and consumed by a new synthetic mission.
+
+The review's JSON-shape question led to a read-only production schema check:
+both Lab tables were absent. Migration 306 therefore backfills the exact eight
+DDL statements from legacy Python migration 124 before creating the lease FK.
+A parity test compares the snapshot with the original producer, and a separate
+PostgreSQL case runs 306 without pre-creating Lab tables. Rollback removes the
+lease table and preserves the shared Lab tables and their data. This prerequisite
+correction has its own frozen review packet after the first two accepted reviews.
+The [preflight record](schema-preflight.json) contains only schema-presence results.
+
+This caught a pre-existing Lab transport defect: `_jsonb()` already serializes
+its value, while the production JSON codec serializes JSON-bound parameters
+again. Binding that serialized value as `text` before casting to `jsonb` fixes
+the existing store's worker path without changing the shared connection codec.
+
+## Boundaries and reconciliation
+
+The executor is an in-process trusted-broker component. A distinct OS service
+identity, credential removal from model processes, native App Server discovery
+and effective configuration isolation, provider launch/resume/cancellation,
+global native-worker supervision, staging/canary activation, and production
+reliability remain unqualified. No migration or daemon is installed on the fleet.
+
+Replay through `execute_synthetic` requires a live, matching authorization and
+lease even when a receipt already exists. An expired or revoked owner cannot use
+replay to regain authority. After an ambiguous commit acknowledgment, inspect the
+immutable Research OS result through an independently authorized read or renew
+admission before replaying. This increment provides no remote-effect reconciliation.
+Idempotency is per canonical intent; distinct authorized intents may produce
+distinct checkpoints for the same run.
+
+The existing `change_map`, `impact_map`, and workflow/merge-group rules remain
+unchanged. The PostgreSQL suite is opt-in; no new general harness job is attached
+to every PR. Raw selected review and design text preserves original bytes,
+including whitespace, so its SHA-256 can be checked exactly.
+Implementation evidence has a 160 KiB budget, separate from the 64 KiB selected
+design-artifact budget; full native transcripts and reasoning blocks are excluded.

--- a/evidence/dual-consul-v4/implementation/fable-review-round-1-input.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-1-input.txt
@@ -1,0 +1,952 @@
+Independent implementation review of Dual Consul v4 FIRST SYNTHETIC SLICE. Review code provided below, not historical design. No tools, no file writes, no network. Find concrete blocking correctness issues only; do not demand production activation, remote effects, OS identity separation or unimplemented native invocation: these are explicitly unqualified future stages. This is a same-database synthetic effect with trusted caller, not a public API. Check fencing concurrency and expiry, review binding, canonical hashes, replay/atomicity, and fail-closed text admission. Existing AutonomousLabWorker now checks false heartbeat/pause/success replies. Real PG17 disposable tests are in progress. Return concise verdict PASS/REWORK plus findings with exact file/symbol and concrete trigger. If no blocking issue say so and list precise residual limits. Do not claim you ran tools/tests. End with END_DUAL_CONSUL_REVIEW.
+
+FILE apps/backend-rag/backend/services/autonomous_lab/consul_store.py
+"""PostgreSQL fencing for the synthetic Dual Consul lifecycle slice.
+
+Only the trusted broker calls ``bind``, after validating authority and the frozen
+review; hashes supplied by a model are not admission. ``guard`` encloses ONLY a
+same-connection synthetic receipt write. Its locks give no remote-effect atomicity
+and this module does not establish a separate operating-system service identity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import asyncpg
+
+
+@dataclass(frozen=True)
+class Lease:
+    run_id: str
+    owner_id: str
+    generation: int
+
+
+async def _lock_parent(conn: asyncpg.Connection, run_id: str) -> asyncpg.Record | None:
+    return await conn.fetchrow(
+        "SELECT worker_id, status FROM autonomous_lab_runs WHERE run_id = $1 FOR UPDATE",
+        run_id,
+    )
+
+
+async def bind(
+    conn: asyncpg.Connection,
+    *,
+    run_id: str,
+    owner_id: str,
+    resource: str,
+    intent_hash: str,
+    approval_hash: str,
+    review_hash: str,
+    packet_hash: str,
+    grant_expires_at: datetime,
+    lease_seconds: int = 60,
+) -> Lease:
+    """Bind a freshly authorized grant; rebind fences every earlier generation."""
+    if not 1 <= lease_seconds <= 3600:
+        raise ValueError("lease_seconds must be between 1 and 3600")
+    if grant_expires_at.utcoffset() is None:
+        raise ValueError("grant expiry must be timezone-aware")
+    async with conn.transaction():
+        parent = await _lock_parent(conn, run_id)
+        if not parent or parent["status"] != "running" or parent["worker_id"] != owner_id:
+            raise PermissionError("run is not owned by this running worker")
+        previous = await conn.fetchrow(
+            "SELECT revoked_approval_hashes FROM autonomous_lab_consul_leases "
+            "WHERE run_id = $1 FOR UPDATE",
+            run_id,
+        )
+        if previous and approval_hash in previous["revoked_approval_hashes"]:
+            raise PermissionError("approval was revoked")
+        now = await conn.fetchval("SELECT clock_timestamp()")
+        if grant_expires_at <= now:
+            raise PermissionError("grant has expired")
+        generation = await conn.fetchval(
+            """
+            INSERT INTO autonomous_lab_consul_leases
+                (run_id, owner_id, generation, resource, intent_hash, approval_hash,
+                 review_hash, packet_hash, lease_expires_at, grant_expires_at)
+            VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (run_id) DO UPDATE SET
+                owner_id = EXCLUDED.owner_id,
+                generation = autonomous_lab_consul_leases.generation + 1,
+                resource = EXCLUDED.resource, intent_hash = EXCLUDED.intent_hash,
+                approval_hash = EXCLUDED.approval_hash, review_hash = EXCLUDED.review_hash,
+                packet_hash = EXCLUDED.packet_hash,
+                lease_expires_at = EXCLUDED.lease_expires_at,
+                grant_expires_at = EXCLUDED.grant_expires_at, revoked_at = NULL
+            RETURNING generation
+            """,
+            run_id,
+            owner_id,
+            resource,
+            intent_hash,
+            approval_hash,
+            review_hash,
+            packet_hash,
+            min(now + timedelta(seconds=lease_seconds), grant_expires_at),
+            grant_expires_at,
+        )
+        return Lease(run_id, owner_id, generation)
+
+
+async def revoke(conn: asyncpg.Connection, lease: Lease) -> bool:
+    """Revoke this generation and remember its approval across future rebinds."""
+    async with conn.transaction():
+        await _lock_parent(conn, lease.run_id)
+        row = await conn.fetchrow(
+            """
+            UPDATE autonomous_lab_consul_leases
+            SET revoked_at = clock_timestamp(),
+                revoked_approval_hashes = array_append(revoked_approval_hashes, approval_hash)
+            WHERE run_id = $1 AND owner_id = $2 AND generation = $3 AND revoked_at IS NULL
+            RETURNING run_id
+            """,
+            lease.run_id,
+            lease.owner_id,
+            lease.generation,
+        )
+        return row is not None
+
+
+@asynccontextmanager
+async def guard(
+    conn: asyncpg.Connection,
+    *,
+    lease: Lease,
+    resource: str,
+    intent_hash: str,
+    approval_hash: str,
+    review_hash: str,
+    packet_hash: str,
+) -> AsyncIterator[datetime]:
+    """Hold parent/lease locks and recheck all authority pins before a DB effect."""
+    async with conn.transaction():
+        parent = await _lock_parent(conn, lease.run_id)
+        row = await conn.fetchrow(
+            "SELECT * FROM autonomous_lab_consul_leases WHERE run_id = $1 FOR UPDATE",
+            lease.run_id,
+        )
+        now = await conn.fetchval("SELECT clock_timestamp()")
+        expected = {
+            "owner_id": lease.owner_id,
+            "generation": lease.generation,
+            "resource": resource,
+            "intent_hash": intent_hash,
+            "approval_hash": approval_hash,
+            "review_hash": review_hash,
+            "packet_hash": packet_hash,
+        }
+        if (
+            not parent
+            or parent["status"] != "running"
+            or parent["worker_id"] != lease.owner_id
+            or not row
+            or any(row[key] != value for key, value in expected.items())
+            or row["revoked_at"] is not None
+            or approval_hash in row["revoked_approval_hashes"]
+            or row["lease_expires_at"] <= now
+            or row["grant_expires_at"] <= now
+        ):
+            raise PermissionError("lease, authorization or frozen review is no longer current")
+        yield now
+
+
+FILE apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+-- Synthetic Dual Consul slice; ownership belongs to the existing Lab run.
+-- Slot 306 was free on origin/main and Pro HEAD at implementation. Recheck at merge.
+-- Broker connections own admission; model processes receive no database connection.
+-- Retained approval tombstones prevent revoke A -> bind B -> resurrect A.
+SET LOCAL lock_timeout = '5s';
+
+CREATE TABLE public.autonomous_lab_consul_leases (
+    run_id TEXT PRIMARY KEY REFERENCES public.autonomous_lab_runs(run_id),
+    owner_id TEXT NOT NULL CHECK (owner_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$'),
+    generation BIGINT NOT NULL CHECK (generation > 0),
+    resource TEXT NOT NULL CHECK (resource ~ '^synthetic:[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$'),
+    intent_hash TEXT NOT NULL CHECK (intent_hash ~ '^[a-f0-9]{64}$'),
+    approval_hash TEXT NOT NULL CHECK (approval_hash ~ '^[a-f0-9]{64}$'),
+    review_hash TEXT NOT NULL CHECK (review_hash ~ '^[a-f0-9]{64}$'),
+    packet_hash TEXT NOT NULL CHECK (packet_hash ~ '^[a-f0-9]{64}$'),
+    lease_expires_at TIMESTAMPTZ NOT NULL CHECK (isfinite(lease_expires_at)),
+    grant_expires_at TIMESTAMPTZ NOT NULL CHECK (isfinite(grant_expires_at)),
+    revoked_at TIMESTAMPTZ CHECK (revoked_at IS NULL OR isfinite(revoked_at)),
+    revoked_approval_hashes TEXT[] NOT NULL DEFAULT '{}'
+        CHECK (array_position(revoked_approval_hashes, NULL) IS NULL
+            AND array_to_string(revoked_approval_hashes, ',') ~ '^([a-f0-9]{64}(,[a-f0-9]{64})*)?$'),
+    CHECK (lease_expires_at <= grant_expires_at),
+    CHECK (revoked_at IS NULL OR approval_hash = ANY (revoked_approval_hashes))
+);
+
+-- === ROLLBACK ===
+DROP TABLE IF EXISTS public.autonomous_lab_consul_leases;
+
+
+FILE apps/backend-rag/backend/services/autonomous_lab/consul_executor.py
+"""Dual Consul's first slice: one fenced, same-database synthetic effect.
+
+The caller is a trusted broker, not a model-facing API. It supplies authenticated
+grants and reviewer observations. This does not establish service-UID isolation
+or qualify a shell, remote tool, model invocation, or production effect.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from typing import Any, Literal, TypeVar
+from uuid import NAMESPACE_URL, uuid5
+
+import asyncpg
+
+from backend.services.research_os import _core_path as _core_path
+
+# isort: split
+
+from research_os.hashing import canonicalize, object_hash
+from research_os.models.action_intent import ActionIntent
+from research_os.models.approval_receipt import ApprovalReceipt, authorizes_action_intent
+from research_os.models.execution_attempt import (
+    ExecutionAttempt,
+    validate_execution_attempt_authorization,
+)
+from research_os.models.operational_receipt import OperationalReceipt, close_execution_attempt
+from research_os.models.verification_receipt import VerificationReceipt
+from research_os.primitives import FrozenCoreModel
+
+from backend.services.autonomous_lab import consul_store
+from backend.services.autonomous_lab.runtime_contracts import (
+    LabArtifactKind,
+    LabStageName,
+    LabStageStatus,
+)
+from backend.services.autonomous_lab.stages import LabStageRiskClass, StageResult
+from backend.services.autonomous_lab.state_store import (
+    LabRunRecord,
+)
+
+EFFECT = "com.balizero.consul.synthetic_checkpoint"
+CRITERIA = "dual-consul/v4-synthetic"
+PRODUCER = {"name": "com.balizero.consul.synthetic_executor", "version": "4.0.0"}
+Model = TypeVar("Model", bound=FrozenCoreModel)
+
+
+@dataclass(frozen=True)
+class FrozenInputs:
+    """Actual bytes received by the executor; only their digests are persisted."""
+
+    run_id: str
+    artifact: bytes
+    effective_input: bytes
+    configuration: bytes
+    evidence: bytes
+    runtime_binding: bytes
+    builder: Literal["astra", "fable"]
+    reviewer: Literal["astra", "fable"]
+
+    @property
+    def digest(self) -> str:
+        packet = {
+            "run_id": self.run_id,
+            "builder": self.builder,
+            "reviewer": self.reviewer,
+            **{
+                key: sha256(getattr(self, key)).hexdigest()
+                for key in (
+                    "artifact",
+                    "effective_input",
+                    "configuration",
+                    "evidence",
+                    "runtime_binding",
+                )
+            },
+        }
+        return sha256(canonicalize(packet)).hexdigest()
+
+    @property
+    def arguments_hash(self) -> str:
+        return sha256(canonicalize({"run_id": self.run_id, "effect": EFFECT})).hexdigest()
+
+
+@dataclass(frozen=True)
+class ConsulRequest:
+    inputs: FrozenInputs
+    intent: ActionIntent
+    approval: ApprovalReceipt
+    review: VerificationReceipt
+
+    @property
+    def pins(self) -> dict[str, str]:
+        return {
+            "resource": f"synthetic:{self.inputs.run_id}",
+            "intent_hash": self.intent.object_hash,
+            "approval_hash": self.approval.object_hash,
+            "review_hash": self.review.object_hash,
+            "packet_hash": self.inputs.digest,
+        }
+
+    def validate(self, at: datetime) -> None:
+        """Check canonical grants plus the effect, resource, and frozen review."""
+        intent, approval, review, inputs = self.intent, self.approval, self.review, self.inputs
+        # Frozen Pydantic models still permit nested mutation / model_copy(update).
+        # Revalidate their wire forms at the trust boundary, including every hash.
+        for model in (intent, approval, review):
+            type(model).model_validate_json(model.model_dump_json(exclude_unset=True))
+        authorizes_action_intent(approval, intent, at=at)
+        if inputs.builder not in {"astra", "fable"} or {inputs.builder, inputs.reviewer} != {
+            "astra",
+            "fable",
+        }:
+            raise PermissionError("independent_consul_required")
+        if (
+            intent.action_type != EFFECT
+            or approval.authorized_effects != (EFFECT,)
+            or intent.target.system != "com.balizero.autonomous_lab"
+            or intent.target.object_ref is None
+            or intent.target.object_ref.object_kind != "com.balizero.lab_run"
+            or intent.target.object_ref.object_id != inputs.run_id
+            or intent.target.object_ref.object_hash != inputs.digest
+            or intent.input_revision_hash != inputs.digest
+            or intent.arguments_hash != inputs.arguments_hash
+            or intent.risk_class != "green"
+            or intent.sensitivity != "internal"
+        ):
+            raise PermissionError("synthetic_scope_or_input_mismatch")
+        if (
+            approval.authority.role != "consul.synthetic_broker"
+            or intent.authority_required.role != approval.authority.role
+            or approval.authority.scope != inputs.run_id
+            or intent.authority_required.scope != inputs.run_id
+            or not (approval.authority.verified_at <= approval.issued_at <= at)
+            or (approval.expires_at - approval.issued_at).total_seconds()
+            > intent.authority_required.expires_after_seconds
+        ):
+            raise PermissionError("authority_scope_mismatch")
+        target = _ref("action_intent", intent.action_intent_id, intent.object_hash)
+        if (
+            review.verdict != "pass"
+            or review.limits
+            or not review.checks
+            or any(check.result != "pass" for check in review.checks)
+            or [ref.model_dump(mode="json") for ref in review.target_objects] != [target]
+            or review.verifier.name != f"com.balizero.consul.{inputs.reviewer}"
+            or review.verifier.independence_class != "cross_family"
+            or review.criteria_version != CRITERIA
+            or review.classification != approval.classification
+            or review.expires_at is None
+            or not (review.issued_at <= review.recorded_at <= at < review.expires_at)
+            or not (intent.created_at <= review.temporal_scope.checked_at <= review.issued_at)
+        ):
+            raise PermissionError("review_missing_stale_or_mismatched")
+
+
+def _ref(kind: str, identifier: object, digest: str) -> dict[str, str]:
+    return {"object_kind": kind, "object_id": str(identifier), "object_hash": digest}
+
+
+def seal(model: type[Model], payload: dict[str, Any]) -> Model:
+    """Create a canonical ROS object without bypassing its validators."""
+    return model.model_validate({**payload, "object_hash": object_hash(payload)})
+
+
+async def _persist(
+    conn: asyncpg.Connection, kind: str, identifier: object, model: FrozenCoreModel
+) -> None:
+    payload = model.model_dump(mode="json", exclude_unset=True)
+    await conn.execute(
+        """INSERT INTO research_os_objects
+           (object_kind, object_id, object_hash, contract_version, tenant, payload)
+           VALUES ($1, $2, $3, $4, 'bali-zero', $5::jsonb)
+           ON CONFLICT (object_id) DO NOTHING""",
+        kind,
+        str(identifier),
+        payload["object_hash"],
+        payload["contract_version"],
+        json.dumps(payload),
+    )
+    stored = await conn.fetchval(
+        "SELECT object_hash FROM research_os_objects WHERE object_id = $1", str(identifier)
+    )
+    if stored != payload["object_hash"]:
+        raise PermissionError("immutable_object_collision")
+
+
+async def execute_synthetic(
+    conn: asyncpg.Connection, *, lease: consul_store.Lease, request: ConsulRequest
+) -> OperationalReceipt:
+    """Commit attempt, synthetic checkpoint and result atomically under PG locks.
+
+    No external callback is accepted: a local timeout cannot be misrepresented as
+    remote cancellation. On a lost commit acknowledgement, replay reads the same
+    immutable receipt instead of repeating the effect.
+    """
+    if lease.run_id != request.inputs.run_id:
+        raise PermissionError("mission_mismatch")
+    async with consul_store.guard(conn, lease=lease, **request.pins) as at:
+        request.validate(at)
+        intent, approval, review = request.intent, request.approval, request.review
+        identity = f"dual-consul:{intent.action_intent_id}:{intent.object_hash}"
+        result_id = uuid5(NAMESPACE_URL, identity + ":result")
+        existing = await conn.fetchval(
+            "SELECT payload FROM research_os_objects WHERE object_id = $1", str(result_id)
+        )
+        if existing is not None:
+            return (
+                OperationalReceipt.model_validate(existing)
+                if isinstance(existing, Mapping)
+                else OperationalReceipt.model_validate_json(existing)
+            )
+        for kind, identifier, obj in (
+            ("action_intent", intent.action_intent_id, intent),
+            ("approval_receipt", approval.approval_receipt_id, approval),
+            ("verification_receipt", review.verification_receipt_id, review),
+        ):
+            await _persist(conn, kind, identifier, obj)
+        stamp = at.isoformat().replace("+00:00", "Z")
+        base = {
+            "contract_version": "research-os/v1.0.0",
+            "tenant": "bali-zero",
+            "producer": PRODUCER,
+            "lineage": {"input_hashes": [intent.object_hash]},
+            "retention": {"retention_class": "audit", "legal_hold": False},
+        }
+        attempt = seal(
+            ExecutionAttempt,
+            {
+                **base,
+                "execution_attempt_id": str(uuid5(NAMESPACE_URL, identity + ":attempt")),
+                "action_intent_ref": {
+                    "action_intent_id": str(intent.action_intent_id),
+                    "object_hash": intent.object_hash,
+                },
+                "approval_receipt_ref": {
+                    "approval_receipt_id": str(approval.approval_receipt_id),
+                    "object_hash": approval.object_hash,
+                },
+                "attempt_number": 1,
+                "state": "started",
+                "idempotency_key": identity,
+                "executor": PRODUCER,
+                "started_at": stamp,
+                "extensions": {
+                    "com.balizero.dual_consul": {
+                        "extension_version": "1.0.0",
+                        "payload": {
+                            "lease_generation": lease.generation,
+                            "bound_context_digest": request.inputs.digest,
+                        },
+                    }
+                },
+            },
+        )
+        validate_execution_attempt_authorization(attempt, intent=intent, receipt=approval)
+        await _persist(conn, "execution_attempt", attempt.execution_attempt_id, attempt)
+        # This is the ONLY effect this implementation can perform.
+        # Expiry remains live while locks are held. Recheck it in the effect
+        # statement itself, even if an earlier receipt insert was delayed.
+        effect_at = await conn.fetchval(
+            """INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+               SELECT run_id, 'run_checkpointed', $3::jsonb
+               FROM autonomous_lab_consul_leases
+               WHERE run_id = $1 AND generation = $2 AND revoked_at IS NULL
+                 AND clock_timestamp() < lease_expires_at
+                 AND clock_timestamp() < grant_expires_at
+               RETURNING clock_timestamp()""",
+            lease.run_id,
+            lease.generation,
+            json.dumps(
+                {
+                    "run_id": lease.run_id,
+                    "stage": "experiment",
+                    "result": "synthetic_confirmed",
+                    "checkpoint_fingerprint": request.inputs.digest,
+                }
+            ),
+        )
+        if effect_at is None:
+            raise PermissionError("lease_expired_before_effect")
+        stamp = effect_at.isoformat().replace("+00:00", "Z")
+        receipt = seal(
+            OperationalReceipt,
+            {
+                **base,
+                "operational_receipt_id": str(result_id),
+                "operational_receipt_family_id": "com.balizero.consul.synthetic_result",
+                "receipt_type": "execution.result",
+                "subject_refs": [
+                    _ref("action_intent", intent.action_intent_id, intent.object_hash)
+                ],
+                "execution_attempt_ref": {
+                    "execution_attempt_id": str(attempt.execution_attempt_id),
+                    "object_hash": attempt.object_hash,
+                },
+                "classification": approval.classification.model_dump(mode="json"),
+                "actor_or_executor": {"producer": PRODUCER},
+                "terminal_outcome": "succeeded",
+                "outcome_code": "com.balizero.consul.synthetic_confirmed",
+                "effects": [{"effect_type": EFFECT, "status": "confirmed"}],
+                "artifact_refs": [],
+                "evidence_refs": [
+                    _ref("verification_receipt", review.verification_receipt_id, review.object_hash)
+                ],
+                "observed_at": stamp,
+                "recorded_at": stamp,
+                "idempotency_key": identity + ":result",
+                "reconciliation": {"state": "confirmed", "checked_at": stamp, "evidence_refs": []},
+            },
+        )
+        close_execution_attempt(receipt, attempt)
+        await _persist(conn, "operational_receipt", result_id, receipt)
+        return receipt
+
+
+@dataclass
+class ConsulSyntheticStage:
+    """Opt-in stage for AutonomousLabWorker; no scheduler or default activation."""
+
+    conn: asyncpg.Connection
+    request: ConsulRequest
+    owner_id: str
+    name = LabStageName.EXPERIMENT
+    input_data_class = "ConsulRequest"
+    output_data_class = "OperationalReceipt"
+    risk_class = LabStageRiskClass.LOW
+
+    async def run(self, run: LabRunRecord, context: Mapping[str, Any]) -> StageResult:
+        if run.run_id != self.request.inputs.run_id:
+            raise PermissionError("mission_mismatch")
+        at = await self.conn.fetchval("SELECT clock_timestamp()")
+        self.request.validate(at)
+        lease = await consul_store.bind(
+            self.conn,
+            run_id=run.run_id,
+            owner_id=self.owner_id,
+            **self.request.pins,
+            grant_expires_at=min(self.request.approval.expires_at, self.request.review.expires_at),
+        )
+        result = await execute_synthetic(self.conn, lease=lease, request=self.request)
+        return StageResult(
+            stage=self.name,
+            status=LabStageStatus.SUCCEEDED,
+            artifact_kind=LabArtifactKind.SANDBOX_RUN_RESULT,
+            summary="synthetic checkpoint confirmed under current ownership",
+            payload={
+                "run_id": run.run_id,
+                "result": "synthetic_confirmed",
+                "checkpoint_fingerprint": result.object_hash,
+            },
+        )
+
+
+FILE scripts/conductor/adapter_contracts.py
+"""Pure dual-consul admission and selected-response contracts; never launches a seat.
+
+Discovery is supplied by a trusted runtime collector. These checks confer no effect
+authority and qualify neither tool execution, native resume nor remote cancellation.
+TP1 envelopes reuse the existing transport's shape, but not its reasoning fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import sys
+from typing import Any, Literal, Mapping
+
+from scripts.conductor.contracts import TaskClass, TaskIntent
+
+
+IdentityEvidence = Literal["response_observed", "request_observed", "unknown"]
+
+
+@dataclass(frozen=True)
+class Surface:
+    model: str | None
+    text_qualified: bool = False
+    effort: str | None = None
+    operations: frozenset[str] = frozenset()
+
+
+# Qualification belongs to each surface, never to a compatible protocol/family.
+SURFACES = {
+    "codex_app_server": Surface(None),
+    "claude_interactive_text": Surface("claude-fable-5-1", True),
+    "kimi_text": Surface("k3", True, "max"),
+    "kimi_native": Surface("k3"),
+    "qwen_tp1": Surface("qwen3.8-max", True, "medium"),
+    "qwen_native": Surface(None),
+    "deepseek_tp1": Surface("deepseek-v4-pro", True),
+    "gemini_agy": Surface("gemini-3.1-pro-high", True),
+    "glm_tp1": Surface("glm-5.2", True),
+    "local_r1": Surface("deepseek-r1:32b"),
+}
+
+
+@dataclass(frozen=True)
+class DiscoveryKey:
+    runtime_version: str
+    config_hash: str
+    host: str
+    auth_context_hash: str
+
+
+@dataclass(frozen=True)
+class DiscoveryObservation:
+    key: DiscoveryKey
+    surface_id: str
+    requested_model: str
+    actual_model: str | None
+    identity_evidence: IdentityEvidence
+    observed_at: datetime
+    expires_at: datetime
+    capabilities: frozenset[str] = frozenset()
+    enforced_caps: tuple[tuple[str, int], ...] = ()
+    worker_limit: int | None = None
+    delegation_observable: bool = False
+
+
+@dataclass(frozen=True)
+class Requirements:
+    exact_model: bool = False
+    output_cap: int | None = None
+    total_cap: int | None = None
+    workers: int = 0
+    effort: str | None = None
+    high_effort_authorized: bool = False
+    operation: str = "text_consultation"
+
+
+def admit(
+    surface_id: str,
+    requested_model: str,
+    task: TaskIntent,
+    observation: DiscoveryObservation,
+    expected_key: DiscoveryKey,
+    now: datetime,
+    requirements: Requirements = Requirements(),
+) -> tuple[str, ...]:
+    """Return all rejection reasons; an empty tuple admits text preparation only."""
+    surface = SURFACES.get(surface_id)
+    if surface is None:
+        return ("unknown_surface",)
+    reasons: list[str] = []
+    if not surface.text_qualified:
+        reasons.append("surface_unqualified")
+    if requirements.operation != "text_consultation":
+        reasons.append("operation_unqualified")
+    if task.mutation or task.required_tools:
+        reasons.append("effects_unqualified")
+    if task.contains_pii:
+        reasons.append("pii_lane_unqualified")
+    if (
+        observation.key != expected_key
+        or observation.surface_id != surface_id
+        or not all(vars(expected_key).values())
+    ):
+        reasons.append("discovery_context_mismatch")
+    timestamps = (observation.observed_at, observation.expires_at, now)
+    if any(value.tzinfo is None for value in timestamps) or not (
+        observation.observed_at <= now < observation.expires_at
+    ):
+        reasons.append("discovery_expired_or_invalid")
+    if (
+        observation.requested_model != requested_model
+        or surface.model is not None
+        and surface.model != requested_model
+    ):
+        reasons.append("requested_model_mismatch")
+    if requirements.exact_model and (
+        observation.identity_evidence != "response_observed"
+        or observation.actual_model != requested_model
+    ):
+        reasons.append("actual_model_unproven")
+    if (
+        observation.identity_evidence == "response_observed"
+        and observation.actual_model != requested_model
+    ):
+        reasons.append("actual_model_mismatch")
+    if (
+        not ({"text"} | task.requires | task.required_modalities)
+        <= observation.capabilities
+    ):
+        reasons.append("capabilities_unproven")
+    if requirements.effort not in (None, surface.effort):
+        reasons.append("effort_unqualified")
+    if surface.effort == "max" and not requirements.high_effort_authorized:
+        reasons.append("high_effort_requires_explicit_admission")
+    for name, requested in (
+        ("output_tokens", requirements.output_cap),
+        ("total_tokens", requirements.total_cap),
+    ):
+        enforced = dict(observation.enforced_caps).get(name)
+        if requested is not None and (
+            type(requested) is not int
+            or requested <= 0
+            or type(enforced) is not int
+            or not 0 < enforced <= requested
+        ):
+            reasons.append(f"{name}_hard_cap_unproven")
+    if type(requirements.workers) is not int or not 0 <= requirements.workers <= 4:
+        reasons.append("worker_limit_invalid")
+    elif requirements.workers == 0 and observation.worker_limit not in (None, 0):
+        reasons.append("delegation_must_be_disabled")
+    elif requirements.workers and (
+        not observation.delegation_observable
+        or type(observation.worker_limit) is not int
+        or not 0 < observation.worker_limit <= requirements.workers
+    ):
+        reasons.append("delegation_limit_unproven")
+    return tuple(reasons)
+
+
+@dataclass(frozen=True)
+class Reply:
+    content: str
+    status: Literal["complete", "incomplete", "unknown"]
+    actual_model: str | None
+    identity_evidence: IdentityEvidence
+    finish_reason: str | None = None
+    native_usage: tuple[tuple[str, int], ...] = ()
+    remote_effect: str = "unknown"
+    local_cancelled: bool = False
+    remote_cancelled: bool | None = None
+
+
+def normalize_text(
+    content: object,
+    finish_reason: object,
+    *,
+    actual_model: str | None = None,
+    identity_evidence: IdentityEvidence = "unknown",
+    local_cancelled: bool = False,
+    remote_cancelled: bool | None = None,
+) -> Reply:
+    """Normalize collector-selected text; native lifecycle outcomes stay separate."""
+    text = content if isinstance(content, str) else ""
+    status = (
+        "complete"
+        if finish_reason in ("stop", "end_turn") and text.strip()
+        else "unknown"
+    )
+    if finish_reason in ("length", "max_tokens") or local_cancelled:
+        status = "incomplete"
+    return Reply(
+        text,
+        status,
+        actual_model,
+        identity_evidence,
+        finish_reason=finish_reason if isinstance(finish_reason, str) else None,
+        local_cancelled=local_cancelled,
+        remote_cancelled=remote_cancelled,
+    )
+
+
+def normalize_tp1(
+    payload: Mapping[str, Any],
+    *,
+    local_cancelled: bool = False,
+    remote_cancelled: bool | None = None,
+) -> Reply:
+    """Accept content only; preserve native counters without adding reasoning twice."""
+    choices = payload.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    choice = choice if isinstance(choice, dict) else {}
+    message = choice.get("message", {})
+    message = message if isinstance(message, dict) else {}
+    model = payload.get("model")
+    model = model if isinstance(model, str) and model else None
+    finish_reason = choice.get("finish_reason")
+    result = normalize_text(
+        message.get("content"),
+        finish_reason if finish_reason in ("stop", "length") else None,
+        actual_model=model,
+        identity_evidence="response_observed" if model else "unknown",
+        local_cancelled=local_cancelled,
+        remote_cancelled=remote_cancelled,
+    )
+    usage = payload.get("usage", {})
+    usage = usage if isinstance(usage, dict) else {}
+    counters: list[tuple[str, int]] = []
+    for name in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = usage.get(name)
+        if type(value) is int and value >= 0:
+            counters.append((name, value))
+    for group, name in (
+        ("completion_tokens_details", "reasoning_tokens"),
+        ("prompt_tokens_details", "cached_tokens"),
+    ):
+        details = usage.get(group, {})
+        if isinstance(details, dict) and type(details.get(name)) is int:
+            if details[name] >= 0:
+                counters.append((f"{group}.{name}", details[name]))
+    return Reply(
+        **{
+            **vars(result),
+            "native_usage": tuple(counters),
+            "finish_reason": finish_reason if isinstance(finish_reason, str) else None,
+        }
+    )
+
+
+def tp1_payload(surface_id: str, prompt: str, output_cap: int) -> dict[str, Any]:
+    """Prepare the existing TP1 user-only transport shape, never a network call."""
+    if surface_id not in {"qwen_tp1", "deepseek_tp1", "glm_tp1"}:
+        raise ValueError("not a qualified TP1 text surface")
+    if type(output_cap) is not int or output_cap <= 0:
+        raise ValueError("output_cap must be positive")
+    surface = SURFACES[surface_id]
+    body: dict[str, Any] = {
+        "model": surface.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": output_cap,
+    }
+    if surface.effort is not None:
+        body["reasoning_effort"] = surface.effort
+    return body
+
+
+def main() -> int:
+    """Offline JSON admission: python -m scripts.conductor.adapter_contracts < packet.json.
+
+    Packet fields: surface_id, requested_model, expected_key, now (ISO timestamp),
+    task (TaskIntent), observation (DiscoveryObservation), requirements (optional).
+    Both discovery keys carry runtime_version/config_hash/host/auth_context_hash.
+    Observation timestamps are ISO strings; sets and cap pairs are JSON arrays.
+    Stdout contains only admission/rejection metadata; no task content is echoed.
+    """
+    try:
+        packet = json.load(sys.stdin)
+        required = {
+            "surface_id",
+            "requested_model",
+            "expected_key",
+            "now",
+            "task",
+            "observation",
+        }
+        if not required <= set(packet) <= required | {"requirements"}:
+            raise ValueError("invalid fields")
+        task = dict(packet["task"])
+        observed = dict(packet["observation"])
+        requirements = dict(packet.get("requirements", {}))
+        for record, fields in (
+            (task, ("mutation", "contains_pii")),
+            (observed, ("delegation_observable",)),
+            (requirements, ("exact_model", "high_effort_authorized")),
+        ):
+            if any(
+                field in record and type(record[field]) is not bool for field in fields
+            ):
+                raise ValueError("invalid boolean")
+        task["task_class"] = TaskClass(task["task_class"])
+        task["files"] = tuple(task["files"])
+        for field in ("requires", "required_modalities", "required_tools"):
+            task[field] = frozenset(task[field])
+        observed["key"] = DiscoveryKey(**observed["key"])
+        for field in ("observed_at", "expires_at"):
+            observed[field] = datetime.fromisoformat(observed[field])
+        observed["capabilities"] = frozenset(observed.get("capabilities", []))
+        observed["enforced_caps"] = tuple(
+            tuple(pair) for pair in observed.get("enforced_caps", [])
+        )
+        reasons = admit(
+            packet["surface_id"],
+            packet["requested_model"],
+            TaskIntent(**task),
+            DiscoveryObservation(**observed),
+            DiscoveryKey(**packet["expected_key"]),
+            datetime.fromisoformat(packet["now"]),
+            Requirements(**requirements),
+        )
+    except (KeyError, TypeError, ValueError):
+        sys.stderr.write("invalid admission packet; no preparation admitted\n")
+        return 1
+    sys.stdout.write(
+        json.dumps(
+            {
+                "admitted": not reasons,
+                "reasons": reasons,
+                "scope": "text_preparation_only",
+            }
+        )
+        + "\n"
+    )
+    return 2 if reasons else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+FILE docs/architecture/dual-consul/common-contract.md
+# Dual Consul Harness: common contract v4
+
+**Design:** Astra and Fable; consolidated from the owner's accepted v4 plan, 2026-09-06.
+**Implementation status:** initial synthetic slice; operational qualification and fleet activation remain separate.
+
+This contract defines one governance layer with two native consul integrations and route-specific adapters. Either consul may lead a mission; the other reviews the frozen artifact. A model, account, runtime, or role change confers no authority and preserves no review automatically. Environment permissions and the owner's scope, interruption, and revocation remain effective. This design adds no mandatory human reapproval or general CI gate.
+
+## Reuse and ownership
+
+Autonomous Lab owns mission state and lifecycle. Research OS owns canonical intents, attempts, handoffs, evidence, and receipts. The existing conductor owns binding discovery and registry integration. There is no second scheduler or parallel canonical ledger.
+
+Reuse the [Research OS canonical contracts](../../../research/operations/specs/evidence-to-action-freeze-2026-08-15/CONTRACTS.md) unchanged. Add route-specific data through versioned reverse-DNS extensions. An extension cannot weaken canonical semantics, become an authorization, or acquire release-gate authority by itself. Canonical semantic changes follow the existing freeze-change protocol.
+
+PostgreSQL is authoritative for mission ownership, scoped grants, expiry, revocation, and monotonically increasing fencing versions. Redis is auxiliary. A trusted executor under a distinct service identity rechecks the grant, current owner and fence, exact resource, action, and input immediately before every effect. The model process receives no general service credentials. Hooks, worktree conventions, and a local lease check alone do not establish this boundary.
+
+An ownership claim succeeds only if its authoritative transaction succeeds. Renewal, takeover, cancellation, and resume never restore a stale owner or expired grant. Tests of simulated ownership are identified as synthetic tests, not evidence of a deployed distinct-identity executor.
+
+## Admission and binding evidence
+
+A binding records requested and observed model, provider and route, runtime version, host, authentication-context digest, effective configuration digest, supported schema, tested capabilities, evidence references, and expiry. Capability eligibility is computed for the specific mission; configured or participation-observed does not imply effects-qualified.
+
+| Identity assurance | Evidence | Exact-model requirement |
+| --- | --- | --- |
+| `response_observed` | Native response metadata matches the requested binding | May satisfy the identity requirement while current |
+| `request_observed` | Requested/resolved alias seen on the request wire only | Insufficient |
+| `unknown` | Effective identity absent or unverified | Insufficient |
+
+These are observation levels, not cryptographic model signatures. Self-assertions, commit trailers, and session links do not authenticate a model. A historical report of metadata is distinguished from original metadata inspected during qualification.
+
+Cache discovery by runtime version, configuration, host, and authentication context, with an explicit expiry. Revalidate after a relevant change. A mission demanding a hard output, total-consumption, tool, identity, or cancellation bound is ineligible when the adapter cannot enforce that requirement; never silently lower the requirement.
+
+## Execution, outcomes, and review
+
+Record an `ActionIntent`, scoped authorization through the existing grant and receipt contracts, and an immutable started `ExecutionAttempt`. Record the actual result separately through `OperationalReceipt`. A local action journal may project `pending`, `started`, `confirmed`, and `reconcile_required`; these names do not redefine canonical closed enums. Journal entries bind action, exact resource, input, and idempotency key.
+
+Text completeness is separate: `complete`, `incomplete`, or `unknown`, based on provider termination evidence. Missing finish metadata means unknown completeness; short length or HTTP 200 does not prove completion. Truncated text is incomplete. An uncertain consequential effect requires reconciliation against the remote system where possible. A local timeout proves neither remote cancellation nor absence of an effect. Replay requires authoritative status/idempotency checks, not an optimistic retry.
+
+A review receipt binds the artifact/tree hash, actual input packet, effective binding/configuration, tool/runtime versions, and evidence set. Material changes invalidate it. The reviewer must be independent of the artifact's generator; receipt construction is not evidence that a review occurred. Resolve disagreements in at most two cycles, suspend the disputed point, and continue independent work.
+
+Resume the same native mission/session only after fresh authorization, ownership/fence, configuration, and input checks. Do not reuse sessions across unrelated missions. Native compaction is context management, not company memory authority. Keep transactional state, working context, episodes, and documentary knowledge separate; retrieved prose and summaries remain untrusted evidence.
+
+## Adapter surface and economy
+
+Each adapter implements discovery, mission admission, invocation, checkpoint/handoff, and cancellation through the existing contracts. Native runtimes retain their own session and tool semantics. Cancellation reports local interruption and remote cancellation separately.
+
+Use one lead, a narrow review packet, and at most four workers: a ceiling, not a target. Admit native delegation only when observable and controllable under that ceiling. Avoid repeated unchanged discovery and context reads. Preserve provider-native usage counters with unknown fields explicit; reasoning already included in output is never added again. An output-token limit is not a total-spend limit, and hiding reasoning does not save generated tokens.
+
+Share executor conformance tests. Add focused adapter fixtures for incompatible parameters, identity gaps, incomplete/unknown responses, excluded fields, and late responses. Run bounded real smoke tests on introduction or relevant changes, not on every PR or every host. Preserve `change_map`, `impact_map`, and advisory exclusions from `merge_group`. Delete tests only for demonstrated redundancy or lack of useful coverage; do not relocate a general harness suite into every PR.
+
+## First slice and rollout boundaries
+
+The first slice connects a synthetic mission through the existing `AutonomousLabWorker(stage_nodes=...)` lifecycle, uses a narrow synthetic grant, binds a review receipt to a frozen packet, and rejects an expired or superseded owner. PostgreSQL parent/lease locks serialize resource, packet hash, owner, epoch, expiry, and revocation checks with a same-database synthetic receipt effect. Canonical `ActionIntent.input_revision_hash` binds the artifact, effective input, configuration, evidence, toolchain, builder, and reviewer identifiers; `VerificationReceipt` targets the exact intent hash. Extensions remain observational.
+
+Acceptance evidence must distinguish the successful path, stale-owner refusal, changed-artifact refusal, and revoked-authority refusal. Synthetic reviewer identifiers exercise independence checks but do not claim an actual model performed a semantic review. Pure adapter admission/normalization fixtures establish only their tested rules. This increment does not qualify remote effects, native launch/resume/cancellation, a distinct-service-identity boundary, provider entitlement, or production reliability.
+
+Activation progresses through local development, shadow without external effects, staging, an authorized canary, and operations. Each transition requires versioned bindings, comparable metrics, evidence for the required capabilities, and rollback to the prior binding. Rollback does not revive revoked ownership or authorization. Pro hosts the authoritative broker; Air-M5 remains a thin client; Mini runs executors only where required and qualified. Host eligibility is verified independently, never inferred from another host's configuration.
+
+## Design provenance
+
+The [evidence manifest](../../../evidence/dual-consul-v4/design/manifest.json) verifies three Fable assistant text blocks from native session `433c29dd-e09f-4070-b1e9-a8da0136970c`, with `message.model=claude-fable-5-1` and runtime `2.1.261`. The final response accepts the design with five corrections. This is historical design review, not review of the implementation.
+
+[Astra](astra-native.md), [Claude](claude-native.md), and the [five adapters](adapters.md) specify their own surfaces. Selected original tool outputs preserve the other-family contributions and their metadata. Four original answer hashes match the packet; Gemini's selected response has its own computed hash because its original stdout bytes are unavailable. Remaining observation gaps are explicit. No consultation is presented as a comparable benchmark.
+

--- a/evidence/dual-consul-v4/implementation/fable-review-round-1.json
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-1.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "scope": "independent text review of the initial synthetic implementation, not runtime qualification or release approval",
+  "session_id": "9db691ab-8167-459b-a921-54857dde0d49",
+  "requested_model": "claude-fable-5-1",
+  "observed_model": "claude-fable-5-1",
+  "runtime_version": "2.1.261",
+  "runtime_surface": "interactive CLI",
+  "permission_mode": "plan",
+  "tools": [],
+  "requested_effort": "xhigh",
+  "finish_reason": "end_turn",
+  "timestamp": "2026-09-05T23:35:42.202Z",
+  "response_sha256": "1f043fa8080d26d86c9552d9a760189fbee6b70bacc80b5fa17121685a03c621",
+  "input_packet_sha256": "0ac386d2b0b51401a78fd64b42eb34650b683fe5eb73f679abafdef9179f88e6",
+  "input_file_sha256": {
+    "apps/backend-rag/backend/services/autonomous_lab/consul_store.py": "b9b4b767c40be0fd47905579d9c90ccf82c87bbd1ff9f8677a4069c7bee94bc1",
+    "apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql": "1b8f61eb1bc68babefaa75c8b1f38fdaa68460ade58c82136a505166f984483f",
+    "apps/backend-rag/backend/services/autonomous_lab/consul_executor.py": "3077ebb61daf776a996a9b65cf0ea95d155e4770ece28c5ef68542f53e3ac03f",
+    "scripts/conductor/adapter_contracts.py": "bb966047aac025e0b14bf12727c1ec0c7abe1bed665a5e2ce1115ca6b6e0b132",
+    "docs/architecture/dual-consul/common-contract.md": "e0db78dfb1ff418d6ab80c27bf0f19f6c57ad38eef8c48860f2f8a07441be1ec"
+  },
+  "claim_limit": "Reviewer inspected the supplied packet with tools disabled. Test execution is evidenced separately. Later changes require a new review.",
+  "input_packet_path": "fable-review-round-1-input.txt"
+}

--- a/evidence/dual-consul-v4/implementation/fable-review-round-1.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-1.txt
@@ -1,0 +1,27 @@
+Verdict: **PASS** for the first synthetic slice. I found no blocking correctness issue in the fencing, expiry, binding, hashing, replay/atomicity or text-admission code as provided. Findings below are non-blocking but concrete.
+
+**Non-blocking findings**
+
+- `consul_store.revoke` cannot tombstone a superseded approval. Trigger: bind approval A (gen 1), bind approval B (gen 2) without revoking, then `revoke(Lease(run, owner, 1))`. The UPDATE matches no row, returns False, and A stays absent from `revoked_approval_hashes`. A later bind with A (gen 3) succeeds while A is unexpired. Fail-closed only if the broker honours the False return. Add an approval-level revoke that appends the hash regardless of generation.
+- `adapter_contracts.admit` treats an unreported worker limit as "delegation disabled". Trigger: `claude_interactive_text`, `worker_limit=None`, `delegation_observable=False`, default `Requirements()` → admitted. Unknown is not disabled for surfaces with native delegation. Harmless for this slice since admission confers no effect authority, but fix before those surfaces are used. Also `worker_limit=False` or `0.0` pass `in (None, 0)` by equality.
+- `execute_synthetic` replay needs a live lease. After a lost commit acknowledgement, if the lease expired or was revoked, the retry raises `PermissionError` inside `guard` rather than returning the committed receipt. No duplicate effect is possible since `result_id` derives from the intent hash and the guard serialises the run. Liveness only.
+
+**Confirmed properties**
+
+- Lock order parent → lease is identical in `bind`, `revoke` and `guard`, so no deadlock and full serialisation per run.
+- Owner change is excluded during the effect by the held `FOR UPDATE` locks; the effect statement rechecks generation, revocation and both expiries with live `clock_timestamp()`.
+- Attempt, outbox effect and result receipt commit in one transaction; any failure rolls back all three.
+- Changed artifact, superseded owner, revoked lease and expired grant each refuse via distinct checks.
+
+**Residual limits, not verifiable from the provided code**
+
+- `FrozenCoreModel` must recompute `object_hash` during `model_validate_json`; otherwise the trust-boundary revalidation checks shape only. `authorizes_action_intent` is assumed to bind approval to intent hash; grant expiry is independently covered by the lease.
+- Success path assumes `approval.authorized_effects` is a tuple and `review.target_objects` entries dump to exactly three keys. Mismatch fails closed.
+- `research_os_objects` needs a unique index on `object_id` alone; `autonomous_lab_runs.run_id` must be TEXT; existing `worker_id` values must satisfy the `owner_id` CHECK regex; outbox columns must match.
+- Migration `SET LOCAL` is a no-op unless the runner wraps the file in a transaction; the rollback marker relies on runner convention.
+- Idempotency is per intent, not per resource: two distinct valid intents for one run yield two checkpoint events.
+- Tombstone array grows without bound; the CHECK regex is linear in its size.
+- Heartbeat writers on other connections block briefly behind the parent lock during an effect.
+- As stated, nothing here qualifies remote effects, native invocation, distinct service identity or production activation.
+
+END_DUAL_CONSUL_REVIEW

--- a/evidence/dual-consul-v4/implementation/fable-review-round-2-input.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-2-input.txt
@@ -1,0 +1,798 @@
+Final bounded delta review, round 2 for the SAME synthetic mission implementation. Your first verdict was PASS. No new scope or external effects. Re-evaluate your concrete findings and changes below against round 1; return PASS/REWORK with remaining blockers/limits and END_DUAL_CONSUL_REVIEW. No tools. Do not claim independent test execution.
+
+Resolved: revoke_approval now records superseded authorization by hash; zero workers requires exact int 0. Existing revoke(lease) retains False for obsolete generation. Fresh-lease replay requirement deliberately remains (no authority revival). Also real PG with production codec exposed double JSON encoding and invalid extension namespace: these are corrected below. Intent producer is now bound to the declared builder. Existing state_store transport gets text::jsonb casts; worker refuses false ownership updates.
+
+--- round1/apps/backend-rag/backend/services/autonomous_lab/consul_store.py
++++ final/apps/backend-rag/backend/services/autonomous_lab/consul_store.py
+@@ -8,6 +8,7 @@
+ 
+ from __future__ import annotations
+ 
++import re
+ from collections.abc import AsyncIterator
+ from contextlib import asynccontextmanager
+ from dataclasses import dataclass
+@@ -110,6 +111,28 @@
+         return row is not None
+ 
+ 
++async def revoke_approval(conn: asyncpg.Connection, *, run_id: str, approval_hash: str) -> bool:
++    """Trusted broker revocation, including superseded grants; False if unchanged."""
++    if not re.fullmatch(r"[a-f0-9]{64}", approval_hash):
++        raise ValueError("approval_hash must be lowercase SHA-256 hex")
++    async with conn.transaction():
++        if await _lock_parent(conn, run_id) is None:
++            return False
++        row = await conn.fetchrow(
++            """
++            UPDATE autonomous_lab_consul_leases
++            SET revoked_approval_hashes = array_append(revoked_approval_hashes, $2),
++                revoked_at = CASE WHEN approval_hash = $2
++                    THEN COALESCE(revoked_at, clock_timestamp()) ELSE revoked_at END
++            WHERE run_id = $1 AND NOT ($2 = ANY (revoked_approval_hashes))
++            RETURNING run_id
++            """,
++            run_id,
++            approval_hash,
++        )
++        return row is not None
++
++
+ @asynccontextmanager
+ async def guard(
+     conn: asyncpg.Connection,
+@@ -151,4 +174,3 @@
+         ):
+             raise PermissionError("lease, authorization or frozen review is no longer current")
+         yield now
+-
+
+--- round1/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
++++ final/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+@@ -25,4 +25,3 @@
+ 
+ -- === ROLLBACK ===
+ DROP TABLE IF EXISTS public.autonomous_lab_consul_leases;
+-
+
+--- round1/apps/backend-rag/backend/services/autonomous_lab/consul_executor.py
++++ final/apps/backend-rag/backend/services/autonomous_lab/consul_executor.py
+@@ -111,10 +111,15 @@
+         for model in (intent, approval, review):
+             type(model).model_validate_json(model.model_dump_json(exclude_unset=True))
+         authorizes_action_intent(approval, intent, at=at)
+-        if inputs.builder not in {"astra", "fable"} or {inputs.builder, inputs.reviewer} != {
+-            "astra",
+-            "fable",
+-        }:
++        if (
++            inputs.builder not in {"astra", "fable"}
++            or {inputs.builder, inputs.reviewer}
++            != {
++                "astra",
++                "fable",
++            }
++            or intent.producer.name != f"com.balizero.consul.{inputs.builder}"
++        ):
+             raise PermissionError("independent_consul_required")
+         if (
+             intent.action_type != EFFECT
+@@ -174,7 +179,7 @@
+     await conn.execute(
+         """INSERT INTO research_os_objects
+            (object_kind, object_id, object_hash, contract_version, tenant, payload)
+-           VALUES ($1, $2, $3, $4, 'bali-zero', $5::jsonb)
++           VALUES ($1, $2, $3, $4, 'bali-zero', $5::text::jsonb)
+            ON CONFLICT (object_id) DO NOTHING""",
+         kind,
+         str(identifier),
+@@ -247,7 +252,7 @@
+                 "executor": PRODUCER,
+                 "started_at": stamp,
+                 "extensions": {
+-                    "com.balizero.dual_consul": {
++                    "com.balizero.dual-consul": {
+                         "extension_version": "1.0.0",
+                         "payload": {
+                             "lease_generation": lease.generation,
+@@ -264,7 +269,7 @@
+         # statement itself, even if an earlier receipt insert was delayed.
+         effect_at = await conn.fetchval(
+             """INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+-               SELECT run_id, 'run_checkpointed', $3::jsonb
++               SELECT run_id, 'run_checkpointed', $3::text::jsonb
+                FROM autonomous_lab_consul_leases
+                WHERE run_id = $1 AND generation = $2 AND revoked_at IS NULL
+                  AND clock_timestamp() < lease_expires_at
+@@ -354,4 +359,3 @@
+                 "checkpoint_fingerprint": result.object_hash,
+             },
+         )
+-
+
+--- round1/scripts/conductor/adapter_contracts.py
++++ final/scripts/conductor/adapter_contracts.py
+@@ -148,7 +148,9 @@
+             reasons.append(f"{name}_hard_cap_unproven")
+     if type(requirements.workers) is not int or not 0 <= requirements.workers <= 4:
+         reasons.append("worker_limit_invalid")
+-    elif requirements.workers == 0 and observation.worker_limit not in (None, 0):
++    elif requirements.workers == 0 and (
++        type(observation.worker_limit) is not int or observation.worker_limit != 0
++    ):
+         reasons.append("delegation_must_be_disabled")
+     elif requirements.workers and (
+         not observation.delegation_observable
+@@ -336,4 +338,3 @@
+ 
+ if __name__ == "__main__":
+     raise SystemExit(main())
+-
+
+--- round1/docs/architecture/dual-consul/common-contract.md
++++ final/docs/architecture/dual-consul/common-contract.md
+@@ -19,11 +19,11 @@
+ 
+ A binding records requested and observed model, provider and route, runtime version, host, authentication-context digest, effective configuration digest, supported schema, tested capabilities, evidence references, and expiry. Capability eligibility is computed for the specific mission; configured or participation-observed does not imply effects-qualified.
+ 
+-| Identity assurance | Evidence | Exact-model requirement |
+-| --- | --- | --- |
++| Identity assurance  | Evidence                                               | Exact-model requirement                            |
++| ------------------- | ------------------------------------------------------ | -------------------------------------------------- |
+ | `response_observed` | Native response metadata matches the requested binding | May satisfy the identity requirement while current |
+-| `request_observed` | Requested/resolved alias seen on the request wire only | Insufficient |
+-| `unknown` | Effective identity absent or unverified | Insufficient |
++| `request_observed`  | Requested/resolved alias seen on the request wire only | Insufficient                                       |
++| `unknown`           | Effective identity absent or unverified                | Insufficient                                       |
+ 
+ These are observation levels, not cryptographic model signatures. Self-assertions, commit trailers, and session links do not authenticate a model. A historical report of metadata is distinguished from original metadata inspected during qualification.
+ 
+@@ -53,6 +53,8 @@
+ 
+ Acceptance evidence must distinguish the successful path, stale-owner refusal, changed-artifact refusal, and revoked-authority refusal. Synthetic reviewer identifiers exercise independence checks but do not claim an actual model performed a semantic review. Pure adapter admission/normalization fixtures establish only their tested rules. This increment does not qualify remote effects, native launch/resume/cancellation, a distinct-service-identity boundary, provider entitlement, or production reliability.
+ 
++The [implementation evidence and reproduction commands](../../../evidence/dual-consul-v4/implementation/README.md) identify the opt-in consumer, real PostgreSQL proof, and remaining activation boundaries.
++
+ Activation progresses through local development, shadow without external effects, staging, an authorized canary, and operations. Each transition requires versioned bindings, comparable metrics, evidence for the required capabilities, and rollback to the prior binding. Rollback does not revive revoked ownership or authorization. Pro hosts the authoritative broker; Air-M5 remains a thin client; Mini runs executors only where required and qualified. Host eligibility is verified independently, never inferred from another host's configuration.
+ 
+ ## Design provenance
+@@ -60,4 +62,3 @@
+ The [evidence manifest](../../../evidence/dual-consul-v4/design/manifest.json) verifies three Fable assistant text blocks from native session `433c29dd-e09f-4070-b1e9-a8da0136970c`, with `message.model=claude-fable-5-1` and runtime `2.1.261`. The final response accepts the design with five corrections. This is historical design review, not review of the implementation.
+ 
+ [Astra](astra-native.md), [Claude](claude-native.md), and the [five adapters](adapters.md) specify their own surfaces. Selected original tool outputs preserve the other-family contributions and their metadata. Four original answer hashes match the packet; Gemini's selected response has its own computed hash because its original stdout bytes are unavailable. Remaining observation gaps are explicit. No consultation is presented as a comparable benchmark.
+-
+
+diff --git a/apps/backend-rag/backend/services/autonomous_lab/state_store.py b/apps/backend-rag/backend/services/autonomous_lab/state_store.py
+index 908b2d9f05..da235599b8 100644
+--- a/apps/backend-rag/backend/services/autonomous_lab/state_store.py
++++ b/apps/backend-rag/backend/services/autonomous_lab/state_store.py
+@@ -294,7 +294,7 @@ WITH inserted AS (
+         priority,
+         max_attempts
+     )
+-    VALUES ($1, $2, $3, $4::jsonb, $5::text[], $6::jsonb, $7, $8)
++    VALUES ($1, $2, $3, $4::text::jsonb, $5::text[], $6::text::jsonb, $7, $8)
+     ON CONFLICT (idempotency_key) DO NOTHING
+     RETURNING
+         run_id,
+@@ -415,7 +415,7 @@ WITH updated AS (
+ ),
+ event_insert AS (
+     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+-    SELECT run_id, 'run_succeeded', $3::jsonb
++    SELECT run_id, 'run_succeeded', $3::text::jsonb
+     FROM updated
+     RETURNING event_id
+ )
+@@ -429,7 +429,7 @@ WITH updated AS (
+     UPDATE autonomous_lab_runs
+     SET
+         status = 'paused',
+-        metadata = metadata || $3::jsonb,
++        metadata = metadata || $3::text::jsonb,
+         worker_id = NULL,
+         updated_at = NOW(),
+         last_error = NULL
+@@ -440,7 +440,7 @@ WITH updated AS (
+ ),
+ event_insert AS (
+     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+-    SELECT run_id, 'run_paused', $4::jsonb
++    SELECT run_id, 'run_paused', $4::text::jsonb
+     FROM updated
+     RETURNING event_id
+ )
+@@ -468,7 +468,7 @@ WITH updated AS (
+ ),
+ event_insert AS (
+     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+-    SELECT run_id, 'run_failed', $5::jsonb
++    SELECT run_id, 'run_failed', $5::text::jsonb
+     FROM updated
+     RETURNING event_id
+ )
+@@ -551,7 +551,7 @@ updated AS (
+     UPDATE autonomous_lab_runs
+     SET
+         status = $4,
+-        metadata = metadata || $5::jsonb,
++        metadata = metadata || $5::text::jsonb,
+         worker_id = NULL,
+         next_attempt_at = CASE WHEN $4 = 'pending' THEN NOW() ELSE next_attempt_at END,
+         updated_at = NOW()
+@@ -565,7 +565,7 @@ updated AS (
+ ),
+ event_insert AS (
+     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+-    SELECT run_id, 'curator_decision_recorded', $6::jsonb
++    SELECT run_id, 'curator_decision_recorded', $6::text::jsonb
+     FROM updated
+     RETURNING event_id
+ )
+@@ -591,7 +591,7 @@ updated AS (
+     UPDATE autonomous_lab_runs
+     SET
+         status = 'cancelled',
+-        metadata = metadata || $3::jsonb,
++        metadata = metadata || $3::text::jsonb,
+         worker_id = NULL,
+         updated_at = NOW()
+     WHERE run_id = $1
+@@ -604,7 +604,7 @@ updated AS (
+ ),
+ event_insert AS (
+     INSERT INTO autonomous_lab_events_outbox (run_id, event_type, payload)
+-    SELECT run_id, 'run_cancelled', $4::jsonb
++    SELECT run_id, 'run_cancelled', $4::text::jsonb
+     FROM updated
+     RETURNING event_id
+ )
+@@ -990,7 +990,7 @@ class AutonomousLabStateStore:
+                 payload,
+                 max_attempts
+             )
+-            VALUES ($1, $2, $3::jsonb, $4)
++            VALUES ($1, $2, $3::text::jsonb, $4)
+             RETURNING event_id
+             """,
+             run_id,
+@@ -1149,6 +1149,8 @@ def _optional_note_reference(note: str | None) -> str | None:
+ 
+ 
+ def _jsonb(value: Mapping[str, Any]) -> str:
++    # Bind these serialized values as SQL text, then cast to jsonb. Passing
++    # them as jsonb parameters would run the pool's JSON encoder a second time.
+     return json.dumps(dict(value), allow_nan=False, ensure_ascii=False, sort_keys=True)
+ 
+ 
+
+diff --git a/apps/backend-rag/backend/services/autonomous_lab/worker.py b/apps/backend-rag/backend/services/autonomous_lab/worker.py
+index fa93065494..fdd5700738 100644
+--- a/apps/backend-rag/backend/services/autonomous_lab/worker.py
++++ b/apps/backend-rag/backend/services/autonomous_lab/worker.py
+@@ -103,9 +103,7 @@ class LabWorkerDryRun:
+             "created_at": self.created_at.isoformat(),
+             "placement": self.placement.to_receipt(),
+             "sandbox_policy": self.sandbox_policy.to_receipt(),
+-            "checkpoints": [
+-                checkpoint.to_receipt() for checkpoint in self.checkpoints
+-            ],
++            "checkpoints": [checkpoint.to_receipt() for checkpoint in self.checkpoints],
+             "paused_at_stage": self.paused_at_stage.value,
+             "execution_allowed": self.execution_allowed,
+             "manual_promotion_required": self.manual_promotion_required,
+@@ -142,11 +140,12 @@ class AutonomousLabWorker:
+ 
+         checkpoints: list[LabCheckpoint] = []
+         try:
+-            await self.state_store.heartbeat_run(
++            if not await self.state_store.heartbeat_run(
+                 conn,
+                 run_id=record.run_id,
+                 worker_id=worker_id,
+-            )
++            ):
++                raise PermissionError("worker no longer owns the run")
+             context: dict[str, Any] = {}
+             for node in _nodes_after_resume(self.stage_nodes, record):
+                 result = await node.run(record, context)
+@@ -160,13 +159,14 @@ class AutonomousLabWorker:
+                 )
+                 context[result.stage.value] = checkpoint.fingerprint
+                 if result.status is LabStageStatus.PAUSED:
+-                    await self.state_store.mark_run_paused(
++                    if not await self.state_store.mark_run_paused(
+                         conn,
+                         run_id=record.run_id,
+                         worker_id=worker_id,
+                         stage=result.stage.value,
+                         checkpoint=checkpoint.to_receipt(),
+-                    )
++                    ):
++                        raise PermissionError("worker lost ownership before pause")
+                     return LabWorkerTickResult.paused(
+                         worker_id=worker_id,
+                         record=record,
+@@ -174,12 +174,13 @@ class AutonomousLabWorker:
+                         paused_at_stage=result.stage,
+                     )
+ 
+-            await self.state_store.mark_run_succeeded(
++            if not await self.state_store.mark_run_succeeded(
+                 conn,
+                 run_id=record.run_id,
+                 worker_id=worker_id,
+                 summary={"checkpoint_count": len(checkpoints)},
+-            )
++            ):
++                raise PermissionError("worker lost ownership before completion")
+             return LabWorkerTickResult.succeeded(
+                 worker_id=worker_id,
+                 record=record,
+
+
+EXISTING CANONICAL VALIDATORS packages/research-os-core/research_os/primitives.py:415-445
+class Classification(FrozenCoreModel):
+    risk_class: RiskClass
+    sensitivity: Sensitivity
+
+
+class ValidTime(FrozenCoreModel):
+    valid_from: UtcDateTime
+    valid_to: UtcDateTime | None
+
+    @model_validator(mode="after")
+    def validate_half_open_interval(self) -> ValidTime:
+        if self.valid_to is not None and self.valid_to <= self.valid_from:
+            raise PydanticCustomError(
+                "valid_time_not_increasing",
+                "valid_to must be strictly later than valid_from",
+            )
+        return self
+
+
+class ExtensionValue(FrozenCoreModel):
+    extension_version: str
+    payload: dict[str, Any]
+
+    @model_validator(mode="after")
+    def validate_semantic_version(self) -> ExtensionValue:
+        try:
+            SemanticVersion.parse(self.extension_version)
+        except ValueError as exc:
+            raise PydanticCustomError(
+                "extension_version_not_semver",
+                "extension_version must be semantic version",
+
+FINAL PG TEST SOURCE apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+"""Opt-in real PostgreSQL proof; exact disposable database only, never models.
+
+DUAL_CONSUL_TEST_DSN must explicitly name dual_consul_test. The fixture resets
+only this slice's tables there and serializes schema setup with an advisory lock.
+Run on Pro against a disposable PostgreSQL instance, not an operational database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncIterator
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+import asyncpg
+import pytest
+
+from backend.app.core.database import init_asyncpg_connection
+from backend.db.migration_base import split_migration_sql
+from backend.migrations.migration_124_autonomous_lab_runtime import apply as apply_lab
+from backend.services.autonomous_lab import consul_executor, consul_store
+from backend.services.autonomous_lab.consul_executor import ConsulSyntheticStage, execute_synthetic
+from backend.services.autonomous_lab.state_store import (
+    AutonomousLabStateStore,
+    LabRunQueueItem,
+    resolve_runtime_placement,
+)
+from backend.services.autonomous_lab.worker import AutonomousLabWorker
+from backend.tests.unit.services.autonomous_lab.consul_fixtures import make_request
+
+pytestmark = pytest.mark.integration
+MIGRATIONS = Path(__file__).resolve().parents[2] / "db" / "migrations_v2"
+OWNER = "consul-astra"
+
+
+def _dsn() -> str:
+    value = os.environ.get("DUAL_CONSUL_TEST_DSN")
+    if not value:
+        pytest.skip("DUAL_CONSUL_TEST_DSN is required for isolated PostgreSQL proof")
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme not in {"postgres", "postgresql"}
+        or unquote(parsed.path) != "/dual_consul_test"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Dual Consul tests require exactly dual_consul_test without DSN overrides")
+    return value
+
+
+@pytest.fixture
+async def dual_db() -> AsyncIterator[asyncpg.Connection]:
+    conn = await asyncpg.connect(_dsn())
+    try:
+        await init_asyncpg_connection(conn)
+        if await conn.fetchval("SELECT current_database()") != "dual_consul_test":
+            raise RuntimeError("connected database is not dual_consul_test")
+        await conn.execute("SELECT pg_advisory_lock(hashtext('dual-consul-test-schema'))")
+        await conn.execute("""
+            DROP TABLE IF EXISTS autonomous_lab_consul_leases,
+                autonomous_lab_events_outbox, autonomous_lab_runs, research_os_objects CASCADE;
+            DROP FUNCTION IF EXISTS public.reject_research_os_objects_mutation();
+        """)
+        async with conn.transaction():
+            await apply_lab(conn)
+            for name in (
+                "279_research_os_contract_core.sql",
+                "280_research_os_objects_truncate_guard.sql",
+                "306_autonomous_lab_consul_leases.sql",
+            ):
+                forward, _ = split_migration_sql((MIGRATIONS / name).read_text())
+                await conn.execute(forward)
+        yield conn
+    finally:
+        await conn.close()
+
+
+def _store() -> AutonomousLabStateStore:
+    store = AutonomousLabStateStore()
+    store.placement = resolve_runtime_placement("Nuzantara", "nuzantara")
+    return store
+
+
+async def _enqueue(conn: asyncpg.Connection, run_id: str) -> AutonomousLabStateStore:
+    store = _store()
+    await store.enqueue_run(
+        conn,
+        LabRunQueueItem(
+            run_id=run_id,
+            idempotency_key=run_id,
+            objective="Synthetic Consul ownership proof",
+            receipt={"run_id": run_id, "blocked": False, "summary": "Synthetic proof only"},
+        ),
+    )
+    return store
+
+
+async def _admit(conn: asyncpg.Connection, run_id: str = "consul-db-proof") -> tuple[Any, Any]:
+    store = await _enqueue(conn, run_id)
+    assert await store.claim_next_run(conn, worker_id=OWNER) is not None
+    request = make_request(await conn.fetchval("SELECT clock_timestamp()"), run_id)
+    request.validate(await conn.fetchval("SELECT clock_timestamp()"))
+    lease = await consul_store.bind(
+        conn,
+        run_id=run_id,
+        owner_id=OWNER,
+        **request.pins,
+        grant_expires_at=request.review.expires_at,
+    )
+    return request, lease
+
+
+async def _counts(conn: asyncpg.Connection) -> tuple[int, int, int]:
+    return (
+        await conn.fetchval(
+            "SELECT count(*) FROM research_os_objects WHERE object_kind='execution_attempt'"
+        ),
+        await conn.fetchval(
+            "SELECT count(*) FROM research_os_objects WHERE object_kind='operational_receipt'"
+        ),
+        await conn.fetchval(
+            "SELECT count(*) FROM autonomous_lab_events_outbox WHERE payload->>'result'='synthetic_confirmed'"
+        ),
+    )
+
+
+async def test_migration_306_rollback_and_reapply_preserve_existing_lifecycle(
+    dual_db: asyncpg.Connection,
+) -> None:
+    forward, rollback = split_migration_sql(
+        (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
+    )
+    assert rollback is not None
+    async with dual_db.transaction():
+        await dual_db.execute(rollback)
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_consul_leases') IS NULL"
+    )
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_runs') IS NOT NULL "
+        "AND to_regclass('public.research_os_objects') IS NOT NULL"
+    )
+    async with dual_db.transaction():
+        await dual_db.execute(forward)
+    assert await dual_db.fetchval(
+        "SELECT to_regclass('public.autonomous_lab_consul_leases') IS NOT NULL"
+    )
+    request, lease = await _admit(dual_db, "consul-after-reapply")
+    await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (1, 1, 1)
+
+
+@pytest.mark.parametrize("builder", ["astra", "fable"])
+async def test_worker_tick_commits_started_attempt_result_and_one_effect(
+    dual_db: asyncpg.Connection, builder: Any
+) -> None:
+    run_id = f"consul-worker-{builder}"
+    store = await _enqueue(dual_db, run_id)
+    request = make_request(
+        await dual_db.fetchval("SELECT clock_timestamp()"), run_id, builder=builder
+    )
+    stage = ConsulSyntheticStage(dual_db, request, OWNER)
+    worker = AutonomousLabWorker(placement=store.placement, state_store=store, stage_nodes=(stage,))
+    result = await worker.tick(dual_db, worker_id=OWNER)
+    assert result.status.value == "succeeded"
+    assert await _counts(dual_db) == (1, 1, 1)
+    assert (
+        await dual_db.fetchval("SELECT status FROM autonomous_lab_runs WHERE run_id=$1", run_id)
+        == "succeeded"
+    )
+    assert (
+        await dual_db.fetchval(
+            "SELECT payload->>'state' FROM research_os_objects WHERE object_kind='execution_attempt'"
+        )
+        == "started"
+    )
+
+
+async def test_exact_replay_returns_same_receipt_without_duplicate_effect(
+    dual_db: asyncpg.Connection,
+) -> None:
+    request, lease = await _admit(dual_db)
+    first = await execute_synthetic(dual_db, lease=lease, request=request)
+    second = await execute_synthetic(dual_db, lease=lease, request=request)
+    assert first == second
+    assert await _counts(dual_db) == (1, 1, 1)
+
+
+@pytest.mark.parametrize("new_owner", [OWNER, "consul-fable"])
+async def test_takeover_fences_old_generation_even_when_owner_name_is_reused(
+    dual_db: asyncpg.Connection, new_owner: str
+) -> None:
+    request, stale = await _admit(dual_db)
+    await dual_db.execute(
+        "UPDATE autonomous_lab_runs SET worker_id=$1 WHERE run_id=$2", new_owner, stale.run_id
+    )
+    current = await consul_store.bind(
+        dual_db,
+        run_id=stale.run_id,
+        owner_id=new_owner,
+        **request.pins,
+        grant_expires_at=request.review.expires_at,
+    )
+    assert current.generation == stale.generation + 1
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=stale, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+
+
+@pytest.mark.parametrize("condition", ["lease_expired", "grant_expired", "revoked", "cancelled"])
+async def test_lapsed_authority_never_reaches_effect(
+    dual_db: asyncpg.Connection, condition: str
+) -> None:
+    request, lease = await _admit(dual_db)
+    if condition == "revoked":
+        assert await consul_store.revoke(dual_db, lease)
+    elif condition == "cancelled":
+        await dual_db.execute(
+            "UPDATE autonomous_lab_runs SET status='cancelled' WHERE run_id=$1", lease.run_id
+        )
+    elif condition == "grant_expired":
+        await dual_db.execute(
+            "UPDATE autonomous_lab_consul_leases SET lease_expires_at=clock_timestamp()-interval '2 seconds', grant_expires_at=clock_timestamp()-interval '1 second'"
+        )
+    else:
+        await dual_db.execute(
+            "UPDATE autonomous_lab_consul_leases SET lease_expires_at=clock_timestamp()-interval '1 second'"
+        )
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+
+
+async def test_revoked_approval_cannot_return_after_new_grant(dual_db: asyncpg.Connection) -> None:
+    request, lease = await _admit(dual_db)
+    assert await consul_store.revoke(dual_db, lease)
+    fresh = make_request(
+        await dual_db.fetchval("SELECT clock_timestamp()"), lease.run_id, grant_revision=2
+    )
+    await consul_store.bind(
+        dual_db,
+        run_id=lease.run_id,
+        owner_id=OWNER,
+        **fresh.pins,
+        grant_expires_at=fresh.review.expires_at,
+    )
+    with pytest.raises(PermissionError, match="revoked"):
+        await consul_store.bind(
+            dual_db,
+            run_id=lease.run_id,
+            owner_id=OWNER,
+            **request.pins,
+            grant_expires_at=request.review.expires_at,
+        )
+
+
+async def test_broker_revokes_superseded_approval_without_revoking_current_grant(
+    dual_db: asyncpg.Connection,
+) -> None:
+    previous, old_lease = await _admit(dual_db)
+    current = make_request(
+        await dual_db.fetchval("SELECT clock_timestamp()"), old_lease.run_id, grant_revision=2
+    )
+    new_lease = await consul_store.bind(
+        dual_db,
+        run_id=old_lease.run_id,
+        owner_id=OWNER,
+        **current.pins,
+        grant_expires_at=current.review.expires_at,
+    )
+    assert new_lease.generation == old_lease.generation + 1
+    assert not await consul_store.revoke(dual_db, old_lease)
+    assert await consul_store.revoke_approval(
+        dual_db, run_id=old_lease.run_id, approval_hash=previous.approval.object_hash
+    )
+    assert not await consul_store.revoke_approval(
+        dual_db, run_id=old_lease.run_id, approval_hash=previous.approval.object_hash
+    )
+    with pytest.raises(PermissionError, match="revoked"):
+        await consul_store.bind(
+            dual_db,
+            run_id=old_lease.run_id,
+            owner_id=OWNER,
+            **previous.pins,
+            grant_expires_at=previous.review.expires_at,
+        )
+    result = await execute_synthetic(dual_db, lease=new_lease, request=current)
+    assert result.terminal_outcome == "succeeded"
+    assert await _counts(dual_db) == (1, 1, 1)
+    assert await dual_db.fetchval(
+        "SELECT revoked_approval_hashes FROM autonomous_lab_consul_leases WHERE run_id=$1",
+        old_lease.run_id,
+    ) == [previous.approval.object_hash]
+
+
+async def test_broker_revocation_of_current_approval_refuses_effect(
+    dual_db: asyncpg.Connection,
+) -> None:
+    request, lease = await _admit(dual_db)
+    assert await consul_store.revoke_approval(
+        dual_db, run_id=lease.run_id, approval_hash=request.approval.object_hash
+    )
+    assert not await consul_store.revoke(dual_db, lease)
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+
+
+async def test_failure_after_effect_rolls_back_all_ros_objects_and_effect(
+    dual_db: asyncpg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request, lease = await _admit(dual_db)
+    original = consul_executor._persist
+
+    async def fail_result(
+        conn: asyncpg.Connection, kind: str, identifier: object, model: Any
+    ) -> None:
+        if kind == "operational_receipt":
+            raise RuntimeError("synthetic injected result-store failure")
+        await original(conn, kind, identifier, model)
+
+    monkeypatch.setattr(consul_executor, "_persist", fail_result)
+    with pytest.raises(RuntimeError, match="injected"):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+    assert await dual_db.fetchval("SELECT count(*) FROM research_os_objects") == 0
+
+
+async def test_expiry_between_guard_and_effect_rolls_back(
+    dual_db: asyncpg.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request, lease = await _admit(dual_db)
+    original = consul_executor._persist
+
+    async def expire_after_attempt(
+        conn: asyncpg.Connection, kind: str, identifier: object, model: Any
+    ) -> None:
+        await original(conn, kind, identifier, model)
+        if kind == "execution_attempt":
+            await conn.execute(
+                "UPDATE autonomous_lab_consul_leases SET lease_expires_at=clock_timestamp()-interval '1 second' WHERE run_id=$1",
+                lease.run_id,
+            )
+
+    monkeypatch.setattr(consul_executor, "_persist", expire_after_attempt)
+    with pytest.raises(PermissionError):
+        await execute_synthetic(dual_db, lease=lease, request=request)
+    assert await _counts(dual_db) == (0, 0, 0)
+    assert await dual_db.fetchval("SELECT count(*) FROM research_os_objects") == 0
+
+
+async def test_concurrent_takeover_waits_for_guard_then_fences_it(
+    dual_db: asyncpg.Connection,
+) -> None:
+    request, lease = await _admit(dual_db)
+    other = await asyncpg.connect(_dsn())
+    await init_asyncpg_connection(other)
+    started = asyncio.Event()
+    task: asyncio.Task[Any] | None = None
+
+    async def takeover() -> Any:
+        started.set()
+        return await consul_store.bind(
+            other,
+            run_id=lease.run_id,
+            owner_id=OWNER,
+            **request.pins,
+            grant_expires_at=request.review.expires_at,
+        )
+
+    try:
+        async with consul_store.guard(dual_db, lease=lease, **request.pins):
+            task = asyncio.create_task(takeover())
+            await started.wait()
+            async with asyncio.timeout(5):
+                while not await dual_db.fetchval(
+                    "SELECT $1::int = ANY(pg_blocking_pids($2::int))",
+                    dual_db.get_server_pid(),
+                    other.get_server_pid(),
+                ):
+                    assert not task.done(), "takeover passed a held owner lock"
+            assert not task.done()
+        newer = await asyncio.wait_for(task, timeout=5)
+        assert newer.generation == lease.generation + 1
+        with pytest.raises(PermissionError):
+            await execute_synthetic(dual_db, lease=lease, request=request)
+    finally:
+        if task and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        await other.close()
+
+
+OBSERVED TEST RESULTS (builder executed, independent reviewer may only assess source)
+{
+  "schema_version": 1,
+  "scope": "synthetic_local_and_disposable_postgresql_only",
+  "checks": [
+    {
+      "name": "lab",
+      "cmd": ". /Users/balizero/nuzantara/apps/backend-rag/.venv/bin/activate\nPYTHONPATH=apps/backend-rag python -m pytest apps/backend-rag/backend/tests/unit/services/autonomous_lab/ --tb=short --color=no",
+      "started_at": "2026-09-05 23:37:54 UTC",
+      "finished_at": "2026-09-05 23:38:10 UTC",
+      "exit": 0,
+      "stdout": "........................................................................ [ 31%]\n........................................................................ [ 62%]\n........................................................................ [ 93%]\n...............                                                          [100%]\n============================= slowest 10 durations =============================\n0.15s call     backend/tests/unit/services/autonomous_lab/test_mass_invariants.py::test_planner_reviewer_and_receipt_store_mass_invariants\n0.07s call     backend/tests/unit/services/autonomous_lab/test_draft_cli.py::test_cli_blocks_workspace_write_requests\n0.07s call     backend/tests/unit/services/autonomous_lab/test_draft_cli.py::test_cli_invalid_input_returns_receipt_safe_json_error\n0.07s call     backend/tests/unit/services/autonomous_lab/test_draft_cli.py::test_cli_writes_receipt_and_omits_raw_text\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_can_persist_orchestration_receipt\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_can_persist_lab_ui_receipt\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_returns_receipt_safe_agent_fleet\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_run_detail_endpoint_returns_receipt_safe_persisted_run\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_accepts_lab_ui_target_paths\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_refuses_persistence_when_flag_disabled\n231 passed in 1.03s\n"
+    },
+    {
+      "name": "conductor",
+      "cmd": ". /Users/balizero/nuzantara/.venv/bin/activate\npython -m pytest scripts/tests/test_conductor_model_registry.py scripts/tests/test_conductor_host_identity.py scripts/tests/test_conductor_host_seat_maps.py scripts/tests/test_conductor_calibration.py scripts/tests/test_conductor_adapter_contracts.py -q --tb=short",
+      "started_at": "2026-09-05 23:37:54 UTC",
+      "finished_at": "2026-09-05 23:38:10 UTC",
+      "exit": 0,
+      "stdout": ".................................................................. [ 74%]\n.......................                                                  [100%]\n89 passed, 798 subtests passed in 4.41s\n"
+    },
+    {
+      "name": "postgres",
+      "cmd": "ssh pro 'cd /Users/nuzantara/nuzantara/.worktrees/infra-dual-consul-proof/apps/backend-rag && source .venv/bin/activate && PGHOST=/tmp/dual-consul-pg.aoqbxz PGPORT=55487 DUAL_CONSUL_TEST_DSN=postgresql:///dual_consul_test PYTHONPATH=. python -m pytest backend/tests/integration/test_dual_consul_postgres.py --tb=short --color=no'",
+      "started_at": "2026-09-05 23:37:54 UTC",
+      "finished_at": "2026-09-05 23:38:10 UTC",
+      "exit": 0,
+      "stdout": "................                                                         [100%]\n============================= slowest 10 durations =============================\n0.16s setup    backend/tests/integration/test_dual_consul_postgres.py::test_migration_306_rollback_and_reapply_preserve_existing_lifecycle\n0.07s setup    backend/tests/integration/test_dual_consul_postgres.py::test_lapsed_authority_never_reaches_effect[revoked]\n0.07s setup    backend/tests/integration/test_dual_consul_postgres.py::test_expiry_between_guard_and_effect_rolls_back\n0.07s setup    backend/tests/integration/test_dual_consul_postgres.py::test_broker_revocation_of_current_approval_refuses_effect\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_lapsed_authority_never_reaches_effect[cancelled]\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_concurrent_takeover_waits_for_guard_then_fences_it\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_takeover_fences_old_generation_even_when_owner_name_is_reused[consul-fable]\n0.05s setup    backend/tests/integration/test_dual_consul_postgres.py::test_lapsed_authority_never_reaches_effect[lease_expired]\n0.05s setup    backend/tests/integration/test_dual_consul_postgres.py::test_failure_after_effect_rolls_back_all_ros_objects_and_effect\n0.05s setup    backend/tests/integration/test_dual_consul_postgres.py::test_exact_replay_returns_same_receipt_without_duplicate_effect\n16 passed in 1.95s\n"
+    }
+  ]
+}
+
+
+BOUNDARY: same-database synthetic only; no native provider invocation, OS UID enforcement, billing proof or fleet activation; two distinct intents may yield two checkpoints per run, tombstones persist; these are not hidden claims.

--- a/evidence/dual-consul-v4/implementation/fable-review-round-2.json
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-2.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "scope": "independent review of frozen source plus round-2 delta; later migration bootstrap change requires its own review",
+  "session_id": "9db691ab-8167-459b-a921-54857dde0d49",
+  "requested_model": "claude-fable-5-1",
+  "observed_model": "claude-fable-5-1",
+  "runtime_version": "2.1.261",
+  "runtime_surface": "interactive CLI",
+  "permission_mode": "plan",
+  "tools": [],
+  "requested_effort": "xhigh",
+  "finish_reason": "end_turn",
+  "timestamp": "2026-09-05T23:40:15.811Z",
+  "response_sha256": "b377ae079bfc63221ecb216cab0e74a0b7d812a6cd137d66b93faa70f955b30e",
+  "input_packet_path": "fable-review-round-2-input.txt",
+  "input_packet_sha256": "08da546f89cb1fe3c4307bdd1b6e891903ba9919ca309f05cdaaae611b214503",
+  "input_file_sha256": {
+    "apps/backend-rag/backend/services/autonomous_lab/consul_store.py": "e273c72691c27f70d6d3f546376e44c5bff317bc62953288f139502ce5cd021f",
+    "apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql": "1b8f61eb1bc68babefaa75c8b1f38fdaa68460ade58c82136a505166f984483f",
+    "apps/backend-rag/backend/services/autonomous_lab/consul_executor.py": "6f3b4a2f68954019868d751ff58b42a536cd929d39f06aaebd1c562fae7e7ccc",
+    "scripts/conductor/adapter_contracts.py": "7e8e4e3f648bc70791857a39dc840720a398bd20bbdc19fca5a837ef330efcd8",
+    "docs/architecture/dual-consul/common-contract.md": "a0803b1922dfa2d8cb5dc93a19382ed76d63d7e6c13a03d24fbe970e2861ad85",
+    "apps/backend-rag/backend/services/autonomous_lab/state_store.py": "a90c5448d4cf6f3f9013b33800d4dfb0de0c21bc65ea84bb8ae5a49bc519ec4c",
+    "apps/backend-rag/backend/services/autonomous_lab/worker.py": "f6c5798f518ae9900310aa6dec17ffafd7b4cfa889adb1043ed37349baaa15b3",
+    "apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py": "f590cc9100af47d28b741ddf3ed340d564df8fbab87d0925d40e6fab633e15f4"
+  },
+  "claim_limit": "No independent test execution claimed. Reviewer supplied the pre-merge JSON shape question that triggered a live read-only prerequisite check."
+}

--- a/evidence/dual-consul-v4/implementation/fable-review-round-2.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-2.txt
@@ -1,0 +1,24 @@
+Verdict: **PASS**. The round-1 findings are resolved in source, and the delta introduces no blocking correctness issue.
+
+**Round-1 findings, re-evaluated**
+
+- **Superseded approval revocation** is resolved. `consul_store.revoke_approval` appends the hash regardless of generation, sets `revoked_at` only when the hash is current, and its predicate `NOT ($2 = ANY(...))` makes it idempotent. Both branches satisfy the table CHECK. Lock order stays parent then lease. `bind` and `guard` both consult the array, so the bind-B-then-revoke-A trigger now refuses.
+- **Zero-worker admission** is resolved. `adapter_contracts.admit` now requires an exact int 0, which rejects `None`, `False` and `0.0`. Collectors must now emit `worker_limit=0` for plain TP1 surfaces or admission fails closed, which is the right direction.
+- **Fresh-lease replay** is retained by decision. No duplicate effect is possible; only liveness is affected.
+
+**Delta checks**
+
+- `$n::text::jsonb` is the correct fix for a pool JSON codec applied to string parameters. Reads still tolerate both Mapping and str.
+- Binding `intent.producer.name` to the declared builder closes the gap where builder identity lived only in the packet digest.
+- Extension key rename and worker false-return checks are consistent with fail-closed behaviour. A raised PermissionError after a lost heartbeat falls into the existing failure path, whose owner-filtered update is a harmless no-op.
+- The PG test source exercises the claimed paths, including a genuine lock wait proven through `pg_blocking_pids`. The in-transaction expiry test checks the effect predicate, not an external race, since the row is locked. That is adequate for its stated purpose.
+
+**Remaining limits, none blocking**
+
+- `revoke_approval` needs an existing lease row. Revoking an approval before its first bind returns False and records nothing. The broker must reject withdrawn approvals before calling `bind`, which the contract already requires.
+- The `state_store` cast change touches the existing production transport, and merging deploys it. Any rows already written double-encoded under the codec are jsonb string scalars. On such a row, `metadata || $3::text::jsonb` silently yields an array rather than an error. Check for existing rows and for other writers still passing string parameters as `::jsonb` before merge.
+- Recomputation of `object_hash` during `model_validate_json` is still not shown in the provided validator excerpt. Reported results are consistent with content-bound checks, but I cannot confirm this from source.
+- Migration `SET LOCAL` takes effect only inside a transaction. The test applies it that way; the production runner's behaviour is unverified.
+- Unchanged and declared: per-intent idempotency, unbounded tombstone array, no remote effects, no native invocation, no OS identity separation, no production activation.
+
+END_DUAL_CONSUL_REVIEW

--- a/evidence/dual-consul-v4/implementation/fable-review-round-3-input.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-3-input.txt
@@ -1,0 +1,488 @@
+New empirical prerequisite review, distinct from the two accepted source review rounds. After your JSON shape question, production READ ONLY presence query returned both autonomous_lab_runs and outbox absent. Prior306 would fail its FK. No rows or credentials read. The final narrow correction backfills exact legacy124 apply SQL before lease creation, preserving foundation on rollback. Review ONLY this prerequisite correction and source-grounded clarifications, not unchanged previously passed executor/adapter code. No tool calls; return PASS/REWORK and concrete blockers, END_DUAL_CONSUL_REVIEW. No disagreement cycle occurred; this is a newly observed deployment prerequisite.
+
+{
+  "schema_version": 1,
+  "recorded_at": "2026-09-05T23:43:02.425178+00:00",
+  "timestamp_semantics": "Recording timestamp; not an exact query start. Actual output observed this session.",
+  "scope": "production schema presence and aggregate JSON shape only; no client or mission contents read",
+  "connection": "existing scripts/pg.sh on Pro using the configured read-only role and already-running proxy",
+  "first_attempt": {
+    "transaction": "BEGIN READ ONLY",
+    "schema_presence": {
+      "lab_runs_present": false,
+      "lab_outbox_present": false
+    },
+    "aggregate_query_exit": 3,
+    "error": "relation public.autonomous_lab_runs does not exist",
+    "mutation": false
+  },
+  "independent_presence_recheck": {
+    "exit": 0,
+    "stdout": "BEGIN\n{\"lab_runs_present\" : false, \"lab_outbox_present\" : false, \"read_only\" : \"on\"}\nROLLBACK\n",
+    "sql": "BEGIN READ ONLY; SELECT json_build_object('lab_runs_present', to_regclass('public.autonomous_lab_runs') IS NOT NULL, 'lab_outbox_present', to_regclass('public.autonomous_lab_events_outbox') IS NOT NULL, 'read_only', current_setting('transaction_read_only')); ROLLBACK;"
+  },
+  "local_dev_check": {
+    "status": "not_verified",
+    "reason": "Configured local read-only credential unavailable; no fallback to privileged access."
+  },
+  "consequence": "Migration 306 must backfill the exact legacy 124 Lab foundation before adding its foreign key. No corrupted legacy Lab JSON rows exist in the inspected production tables because those tables are absent. Other databases remain unverified."
+}
+
+diff --git a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+index 0f83e5cc85..b27a3f93dc 100644
+--- a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
++++ b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+@@ -4,6 +4,125 @@
+ -- Retained approval tombstones prevent revoke A -> bind B -> resurrect A.
+ SET LOCAL lock_timeout = '5s';
+ 
++-- The legacy Python migration 124 is not guaranteed to have run before the SQL
++-- migration chain. Backfill its canonical Lab tables/indexes before the lease FK.
++-- This immutable snapshot reuses every apply() statement verbatim after dedent;
++-- the focused parity test detects drift. No worker or scheduler is activated.
++-- BEGIN LEGACY 124 APPLY SNAPSHOT
++CREATE TABLE IF NOT EXISTS autonomous_lab_runs (
++    run_id TEXT PRIMARY KEY,
++    idempotency_key TEXT NOT NULL UNIQUE,
++
++    status TEXT NOT NULL DEFAULT 'pending'
++        CHECK (status IN (
++            'pending',
++            'running',
++            'paused',
++            'succeeded',
++            'failed',
++            'cancelled'
++        )),
++    priority INTEGER NOT NULL DEFAULT 0,
++
++    -- Machine placement and worker ownership.
++    machine_role TEXT
++        CHECK (
++            machine_role IS NULL
++            OR machine_role IN (
++                'air_m5_cockpit',
++                'pro_runtime',
++                'mini_scheduler',
++                'unknown'
++            )
++        ),
++    worker_id TEXT,
++
++    -- Receipt-safe control-plane payloads only.
++    objective TEXT NOT NULL,
++    receipt JSONB NOT NULL,
++    target_paths TEXT[] NOT NULL DEFAULT '{}',
++    metadata JSONB NOT NULL DEFAULT '{}',
++
++    -- Retry and lease state.
++    attempts INTEGER NOT NULL DEFAULT 0,
++    max_attempts INTEGER NOT NULL DEFAULT 3,
++    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
++    claimed_at TIMESTAMPTZ,
++    heartbeat_at TIMESTAMPTZ,
++    completed_at TIMESTAMPTZ,
++    last_error TEXT,
++
++    -- Audit.
++    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
++    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
++);
++
++CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_claimable
++    ON autonomous_lab_runs (priority DESC, created_at ASC)
++    WHERE status = 'pending';
++
++CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_status_updated
++    ON autonomous_lab_runs (status, updated_at);
++
++CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_worker
++    ON autonomous_lab_runs (worker_id)
++    WHERE worker_id IS NOT NULL;
++
++CREATE TABLE IF NOT EXISTS autonomous_lab_events_outbox (
++    event_id BIGSERIAL PRIMARY KEY,
++    run_id TEXT NOT NULL
++        REFERENCES autonomous_lab_runs(run_id)
++        ON DELETE CASCADE,
++    event_type TEXT NOT NULL
++        CHECK (event_type IN (
++            'run_enqueued',
++            'run_claimed',
++            'run_checkpointed',
++            'run_paused',
++            'run_succeeded',
++            'run_failed',
++            'run_cancelled',
++            'material_ingested',
++            'run_drafted',
++            'experiment_ready',
++            'verification_failed',
++            'candidate_ready',
++            'evaluation_recorded',
++            'curator_decision_recorded',
++            'shadow_run_completed'
++        )),
++    payload JSONB NOT NULL,
++
++    status TEXT NOT NULL DEFAULT 'pending'
++        CHECK (status IN (
++            'pending',
++            'in_progress',
++            'consumed',
++            'failed_dlq'
++        )),
++    attempts INTEGER NOT NULL DEFAULT 0,
++    max_attempts INTEGER NOT NULL DEFAULT 5,
++    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
++    claimed_by TEXT,
++    claimed_at TIMESTAMPTZ,
++    consumed_at TIMESTAMPTZ,
++    last_error TEXT,
++
++    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
++    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
++);
++
++CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_claimable
++    ON autonomous_lab_events_outbox (created_at ASC)
++    WHERE status = 'pending';
++
++CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_run_id
++    ON autonomous_lab_events_outbox (run_id);
++
++CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_status_updated
++    ON autonomous_lab_events_outbox (status, updated_at);
++-- END LEGACY 124 APPLY SNAPSHOT
++
+ CREATE TABLE public.autonomous_lab_consul_leases (
+     run_id TEXT PRIMARY KEY REFERENCES public.autonomous_lab_runs(run_id),
+     owner_id TEXT NOT NULL CHECK (owner_id ~ '^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,191}$'),
+@@ -24,4 +143,6 @@ CREATE TABLE public.autonomous_lab_consul_leases (
+ );
+ 
+ -- === ROLLBACK ===
++-- Preserve shared Lab tables and their data, including tables bootstrapped above.
++-- Reverting this slice removes only its lease table.
+ DROP TABLE IF EXISTS public.autonomous_lab_consul_leases;
+diff --git a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+index 137aec6b57..3966a2066e 100644
+--- a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
++++ b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+@@ -12,6 +12,7 @@ import os
+ from collections.abc import AsyncIterator
+ from contextlib import suppress
+ from pathlib import Path
++from textwrap import dedent
+ from typing import Any
+ from urllib.parse import unquote, urlsplit
+ 
+@@ -127,6 +128,65 @@ async def _counts(conn: asyncpg.Connection) -> tuple[int, int, int]:
+     )
+ 
+ 
++async def test_migration_306_reuses_every_canonical_124_statement() -> None:
++    statements: list[str] = []
++
++    class Recorder:
++        async def execute(self, sql: str) -> None:
++            statements.append(dedent(sql).strip())
++
++    await apply_lab(Recorder())
++    forward, _ = split_migration_sql(
++        (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
++    )
++    snapshot = (
++        forward.split("-- BEGIN LEGACY 124 APPLY SNAPSHOT\n", 1)[1]
++        .split("-- END LEGACY 124 APPLY SNAPSHOT", 1)[0]
++        .strip()
++    )
++    assert statements
++    assert snapshot == "\n\n".join(statements)
++
++
++async def test_migration_306_bootstraps_absent_lab_and_preserves_rows_on_rollback(
++    dual_db: asyncpg.Connection,
++) -> None:
++    await dual_db.execute(
++        "DROP TABLE public.autonomous_lab_consul_leases, "
++        "public.autonomous_lab_events_outbox, public.autonomous_lab_runs"
++    )
++    assert await dual_db.fetchval(
++        "SELECT to_regclass('public.autonomous_lab_runs') IS NULL "
++        "AND to_regclass('public.autonomous_lab_events_outbox') IS NULL"
++    )
++    forward, rollback = split_migration_sql(
++        (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
++    )
++    async with dual_db.transaction():
++        await dual_db.execute(forward)
++    run_id = "consul-bootstrap-proof"
++    store = await _enqueue(dual_db, run_id)
++    request = make_request(await dual_db.fetchval("SELECT clock_timestamp()"), run_id)
++    worker = AutonomousLabWorker(
++        placement=store.placement,
++        state_store=store,
++        stage_nodes=(ConsulSyntheticStage(dual_db, request, OWNER),),
++    )
++    assert (await worker.tick(dual_db, worker_id=OWNER)).status.value == "succeeded"
++    assert await _counts(dual_db) == (1, 1, 1)
++    assert rollback is not None
++    async with dual_db.transaction():
++        await dual_db.execute(rollback)
++    assert await dual_db.fetchval(
++        "SELECT to_regclass('public.autonomous_lab_consul_leases') IS NULL"
++    )
++    assert (
++        await dual_db.fetchval("SELECT status FROM autonomous_lab_runs WHERE run_id=$1", run_id)
++        == "succeeded"
++    )
++    assert await _counts(dual_db) == (1, 1, 1)
++
++
+ async def test_migration_306_rollback_and_reapply_preserve_existing_lifecycle(
+     dual_db: asyncpg.Connection,
+ ) -> None:
+
+ACTUAL EXISTING SOURCE packages/research-os-core/research_os/models/action_intent.py:84-93
+    @model_validator(mode="after")
+    def validate_action_intent(self) -> ActionIntent:
+        validate_extensions(self.extensions)
+        expected = object_hash(self)
+        if self.object_hash != expected:
+            raise PydanticCustomError(
+                "object_hash_mismatch",
+                "object_hash does not match the canonical object",
+            )
+        return self
+ACTUAL EXISTING SOURCE packages/research-os-core/research_os/models/approval_receipt.py:186-193
+        validate_extensions(self.extensions)
+        expected = object_hash(self)
+        if self.object_hash != expected:
+            raise PydanticCustomError(
+                "object_hash_mismatch",
+                "object_hash does not match the canonical object",
+            )
+        return self
+ACTUAL EXISTING SOURCE packages/research-os-core/research_os/models/verification_receipt.py:119-128
+    @model_validator(mode="after")
+    def validate_receipt(self) -> VerificationReceipt:
+        validate_extensions(self.extensions)
+        expected = object_hash(self)
+        if self.object_hash != expected:
+            raise PydanticCustomError(
+                "object_hash_mismatch",
+                "object_hash does not match the canonical object",
+            )
+        return self
+ACTUAL EXISTING SOURCE apps/backend-rag/backend/db/migration_base.py:638-683
+        # transaction. Apply the forward portion only; the rollback string is
+        # stored separately on `self.rollback_sql` for `rollback_migration()`.
+        sql_forward, _embedded_rollback = split_migration_sql(sql)
+
+        # Validate SQL
+        try:
+            self._validate_sql(sql_forward)
+        except MigrationError as e:
+            logger.error(f"SQL validation failed for {self.migration_name}: {e}")
+            raise
+
+        # Sanitize URL for logging
+        safe_url = self._sanitize_db_url(settings.database_url)
+        logger.info(f"Applying migration {self.migration_name} to {safe_url}")
+
+        # Connect to database
+        try:
+            conn = await asyncpg.connect(settings.database_url)
+        except Exception as e:
+            raise MigrationError(f"Cannot connect to database: {e}") from e
+
+        import time
+
+        start_time = time.time()
+
+        try:
+            # Use transaction for atomicity
+            async with conn.transaction():
+                # Check dependencies
+                await self._check_dependencies(conn)
+
+                # Check if already applied
+                if await self._is_applied(conn):
+                    execution_time_ms = int((time.time() - start_time) * 1000)
+                    await self._log_migration(
+                        conn,
+                        sql,
+                        execution_time_ms,
+                        self.rollback_sql,
+                    )
+                    logger.info(
+                        "Migration %s already applied; migration ledgers reconciled",
+                        self.migration_name,
+                    )
+                    return True
+
+CANONICAL LEGACY FOUNDATION
+"""Migration 124: Autonomous Lab runtime queue and events outbox.
+
+Purpose:
+- Create ``autonomous_lab_runs`` for idempotent, resumable Lab work.
+- Create ``autonomous_lab_events_outbox`` for ack-after-success Lab events.
+
+This is the v1 control-plane foundation only. Workers remain feature-gated and
+must run on Pro/Mini according to the machine-placement policy.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def apply(conn: Any) -> None:
+    """Apply migration 124."""
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS autonomous_lab_runs (
+            run_id TEXT PRIMARY KEY,
+            idempotency_key TEXT NOT NULL UNIQUE,
+
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN (
+                    'pending',
+                    'running',
+                    'paused',
+                    'succeeded',
+                    'failed',
+                    'cancelled'
+                )),
+            priority INTEGER NOT NULL DEFAULT 0,
+
+            -- Machine placement and worker ownership.
+            machine_role TEXT
+                CHECK (
+                    machine_role IS NULL
+                    OR machine_role IN (
+                        'air_m5_cockpit',
+                        'pro_runtime',
+                        'mini_scheduler',
+                        'unknown'
+                    )
+                ),
+            worker_id TEXT,
+
+            -- Receipt-safe control-plane payloads only.
+            objective TEXT NOT NULL,
+            receipt JSONB NOT NULL,
+            target_paths TEXT[] NOT NULL DEFAULT '{}',
+            metadata JSONB NOT NULL DEFAULT '{}',
+
+            -- Retry and lease state.
+            attempts INTEGER NOT NULL DEFAULT 0,
+            max_attempts INTEGER NOT NULL DEFAULT 3,
+            next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            claimed_at TIMESTAMPTZ,
+            heartbeat_at TIMESTAMPTZ,
+            completed_at TIMESTAMPTZ,
+            last_error TEXT,
+
+            -- Audit.
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+    """)
+
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_claimable
+            ON autonomous_lab_runs (priority DESC, created_at ASC)
+            WHERE status = 'pending';
+    """)
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_status_updated
+            ON autonomous_lab_runs (status, updated_at);
+    """)
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_autonomous_lab_runs_worker
+            ON autonomous_lab_runs (worker_id)
+            WHERE worker_id IS NOT NULL;
+    """)
+
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS autonomous_lab_events_outbox (
+            event_id BIGSERIAL PRIMARY KEY,
+            run_id TEXT NOT NULL
+                REFERENCES autonomous_lab_runs(run_id)
+                ON DELETE CASCADE,
+            event_type TEXT NOT NULL
+                CHECK (event_type IN (
+                    'run_enqueued',
+                    'run_claimed',
+                    'run_checkpointed',
+                    'run_paused',
+                    'run_succeeded',
+                    'run_failed',
+                    'run_cancelled',
+                    'material_ingested',
+                    'run_drafted',
+                    'experiment_ready',
+                    'verification_failed',
+                    'candidate_ready',
+                    'evaluation_recorded',
+                    'curator_decision_recorded',
+                    'shadow_run_completed'
+                )),
+            payload JSONB NOT NULL,
+
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN (
+                    'pending',
+                    'in_progress',
+                    'consumed',
+                    'failed_dlq'
+                )),
+            attempts INTEGER NOT NULL DEFAULT 0,
+            max_attempts INTEGER NOT NULL DEFAULT 5,
+            next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            claimed_by TEXT,
+            claimed_at TIMESTAMPTZ,
+            consumed_at TIMESTAMPTZ,
+            last_error TEXT,
+
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+    """)
+
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_claimable
+            ON autonomous_lab_events_outbox (created_at ASC)
+            WHERE status = 'pending';
+    """)
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_run_id
+            ON autonomous_lab_events_outbox (run_id);
+    """)
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_autonomous_lab_outbox_status_updated
+            ON autonomous_lab_events_outbox (status, updated_at);
+    """)
+
+    logger.info("Migration 124: autonomous_lab_runs + autonomous_lab_events_outbox applied")
+
+
+async def rollback(conn: Any) -> None:
+    """Rollback migration 124."""
+    await conn.execute("DROP INDEX IF EXISTS idx_autonomous_lab_outbox_status_updated;")
+    await conn.execute("DROP INDEX IF EXISTS idx_autonomous_lab_outbox_run_id;")
+    await conn.execute("DROP INDEX IF EXISTS idx_autonomous_lab_outbox_claimable;")
+    await conn.execute("DROP TABLE IF EXISTS autonomous_lab_events_outbox;")
+
+    await conn.execute("DROP INDEX IF EXISTS idx_autonomous_lab_runs_worker;")
+    await conn.execute("DROP INDEX IF EXISTS idx_autonomous_lab_runs_status_updated;")
+    await conn.execute("DROP INDEX IF EXISTS idx_autonomous_lab_runs_claimable;")
+    await conn.execute("DROP TABLE IF EXISTS autonomous_lab_runs;")
+
+    logger.info("Migration 124 rollback: autonomous_lab runtime tables dropped")
+
+Test observation from independent code worker:18 PostgreSQL tests PASSED2.22s, including exact eight-statement parity and absence→306-only→worker success→rollback preserves shared state. Root confirmation is running. Squawk (existing CI rule set) reports0 issues. No prod writes or fleet activation. Local dev readonly credential unavailable, explicitly unverified; no privileged fallback. The original source review remains scoped to its hashes, this review updates the changed migration/test hashes.

--- a/evidence/dual-consul-v4/implementation/fable-review-round-3.json
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-3.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "scope": "new empirical missing-foundation prerequisite review, after two accepted implementation rounds",
+  "session_id": "9db691ab-8167-459b-a921-54857dde0d49",
+  "observed_model": "claude-fable-5-1",
+  "runtime_version": "2.1.261",
+  "permission_mode": "plan",
+  "tools": [],
+  "finish_reason": "end_turn",
+  "timestamp": "2026-09-05T23:46:29.999Z",
+  "response_sha256": "abd7a7be84734373618d3b9ac9b85e1c1a4852a0d50703edc0a7891e27ddf7bf",
+  "input_packet_path": "fable-review-round-3-input.txt",
+  "input_packet_sha256": "6399846ec91d53377a1373dcf4add691f0381a530a8f15bd99b90ea296726038",
+  "input_file_sha256": {
+    "apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql": "f0ab2b6c045fe66df91be8e2139d1a649b5a51b6090b43b17455f1a02b453dbc",
+    "apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py": "58c5ca731ecaac70d5db038a9cb04ff4ac2331a5dc9b290074f735e6b58af928"
+  },
+  "claim_limit": "Reviewer prescribed a final explicit search_path pin; resulting exact delta and hashes require the short final acknowledgment."
+}

--- a/evidence/dual-consul-v4/implementation/fable-review-round-3.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-3.txt
@@ -1,0 +1,24 @@
+Verdict: **PASS**. The prerequisite correction is sound as written, and I found no concrete blocker in the migration or the two new tests.
+
+**What the correction gets right**
+
+- The snapshot is a verbatim, dedented copy of all eight legacy apply statements, and the parity test enforces that by exact string equality against the live Python migration. Drift in either direction fails the test.
+- Every backfilled statement is `IF NOT EXISTS`, so 306 is a no-op on databases where 124 already ran, and a later 124 apply is a no-op after 306. Both orders converge.
+- The runner wraps the forward SQL in one transaction, so a failing FK leaves no partial state, and `SET LOCAL lock_timeout` is effective there.
+- Rollback drops only the lease table. The bootstrap test proves the shared tables and a succeeded run survive rollback, and the earlier test proves reapply works.
+- Legacy 124 rollback now fails while 306 is applied, because the lease FK has no cascade. That is the correct fail-closed ordering, not a defect.
+- The hash validators shown in `action_intent`, `approval_receipt` and `verification_receipt` close my earlier residual: wire-form revalidation does recompute `object_hash`.
+
+**One environment-dependent hazard, one line to remove it**
+
+The snapshot creates `autonomous_lab_runs` unqualified, but the lease FK references `public.autonomous_lab_runs`. Trigger: the migration role's effective `search_path` resolves unqualified names elsewhere, for example a schema named after the role exists or the role has an `ALTER ROLE ... SET search_path`. Then the backfill lands outside `public` and 306 fails atomically with the same "does not exist" error. The existing 124 path and the application share this assumption, so it is not new, but 306 is the first place both conventions meet. Adding `SET LOCAL search_path = public, pg_catalog;` next to the lock timeout, outside the snapshot markers, removes the hazard without breaking parity. Alternatively verify the production role's `search_path` read-only before merge.
+
+**Residual limits, not blocking**
+
+- The disposable tests execute the forward SQL directly. The runner path, including `_validate_sql`, `_check_dependencies` and ledger logging, is not exercised. A runner dry run against the disposable database would close that.
+- Production presence of `research_os_objects` from migrations 279 and 280 is not in the evidence. Absence would make the executor fail closed at first persist, with no effect, but the slice would be inert.
+- The lease FK has no `ON DELETE`. Any existing purge path that deletes runs will now error on runs holding a lease row. That is consistent with tombstone retention but should be known.
+- Slot 306 still needs its merge-time recheck, and the application role must hold DML on the two bootstrapped tables if it differs from the migration role.
+- Local dev and other databases remain unverified, as the evidence states.
+
+END_DUAL_CONSUL_REVIEW

--- a/evidence/dual-consul-v4/implementation/fable-review-round-4-input.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-4-input.txt
@@ -1,0 +1,31 @@
+Final acknowledgment of your exact prescribed one-line change. Added SET LOCAL search_path = public, pg_catalog; adjacent to lock_timeout, outside snapshot markers. Strengthened existing absence-path test to enter with dual_consul_alternate,public and assert tables land in public. No other changes. This closes your stated environment hazard; approve/reject this exact delta to the already accepted migration. No tools, no new broad review. Return concise PASS/REWORK and END_DUAL_CONSUL_REVIEW.
+diff --git a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+index b27a3f93dc..2dc699d40d 100644
+--- a/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
++++ b/apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql
+@@ -3,6 +3,7 @@
+ -- Broker connections own admission; model processes receive no database connection.
+ -- Retained approval tombstones prevent revoke A -> bind B -> resurrect A.
+ SET LOCAL lock_timeout = '5s';
++SET LOCAL search_path = public, pg_catalog;
+ 
+ -- The legacy Python migration 124 is not guaranteed to have run before the SQL
+ -- migration chain. Backfill its canonical Lab tables/indexes before the lease FK.
+diff --git a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+index 3966a2066e..1ee37fb3b2 100644
+--- a/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
++++ b/apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py
+@@ -163,7 +163,13 @@ async def test_migration_306_bootstraps_absent_lab_and_preserves_rows_on_rollbac
+         (MIGRATIONS / "306_autonomous_lab_consul_leases.sql").read_text()
+     )
+     async with dual_db.transaction():
++        await dual_db.execute("CREATE SCHEMA IF NOT EXISTS dual_consul_alternate")
++        await dual_db.execute("SET LOCAL search_path = dual_consul_alternate, public")
+         await dual_db.execute(forward)
++        assert await dual_db.fetchval(
++            "SELECT to_regclass('public.autonomous_lab_runs') IS NOT NULL "
++            "AND to_regclass('dual_consul_alternate.autonomous_lab_runs') IS NULL"
++        )
+     run_id = "consul-bootstrap-proof"
+     store = await _enqueue(dual_db, run_id)
+     request = make_request(await dual_db.fetchval("SELECT clock_timestamp()"), run_id)

--- a/evidence/dual-consul-v4/implementation/fable-review-round-4.json
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-4.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "scope": "final acknowledgment of exact prescribed schema pin and strengthened existing test; completes prior accepted source and prerequisite reviews",
+  "session_id": "9db691ab-8167-459b-a921-54857dde0d49",
+  "observed_model": "claude-fable-5-1",
+  "runtime_version": "2.1.261",
+  "permission_mode": "plan",
+  "tools": [],
+  "finish_reason": "end_turn",
+  "timestamp": "2026-09-05T23:48:16.924Z",
+  "response_sha256": "3386935f7301251b9fe6d867d02da03c15c8c91d0acd8c43138e1d5e09d49bde",
+  "input_packet_path": "fable-review-round-4-input.txt",
+  "input_packet_sha256": "bbb811b949b116b3c951f484d190176b4a0943b3b653920a0c7b76f16d864c5e",
+  "input_file_sha256": {
+    "apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql": "f2f95ffff2cdbe6b9d00c291dad7fd2fb264f0f2c1565a321823686de5a14f7d",
+    "apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py": "d73eb8932a1d894eef11e0b9f87d2a1a70259c441c6489e4d4753e9bbb0faf17"
+  },
+  "claim_limit": "Source review only, not independent test execution, release-gate publication or native provider qualification."
+}

--- a/evidence/dual-consul-v4/implementation/fable-review-round-4.txt
+++ b/evidence/dual-consul-v4/implementation/fable-review-round-4.txt
@@ -1,0 +1,12 @@
+Verdict: **PASS**. This exact delta is correct and closes the hazard.
+
+- `SET LOCAL search_path = public, pg_catalog;` sits outside the snapshot markers, so the eight-statement parity test is unaffected, and it applies for the whole runner transaction, so the backfill and the lease FK resolve in the same schema.
+- The strengthened test enters with `dual_consul_alternate, public`, runs the forward SQL, and asserts the tables land in `public` and not in the alternate schema. That directly exercises the trigger I described. Session `search_path` reverts after commit, so the enqueue and worker steps that follow are unaffected.
+- The leftover empty `dual_consul_alternate` schema in the disposable database is harmless and idempotent across fixture runs.
+
+Two notes, neither blocking:
+
+- Listing `pg_catalog` after `public` lets a public object shadow a catalog name. Nothing in this migration collides, so it is functionally fine.
+- The pin also scopes the runner's own ledger write inside the same transaction. That is correct if the migration ledger lives in `public`, which every prior SQL migration already assumes. If it did not, the transaction would fail atomically, which is the same fail-closed outcome as before the pin.
+
+END_DUAL_CONSUL_REVIEW

--- a/evidence/dual-consul-v4/implementation/manifest.json
+++ b/evidence/dual-consul-v4/implementation/manifest.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-09-05T23:49:00.301570+00:00",
+  "retention_budget_bytes": 163840,
+  "selected_files": {
+    "README.md": "6f954e1a7be0648ee8b83e1dabc788be6a0080b522189b44b084b0cc040081d1",
+    "fable-review-round-1-input.txt": "0ac386d2b0b51401a78fd64b42eb34650b683fe5eb73f679abafdef9179f88e6",
+    "fable-review-round-1.json": "aba896fcda0d04a01d533c1d7122d4926b022f81316fb6021156095c00738447",
+    "fable-review-round-1.txt": "1f043fa8080d26d86c9552d9a760189fbee6b70bacc80b5fa17121685a03c621",
+    "fable-review-round-2-input.txt": "08da546f89cb1fe3c4307bdd1b6e891903ba9919ca309f05cdaaae611b214503",
+    "fable-review-round-2.json": "c2bae5c562402f532a42f87d5fdb993c1e911a5698d0d3524bd5f317530e49d8",
+    "fable-review-round-2.txt": "b377ae079bfc63221ecb216cab0e74a0b7d812a6cd137d66b93faa70f955b30e",
+    "fable-review-round-3-input.txt": "6399846ec91d53377a1373dcf4add691f0381a530a8f15bd99b90ea296726038",
+    "fable-review-round-3.json": "d50caee284d7e3fd65defdf383872feafd3835aa7c229eb72802b2243de2681f",
+    "fable-review-round-3.txt": "abd7a7be84734373618d3b9ac9b85e1c1a4852a0d50703edc0a7891e27ddf7bf",
+    "fable-review-round-4-input.txt": "bbb811b949b116b3c951f484d190176b4a0943b3b653920a0c7b76f16d864c5e",
+    "fable-review-round-4.json": "f41aba809cea69a0886a227c158891a3ebf7dfedf0c7bf19fb33539436f2a34e",
+    "fable-review-round-4.txt": "3386935f7301251b9fe6d867d02da03c15c8c91d0acd8c43138e1d5e09d49bde",
+    "schema-preflight.json": "bc0b7dad00d8fc9814a0dbf1610294f07c768bba785a91ad64f39e2057d1cedd",
+    "test-results.json": "72432607f89b2c88d135580fc447fbec900f3f2feba36ce305e719663f444fe0"
+  },
+  "final_source_review_bindings": {
+    "apps/backend-rag/backend/services/autonomous_lab/consul_store.py": "e273c72691c27f70d6d3f546376e44c5bff317bc62953288f139502ce5cd021f",
+    "apps/backend-rag/backend/db/migrations_v2/306_autonomous_lab_consul_leases.sql": "f2f95ffff2cdbe6b9d00c291dad7fd2fb264f0f2c1565a321823686de5a14f7d",
+    "apps/backend-rag/backend/services/autonomous_lab/consul_executor.py": "6f3b4a2f68954019868d751ff58b42a536cd929d39f06aaebd1c562fae7e7ccc",
+    "scripts/conductor/adapter_contracts.py": "7e8e4e3f648bc70791857a39dc840720a398bd20bbdc19fca5a837ef330efcd8",
+    "docs/architecture/dual-consul/common-contract.md": "a0803b1922dfa2d8cb5dc93a19382ed76d63d7e6c13a03d24fbe970e2861ad85",
+    "apps/backend-rag/backend/services/autonomous_lab/state_store.py": "a90c5448d4cf6f3f9013b33800d4dfb0de0c21bc65ea84bb8ae5a49bc519ec4c",
+    "apps/backend-rag/backend/services/autonomous_lab/worker.py": "f6c5798f518ae9900310aa6dec17ffafd7b4cfa889adb1043ed37349baaa15b3",
+    "apps/backend-rag/backend/tests/integration/test_dual_consul_postgres.py": "d73eb8932a1d894eef11e0b9f87d2a1a70259c441c6489e4d4753e9bbb0faf17"
+  },
+  "qualification": "synthetic same-database effects and offline adapter rules only",
+  "review_sequence": "Two accepted source rounds; one newly observed migration prerequisite review; final acknowledgment of its exact prescribed schema pin. No disagreement cycle or full model-consultation retry."
+}

--- a/evidence/dual-consul-v4/implementation/schema-preflight.json
+++ b/evidence/dual-consul-v4/implementation/schema-preflight.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "recorded_at": "2026-09-05T23:43:02.425178+00:00",
+  "timestamp_semantics": "Recording timestamp; not an exact query start. Actual output observed this session.",
+  "scope": "production schema presence and aggregate JSON shape only; no client or mission contents read",
+  "connection": "existing scripts/pg.sh on Pro using the configured read-only role and already-running proxy",
+  "first_attempt": {
+    "transaction": "BEGIN READ ONLY",
+    "schema_presence": {
+      "lab_runs_present": false,
+      "lab_outbox_present": false
+    },
+    "aggregate_query_exit": 3,
+    "error": "relation public.autonomous_lab_runs does not exist",
+    "mutation": false
+  },
+  "independent_presence_recheck": {
+    "exit": 0,
+    "stdout": "BEGIN\n{\"lab_runs_present\" : false, \"lab_outbox_present\" : false, \"read_only\" : \"on\"}\nROLLBACK\n",
+    "sql": "BEGIN READ ONLY; SELECT json_build_object('lab_runs_present', to_regclass('public.autonomous_lab_runs') IS NOT NULL, 'lab_outbox_present', to_regclass('public.autonomous_lab_events_outbox') IS NOT NULL, 'read_only', current_setting('transaction_read_only')); ROLLBACK;"
+  },
+  "local_dev_check": {
+    "status": "not_verified",
+    "reason": "Configured local read-only credential unavailable; no fallback to privileged access."
+  },
+  "consequence": "Migration 306 must backfill the exact legacy 124 Lab foundation before adding its foreign key. No corrupted legacy Lab JSON rows exist in the inspected production tables because those tables are absent. Other databases remain unverified."
+}

--- a/evidence/dual-consul-v4/implementation/test-results.json
+++ b/evidence/dual-consul-v4/implementation/test-results.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "scope": "synthetic_local_and_disposable_postgresql_only",
+  "checks": [
+    {
+      "name": "lab",
+      "cmd": ". /Users/balizero/nuzantara/apps/backend-rag/.venv/bin/activate\nPYTHONPATH=apps/backend-rag python -m pytest apps/backend-rag/backend/tests/unit/services/autonomous_lab/ --tb=short --color=no",
+      "started_at": "2026-09-05 23:37:54 UTC",
+      "finished_at": "2026-09-05 23:38:10 UTC",
+      "exit": 0,
+      "stdout": "........................................................................ [ 31%]\n........................................................................ [ 62%]\n........................................................................ [ 93%]\n...............                                                          [100%]\n============================= slowest 10 durations =============================\n0.15s call     backend/tests/unit/services/autonomous_lab/test_mass_invariants.py::test_planner_reviewer_and_receipt_store_mass_invariants\n0.07s call     backend/tests/unit/services/autonomous_lab/test_draft_cli.py::test_cli_blocks_workspace_write_requests\n0.07s call     backend/tests/unit/services/autonomous_lab/test_draft_cli.py::test_cli_invalid_input_returns_receipt_safe_json_error\n0.07s call     backend/tests/unit/services/autonomous_lab/test_draft_cli.py::test_cli_writes_receipt_and_omits_raw_text\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_can_persist_orchestration_receipt\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_can_persist_lab_ui_receipt\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_returns_receipt_safe_agent_fleet\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_run_detail_endpoint_returns_receipt_safe_persisted_run\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_accepts_lab_ui_target_paths\n0.01s call     backend/tests/unit/services/autonomous_lab/test_router.py::test_draft_endpoint_refuses_persistence_when_flag_disabled\n231 passed in 1.03s\n"
+    },
+    {
+      "name": "conductor",
+      "cmd": ". /Users/balizero/nuzantara/.venv/bin/activate\npython -m pytest scripts/tests/test_conductor_model_registry.py scripts/tests/test_conductor_host_identity.py scripts/tests/test_conductor_host_seat_maps.py scripts/tests/test_conductor_calibration.py scripts/tests/test_conductor_adapter_contracts.py -q --tb=short",
+      "started_at": "2026-09-05 23:37:54 UTC",
+      "finished_at": "2026-09-05 23:38:10 UTC",
+      "exit": 0,
+      "stdout": ".................................................................. [ 74%]\n.......................                                                  [100%]\n89 passed, 798 subtests passed in 4.41s\n"
+    },
+    {
+      "name": "postgres",
+      "cmd": "ssh pro 'cd /Users/nuzantara/nuzantara/.worktrees/infra-dual-consul-proof/apps/backend-rag && source .venv/bin/activate && PGHOST=/tmp/dual-consul-pg.aoqbxz PGPORT=55487 DUAL_CONSUL_TEST_DSN=postgresql:///dual_consul_test PYTHONPATH=. python -m pytest backend/tests/integration/test_dual_consul_postgres.py --tb=short --color=no'",
+      "observed_running_at": "2026-09-05 23:47:46 UTC",
+      "finished_at": "2026-09-05 23:47:57 UTC",
+      "exit": 0,
+      "stdout": "..................                                                       [100%]\n============================= slowest 10 durations =============================\n0.07s setup    backend/tests/integration/test_dual_consul_postgres.py::test_lapsed_authority_never_reaches_effect[grant_expired]\n0.07s setup    backend/tests/integration/test_dual_consul_postgres.py::test_revoked_approval_cannot_return_after_new_grant\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_migration_306_bootstraps_absent_lab_and_preserves_rows_on_rollback\n0.06s call     backend/tests/integration/test_dual_consul_postgres.py::test_migration_306_bootstraps_absent_lab_and_preserves_rows_on_rollback\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_takeover_fences_old_generation_even_when_owner_name_is_reused[consul-astra]\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_takeover_fences_old_generation_even_when_owner_name_is_reused[consul-fable]\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_concurrent_takeover_waits_for_guard_then_fences_it\n0.06s setup    backend/tests/integration/test_dual_consul_postgres.py::test_lapsed_authority_never_reaches_effect[lease_expired]\n0.05s setup    backend/tests/integration/test_dual_consul_postgres.py::test_migration_306_reuses_every_canonical_124_statement\n0.05s setup    backend/tests/integration/test_dual_consul_postgres.py::test_worker_tick_commits_started_attempt_result_and_one_effect[fable]\n18 passed in 1.96s\n"
+    }
+  ]
+}

--- a/infra/conductor/model_capability_index.v1.json
+++ b/infra/conductor/model_capability_index.v1.json
@@ -238,13 +238,18 @@
       "model_card_id": "deepseek-v4-flash-0731",
       "family": "deepseek-v4",
       "kind": "language",
-      "routing_status": "eligible",
+      "routing_status": "probation",
       "automated_routing": false,
       "evidence": [
         {
           "level": "production",
           "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
           "observed_at": "2026-08-14"
+        },
+        {
+          "level": "production",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-27"
         }
       ]
     },
@@ -432,7 +437,7 @@
       "model_card_id": "glm-5.2",
       "family": "glm",
       "kind": "language",
-      "routing_status": "eligible",
+      "routing_status": "probation",
       "automated_routing": false,
       "evidence": [
         {
@@ -444,6 +449,11 @@
           "level": "declared",
           "ref": "https://help.aliyun.com/en/model-studio/newly-released-models | Newly released models | accessed 2026-08-21 | Exact claim: glm-5.2 documents a 1M-token context and long-horizon reasoning, text generation, and coding capabilities.",
           "observed_at": "2026-08-21"
+        },
+        {
+          "level": "production",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-27"
         }
       ]
     },
@@ -1216,6 +1226,11 @@
           "level": "declared",
           "ref": "https://help.aliyun.com/en/model-studio/qwen3-6-flash | qwen3.6-flash Model Info | accessed 2026-08-21 | Exact claim: text, image, and video input; text output; 1,000,000-token context; 65,536-token output limit; Function Calling and related documented features; Batch Inference is region-dependent.",
           "observed_at": "2026-08-21"
+        },
+        {
+          "level": "production",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-27"
         }
       ]
     },
@@ -1249,6 +1264,11 @@
           "level": "declared",
           "ref": "https://help.aliyun.com/en/model-studio/qwen3-7-max | qwen3.7-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.7-max has text input/output, a 1,000,000-token context, a 131,072-token output limit, documents Structured Outputs, and has region-dependent documented feature support.",
           "observed_at": "2026-08-21"
+        },
+        {
+          "level": "production",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-27"
         }
       ]
     },
@@ -1256,7 +1276,7 @@
       "model_card_id": "qwen3.7-plus",
       "family": "qwen-3",
       "kind": "language",
-      "routing_status": "eligible",
+      "routing_status": "probation",
       "automated_routing": false,
       "evidence": [
         {
@@ -1268,6 +1288,11 @@
           "level": "declared",
           "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.7-plus has a 1,000,000-token context length.",
           "observed_at": "2026-08-21"
+        },
+        {
+          "level": "production",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-27"
         }
       ]
     },
@@ -1303,7 +1328,7 @@
       "model_card_id": "qwen3.8-max",
       "family": "qwen-3",
       "kind": "language",
-      "routing_status": "eligible",
+      "routing_status": "probation",
       "automated_routing": false,
       "evidence": [
         {
@@ -1315,6 +1340,11 @@
           "level": "declared",
           "ref": "https://help.aliyun.com/en/model-studio/qwen3-8-max | qwen3.8-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.8-max documents text, image, and video input; text output; Function Calling, Structured Outputs, Web Search, Prefix Completion, and Context Caching; Batch Inference is region-dependent.",
           "observed_at": "2026-08-21"
+        },
+        {
+          "level": "production",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-27"
         }
       ]
     },

--- a/scripts/conductor/adapter_contracts.py
+++ b/scripts/conductor/adapter_contracts.py
@@ -1,0 +1,340 @@
+"""Pure dual-consul admission and selected-response contracts; never launches a seat.
+
+Discovery is supplied by a trusted runtime collector. These checks confer no effect
+authority and qualify neither tool execution, native resume nor remote cancellation.
+TP1 envelopes reuse the existing transport's shape, but not its reasoning fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import sys
+from typing import Any, Literal, Mapping
+
+from scripts.conductor.contracts import TaskClass, TaskIntent
+
+
+IdentityEvidence = Literal["response_observed", "request_observed", "unknown"]
+
+
+@dataclass(frozen=True)
+class Surface:
+    model: str | None
+    text_qualified: bool = False
+    effort: str | None = None
+    operations: frozenset[str] = frozenset()
+
+
+# Qualification belongs to each surface, never to a compatible protocol/family.
+SURFACES = {
+    "codex_app_server": Surface(None),
+    "claude_interactive_text": Surface("claude-fable-5-1", True),
+    "kimi_text": Surface("k3", True, "max"),
+    "kimi_native": Surface("k3"),
+    "qwen_tp1": Surface("qwen3.8-max", True, "medium"),
+    "qwen_native": Surface(None),
+    "deepseek_tp1": Surface("deepseek-v4-pro", True),
+    "gemini_agy": Surface("gemini-3.1-pro-high", True),
+    "glm_tp1": Surface("glm-5.2", True),
+    "local_r1": Surface("deepseek-r1:32b"),
+}
+
+
+@dataclass(frozen=True)
+class DiscoveryKey:
+    runtime_version: str
+    config_hash: str
+    host: str
+    auth_context_hash: str
+
+
+@dataclass(frozen=True)
+class DiscoveryObservation:
+    key: DiscoveryKey
+    surface_id: str
+    requested_model: str
+    actual_model: str | None
+    identity_evidence: IdentityEvidence
+    observed_at: datetime
+    expires_at: datetime
+    capabilities: frozenset[str] = frozenset()
+    enforced_caps: tuple[tuple[str, int], ...] = ()
+    worker_limit: int | None = None
+    delegation_observable: bool = False
+
+
+@dataclass(frozen=True)
+class Requirements:
+    exact_model: bool = False
+    output_cap: int | None = None
+    total_cap: int | None = None
+    workers: int = 0
+    effort: str | None = None
+    high_effort_authorized: bool = False
+    operation: str = "text_consultation"
+
+
+def admit(
+    surface_id: str,
+    requested_model: str,
+    task: TaskIntent,
+    observation: DiscoveryObservation,
+    expected_key: DiscoveryKey,
+    now: datetime,
+    requirements: Requirements = Requirements(),
+) -> tuple[str, ...]:
+    """Return all rejection reasons; an empty tuple admits text preparation only."""
+    surface = SURFACES.get(surface_id)
+    if surface is None:
+        return ("unknown_surface",)
+    reasons: list[str] = []
+    if not surface.text_qualified:
+        reasons.append("surface_unqualified")
+    if requirements.operation != "text_consultation":
+        reasons.append("operation_unqualified")
+    if task.mutation or task.required_tools:
+        reasons.append("effects_unqualified")
+    if task.contains_pii:
+        reasons.append("pii_lane_unqualified")
+    if (
+        observation.key != expected_key
+        or observation.surface_id != surface_id
+        or not all(vars(expected_key).values())
+    ):
+        reasons.append("discovery_context_mismatch")
+    timestamps = (observation.observed_at, observation.expires_at, now)
+    if any(value.tzinfo is None for value in timestamps) or not (
+        observation.observed_at <= now < observation.expires_at
+    ):
+        reasons.append("discovery_expired_or_invalid")
+    if (
+        observation.requested_model != requested_model
+        or surface.model is not None
+        and surface.model != requested_model
+    ):
+        reasons.append("requested_model_mismatch")
+    if requirements.exact_model and (
+        observation.identity_evidence != "response_observed"
+        or observation.actual_model != requested_model
+    ):
+        reasons.append("actual_model_unproven")
+    if (
+        observation.identity_evidence == "response_observed"
+        and observation.actual_model != requested_model
+    ):
+        reasons.append("actual_model_mismatch")
+    if (
+        not ({"text"} | task.requires | task.required_modalities)
+        <= observation.capabilities
+    ):
+        reasons.append("capabilities_unproven")
+    if requirements.effort not in (None, surface.effort):
+        reasons.append("effort_unqualified")
+    if surface.effort == "max" and not requirements.high_effort_authorized:
+        reasons.append("high_effort_requires_explicit_admission")
+    for name, requested in (
+        ("output_tokens", requirements.output_cap),
+        ("total_tokens", requirements.total_cap),
+    ):
+        enforced = dict(observation.enforced_caps).get(name)
+        if requested is not None and (
+            type(requested) is not int
+            or requested <= 0
+            or type(enforced) is not int
+            or not 0 < enforced <= requested
+        ):
+            reasons.append(f"{name}_hard_cap_unproven")
+    if type(requirements.workers) is not int or not 0 <= requirements.workers <= 4:
+        reasons.append("worker_limit_invalid")
+    elif requirements.workers == 0 and (
+        type(observation.worker_limit) is not int or observation.worker_limit != 0
+    ):
+        reasons.append("delegation_must_be_disabled")
+    elif requirements.workers and (
+        not observation.delegation_observable
+        or type(observation.worker_limit) is not int
+        or not 0 < observation.worker_limit <= requirements.workers
+    ):
+        reasons.append("delegation_limit_unproven")
+    return tuple(reasons)
+
+
+@dataclass(frozen=True)
+class Reply:
+    content: str
+    status: Literal["complete", "incomplete", "unknown"]
+    actual_model: str | None
+    identity_evidence: IdentityEvidence
+    finish_reason: str | None = None
+    native_usage: tuple[tuple[str, int], ...] = ()
+    remote_effect: str = "unknown"
+    local_cancelled: bool = False
+    remote_cancelled: bool | None = None
+
+
+def normalize_text(
+    content: object,
+    finish_reason: object,
+    *,
+    actual_model: str | None = None,
+    identity_evidence: IdentityEvidence = "unknown",
+    local_cancelled: bool = False,
+    remote_cancelled: bool | None = None,
+) -> Reply:
+    """Normalize collector-selected text; native lifecycle outcomes stay separate."""
+    text = content if isinstance(content, str) else ""
+    status = (
+        "complete"
+        if finish_reason in ("stop", "end_turn") and text.strip()
+        else "unknown"
+    )
+    if finish_reason in ("length", "max_tokens") or local_cancelled:
+        status = "incomplete"
+    return Reply(
+        text,
+        status,
+        actual_model,
+        identity_evidence,
+        finish_reason=finish_reason if isinstance(finish_reason, str) else None,
+        local_cancelled=local_cancelled,
+        remote_cancelled=remote_cancelled,
+    )
+
+
+def normalize_tp1(
+    payload: Mapping[str, Any],
+    *,
+    local_cancelled: bool = False,
+    remote_cancelled: bool | None = None,
+) -> Reply:
+    """Accept content only; preserve native counters without adding reasoning twice."""
+    choices = payload.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    choice = choice if isinstance(choice, dict) else {}
+    message = choice.get("message", {})
+    message = message if isinstance(message, dict) else {}
+    model = payload.get("model")
+    model = model if isinstance(model, str) and model else None
+    finish_reason = choice.get("finish_reason")
+    result = normalize_text(
+        message.get("content"),
+        finish_reason if finish_reason in ("stop", "length") else None,
+        actual_model=model,
+        identity_evidence="response_observed" if model else "unknown",
+        local_cancelled=local_cancelled,
+        remote_cancelled=remote_cancelled,
+    )
+    usage = payload.get("usage", {})
+    usage = usage if isinstance(usage, dict) else {}
+    counters: list[tuple[str, int]] = []
+    for name in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = usage.get(name)
+        if type(value) is int and value >= 0:
+            counters.append((name, value))
+    for group, name in (
+        ("completion_tokens_details", "reasoning_tokens"),
+        ("prompt_tokens_details", "cached_tokens"),
+    ):
+        details = usage.get(group, {})
+        if isinstance(details, dict) and type(details.get(name)) is int:
+            if details[name] >= 0:
+                counters.append((f"{group}.{name}", details[name]))
+    return Reply(
+        **{
+            **vars(result),
+            "native_usage": tuple(counters),
+            "finish_reason": finish_reason if isinstance(finish_reason, str) else None,
+        }
+    )
+
+
+def tp1_payload(surface_id: str, prompt: str, output_cap: int) -> dict[str, Any]:
+    """Prepare the existing TP1 user-only transport shape, never a network call."""
+    if surface_id not in {"qwen_tp1", "deepseek_tp1", "glm_tp1"}:
+        raise ValueError("not a qualified TP1 text surface")
+    if type(output_cap) is not int or output_cap <= 0:
+        raise ValueError("output_cap must be positive")
+    surface = SURFACES[surface_id]
+    body: dict[str, Any] = {
+        "model": surface.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": output_cap,
+    }
+    if surface.effort is not None:
+        body["reasoning_effort"] = surface.effort
+    return body
+
+
+def main() -> int:
+    """Offline JSON admission: python -m scripts.conductor.adapter_contracts < packet.json.
+
+    Packet fields: surface_id, requested_model, expected_key, now (ISO timestamp),
+    task (TaskIntent), observation (DiscoveryObservation), requirements (optional).
+    Both discovery keys carry runtime_version/config_hash/host/auth_context_hash.
+    Observation timestamps are ISO strings; sets and cap pairs are JSON arrays.
+    Stdout contains only admission/rejection metadata; no task content is echoed.
+    """
+    try:
+        packet = json.load(sys.stdin)
+        required = {
+            "surface_id",
+            "requested_model",
+            "expected_key",
+            "now",
+            "task",
+            "observation",
+        }
+        if not required <= set(packet) <= required | {"requirements"}:
+            raise ValueError("invalid fields")
+        task = dict(packet["task"])
+        observed = dict(packet["observation"])
+        requirements = dict(packet.get("requirements", {}))
+        for record, fields in (
+            (task, ("mutation", "contains_pii")),
+            (observed, ("delegation_observable",)),
+            (requirements, ("exact_model", "high_effort_authorized")),
+        ):
+            if any(
+                field in record and type(record[field]) is not bool for field in fields
+            ):
+                raise ValueError("invalid boolean")
+        task["task_class"] = TaskClass(task["task_class"])
+        task["files"] = tuple(task["files"])
+        for field in ("requires", "required_modalities", "required_tools"):
+            task[field] = frozenset(task[field])
+        observed["key"] = DiscoveryKey(**observed["key"])
+        for field in ("observed_at", "expires_at"):
+            observed[field] = datetime.fromisoformat(observed[field])
+        observed["capabilities"] = frozenset(observed.get("capabilities", []))
+        observed["enforced_caps"] = tuple(
+            tuple(pair) for pair in observed.get("enforced_caps", [])
+        )
+        reasons = admit(
+            packet["surface_id"],
+            packet["requested_model"],
+            TaskIntent(**task),
+            DiscoveryObservation(**observed),
+            DiscoveryKey(**packet["expected_key"]),
+            datetime.fromisoformat(packet["now"]),
+            Requirements(**requirements),
+        )
+    except (KeyError, TypeError, ValueError):
+        sys.stderr.write("invalid admission packet; no preparation admitted\n")
+        return 1
+    sys.stdout.write(
+        json.dumps(
+            {
+                "admitted": not reasons,
+                "reasons": reasons,
+                "scope": "text_preparation_only",
+            }
+        )
+        + "\n"
+    )
+    return 2 if reasons else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_conductor_adapter_contracts.py
+++ b/scripts/tests/test_conductor_adapter_contracts.py
@@ -1,0 +1,331 @@
+"""Offline fixtures for v4 admission boundaries and selected response evidence."""
+
+from dataclasses import asdict, replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from scripts.conductor.adapter_contracts import (
+    SURFACES,
+    DiscoveryKey,
+    DiscoveryObservation,
+    Requirements,
+    admit,
+    normalize_text,
+    normalize_tp1,
+    tp1_payload,
+)
+from scripts.conductor.contracts import TaskClass, TaskIntent
+
+
+NOW = datetime(2026, 9, 6, tzinfo=timezone.utc)
+KEY = DiscoveryKey("1.0", "config-sha256", "pro", "auth-context-sha256")
+TASK = TaskIntent(
+    "synthetic",
+    TaskClass.READ_ONLY,
+    1,
+    False,
+    (),
+    frozenset(),
+    "synthetic",
+    100,
+    frozenset({"text"}),
+    frozenset(),
+    False,
+)
+
+
+def observation(surface: str = "qwen_tp1", **changes: object) -> DiscoveryObservation:
+    model = SURFACES[surface].model or "discovered-model"
+    base = DiscoveryObservation(
+        KEY,
+        surface,
+        model,
+        model,
+        "response_observed",
+        NOW - timedelta(minutes=1),
+        NOW + timedelta(minutes=1),
+        frozenset({"text"}),
+        worker_limit=0,
+    )
+    return replace(base, **changes)
+
+
+def rejection(
+    surface: str = "qwen_tp1",
+    *,
+    observed: DiscoveryObservation | None = None,
+    required: Requirements = Requirements(),
+    task: TaskIntent = TASK,
+    key: DiscoveryKey = KEY,
+) -> tuple[str, ...]:
+    observed = observed or observation(surface)
+    return admit(surface, observed.requested_model, task, observed, key, NOW, required)
+
+
+@pytest.mark.parametrize("surface", SURFACES)
+def test_surface_qualification_never_grants_native_effects(surface: str) -> None:
+    reasons = rejection(surface, required=Requirements(high_effort_authorized=True))
+    assert ("surface_unqualified" in reasons) is (not SURFACES[surface].text_qualified)
+    assert not SURFACES[surface].operations
+    for operation in ("invoke", "resume", "cancel"):
+        assert "operation_unqualified" in rejection(
+            surface, required=Requirements(operation=operation)
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("runtime_version", "2.0"),
+        ("config_hash", "changed"),
+        ("host", "air-m5"),
+        ("auth_context_hash", "rotated"),
+    ],
+)
+def test_discovery_cannot_cross_context(field: str, value: str) -> None:
+    assert "discovery_context_mismatch" in rejection(key=replace(KEY, **{field: value}))
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"expires_at": NOW},
+        {"observed_at": NOW + timedelta(seconds=1)},
+        {"observed_at": NOW.replace(tzinfo=None)},
+    ],
+)
+def test_stale_future_and_naive_discovery_is_rejected(changes: dict) -> None:
+    assert "discovery_expired_or_invalid" in rejection(observed=observation(**changes))
+
+
+@pytest.mark.parametrize("proof", ["request_observed", "unknown"])
+def test_exact_identity_requires_response_observation(proof: str) -> None:
+    observed = observation("gemini_agy", actual_model=None, identity_evidence=proof)
+    assert not rejection("gemini_agy", observed=observed)
+    assert "actual_model_unproven" in rejection(
+        "gemini_agy", observed=observed, required=Requirements(exact_model=True)
+    )
+
+
+def test_wrong_model_capability_and_effects_cannot_be_admitted() -> None:
+    assert "actual_model_mismatch" in rejection(
+        observed=observation(actual_model="other")
+    )
+    assert "capabilities_unproven" in rejection(
+        observed=observation(capabilities=frozenset())
+    )
+    assert "effects_unqualified" in rejection(task=replace(TASK, mutation=True))
+    assert "effects_unqualified" in rejection(
+        task=replace(TASK, required_tools=frozenset({"shell"}))
+    )
+    assert "pii_lane_unqualified" in rejection(task=replace(TASK, contains_pii=True))
+
+
+def test_caps_require_separate_verified_enforcement_and_workers_are_observable() -> (
+    None
+):
+    required = Requirements(output_cap=100, total_cap=200, workers=4)
+    observed = observation(enforced_caps=(("output_tokens", 100),), worker_limit=4)
+    reasons = rejection(observed=observed, required=required)
+    assert "total_tokens_hard_cap_unproven" in reasons
+    assert "delegation_limit_unproven" in reasons
+    observed = replace(
+        observed,
+        enforced_caps=(("output_tokens", 100), ("total_tokens", 200)),
+        delegation_observable=True,
+    )
+    assert not rejection(observed=observed, required=required)
+    assert "delegation_limit_unproven" in rejection(
+        observed=observed, required=Requirements(workers=2)
+    )
+    assert "worker_limit_invalid" in rejection(required=Requirements(workers=5))
+    assert "delegation_must_be_disabled" in rejection(observed=observed)
+    assert not rejection(observed=replace(observed, worker_limit=0))
+    assert "output_tokens_hard_cap_unproven" in rejection(
+        observed=observed, required=Requirements(output_cap=50)
+    )
+
+
+@pytest.mark.parametrize("limit", [None, False, True, 0.0, 1, 4])
+def test_zero_workers_requires_proven_disabled_integer_limit(limit: object) -> None:
+    assert "delegation_must_be_disabled" in rejection(
+        observed=observation(worker_limit=limit)
+    )
+    assert not rejection(observed=observation(worker_limit=0))
+
+
+@pytest.mark.parametrize(
+    "surface,effort",
+    [
+        ("qwen_tp1", "max"),
+        ("deepseek_tp1", "medium"),
+        ("glm_tp1", "medium"),
+        ("gemini_agy", "high"),
+        ("kimi_text", "medium"),
+    ],
+)
+def test_no_cross_provider_effort_translation(surface: str, effort: str) -> None:
+    assert "effort_unqualified" in rejection(
+        surface, required=Requirements(effort=effort)
+    )
+
+
+def test_kimi_inherited_max_requires_deliberate_mission_admission() -> None:
+    assert "high_effort_requires_explicit_admission" in rejection("kimi_text")
+    assert not rejection(
+        "kimi_text", required=Requirements(high_effort_authorized=True)
+    )
+
+
+@pytest.mark.parametrize("surface", ["qwen_tp1", "deepseek_tp1", "glm_tp1"])
+def test_tp1_fields_are_user_only_and_effort_is_route_specific(surface: str) -> None:
+    body = tp1_payload(surface, "Synthetic prompt", 100)
+    assert body["messages"] == [{"role": "user", "content": "Synthetic prompt"}]
+    assert body["model"] == SURFACES[surface].model
+    expected = {"model", "messages", "max_tokens"}
+    if surface == "qwen_tp1":
+        expected.add("reasoning_effort")
+        assert body["reasoning_effort"] == "medium"
+    assert set(body) == expected
+
+
+@pytest.mark.parametrize(
+    "finish,status", [("stop", "complete"), ("length", "incomplete"), (None, "unknown")]
+)
+def test_reply_completion_and_remote_outcome_are_independent(
+    finish: str | None, status: str
+) -> None:
+    reply = normalize_tp1(
+        {
+            "model": "qwen3.8-max",
+            "choices": [
+                {
+                    "message": {
+                        "content": "Selected answer",
+                        "reasoning_content": "EXCLUDED",
+                    },
+                    "finish_reason": finish,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 30,
+                "total_tokens": 40,
+                "completion_tokens_details": {"reasoning_tokens": 20},
+                "prompt_tokens_details": {"cached_tokens": 5},
+                "api_key": "EXCLUDED",
+            },
+        }
+    )
+    assert reply.status == status
+    assert reply.remote_effect == "unknown"
+    assert reply.actual_model == "qwen3.8-max"
+    assert reply.identity_evidence == "response_observed"
+    assert dict(reply.native_usage)["total_tokens"] == 40
+    assert dict(reply.native_usage)["prompt_tokens_details.cached_tokens"] == 5
+    assert len(reply.native_usage) == 5
+    assert reply.finish_reason == finish
+    assert "EXCLUDED" not in repr(reply)
+
+
+def test_reasoning_only_missing_identity_and_late_reply_after_cancel_are_not_success() -> (
+    None
+):
+    reply = normalize_tp1(
+        {
+            "choices": [
+                {"message": {"reasoning_content": "EXCLUDED"}, "finish_reason": "stop"}
+            ]
+        }
+    )
+    assert reply.content == "" and reply.status == "unknown"
+    assert reply.identity_evidence == "unknown" and reply.actual_model is None
+    late = normalize_text("Late answer", "stop", local_cancelled=True)
+    assert late.status == "incomplete" and late.local_cancelled
+    assert late.remote_cancelled is None and late.remote_effect == "unknown"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{}, {"choices": None}, {"choices": [None]}, {"choices": [{"message": None}]}],
+)
+def test_malformed_envelopes_never_become_complete(payload: dict) -> None:
+    assert normalize_tp1(payload).status == "unknown"
+
+
+def test_native_claude_completion_does_not_change_tp1_finish_contract() -> None:
+    native = normalize_text("Selected answer", "end_turn")
+    assert native.status == "complete" and native.finish_reason == "end_turn"
+    assert normalize_text("Partial", "max_tokens").status == "incomplete"
+    incompatible = normalize_tp1(
+        {"choices": [{"message": {"content": "answer"}, "finish_reason": "end_turn"}]}
+    )
+    assert incompatible.status == "unknown"
+    assert incompatible.finish_reason == "end_turn"
+
+
+def _admission_packet() -> dict:
+    """The CLI's documented packet, kept synthetic and free of prompt text."""
+    return {
+        "surface_id": "qwen_tp1",
+        "requested_model": "qwen3.8-max",
+        "expected_key": asdict(KEY),
+        "now": NOW.isoformat(),
+        "task": asdict(TASK),
+        "observation": asdict(observation()),
+        "requirements": {"exact_model": True},
+    }
+
+
+def _json_default(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, frozenset):
+        return sorted(value)
+    raise TypeError("unsupported fixture value")
+
+
+@pytest.mark.parametrize(
+    "proof,exit_code", [("response_observed", 0), ("request_observed", 2)]
+)
+def test_offline_cli_is_a_real_admission_consumer(proof: str, exit_code: int) -> None:
+    packet = _admission_packet()
+    packet["observation"]["identity_evidence"] = proof
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.conductor.adapter_contracts"],
+        cwd=Path(__file__).resolve().parents[2],
+        input=json.dumps(packet, default=_json_default),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == exit_code, result.stderr
+    receipt = json.loads(result.stdout)
+    assert receipt["admitted"] is (exit_code == 0)
+    assert receipt["scope"] == "text_preparation_only"
+    if exit_code:
+        assert "actual_model_unproven" in receipt["reasons"]
+
+
+@pytest.mark.parametrize("change", ["unknown_field", "string_boolean"])
+def test_invalid_cli_packet_rejects_without_echoing_content(change: str) -> None:
+    packet = _admission_packet()
+    if change == "unknown_field":
+        packet["prompt"] = "EXCLUDED"
+    else:
+        packet["requirements"]["exact_model"] = "false"
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.conductor.adapter_contracts"],
+        cwd=Path(__file__).resolve().parents[2],
+        input=json.dumps(packet, default=_json_default),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 1 and not result.stdout
+    assert "EXCLUDED" not in result.stderr

--- a/scripts/tests/test_conductor_calibration.py
+++ b/scripts/tests/test_conductor_calibration.py
@@ -241,7 +241,10 @@ class CalibrationOverlayTest(unittest.TestCase):
         ]
         effective_eligible = registry.endpoints()
 
-        self.assertEqual(len(source_eligible), 4)
+        self.assertTrue(
+            source_eligible,
+            "static eligibility must exist to exercise the effective evidence gate",
+        )
         self.assertEqual(effective_eligible, ())
         self.assertFalse(registry.operational)
         self.assertTrue(

--- a/scripts/tests/test_conductor_model_registry.py
+++ b/scripts/tests/test_conductor_model_registry.py
@@ -14,12 +14,12 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from collections import Counter
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 from scripts.conductor.calibration import CalibrationRecord, EndpointHostObservation
+from scripts.conductor.contracts import AuthSurface
 from scripts.conductor.model_registry import (
     RegistryValidationError,
     _candidate_from_records,
@@ -45,14 +45,7 @@ STATUSES = {
 }
 EVIDENCE_LEVELS = {"declared", "probed", "benchmarked", "production", "unmeasured"}
 PUBLIC_URL_PATTERN = re.compile(r"https?://[^\s|]+")
-AUTH_SURFACE_COUNTS = {
-    "anthropic_oauth_subscription": 6,
-    "google_oauth_subscription": 5,
-    "local_runtime": 14,
-    "manual_gui": 1,
-    "openai_chatgpt_subscription": 10,
-    "unknown": 45,
-}
+AUTH_SURFACES = {surface.value for surface in AuthSurface}
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -522,7 +515,7 @@ class ModelIntelligenceRegistryTest(unittest.TestCase):
 
     def test_cards_have_evidenced_claims_and_unique_ids(self) -> None:
         cards = [load_json(path) for path in sorted(CARD_DIR.glob("*.json"))]
-        self.assertEqual(len(cards), 80)
+        self.assertTrue(cards, "MIR must contain at least one evidenced ModelCard")
         ids = [card["id"] for card in cards]
         self.assertEqual(len(ids), len(set(ids)))
         aliases = [alias for card in cards for alias in card["identity"]["aliases"]]
@@ -686,12 +679,16 @@ class ModelIntelligenceRegistryTest(unittest.TestCase):
             len(set(invocation_keys)),
             "a concrete provider invocation must identify exactly one EndpointProfile",
         )
-        self.assertGreaterEqual(len(endpoints), len(cards))
+        self.assertEqual(
+            {endpoint["model_card_id"] for endpoint in endpoints},
+            set(cards),
+            "every ModelCard must have a concrete endpoint profile",
+        )
         for endpoint in endpoints:
             with self.subTest(endpoint=endpoint["id"]):
                 self.assertEqual(endpoint["schema_version"], "endpoint-profile.v1")
                 self.assertIn(endpoint["model_card_id"], cards)
-                self.assertIn(endpoint["auth_surface"], AUTH_SURFACE_COUNTS)
+                self.assertIn(endpoint["auth_surface"], AUTH_SURFACES)
                 self.assertIn(endpoint["routing"]["status"], STATUSES)
                 if endpoint["routing"]["automated_routing"]:
                     self.assertEqual(endpoint["routing"]["status"], "eligible")
@@ -721,14 +718,21 @@ class ModelIntelligenceRegistryTest(unittest.TestCase):
                     endpoint["id"] + ".exposed_capabilities",
                 )
 
-    def test_auth_surface_migration_has_conservative_complete_counts(self) -> None:
+    def test_auth_surfaces_are_complete_and_conservatively_routable(self) -> None:
         """Every concrete endpoint states an authority; unverified providers stay denied."""
-        endpoints = [load_json(path) for path in sorted(ENDPOINT_DIR.glob("*.json"))]
-        counts = Counter(endpoint["auth_surface"] for endpoint in endpoints)
-
-        self.assertEqual(dict(sorted(counts.items())), AUTH_SURFACE_COUNTS)
-        self.assertEqual(sum(counts.values()), 81)
-        self.assertNotIn("anthropic_paid_api", counts)
+        schema = load_json(MIR / "endpoint_profile.schema.json")
+        self.assertEqual(
+            set(schema["properties"]["auth_surface"]["enum"]), AUTH_SURFACES
+        )
+        registry = load_registry(ROOT)
+        for endpoint in registry.endpoint_profiles.values():
+            with self.subTest(endpoint=endpoint["id"]):
+                self.assertIn(endpoint["auth_surface"], AUTH_SURFACES)
+                self.assertNotEqual(endpoint["auth_surface"], "anthropic_paid_api")
+                candidate = registry.endpoint(endpoint["id"])
+                self.assertEqual(candidate.auth_surface.value, endpoint["auth_surface"])
+                if candidate.auth_surface is AuthSurface.UNKNOWN:
+                    self.assertFalse(candidate.automated_routing)
 
     def test_index_is_a_complete_normalized_projection(self) -> None:
         cards = [load_json(path) for path in sorted(CARD_DIR.glob("*.json"))]


### PR DESCRIPTION
## Change

The MIR projection had drifted from its source evidence, and Autonomous Lab had no executable binding between current ownership, a scoped synthetic authorization, and a frozen cross-consul review. This PR regenerates MIR and adds an opt-in synthetic stage to the existing Lab worker using canonical Research OS objects.

The executor serializes the owner/fence/grant/input checks and its only effect, a same-database checkpoint, in PostgreSQL. Attempt, effect, and confirmed result are atomic; a stale owner cannot execute or revive a revoked grant. Text-only adapter contracts reject unproven identity, hard caps, effects, and delegation, and distinguish incomplete output from uncertain remote effects.

A read-only production prerequisite check found the legacy Lab tables absent. Migration 306 therefore includes the exact eight DDL statements from legacy migration 124 before its foreign key. Rollback drops only the lease table and retains shared Lab tables and data. Parity and absent-table installation are exercised against real PostgreSQL.

The four English v4 specifications and selected authentic design/review evidence are versioned. No native provider integration or fleet service is activated. `change_map`, `impact_map`, and merge-group advisory rules are unchanged; no general harness job is added to all PRs.

Bites: `AutonomousLabWorker(stage_nodes=(ConsulSyntheticStage(...),))` completes synthetic missions in both consul directions; the disposable PostgreSQL proof observes one confirmed checkpoint on replay and zero effects from stale, expired, revoked, or cancelled ownership. `python -m scripts.conductor.adapter_contracts` consumes JSON admission packets and returns only qualified text-preparation admission or explicit refusal.

## Verification

- Autonomous Lab units: 231 passed; strengthened admission-success assertion subsequently rechecked with 28 executor tests passing.
- Conductor registry, host identity, seat maps, calibration, and adapters: 89 passed, 798 subtests passed.
- Disposable PostgreSQL 17.8 on Pro, production JSON codec: 18 passed, including concurrency, atomic rollback, expiry at effect time, historical-grant revocation, migration rollback/reapply, and absent Lab foundation.
- MIR generator `--check`, Ruff, Prettier, and migration Squawk with the existing CI rule set passed.
- Production read-only check: both Lab foundation tables absent; no mission content or client rows read and no production writes.

Exact commands, captured output, frozen review inputs, response hashes, and reproduction instructions are under `evidence/dual-consul-v4/implementation/`.

## Adversarial review

Independent native `claude-fable-5-1`, interactive plan mode with no tools, session `9db691ab-8167-459b-a921-54857dde0d49`. The reviewer assessed bounded frozen source packets rather than executing tests. Review metadata states the exact covered files, input hashes, observed model, and response hashes. The initial review's superseded-grant and unknown-delegation findings were corrected and re-reviewed. Its JSON-shape question triggered the production prerequisite check and a separate narrow migration correction review.

This is an external-builder draft. No release-gate status, auto-merge, merge, or deployment is armed by this PR author. Native App Server/Claude operational launch, credential isolation under a distinct service identity, provider cancellation/resume, fleet activation, and production reliability remain separate qualification work.
