### PR TITLE
fix(mouth): correct homepage founding year and stale dateline

### DIFF
--- a/apps/mouth/src/app/v2/_components/HeroBlueprint.tsx
+++ b/apps/mouth/src/app/v2/_components/HeroBlueprint.tsx
@@ -67,7 +67,7 @@ export function HeroBlueprint() {
                 className="text-[10px] font-semibold uppercase tracking-[0.28em] mb-2"
                 style={{ color: "rgba(255,255,255,0.5)" }}
               >
-                Bali Zero · Dispatch · April 2026 · Kerobokan
+                Bali Zero · Kerobokan · Indonesia
               </div>
               {/* Tagline */}
               <div
@@ -140,7 +140,7 @@ export function HeroBlueprint() {
               >
                 Filed this month: 47 KITAS, 9 PT PMAs · Office in Kerobokan
                 <br />
-                Licensed konsultan pajak · Registered PPJK · Since 2019
+                Licensed konsultan pajak · Registered PPJK · Since 2020
               </div>
             </div>
           </div>

--- a/apps/mouth/src/app/v2/_components/SocialProof.tsx
+++ b/apps/mouth/src/app/v2/_components/SocialProof.tsx
@@ -148,7 +148,7 @@ export function SocialProof() {
             }}
           >
             <BadgeCheck size={12} strokeWidth={2} />
-            5,000+ expats and founders · since 2019
+            5,000+ expats and founders · since 2020
           </div>
           <h2
             className="tracking-tight mb-4"
@@ -170,7 +170,7 @@ export function SocialProof() {
             className="text-[14px] max-w-xl mx-auto"
             style={{ color: "var(--text-secondary)" }}
           >
-            Real consultants handling real cases in Bali since 2019. AI drafts
+            Real consultants handling real cases in Bali since 2020. AI drafts
             the analysis. Our licensed Indonesian team signs the filings.
           </p>
         </div>
@@ -453,7 +453,7 @@ export function SocialProof() {
         >
           <TrustItem
             icon={<BadgeCheck size={14} strokeWidth={2} />}
-            label="5,000+ Clients since 2019"
+            label="5,000+ Clients since 2020"
           />
           <TrustItem
             icon={<Star size={14} strokeWidth={0} fill="currentColor" />}


### PR DESCRIPTION
The public homepage says “since 2019” in four places while its footer correctly says 2020. The owner confirms 2020. Update the shared hero and social-proof copy so the public marketing homepage and the v2 preview agree.

Replace the stale “Dispatch · April 2026 · Kerobokan” hero dateline with the evergreen location “Bali Zero · Kerobokan · Indonesia”. Article publication dates and other claims are unchanged.

Bites: the public `app/(marketing)/page.tsx` imports both edited components. Its hero and three social-proof founding-year references now render 2020; the hero no longer displays the stale April 2026 dateline. Source imports and all five replacements were checked locally. Production observation remains pending independent review and release.

Validation:
- Targeted ESLint: 0 errors; 2 existing warnings for the unrelated `/team/` anchor.
- `npm run typecheck`: passed.
- Normal pre-commit hooks: passed; no bypasses.
- `git diff --check`: passed.
- The initial typecheck exposed missing/outdated shared local dependencies. An isolated worktree dependency overlay supplied lockfile versions `zod@4.5.4` and `recharts@3.10.1`; no manifest, lockfile or shared dependency tree changed.

Scope: 2 components, 5 text replacements. No redesign, rule-engine, pricing or infrastructure changes. External-builder handoff: prepared for independent Claude review; auto-merge is not armed and this branch has not been deployed by the builder.
